### PR TITLE
chore(ci): use RELEASE_PLEASE_TOKEN PAT for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (RELEASE_PLEASE_TOKEN) so PRs opened by release-please trigger ci.yml.
+          # GITHUB_TOKEN-driven actions cannot trigger workflows on other workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish-mcp:
     needs: release-please


### PR DESCRIPTION
## Summary

Branch protection requires the `verify` status check on `main`, but
release-please's bot PR uses the implicit `GITHUB_TOKEN`. GitHub does not
trigger downstream workflows from `GITHUB_TOKEN`-driven actions, so `ci.yml`
never runs on the auto-PR and it cannot be merged.

Switch the release-please action to a PAT stored as `RELEASE_PLEASE_TOKEN`.
This is the workaround [documented by release-please](https://github.com/googleapis/release-please-action#github-credentials).

The PAT is scoped to this repo only, with `Contents`, `Pull requests`, and
`Workflows` write permissions.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next release.yml run regenerates PR #8 and `verify`
  runs against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
