### PR TITLE
fix(mcp): close PR #45 review follow-ups (6 issues)

### DIFF
--- a/packages/mcp-server/scripts/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/mcp-e2e-smoke.mjs
@@ -183,8 +183,13 @@ async function main() {
     const r = await callTool('annotate', {
       canvasId: created.id,
       type: 'rectangle',
-      target: { x: 200 + i * 50, y: 200 + i * 30, width: 60, height: 40 },
+      // target's Zod schema is { x, y } — Zod v4 strips unknown keys, so
+      // width/height nested inside target would be silently discarded.
+      // Hoist them to the top-level annotate parameters.
+      target: { x: 200 + i * 50, y: 200 + i * 30 },
       coords: 'absolute',
+      width: 60,
+      height: 40,
       color: '#1971c2',
     })
     const id = r.elementId ?? r.elementIds?.[0]

--- a/packages/mcp-server/scripts/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/mcp-e2e-smoke.mjs
@@ -175,6 +175,40 @@ async function main() {
   }
   console.log(`[e2e] create_frame → ${frame.elementId} (${frame.assignedMembers.length} members)`)
 
+  // Exercise align_elements / distribute_elements so any drift between
+  // their Zod input schema and the registered tool surface trips the SDK
+  // structured-content validator here instead of in production.
+  const layoutIds = []
+  for (let i = 0; i < 3; i++) {
+    const r = await callTool('annotate', {
+      canvasId: created.id,
+      type: 'rectangle',
+      target: { x: 200 + i * 50, y: 200 + i * 30, width: 60, height: 40 },
+      coords: 'absolute',
+      color: '#1971c2',
+    })
+    const id = r.elementId ?? r.elementIds?.[0]
+    if (!id) throw new Error(`layout annotate ${i} returned no id`)
+    layoutIds.push(id)
+  }
+  const aligned = await callTool('align_elements', {
+    canvasId: created.id,
+    elementIds: layoutIds,
+    alignment: 'left',
+  })
+  if (aligned.alignment !== 'left' || aligned.elementIds.length !== 3) {
+    throw new Error(`align_elements returned unexpected shape: ${JSON.stringify(aligned)}`)
+  }
+  const distributed = await callTool('distribute_elements', {
+    canvasId: created.id,
+    elementIds: layoutIds,
+    direction: 'horizontal',
+  })
+  if (distributed.direction !== 'horizontal' || distributed.elementIds.length !== 3) {
+    throw new Error(`distribute_elements returned unexpected shape: ${JSON.stringify(distributed)}`)
+  }
+  console.log('[e2e] align_elements / distribute_elements → OK')
+
   const insBefore = await callTool('canvas_inspect', { canvasId: created.id })
   if (insBefore.elementCount < 1) throw new Error(`source canvas missing element: ${JSON.stringify(insBefore)}`)
 

--- a/packages/mcp-server/src/app/pages/IndexPage.browser.test.tsx
+++ b/packages/mcp-server/src/app/pages/IndexPage.browser.test.tsx
@@ -92,6 +92,17 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   cleanup()
+  // The "reuses the freshly-minted workspace id" case writes
+  // whiteboard.indexPage.primaryWorkspaceId; clear it here so later
+  // browser tests in the same suite do not silently rehydrate from a
+  // previous case's stash.
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem('whiteboard.indexPage.primaryWorkspaceId')
+    } catch {
+      // Defensive — some envs may disallow storage access.
+    }
+  }
 })
 
 describe('IndexPage browser mode', () => {

--- a/packages/mcp-server/src/app/pages/IndexPage.browser.test.tsx
+++ b/packages/mcp-server/src/app/pages/IndexPage.browser.test.tsx
@@ -347,6 +347,120 @@ describe('IndexPage browser mode', () => {
     })
   })
 
+  it('reuses the freshly-minted workspace id across sequential creates when no workspaces exist yet', async () => {
+    // Cold-start flow: GET /api/workspaces returns []. The first New
+    // canvas mints a workspace id; the second click MUST land in the same
+    // workspace, otherwise every successive canvas spawns its own
+    // throwaway workspace and the user can never group them together
+    // until a page reload.
+    const postedWorkspaceIds: string[] = []
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (init?.method === 'POST' && url.startsWith('/api/workspaces/') && url.endsWith('/canvases')) {
+        const wid = url.split('/')[3]
+        postedWorkspaceIds.push(wid)
+        return Promise.resolve(jsonResponse({ slug: 'first' }))
+      }
+      if (url === '/api/workspaces') {
+        // No pre-existing workspaces — the dialog has to mint one.
+        return Promise.resolve(jsonResponse({ workspaces: [] }))
+      }
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(
+          jsonResponse({
+            totalBytes: 0,
+            fileCount: 0,
+            byCategory: {
+              blobs: { bytes: 0, files: 0 },
+              versions: { bytes: 0, files: 0 },
+              files: { bytes: 0, files: 0 },
+              libraries: { bytes: 0, files: 0 },
+              db: { bytes: 0, files: 0 },
+              other: { bytes: 0, files: 0 },
+            },
+          }),
+        )
+      }
+      if (url.endsWith('/canvases')) return Promise.resolve(jsonResponse({ canvases: [] }))
+      if (url.endsWith('/names')) return Promise.resolve(jsonResponse({ canvases: {}, pinned: [] }))
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    // Clean slate so the test does not pick up another test's stash.
+    if (typeof window !== 'undefined') window.localStorage.clear()
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<IndexPage />} />
+          {/* Stub destination so the post-create navigate has somewhere to go. */}
+          <Route path="/canvas/:wid/*" element={<div data-testid="canvas-page" />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await expect.element(page.getByRole('heading', { name: /Whiteboard/i })).toBeInTheDocument()
+
+    // First create: empty workspaces list, dialog mints a fresh id.
+    const trigger = await page.getByRole('button', { name: /new canvas/i }).element()
+    ;(trigger as HTMLButtonElement).click()
+    const inputEl = (await waitFor(() => {
+      const el = document.getElementById('new-canvas-slug') as HTMLInputElement | null
+      if (!el) throw new Error('slug input not yet mounted')
+      return el
+    })) as HTMLInputElement
+    fireEvent.change(inputEl, { target: { value: 'first' } })
+    const submit = await page.getByRole('button', { name: /^create$/i }).element()
+    fireEvent.submit(submit.closest('form')!)
+
+    await waitFor(() => {
+      expect(postedWorkspaceIds).toHaveLength(1)
+    })
+    const firstWs = postedWorkspaceIds[0]
+    expect(firstWs).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(firstWs.length).toBeGreaterThan(0)
+
+    // The whole point of the regression: the minted id must be persisted
+    // somewhere durable (localStorage) so the next IndexPage mount
+    // reuses it. Without this, every cold-start create spawns a fresh
+    // workspace and orphans the previous canvas.
+    expect(window.localStorage.getItem('whiteboard.indexPage.primaryWorkspaceId')).toBe(firstWs)
+
+    // And the bug-mirror: a fresh IndexPage mount (the user navigates back
+    // to `/` after seeing their new canvas) reads the id from
+    // localStorage and uses it as `workspaceId`. Verify by remounting
+    // and asserting the next POST goes to the same workspace id.
+    cleanup()
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<IndexPage />} />
+          <Route path="/canvas/:wid/*" element={<div data-testid="canvas-page" />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await expect.element(page.getByRole('heading', { name: /Whiteboard/i })).toBeInTheDocument()
+    const trigger2 = await page.getByRole('button', { name: /new canvas/i }).element()
+    ;(trigger2 as HTMLButtonElement).click()
+    const inputEl2 = (await waitFor(() => {
+      const el = document.getElementById('new-canvas-slug') as HTMLInputElement | null
+      if (!el) throw new Error('slug input not yet mounted (second mount)')
+      return el
+    })) as HTMLInputElement
+    fireEvent.change(inputEl2, { target: { value: 'second' } })
+    const submit2 = await page.getByRole('button', { name: /^create$/i }).element()
+    fireEvent.submit(submit2.closest('form')!)
+
+    await waitFor(() => {
+      expect(postedWorkspaceIds).toHaveLength(2)
+    })
+    expect(postedWorkspaceIds[1]).toBe(firstWs)
+  })
+
   it('exposes Optimize on each canvas card kebab and POSTs to the compact endpoint', async () => {
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/mcp-server/src/app/pages/IndexPage.tsx
+++ b/packages/mcp-server/src/app/pages/IndexPage.tsx
@@ -73,6 +73,12 @@ interface FlatCanvas {
 
 type TabKey = 'canvases' | 'storage'
 
+// localStorage key for the implicit primary workspace id. Survives
+// remount so a freshly-minted workspace is reused across the
+// post-create navigate → user-comes-back flow instead of being
+// re-minted on every open.
+const PRIMARY_WORKSPACE_KEY = 'whiteboard.indexPage.primaryWorkspaceId'
+
 function readTabFromHash(): TabKey {
   if (typeof window === 'undefined') return 'canvases'
   const h = window.location.hash.replace(/^#/, '')
@@ -125,7 +131,30 @@ export default function IndexPage() {
   // The first workspace from /api/workspaces is the implicit "current"
   // workspace for new-canvas creation. Workspace identity stays internal —
   // the user never names it — but creates need *some* target id.
-  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(null)
+  //
+  // Persist the chosen id in localStorage so a freshly-minted workspace
+  // (no pre-existing /api/workspaces entry) is still reused on the next
+  // create after the user navigates between pages. Without this every
+  // sequential create from a cold-start install would mint its own
+  // throwaway workspace.
+  const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
+    try {
+      return window.localStorage.getItem(PRIMARY_WORKSPACE_KEY)
+    } catch {
+      return null
+    }
+  })
+  const rememberPrimaryWorkspace = useCallback((id: string) => {
+    setPrimaryWorkspaceId(id)
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(PRIMARY_WORKSPACE_KEY, id)
+    } catch {
+      // Storage failures are not user-facing — falling back to in-memory
+      // state is still better than minting a new workspace per click.
+    }
+  }, [])
   // Theme toggle lives in the IndexPage header so users do not have to open a
   // canvas to flip light/dark/system.
   const { theme, setTheme } = useThemeMode()
@@ -151,7 +180,10 @@ export default function IndexPage() {
       try {
         const res = await apiFetch('/api/workspaces')
         const workspaces = listWorkspacesResponseSchema.parse(await res.json()).workspaces
-        setPrimaryWorkspaceId(workspaces[0]?.workspaceId ?? null)
+        // Prefer the server's first workspace when present; otherwise leave
+        // whatever was rehydrated from localStorage in place so a minted
+        // id from an earlier session survives until the server catches up.
+        if (workspaces[0]?.workspaceId) rememberPrimaryWorkspace(workspaces[0].workspaceId)
         const perWorkspace = await Promise.all(
           workspaces.map(async (ws: RawWorkspace): Promise<FlatCanvas[]> => {
             const id = ws.workspaceId
@@ -343,7 +375,14 @@ export default function IndexPage() {
         open={createOpen}
         onOpenChange={setCreateOpen}
         workspaceId={primaryWorkspaceId}
-        onCreated={navigate}
+        onCreated={(targetWs, path) => {
+          // Capture the (possibly freshly-minted) workspace id back into
+          // shared state + localStorage so a second create from the same
+          // session reuses it. Without this, every cold-start create
+          // spawns its own throwaway workspace.
+          rememberPrimaryWorkspace(targetWs)
+          navigate(path)
+        }}
       />
     </div>
   )
@@ -539,7 +578,9 @@ function NewCanvasDialog({
   open: boolean
   onOpenChange: (next: boolean) => void
   workspaceId: string | null
-  onCreated: (path: string) => void
+  // Receives both the (possibly freshly-minted) workspace id and the
+  // canvas path so the parent can persist the id and run the navigate.
+  onCreated: (workspaceId: string, path: string) => void
 }) {
   const [slug, setSlug] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -572,7 +613,7 @@ function NewCanvasDialog({
         }
         onOpenChange(false)
         setSlug('')
-        onCreated(`/canvas/${targetWs}/${encodeURIComponent(value)}`)
+        onCreated(targetWs, `/canvas/${targetWs}/${encodeURIComponent(value)}`)
       } catch (err) {
         setErrorMsg(String(err))
       } finally {

--- a/packages/mcp-server/src/app/pages/IndexPage.tsx
+++ b/packages/mcp-server/src/app/pages/IndexPage.tsx
@@ -79,6 +79,13 @@ type TabKey = 'canvases' | 'storage'
 // re-minted on every open.
 const PRIMARY_WORKSPACE_KEY = 'whiteboard.indexPage.primaryWorkspaceId'
 
+// localStorage is shared across pages and writable from the dev
+// console, so the read-back value cannot be trusted blindly. Mirrors
+// the server-side `validateWorkspaceId` shape so an attacker-supplied
+// stash containing path separators can NOT flow into the create POST
+// URL or the post-create navigate.
+const WORKSPACE_ID_RE = /^[A-Za-z0-9_-]+$/
+
 function readTabFromHash(): TabKey {
   if (typeof window === 'undefined') return 'canvases'
   const h = window.location.hash.replace(/^#/, '')
@@ -140,12 +147,14 @@ export default function IndexPage() {
   const [primaryWorkspaceId, setPrimaryWorkspaceId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null
     try {
-      return window.localStorage.getItem(PRIMARY_WORKSPACE_KEY)
+      const stored = window.localStorage.getItem(PRIMARY_WORKSPACE_KEY)
+      return stored && WORKSPACE_ID_RE.test(stored) ? stored : null
     } catch {
       return null
     }
   })
   const rememberPrimaryWorkspace = useCallback((id: string) => {
+    if (!WORKSPACE_ID_RE.test(id)) return
     setPrimaryWorkspaceId(id)
     if (typeof window === 'undefined') return
     try {

--- a/packages/mcp-server/src/server/export/headless-export.test.ts
+++ b/packages/mcp-server/src/server/export/headless-export.test.ts
@@ -103,7 +103,6 @@ describe('exportCanvasHeadless minFontPx', () => {
     await exportCanvasHeadless({
       workspaceId: 'ws_a',
       slug: 'design',
-      dataDir: tempDir,
       options: { minFontPx: 14 },
     })
 
@@ -136,7 +135,6 @@ describe('exportCanvasHeadless minFontPx', () => {
     const result = await exportCanvasHeadless({
       workspaceId: 'ws_c',
       slug: 'design',
-      dataDir: tempDir,
     })
 
     const text = findTextChunk(result.png)
@@ -167,7 +165,6 @@ describe('exportCanvasHeadless minFontPx', () => {
     await exportCanvasHeadless({
       workspaceId: 'ws_b',
       slug: 'design',
-      dataDir: tempDir,
     })
 
     const scene = renderSpy.mock.calls[0][0] as {

--- a/packages/mcp-server/src/server/export/headless-export.ts
+++ b/packages/mcp-server/src/server/export/headless-export.ts
@@ -1,6 +1,12 @@
 // High-level headless export: take a canvas {workspaceId, slug} and produce a
 // PNG buffer using the browser-less renderer. Used by routes/export.ts as a
 // fallback when no browser client is connected.
+//
+// Reads the data root from the daemon's configured DATA_DIR rather than
+// taking it as a per-call argument. Mixing roots within one export was
+// previously possible because the doc cache reads from DATA_DIR while the
+// file loader took an explicit dataDir; tying both ends to the same
+// canonical path closes that mismatch.
 
 import { applyMinFontPx } from '../../shared/min-font-px.js'
 import { embedExcalidrawScene } from '../../shared/png-embed-scene.js'
@@ -24,7 +30,6 @@ export interface HeadlessCanvasExportOptions {
 export async function exportCanvasHeadless(args: {
   workspaceId: string
   slug: string
-  dataDir: string
   options?: HeadlessCanvasExportOptions
 }): Promise<HeadlessExportResult> {
   const doc = await getDoc(args.workspaceId, args.slug)
@@ -36,7 +41,7 @@ export async function exportCanvasHeadless(args: {
   ) as unknown as Array<Record<string, unknown> & { id: string; type: string; isDeleted?: boolean }>
   const liveElements = elements.filter((e) => e.isDeleted !== true)
   const sizedElements = applyMinFontPx(liveElements, args.options?.minFontPx)
-  const files = await loadCanvasFiles(args.dataDir, args.workspaceId)
+  const files = await loadCanvasFiles(args.workspaceId)
 
   const scene = {
     type: 'excalidraw' as const,

--- a/packages/mcp-server/src/server/export/headless-export.ts
+++ b/packages/mcp-server/src/server/export/headless-export.ts
@@ -41,7 +41,17 @@ export async function exportCanvasHeadless(args: {
   ) as unknown as Array<Record<string, unknown> & { id: string; type: string; isDeleted?: boolean }>
   const liveElements = elements.filter((e) => e.isDeleted !== true)
   const sizedElements = applyMinFontPx(liveElements, args.options?.minFontPx)
-  const files = await loadCanvasFiles(args.workspaceId)
+  // Pick the fileIds the canvas actually references so the file loader
+  // does NOT touch attachments owned by other canvases in the same
+  // workspace. Skipping deleted elements means a tombstoned image
+  // does not pin the underlying blob into the export payload.
+  const referencedFileIds = new Set<string>()
+  for (const el of liveElements) {
+    if (el.type !== 'image') continue
+    const fileId = el.fileId
+    if (typeof fileId === 'string' && fileId.length > 0) referencedFileIds.add(fileId)
+  }
+  const files = await loadCanvasFiles(args.workspaceId, referencedFileIds)
 
   const scene = {
     type: 'excalidraw' as const,

--- a/packages/mcp-server/src/server/export/load-canvas-files.test.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.test.ts
@@ -32,7 +32,10 @@ afterEach(async () => {
 
 describe('loadCanvasFiles selective loading', () => {
   it('returns an empty map when the workspace has no files dir yet', async () => {
-    const out = await loadCanvasFiles('ws_empty', new Set())
+    // Pass a non-empty set so the function does NOT short-circuit at
+    // `referencedFileIds.size === 0` — that lets the test actually
+    // exercise the stat(dir) → ENOENT fallback branch.
+    const out = await loadCanvasFiles('ws_empty', new Set(['missing-file']))
     expect(out).toEqual({})
   })
 
@@ -50,6 +53,17 @@ describe('loadCanvasFiles selective loading', () => {
     expect(out['used-2'].mimeType).toBe('image/jpeg')
     // The unrelated file must be entirely absent from the result.
     expect(out['unrelated']).toBeUndefined()
+  })
+
+  it('treats a non-directory at <ws>/files as gracefully as a missing dir', async () => {
+    // Plant a regular file where the workspace's files DIRECTORY is
+    // expected. Without the isDirectory() guard the loader stat()s
+    // through and then the per-id readFile() raises ENOTDIR; the
+    // graceful fallback is the empty result.
+    await mkdir(join(tempDir, 'ws_notdir'), { recursive: true })
+    await writeFile(join(tempDir, 'ws_notdir', 'files'), Buffer.alloc(4, 0xff))
+    const out = await loadCanvasFiles('ws_notdir', new Set(['anything']))
+    expect(out).toEqual({})
   })
 
   it('returns {} when the referenced set is empty even if files exist on disk', async () => {

--- a/packages/mcp-server/src/server/export/load-canvas-files.test.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.test.ts
@@ -70,6 +70,42 @@ describe('loadCanvasFiles selective loading', () => {
     expect(Object.keys(out)).toEqual(['real'])
   })
 
+  it('refuses to read files whose id contains path separators (no traversal)', async () => {
+    // The fileId travels through Excalidraw element data, which can be
+    // mutated by any tool (annotate / update_element) or a malicious
+    // canvas import. A traversal id like `../../secrets/hostkey` must
+    // NOT resolve to a path outside the workspace's files dir, even
+    // when such a file exists on disk with a known extension. Plant
+    // a "secret" file at the resolved-traversal location so a regression
+    // would be observable as actual file leakage.
+    const outsideRoot = join(tempDir, 'secrets')
+    await mkdir(outsideRoot, { recursive: true })
+    await writeFile(join(outsideRoot, 'hostkey.png'), Buffer.from('SECRET'))
+    // The workspace's files dir must exist so the function does not
+    // short-circuit on the stat() probe before reaching the per-id loop.
+    await mkdir(join(tempDir, 'ws_evil', 'files'), { recursive: true })
+
+    const out = await loadCanvasFiles(
+      'ws_evil',
+      new Set(['../../secrets/hostkey']),
+    )
+    // The traversal id must be silently dropped — never returned, never
+    // base64 in the response, never read from disk.
+    expect(out).toEqual({})
+  })
+
+  it('refuses absolute fileIds (no escape via leading /)', async () => {
+    await mkdir(tempDir, { recursive: true })
+    await writeFile(join(tempDir, 'absolute-leak.png'), Buffer.from('SECRET'))
+    await mkdir(join(tempDir, 'ws_evil', 'files'), { recursive: true })
+
+    const out = await loadCanvasFiles(
+      'ws_evil',
+      new Set([join(tempDir, 'absolute-leak')]),
+    )
+    expect(out).toEqual({})
+  })
+
   it('honours every supported MIME extension from the lookup table', async () => {
     await seedFile('ws_mime', 'a', '.png', 1)
     await seedFile('ws_mime', 'b', '.jpg', 1)

--- a/packages/mcp-server/src/server/export/load-canvas-files.test.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let tempDir: string
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+  DIST_APP_DIR: '/tmp/whiteboard/dist/app',
+}))
+
+const { loadCanvasFiles } = await import('./load-canvas-files.js')
+
+async function seedFile(workspaceId: string, fileId: string, ext: string, bytes: number): Promise<void> {
+  const dir = join(tempDir, workspaceId, 'files')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, `${fileId}${ext}`), Buffer.alloc(bytes, 0xab))
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'load-canvas-files-test-'))
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('loadCanvasFiles selective loading', () => {
+  it('returns an empty map when the workspace has no files dir yet', async () => {
+    const out = await loadCanvasFiles('ws_empty', new Set())
+    expect(out).toEqual({})
+  })
+
+  it('only loads files whose id appears in the referenced-id set', async () => {
+    // Three files exist; only two are referenced by the canvas being
+    // exported. The third is a leftover from another canvas in the same
+    // workspace and must NOT inflate the export payload.
+    await seedFile('ws_a', 'used-1', '.png', 100)
+    await seedFile('ws_a', 'used-2', '.jpg', 200)
+    await seedFile('ws_a', 'unrelated', '.png', 999)
+
+    const out = await loadCanvasFiles('ws_a', new Set(['used-1', 'used-2']))
+    expect(Object.keys(out).sort()).toEqual(['used-1', 'used-2'])
+    expect(out['used-1'].mimeType).toBe('image/png')
+    expect(out['used-2'].mimeType).toBe('image/jpeg')
+    // The unrelated file must be entirely absent from the result.
+    expect(out['unrelated']).toBeUndefined()
+  })
+
+  it('returns {} when the referenced set is empty even if files exist on disk', async () => {
+    await seedFile('ws_b', 'orphan', '.png', 50)
+    const out = await loadCanvasFiles('ws_b', new Set())
+    expect(out).toEqual({})
+  })
+
+  it('skips a referenced file that vanished between scan and read instead of failing the export', async () => {
+    // Reference an id that is not on disk — simulates the GC race where a
+    // file is deleted between elements computing the set and readFile()
+    // being called. Old behaviour walked the whole directory and would
+    // throw ENOENT only if the entry it had already enumerated vanished;
+    // the new selective path checks for ENOENT explicitly so the entire
+    // export does not abort on one missing attachment.
+    await seedFile('ws_c', 'real', '.png', 50)
+    const out = await loadCanvasFiles('ws_c', new Set(['real', 'phantom']))
+    expect(Object.keys(out)).toEqual(['real'])
+  })
+
+  it('honours every supported MIME extension from the lookup table', async () => {
+    await seedFile('ws_mime', 'a', '.png', 1)
+    await seedFile('ws_mime', 'b', '.jpg', 1)
+    await seedFile('ws_mime', 'c', '.jpeg', 1)
+    await seedFile('ws_mime', 'd', '.gif', 1)
+    await seedFile('ws_mime', 'e', '.webp', 1)
+    await seedFile('ws_mime', 'f', '.svg', 1)
+
+    const out = await loadCanvasFiles(
+      'ws_mime',
+      new Set(['a', 'b', 'c', 'd', 'e', 'f']),
+    )
+    expect(out['a'].mimeType).toBe('image/png')
+    expect(out['b'].mimeType).toBe('image/jpeg')
+    expect(out['c'].mimeType).toBe('image/jpeg')
+    expect(out['d'].mimeType).toBe('image/gif')
+    expect(out['e'].mimeType).toBe('image/webp')
+    expect(out['f'].mimeType).toBe('image/svg+xml')
+  })
+})

--- a/packages/mcp-server/src/server/export/load-canvas-files.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.ts
@@ -56,8 +56,12 @@ export async function loadCanvasFiles(
   const dir = join(DATA_DIR, workspaceId, 'files')
   // Probe the directory once so a freshly-created workspace doesn't pay
   // for one stat() per referenced id when nothing is on disk yet.
+  // Treat a non-directory at this path the same as a missing dir:
+  // otherwise readFile(join(dir, ...)) below would surface ENOTDIR
+  // instead of the graceful empty-result fallback.
   try {
-    await stat(dir)
+    const dirStat = await stat(dir)
+    if (!dirStat.isDirectory()) return {}
   } catch (err) {
     if (isMissingFileError(err)) return {}
     throw err

--- a/packages/mcp-server/src/server/export/load-canvas-files.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.ts
@@ -13,9 +13,22 @@
 // for unrelated entries.
 
 import { readFile, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { DATA_DIR } from '../config.js'
 import { isMissingFileError } from '../store/corrupt-stored-data.js'
+
+// `fileId` rides through Excalidraw element data, which any tool
+// (annotate, update_element) or a malicious canvas import can mutate.
+// Path separators / parent-directory escapes / NUL bytes have no
+// legitimate use and would resolve outside the workspace files dir, so
+// drop them before constructing any path.
+function isSafeFileId(id: string): boolean {
+  if (id.length === 0 || id.length > 256) return false
+  if (id.includes('/') || id.includes('\\')) return false
+  if (id.includes('\0')) return false
+  if (id === '.' || id === '..') return false
+  return true
+}
 
 const EXT_TO_MIME: Record<string, string> = {
   '.png': 'image/png',
@@ -51,10 +64,16 @@ export async function loadCanvasFiles(
   }
 
   const out: Record<string, CanvasFile> = {}
+  const resolvedDir = resolve(dir)
   for (const fileId of referencedFileIds) {
+    if (!isSafeFileId(fileId)) continue
     for (const ext of KNOWN_EXTS) {
       const mime = EXT_TO_MIME[ext] as string
       const path = join(dir, `${fileId}${ext}`)
+      // Belt + suspenders: even if isSafeFileId regresses, refuse to
+      // read anything that resolves outside the per-workspace files dir.
+      const resolved = resolve(path)
+      if (resolved !== resolvedDir && !resolved.startsWith(resolvedDir + sep)) continue
       let buf: Buffer
       try {
         buf = await readFile(path)

--- a/packages/mcp-server/src/server/export/load-canvas-files.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.ts
@@ -7,6 +7,7 @@
 
 import { readdir, readFile } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
+import { DATA_DIR } from '../config.js'
 import { isMissingFileError } from '../store/corrupt-stored-data.js'
 
 const EXT_TO_MIME: Record<string, string> = {
@@ -26,10 +27,9 @@ export interface CanvasFile {
 }
 
 export async function loadCanvasFiles(
-  dataDir: string,
   workspaceId: string,
 ): Promise<Record<string, CanvasFile>> {
-  const dir = join(dataDir, workspaceId, 'files')
+  const dir = join(DATA_DIR, workspaceId, 'files')
   let entries: string[]
   try {
     entries = await readdir(dir)

--- a/packages/mcp-server/src/server/export/load-canvas-files.ts
+++ b/packages/mcp-server/src/server/export/load-canvas-files.ts
@@ -1,12 +1,19 @@
-// Read all binary files attached to a workspace and shape them as the
-// `files` map that @excalidraw/utils.exportToSvg expects.
+// Read the binary files referenced by an exported canvas and shape them
+// as the `files` map that @excalidraw/utils.exportToSvg expects.
 //
 // Files are stored under DATA_DIR/{workspaceId}/files/{fileId}{ext}. The
-// browser-facing route in routes/files.ts already reads from this same layout
-// and serves a 200 with Content-Type derived from the extension.
+// browser-facing route in routes/files.ts already reads from this same
+// layout and serves a 200 with Content-Type derived from the extension.
+//
+// The set of referenced fileIds is supplied by the caller (computed from
+// the canvas elements). Walking the whole directory and base64-encoding
+// every attachment in the workspace was the previous behaviour — that
+// scaled the export payload with the entire workspace, not the canvas
+// being exported, AND raced file GC between readdir() and readFile()
+// for unrelated entries.
 
-import { readdir, readFile } from 'node:fs/promises'
-import { basename, extname, join } from 'node:path'
+import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
 import { DATA_DIR } from '../config.js'
 import { isMissingFileError } from '../store/corrupt-stored-data.js'
 
@@ -19,6 +26,8 @@ const EXT_TO_MIME: Record<string, string> = {
   '.svg': 'image/svg+xml',
 }
 
+const KNOWN_EXTS = Object.keys(EXT_TO_MIME)
+
 export interface CanvasFile {
   mimeType: string
   id: string
@@ -28,27 +37,40 @@ export interface CanvasFile {
 
 export async function loadCanvasFiles(
   workspaceId: string,
+  referencedFileIds: ReadonlySet<string>,
 ): Promise<Record<string, CanvasFile>> {
+  if (referencedFileIds.size === 0) return {}
   const dir = join(DATA_DIR, workspaceId, 'files')
-  let entries: string[]
+  // Probe the directory once so a freshly-created workspace doesn't pay
+  // for one stat() per referenced id when nothing is on disk yet.
   try {
-    entries = await readdir(dir)
+    await stat(dir)
   } catch (err) {
     if (isMissingFileError(err)) return {}
     throw err
   }
+
   const out: Record<string, CanvasFile> = {}
-  for (const entry of entries) {
-    const ext = extname(entry).toLowerCase()
-    const mime = EXT_TO_MIME[ext]
-    if (!mime) continue
-    const fileId = basename(entry, ext)
-    const buf = await readFile(join(dir, entry))
-    out[fileId] = {
-      mimeType: mime,
-      id: fileId,
-      dataURL: `data:${mime};base64,${buf.toString('base64')}`,
-      created: Date.now(),
+  for (const fileId of referencedFileIds) {
+    for (const ext of KNOWN_EXTS) {
+      const mime = EXT_TO_MIME[ext] as string
+      const path = join(dir, `${fileId}${ext}`)
+      let buf: Buffer
+      try {
+        buf = await readFile(path)
+      } catch (err) {
+        if (isMissingFileError(err)) continue
+        throw err
+      }
+      out[fileId] = {
+        mimeType: mime,
+        id: fileId,
+        dataURL: `data:${mime};base64,${buf.toString('base64')}`,
+        created: Date.now(),
+      }
+      // First match wins — multiple extensions for the same id would be
+      // a bug in the file router, not something to handle here.
+      break
     }
   }
   return out

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -41,6 +41,7 @@ import {
 } from './tools/canvas.js'
 import {
   alignElementsTool,
+  alignInputSchema,
   alignOutputSchema,
   assignGroupOutputSchema,
   assignToGroupTool,
@@ -51,6 +52,7 @@ import {
   deleteElementTool,
   deleteGroupTool,
   distributeElementsTool,
+  distributeInputSchema,
   distributeOutputSchema,
   elementIdOutputSchema,
   elementIdsOutputSchema,
@@ -1472,17 +1474,10 @@ export async function createExcalidrawMcpServer() {
     alignTool.name,
     {
       description: alignTool.description,
-      inputSchema: {
-        canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
-        elementIds: z.array(z.string()).min(2).describe(
-          'Element ids to align. Needs at least 2; the orthogonal axis is left untouched.',
-        ),
-        alignment: z
-          .enum(['left', 'center', 'right', 'top', 'middle', 'bottom'])
-          .describe(
-            "Target axis. 'left'/'right'/'center' move x; 'top'/'bottom'/'middle' move y.",
-          ),
-      },
+      // Input + output schemas come from element-ops-tools.ts as the single
+      // source of truth — execute()'s arg type is z.infer<typeof
+      // alignInputSchema> there, so registration and runtime stay in sync.
+      inputSchema: alignInputSchema.shape,
       outputSchema: alignOutputSchema,
     },
     async ({ canvasId, elementIds, alignment }) => {
@@ -1497,15 +1492,7 @@ export async function createExcalidrawMcpServer() {
     distributeTool.name,
     {
       description: distributeTool.description,
-      inputSchema: {
-        canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
-        elementIds: z.array(z.string()).min(3).describe(
-          'Element ids to distribute. Needs at least 3; first and last (along the chosen axis) stay fixed.',
-        ),
-        direction: z
-          .enum(['horizontal', 'vertical'])
-          .describe('"horizontal" distributes along x; "vertical" distributes along y.'),
-      },
+      inputSchema: distributeInputSchema.shape,
       outputSchema: distributeOutputSchema,
     },
     async ({ canvasId, elementIds, direction }) => {

--- a/packages/mcp-server/src/server/mcp/tools/element-ops-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops-tools.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  alignElementsTool,
+  alignInputSchema,
+  distributeElementsTool,
+  distributeInputSchema,
+} from './element-ops-tools.js'
+
+// Locks in the single-source-of-truth contract for align_elements /
+// distribute_elements: the factory's `inputSchema` is the same Zod object
+// that the MCP server registers, and execute()'s arg type is inferred
+// from it. Drifting any of these — adding a hand-written TS shape, an
+// inline JSON inputSchema, or a separate Zod for index.ts — would make
+// these assertions fail.
+
+describe('align_elements / distribute_elements contract', () => {
+  it('exposes a Zod input schema as the factory contract (no inline JSON)', () => {
+    const align = alignElementsTool()
+    const distribute = distributeElementsTool()
+    // Same identity — registration and runtime parse must come off the
+    // exact same schema instance, not a copy.
+    expect(align.inputSchema).toBe(alignInputSchema)
+    expect(distribute.inputSchema).toBe(distributeInputSchema)
+  })
+
+  it('alignInputSchema rejects fewer than 2 elementIds', () => {
+    const result = alignInputSchema.safeParse({
+      canvasId: 'ws/c',
+      elementIds: ['only-one'],
+      alignment: 'left',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('alignInputSchema accepts a valid payload and surfaces the typed shape', () => {
+    const parsed = alignInputSchema.parse({
+      canvasId: 'ws_main/design',
+      elementIds: ['a', 'b', 'c'],
+      alignment: 'center',
+    })
+    expect(parsed.alignment).toBe('center')
+    expect(parsed.elementIds).toEqual(['a', 'b', 'c'])
+  })
+
+  it('alignInputSchema rejects an alignment value outside the documented enum', () => {
+    const result = alignInputSchema.safeParse({
+      canvasId: 'ws/c',
+      elementIds: ['a', 'b'],
+      alignment: 'diagonal',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('distributeInputSchema rejects fewer than 3 elementIds', () => {
+    const result = distributeInputSchema.safeParse({
+      canvasId: 'ws/c',
+      elementIds: ['only-two-1', 'only-two-2'],
+      direction: 'horizontal',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('distributeInputSchema accepts a valid payload', () => {
+    const parsed = distributeInputSchema.parse({
+      canvasId: 'ws/c',
+      elementIds: ['a', 'b', 'c'],
+      direction: 'vertical',
+    })
+    expect(parsed.direction).toBe('vertical')
+  })
+
+  it('distributeInputSchema rejects an unknown direction', () => {
+    const result = distributeInputSchema.safeParse({
+      canvasId: 'ws/c',
+      elementIds: ['a', 'b', 'c'],
+      direction: 'diagonal',
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
@@ -32,9 +32,37 @@ export const assignGroupOutputSchema = z.object({
   elementIds: z.array(z.string()),
 })
 
+export const alignInputSchema = z.object({
+  canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
+  elementIds: z
+    .array(z.string())
+    .min(2)
+    .describe(
+      'Element ids to align. Needs at least 2; the orthogonal axis is left untouched.',
+    ),
+  alignment: z
+    .enum(['left', 'center', 'right', 'top', 'middle', 'bottom'])
+    .describe(
+      "Target axis. 'left'/'right'/'center' move x; 'top'/'bottom'/'middle' move y.",
+    ),
+})
+
 export const alignOutputSchema = z.object({
   elementIds: z.array(z.string()),
   alignment: z.enum(['left', 'center', 'right', 'top', 'middle', 'bottom']),
+})
+
+export const distributeInputSchema = z.object({
+  canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
+  elementIds: z
+    .array(z.string())
+    .min(3)
+    .describe(
+      'Element ids to distribute. Needs at least 3; first and last (along the chosen axis) stay fixed.',
+    ),
+  direction: z
+    .enum(['horizontal', 'vertical'])
+    .describe('"horizontal" distributes along x; "vertical" distributes along y.'),
 })
 
 export const distributeOutputSchema = z.object({
@@ -225,30 +253,12 @@ export function alignElementsTool() {
     name: 'align_elements',
     description:
       'Align multiple elements to a shared edge or centre. left / right / center act on x; top / bottom / middle act on y. The orthogonal axis is left untouched so align_left + distribute_vertical can be chained. Needs ≥ 2 elements. All-or-nothing on missing ids.',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        canvasId: { type: 'string', description: 'Canvas ID (workspaceId/slug)' },
-        elementIds: {
-          type: 'array',
-          items: { type: 'string' },
-          minItems: 2,
-        },
-        alignment: {
-          type: 'string',
-          enum: ['left', 'center', 'right', 'top', 'middle', 'bottom'],
-          description:
-            "Target axis. 'left'/'right'/'center' move x; 'top'/'bottom'/'middle' move y.",
-        },
-      },
-      required: ['canvasId', 'elementIds', 'alignment'],
-    },
+    // Single source of truth for the contract: the Zod input/output schemas.
+    // execute()'s arg + return types are inferred so a future schema edit
+    // can't drift from the handler signature.
+    inputSchema: alignInputSchema,
     execute: async (
-      args: {
-        canvasId: string
-        elementIds: string[]
-        alignment: 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom'
-      },
+      args: z.infer<typeof alignInputSchema>,
       client: DaemonClient,
     ): Promise<z.infer<typeof alignOutputSchema>> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
@@ -269,29 +279,9 @@ export function distributeElementsTool() {
     name: 'distribute_elements',
     description:
       'Distribute multiple elements with even spacing along an axis. Sorts by the chosen axis, keeps the leading and trailing element fixed, and shifts everything in between so the gap between adjacent elements is constant. Needs ≥ 3 elements. All-or-nothing on missing ids.',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        canvasId: { type: 'string', description: 'Canvas ID (workspaceId/slug)' },
-        elementIds: {
-          type: 'array',
-          items: { type: 'string' },
-          minItems: 3,
-        },
-        direction: {
-          type: 'string',
-          enum: ['horizontal', 'vertical'],
-          description: '"horizontal" distributes along x; "vertical" distributes along y.',
-        },
-      },
-      required: ['canvasId', 'elementIds', 'direction'],
-    },
+    inputSchema: distributeInputSchema,
     execute: async (
-      args: {
-        canvasId: string
-        elementIds: string[]
-        direction: 'horizontal' | 'vertical'
-      },
+      args: z.infer<typeof distributeInputSchema>,
       client: DaemonClient,
     ): Promise<z.infer<typeof distributeOutputSchema>> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)

--- a/packages/mcp-server/src/server/observability/http-tracing.test.ts
+++ b/packages/mcp-server/src/server/observability/http-tracing.test.ts
@@ -78,4 +78,23 @@ describe('tracingMiddleware http.route attribute', () => {
     expect(span.attributes['http.response.status_code']).toBe(200)
     expect(span.attributes['http.route']).toBe('/health')
   })
+
+  it('omits http.route and uses {method} span name for unmatched 404 paths', async () => {
+    // Per OpenTelemetry HTTP semconv v1.41+, server spans MUST NOT use
+    // the raw request path as a substitute for http.route, and the span
+    // name MUST be `{method}` alone when no low-cardinality route
+    // template is available. Without this, a single 404 hit on a typoed
+    // URL pollutes per-route latency aggregations with a unique label.
+    const app = buildApp()
+    const res = await app.request('/totally/made/up/url')
+    expect(res.status).toBe(404)
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    const span = spans[0]
+    expect(span.attributes['http.route']).toBeUndefined()
+    expect(span.name).toBe('GET')
+    // url.path stays high-cardinality on purpose — it is the per-request
+    // attribute, not the per-route grouper.
+    expect(span.attributes['url.path']).toBe('/totally/made/up/url')
+  })
 })

--- a/packages/mcp-server/src/server/observability/http-tracing.ts
+++ b/packages/mcp-server/src/server/observability/http-tracing.ts
@@ -21,25 +21,29 @@ import { extractContextFromHeaders, getTracer } from './tracing.js'
 // can group by low-cardinality route, so getting that right matters more
 // than naming the span at start time.
 
-function resolveMatchedRoute(c: Parameters<MiddlewareHandler>[0]): string {
+function resolveMatchedRoute(c: Parameters<MiddlewareHandler>[0]): string | undefined {
   // Hono populates `matchedRoutes` with every middleware + handler the
   // request hit, in order. Skip the wildcard middlewares (those whose
-  // path is "/*" or "/api/*" etc.) and return the first concrete one.
-  // Falls back to the path itself for unrouted requests.
+  // path contains "/*") and return the first concrete one.
+  // Returns undefined for genuinely unmatched requests (404s, probes,
+  // typos) — per OpenTelemetry HTTP semconv v1.41+, http.route MUST be
+  // omitted in that case rather than substituted with the raw request
+  // path, otherwise per-route latency dashboards collapse under
+  // unique-per-request cardinality.
   type MatchedRoute = { path?: string; handler?: unknown; method?: string }
   const matched = (c.req as unknown as { matchedRoutes?: MatchedRoute[] }).matchedRoutes
   if (Array.isArray(matched)) {
     for (let i = matched.length - 1; i >= 0; i--) {
       const path = matched[i]?.path
-      if (typeof path === 'string' && !path.endsWith('/*') && !path.includes('/*')) {
+      if (typeof path === 'string' && !path.includes('/*')) {
         return path
       }
     }
   }
   // routePath is the registered path of the *current* middleware/handler;
   // when a concrete route handled the request it is the right value.
-  if (c.req.routePath && !c.req.routePath.endsWith('/*')) return c.req.routePath
-  return c.req.path
+  if (c.req.routePath && !c.req.routePath.includes('/*')) return c.req.routePath
+  return undefined
 }
 
 export function tracingMiddleware(): MiddlewareHandler {
@@ -50,8 +54,11 @@ export function tracingMiddleware(): MiddlewareHandler {
     const parentCtx = extractContextFromHeaders(headers)
     const tracer = getTracer('whiteboard.http')
     const span = tracer.startSpan(
-      // Provisional name; renamed once the route is known.
-      `${c.req.method} ${c.req.path}`,
+      // Provisional name; renamed once the route is known. Use the
+      // method-only form for the provisional value too so an unmatched
+      // 404 stays low-cardinality even if next() throws before we can
+      // resolve a concrete route.
+      c.req.method,
       {
         kind: SpanKind.SERVER,
         attributes: {
@@ -63,17 +70,22 @@ export function tracingMiddleware(): MiddlewareHandler {
       parentCtx,
     )
     const ctxWithSpan = trace.setSpan(parentCtx, span)
+    const applyRoute = (): void => {
+      const route = resolveMatchedRoute(c)
+      if (route) {
+        span.updateName(`${c.req.method} ${route}`)
+        span.setAttribute(ATTR_HTTP_ROUTE, route)
+      }
+    }
     try {
       await context.with(ctxWithSpan, () => next())
-      const route = resolveMatchedRoute(c)
-      span.updateName(`${c.req.method} ${route}`)
-      span.setAttribute(ATTR_HTTP_ROUTE, route)
+      applyRoute()
       span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, c.res.status)
       if (c.res.status >= 500) {
         span.setStatus({ code: SpanStatusCode.ERROR })
       }
     } catch (err) {
-      span.setAttribute(ATTR_HTTP_ROUTE, resolveMatchedRoute(c))
+      applyRoute()
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: err instanceof Error ? err.message : String(err),

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -44,7 +44,6 @@ vi.mock('./ws.js', () => ({
 type MockHeadlessArgs = {
   workspaceId: string
   slug: string
-  dataDir: string
   options?: {
     padding?: number
     scale?: number

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -163,7 +163,6 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
       const result = await exportCanvasHeadless({
         workspaceId,
         slug,
-        dataDir: DATA_DIR,
         options: {
           padding: body.padding,
           scale: body.scale,

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -15,6 +15,7 @@ import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getCanvasIdBySlug, upsertWorkspaceRow } from './db/upsert-workspace.js'
 import type { VersionStore } from './version-store.js'
+import { withWorkspaceWriteLock } from './workspace-lock.js'
 
 // Give the error a stable name so callers, including MCP tools, can detect overwrite conflicts.
 export class ConflictError extends Error {
@@ -65,6 +66,13 @@ export async function saveCanvas(
 ): Promise<void> {
   validateWorkspaceId(workspaceId)
   validateSlug(slug)
+  // Hold the workspace write barrier across the snapshot write + DB
+  // upsert so a concurrent purgeDanglingFiles cannot observe a referenced
+  // file as dangling: GC's collectReferencedFileIds() runs over the same
+  // workspace blobs we are about to mutate, and chaining both behind the
+  // workspace lock ensures it sees this save as either fully applied or
+  // not yet started.
+  return withWorkspaceWriteLock(workspaceId, async () => {
   const overwrite = options.overwrite ?? false
   const db = await dbReady()
   const existingCanvasId = await getCanvasIdBySlug(db, workspaceId, slug)
@@ -132,6 +140,7 @@ export async function saveCanvas(
       getLogger('canvas-store').warning({ workspaceId, slug, err }, 'autoCompactTrigger threw')
     }
   }
+  })
 }
 
 // ── load LoroDoc, returning an empty document when the blob is missing ──

--- a/packages/mcp-server/src/server/store/file-gc.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc.test.ts
@@ -195,4 +195,39 @@ describe('purgeDanglingFiles', () => {
       cap.restore()
     }
   })
+
+  it('serialises against a concurrent saveCanvas that adds a new file reference', async () => {
+    // Race scenario: user has foo.png on disk left over from an earlier
+    // session, but no canvas references it yet. They open a canvas and
+    // add an image element pointing at foo. Just as that saveCanvas is
+    // committing, a background purgeDanglingFiles fires.
+    //
+    // Without a workspace write barrier, GC's collectReferencedFileIds
+    // could observe the pre-save state (no references) and unlink
+    // foo.png. With the lock, the save commits first and the purge
+    // pass sees the new reference.
+    await seedFile('ws_race', 'about-to-reference', '.png', 200)
+
+    const empty = new LoroDoc()
+    await saveCanvas('ws_race', 'page', empty)
+
+    // Build the post-save doc by extending the empty doc.
+    const next = await import('./canvas-store.js').then((m) => m.loadCanvas('ws_race', 'page'))
+    const list = next.getMovableList('elements')
+    const map = list.insertContainer(0, new LoroMap())
+    map.set('id', 'el-late-binding')
+    map.set('type', 'image')
+    map.set('fileId', 'about-to-reference')
+    map.set('isDeleted', false)
+    next.commit()
+
+    // Kick the save first so it acquires the lock; then kick the purge.
+    const savePromise = saveCanvas('ws_race', 'page', next, { overwrite: true })
+    const purgePromise = purgeDanglingFiles('ws_race')
+    const [, purgeResult] = await Promise.all([savePromise, purgePromise])
+
+    expect(purgeResult.purgedCount).toBe(0)
+    const remaining = (await readdir(join(tempDir, 'ws_race', 'files'))).sort()
+    expect(remaining).toEqual(['about-to-reference.png'])
+  })
 })

--- a/packages/mcp-server/src/server/store/file-gc.ts
+++ b/packages/mcp-server/src/server/store/file-gc.ts
@@ -8,6 +8,7 @@ import { listCanvases, loadCanvas } from './canvas-store.js'
 import { isMissingFileError } from './corrupt-stored-data.js'
 import { assertPathWithinDir } from './path-guard.js'
 import type { VersionStore } from './version-store.js'
+import { withWorkspaceWriteLock } from './workspace-lock.js'
 
 // Garbage-collect files in <DATA_DIR>/<workspaceId>/files/ that are not
 // referenced by any live canvas in the workspace — and, when a versionStore
@@ -114,39 +115,46 @@ export async function purgeDanglingFiles(
   options: PurgeFilesOptions = {},
 ): Promise<PurgeFilesResult> {
   validateWorkspaceId(workspaceId)
-  const referenced = await collectReferencedFileIds(workspaceId, options.versionStore)
+  // Hold the workspace write barrier across the collect + unlink pass so
+  // a concurrent saveCanvas / version-save cannot insert a new file
+  // reference between snapshot and delete and have its file unlinked
+  // as "dangling".
+  return withWorkspaceWriteLock(workspaceId, async () => {
+    const referenced = await collectReferencedFileIds(workspaceId, options.versionStore)
 
-  const dir = workspaceFilesDir(workspaceId)
-  let entries: string[]
-  try {
-    entries = await readdir(dir)
-  } catch (err) {
-    if (isMissingFileError(err)) return { purgedCount: 0, purgedBytes: 0 }
-    throw err
-  }
-
-  let purgedCount = 0
-  let purgedBytes = 0
-  for (const entry of entries) {
-    const ext = extname(entry).toLowerCase()
-    // Skip anything that does not look like an image upload — the dir is
-    // ours, but stray files (.tmp, partial uploads) should not be deleted
-    // by the dangling-references heuristic; leave them for a future, more
-    // explicit cleanup.
-    if (!IMAGE_EXTS.has(ext)) continue
-    const fileId = basename(entry, ext)
-    if (referenced.has(fileId)) continue
-    const fullPath = join(dir, entry)
+    const dir = workspaceFilesDir(workspaceId)
+    let entries: string[]
     try {
-      const info = await stat(fullPath)
-      await unlink(fullPath)
-      purgedCount += 1
-      purgedBytes += info.size
+      entries = await readdir(dir)
     } catch (err) {
-      // Race: file vanished between stat and unlink, or unlink failed for
-      // another reason — log and move on. Subsequent runs will retry.
-      getLogger('file-gc').warning({ workspaceId, entry, err }, 'purge skipped')
+      if (isMissingFileError(err)) return { purgedCount: 0, purgedBytes: 0 }
+      throw err
     }
-  }
-  return { purgedCount, purgedBytes }
+
+    let purgedCount = 0
+    let purgedBytes = 0
+    for (const entry of entries) {
+      const ext = extname(entry).toLowerCase()
+      // Skip anything that does not look like an image upload — the dir
+      // is ours, but stray files (.tmp, partial uploads) should not be
+      // deleted by the dangling-references heuristic; leave them for a
+      // future, more explicit cleanup.
+      if (!IMAGE_EXTS.has(ext)) continue
+      const fileId = basename(entry, ext)
+      if (referenced.has(fileId)) continue
+      const fullPath = join(dir, entry)
+      try {
+        const info = await stat(fullPath)
+        await unlink(fullPath)
+        purgedCount += 1
+        purgedBytes += info.size
+      } catch (err) {
+        // Race: file vanished between stat and unlink, or unlink failed
+        // for another reason — log and move on. Subsequent runs will
+        // retry.
+        getLogger('file-gc').warning({ workspaceId, entry, err }, 'purge skipped')
+      }
+    }
+    return { purgedCount, purgedBytes }
+  })
 }

--- a/packages/mcp-server/src/server/store/workspace-lock.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-lock.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { _resetWorkspaceLocksForTests, withWorkspaceWriteLock } from './workspace-lock.js'
+
+afterEach(() => {
+  _resetWorkspaceLocksForTests()
+})
+
+describe('withWorkspaceWriteLock', () => {
+  it('serializes critical sections within the same workspace', async () => {
+    const events: string[] = []
+    const start = (label: string, ms: number) =>
+      withWorkspaceWriteLock('ws_a', async () => {
+        events.push(`enter-${label}`)
+        await new Promise((r) => setTimeout(r, ms))
+        events.push(`exit-${label}`)
+      })
+
+    await Promise.all([start('first', 30), start('second', 5), start('third', 1)])
+
+    // The whole point: even though "third" is the fastest body, it has
+    // to wait until "second" and "first" finish. Order is
+    // enter-first, exit-first, enter-second, exit-second, enter-third, exit-third.
+    expect(events).toEqual([
+      'enter-first',
+      'exit-first',
+      'enter-second',
+      'exit-second',
+      'enter-third',
+      'exit-third',
+    ])
+  })
+
+  it('does not block writers on a different workspace', async () => {
+    let firstResolve: () => void = () => undefined
+    const firstStarted = new Promise<void>((resolve) => {
+      firstResolve = resolve
+    })
+    let releaseFirst: () => void = () => undefined
+    const firstHolds = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+
+    const firstPromise = withWorkspaceWriteLock('ws_a', async () => {
+      firstResolve()
+      await firstHolds
+    })
+    await firstStarted
+    // Even though ws_a's lock is held, ws_b should run immediately.
+    let secondRan = false
+    const secondPromise = withWorkspaceWriteLock('ws_b', async () => {
+      secondRan = true
+    })
+    await secondPromise
+    expect(secondRan).toBe(true)
+    releaseFirst()
+    await firstPromise
+  })
+
+  it('keeps draining the queue after a critical section throws', async () => {
+    // A buggy holder that throws must not poison the queue. The next
+    // acquirer should still get the lock.
+    const events: string[] = []
+    const failing = withWorkspaceWriteLock('ws_a', async () => {
+      events.push('fail-enter')
+      throw new Error('boom')
+    }).catch(() => undefined)
+    const next = withWorkspaceWriteLock('ws_a', async () => {
+      events.push('next-ran')
+    })
+    await Promise.all([failing, next])
+    expect(events).toEqual(['fail-enter', 'next-ran'])
+  })
+
+  it('returns the value produced by fn', async () => {
+    const result = await withWorkspaceWriteLock('ws_a', async () => 42)
+    expect(result).toBe(42)
+  })
+})

--- a/packages/mcp-server/src/server/store/workspace-lock.ts
+++ b/packages/mcp-server/src/server/store/workspace-lock.ts
@@ -1,0 +1,65 @@
+// Per-workspace write barrier.
+//
+// Background: file-gc walks every canvas + version of a workspace to
+// compute the referenced-fileId set, then unlinks every file not in
+// the set. Without a write barrier a concurrent saveCanvas() that
+// introduces a new image reference between collect and unlink can have
+// its file deleted as "dangling". The window is widest on workspaces
+// with many versions because the collect pass is O(versions × frontiers).
+//
+// We serialize the offending writers + GC by chaining their critical
+// sections onto a per-workspace Promise queue. The lock is in-process
+// only — fine because the daemon is single-process and every blob
+// read / write goes through this server. If the daemon is ever forked
+// this needs to become a file lock.
+
+const queues = new Map<string, Promise<void>>()
+
+export async function withWorkspaceWriteLock<T>(
+  workspaceId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  // Read the current tail (may be undefined for a fresh workspace).
+  const previous = queues.get(workspaceId) ?? Promise.resolve()
+  // Create a new tail that waits for the previous one to settle, then
+  // runs fn(). We DON'T let fn's rejection propagate into the queue
+  // because that would poison every subsequent acquirer for this
+  // workspace — chain on `previous.catch(() => undefined)` instead so
+  // the queue keeps draining.
+  let release!: () => void
+  const next = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  queues.set(
+    workspaceId,
+    previous.catch(() => undefined).then(() => next),
+  )
+  try {
+    await previous
+  } catch {
+    // Earlier holder threw; we still acquire — file-gc + saveCanvas
+    // must run independently. The original error has already been
+    // surfaced to that caller.
+  }
+  try {
+    return await fn()
+  } finally {
+    release()
+    // Once we drain, drop the entry if we are still the tail so the
+    // map does not grow unbounded for short-lived workspaces.
+    const tail = queues.get(workspaceId)
+    if (tail) {
+      // Wait for our own tail to settle before deciding whether to
+      // delete; if a new acquirer enqueued after us, the map has
+      // already been overwritten and this no-ops.
+      tail.then(() => {
+        if (queues.get(workspaceId) === tail) queues.delete(workspaceId)
+      })
+    }
+  }
+}
+
+// Test-only helper.
+export function _resetWorkspaceLocksForTests(): void {
+  queues.clear()
+}


### PR DESCRIPTION
## Summary

TDD-driven follow-up to PR #45 review findings. Each commit closes
one of the items previously parked under `tmp/issues/`. All test +
typecheck + smoke green at every commit.

| # | Commit | Issue note |
|---|---|---|
| 1 | `fix(observability): omit http.route for unmatched 404 paths` | OTel HTTP semconv compliance — 404s no longer pollute per-route latency dashboards |
| 2 | `refactor(export): drop redundant dataDir from headless export API` | Doc cache + file loader now read from the same canonical `DATA_DIR` |
| 3 | `refactor(mcp): unify align/distribute schemas through Zod` | Single Zod input/output schema as the source of truth; smoke covers both tools |
| 4 | `fix(app): persist freshly-minted workspace id across IndexPage mounts` | Cold-start sequential creates land in the same workspace via localStorage rehydration |
| 5 | `perf(export): load only referenced files for headless export` | Selective file loading with per-file ENOENT tolerance |
| 6 | `fix(store): serialise saveCanvas + file-gc through a workspace lock` | New `withWorkspaceWriteLock` primitive closes Race A in file GC |

The seventh issue note (`@excalidraw/utils` stable bump) stays open — npm
returns only `0.1.3-testN` pre-releases; the alternative (vendoring the
helper) is heavy and the test pin is currently safe.

## Test plan

- [x] `pnpm test` — 1287 / 1287 passed (132 files, +18 new tests across the 6 commits)
- [x] `pnpm typecheck` — clean
- [x] `pnpm smoke:e2e` — ALL OK (real daemon, includes new align / distribute calls)
- [x] Mutation checks (red→green) for every TDD step
- [x] Each commit's test exists in the same commit as the production fix

## Notes

- Two follow-ups remain captured under `tmp/issues/`:
  - File-GC TOCTOU Race C (uploaded-but-not-referenced files) and
    version-store.save lock coverage.
  - `@excalidraw/utils` stable migration once upstream ships one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace persistence—your primary workspace is now saved locally and reused across sessions.
  * Optimized exports to include only files actually referenced in your canvas.

* **Bug Fixes**
  * Improved stability by preventing concurrent canvas saves and file cleanup from interfering with each other.
  * Enhanced path security for file attachments.

* **Tests**
  * Added comprehensive test coverage for workspace operations, file handling, and export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->