### PR TITLE
feat(mcp): support outputPath and overwrite on export tools

### DIFF
--- a/packages/mcp-server/skills/whiteboard/SKILL.md
+++ b/packages/mcp-server/skills/whiteboard/SKILL.md
@@ -207,6 +207,8 @@ Options:
 - `scale`: export DPI multiplier, default 1
 - `minFontPx`: boosts font size only in the export clone
 - `frameId`: exports only the frame plus its child elements
+- `outputPath`: absolute path to write the PNG to. When omitted, write to the workspace exports dir
+- `overwrite`: replace an existing file at `outputPath`. Default false; without it an existing file rejects with `output_exists`
 
 Inspect the exported PNG visually:
 

--- a/packages/mcp-server/src/server/export-json.test.ts
+++ b/packages/mcp-server/src/server/export-json.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LoroDoc, LoroMap } from 'loro-crdt'
+import { exportCanvasJsonDoc } from './export-json.js'
+
+function buildDocWithRect(): LoroDoc {
+  const doc = new LoroDoc()
+  const list = doc.getMovableList('elements')
+  const map = list.insertContainer(0, new LoroMap())
+  map.set('id', 'rect-1')
+  map.set('type', 'rectangle')
+  map.set('x', 10)
+  map.set('y', 20)
+  map.set('width', 100)
+  map.set('height', 50)
+  doc.commit()
+  return doc
+}
+
+describe('exportCanvasJsonDoc with outputPath', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-json-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('writes to the provided absolute outputPath instead of the default exports dir', async () => {
+    const outputPath = join(tempDir, 'custom-export.excalidraw')
+
+    const result = await exportCanvasJsonDoc({
+      sessionId: 'sid',
+      slug: 'canvas-a',
+      doc: buildDocWithRect(),
+      dataDir: tempDir,
+      outputPath,
+    })
+
+    expect(result.filePath).toBe(outputPath)
+    expect(result.elementCount).toBe(1)
+    const written = JSON.parse(await readFile(outputPath, 'utf-8'))
+    expect(written).toMatchObject({
+      type: 'excalidraw',
+      version: 2,
+      elements: [expect.objectContaining({ id: 'rect-1' })],
+    })
+  })
+
+  it('creates parent directories for outputPath when they do not exist', async () => {
+    const outputPath = join(tempDir, 'nested', 'deep', 'out.excalidraw')
+
+    const result = await exportCanvasJsonDoc({
+      sessionId: 'sid',
+      slug: 'canvas-a',
+      doc: buildDocWithRect(),
+      dataDir: tempDir,
+      outputPath,
+    })
+
+    expect(result.filePath).toBe(outputPath)
+    await expect(readFile(outputPath, 'utf-8')).resolves.toMatch(/"type": "excalidraw"/)
+  })
+
+  it('rejects a relative outputPath with a typed OutputPathError', async () => {
+    await expect(
+      exportCanvasJsonDoc({
+        sessionId: 'sid',
+        slug: 'canvas-a',
+        doc: buildDocWithRect(),
+        dataDir: tempDir,
+        outputPath: 'relative/out.excalidraw',
+      }),
+    ).rejects.toMatchObject({
+      name: 'OutputPathError',
+      code: 'invalid_output_path',
+    })
+  })
+
+  it('refuses to overwrite an existing file by default and throws output_exists', async () => {
+    const outputPath = join(tempDir, 'already-here.excalidraw')
+    await writeFile(outputPath, '{"type":"excalidraw","existing":true}')
+
+    await expect(
+      exportCanvasJsonDoc({
+        sessionId: 'sid',
+        slug: 'canvas-a',
+        doc: buildDocWithRect(),
+        dataDir: tempDir,
+        outputPath,
+      }),
+    ).rejects.toMatchObject({
+      name: 'OutputPathError',
+      code: 'output_exists',
+    })
+
+    // Original file untouched.
+    await expect(readFile(outputPath, 'utf-8')).resolves.toContain('"existing":true')
+  })
+
+  it('replaces an existing file when overwrite=true', async () => {
+    const outputPath = join(tempDir, 'will-be-replaced.excalidraw')
+    await mkdir(tempDir, { recursive: true })
+    await writeFile(outputPath, 'OLD CONTENTS')
+
+    const result = await exportCanvasJsonDoc({
+      sessionId: 'sid',
+      slug: 'canvas-a',
+      doc: buildDocWithRect(),
+      dataDir: tempDir,
+      outputPath,
+      overwrite: true,
+    })
+
+    expect(result.filePath).toBe(outputPath)
+    const written = JSON.parse(await readFile(outputPath, 'utf-8'))
+    expect(written.elements).toHaveLength(1)
+  })
+
+  it('still falls back to the default exports dir when outputPath is omitted', async () => {
+    const result = await exportCanvasJsonDoc({
+      sessionId: 'sid-fallback',
+      slug: 'canvas-a',
+      doc: buildDocWithRect(),
+      dataDir: tempDir,
+    })
+
+    expect(result.filePath).toContain(join(tempDir, 'sid-fallback', 'exports'))
+    expect(result.filePath.endsWith('.excalidraw')).toBe(true)
+  })
+})

--- a/packages/mcp-server/src/server/export-json.ts
+++ b/packages/mcp-server/src/server/export-json.ts
@@ -1,25 +1,19 @@
-import { mkdir, stat, writeFile } from 'node:fs/promises'
-import { dirname, isAbsolute, join } from 'node:path'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import type { LoroDoc } from 'loro-crdt'
 import { DATA_DIR } from './config.js'
+import { validateOutputPath } from './output-path.js'
 import {
   resolveParentedElements,
   type ParentedElement,
 } from '../shared/resolve-parented-elements.js'
 
+// Re-exported so existing route imports (`import { ..., OutputPathError } from
+// './export-json.js'`) keep compiling without churn.
+export { OutputPathError } from './output-path.js'
+export type { OutputPathErrorCode } from './output-path.js'
+
 const STRIP_CUSTOM_FIELDS = ['templateInstanceId'] as const
-
-export type OutputPathErrorCode = 'invalid_output_path' | 'output_exists'
-
-export class OutputPathError extends Error {
-  readonly name = 'OutputPathError'
-  constructor(
-    readonly code: OutputPathErrorCode,
-    message: string,
-  ) {
-    super(message)
-  }
-}
 
 function stripTemplateInstanceId(
   elements: Array<Record<string, unknown>>,
@@ -45,15 +39,6 @@ function normalizeExportElements(
   )
 }
 
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path)
-    return true
-  } catch {
-    return false
-  }
-}
-
 async function resolveOutputPath(args: {
   sessionId: string
   slug: string
@@ -62,18 +47,7 @@ async function resolveOutputPath(args: {
   overwrite?: boolean
 }): Promise<string> {
   if (args.outputPath !== undefined) {
-    if (!isAbsolute(args.outputPath)) {
-      throw new OutputPathError(
-        'invalid_output_path',
-        `outputPath must be an absolute path (received: ${args.outputPath})`,
-      )
-    }
-    if (!args.overwrite && (await fileExists(args.outputPath))) {
-      throw new OutputPathError(
-        'output_exists',
-        `outputPath already exists. Pass overwrite=true to replace it: ${args.outputPath}`,
-      )
-    }
+    await validateOutputPath(args.outputPath, args.overwrite === true)
     return args.outputPath
   }
 

--- a/packages/mcp-server/src/server/export-json.ts
+++ b/packages/mcp-server/src/server/export-json.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join } from 'node:path'
 import type { LoroDoc } from 'loro-crdt'
 import { DATA_DIR } from './config.js'
 import {
@@ -8,6 +8,18 @@ import {
 } from '../shared/resolve-parented-elements.js'
 
 const STRIP_CUSTOM_FIELDS = ['templateInstanceId'] as const
+
+export type OutputPathErrorCode = 'invalid_output_path' | 'output_exists'
+
+export class OutputPathError extends Error {
+  readonly name = 'OutputPathError'
+  constructor(
+    readonly code: OutputPathErrorCode,
+    message: string,
+  ) {
+    super(message)
+  }
+}
 
 function stripTemplateInstanceId(
   elements: Array<Record<string, unknown>>,
@@ -33,12 +45,52 @@ function normalizeExportElements(
   )
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveOutputPath(args: {
+  sessionId: string
+  slug: string
+  dataDir?: string
+  outputPath?: string
+  overwrite?: boolean
+}): Promise<string> {
+  if (args.outputPath !== undefined) {
+    if (!isAbsolute(args.outputPath)) {
+      throw new OutputPathError(
+        'invalid_output_path',
+        `outputPath must be an absolute path (received: ${args.outputPath})`,
+      )
+    }
+    if (!args.overwrite && (await fileExists(args.outputPath))) {
+      throw new OutputPathError(
+        'output_exists',
+        `outputPath already exists. Pass overwrite=true to replace it: ${args.outputPath}`,
+      )
+    }
+    return args.outputPath
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const fileName = `${args.slug}-${timestamp}.excalidraw`
+  const exportsDir = join(args.dataDir ?? DATA_DIR, args.sessionId, 'exports')
+  return join(exportsDir, fileName)
+}
+
 export async function exportCanvasJsonDoc(args: {
   sessionId: string
   slug: string
   doc: LoroDoc
   includeCustomFields?: boolean
   dataDir?: string
+  outputPath?: string
+  overwrite?: boolean
 }): Promise<{ filePath: string; elementCount: number }> {
   const rawElements = args.doc.getMovableList('elements').toJSON() as Array<
     Record<string, unknown>
@@ -56,10 +108,7 @@ export async function exportCanvasJsonDoc(args: {
     files: {},
   }
 
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-  const fileName = `${args.slug}-${timestamp}.excalidraw`
-  const exportsDir = join(args.dataDir ?? DATA_DIR, args.sessionId, 'exports')
-  const filePath = join(exportsDir, fileName)
+  const filePath = await resolveOutputPath(args)
   await mkdir(dirname(filePath), { recursive: true })
   await writeFile(filePath, JSON.stringify(payload, null, 2))
 

--- a/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
@@ -64,4 +64,66 @@ describe('canvas_export_json', () => {
       elementCount: 1,
     })
   })
+
+  it('forwards outputPath and overwrite to the daemon route', async () => {
+    const tool = canvasExportJsonTool()
+    let captured: unknown
+    globalThis.fetch = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      captured = init?.body !== undefined ? JSON.parse(init.body as string) : undefined
+      return new Response(
+        JSON.stringify({ filePath: '/abs/out.excalidraw', elementCount: 0 }),
+        { status: 200 },
+      )
+    }) as typeof globalThis.fetch
+
+    await tool.execute(
+      { canvasId: 'sid/canvas-a', outputPath: '/abs/out.excalidraw', overwrite: true },
+      client,
+    )
+    expect(captured).toEqual({
+      includeCustomFields: false,
+      outputPath: '/abs/out.excalidraw',
+      overwrite: true,
+    })
+  })
+
+  it('surfaces invalid_output_path errors from the daemon route as a clear message', async () => {
+    const tool = canvasExportJsonTool()
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          error: 'invalid_output_path',
+          message: 'outputPath must be an absolute path (received: relative.json)',
+        }),
+        { status: 400 },
+      )
+    }) as typeof globalThis.fetch
+
+    await expect(
+      tool.execute(
+        { canvasId: 'sid/canvas-a', outputPath: 'relative.json' },
+        client,
+      ),
+    ).rejects.toThrow(/absolute path/)
+  })
+
+  it('surfaces output_exists errors when overwrite is omitted', async () => {
+    const tool = canvasExportJsonTool()
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          error: 'output_exists',
+          message: 'outputPath already exists. Pass overwrite=true to replace it: /abs/out.json',
+        }),
+        { status: 409 },
+      )
+    }) as typeof globalThis.fetch
+
+    await expect(
+      tool.execute(
+        { canvasId: 'sid/canvas-a', outputPath: '/abs/out.json' },
+        client,
+      ),
+    ).rejects.toThrow(/already exists/)
+  })
 })

--- a/packages/mcp-server/src/server/mcp/tools/canvas-export-json.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-export-json.ts
@@ -1,5 +1,13 @@
 import type { DaemonClient } from '../daemon-client.js'
 import { parseCanvasId } from './canvas-id.js'
+
+interface CanvasExportJsonArgs {
+  canvasId: string
+  includeCustomFields?: boolean
+  outputPath?: string
+  overwrite?: boolean
+}
+
 export function canvasExportJsonTool() {
   return {
     name: 'canvas_export_json',
@@ -14,24 +22,48 @@ export function canvasExportJsonTool() {
           description:
             'Keep internal custom fields (parentId / relX / relY) in the exported JSON. Default: false. Set true for debugging or round-tripping through this tool.',
         },
+        outputPath: {
+          type: 'string',
+          description:
+            'Absolute path to write the .excalidraw file to. Useful when round-tripping a local file. Parent directories are created as needed. When omitted, write to the workspace exports directory.',
+        },
+        overwrite: {
+          type: 'boolean',
+          description:
+            'Replace an existing file at outputPath. Default: false. Without this, an existing outputPath is rejected with output_exists.',
+        },
       },
       required: ['canvasId'],
     },
-    execute: async (
-      args: { canvasId: string; includeCustomFields?: boolean },
-      client: DaemonClient,
-    ) => {
+    execute: async (args: CanvasExportJsonArgs, client: DaemonClient) => {
       const { sessionId, slug } = parseCanvasId(args.canvasId)
-      const res = await client.request(`/api/canvas/${sessionId}/${encodeURIComponent(slug)}/export-json`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          includeCustomFields: args.includeCustomFields === true,
-        }),
-      })
+      const body: {
+        includeCustomFields: boolean
+        outputPath?: string
+        overwrite?: boolean
+      } = {
+        includeCustomFields: args.includeCustomFields === true,
+      }
+      if (args.outputPath !== undefined) body.outputPath = args.outputPath
+      if (args.overwrite !== undefined) body.overwrite = args.overwrite
+
+      const res = await client.request(
+        `/api/canvas/${sessionId}/${encodeURIComponent(slug)}/export-json`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      )
       if (!res.ok) {
-        const body = (await res.json().catch(() => null)) as { error?: string } | null
-        throw new Error(body?.error ?? `Failed to export canvas JSON: ${res.status}`)
+        const errBody = (await res.json().catch(() => null)) as
+          | { error?: string; message?: string }
+          | null
+        // Prefer the human-readable message so the LLM sees enough context to
+        // adjust outputPath instead of a bare error code.
+        throw new Error(
+          errBody?.message ?? errBody?.error ?? `Failed to export canvas JSON: ${res.status}`,
+        )
       }
       return (await res.json()) as { filePath: string; elementCount: number }
     },

--- a/packages/mcp-server/src/server/mcp/tools/export.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export.test.ts
@@ -296,4 +296,73 @@ describe('exportPngTool execute', () => {
     const [url] = fetchMock.mock.calls[0]
     expect(url.toString()).toBe('http://localhost:3099/api/canvas/sid/621%2Fheader/export')
   })
+
+  it('forwards outputPath and overwrite to the daemon export route', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ filePath: '/abs/canvas.excalidraw.png' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const { exportPngTool } = await import('./export.js')
+    const tool = exportPngTool()
+    await tool.execute(
+      {
+        canvasId: 'sid/slug',
+        outputPath: '/abs/canvas.excalidraw.png',
+        overwrite: true,
+      },
+      client,
+    )
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init?.body as string)).toEqual({
+      outputPath: '/abs/canvas.excalidraw.png',
+      overwrite: true,
+    })
+  })
+
+  it('surfaces invalid_output_path errors from the export route', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'invalid_output_path',
+          message: 'outputPath must be an absolute path (received: relative.png)',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const { exportPngTool } = await import('./export.js')
+    const tool = exportPngTool()
+    await expect(
+      tool.execute(
+        { canvasId: 'sid/slug', outputPath: 'relative.png' },
+        client,
+      ),
+    ).rejects.toThrow(/absolute path/)
+  })
+
+  it('surfaces output_exists when the target file already exists', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'output_exists',
+          message:
+            'outputPath already exists. Pass overwrite=true to replace it: /abs/canvas.png',
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const { exportPngTool } = await import('./export.js')
+    const tool = exportPngTool()
+    await expect(
+      tool.execute(
+        { canvasId: 'sid/slug', outputPath: '/abs/canvas.png' },
+        client,
+      ),
+    ).rejects.toThrow(/already exists/)
+  })
 })

--- a/packages/mcp-server/src/server/mcp/tools/export.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export.ts
@@ -13,6 +13,8 @@ interface ExportPngArgs {
   scale?: number
   minFontPx?: number
   frameId?: string
+  outputPath?: string
+  overwrite?: boolean
 }
 
 interface ExportErrorBody {
@@ -21,12 +23,14 @@ interface ExportErrorBody {
   hint?: string
 }
 
-function buildExportBody(args: ExportPngArgs): Record<string, number | string> {
-  const body: Record<string, number | string> = {}
+function buildExportBody(args: ExportPngArgs): Record<string, number | string | boolean> {
+  const body: Record<string, number | string | boolean> = {}
   if (args.padding !== undefined) body.padding = args.padding
   if (args.scale !== undefined) body.scale = args.scale
   if (args.minFontPx !== undefined) body.minFontPx = args.minFontPx
   if (args.frameId !== undefined) body.frameId = args.frameId
+  if (args.outputPath !== undefined) body.outputPath = args.outputPath
+  if (args.overwrite !== undefined) body.overwrite = args.overwrite
   return body
 }
 
@@ -34,7 +38,7 @@ async function requestExport(
   client: DaemonClient,
   sessionId: string,
   slug: string,
-  body: Record<string, number | string>,
+  body: Record<string, number | string | boolean>,
 ): Promise<Response> {
   return client.request(`/api/canvas/${sessionId}/${encodeURIComponent(slug)}/export`, {
     method: 'POST',
@@ -79,6 +83,9 @@ function throwExportError(res: Response, body: ExportErrorBody | null): never {
   if (body?.error === 'timeout') {
     throw new Error(body.message ?? 'Export timed out.')
   }
+  if (body?.error === 'invalid_output_path' || body?.error === 'output_exists') {
+    throw new Error(body.message ?? body.error)
+  }
   throw new Error(`Export failed: ${res.status} ${body?.message ?? 'unknown error'}`)
 }
 
@@ -109,6 +116,16 @@ export function exportPngTool() {
           type: 'string',
           description:
             'When set, export only the elements inside the given frame (plus the frame itself). Useful for section-scoped exports on large canvases to keep the resulting PNG small.',
+        },
+        outputPath: {
+          type: 'string',
+          description:
+            'Absolute path to write the PNG to. Useful for placing the export next to a source asset. Parent directories are created as needed. When omitted, write to the workspace exports directory.',
+        },
+        overwrite: {
+          type: 'boolean',
+          description:
+            'Replace an existing file at outputPath. Default: false. Without this, an existing outputPath is rejected with output_exists.',
         },
       },
       required: ['canvasId'],

--- a/packages/mcp-server/src/server/output-path.test.ts
+++ b/packages/mcp-server/src/server/output-path.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm, writeFile, mkdir, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { OutputPathError, validateOutputPath } from './output-path.js'
+
+describe('validateOutputPath', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-output-path-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('accepts an absolute path that does not exist yet', async () => {
+    await expect(
+      validateOutputPath(join(tempDir, 'fresh.bin'), false),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws invalid_output_path for a relative path', async () => {
+    await expect(validateOutputPath('relative.bin', false)).rejects.toMatchObject({
+      name: 'OutputPathError',
+      code: 'invalid_output_path',
+    })
+  })
+
+  it('throws output_exists when the file already exists and overwrite=false', async () => {
+    const path = join(tempDir, 'already.bin')
+    await writeFile(path, 'x')
+    await expect(validateOutputPath(path, false)).rejects.toMatchObject({
+      name: 'OutputPathError',
+      code: 'output_exists',
+    })
+  })
+
+  it('does not throw when the file exists but overwrite=true', async () => {
+    const path = join(tempDir, 'already.bin')
+    await writeFile(path, 'x')
+    await expect(validateOutputPath(path, true)).resolves.toBeUndefined()
+  })
+
+  it('treats only ENOENT as "missing" and propagates other stat errors', async () => {
+    // Make a directory unreadable, then probe a path inside it. stat() should
+    // fail with EACCES rather than ENOENT, and validateOutputPath must
+    // surface that instead of pretending the file is absent.
+    if (process.platform === 'win32') {
+      // Skipping: posix permission semantics are not portable to Windows.
+      return
+    }
+    const lockedDir = join(tempDir, 'locked')
+    await mkdir(lockedDir)
+    const probe = join(lockedDir, 'probe.bin')
+    await chmod(lockedDir, 0o000)
+    try {
+      await expect(validateOutputPath(probe, false)).rejects.toThrow()
+      // The thrown error must NOT be the friendly OutputPathError for
+      // output_exists / invalid_output_path; it should be the underlying
+      // EACCES so the caller is not silently stepped over.
+      await validateOutputPath(probe, false).catch((err) => {
+        expect(err).not.toBeInstanceOf(OutputPathError)
+      })
+    } finally {
+      await chmod(lockedDir, 0o755)
+    }
+  })
+})

--- a/packages/mcp-server/src/server/output-path.ts
+++ b/packages/mcp-server/src/server/output-path.ts
@@ -1,0 +1,48 @@
+import { stat } from 'node:fs/promises'
+import { isAbsolute } from 'node:path'
+
+export type OutputPathErrorCode = 'invalid_output_path' | 'output_exists'
+
+export class OutputPathError extends Error {
+  readonly name = 'OutputPathError'
+  constructor(
+    readonly code: OutputPathErrorCode,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+// Returns true only when stat reports ENOENT. Any other failure (EACCES, etc.)
+// surfaces as a thrown error so callers do not silently treat permission
+// problems as "file does not exist" and step over them with writeFile.
+async function fileExistsOrThrow(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+export async function validateOutputPath(
+  outputPath: string,
+  overwrite: boolean,
+): Promise<void> {
+  if (!isAbsolute(outputPath)) {
+    throw new OutputPathError(
+      'invalid_output_path',
+      `outputPath must be an absolute path (received: ${outputPath})`,
+    )
+  }
+  if (overwrite) return
+  if (await fileExistsOrThrow(outputPath)) {
+    throw new OutputPathError(
+      'output_exists',
+      `outputPath already exists. Pass overwrite=true to replace it: ${outputPath}`,
+    )
+  }
+}

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -968,6 +968,83 @@ describe('versions API', () => {
     expect(body.elementCount).toBe(1)
   })
 
+  it('export-json writes to an explicit absolute outputPath when provided', async () => {
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    const map = list.insertContainer(0, new LoroMap())
+    map.set('id', 'rect-1')
+    map.set('type', 'rectangle')
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc)
+
+    const outputPath = join(tempDir, 'explicit', 'out.excalidraw')
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/canvas-a/export-json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { filePath: string; elementCount: number }
+    expect(body.filePath).toBe(outputPath)
+  })
+
+  it('export-json rejects a relative outputPath with 400 invalid_output_path', async () => {
+    const doc = new LoroDoc()
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc)
+
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/canvas-a/export-json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath: 'relative/out.excalidraw' }),
+    })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
+  })
+
+  it('export-json refuses to overwrite an existing file by default and returns 409', async () => {
+    const doc = new LoroDoc()
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc)
+
+    const outputPath = join(tempDir, 'existing.excalidraw')
+    await writeFile(outputPath, 'OLD')
+
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/canvas-a/export-json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath }),
+    })
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ error: 'output_exists' })
+  })
+
+  it('export-json overwrites the existing file when overwrite=true', async () => {
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    const map = list.insertContainer(0, new LoroMap())
+    map.set('id', 'rect-1')
+    map.set('type', 'rectangle')
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc)
+
+    const outputPath = join(tempDir, 'replace-me.excalidraw')
+    await writeFile(outputPath, 'OLD')
+
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/canvas-a/export-json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath, overwrite: true }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { filePath: string }
+    expect(body.filePath).toBe(outputPath)
+  })
+
   it('returns 400 for an invalid checkpointId', async () => {
     const app = createCanvasRouter()
     const res = await app.request('/api/sessions/session1/checkpoints/bad.id/restore', {

--- a/packages/mcp-server/src/server/routes/canvas.ts
+++ b/packages/mcp-server/src/server/routes/canvas.ts
@@ -25,7 +25,7 @@ import {
   setCanvasPinned,
 } from '../store/names-store.js'
 import { corruptStoredDataBody, isCorruptStoredDataError } from '../store/corrupt-stored-data.js'
-import { exportCanvasJsonDoc } from '../export-json.js'
+import { exportCanvasJsonDoc, OutputPathError } from '../export-json.js'
 import {
   validationErrorBody,
   validateSessionId,
@@ -630,23 +630,41 @@ export function createCanvasRouter(options: CanvasRouterOptions = {}) {
       throw err
     }
     let includeCustomFields = false
+    let outputPath: string | undefined
+    let overwrite = false
     try {
       const body = (await c.req.json().catch(() => ({}))) as {
         includeCustomFields?: unknown
+        outputPath?: unknown
+        overwrite?: unknown
       }
       includeCustomFields = body.includeCustomFields === true
+      if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
+        outputPath = body.outputPath
+      }
+      overwrite = body.overwrite === true
     } catch {
       /* empty body -> defaults */
     }
     const doc = await getDoc(sessionId, slug)
-    return c.json(
-      await exportCanvasJsonDoc({
-        sessionId,
-        slug,
-        doc,
-        includeCustomFields,
-      }),
-    )
+    try {
+      return c.json(
+        await exportCanvasJsonDoc({
+          sessionId,
+          slug,
+          doc,
+          includeCustomFields,
+          outputPath,
+          overwrite,
+        }),
+      )
+    } catch (err) {
+      if (err instanceof OutputPathError) {
+        const status = err.code === 'output_exists' ? 409 : 400
+        return c.json({ error: err.code, message: err.message }, status)
+      }
+      throw err
+    }
   })
 
   // PUT /api/sessions/:sessionId/canvases/:slug/versions/:id/thumbnail

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Hono } from 'hono'
@@ -295,5 +295,95 @@ describe('POST /api/canvas/:sessionId/:slug/export - error handling', () => {
     })
     expect(badSlug.status).toBe(400)
     expect(mockSendExportRequest).not.toHaveBeenCalled()
+  })
+
+  it('writes the PNG to an explicit absolute outputPath when provided', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
+      queueMicrotask(() => {
+        resolveExportRequest(
+          requestId,
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+        )
+      })
+    })
+    const app = makeApp()
+    const outputPath = join(tempDir, 'subdir', 'custom.excalidraw.png')
+
+    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { filePath: string }
+    expect(body.filePath).toBe(outputPath)
+    const bytes = await readFile(outputPath)
+    // PNG signature
+    expect(bytes[0]).toBe(0x89)
+  })
+
+  it('rejects a relative PNG outputPath with 400 invalid_output_path', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    const app = makeApp()
+    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath: 'relative/out.png' }),
+    })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
+    expect(mockSendExportRequest).not.toHaveBeenCalled()
+  })
+
+  it('refuses to overwrite an existing PNG by default and returns 409', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
+      queueMicrotask(() => {
+        resolveExportRequest(
+          requestId,
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+        )
+      })
+    })
+    const app = makeApp()
+    const outputPath = join(tempDir, 'pre-existing.png')
+    await writeFile(outputPath, 'OLD')
+
+    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath }),
+    })
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ error: 'output_exists' })
+    // Still the old contents.
+    await expect(readFile(outputPath, 'utf-8')).resolves.toBe('OLD')
+  })
+
+  it('overwrites an existing PNG when overwrite=true', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
+      queueMicrotask(() => {
+        resolveExportRequest(
+          requestId,
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+        )
+      })
+    })
+    const app = makeApp()
+    const outputPath = join(tempDir, 'replace.png')
+    await writeFile(outputPath, 'OLD')
+
+    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ outputPath, overwrite: true }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { filePath: string }
+    expect(body.filePath).toBe(outputPath)
+    const bytes = await readFile(outputPath)
+    expect(bytes[0]).toBe(0x89)
   })
 })

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -1,10 +1,19 @@
 import { Hono } from 'hono'
-import { join, dirname } from 'node:path'
-import { writeFile, mkdir } from 'node:fs/promises'
+import { join, dirname, isAbsolute } from 'node:path'
+import { writeFile, mkdir, stat } from 'node:fs/promises'
 import { nanoid } from 'nanoid'
 import { DATA_DIR } from '../config.js'
 import { sendExportRequest, getClientCount } from './ws.js'
 import { validationErrorBody, validateSessionId, validateSlug } from '../validators.js'
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
 
 // requestId -> { resolve, reject }
 const pendingExports = new Map<
@@ -45,14 +54,42 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
       scale?: number
       minFontPx?: number
       frameId?: string
+      outputPath?: string
+      overwrite?: boolean
     }
     const body = await c.req.json<ExportBody>().catch(() => ({}) as ExportBody)
-    const options: ExportBody = {}
+    const options: Pick<ExportBody, 'padding' | 'scale' | 'minFontPx' | 'frameId'> = {}
     if (body.padding !== undefined) options.padding = body.padding
     if (body.scale !== undefined) options.scale = body.scale
     if (body.minFontPx !== undefined) options.minFontPx = body.minFontPx
     if (body.frameId !== undefined) options.frameId = body.frameId
     const hasOptions = Object.keys(options).length > 0
+
+    // Validate outputPath up front, before contacting the browser. Reject
+    // relative paths and pre-existing files (unless overwrite=true) so the
+    // caller does not waste a browser round-trip on a write that will fail.
+    let outputPath: string | undefined
+    if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
+      if (!isAbsolute(body.outputPath)) {
+        return c.json(
+          {
+            error: 'invalid_output_path',
+            message: `outputPath must be an absolute path (received: ${body.outputPath})`,
+          },
+          400,
+        )
+      }
+      if (body.overwrite !== true && (await fileExists(body.outputPath))) {
+        return c.json(
+          {
+            error: 'output_exists',
+            message: `outputPath already exists. Pass overwrite=true to replace it: ${body.outputPath}`,
+          },
+          409,
+        )
+      }
+      outputPath = body.outputPath
+    }
 
     // Fast-fail with 503 if no WS client is connected.
     // Do not wait for the timeout because that would not fix a missing client; report
@@ -87,14 +124,19 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
       })
 
       const buffer = Buffer.from(base64Data.replace(/^data:image\/\w+;base64,/, ''), 'base64')
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-      // .excalidraw.png is a PNG with embedded scene JSON. Normal image viewers treat
-      // it as a PNG, and dropping it into Excalidraw restores the scene for editing.
-      const fileName = `${slug}-${timestamp}.excalidraw.png`
-      const exportsDir = join(DATA_DIR, sessionId, 'exports')
-      const filePath = join(exportsDir, fileName)
-      // If slug contains "/" (nested canvas paths), create parent directories all the
-      // way to the final file path so writes do not fail with ENOENT.
+      let filePath: string
+      if (outputPath !== undefined) {
+        filePath = outputPath
+      } else {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+        // .excalidraw.png is a PNG with embedded scene JSON. Normal image viewers treat
+        // it as a PNG, and dropping it into Excalidraw restores the scene for editing.
+        const fileName = `${slug}-${timestamp}.excalidraw.png`
+        const exportsDir = join(DATA_DIR, sessionId, 'exports')
+        filePath = join(exportsDir, fileName)
+      }
+      // If slug contains "/" (nested canvas paths) or outputPath points into a
+      // non-existent directory, create the parents recursively to avoid ENOENT.
       await mkdir(dirname(filePath), { recursive: true })
       await writeFile(filePath, buffer)
 

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -1,19 +1,11 @@
 import { Hono } from 'hono'
-import { join, dirname, isAbsolute } from 'node:path'
-import { writeFile, mkdir, stat } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { writeFile, mkdir } from 'node:fs/promises'
 import { nanoid } from 'nanoid'
 import { DATA_DIR } from '../config.js'
+import { OutputPathError, validateOutputPath } from '../output-path.js'
 import { sendExportRequest, getClientCount } from './ws.js'
 import { validationErrorBody, validateSessionId, validateSlug } from '../validators.js'
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path)
-    return true
-  } catch {
-    return false
-  }
-}
 
 // requestId -> { resolve, reject }
 const pendingExports = new Map<
@@ -70,23 +62,14 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
     // caller does not waste a browser round-trip on a write that will fail.
     let outputPath: string | undefined
     if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
-      if (!isAbsolute(body.outputPath)) {
-        return c.json(
-          {
-            error: 'invalid_output_path',
-            message: `outputPath must be an absolute path (received: ${body.outputPath})`,
-          },
-          400,
-        )
-      }
-      if (body.overwrite !== true && (await fileExists(body.outputPath))) {
-        return c.json(
-          {
-            error: 'output_exists',
-            message: `outputPath already exists. Pass overwrite=true to replace it: ${body.outputPath}`,
-          },
-          409,
-        )
+      try {
+        await validateOutputPath(body.outputPath, body.overwrite === true)
+      } catch (err) {
+        if (err instanceof OutputPathError) {
+          const status = err.code === 'output_exists' ? 409 : 400
+          return c.json({ error: err.code, message: err.message }, status)
+        }
+        throw err
       }
       outputPath = body.outputPath
     }


### PR DESCRIPTION
## Summary
- Add `outputPath` (absolute path) and `overwrite` options to `export_png` and `canvas_export_json`. When set, the export is written there directly; otherwise it falls back to the current `{DATA_DIR}/{sessionId}/exports/` location.
- Lets a local `.excalidraw` round-trip back into its source file and lets a PNG land next to a source asset in one step instead of a copy.
- Validation runs in both the daemon route and the MCP tool surface: a relative path returns 400 `invalid_output_path`, an existing file with `overwrite!=true` returns 409 `output_exists`. Parent directories are created via `mkdir -p`.
- The arbitrary-path write surface stays scoped to the export tools only.

## Test plan
- [x] `pnpm test --project mcp-node` (1082 passed, +18 new across server fn / route / tool / shared util layers)
- [x] `pnpm typecheck`
- [x] `pnpm smoke:e2e` (`[e2e] ALL OK`, including `canvas_export_json`)

## Notes
- Shared `OutputPathError` (`code: 'invalid_output_path' | 'output_exists'`) lives in `src/server/output-path.ts` and is reused by `export-json.ts` and `routes/export.ts`. Route handlers translate it into 400 / 409 responses.
- The MCP tool re-throws the daemon's `error` / `message` verbatim so the LLM can tell whether the path was relative or already existed.
- `output-path.ts` validates the `stat()` result with an `ENOENT`-only check, so permission errors (e.g. EACCES) propagate instead of being silently treated as "file does not exist".
- `SKILL.md` lists `outputPath` / `overwrite` under the `export_png` options block to keep the SKILL ↔ schema consistency test green.
