### PR TITLE
fix(release): pin node-version inline in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          # Pinned via .node-version. Node 24 ships with npm 11.x which already meets Trusted
-          # Publishing's >= 11.5.1 requirement and avoids the `npm i -g npm@latest` self-upgrade bug.
-          node-version-file: .node-version
+          # Pinned inline (not via .node-version) because publish-mcp checks out an old tag whose
+          # source tree may predate .node-version. Node 24 ships with npm 11.x which already meets
+          # Trusted Publishing's >= 11.5.1 requirement and avoids the `npm i -g npm@latest` bug.
+          # Keep this in sync with .node-version manually.
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -52,7 +52,7 @@ describe('publish contract', () => {
     // Node 24 ships with npm 11.x; relying on the bundled npm avoids the
     // `npm i -g npm@latest` self-upgrade bug.
     expect(releaseWorkflow).toContain('id-token: write')
-    expect(releaseWorkflow).toContain('node-version-file: .node-version')
+    expect(releaseWorkflow).toMatch(/node-version:\s*2[4-9]/)
     // Should not fall back to long-lived NPM_TOKEN or GitHub Packages auth.
     expect(releaseWorkflow).not.toContain('Publish to GitHub Packages')
     expect(releaseWorkflow).not.toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}')


### PR DESCRIPTION
## Summary

`force_publish_tag=mcp-server-v0.0.2` failed because publish-mcp checks
out the v0.0.2 source tree, which predates `.node-version` (added in
PR #18). `actions/setup-node` then errored: "node version file
.node-version does not exist".

Fix: pin `node-version` inline (24) in release.yml so the action does not
depend on files that may not exist in older tags. ci.yml continues to use
`.node-version` (which always reads from the trigger commit on a feature
branch where the file is present).

Two source-of-truth files for "what Node version we use" — keep them in
sync manually.

## Test plan

- [ ] CI green
- [ ] After merge, dispatch release.yml with
  `force_publish_tag=mcp-server-v0.0.2` again — publish-mcp should reach
  `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
