### PR TITLE
fix(release-please): linked-versions + server.json at root extras

### DIFF
--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -130,13 +130,7 @@ describe('publish contract', () => {
   })
 
   it('keeps published wrappers on @latest so release-please does not need extra-files sync', () => {
-    // mcp-server may sync MCP Registry metadata (server.json) but must not pull in
-    // any of the wrapper plugin manifests — those stay on @latest.
-    const mcpExtras = rootReleaseConfig.packages['packages/mcp-server']['extra-files'] ?? []
-    const wrapperPaths = ['.claude-plugin/plugin.json', '.codex-plugin/plugin.json', 'packages/mcp-server/.mcp.json']
-    for (const wp of wrapperPaths) {
-      expect(mcpExtras.some((e) => e.path?.endsWith(wp))).toBe(false)
-    }
+    expect(rootReleaseConfig.packages['packages/mcp-server']['extra-files']).toBeUndefined()
     expect(publishedMcpConfig.mcpServers.whiteboard).toEqual({
       command: 'npx',
       args: ['-y', '@kamiazya/whiteboard-mcp@latest'],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,16 @@
           "type": "json",
           "path": ".codex-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
         }
       ]
     },
@@ -35,20 +45,14 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "../../server.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "../../server.json",
-          "jsonpath": "$.packages[0].version"
-        }
-      ]
+      "prerelease": false
     }
   },
-  "plugins": []
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "whiteboard",
+      "components": ["whiteboard-plugin", "mcp-server"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Previous attempt (PR #25) tried `path: "../../server.json"` under
`packages/mcp-server`. release-please rejects that with
`illegal pathing characters in path: packages/mcp-server/../../server.json`.

Two changes:

1. **Move server.json extras back to root `.`** — release-please paths must
   stay inside the package directory, so wrapping must happen at the root
   package config.
2. **Add `linked-versions` plugin** — addresses Gemini's earlier concern
   about the two packages releasing independently. With linked-versions,
   `whiteboard-plugin` and `mcp-server` always release together at the
   same version, so root's `extra-files` reliably bumps `server.json` on
   every mcp release.

## Test plan

- [x] `pnpm test` green locally
- [ ] CI green
- [ ] After merge, release.yml regenerates the release PR with `server.json`
  bumped, and verify passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
