### PR TITLE
fix(mcp): default box_with_label fillStyle to solid when backgroundColor is themed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,25 @@ Workflow:
 
 Skip this rule for changes that are invisible to humans — purely backend, schema, internal helper, etc. — but lean toward attaching when in doubt; even a `pnpm test` output paste counts as visual evidence for `mcp-browser` regressions.
 
+## Source Comment Discipline
+
+Code lives a long time; comments live with the code. Only write comments that will still be useful five PRs from now.
+
+Keep:
+
+- The non-obvious **why** (a hidden constraint, an invariant, a workaround for a specific upstream bug, behavior that would surprise a reader).
+- A pointer to a durable spec, RFC, or vendor doc when behavior follows it.
+
+Drop:
+
+- References to the PR / issue / dogfood pass that introduced or surfaced the change ("Surfaced during PR #35 dogfood", "see tmp/issues/...md item #N", "the create_frame bug...").
+- Pointers to `tmp/notes/`, `tmp/issues/`, or `tmp/screenshots/` files. The `tmp/` directory is short-lived and the linked file may already be gone.
+- Personal narrative ("we found this when...") and TODO-style chronology.
+
+Process context belongs in the commit message, the PR body, and `git log`/`git blame`. The source file is for the long-term reader who has neither.
+
+If a comment looks valuable when written but you'd be embarrassed to read it three years from now, rewrite it as an enduring rationale or delete it.
+
 ## Avoid
 
 - Do not implement first and add tests later.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,24 @@ pnpm build
 - This matters because release-please reads the merged commit history to decide version bumps and changelog entries.
 - Release Please PRs are also valid under the same rule, for example `chore(main): release vX.Y.Z` and `chore(main): release mcp-server vX.Y.Z`.
 
+## PR Visual Evidence
+
+When the change has a user-visible effect (canvas rendering, UI surface, MCP tool result that depends on state), attach the verification screenshot to the PR body. Reviewers should be able to see the bug and the fix without having to clone and reproduce.
+
+Workflow:
+
+1. Capture screenshots while doing the manual verification step from the workflow above. Save them under `tmp/screenshots/` per the tmp-workspace rule.
+2. Upload the captured screenshots to GitHub via the `gh image` extension (`drogers0/gh-image`):
+   ```
+   gh extension install drogers0/gh-image  # one-time setup
+   gh image tmp/screenshots/before.png tmp/screenshots/after.png
+   ```
+   This prints `![file.png](https://github.com/user-attachments/...)` lines.
+3. Paste the markdown into the PR body under a `## Visual repro` (or similarly named) section. Show before/after when the change is a fix; show one annotated capture when adding a new affordance.
+4. Keep the actual screenshot file in `tmp/screenshots/` until the PR merges; remove it afterward to keep the dir lean (the GitHub upload is the durable copy).
+
+Skip this rule for changes that are invisible to humans — purely backend, schema, internal helper, etc. — but lean toward attaching when in doubt; even a `pnpm test` output paste counts as visual evidence for `mcp-browser` regressions.
+
 ## Avoid
 
 - Do not implement first and add tests later.

--- a/packages/mcp-server/src/server/mcp/tools/box-with-label.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/box-with-label.test.ts
@@ -567,3 +567,45 @@ describe('decomposeBoxWithLabel', () => {
     })
   })
 })
+
+describe('decomposeBoxWithLabel - fillStyle defaults', () => {
+  it('leaves fillStyle undefined when no backgroundColor is set so the rectangle keeps the Excalidraw hand-drawn default', () => {
+    const [rect] = decomposeBoxWithLabel({
+      target: { x: 0, y: 0 },
+      width: 200,
+      height: 80,
+      text: 'hello',
+    })
+    expect(rect.backgroundColor).toBeUndefined()
+    expect(rect.fillStyle).toBeUndefined()
+  })
+
+  it('defaults fillStyle to "solid" when backgroundColor is themed so light text on a colored bg stays legible', () => {
+    // Without this default the box renders with diagonal hachure lines on top
+    // of the colored bg; pairing with an inverted text color (white-on-blue,
+    // for example) makes the label nearly invisible. Surfaced during dogfood
+    // of PR #35 — see tmp/issues/2026-04-26-mcp-dogfood-findings.md item #7.
+    const [rect] = decomposeBoxWithLabel({
+      target: { x: 0, y: 0 },
+      width: 200,
+      height: 80,
+      title: 'Client',
+      text: 'Browser / Mobile',
+      backgroundColor: '#1e88e5',
+      color: '#ffffff',
+    })
+    expect(rect.fillStyle).toBe('solid')
+  })
+
+  it('preserves an explicit fillStyle even when backgroundColor is set', () => {
+    const [rect] = decomposeBoxWithLabel({
+      target: { x: 0, y: 0 },
+      width: 200,
+      height: 80,
+      text: 'hello',
+      backgroundColor: '#1e88e5',
+      fillStyle: 'cross-hatch',
+    })
+    expect(rect.fillStyle).toBe('cross-hatch')
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/box-with-label.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/box-with-label.test.ts
@@ -581,10 +581,6 @@ describe('decomposeBoxWithLabel - fillStyle defaults', () => {
   })
 
   it('defaults fillStyle to "solid" when backgroundColor is themed so light text on a colored bg stays legible', () => {
-    // Without this default the box renders with diagonal hachure lines on top
-    // of the colored bg; pairing with an inverted text color (white-on-blue,
-    // for example) makes the label nearly invisible. Surfaced during dogfood
-    // of PR #35 — see tmp/issues/2026-04-26-mcp-dogfood-findings.md item #7.
     const [rect] = decomposeBoxWithLabel({
       target: { x: 0, y: 0 },
       width: 200,

--- a/packages/mcp-server/src/server/mcp/tools/box-with-label.ts
+++ b/packages/mcp-server/src/server/mcp/tools/box-with-label.ts
@@ -141,13 +141,9 @@ export function decomposeBoxWithLabel(
     ? Math.max(input.height, neededTotalHeight)
     : input.height
 
-  // Excalidraw's default fill is "hachure" (diagonal lines on a transparent
-  // base). That looks great on the empty-canvas aesthetic, but once a caller
-  // sets `backgroundColor` they almost always want the body to be readable —
-  // hachure leaves big white gaps that swallow light-on-color labels (the
-  // dogfood found this with `color: '#ffffff'` on a palette-tinted bg).
-  // Default to solid when a background is explicitly themed; preserve any
-  // explicit caller override.
+  // Default fillStyle to solid when backgroundColor is explicit. Excalidraw's
+  // hachure default leaves white gaps that swallow light text on a colored
+  // bg; an explicit fillStyle from the caller still wins.
   const rect: RectSpec = {
     type: 'rectangle',
     target: input.target,

--- a/packages/mcp-server/src/server/mcp/tools/box-with-label.ts
+++ b/packages/mcp-server/src/server/mcp/tools/box-with-label.ts
@@ -141,6 +141,13 @@ export function decomposeBoxWithLabel(
     ? Math.max(input.height, neededTotalHeight)
     : input.height
 
+  // Excalidraw's default fill is "hachure" (diagonal lines on a transparent
+  // base). That looks great on the empty-canvas aesthetic, but once a caller
+  // sets `backgroundColor` they almost always want the body to be readable —
+  // hachure leaves big white gaps that swallow light-on-color labels (the
+  // dogfood found this with `color: '#ffffff'` on a palette-tinted bg).
+  // Default to solid when a background is explicitly themed; preserve any
+  // explicit caller override.
   const rect: RectSpec = {
     type: 'rectangle',
     target: input.target,
@@ -148,7 +155,7 @@ export function decomposeBoxWithLabel(
     height: effectiveHeight,
     color: input.color,
     backgroundColor: input.backgroundColor,
-    fillStyle: input.fillStyle,
+    fillStyle: input.fillStyle ?? (input.backgroundColor ? 'solid' : undefined),
     strokeWidth: input.strokeWidth,
     templateInstanceId: input.templateInstanceId,
   }


### PR DESCRIPTION
## Summary

Excalidraw's default fill is hachure (diagonal lines on a transparent base). When a caller passes `backgroundColor` (e.g. via the workspace palette) plus a contrasting `color` like `#ffffff`, the diagonal-on-transparent fill leaves big white gaps in the rectangle and the white label sitting on top renders as practically invisible.

## Visual repro

Before (hachure default with `backgroundColor: 'role.client'` + `color: '#ffffff'`) — labels swallowed by the white gaps:

![before](https://github.com/user-attachments/assets/3677d57e-5387-48e5-831a-b8e980e44680)

After this PR (now defaults to `solid` automatically when a background is themed, no caller change needed):

![after](https://github.com/user-attachments/assets/d0265331-d954-40c7-bf2c-3b5df8585456)

## What changes

In `box-with-label.ts`, when no `fillStyle` is provided AND `backgroundColor` is set, default to `solid`. Three behavior branches:

| caller backgroundColor | caller fillStyle | result |
|---|---|---|
| not set | not set | unchanged — Excalidraw renders the hand-drawn hachure default |
| set | not set | now `solid` — themed cards render legibly |
| set | explicit (e.g. `cross-hatch`) | unchanged — caller override wins |

Surfaced during the PR #35 dogfood pass — see `tmp/issues/2026-04-26-mcp-dogfood-findings.md` item #7.

## Test plan

- [x] Three regression tests in `box-with-label.test.ts` covering the three branches.
- [x] Mutation: dropping the new `?? (backgroundColor ? 'solid' : undefined)` fallback makes exactly the second test fail.
- [x] `pnpm test` (1027 PASS), `pnpm typecheck`, `pnpm build`, `pnpm smoke:e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)