### PR TITLE
fix(release): force npm upgrade to avoid promise-retry MODULE_NOT_FOUND

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
-        run: npm install -g npm@latest
+        # --force avoids ERR_MODULE_NOT_FOUND from mixing the new npm cli with the old node_modules layout.
+        run: npm install -g --force npm@latest
 
       - name: Install dependencies (workspace root)
         working-directory: .

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -50,7 +50,7 @@ describe('publish contract', () => {
     expect(releaseWorkflow).toContain('npm publish --access public --provenance')
     // OIDC trusted publisher requires id-token: write permission and bumps npm to >= 11.5.1.
     expect(releaseWorkflow).toContain('id-token: write')
-    expect(releaseWorkflow).toMatch(/npm install -g(?: --force)? npm@latest/)
+    expect(releaseWorkflow).toContain('npm install -g --force npm@latest')
     // Should not fall back to long-lived NPM_TOKEN or GitHub Packages auth.
     expect(releaseWorkflow).not.toContain('Publish to GitHub Packages')
     expect(releaseWorkflow).not.toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}')

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -50,7 +50,7 @@ describe('publish contract', () => {
     expect(releaseWorkflow).toContain('npm publish --access public --provenance')
     // OIDC trusted publisher requires id-token: write permission and bumps npm to >= 11.5.1.
     expect(releaseWorkflow).toContain('id-token: write')
-    expect(releaseWorkflow).toContain('npm install -g npm@latest')
+    expect(releaseWorkflow).toMatch(/npm install -g(?: --force)? npm@latest/)
     // Should not fall back to long-lived NPM_TOKEN or GitHub Packages auth.
     expect(releaseWorkflow).not.toContain('Publish to GitHub Packages')
     expect(releaseWorkflow).not.toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}')


### PR DESCRIPTION
## Summary

`npm install -g npm@latest` failed in the publish-mcp job with
`MODULE_NOT_FOUND: 'promise-retry'` — caused by mixing the new npm cli with
the old npm's `node_modules` layout on the GitHub-hosted runner.

Adding `--force` lets the upgrade overwrite the in-place install.

## Recovery context

The previous publish run created GitHub releases `mcp-server-v0.0.1` and
`whiteboard-plugin-v0.0.1` before failing the upgrade step, so re-running
release.yml as-is will set `mcp_release_created=false` and skip publish.
Recovery plan after this PR merges: delete the two releases + tags, then
dispatch release.yml manually so release-please re-creates them and runs
publish-mcp.

## Test plan

- [ ] CI green
- [ ] After merge + recovery dispatch, `publish-mcp` reaches `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
