### PR TITLE
chore(ci): pin actions to SHAs and bump to latest majors (pinact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       root_release_created: ${{ steps.release.outputs['--release_created'] }}
       root_tag_name: ${{ steps.release.outputs['--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json
@@ -60,15 +60,15 @@ jobs:
       run:
         working-directory: packages/mcp-server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.force_publish_tag != '' && inputs.force_publish_tag || needs.release-please.outputs.mcp_tag_name }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # Pinned inline (not via .node-version) because publish-mcp checks out an old tag whose
           # source tree may predate .node-version. Node 24 ships with npm 11.x which already meets

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+ignore_actions:
+# - name: slsa-framework/slsa-github-generator/\.github/workflows/generator_generic_slsa3\.yml
+#   ref: v\d+\.\d+\.\d+
+# - name: actions/.*
+#   ref: main
+# - name: suzuki-shunsuke/.*
+#   ref: release-.*

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,14 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
-# pinact - https://github.com/suzuki-shunsuke/pinact
+# pinact — https://github.com/suzuki-shunsuke/pinact
+# Default scan: .github/workflows/*.{yml,yaml}. Add `files:` if action.yml files appear under packages/.
 version: 3
-# files:
-#   - pattern: action.yaml
-#   - pattern: */action.yaml
-
-ignore_actions:
-# - name: slsa-framework/slsa-github-generator/\.github/workflows/generator_generic_slsa3\.yml
-#   ref: v\d+\.\d+\.\d+
-# - name: actions/.*
-#   ref: main
-# - name: suzuki-shunsuke/.*
-#   ref: release-.*


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to commit SHAs and bump to latest majors via
[pinact](https://github.com/suzuki-shunsuke/pinact).

| Action | Before | After |
|---|---|---|
| actions/checkout | `@v4` | `de0fac2` (v6.0.2) |
| pnpm/action-setup | `@v4` | `903f9c1` (v6.0.3) |
| actions/setup-node | `@v4` | `48b55a0` (v6.4.0) |
| googleapis/release-please-action | `@v4` | `45996ed` (v5.0.0) |

Adds `.pinact.yaml` for future runs of `pinact run [--update]`.

## Breaking-change review (research summary)

All four bumps are **runtime upgrades only** for our setup:

- **checkout v5/v6**: action runtime moved to Node 24. We use ubuntu-latest
  (runner already past v2.329.0) and no Docker container actions, so no
  impact.
- **pnpm/action-setup v5/v6**: bundled pnpm bumped to 11. We pin
  `with: version: 9` explicitly, so the bundled-pnpm bump is irrelevant.
- **setup-node v5/v6**: auto package-manager caching introduced in v5,
  narrowed to npm-only in v6. We explicitly set `cache: pnpm`, which still
  wins. `always-auth` removal does not affect us.
- **release-please-action v5**: runtime upgrade only. Inputs/outputs
  unchanged. Our PAT (`RELEASE_PLEASE_TOKEN`) flow is untouched.

## Optional follow-up (not in this PR)

Adding `"packageManager": "pnpm@9.x.x"` to root `package.json` would let us
drop `with: version: 9` from both workflows and centralize the
package-manager pin in one place. Worth a small follow-up PR if desired.

## Test plan

- [ ] CI green
- [ ] Next release.yml run on main still opens / merges release-please PR
  correctly with the new v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies to use pinned commit versions for improved build stability, reproducibility, and security.
  * Introduced a new configuration system for managing GitHub workflow tooling and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->