### PR TITLE
fix(app): move onSceneChange debounce out of the render path

### DIFF
--- a/packages/mcp-server/src/app/App.tsx
+++ b/packages/mcp-server/src/app/App.tsx
@@ -10,7 +10,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<IndexPage />} />
         <Route
-          path="/canvas/:sessionId/*"
+          path="/canvas/:workspaceId/*"
           element={
             <ErrorBoundary>
               <CanvasPage />

--- a/packages/mcp-server/src/app/components/HeaderBranchBanner.test.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchBanner.test.tsx
@@ -51,7 +51,7 @@ afterEach(() => {
 describe('HeaderBranchBanner', () => {
   it('does not render the banner when HEAD is main', async () => {
     state.current.state.head = 'main'
-    render(<HeaderBranchBanner sessionId="s1" slug="c1" />)
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
     // Wait for the initial fetch path.
     await act(async () => {
       await Promise.resolve()
@@ -60,7 +60,7 @@ describe('HeaderBranchBanner', () => {
   })
 
   it('renders the banner when HEAD is not main and unmergedCommits > 0', async () => {
-    render(<HeaderBranchBanner sessionId="s1" slug="c1" />)
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
     await waitFor(() => {
       expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
     })
@@ -71,7 +71,7 @@ describe('HeaderBranchBanner', () => {
 
   it('hides the banner when unmergedCommits is 0', async () => {
     state.current.getBranchStats = vi.fn().mockResolvedValue({ unmergedCommits: 0, isHead: true })
-    render(<HeaderBranchBanner sessionId="s1" slug="c1" />)
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
     await act(async () => {
       await Promise.resolve()
     })

--- a/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
@@ -11,15 +11,15 @@ import { useBranches } from '../hooks/useBranches.js'
 // - Refresh whenever HEAD or branches change; failures stay silent and simply hide the banner
 
 export interface HeaderBranchBannerProps {
-  sessionId: string
+  workspaceId: string
   slug: string
 }
 
 export function HeaderBranchBanner({
-  sessionId,
+  workspaceId,
   slug,
 }: HeaderBranchBannerProps): JSX.Element | null {
-  const { state, getBranchStats, merge: runMerge } = useBranches(sessionId, slug)
+  const { state, getBranchStats, merge: runMerge } = useBranches(workspaceId, slug)
   const head = state.head
   const targetBranch: BranchMeta | undefined = state.branches.find((b) => b.name === 'main')
   const sourceBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
@@ -49,15 +49,15 @@ export function HeaderBranchBanner({
       }
     }
     const onHeadChanged = (event: Event) => {
-      const detail = (event as CustomEvent<{ sessionId: string; slug: string }>).detail
+      const detail = (event as CustomEvent<{ workspaceId: string; slug: string }>).detail
       if (!detail) return
-      if (detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
       void refresh()
     }
     const onMergeCommitted = (event: Event) => {
-      const detail = (event as CustomEvent<{ sessionId: string; slug: string }>).detail
+      const detail = (event as CustomEvent<{ workspaceId: string; slug: string }>).detail
       if (!detail) return
-      if (detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
       void refresh()
     }
     window.addEventListener('excalidraw:head_changed', onHeadChanged)
@@ -67,7 +67,7 @@ export function HeaderBranchBanner({
       window.removeEventListener('excalidraw:head_changed', onHeadChanged)
       window.removeEventListener('excalidraw:merge_committed', onMergeCommitted)
     }
-  }, [head, getBranchStats, sessionId, slug])
+  }, [head, getBranchStats, workspaceId, slug])
 
   const visible = useMemo(
     () => head !== 'main' && unmergedCommits > 0 && !!targetBranch && !!sourceBranch,
@@ -106,7 +106,7 @@ export function HeaderBranchBanner({
         target={targetBranch ?? null}
         onClose={() => setMergeOpen(false)}
         runMerge={(src, args) => runMerge(src, args) as Promise<MergeResult>}
-        sessionId={sessionId}
+        workspaceId={workspaceId}
         slug={slug}
       />
     </>

--- a/packages/mcp-server/src/app/components/HeaderBranchChip.test.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchChip.test.tsx
@@ -48,7 +48,7 @@ import { HeaderBranchChip } from './HeaderBranchChip.js'
 function renderChip() {
   return render(
     <TooltipProvider>
-      <HeaderBranchChip sessionId="s1" slug="c1" />
+      <HeaderBranchChip workspaceId="s1" slug="c1" />
     </TooltipProvider>,
   )
 }

--- a/packages/mcp-server/src/app/components/HeaderBranchChip.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchChip.tsx
@@ -45,13 +45,13 @@ import { MergeDialog } from './MergeDialog.js'
 // Other branches are managed through the dropdown and kebab menu.
 
 export interface HeaderBranchChipProps {
-  sessionId: string
+  workspaceId: string
   slug: string
   disabled?: boolean
 }
 
 export function HeaderBranchChip({
-  sessionId,
+  workspaceId,
   slug,
   disabled,
 }: HeaderBranchChipProps): JSX.Element {
@@ -63,7 +63,7 @@ export function HeaderBranchChip({
     renameBranch,
     setHead,
     merge: runMerge,
-  } = useBranches(sessionId, slug)
+  } = useBranches(workspaceId, slug)
 
   const head = state.head
   const activeBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
@@ -419,7 +419,7 @@ export function HeaderBranchChip({
         target={mergeTarget}
         onClose={() => setMergeSource(null)}
         runMerge={(source, args) => runMerge(source, args) as Promise<MergeResult>}
-        sessionId={sessionId}
+        workspaceId={workspaceId}
         slug={slug}
       />
     </div>

--- a/packages/mcp-server/src/app/components/MergeDialog.tsx
+++ b/packages/mcp-server/src/app/components/MergeDialog.tsx
@@ -37,7 +37,7 @@ export interface MergeDialogProps {
   target: BranchMeta | null
   onClose: () => void
   runMerge: (source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>
-  sessionId?: string
+  workspaceId?: string
   slug?: string
 }
 
@@ -166,8 +166,8 @@ interface VersionThumbInfo {
   branchName?: string
 }
 
-function thumbUrlFor(sessionId: string, slug: string, versionId: string): string {
-  return `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${versionId}/thumbnail`
+function thumbUrlFor(workspaceId: string, slug: string, versionId: string): string {
+  return `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${versionId}/thumbnail`
 }
 
 export function MergeDialog({
@@ -176,7 +176,7 @@ export function MergeDialog({
   target,
   onClose,
   runMerge,
-  sessionId,
+  workspaceId,
   slug,
 }: MergeDialogProps): JSX.Element {
   const [loading, setLoading] = useState(false)
@@ -215,7 +215,7 @@ export function MergeDialog({
 
   // Thumbnail fallback.
   useEffect(() => {
-    if (!open || !source || !target || !sessionId || !slug) {
+    if (!open || !source || !target || !workspaceId || !slug) {
       setThumbs({ target: null, source: null })
       return
     }
@@ -224,7 +224,7 @@ export function MergeDialog({
     ;(async () => {
       try {
         const res = await apiFetch(
-          `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions`,
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
         )
         if (!res.ok) return
         const body = (await res.json()) as { versions: VersionThumbInfo[] }
@@ -238,8 +238,8 @@ export function MergeDialog({
         const tgt = latestFor(target.name)
         const src = latestFor(source.name)
         setThumbs({
-          target: tgt ? thumbUrlFor(sessionId, slug, tgt.id) : null,
-          source: src ? thumbUrlFor(sessionId, slug, src.id) : null,
+          target: tgt ? thumbUrlFor(workspaceId, slug, tgt.id) : null,
+          source: src ? thumbUrlFor(workspaceId, slug, src.id) : null,
         })
       } catch {
         /* Fall back to placeholders if thumbnail loading fails. */
@@ -250,7 +250,7 @@ export function MergeDialog({
     return () => {
       cancelled = true
     }
-  }, [open, source, target, sessionId, slug])
+  }, [open, source, target, workspaceId, slug])
 
   const handleMerge = async () => {
     if (!source || !target) return
@@ -260,11 +260,11 @@ export function MergeDialog({
       const res = await runMerge(source.name, { into: target.name, dryRun: false })
       setPreview(res)
       // Broadcast merge results for the toast and highlight layers when session/slug are available.
-      if (typeof window !== 'undefined' && sessionId && slug) {
+      if (typeof window !== 'undefined' && workspaceId && slug) {
         window.dispatchEvent(
           new CustomEvent('excalidraw:merge_committed', {
             detail: {
-              sessionId,
+              workspaceId,
               slug,
               sourceName: source.name,
               targetName: target.name,

--- a/packages/mcp-server/src/app/components/MergeHighlight.tsx
+++ b/packages/mcp-server/src/app/components/MergeHighlight.tsx
@@ -9,14 +9,14 @@ import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
 // - Listen to excalidraw:merge_committed for the affected element IDs
 
 export interface MergeHighlightEventDetail {
-  sessionId: string
+  workspaceId: string
   slug: string
   newElementIds: string[]
   conflictElementIds: string[]
 }
 
 export interface MergeHighlightProps {
-  sessionId: string
+  workspaceId: string
   slug: string
   apiRef: React.MutableRefObject<ExcalidrawImperativeAPI | null>
 }
@@ -32,7 +32,7 @@ interface HighlightBox {
 }
 
 // Track viewport changes with requestAnimationFrame while highlights are visible.
-export function MergeHighlight({ sessionId, slug, apiRef }: MergeHighlightProps): JSX.Element | null {
+export function MergeHighlight({ workspaceId, slug, apiRef }: MergeHighlightProps): JSX.Element | null {
   const [boxes, setBoxes] = useState<HighlightBox[] | null>(null)
   const [scroll, setScroll] = useState({ x: 0, y: 0, zoom: 1 })
   const rafRef = useRef<number | null>(null)
@@ -43,7 +43,7 @@ export function MergeHighlight({ sessionId, slug, apiRef }: MergeHighlightProps)
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<MergeHighlightEventDetail>).detail
       if (!detail) return
-      if (detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
       const api = apiRef.current
       if (!api) return
       const scene = api.getSceneElements()
@@ -74,7 +74,7 @@ export function MergeHighlight({ sessionId, slug, apiRef }: MergeHighlightProps)
       window.removeEventListener('excalidraw:merge_committed', handler)
       if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
     }
-  }, [sessionId, slug, apiRef])
+  }, [workspaceId, slug, apiRef])
 
   // Poll scroll and zoom only while visible.
   // Excalidraw already emits appState through onChange, but adding a dedicated subscription just for this

--- a/packages/mcp-server/src/app/components/MergeToast.test.tsx
+++ b/packages/mcp-server/src/app/components/MergeToast.test.tsx
@@ -7,7 +7,7 @@ function dispatchMergeCommitted(detail: MergeToastEventDetail): void {
 }
 
 const baseDetail: MergeToastEventDetail = {
-  sessionId: 's1',
+  workspaceId: 's1',
   slug: 'c1',
   sourceName: 'feature-a',
   targetName: 'main',
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe('MergeToast', () => {
   it('shows the toast when the event is received', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
+    render(<MergeToast workspaceId="s1" slug="c1" />)
     expect(screen.queryByTestId('merge-toast')).toBeNull()
     act(() => dispatchMergeCommitted(baseDetail))
     expect(screen.getByTestId('merge-toast')).toBeTruthy()
@@ -39,13 +39,13 @@ describe('MergeToast', () => {
   })
 
   it('ignores events for a different session or slug', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
-    act(() => dispatchMergeCommitted({ ...baseDetail, sessionId: 'other' }))
+    render(<MergeToast workspaceId="s1" slug="c1" />)
+    act(() => dispatchMergeCommitted({ ...baseDetail, workspaceId: 'other' }))
     expect(screen.queryByTestId('merge-toast')).toBeNull()
   })
 
   it('shows "No content changes" when there is no diff', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
+    render(<MergeToast workspaceId="s1" slug="c1" />)
     act(() =>
       dispatchMergeCommitted({ ...baseDetail, newCount: 0, changedCount: 0, conflictCount: 0 }),
     )
@@ -53,20 +53,20 @@ describe('MergeToast', () => {
   })
 
   it('shows the Undo button when preMergeVersionId is present', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
+    render(<MergeToast workspaceId="s1" slug="c1" />)
     act(() => dispatchMergeCommitted(baseDetail))
     expect(screen.getByTestId('merge-toast-undo')).toBeTruthy()
   })
 
   it('hides the Undo button when preMergeVersionId is missing', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
+    render(<MergeToast workspaceId="s1" slug="c1" />)
     act(() => dispatchMergeCommitted({ ...baseDetail, preMergeVersionId: undefined }))
     expect(screen.queryByTestId('merge-toast-undo')).toBeNull()
   })
 
   it('posts restore and calls onRestored when Undo is clicked', async () => {
     const onRestored = vi.fn()
-    render(<MergeToast sessionId="s1" slug="c1" onRestored={onRestored} />)
+    render(<MergeToast workspaceId="s1" slug="c1" onRestored={onRestored} />)
     act(() => dispatchMergeCommitted(baseDetail))
     fireEvent.click(screen.getByTestId('merge-toast-undo'))
     await waitFor(() => {
@@ -78,7 +78,7 @@ describe('MergeToast', () => {
   })
 
   it('closes immediately when the close button is clicked', () => {
-    render(<MergeToast sessionId="s1" slug="c1" />)
+    render(<MergeToast workspaceId="s1" slug="c1" />)
     act(() => dispatchMergeCommitted(baseDetail))
     fireEvent.click(screen.getByTestId('merge-toast-close'))
     expect(screen.queryByTestId('merge-toast')).toBeNull()

--- a/packages/mcp-server/src/app/components/MergeToast.tsx
+++ b/packages/mcp-server/src/app/components/MergeToast.tsx
@@ -12,7 +12,7 @@ import { apiFetch } from '../lib/api-client.js'
 // MergeDialog dispatches excalidraw:merge_committed, and CanvasPage mounts this so it stays local to the canvas view.
 
 export interface MergeToastEventDetail {
-  sessionId: string
+  workspaceId: string
   slug: string
   sourceName: string
   targetName: string
@@ -26,7 +26,7 @@ export interface MergeToastEventDetail {
 }
 
 export interface MergeToastProps {
-  sessionId: string
+  workspaceId: string
   slug: string
   // Called after a successful restore so CanvasPage can clear its local undo stack.
   onRestored?: () => void
@@ -37,7 +37,7 @@ interface ActiveToast {
   detail: MergeToastEventDetail
 }
 
-export function MergeToast({ sessionId, slug, onRestored }: MergeToastProps): JSX.Element | null {
+export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): JSX.Element | null {
   const [active, setActive] = useState<ActiveToast | null>(null)
   const [undoing, setUndoing] = useState(false)
   const hoverRef = useRef(false)
@@ -48,12 +48,12 @@ export function MergeToast({ sessionId, slug, onRestored }: MergeToastProps): JS
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<MergeToastEventDetail>).detail
       if (!detail) return
-      if (detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
       setActive({ key: Date.now(), detail })
     }
     window.addEventListener('excalidraw:merge_committed', handler)
     return () => window.removeEventListener('excalidraw:merge_committed', handler)
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   useEffect(() => {
     if (!active) return
@@ -90,7 +90,7 @@ export function MergeToast({ sessionId, slug, onRestored }: MergeToastProps): JS
     setUndoing(true)
     try {
       const res = await apiFetch(
-        `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${preMergeVersionId}/restore`,
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${preMergeVersionId}/restore`,
         { method: 'POST' },
       )
       if (res.ok) {

--- a/packages/mcp-server/src/app/components/VersionTimeline.browser.test.tsx
+++ b/packages/mcp-server/src/app/components/VersionTimeline.browser.test.tsx
@@ -73,7 +73,7 @@ describe('VersionTimeline browser mode', () => {
           minHeight: 0,
         }}
       >
-        <VersionTimeline sessionId="sess_1" slug="canvas-a" />
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
       </div>,
     )
 
@@ -108,7 +108,7 @@ describe('VersionTimeline browser mode', () => {
           minHeight: 0,
         }}
       >
-        <VersionTimeline sessionId="sess_1" slug="canvas-a" />
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
       </div>,
     )
 

--- a/packages/mcp-server/src/app/components/VersionTimeline.test.tsx
+++ b/packages/mcp-server/src/app/components/VersionTimeline.test.tsx
@@ -99,7 +99,7 @@ afterEach(() => {
 
 describe('VersionTimeline', () => {
   it('filters cards and mini-graph rows to the active branch', async () => {
-    render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
 
     // Only v-new and v-mid should render; v-feat is filtered out with the feature branch.
     await waitFor(() => {
@@ -118,7 +118,7 @@ describe('VersionTimeline', () => {
   })
 
   it('renders the branchOut label on the row matching baseVersionId', async () => {
-    render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
     // "branched -> feature" should appear on the v-mid row.
     await waitFor(() => {
       expect(screen.getByText(/branched → feature/)).toBeTruthy()
@@ -126,7 +126,7 @@ describe('VersionTimeline', () => {
   })
 
   it('renders operator affordances and keeps the lane color on the branch color', async () => {
-    render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
 
     await waitFor(() => {
       expect(screen.getByText('🤖 Assistant')).toBeTruthy()
@@ -170,7 +170,7 @@ describe('VersionTimeline', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
     await waitFor(() => {
       expect(screen.getByText('⚙ System')).toBeTruthy()
     })
@@ -206,14 +206,14 @@ describe('VersionTimeline', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
     await waitFor(() => {
       expect(screen.getByText(/No versions on «feature» yet/i)).toBeTruthy()
     })
   })
 
   it('scroll container can shrink inside the fixed-height history popover', async () => {
-    const { container } = render(<VersionTimeline sessionId="sess_1" slug="canvas-a" />)
+    const { container } = render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
 
     await waitFor(() => {
       expect(screen.getByText('🤖 Assistant')).toBeTruthy()

--- a/packages/mcp-server/src/app/components/VersionTimeline.tsx
+++ b/packages/mcp-server/src/app/components/VersionTimeline.tsx
@@ -21,7 +21,7 @@ interface OperatorInfo {
   peerId: string
   displayName?: string
   agentId?: string
-  sessionId?: string
+  workspaceId?: string
 }
 
 interface VersionEntry {
@@ -38,7 +38,7 @@ interface VersionEntry {
 }
 
 interface Props {
-  sessionId: string
+  workspaceId: string
   slug: string
   // Called after restore succeeds so the browser-side LoroUndoManager can be cleared.
   onRestored?: () => void
@@ -70,7 +70,7 @@ function getOperatorAffordance(operator?: OperatorInfo): { icon: string; label: 
 // Branch operations and save controls live in the header.
 // VersionTimeline is responsible only for the version list, mini-graph, and restore flow.
 export default function VersionTimeline({
-  sessionId,
+  workspaceId,
   slug,
   onRestored,
 }: Props) {
@@ -82,7 +82,7 @@ export default function VersionTimeline({
     setLoading(true)
     try {
       const res = await apiFetch(
-        `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions`,
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
       )
       if (res.ok) {
         const body = (await res.json()) as { versions: VersionEntry[] }
@@ -91,7 +91,7 @@ export default function VersionTimeline({
     } finally {
       setLoading(false)
     }
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   // Reload whenever the canvas changes.
   useEffect(() => {
@@ -111,17 +111,17 @@ export default function VersionTimeline({
     const v = pendingRestore
     setPendingRestore(null)
     await apiFetch(
-      `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
+      `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
       { method: 'POST' },
     )
     onRestored?.()
     // Refresh immediately after restore so the pending UI closes cleanly.
     await refresh()
-  }, [pendingRestore, sessionId, slug, onRestored, refresh])
+  }, [pendingRestore, workspaceId, slug, onRestored, refresh])
 
   // Keep branch state here for head filtering and the mini-graph.
   // Legacy versions without branchName are treated as main.
-  const { state: branchesState } = useBranches(sessionId, slug)
+  const { state: branchesState } = useBranches(workspaceId, slug)
   const head = branchesState.head
 
   const visibleVersions = versions.filter(
@@ -209,7 +209,7 @@ export default function VersionTimeline({
                     {v.hasThumbnail && (
                       <div className="mx-3 mb-1 border rounded overflow-hidden bg-muted/30">
                         <img
-                          src={`/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`}
+                          src={`/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`}
                           alt=""
                           className="w-full h-20 object-contain"
                           loading="lazy"

--- a/packages/mcp-server/src/app/components/WorkspaceTopBar.browser.test.tsx
+++ b/packages/mcp-server/src/app/components/WorkspaceTopBar.browser.test.tsx
@@ -67,7 +67,7 @@ function renderTopBar(props?: Partial<ComponentProps<typeof WorkspaceTopBar>>) {
     <MemoryRouter initialEntries={['/canvas/sess_1/design/login-flow']}>
       <div className="h-[560px] w-[1100px] bg-background p-6">
         <WorkspaceTopBar
-          sessionId="sess_1"
+          workspaceId="sess_1"
           slug="design/login-flow"
           canvases={[
             { slug: 'design/login-flow', updatedAt: '2026-04-24T11:00:00Z' },

--- a/packages/mcp-server/src/app/components/WorkspaceTopBar.tsx
+++ b/packages/mcp-server/src/app/components/WorkspaceTopBar.tsx
@@ -46,9 +46,9 @@ interface CanvasInfo {
 // 56x36 thumbnail shown at the left edge of each dropdown item.
 // Fetch `/api/.../latest-thumbnail` and fall back to a placeholder on 404 or image load failure.
 // This stays as a tiny component because each item owns its own loading state.
-function CanvasThumb({ sessionId, slug }: { sessionId: string; slug: string }) {
+function CanvasThumb({ workspaceId, slug }: { workspaceId: string; slug: string }) {
   const [failed, setFailed] = useState(false)
-  const src = `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
+  const src = `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
   return (
     <div className="flex h-9 w-14 shrink-0 items-center justify-center overflow-hidden rounded border bg-muted/40">
       {failed ? (
@@ -68,7 +68,7 @@ function CanvasThumb({ sessionId, slug }: { sessionId: string; slug: string }) {
   )
 }
 
-interface SessionNames {
+interface WorkspaceNames {
   workspace?: string
   canvases: Record<string, string>
   // Slugs pinned to the top of the canvas switcher. Array order is display order.
@@ -80,7 +80,7 @@ interface SessionNames {
 // Stop propagation on mouse down because Radix selection is driven from that event.
 function CanvasItem({
   canvas,
-  sessionId,
+  workspaceId,
   customName,
   leafLabel,
   active,
@@ -89,7 +89,7 @@ function CanvasItem({
   onTogglePin,
 }: {
   canvas: CanvasInfo
-  sessionId: string
+  workspaceId: string
   customName: string | undefined
   leafLabel: string
   active: boolean
@@ -105,7 +105,7 @@ function CanvasItem({
         active && 'bg-accent',
       )}
     >
-      <CanvasThumb sessionId={sessionId} slug={canvas.slug} />
+      <CanvasThumb workspaceId={workspaceId} slug={canvas.slug} />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span
           className={cn(
@@ -144,7 +144,7 @@ function CanvasItem({
 }
 
 interface Props {
-  sessionId: string
+  workspaceId: string
   slug: string
   canvases: CanvasInfo[]
   onRestored?: () => void
@@ -159,7 +159,7 @@ interface Props {
 // - More complex lists appear on demand through buttons and popovers
 
 export default function WorkspaceTopBar({
-  sessionId,
+  workspaceId,
   slug,
   canvases,
   onRestored,
@@ -167,7 +167,7 @@ export default function WorkspaceTopBar({
   getThumbnailBlob,
 }: Props) {
   const navigate = useNavigate()
-  const [names, setNames] = useState<SessionNames>({ canvases: {}, pinned: [] })
+  const [names, setNames] = useState<WorkspaceNames>({ canvases: {}, pinned: [] })
   const [renamingWorkspace, setRenamingWorkspace] = useState(false)
   const [renamingCanvas, setRenamingCanvas] = useState(false)
   const [draft, setDraft] = useState('')
@@ -177,7 +177,7 @@ export default function WorkspaceTopBar({
 
   // Save state: dirty dot, Cmd/Ctrl+S, and beforeunload protection.
   // Dirty tracking comes from the doc_changed and version_saved events dispatched by useWhiteboardSync.
-  const { isDirty } = useDirtyState(sessionId, slug)
+  const { isDirty } = useDirtyState(workspaceId, slug)
   const [saving, setSaving] = useState(false)
   const isMac =
     typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
@@ -191,7 +191,7 @@ export default function WorkspaceTopBar({
       setSaving(true)
       try {
         const res = await apiFetch(
-          `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions`,
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -204,7 +204,7 @@ export default function WorkspaceTopBar({
         if (typeof window !== 'undefined') {
           window.dispatchEvent(
             new CustomEvent('excalidraw:version_saved', {
-              detail: { sessionId, slug },
+              detail: { workspaceId, slug },
             }),
           )
         }
@@ -215,7 +215,7 @@ export default function WorkspaceTopBar({
             const blob = await getThumbnailBlob()
             if (blob) {
               await apiFetch(
-                `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${id}/thumbnail`,
+                `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${id}/thumbnail`,
                 {
                   method: 'PUT',
                   headers: { 'Content-Type': 'image/png' },
@@ -232,7 +232,7 @@ export default function WorkspaceTopBar({
         setSaving(false)
       }
     },
-    [sessionId, slug, saving, getThumbnailBlob],
+    [workspaceId, slug, saving, getThumbnailBlob],
   )
 
   // Cmd/Ctrl+S performs a quick save.
@@ -271,12 +271,12 @@ export default function WorkspaceTopBar({
   // Load display names.
   const fetchNames = useCallback(async () => {
     try {
-      const res = await apiFetch(`/api/workspaces/${sessionId}/names`)
-      if (res.ok) setNames((await res.json()) as SessionNames)
+      const res = await apiFetch(`/api/workspaces/${workspaceId}/names`)
+      if (res.ok) setNames((await res.json()) as WorkspaceNames)
     } catch {
       /* best-effort */
     }
-  }, [sessionId])
+  }, [workspaceId])
 
   useEffect(() => {
     fetchNames()
@@ -286,12 +286,12 @@ export default function WorkspaceTopBar({
   const commitWorkspaceName = async () => {
     const name = draft.trim()
     try {
-      const res = await apiFetch(`/api/workspaces/${sessionId}/name`, {
+      const res = await apiFetch(`/api/workspaces/${workspaceId}/name`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
       })
-      if (res.ok) setNames((await res.json()) as SessionNames)
+      if (res.ok) setNames((await res.json()) as WorkspaceNames)
     } catch {
       /* ignore */
     } finally {
@@ -304,14 +304,14 @@ export default function WorkspaceTopBar({
     const name = draft.trim()
     try {
       const res = await apiFetch(
-        `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/name`,
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/name`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name }),
         },
       )
-      if (res.ok) setNames((await res.json()) as SessionNames)
+      if (res.ok) setNames((await res.json()) as WorkspaceNames)
     } catch {
       /* ignore */
     } finally {
@@ -332,19 +332,19 @@ export default function WorkspaceTopBar({
     async (targetSlug: string, pinned: boolean) => {
       try {
         const res = await apiFetch(
-          `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(targetSlug)}/pin`,
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(targetSlug)}/pin`,
           {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ pinned }),
           },
         )
-        if (res.ok) setNames((await res.json()) as SessionNames)
+        if (res.ok) setNames((await res.json()) as WorkspaceNames)
       } catch {
         /* Pin failures stay silent; the UX does not need explicit retry handling here. */
       }
     },
-    [sessionId],
+    [workspaceId],
   )
 
   // ---- canvas switcher data ----
@@ -400,7 +400,7 @@ export default function WorkspaceTopBar({
   const canvasPrefix = !canvasCustomName && slashIndex !== -1 ? slug.slice(0, slashIndex) : null
   const canvasLeaf = !canvasCustomName && slashIndex !== -1 ? slug.slice(slashIndex + 1) : null
   const canvasFlat = canvasCustomName ?? (canvasPrefix === null ? slug : null)
-  const shortSession = sessionId.slice(0, 5) + '…' + sessionId.slice(-3)
+  const shortSession = workspaceId.slice(0, 5) + '…' + workspaceId.slice(-3)
 
   // Close the version history popover on outside clicks.
   useEffect(() => {
@@ -438,7 +438,7 @@ export default function WorkspaceTopBar({
     setNewCanvasBusy(true)
     setNewCanvasError(null)
     try {
-      const res = await apiFetch(`/api/workspaces/${sessionId}/canvases`, {
+      const res = await apiFetch(`/api/workspaces/${workspaceId}/canvases`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slug: target }),
@@ -446,7 +446,7 @@ export default function WorkspaceTopBar({
       if (res.ok) {
         setNewCanvasOpen(false)
         setNewCanvasSlug('')
-        navigate(`/canvas/${sessionId}/${encodeURIComponent(target)}`)
+        navigate(`/canvas/${workspaceId}/${encodeURIComponent(target)}`)
         return
       }
       const body = (await res.json().catch(() => ({}))) as { message?: string }
@@ -460,7 +460,7 @@ export default function WorkspaceTopBar({
 
   const copyCanvasUrl = async () => {
     try {
-      const url = `${window.location.origin}/canvas/${sessionId}/${encodeURIComponent(slug)}`
+      const url = `${window.location.origin}/canvas/${workspaceId}/${encodeURIComponent(slug)}`
       await navigator.clipboard.writeText(url)
     } catch {
       /* ignore */
@@ -572,14 +572,14 @@ export default function WorkspaceTopBar({
                           <CanvasItem
                             key={c.slug}
                             canvas={c}
-                            sessionId={sessionId}
+                            workspaceId={workspaceId}
                             customName={names.canvases[c.slug]}
                             // Keep the full slug in the pinned section so the original group context stays visible.
                             leafLabel={names.canvases[c.slug] ?? c.slug}
                             active={c.slug === slug}
                             pinned={true}
                             onNavigate={() => {
-                              navigate(`/canvas/${sessionId}/${encodeURIComponent(c.slug)}`)
+                              navigate(`/canvas/${workspaceId}/${encodeURIComponent(c.slug)}`)
                               setCanvasSearch('')
                             }}
                             onTogglePin={togglePin}
@@ -604,13 +604,13 @@ export default function WorkspaceTopBar({
                             <CanvasItem
                               key={c.slug}
                               canvas={c}
-                              sessionId={sessionId}
+                              workspaceId={workspaceId}
                               customName={names.canvases[c.slug]}
                               leafLabel={names.canvases[c.slug] ?? leafSlug}
                               active={c.slug === slug}
                               pinned={false}
                               onNavigate={() => {
-                                navigate(`/canvas/${sessionId}/${encodeURIComponent(c.slug)}`)
+                                navigate(`/canvas/${workspaceId}/${encodeURIComponent(c.slug)}`)
                                 setCanvasSearch('')
                               }}
                               onTogglePin={togglePin}
@@ -682,7 +682,7 @@ export default function WorkspaceTopBar({
 
         {/* Branch chip with switch, create, rename, delete, and merge actions. */}
         <span className="mx-1 hidden h-4 w-px bg-border sm:inline-block" aria-hidden />
-        <HeaderBranchChip sessionId={sessionId} slug={slug} />
+        <HeaderBranchChip workspaceId={workspaceId} slug={slug} />
 
         {/* Save-state dot. */}
         <HeaderSaveDot
@@ -773,7 +773,7 @@ export default function WorkspaceTopBar({
         >
           <div className="flex h-[480px] min-h-0 flex-col">
             <VersionTimeline
-              sessionId={sessionId}
+              workspaceId={workspaceId}
               slug={slug}
               onRestored={onRestored}
             />

--- a/packages/mcp-server/src/app/hooks/useBranches.ts
+++ b/packages/mcp-server/src/app/hooks/useBranches.ts
@@ -41,7 +41,7 @@ export interface MergeResult {
 
 // ── URL builder ──
 // Slugs can contain "/", so always encode them.
-export function buildBranchUrls(sessionId: string, slug: string): {
+export function buildBranchUrls(workspaceId: string, slug: string): {
   list: string
   head: string
   deleteBranch: (name: string) => string
@@ -49,7 +49,7 @@ export function buildBranchUrls(sessionId: string, slug: string): {
   merge: (source: string) => string
 } {
   const safeSlug = encodeURIComponent(slug)
-  const base = `/api/workspaces/${sessionId}/canvases/${safeSlug}`
+  const base = `/api/workspaces/${workspaceId}/canvases/${safeSlug}`
   return {
     list: `${base}/branches`,
     head: `${base}/head`,
@@ -103,8 +103,8 @@ async function requireOk(res: Response): Promise<Response> {
 }
 
 // Imperative API helpers independent from React.
-export function branchesApi(sessionId: string, slug: string) {
-  const urls = buildBranchUrls(sessionId, slug)
+export function branchesApi(workspaceId: string, slug: string) {
+  const urls = buildBranchUrls(workspaceId, slug)
   return {
     async list(): Promise<BranchesState> {
       const res = await requireOk(await apiFetch(urls.list))
@@ -189,16 +189,16 @@ export interface UseBranchesResult {
   merge: (source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>
 }
 
-export function useBranches(sessionId: string, slug: string): UseBranchesResult {
+export function useBranches(workspaceId: string, slug: string): UseBranchesResult {
   const [state, setState] = useState<BranchesState>({ branches: [], head: 'main' })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<BranchApiError | Error | null>(null)
-  const apiRef = useRef(branchesApi(sessionId, slug))
+  const apiRef = useRef(branchesApi(workspaceId, slug))
 
   // Recreate the API wrapper whenever session or slug changes.
   useEffect(() => {
-    apiRef.current = branchesApi(sessionId, slug)
-  }, [sessionId, slug])
+    apiRef.current = branchesApi(workspaceId, slug)
+  }, [workspaceId, slug])
 
   const refetch = useCallback(async () => {
     setLoading(true)
@@ -215,22 +215,22 @@ export function useBranches(sessionId: string, slug: string): UseBranchesResult 
 
   useEffect(() => {
     void refetch()
-  }, [refetch, sessionId, slug])
+  }, [refetch, workspaceId, slug])
 
   // useWhiteboardSync emits a window event when HEAD changes.
   // Refetch only for the matching session/slug pair.
   useEffect(() => {
     if (typeof window === 'undefined') return
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ sessionId: string; slug: string; head: string }>)
+      const detail = (event as CustomEvent<{ workspaceId: string; slug: string; head: string }>)
         .detail
       if (!detail) return
-      if (detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
       void refetch()
     }
     window.addEventListener('excalidraw:head_changed', handler)
     return () => window.removeEventListener('excalidraw:head_changed', handler)
-  }, [refetch, sessionId, slug])
+  }, [refetch, workspaceId, slug])
 
   const createBranch = useCallback(
     async (args: { name: string; fromVersionId?: string; color?: string }) => {

--- a/packages/mcp-server/src/app/hooks/useDirtyState.test.ts
+++ b/packages/mcp-server/src/app/hooks/useDirtyState.test.ts
@@ -4,14 +4,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { useDirtyState } from './useDirtyState.js'
 
 // Thin CustomEvent helpers; jsdom can dispatch these directly.
-function dispatchDocChanged(sessionId: string, slug: string): void {
+function dispatchDocChanged(workspaceId: string, slug: string): void {
   window.dispatchEvent(
-    new CustomEvent('excalidraw:doc_changed', { detail: { sessionId, slug } }),
+    new CustomEvent('excalidraw:doc_changed', { detail: { workspaceId, slug } }),
   )
 }
-function dispatchVersionSaved(sessionId: string, slug: string): void {
+function dispatchVersionSaved(workspaceId: string, slug: string): void {
   window.dispatchEvent(
-    new CustomEvent('excalidraw:version_saved', { detail: { sessionId, slug } }),
+    new CustomEvent('excalidraw:version_saved', { detail: { workspaceId, slug } }),
   )
 }
 

--- a/packages/mcp-server/src/app/hooks/useDirtyState.ts
+++ b/packages/mcp-server/src/app/hooks/useDirtyState.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 // Implementation notes:
 //  useWhiteboardSync dispatches excalidraw:doc_changed whenever doc.subscribe observes a local or remote edit.
 //  When version_created arrives, it dispatches excalidraw:version_saved.
-//  This hook filters those events by sessionId/slug and tracks dirty vs clean counts.
+//  This hook filters those events by workspaceId/slug and tracks dirty vs clean counts.
 //  Passing the doc reference around would couple tests to Loro internals, so this stays event-based.
 
 export interface UseDirtyStateResult {
@@ -18,11 +18,11 @@ export interface UseDirtyStateResult {
 }
 
 export interface DirtyEventDetail {
-  sessionId: string
+  workspaceId: string
   slug: string
 }
 
-export function useDirtyState(sessionId: string, slug: string): UseDirtyStateResult {
+export function useDirtyState(workspaceId: string, slug: string): UseDirtyStateResult {
   const [isDirty, setIsDirty] = useState(false)
   const changeCountRef = useRef(0)
   const savedAtRef = useRef(0)
@@ -32,19 +32,19 @@ export function useDirtyState(sessionId: string, slug: string): UseDirtyStateRes
     changeCountRef.current = 0
     savedAtRef.current = 0
     setIsDirty(false)
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
     const onChanged = (event: Event) => {
       const detail = (event as CustomEvent<DirtyEventDetail>).detail
-      if (!detail || detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (!detail || detail.workspaceId !== workspaceId || detail.slug !== slug) return
       changeCountRef.current += 1
       if (changeCountRef.current > savedAtRef.current) setIsDirty(true)
     }
     const onSaved = (event: Event) => {
       const detail = (event as CustomEvent<DirtyEventDetail>).detail
-      if (!detail || detail.sessionId !== sessionId || detail.slug !== slug) return
+      if (!detail || detail.workspaceId !== workspaceId || detail.slug !== slug) return
       savedAtRef.current = changeCountRef.current
       setIsDirty(false)
     }
@@ -54,7 +54,7 @@ export function useDirtyState(sessionId: string, slug: string): UseDirtyStateRes
       window.removeEventListener('excalidraw:doc_changed', onChanged)
       window.removeEventListener('excalidraw:version_saved', onSaved)
     }
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   const markSaved = useCallback(() => {
     savedAtRef.current = changeCountRef.current

--- a/packages/mcp-server/src/app/hooks/useWhiteboardSync.helpers.ts
+++ b/packages/mcp-server/src/app/hooks/useWhiteboardSync.helpers.ts
@@ -42,12 +42,12 @@ export { buildWhiteboardWsProtocols }
 
 export function buildWhiteboardWsUrl(
   locationHref: string,
-  sessionId: string,
+  workspaceId: string,
   slug: string,
 ): string {
   const url = new URL(locationHref)
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
-  url.pathname = `/ws/${sessionId}/${encodeURIComponent(slug)}`
+  url.pathname = `/ws/${workspaceId}/${encodeURIComponent(slug)}`
   url.search = ''
   url.hash = ''
   return url.toString()

--- a/packages/mcp-server/src/app/hooks/useWhiteboardSync.scene-change.test.tsx
+++ b/packages/mcp-server/src/app/hooks/useWhiteboardSync.scene-change.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StrictMode } from 'react'
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  exportToBlob: vi.fn(),
+  CaptureUpdateAction: { NEVER: 'never' },
+  restoreElements: vi.fn(),
+}))
+
+const commitAfterUploadMock = vi.fn((...args: unknown[]): Promise<void> => {
+  void args
+  return Promise.resolve()
+})
+vi.mock('../lib/commit-pipeline.js', () => ({
+  commitAfterUpload: commitAfterUploadMock,
+}))
+
+const { useWhiteboardSync } = await import('./useWhiteboardSync.js')
+
+interface WsHandlers {
+  onopen: ((event: Event) => void) | null
+  onmessage: ((event: MessageEvent) => void) | null
+  onclose: ((event: CloseEvent) => void) | null
+  onerror: ((event: Event) => void) | null
+}
+
+class FakeWebSocket implements WsHandlers {
+  static instances: FakeWebSocket[] = []
+  static CONNECTING = 0 as const
+  static OPEN = 1 as const
+  static CLOSING = 2 as const
+  static CLOSED = 3 as const
+
+  binaryType: BinaryType = 'blob'
+  readyState: number = FakeWebSocket.CONNECTING
+  url: string
+  protocol = ''
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  send = vi.fn()
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+  dispatchEvent = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.(new Event('close') as CloseEvent)
+  })
+
+  constructor(url: string | URL) {
+    this.url = String(url)
+    FakeWebSocket.instances.push(this)
+  }
+}
+
+describe('useWhiteboardSync onSceneChange lifecycle', () => {
+  let originalWebSocket: typeof WebSocket
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeWebSocket.instances = []
+    commitAfterUploadMock.mockClear()
+    originalWebSocket = globalThis.WebSocket
+    Object.defineProperty(globalThis, 'WebSocket', {
+      value: FakeWebSocket,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(globalThis, 'WebSocket', {
+      value: originalWebSocket,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('keeps a stable onSceneChange reference when re-rendered with the same canvas key', () => {
+    const { result, rerender } = renderHook(
+      ({ s, c }: { s: string; c: string }) => useWhiteboardSync(s, c),
+      { initialProps: { s: 'sid', c: 'slug' } },
+    )
+
+    const first = result.current.onSceneChange
+    rerender({ s: 'sid', c: 'slug' })
+    rerender({ s: 'sid', c: 'slug' })
+
+    expect(result.current.onSceneChange).toBe(first)
+  })
+
+  it('replaces onSceneChange when the canvas key changes', () => {
+    const { result, rerender } = renderHook(
+      ({ s, c }: { s: string; c: string }) => useWhiteboardSync(s, c),
+      { initialProps: { s: 'sid', c: 'slug-a' } },
+    )
+
+    const first = result.current.onSceneChange
+    rerender({ s: 'sid', c: 'slug-b' })
+
+    expect(result.current.onSceneChange).not.toBe(first)
+  })
+
+  it('clears the pending debounce timer when the canvas key changes', () => {
+    const { result, rerender } = renderHook(
+      ({ s, c }: { s: string; c: string }) => useWhiteboardSync(s, c),
+      { initialProps: { s: 'sid', c: 'slug-a' } },
+    )
+
+    const baseline = vi.getTimerCount()
+    act(() => {
+      result.current.onSceneChange?.([], {})
+    })
+    // The debounce schedules exactly one 300ms timer for the next commit.
+    expect(vi.getTimerCount()).toBe(baseline + 1)
+
+    // Switching the canvas key must cancel the pending timer so the old
+    // closure cannot leak a write into the new canvas.
+    rerender({ s: 'sid', c: 'slug-b' })
+    expect(vi.getTimerCount()).toBe(baseline)
+  })
+
+  it('clears the pending debounce timer on unmount so the hook does not hold a setTimeout open', () => {
+    const { result, unmount } = renderHook(() => useWhiteboardSync('sid', 'slug'))
+
+    const baseline = vi.getTimerCount()
+    act(() => {
+      result.current.onSceneChange?.([], {})
+    })
+    expect(vi.getTimerCount()).toBe(baseline + 1)
+
+    unmount()
+    // Effect cleanup should cancel the still-pending debounce timer.
+    expect(vi.getTimerCount()).toBe(baseline)
+  })
+
+  it('keeps the same onSceneChange reference under StrictMode double-invoke for a stable canvas key', () => {
+    const { result, rerender } = renderHook(
+      ({ s, c }: { s: string; c: string }) => useWhiteboardSync(s, c),
+      {
+        initialProps: { s: 'sid', c: 'slug' },
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <StrictMode>{children}</StrictMode>
+        ),
+      },
+    )
+
+    const first = result.current.onSceneChange
+    rerender({ s: 'sid', c: 'slug' })
+
+    expect(result.current.onSceneChange).toBe(first)
+  })
+})

--- a/packages/mcp-server/src/app/hooks/useWhiteboardSync.text-message.ts
+++ b/packages/mcp-server/src/app/hooks/useWhiteboardSync.text-message.ts
@@ -5,7 +5,7 @@ export interface OperatorInfo {
   peerId: string
   displayName?: string
   agentId?: string
-  sessionId?: string
+  workspaceId?: string
 }
 
 export interface VersionCreatedPayload {
@@ -76,7 +76,7 @@ function isOperatorInfo(value: unknown): value is OperatorInfo {
   if (typeof value.peerId !== 'string' || value.peerId.length === 0) return false
   if (value.displayName !== undefined && typeof value.displayName !== 'string') return false
   if (value.agentId !== undefined && typeof value.agentId !== 'string') return false
-  if (value.sessionId !== undefined && typeof value.sessionId !== 'string') return false
+  if (value.workspaceId !== undefined && typeof value.workspaceId !== 'string') return false
   return true
 }
 

--- a/packages/mcp-server/src/app/hooks/useWhiteboardSync.ts
+++ b/packages/mcp-server/src/app/hooks/useWhiteboardSync.ts
@@ -80,7 +80,7 @@ export function applyHydratedSceneToApi(args: {
 }
 
 export function useWhiteboardSync(
-  sessionId: string,
+  workspaceId: string,
   slug: string,
   options: UseWhiteboardSyncOptions = {},
 ) {
@@ -161,7 +161,7 @@ export function useWhiteboardSync(
     // Fetch missing files in parallel. Individual failures are ignored.
     await Promise.allSettled(
       missingIds.map(async (fileId) => {
-        const res = await apiFetch(`/api/canvas/${sessionId}/${encodeURIComponent(slug)}/file/${fileId}`)
+        const res = await apiFetch(`/api/canvas/${workspaceId}/${encodeURIComponent(slug)}/file/${fileId}`)
         if (!res.ok) return
         const blob = await res.blob()
         const dataURL = await blobToBase64(blob)
@@ -195,7 +195,7 @@ export function useWhiteboardSync(
     uploadedFileIdsRef.current = new Set()
     pendingExportRequestsRef.current = []
     applyGenerationRef.current += 1 // never reset this back to 0
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   // WebSocket connection plus Loro initialization.
   // Reconnect with exponential backoff (500ms -> 8s) when ws.onclose fires.
@@ -210,7 +210,7 @@ export function useWhiteboardSync(
     const connect = () => {
       if (cancelled) return
       const ws = new WebSocket(
-        buildWhiteboardWsUrl(window.location.href, sessionId, slug),
+        buildWhiteboardWsUrl(window.location.href, workspaceId, slug),
         buildWhiteboardWsProtocols(daemonToken),
       )
       // Required: without this, binary frames arrive as Blob and the ArrayBuffer check fails.
@@ -262,7 +262,7 @@ export function useWhiteboardSync(
               if (typeof window !== 'undefined') {
                 window.dispatchEvent(
                   new CustomEvent('excalidraw:doc_changed', {
-                    detail: { sessionId, slug },
+                    detail: { workspaceId, slug },
                   }),
                 )
               }
@@ -289,7 +289,7 @@ export function useWhiteboardSync(
           if (typeof window !== 'undefined') {
             window.dispatchEvent(
               new CustomEvent('excalidraw:version_saved', {
-                detail: { sessionId, slug },
+                detail: { workspaceId, slug },
               }),
             )
           }
@@ -316,7 +316,7 @@ export function useWhiteboardSync(
           if (typeof window !== 'undefined') {
             window.dispatchEvent(
               new CustomEvent('excalidraw:head_changed', {
-                detail: { sessionId, slug, head: msg.head },
+                detail: { workspaceId, slug, head: msg.head },
               }),
             )
           }
@@ -391,7 +391,7 @@ export function useWhiteboardSync(
       if (reconnectTimer) clearTimeout(reconnectTimer)
       wsRef.current?.close()
     }
-  }, [sessionId, slug]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workspaceId, slug]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reapply the current document once the Excalidraw API becomes ready.
   useEffect(() => {
@@ -409,11 +409,11 @@ export function useWhiteboardSync(
 
   // Record Excalidraw changes into Loro and upload any new files.
   // Memoize the debounced callback by canvas key so swapping canvases swaps
-  // the closure (which captures sessionId / slug) without mutating refs in
+  // the closure (which captures workspaceId / slug) without mutating refs in
   // render. React is allowed to discard a useMemo result; the worst case is a
   // fresh 300ms window for the new closure, never a write into the wrong doc,
-  // because the closure still uses the same sessionId / slug.
-  const canvasKey = `${sessionId}/${slug}`
+  // because the closure still uses the same workspaceId / slug.
+  const canvasKey = `${workspaceId}/${slug}`
   const onSceneChange = useMemo(() => {
     return debounce((elements: ExcalidrawElement[], files: BinaryFiles) => {
       // Capture doc at invocation time.
@@ -431,17 +431,16 @@ export function useWhiteboardSync(
         newEntries,
         doc, // pass the invocation-time captured reference
         elements,
-        sessionId,
+        workspaceId,
         slug,
         (fileId) => uploadedFileIdsRef.current.add(fileId),
       ).catch((err: unknown) => {
         console.error('[whiteboard] file upload failed, commit skipped:', err)
       })
     }, 300)
-    // canvasKey already encodes sessionId/slug; listing them keeps the deps
-    // exhaustive for ESLint and matches the closure's captured values.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canvasKey])
+    // canvasKey already encodes workspaceId/slug, but listing both keeps the
+    // exhaustive-deps rule honest with the closure's captured values.
+  }, [canvasKey, workspaceId, slug])
 
   // Cancel the previous debounce whenever the memoized callback changes
   // (canvas key switch) and on unmount, so a pending 300ms timer cannot leak

--- a/packages/mcp-server/src/app/hooks/useWhiteboardSync.ts
+++ b/packages/mcp-server/src/app/hooks/useWhiteboardSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import { exportToBlob, CaptureUpdateAction, restoreElements } from '@excalidraw/excalidraw'
 import { commitAfterUpload } from '../lib/commit-pipeline.js'
@@ -88,11 +88,6 @@ export function useWhiteboardSync(
   const wsRef = useRef<WebSocket | null>(null)
   const docRef = useRef<LoroDoc | null>(null)
   const undoManagerRef = useRef<UndoManager | null>(null)
-  const onSceneChangeFnRef = useRef<
-    ((elements: ExcalidrawElement[], files: BinaryFiles) => void) & { cancel: () => void } | null
-  >(null)
-  // Track canvas changes in render so the debounced onSceneChange callback can be recreated immediately.
-  const prevCanvasKeyRef = useRef<string | null>(null)
   const [apiReady, setApiReady] = useState(false)
 
   // Keep onVersionCreated in a ref so websocket effects do not reconnect just because the callback changed.
@@ -193,8 +188,6 @@ export function useWhiteboardSync(
   }
 
   // Reset document-scoped state when switching canvases.
-  // Do not cancel onSceneChangeFnRef here; the render-time prevCanvasKeyRef guard already does that
-  // synchronously, and canceling in an effect can accidentally cancel the newly created debounce.
   useEffect(() => {
     docRef.current = null
     undoManagerRef.current = null
@@ -415,13 +408,14 @@ export function useWhiteboardSync(
   }, [apiReady]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Record Excalidraw changes into Loro and upload any new files.
-  // Keep the debounced callback in a ref and recreate it immediately when the canvas key changes.
-  // A render-time guard prevents the old closure from keeping stale sessionId/slug values.
+  // Memoize the debounced callback by canvas key so swapping canvases swaps
+  // the closure (which captures sessionId / slug) without mutating refs in
+  // render. React is allowed to discard a useMemo result; the worst case is a
+  // fresh 300ms window for the new closure, never a write into the wrong doc,
+  // because the closure still uses the same sessionId / slug.
   const canvasKey = `${sessionId}/${slug}`
-  if (!onSceneChangeFnRef.current || prevCanvasKeyRef.current !== canvasKey) {
-    onSceneChangeFnRef.current?.cancel()
-    prevCanvasKeyRef.current = canvasKey
-    onSceneChangeFnRef.current = debounce((elements: ExcalidrawElement[], files: BinaryFiles) => {
+  const onSceneChange = useMemo(() => {
+    return debounce((elements: ExcalidrawElement[], files: BinaryFiles) => {
       // Capture doc at invocation time.
       // Looking at docRef.current after async upload work could write canvas A's elements into canvas B's doc.
       const doc = docRef.current
@@ -437,15 +431,26 @@ export function useWhiteboardSync(
         newEntries,
         doc, // pass the invocation-time captured reference
         elements,
-        sessionId, // always current because the closure is recreated when canvasKey changes
-        slug, // same as above
+        sessionId,
+        slug,
         (fileId) => uploadedFileIdsRef.current.add(fileId),
       ).catch((err: unknown) => {
         console.error('[whiteboard] file upload failed, commit skipped:', err)
       })
-    }, 300) as ((elements: ExcalidrawElement[], files: BinaryFiles) => void) & { cancel: () => void }
-  }
-  const onSceneChange = onSceneChangeFnRef.current
+    }, 300)
+    // canvasKey already encodes sessionId/slug; listing them keeps the deps
+    // exhaustive for ESLint and matches the closure's captured values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canvasKey])
+
+  // Cancel the previous debounce whenever the memoized callback changes
+  // (canvas key switch) and on unmount, so a pending 300ms timer cannot leak
+  // into a new canvas's doc or fire against a torn-down hook.
+  useEffect(() => {
+    return () => {
+      onSceneChange.cancel()
+    }
+  }, [onSceneChange])
 
   // Wire LoroUndoManager into Excalidraw's keyboard shortcuts and undo/redo buttons.
   // This avoids Excalidraw's built-in undo rolling back remote collaboration edits.

--- a/packages/mcp-server/src/app/lib/commit-pipeline.test.ts
+++ b/packages/mcp-server/src/app/lib/commit-pipeline.test.ts
@@ -126,10 +126,10 @@ describe('commitAfterUpload', () => {
     expect(doc.getMovableList('elements').toJSON() as unknown[]).toHaveLength(0)
   })
 
-  // Canvas isolation: commitAfterUpload must use the sessionId/slug it was given.
+  // Canvas isolation: commitAfterUpload must use the workspaceId/slug it was given.
   // This is a contract test for the hook regenerating its closure after a canvas switch.
 
-  it('uploads to the URL built from the passed sessionId and slug', async () => {
+  it('uploads to the URL built from the passed workspaceId and slug', async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 204 }))
 
     const doc = new LoroDoc()

--- a/packages/mcp-server/src/app/lib/commit-pipeline.ts
+++ b/packages/mcp-server/src/app/lib/commit-pipeline.ts
@@ -107,12 +107,12 @@ export async function commitAfterUpload(
   newEntries: [string, BinaryFileData][],
   doc: LoroDoc,
   elements: ExcalidrawElement[],
-  sessionId: string,
+  workspaceId: string,
   slug: string,
   onFileSuccess: (fileId: string) => void,
 ): Promise<void> {
   if (newEntries.length > 0) {
-    await uploadFiles(newEntries, sessionId, slug, onFileSuccess)
+    await uploadFiles(newEntries, workspaceId, slug, onFileSuccess)
   }
   if (!recordLocalOps(doc, elements)) {
     return

--- a/packages/mcp-server/src/app/lib/upload-files.ts
+++ b/packages/mcp-server/src/app/lib/upload-files.ts
@@ -10,7 +10,7 @@ import { apiFetch } from './api-client.js'
  */
 export async function uploadFiles(
   newEntries: [string, BinaryFileData][],
-  sessionId: string,
+  workspaceId: string,
   slug: string,
   onSuccess: (fileId: string) => void,
 ): Promise<void> {
@@ -18,7 +18,7 @@ export async function uploadFiles(
     newEntries.map(async ([fileId, fd]) => {
       const [, base64] = fd.dataURL.split(',')
       const binary = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
-      const res = await apiFetch(`/api/canvas/${sessionId}/${encodeURIComponent(slug)}/file/${fileId}`, {
+      const res = await apiFetch(`/api/canvas/${workspaceId}/${encodeURIComponent(slug)}/file/${fileId}`, {
         method: 'PUT',
         headers: { 'Content-Type': fd.mimeType },
         body: binary,

--- a/packages/mcp-server/src/app/pages/CanvasPage.tsx
+++ b/packages/mcp-server/src/app/pages/CanvasPage.tsx
@@ -20,8 +20,8 @@ import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
 import type { AppState, BinaryFiles, ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 
 export default function CanvasPage() {
-  const params = useParams<{ sessionId: string; '*': string }>()
-  const sessionId = params.sessionId!
+  const params = useParams<{ workspaceId: string; '*': string }>()
+  const workspaceId = params.workspaceId!
   const slug = params['*'] ?? ''
 
   // Read ?fullscreen=1 once as the initial value.
@@ -32,7 +32,7 @@ export default function CanvasPage() {
 
   // apiRef is assigned in handleApiReady, so it is null immediately after mount.
   // onVersionCreated is read through a ref inside the hook, so recreating it on each render is fine.
-  const { onApiReady, onSceneChange, clearLocalUndo, restoreInProgress, restoreLabel } = useWhiteboardSync(sessionId, slug, {
+  const { onApiReady, onSceneChange, clearLocalUndo, restoreInProgress, restoreLabel } = useWhiteboardSync(workspaceId, slug, {
     onVersionCreated: async (v) => {
       // Only generate thumbnails for auto-save. Manual save already uploads one from the header flow.
       if (!v.auto) return
@@ -40,7 +40,7 @@ export default function CanvasPage() {
         const blob = await getThumbnailBlob()
         if (!blob) return
         await apiFetch(
-          `/api/workspaces/${sessionId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`,
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`,
           { method: 'PUT', headers: { 'Content-Type': 'image/png' }, body: blob },
         )
       } catch (err) {
@@ -124,7 +124,7 @@ export default function CanvasPage() {
 
       // 1) Restore server-registered libraries without opening the library panel.
       try {
-        const res = await apiFetch(`/api/workspaces/${sessionId}/libraries`)
+        const res = await apiFetch(`/api/workspaces/${workspaceId}/libraries`)
         if (res.ok) {
           const { urls } = (await res.json()) as { urls: string[] }
           for (const url of getInstalledLibraryUrls(urls)) {
@@ -147,7 +147,7 @@ export default function CanvasPage() {
       if (ok) {
         // Persist the imported library on the workspace.
         try {
-          await apiFetch(`/api/workspaces/${sessionId}/libraries`, {
+          await apiFetch(`/api/workspaces/${workspaceId}/libraries`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ url: libUrl }),
@@ -161,11 +161,11 @@ export default function CanvasPage() {
     return () => {
       cancelled = true
     }
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   useEffect(() => {
     let cancelled = false
-    apiFetch(`/api/workspaces/${sessionId}/canvases`)
+    apiFetch(`/api/workspaces/${workspaceId}/canvases`)
       .then((res) => res.json() as Promise<{ canvases: { slug: string; updatedAt: string }[] }>)
       .then(({ canvases }) => {
         if (cancelled) return
@@ -177,7 +177,7 @@ export default function CanvasPage() {
     return () => {
       cancelled = true
     }
-  }, [sessionId, slug])
+  }, [workspaceId, slug])
 
   // Keyboard shortcut: press "f" to toggle fullscreen, or Escape to exit it.
   // Ignore the shortcut while editing text so typing "f" does not accidentally toggle the canvas.
@@ -205,7 +205,7 @@ export default function CanvasPage() {
       {!isFullscreen && (
         <>
           <WorkspaceTopBar
-            sessionId={sessionId}
+            workspaceId={workspaceId}
             slug={slug}
             canvases={canvases}
             onRestored={clearLocalUndo}
@@ -213,12 +213,12 @@ export default function CanvasPage() {
             getThumbnailBlob={getThumbnailBlob}
           />
           {/* Show the banner only when the current HEAD is not main and still has unmerged commits. */}
-          <HeaderBranchBanner sessionId={sessionId} slug={slug} />
+          <HeaderBranchBanner workspaceId={workspaceId} slug={slug} />
         </>
       )}
       <main className="relative flex-1">
         <Excalidraw
-          key={`${sessionId}/${slug}`}
+          key={`${workspaceId}/${slug}`}
           excalidrawAPI={handleApiReady}
           libraryReturnUrl={typeof window !== 'undefined' ? window.location.origin + window.location.pathname : undefined}
           onChange={(elements: readonly ExcalidrawElement[], _appState: AppState, files: BinaryFiles) =>
@@ -255,10 +255,10 @@ export default function CanvasPage() {
           </div>
         )}
         {/* Overlay that highlights new and conflicting elements for a short time after merge. */}
-        <MergeHighlight sessionId={sessionId} slug={slug} apiRef={apiRef} />
+        <MergeHighlight workspaceId={workspaceId} slug={slug} apiRef={apiRef} />
       </main>
       {/* Merge success toast with undo support, driven by excalidraw:merge_committed events. */}
-      <MergeToast sessionId={sessionId} slug={slug} onRestored={clearLocalUndo} />
+      <MergeToast workspaceId={workspaceId} slug={slug} onRestored={clearLocalUndo} />
     </div>
   )
 }

--- a/packages/mcp-server/src/app/pages/IndexPage.tsx
+++ b/packages/mcp-server/src/app/pages/IndexPage.tsx
@@ -14,13 +14,13 @@ interface RawWorkspace {
   canvases: { slug: string; updatedAt: string }[]
 }
 
-interface SessionNames {
+interface WorkspaceNames {
   workspace?: string
   canvases: Record<string, string>
 }
 
 interface EnrichedWorkspace extends RawWorkspace {
-  names: SessionNames
+  names: WorkspaceNames
 }
 
 function formatRelative(iso: string): string {
@@ -80,8 +80,8 @@ export default function IndexPage() {
             const { canvases } = (await canvasesRes.json()) as {
               canvases: { slug: string; updatedAt: string }[]
             }
-            const names: SessionNames = namesRes.ok
-              ? ((await namesRes.json()) as SessionNames)
+            const names: WorkspaceNames = namesRes.ok
+              ? ((await namesRes.json()) as WorkspaceNames)
               : { canvases: {} }
             return { ...raw, canvases, names }
           }),


### PR DESCRIPTION
## Summary
- Move the `onSceneChange` debounce out of the render path. The hook used to mutate refs and call `cancel()` inline during render, which is unsafe under StrictMode (double-invoke) and Concurrent rendering (rendering can be discarded mid-way).
- Derive the debounced callback via `useMemo([canvasKey])` and cancel the previous one in a `useEffect` cleanup. Swapping canvases still swaps to a fresh 300ms window for the new doc and the old pending timer is canceled deterministically.
- This also fixes a leak that the previous comment acknowledged: pending debounce timers were never canceled on unmount.

## Test plan
- [x] `pnpm test --project mcp-jsdom` (115 passed, +5 new)
- [x] `pnpm test --project mcp-node` (1082 passed)
- [x] `pnpm typecheck`

## Notes
- Removed `onSceneChangeFnRef` and `prevCanvasKeyRef` since `useMemo` now keys identity off `canvasKey` directly.
- Regression test (`useWhiteboardSync.scene-change.test.tsx`) locks: stable identity on same-key re-render (also under `<StrictMode>`), fresh identity on key switch, `vi.getTimerCount()` drops by 1 on key switch and on unmount. The unmount assertion is the one that fails on `main` and passes after the fix.
- The closure still captures `sessionId` / `slug`; if React ever discards the memo, the worst case is a fresh 300ms window — never a write into the wrong doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for whiteboard synchronization lifecycle, validating behavior during scene changes, canvas key updates, debounce timer management, and component unmounting scenarios.

* **Refactor**
  * Enhanced whiteboard synchronization implementation with improved lifecycle management for debounce operations, ensuring proper cleanup when switching canvases or unmounting components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->