### PR TITLE
fix(mcp): start via npx/bin symlink (entrypoint detection broken on 0.0.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,11 @@ jobs:
       - name: Packaged stdio smoke
         run: pnpm smoke:packaged
 
+      - name: Bin symlink smoke (npx / claude mcp / codex install path)
+        run: pnpm smoke:bin
+
+      - name: Template smoke
+        run: pnpm smoke:template
+
       - name: Codex config smoke
         run: pnpm smoke:codex-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
         working-directory: .
         run: pnpm smoke:packaged
 
+      - name: Bin symlink smoke (npx / claude mcp / codex install path)
+        working-directory: .
+        run: pnpm smoke:bin
+
       - name: Codex config smoke
         working-directory: .
         run: pnpm smoke:codex-config

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "smoke": "pnpm --filter @kamiazya/whiteboard-mcp smoke",
     "smoke:e2e": "pnpm --filter @kamiazya/whiteboard-mcp smoke:e2e",
     "smoke:packaged": "pnpm --filter @kamiazya/whiteboard-mcp smoke:packaged",
+    "smoke:bin": "pnpm --filter @kamiazya/whiteboard-mcp smoke:bin",
     "smoke:codex-config": "pnpm --filter @kamiazya/whiteboard-mcp smoke:codex-config",
     "smoke:template": "pnpm --filter @kamiazya/whiteboard-mcp smoke:template",
     "smoke:claude": "pnpm --filter @kamiazya/whiteboard-mcp smoke:claude",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -73,6 +73,7 @@
     "smoke:checkpoint": "node scripts/mcp-e2e-checkpoint.mjs",
     "smoke:e2e": "node scripts/mcp-e2e-checkpoint.mjs",
     "smoke:packaged": "node scripts/mcp-e2e-checkpoint.mjs --entry=dist/server/mcp/index.js",
+    "smoke:bin": "node scripts/mcp-bin-symlink-smoke.mjs",
     "smoke:codex-config": "node scripts/mcp-codex-config-smoke.mjs",
     "smoke:template": "tsx scripts/mcp-template-smoke.mjs",
     "smoke:claude": "node scripts/mcp-claude-cli-smoke.mjs",

--- a/packages/mcp-server/scripts/mcp-bin-symlink-smoke.mjs
+++ b/packages/mcp-server/scripts/mcp-bin-symlink-smoke.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Smoke test: install the packed tarball into a tmp dir and start the MCP server
+// through node_modules/.bin/whiteboard-mcp (a symlink). This is how `npx`,
+// `claude mcp add ... -- npx`, and Codex's `command = "npx"` invoke the binary.
+//
+// Catches the regression where `process.argv[1] === fileURLToPath(import.meta.url)`
+// silently returns false through symlinks and main() never runs.
+
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkgDir = resolve(__dirname, '..')
+const distEntry = join(pkgDir, 'dist/server/mcp/index.js')
+if (!existsSync(distEntry)) {
+  console.error('[bin-smoke] FAIL: dist not found at', distEntry, '— run pnpm build first')
+  process.exit(1)
+}
+
+const workDir = mkdtempSync(join(tmpdir(), 'whiteboard-bin-smoke-'))
+let exitCode = 1
+
+function cleanup() {
+  try {
+    rmSync(workDir, { recursive: true, force: true })
+  } catch {}
+}
+
+try {
+  console.log('[bin-smoke] pack into', workDir)
+  const packResult = spawnSync('npm', ['pack', '--pack-destination', workDir, '--silent'], {
+    cwd: pkgDir,
+    stdio: ['ignore', 'pipe', 'inherit'],
+    encoding: 'utf-8',
+  })
+  if (packResult.status !== 0) throw new Error(`npm pack failed: ${packResult.status}`)
+  const tarball = packResult.stdout.trim().split('\n').pop()
+  if (!tarball) throw new Error('npm pack produced no tarball name')
+  const tarballPath = join(workDir, tarball)
+
+  console.log('[bin-smoke] install', tarball)
+  const npmInit = spawnSync('npm', ['init', '-y'], { cwd: workDir, stdio: 'ignore' })
+  if (npmInit.status !== 0) throw new Error(`npm init failed: ${npmInit.status}`)
+  const installResult = spawnSync('npm', ['install', '--no-fund', '--no-audit', '--silent', tarballPath], {
+    cwd: workDir,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+  if (installResult.status !== 0) throw new Error(`npm install failed: ${installResult.status}`)
+
+  const binPath = join(workDir, 'node_modules/.bin/whiteboard-mcp')
+  if (!existsSync(binPath)) throw new Error(`bin not present at ${binPath}`)
+
+  console.log('[bin-smoke] spawn via .bin symlink')
+  const child = spawn(binPath, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+  let out = ''
+  let err = ''
+  child.stdout.on('data', (d) => { out += d.toString() })
+  child.stderr.on('data', (d) => { err += d.toString() })
+
+  const send = (msg) => child.stdin.write(JSON.stringify(msg) + '\n')
+  await new Promise((r) => setTimeout(r, 1000))
+  send({
+    jsonrpc: '2.0', id: 1, method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'bin-smoke', version: '1' } },
+  })
+  await new Promise((r) => setTimeout(r, 4000))
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+  await new Promise((r) => setTimeout(r, 200))
+  send({ jsonrpc: '2.0', id: 2, method: 'tools/list' })
+  await new Promise((r) => setTimeout(r, 3000))
+  child.kill()
+  await new Promise((r) => setTimeout(r, 200))
+
+  const responses = out
+    .split('\n')
+    .filter((l) => l.trim().startsWith('{'))
+    .map((l) => { try { return JSON.parse(l) } catch { return null } })
+    .filter(Boolean)
+  const init = responses.find((r) => r.id === 1)
+  const list = responses.find((r) => r.id === 2)
+
+  if (!init?.result?.serverInfo) {
+    console.error('[bin-smoke] FAIL: no initialize response')
+    if (err) console.error('stderr:', err.slice(0, 500))
+    throw new Error('no initialize response')
+  }
+  console.log(`[bin-smoke] init OK (${init.result.serverInfo.name} ${init.result.serverInfo.version})`)
+
+  const tools = list?.result?.tools ?? []
+  if (tools.length === 0) {
+    console.error('[bin-smoke] FAIL: empty tools list')
+    throw new Error('empty tools list')
+  }
+  console.log(`[bin-smoke] tools/list OK (${tools.length} tools)`)
+  console.log('[bin-smoke] ALL OK')
+  exitCode = 0
+} catch (e) {
+  console.error('[bin-smoke] FAIL:', e.message)
+} finally {
+  cleanup()
+  process.exit(exitCode)
+}

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -1688,8 +1689,22 @@ async function main() {
   await server.connect(transport)
 }
 
-const isEntryPoint = process.argv[1] === fileURLToPath(import.meta.url)
-if (isEntryPoint) {
+// `process.argv[1]` may be a symlink (e.g. when invoked via npx, which routes through
+// node_modules/.bin/whiteboard-mcp -> ../@kamiazya/whiteboard-mcp/dist/server/mcp/index.js).
+// `fileURLToPath(import.meta.url)` resolves to the real file, so a direct `===` check
+// silently returns false through symlinks and main() never runs. Compare realpaths to
+// support both direct `node entry.js` and bin/npx invocation.
+function isInvokedAsEntryPoint(): boolean {
+  const argv1 = process.argv[1]
+  if (!argv1) return false
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+if (isInvokedAsEntryPoint()) {
   main().catch((err) => {
     process.stderr.write(`MCP server error: ${err}\n`)
     process.exit(1)


### PR DESCRIPTION
## Summary

Verified that `@kamiazya/whiteboard-mcp@0.0.3` cannot start when invoked
through the npm `bin` symlink (which is how `npx` and `claude mcp add ... -- npx`
and Codex's `command = "npx"` invoke it).

### Root cause

`packages/mcp-server/src/server/mcp/index.ts:1691`:

```ts
const isEntryPoint = process.argv[1] === fileURLToPath(import.meta.url)
```

When invoked via `node_modules/.bin/whiteboard-mcp`, `process.argv[1]`
is the symlink path while `fileURLToPath(import.meta.url)` is the real
file path. The strict `===` returns false, `main()` is never called,
the process exits 0 silently, and `claude mcp list` reports
"Failed to connect".

### Fix

Resolve both sides through `realpathSync` before comparing.

### Why the bug shipped

`smoke:e2e` and `smoke:packaged` both spawn `node <entry.js>` directly,
so neither passes through the symlink that real installs use. Added a
new `smoke:bin` that:

1. `npm pack` the workspace
2. `npm install` the tarball into a tmp dir
3. Spawn `node_modules/.bin/whiteboard-mcp` (the symlink path)
4. Verify `initialize` and `tools/list` round-trip

Wired into `ci.yml` and `release.yml` so this regression cannot recur.
Also added `smoke:template` to ci.yml (was only running in release.yml,
which is how a similar regression slipped in earlier).

## Test plan

- [x] `pnpm smoke:bin` → `[bin-smoke] ALL OK` locally
- [x] `pnpm test`, `pnpm typecheck` green
- [ ] CI green (smoke:bin runs and passes)
- [ ] After merge + release-please cycle, `claude mcp add whiteboard -- npx -y @kamiazya/whiteboard-mcp@latest` connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
