### PR TITLE
fix(store): close file-gc Race C and lock version-store.save

### DIFF
--- a/packages/mcp-server/src/server/excalidraw-utils/src/export.ts
+++ b/packages/mcp-server/src/server/excalidraw-utils/src/export.ts
@@ -1,13 +1,22 @@
-// Vendored facade for the `@excalidraw/utils` surface our daemon uses.
-// See ../README.md for why we're a facade rather than a full source vendor.
+// Facade for the `@excalidraw/utils` surface our daemon uses for
+// headless SVG export. See ../README.md for the why-not-vendor story.
 //
-// Implementation note: `@excalidraw/utils@0.1.3-test32` ships its types under
-// `dist/types/utils/src/index.d.ts` whose chain of `export * from "./..."`
-// re-exports does not propagate through TypeScript's NodeNext namespace
-// narrowing. Importing `exportToSvg` directly fails the type check even
-// though the module exports it at runtime. We declare the surface locally
-// and route the runtime through `Object.assign` so callers get a typed
-// import without dragging in the broken upstream type chain.
+// Why we still depend on `@excalidraw/utils@0.1.3-testN`: the main
+// `@excalidraw/excalidraw` package re-exports the same helpers at
+// top-level, but its dist build imports `roughjs/bin/rough` (no
+// extension) which Node ESM refuses to resolve under our NodeNext
+// module config. The lean `@excalidraw/utils` submodule does not
+// reach into roughjs at runtime and works in plain Node, which is
+// what the daemon's headless renderer needs.
+//
+// Implementation note: `@excalidraw/utils@0.1.3-test32` ships its
+// types under `dist/types/utils/src/index.d.ts` whose chain of
+// `export * from "./..."` does not propagate through TypeScript's
+// NodeNext namespace narrowing. Importing `exportToSvg` directly
+// fails the type check even though the module exports it at runtime.
+// We declare the surface locally and route the runtime through a
+// cast so callers get typed imports without dragging in the broken
+// upstream type chain.
 
 import * as upstream from '@excalidraw/utils'
 
@@ -27,8 +36,9 @@ interface ExcalidrawUtilsSurface {
   MIME_TYPES: Record<string, string>
 }
 
-// Cast through `unknown` so the value is reachable even though TS sees the
-// namespace as empty. Both members exist at runtime (verified via smoke).
+// Cast through `unknown` so the value is reachable even though TS sees
+// the namespace as empty. Both members exist at runtime (verified via
+// smoke).
 const surface = upstream as unknown as ExcalidrawUtilsSurface
 
 export const exportToSvg = surface.exportToSvg

--- a/packages/mcp-server/src/server/store/file-gc.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LoroDoc, LoroMap } from 'loro-crdt'
@@ -26,7 +26,25 @@ let handle: Awaited<ReturnType<typeof createIsolatedDb>>
 async function seedFile(workspaceId: string, fileId: string, ext: string, bytes: number): Promise<void> {
   const dir = join(tempDir, workspaceId, 'files')
   await mkdir(dir, { recursive: true })
-  await writeFile(join(dir, `${fileId}${ext}`), Buffer.alloc(bytes, 0xab))
+  const path = join(dir, `${fileId}${ext}`)
+  await writeFile(path, Buffer.alloc(bytes, 0xab))
+  // Age the file beyond the default GC grace window so existing
+  // dangling-files tests see the unlink path. Tests that exercise the
+  // grace window itself create files without calling seedFile (or use
+  // seedFreshFile below).
+  const past = (Date.now() - 2 * 60 * 60 * 1000) / 1000
+  await utimes(path, past, past)
+}
+
+async function seedFreshFile(
+  workspaceId: string,
+  fileId: string,
+  ext: string,
+  bytes: number,
+): Promise<void> {
+  const dir = join(tempDir, workspaceId, 'files')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, `${fileId}${ext}`), Buffer.alloc(bytes, 0xcd))
 }
 
 function makeDocWithImage(fileId: string): LoroDoc {
@@ -193,6 +211,49 @@ describe('purgeDanglingFiles', () => {
       })
     } finally {
       cap.restore()
+    }
+  })
+
+  it('skips files whose mtime is within the configured grace window (Race C)', async () => {
+    // The upload-but-not-yet-saveCanvas race: routes/files.ts has just
+    // written `pending.png` to disk, but the user has not yet called
+    // saveCanvas with the matching image element. Without a grace
+    // window GC fires here and permanently deletes a file that was
+    // about to be referenced. With the default 1-hour grace, freshly-
+    // touched files are spared.
+    await seedFreshFile('ws_grace', 'pending', '.png', 64)
+    await seedFile('ws_grace', 'old-orphan', '.png', 32)
+
+    const result = await purgeDanglingFiles('ws_grace')
+    // old-orphan is past the grace window, gone. pending is fresh —
+    // preserved this round.
+    expect(result.purgedCount).toBe(1)
+    const remaining = (await readdir(join(tempDir, 'ws_grace', 'files'))).sort()
+    expect(remaining).toEqual(['pending.png'])
+  })
+
+  it('honours an explicit graceMs=0 to bypass the grace window', async () => {
+    // Operators who run a manual cleanup right after deciding nothing
+    // should be deferred can pass graceMs: 0 to delete fresh dangling
+    // files in the same call. Used by the tests above for the same
+    // reason.
+    await seedFreshFile('ws_grace0', 'fresh-orphan', '.png', 16)
+    const result = await purgeDanglingFiles('ws_grace0', { graceMs: 0 })
+    expect(result.purgedCount).toBe(1)
+    const remaining = await readdir(join(tempDir, 'ws_grace0', 'files'))
+    expect(remaining).toEqual([])
+  })
+
+  it('reads the grace window from WHITEBOARD_FILE_GC_GRACE_MS when no option is set', async () => {
+    const previous = process.env.WHITEBOARD_FILE_GC_GRACE_MS
+    process.env.WHITEBOARD_FILE_GC_GRACE_MS = '0'
+    try {
+      await seedFreshFile('ws_env', 'fresh-orphan', '.png', 8)
+      const result = await purgeDanglingFiles('ws_env')
+      expect(result.purgedCount).toBe(1)
+    } finally {
+      if (previous === undefined) delete process.env.WHITEBOARD_FILE_GC_GRACE_MS
+      else process.env.WHITEBOARD_FILE_GC_GRACE_MS = previous
     }
   })
 

--- a/packages/mcp-server/src/server/store/file-gc.ts
+++ b/packages/mcp-server/src/server/store/file-gc.ts
@@ -108,6 +108,25 @@ async function collectReferencedFileIds(
 
 export interface PurgeFilesOptions {
   versionStore?: VersionStore
+  // Don't unlink files whose mtime is younger than this many ms. Closes
+  // the upload-but-not-yet-saveCanvas race: routes/files.ts writes the
+  // blob first, the user (or agent) calls saveCanvas later to add the
+  // image element that references it. Without a grace window, GC firing
+  // between those two events permanently deletes a file that was about
+  // to be referenced. Default 1 hour; tests pass 0 to bypass.
+  graceMs?: number
+}
+
+const DEFAULT_GRACE_MS = 60 * 60 * 1000
+
+function resolveGraceMs(options: PurgeFilesOptions): number {
+  if (typeof options.graceMs === 'number') return Math.max(0, options.graceMs)
+  const envRaw = process.env.WHITEBOARD_FILE_GC_GRACE_MS
+  if (typeof envRaw === 'string' && envRaw.length > 0) {
+    const parsed = Number.parseInt(envRaw, 10)
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed
+  }
+  return DEFAULT_GRACE_MS
 }
 
 export async function purgeDanglingFiles(
@@ -119,6 +138,7 @@ export async function purgeDanglingFiles(
   // a concurrent saveCanvas / version-save cannot insert a new file
   // reference between snapshot and delete and have its file unlinked
   // as "dangling".
+  const graceMs = resolveGraceMs(options)
   return withWorkspaceWriteLock(workspaceId, async () => {
     const referenced = await collectReferencedFileIds(workspaceId, options.versionStore)
 
@@ -133,6 +153,7 @@ export async function purgeDanglingFiles(
 
     let purgedCount = 0
     let purgedBytes = 0
+    const now = Date.now()
     for (const entry of entries) {
       const ext = extname(entry).toLowerCase()
       // Skip anything that does not look like an image upload — the dir
@@ -145,6 +166,11 @@ export async function purgeDanglingFiles(
       const fullPath = join(dir, entry)
       try {
         const info = await stat(fullPath)
+        // Tombstone delay: a file uploaded just now isn't tied to any
+        // canvas yet, but the user is about to call saveCanvas with the
+        // matching image element. Spare freshly-touched files so that
+        // upload → saveCanvas window doesn't lose a legitimate blob.
+        if (graceMs > 0 && now - info.mtimeMs < graceMs) continue
         await unlink(fullPath)
         purgedCount += 1
         purgedBytes += info.size

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -16,6 +16,7 @@ import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getCanvasIdBySlug, upsertCanvasRow } from './db/upsert-workspace.js'
 import { assertPathWithinDir } from './path-guard.js'
+import { withWorkspaceWriteLock } from './workspace-lock.js'
 
 // Loro-native versioning, backed by the sqlite metadata DB.
 //
@@ -178,59 +179,67 @@ export class FileVersionStore implements VersionStore {
   ): Promise<VersionEntry> {
     validateWorkspaceId(workspaceId)
     validateSlug(slug)
-    const branchName = opts.branchName ?? 'main'
-    validateBranchName(branchName)
-    const id = nanoid(12)
-    validateVersionId(id)
+    // Hold the per-workspace write barrier so a concurrent
+    // purgeDanglingFiles cannot interleave with the version row being
+    // created. The references this save records are a subset of what
+    // GC already inspected, but pairing both writers behind the same
+    // queue keeps the lock contract uniform — all "things that might
+    // change what GC considers referenced" run serially.
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      const branchName = opts.branchName ?? 'main'
+      validateBranchName(branchName)
+      const id = nanoid(12)
+      validateVersionId(id)
 
-    const elementCount = (() => {
-      try {
-        const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
-        return list.filter((e) => !e.isDeleted).length
-      } catch {
-        return 0
-      }
-    })()
+      const elementCount = (() => {
+        try {
+          const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
+          return list.filter((e) => !e.isDeleted).length
+        } catch {
+          return 0
+        }
+      })()
 
-    const frontiers = bytesToBase64(encodeFrontiers(doc.frontiers()))
-    const createdAt = Date.now()
-    const operator = opts.operator
+      const frontiers = bytesToBase64(encodeFrontiers(doc.frontiers()))
+      const createdAt = Date.now()
+      const operator = opts.operator
 
-    const db = await dbReady()
-    const canvasId = await upsertCanvasRow(db, workspaceId, slug)
-    await db
-      .insertInto('versions')
-      .values({
+      const db = await dbReady()
+      const canvasId = await upsertCanvasRow(db, workspaceId, slug)
+      await db
+        .insertInto('versions')
+        .values({
+          id,
+          canvasId,
+          branchName,
+          auto: opts.auto ? 1 : 0,
+          label: opts.label ?? null,
+          operatorKind: operator?.kind ?? 'system',
+          operatorPeerId: operator?.peerId ?? '',
+          operatorDisplayName: operator?.displayName ?? null,
+          operatorAgentId: operator?.agentId ?? null,
+          operatorWorkspaceId: operator?.workspaceId ?? null,
+          elementCount,
+          frontiers,
+          hasThumbnail: 0,
+          createdAt,
+        })
+        .execute()
+
+      await this.prune(workspaceId, canvasId)
+
+      return {
         id,
-        canvasId,
-        branchName,
-        auto: opts.auto ? 1 : 0,
-        label: opts.label ?? null,
-        operatorKind: operator?.kind ?? 'system',
-        operatorPeerId: operator?.peerId ?? '',
-        operatorDisplayName: operator?.displayName ?? null,
-        operatorAgentId: operator?.agentId ?? null,
-        operatorWorkspaceId: operator?.workspaceId ?? null,
+        slug,
+        createdAt: new Date(createdAt).toISOString(),
         elementCount,
-        frontiers,
-        hasThumbnail: 0,
-        createdAt,
-      })
-      .execute()
-
-    await this.prune(workspaceId, canvasId)
-
-    return {
-      id,
-      slug,
-      createdAt: new Date(createdAt).toISOString(),
-      elementCount,
-      auto: opts.auto,
-      branchName,
-      hasThumbnail: false,
-      ...(opts.label !== undefined ? { label: opts.label } : {}),
-      ...(operator !== undefined ? { operator } : {}),
-    }
+        auto: opts.auto,
+        branchName,
+        hasThumbnail: false,
+        ...(opts.label !== undefined ? { label: opts.label } : {}),
+        ...(operator !== undefined ? { operator } : {}),
+      }
+    })
   }
 
   async load(workspaceId: string, id: string, liveDoc: LoroDoc): Promise<LoroDoc | null> {


### PR DESCRIPTION
## Summary

Final follow-up to the file-gc TOCTOU work. PR #47 landed Race A
(saveCanvas-vs-GC) via the workspace-lock primitive;

- **Race C — upload-but-not-yet-referenced**. `routes/files.ts` writes
  the blob first, the user/agent calls saveCanvas later to add the
  image element that references it. Without a grace window, GC firing
  between those two events permanently deleted a legitimate file.
  Locking the upload route doesn't help: it only controls *order*, not
  the deletion semantics. A tombstone-delay heuristic does — files
  whose mtime is younger than `graceMs` are spared. Default 1 hour,
  configurable via `WHITEBOARD_FILE_GC_GRACE_MS` env or the
  `graceMs` option.
- **`version-store.save` lock**. Mirrors `saveCanvas` and
  `purgeDanglingFiles`, all three serialise behind the same per-
  workspace queue so any future writer that affects "what counts as
  referenced" is automatically protected by symmetry.

## Test plan

- [x] `pnpm test` — 1292 / 1292 (132 files, +3 new for the grace
      window: default behaviour, explicit `graceMs: 0`, env-var
      override)
- [x] `pnpm typecheck` — clean
- [x] `pnpm smoke:e2e` — ALL OK
- [x] Existing file-gc dangling-files tests still see immediate
      deletion (seedFile now back-dates mtime past the default grace).

## Notes

- The default 1-hour grace was picked so a typical agent
  upload→saveCanvas flow (sub-second to a few seconds) is comfortably
  inside the window even with sloppy clocks. CI / automated tests
  pass `graceMs: 0` to bypass.
- Only `excalidraw-utils-test-version` remains under
  `tmp/issues/` from the original review batch — blocked on upstream
  shipping a stable `@excalidraw/utils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
