### PR TITLE
fix(mcp): bind tool handler return type to outputSchema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,24 @@ If the issue is client-specific:
 - Capture the mismatch between Inspector and the real client before changing server behavior.
 - Keep `docs/mcp-debugging.md` aligned with any new debugging workflow learned during the fix.
 
+## Zod Schema Discipline
+
+Use Zod as the **single source of truth** for every contract that crosses a process boundary (MCP tools, HTTP routes, persisted JSON, daemon registry, websocket messages).
+
+Concrete rules when adding or editing an MCP tool:
+
+- Declare each tool's `outputSchema` (and `inputSchema`) once. Tools are registered through `registerToolWithAnnotations`, which is generic over `O extends z.ZodTypeAny | undefined` and constrains the handler's return to `Promise<ToolHandlerReturn<O>>`. Never widen `outputSchema` to `unknown` or cast around the type binding to silence the compiler.
+- Annotate the matching `tools/*.ts` `execute` return type as `Promise<z.infer<typeof xxxOutputSchema>>` (or import the inferred type from the schema). A separately-written TypeScript interface alongside a Zod schema is the recipe that shipped the `create_frame` `assignedMembers: number` vs `string[]` bug — use `z.infer<>` instead.
+- When you add a new tool, extend `pnpm smoke:e2e` (`scripts/mcp-e2e-checkpoint.mjs`) to call it at least once. The MCP SDK validates `structuredContent` against `outputSchema` at runtime, so the smoke is the last line of defense against drift the type system can't see.
+- When you fix a schema-vs-runtime drift, also commit the test or smoke step that would have caught it. Mutation-check the regression: revert the production fix, confirm `pnpm build` (compile-time guard) **or** `pnpm smoke:e2e` (runtime guard) fails, then restore.
+
+The same discipline applies elsewhere where a schema and a runtime payload travel separately:
+
+- Persisted JSON (`palette`, `manifestJson`, `frontiers`, etc.) → declare a Zod schema next to the parser, hydrate through `schema.parse(...)` instead of casting the JSON.
+- Hono routes whose response shape is consumed by typed clients (`packages/mcp-server/src/app/...`) → declare the response schema once and let both server and client import `z.infer<typeof responseSchema>`.
+
+If a contract is so loose that Zod would always be `z.unknown()` or `z.any()`, mark that intent in a comment so reviewers know it's deliberate, not an oversight.
+
 ## Tmp Workspace Discipline
 
 Store temporary working artifacts under top-level `./tmp/`, grouped by type instead of dropping files in the root of `tmp/`.

--- a/packages/mcp-server/scripts/mcp-e2e-checkpoint.mjs
+++ b/packages/mcp-server/scripts/mcp-e2e-checkpoint.mjs
@@ -152,6 +152,21 @@ async function main() {
   }
   console.log(`[e2e] annotate → rect`)
 
+  // Exercise create_frame so any drift between its zod outputSchema
+  // (assignedMembers etc.) and the runtime payload trips the SDK's structured-
+  // content validator at this layer instead of leaking out to MCP clients.
+  const rectId = ann.elementId ?? ann.elementIds?.[0]
+  if (!rectId) throw new Error('annotate returned no rectangle id to seed create_frame')
+  const frame = await callTool('create_frame', {
+    canvasId: created.id,
+    name: 'e2e-frame',
+    memberIds: [rectId],
+  })
+  if (!frame.elementId || !Array.isArray(frame.assignedMembers)) {
+    throw new Error(`create_frame returned unexpected shape: ${JSON.stringify(frame)}`)
+  }
+  console.log(`[e2e] create_frame → ${frame.elementId} (${frame.assignedMembers.length} members)`)
+
   const insBefore = await callTool('canvas_inspect', { canvasId: created.id })
   if (insBefore.elementCount < 1) throw new Error(`source canvas missing element: ${JSON.stringify(insBefore)}`)
 

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -238,11 +238,7 @@ const boundsSchema = z.object({
 const createFrameOutputSchema = z.object({
   elementId: z.string(),
   bounds: boundsSchema,
-  // tools/frame-embed.ts returns the ids of elements that were enclosed by
-  // the new frame (their frameId now points at it). Declaring this as
-  // z.number() previously turned every successful create_frame call into an
-  // MCP "Output validation error" even though the frame committed cleanly,
-  // so clients on the error path could wrongly retry.
+  // Element ids whose frameId was set to this new frame.
   assignedMembers: z.array(z.string()),
 })
 
@@ -308,12 +304,8 @@ const libraryInsertBatchOutputSchema = z.object({
 const libraryCatalogListOutputSchema = z.object({
   totalCount: z.number(),
   returnedCount: z.number(),
-  // Mirror the upstream CatalogEntry shape from tools/library-catalog.ts: `id`
-  // is optional (some catalog entries omit it), and `authors` is an array of
-  // {name?, url?} objects, not strings. The previous shape said authors:
-  // string[] which silently mismatched the runtime — clients on strict
-  // structuredContent would have hit "Output validation error" the first time
-  // they queried the catalog.
+  // Mirrors the upstream CatalogEntry shape from tools/library-catalog.ts:
+  // `id` may be omitted, and `authors` is an array of {name?, url?} objects.
   items: z.array(
     z.object({
       id: z.string().optional(),
@@ -403,12 +395,10 @@ function structuredJsonResult<T extends object>(result: T) {
   }
 }
 
-// Used by registerToolWithAnnotations to bind the handler's return type to the
-// declared outputSchema. When outputSchema is given, the handler must hand
-// structuredContent whose shape matches z.infer<O>; if it drifts, the call
-// site stops compiling instead of shipping an MCP "Output validation error"
-// to clients (the create_frame `assignedMembers: number` vs `string[]` bug
-// was exactly this gap).
+// Binds a registered tool's handler return shape to its declared outputSchema.
+// When outputSchema is given, the handler must hand structuredContent whose
+// shape matches z.infer<O>; drift becomes a compile error instead of a
+// runtime "Output validation error" reaching MCP clients.
 type ToolHandlerReturn<O extends z.ZodTypeAny | undefined> = O extends z.ZodTypeAny
   ?
       | {

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -308,12 +308,20 @@ const libraryInsertBatchOutputSchema = z.object({
 const libraryCatalogListOutputSchema = z.object({
   totalCount: z.number(),
   returnedCount: z.number(),
+  // Mirror the upstream CatalogEntry shape from tools/library-catalog.ts: `id`
+  // is optional (some catalog entries omit it), and `authors` is an array of
+  // {name?, url?} objects, not strings. The previous shape said authors:
+  // string[] which silently mismatched the runtime — clients on strict
+  // structuredContent would have hit "Output validation error" the first time
+  // they queried the catalog.
   items: z.array(
     z.object({
-      id: z.string(),
+      id: z.string().optional(),
       name: z.string(),
       description: z.string().optional(),
-      authors: z.array(z.string()).optional(),
+      authors: z
+        .array(z.object({ name: z.string().optional(), url: z.string().optional() }))
+        .optional(),
       url: z.string(),
       previewUrl: z.string().optional(),
       created: z.string().optional(),
@@ -394,6 +402,30 @@ function structuredJsonResult<T extends object>(result: T) {
     content: [{ type: 'text' as const, text: JSON.stringify(structuredContent) }],
   }
 }
+
+// Used by registerToolWithAnnotations to bind the handler's return type to the
+// declared outputSchema. When outputSchema is given, the handler must hand
+// structuredContent whose shape matches z.infer<O>; if it drifts, the call
+// site stops compiling instead of shipping an MCP "Output validation error"
+// to clients (the create_frame `assignedMembers: number` vs `string[]` bug
+// was exactly this gap).
+type ToolHandlerReturn<O extends z.ZodTypeAny | undefined> = O extends z.ZodTypeAny
+  ?
+      | {
+          structuredContent: z.infer<O>
+          content: ReadonlyArray<{ type: 'text'; text: string } | Record<string, unknown>>
+          isError?: false
+        }
+      | {
+          isError: true
+          content: ReadonlyArray<{ type: 'text'; text: string } | Record<string, unknown>>
+        }
+  :
+      | {
+          content: ReadonlyArray<{ type: 'text'; text: string } | Record<string, unknown>>
+          structuredContent?: unknown
+          isError?: boolean
+        }
 
 // MCP tool annotations profile.
 // MCP spec: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations
@@ -483,20 +515,21 @@ const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: string 
 // It also converts handler throws into MCP `{ isError: true, content: [...] }`
 // responses. The MCP spec recommends tool errors use isError responses rather
 // than JSON-RPC errors so the LLM can react on the next call.
-function registerToolWithAnnotations<I extends z.ZodRawShape>(
+function registerToolWithAnnotations<
+  I extends z.ZodRawShape,
+  O extends z.ZodTypeAny | undefined = undefined,
+>(
   server: McpServer,
   name: string,
   config: {
     description?: string
     inputSchema?: I
-    // SDK 1.x accepts both ZodObject and ZodRawShape overloads here, so the
-    // wrapper keeps the type broad and lets registerTool validate at runtime.
-    outputSchema?: unknown
+    outputSchema?: O
   },
   handler: (
     args: { [K in keyof I]: z.infer<I[K]> },
     extra: Parameters<Parameters<McpServer['registerTool']>[2]>[1],
-  ) => unknown,
+  ) => Promise<ToolHandlerReturn<O>> | ToolHandlerReturn<O>,
 ): unknown {
   const profile = TOOL_PROFILES[name]
   if (!profile) {

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -238,7 +238,12 @@ const boundsSchema = z.object({
 const createFrameOutputSchema = z.object({
   elementId: z.string(),
   bounds: boundsSchema,
-  assignedMembers: z.number(),
+  // tools/frame-embed.ts returns the ids of elements that were enclosed by
+  // the new frame (their frameId now points at it). Declaring this as
+  // z.number() previously turned every successful create_frame call into an
+  // MCP "Output validation error" even though the frame committed cleanly,
+  // so clients on the error path could wrongly retry.
+  assignedMembers: z.array(z.string()),
 })
 
 const updateFrameMembersOutputSchema = z.object({

--- a/packages/mcp-server/vitest.node.config.ts
+++ b/packages/mcp-server/vitest.node.config.ts
@@ -12,6 +12,12 @@ export default mergeConfig(
         'src/shared/**/*.test.ts',
       ],
       environment: 'node',
+      // Several mcp-node tests stand up a full createApp + MCP client + JSON-RPC
+      // roundtrip in one case, which on slower CI runners flirts with vitest's
+      // 5s default. 10s leaves slack for cold-start migrations + handler dispatch
+      // without masking real hangs.
+      testTimeout: 10_000,
+      hookTimeout: 10_000,
     },
   }),
 )


### PR DESCRIPTION
## Summary

Two related fixes that came out of the PR #35 dogfood pass.

The dogfood found that `create_frame` returned `assignedMembers: string[]` while its zod outputSchema declared `assignedMembers: z.number()`, so every successful call surfaced as an MCP \"Output validation error\" to clients even though the side effect committed cleanly. Patching the one schema is easy. Preventing the next instance of the same bug — schema in `mcp/index.ts` and runtime impl in `tools/*.ts` drifting silently — is the actual fix.

### What changed

- **(A) Compile-time guard**: `registerToolWithAnnotations` is now generic over `O extends z.ZodTypeAny | undefined`, and the handler's return type is constrained to `Promise<ToolHandlerReturn<O>>`. When `outputSchema` is provided, `structuredContent` must match `z.infer<O>` at compile time. Any future drift between schema and runtime stops compiling.
- **(C) Runtime safety net**: `mcp-e2e-checkpoint.mjs` smoke now calls `create_frame` so the SDK's structured-content validator runs on this tool too. The original bug escaped because no smoke exercised it.
- **Drift caught by (A) and fixed**:
  - `create_frame.assignedMembers`: `z.number()` → `z.array(z.string())` (matches the runtime in `tools/frame-embed.ts`).
  - `library_catalog_list`: `id` was `z.string()` but the upstream `CatalogEntry` declares `id?: string`. `authors` was `z.array(z.string()).optional()` but the runtime maps over `Array<{ name?, url? }>`. Loosen + correct both to the actual shape.

### What this prevents going forward

Mutation-verified end-to-end:

- Revert the `assignedMembers` schema and `pnpm build` fails (compile error in `mcp/index.ts`).
- Revert the schema and run `pnpm smoke:e2e` and it now fails with `Invalid input: expected number, received array`. Before this PR the smoke didn't touch `create_frame`, so this class of bug shipped.

A future Step B (registerTool helper that exposes only the constrained API) is no longer needed because `registerToolWithAnnotations` already has the tight types.

## Test plan

- [x] `pnpm test --project mcp-node` (1024 PASS)
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` PASS
- [x] `pnpm --filter @kamiazya/whiteboard-mcp build` PASS
- [x] `pnpm --filter @kamiazya/whiteboard-mcp smoke:e2e` PASS (now exercises create_frame)
- [x] Mutation: revert each schema/run-time pair → exactly one of build/smoke fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)