### PR TITLE
chore(ci): add workflow_dispatch trigger to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ name: release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Add `workflow_dispatch:` to release.yml so it can be re-run on demand
without pushing a new commit. Useful when release-please's branch was
deleted or its state needs to be re-evaluated.

Merging this PR also serves as the push needed to trigger release-please to
recreate PR #8 (which was closed to switch from `GITHUB_TOKEN` to PAT, so
the regenerated PR will run `verify`).

## Test plan

- [ ] CI green
- [ ] After merge, release.yml runs and release-please opens a fresh "chore:
  release main" PR that triggers `verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
