### PR TITLE
fix(mcp): treat text as label alias on arrow annotations in annotate_batch

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -152,7 +152,7 @@
     "open": "^11.0.0",
     "pino": "^10.3.1",
     "wawoff2": "^2.0.1",
-    "ws": "^8",
+    "ws": "^8.21.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -31,7 +31,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
 const tmpDataDir = mkdtempSync(join(tmpdir(), 'whiteboard-e2e-'))
 const entryArg = process.argv.find((arg) => arg.startsWith('--entry='))
-const entry = resolve(root, entryArg ? entryArg.slice('--entry='.length) : 'src/server/mcp/index.ts')
+const entry = resolve(
+  root,
+  entryArg ? entryArg.slice('--entry='.length) : 'src/server/mcp/index.ts',
+)
 const childArgs = entry.endsWith('.ts') ? ['--import', 'tsx/esm', entry] : [entry]
 
 const child = spawn('node', childArgs, {
@@ -160,6 +163,30 @@ async function main() {
   }
   console.log(`[e2e] annotate → rect`)
 
+  // Exercise annotate_batch with an arrow that uses text as a label alias.
+  // The SDK validates structuredContent against outputSchema at runtime, so
+  // any drift between the Zod schema and the actual payload surfaces here.
+  const batchArrow = await callTool('annotate_batch', {
+    canvasId: created.id,
+    annotations: [
+      {
+        type: 'arrow',
+        target: { x: 0, y: 0 },
+        endTarget: { x: 100, y: 0 },
+        coords: 'absolute',
+        text: 'smoke-label',
+      },
+    ],
+  })
+  if (!batchArrow.annotations?.[0]?.labelId) {
+    throw new Error(
+      `annotate_batch arrow with text alias did not produce labelId: ${JSON.stringify(batchArrow)}`,
+    )
+  }
+  console.log(
+    `[e2e] annotate_batch → arrow with text-as-label alias (labelId=${batchArrow.annotations[0].labelId})`,
+  )
+
   // Exercise create_frame so any drift between its zod outputSchema
   // (assignedMembers etc.) and the runtime payload trips the SDK's structured-
   // content validator at this layer instead of leaking out to MCP clients.
@@ -215,7 +242,8 @@ async function main() {
   console.log('[e2e] align_elements / distribute_elements → OK')
 
   const insBefore = await callTool('canvas_inspect', { canvasId: created.id })
-  if (insBefore.elementCount < 1) throw new Error(`source canvas missing element: ${JSON.stringify(insBefore)}`)
+  if (insBefore.elementCount < 1)
+    throw new Error(`source canvas missing element: ${JSON.stringify(insBefore)}`)
 
   // version_save labels the current state and returns a versionId. The
   // restore-as-new-canvas flow (formerly the checkpoint pair) is now
@@ -223,7 +251,9 @@ async function main() {
   const saved = await callTool('version_save', { canvasId: created.id, label: 'e2e' })
   if (!saved.versionId) throw new Error('version_save returned no id')
   if (saved.elementCount !== insBefore.elementCount) {
-    throw new Error(`element count mismatch: save=${saved.elementCount} inspect=${insBefore.elementCount}`)
+    throw new Error(
+      `element count mismatch: save=${saved.elementCount} inspect=${insBefore.elementCount}`,
+    )
   }
   console.log(`[e2e] version_save → ${saved.versionId} (${saved.elementCount} elems)`)
 
@@ -247,8 +277,11 @@ async function main() {
     )
   }
   const types = (insAfter.elements ?? []).map((e) => e.type)
-  if (!types.includes('rectangle')) throw new Error(`restored canvas missing rectangle: ${JSON.stringify(insAfter)}`)
-  console.log(`[e2e] canvas_inspect(restored) → ${insAfter.elementCount} elems, types=${types.join(',')}`)
+  if (!types.includes('rectangle'))
+    throw new Error(`restored canvas missing rectangle: ${JSON.stringify(insAfter)}`)
+  console.log(
+    `[e2e] canvas_inspect(restored) → ${insAfter.elementCount} elems, types=${types.join(',')}`,
+  )
 
   // Confirm overwrite behavior when the restore target already exists.
   await expectRejected(
@@ -325,9 +358,7 @@ async function main() {
   // .excalidraw.png file path back instead of a no_client rejection.
   const exportedPng = await callTool('export_png', { canvasId: created.id })
   if (!exportedPng.filePath || !exportedPng.filePath.endsWith('.excalidraw.png')) {
-    throw new Error(
-      `export_png returned unexpected shape: ${JSON.stringify(exportedPng)}`,
-    )
+    throw new Error(`export_png returned unexpected shape: ${JSON.stringify(exportedPng)}`)
   }
   console.log(`[e2e] export_png (headless) → ${exportedPng.filePath}`)
 
@@ -437,14 +468,20 @@ async function main() {
   }
   const body = JSON.parse(await readFile(exported.filePath, 'utf-8'))
   if (body.type !== 'excalidraw' || body.version !== 2) {
-    throw new Error(`exported JSON has wrong wrapper: ${JSON.stringify({ type: body.type, version: body.version })}`)
+    throw new Error(
+      `exported JSON has wrong wrapper: ${JSON.stringify({ type: body.type, version: body.version })}`,
+    )
   }
   if (!Array.isArray(body.elements) || body.elements.length !== exported.elementCount) {
-    throw new Error(`element count mismatch: body.elements=${body.elements?.length} elementCount=${exported.elementCount}`)
+    throw new Error(
+      `element count mismatch: body.elements=${body.elements?.length} elementCount=${exported.elementCount}`,
+    )
   }
   const rectInExport = body.elements.find((el) => el.type === 'rectangle')
   if (!rectInExport) throw new Error('exported JSON missing rectangle we annotated earlier')
-  console.log(`[e2e] canvas_export_json → ${body.elements.length} elems in standard JSON (type=${body.type}, v${body.version})`)
+  console.log(
+    `[e2e] canvas_export_json → ${body.elements.length} elems in standard JSON (type=${body.type}, v${body.version})`,
+  )
 
   // library_list_items via a local .excalidrawlib file: validates that the
   // schema-based normalizeLibraryPayload accepts a standard v2 payload and that
@@ -468,7 +505,9 @@ async function main() {
   if (libListed.itemCount !== 1 || libListed.items[0]?.name !== 'smoke rect') {
     throw new Error(`library_list_items returned unexpected shape: ${JSON.stringify(libListed)}`)
   }
-  console.log(`[e2e] library_list_items → itemCount=${libListed.itemCount} name=${libListed.items[0].name}`)
+  console.log(
+    `[e2e] library_list_items → itemCount=${libListed.itemCount} name=${libListed.items[0].name}`,
+  )
 
   console.log('\n[e2e] ALL OK')
 }

--- a/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
@@ -188,7 +188,12 @@ describe('annotate_batch', () => {
         {
           canvasId: 'sid/slug',
           annotations: [
-            { type: 'text', target: { x: 0, y: 0 }, text: 'very long text in a text element', coords: 'absolute' },
+            {
+              type: 'text',
+              target: { x: 0, y: 0 },
+              text: 'very long text in a text element',
+              coords: 'absolute',
+            },
             { type: 'rectangle', target: { x: 600, y: 600 }, coords: 'absolute' },
           ],
         },
@@ -341,9 +346,7 @@ describe('annotate_batch', () => {
       const res = await tool.execute(
         {
           canvasId: 'sid/slug',
-          annotations: [
-            { type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute' },
-          ],
+          annotations: [{ type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute' }],
         },
         client,
       )
@@ -601,7 +604,9 @@ describe('annotate_batch', () => {
       )
       const updateDoc = new LoroDoc()
       updateDoc.import(postedUpdate!)
-      const elements = updateDoc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+      const elements = updateDoc.getMovableList('elements').toJSON() as Array<
+        Record<string, unknown>
+      >
       const rect = elements.find((el) => el.type === 'rectangle')
       expect(rect).toMatchObject({
         x: 680,
@@ -641,7 +646,9 @@ describe('annotate_batch', () => {
       )
       const updateDoc = new LoroDoc()
       updateDoc.import(postedUpdate!)
-      const elements = updateDoc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+      const elements = updateDoc.getMovableList('elements').toJSON() as Array<
+        Record<string, unknown>
+      >
       const rect = elements.find((el) => el.type === 'rectangle')
       expect(rect).toMatchObject({
         x: 110,
@@ -664,17 +671,27 @@ describe('annotate_batch', () => {
           canvasId: 'sid/slug',
           dryRun: true,
           annotations: [
-            { type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute', width: 120, height: 80 },
-            { type: 'rectangle', target: { x: 60, y: 20 }, coords: 'absolute', width: 120, height: 80 },
+            {
+              type: 'rectangle',
+              target: { x: 0, y: 0 },
+              coords: 'absolute',
+              width: 120,
+              height: 80,
+            },
+            {
+              type: 'rectangle',
+              target: { x: 60, y: 20 },
+              coords: 'absolute',
+              width: 120,
+              height: 80,
+            },
           ],
         } as never,
         client,
       )
       expect(postedUpdate).toBeNull()
       expect(res.placements).toHaveLength(2)
-      expect(res.overlaps).toEqual([
-        expect.objectContaining({ a: 0, b: 1 }),
-      ])
+      expect(res.overlaps).toEqual([expect.objectContaining({ a: 0, b: 1 })])
     })
   })
 
@@ -687,7 +704,12 @@ describe('annotate_batch', () => {
           canvasId: 'sid/slug',
           annotations: [
             { type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute', color: 'role.client' },
-            { type: 'rectangle', target: { x: 100, y: 0 }, coords: 'absolute', backgroundColor: 'role.server' },
+            {
+              type: 'rectangle',
+              target: { x: 100, y: 0 },
+              coords: 'absolute',
+              backgroundColor: 'role.server',
+            },
           ],
         },
         client,
@@ -704,7 +726,12 @@ describe('annotate_batch', () => {
           canvasId: 'sid/slug',
           annotations: [
             { type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute', color: 'role.client' },
-            { type: 'rectangle', target: { x: 100, y: 0 }, coords: 'absolute', color: 'role.client' },
+            {
+              type: 'rectangle',
+              target: { x: 100, y: 0 },
+              coords: 'absolute',
+              color: 'role.client',
+            },
           ],
         },
         client,
@@ -716,7 +743,9 @@ describe('annotate_batch', () => {
       fetchMock.mockImplementation(async (url: string | URL, init?: { body?: unknown }) => {
         const u = url.toString()
         if (u.endsWith('/palette')) {
-          return new Response(JSON.stringify({ palette: { 'role.client': '#ff0000' } }), { status: 200 })
+          return new Response(JSON.stringify({ palette: { 'role.client': '#ff0000' } }), {
+            status: 200,
+          })
         }
         if (u.endsWith('/snapshot')) {
           const emptyDoc = new LoroDoc()
@@ -740,6 +769,78 @@ describe('annotate_batch', () => {
         client,
       )
       expect(res.unknownPaletteKeys).toBeUndefined()
+    })
+  })
+
+  describe('arrow text as label alias', () => {
+    it('case 341 — text field on arrow is treated as label (creates midpoint labelId)', async () => {
+      const { annotateBatchTool } = await import('./annotate-batch.js')
+      const tool = annotateBatchTool()
+      const res = await tool.execute(
+        {
+          canvasId: 'sid/slug',
+          annotations: [
+            {
+              type: 'arrow',
+              target: { x: 0, y: 0 },
+              endTarget: { x: 100, y: 0 },
+              coords: 'absolute',
+              text: 'gRPC · p50 2ms',
+            },
+          ],
+        },
+        client,
+      )
+      expect(res.annotations).toHaveLength(1)
+      expect(res.annotations![0].type).toBe('arrow')
+      expect(res.annotations![0].arrowId).toBeDefined()
+      // text on arrow should produce a midpoint label element
+      expect(res.annotations![0].labelId).toBeDefined()
+      expect(res.elementIds).toHaveLength(2)
+    })
+
+    it('case 341b — arrow + both text and label: label wins over text alias', async () => {
+      const { annotateBatchTool } = await import('./annotate-batch.js')
+      const tool = annotateBatchTool()
+      const res = await tool.execute(
+        {
+          canvasId: 'sid/slug',
+          annotations: [
+            {
+              type: 'arrow',
+              target: { x: 0, y: 0 },
+              endTarget: { x: 100, y: 0 },
+              coords: 'absolute',
+              text: 'alias-value',
+              label: 'explicit-value',
+            },
+          ],
+        },
+        client,
+      )
+      expect(res.annotations![0].labelId).toBeDefined()
+    })
+
+    it('case 341c — arrow + text as string[] produces midpoint labelId', async () => {
+      const { annotateBatchTool } = await import('./annotate-batch.js')
+      const tool = annotateBatchTool()
+      const res = await tool.execute(
+        {
+          canvasId: 'sid/slug',
+          annotations: [
+            {
+              type: 'arrow',
+              target: { x: 0, y: 0 },
+              endTarget: { x: 100, y: 0 },
+              coords: 'absolute',
+              text: ['line1', 'line2'],
+            },
+          ],
+        },
+        client,
+      )
+      expect(res.annotations![0].labelId).toBeDefined()
+      expect(res.elementIds).toHaveLength(2)
     })
   })
 

--- a/packages/mcp-server/src/server/mcp/tools/annotate-batch.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate-batch.ts
@@ -193,7 +193,7 @@ export function annotateBatchTool() {
               },
               text: {
                 description:
-                  'Text content. string for single line, string[] for multi-line (joined with "\\n"). box_with_label centers multi-line vertically and does NOT auto-wrap — pre-split long text into string[] to fit within width/cellW.',
+                  'Text content. string for single line, string[] for multi-line (joined with "\\n"). box_with_label centers multi-line vertically and does NOT auto-wrap — pre-split long text into string[] to fit within width/cellW. For arrow type, text is an alias for label (midpoint label text node); label takes precedence when both are supplied.',
                 oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
               },
               title: {

--- a/packages/mcp-server/src/server/mcp/tools/annotate.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.test.ts
@@ -721,6 +721,73 @@ describe('arrow routing ignores bound text of start/end boxes', () => {
   })
 })
 
+describe('arrow text-as-label alias (single tool)', () => {
+  it('case 342a — arrow + text produces midpoint labelId', async () => {
+    const { appendAnnotationToDoc } = await import('./annotate.js')
+    const doc = new LoroDoc()
+    const result = appendAnnotationToDoc(doc, {
+      type: 'arrow',
+      coords: 'absolute',
+      target: { x: 0, y: 0 },
+      endTarget: { x: 100, y: 0 },
+      text: 'gRPC · p50 2ms',
+    })
+    expect(result.type).toBe('arrow')
+    expect(result.arrowId).toBeDefined()
+    expect(result.labelId).toBeDefined()
+  })
+
+  it('case 342b — arrow + both text and label: label wins', async () => {
+    const { appendAnnotationToDoc } = await import('./annotate.js')
+    const doc = new LoroDoc()
+    const result = appendAnnotationToDoc(doc, {
+      type: 'arrow',
+      coords: 'absolute',
+      target: { x: 0, y: 0 },
+      endTarget: { x: 100, y: 0 },
+      text: 'alias-value',
+      label: 'explicit-value',
+    })
+    expect(result.type).toBe('arrow')
+    expect(result.labelId).toBeDefined()
+    // The label text node should carry 'explicit-value', not 'alias-value'
+    const els = doc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+    const labelEl = els.find((e) => e.id === result.labelId)
+    expect((labelEl as { text?: string } | undefined)?.text).toBe('explicit-value')
+  })
+
+  it('case 342c — arrow + text as string[] produces midpoint labelId (joined)', async () => {
+    const { appendAnnotationToDoc } = await import('./annotate.js')
+    const doc = new LoroDoc()
+    const result = appendAnnotationToDoc(doc, {
+      type: 'arrow',
+      coords: 'absolute',
+      target: { x: 0, y: 0 },
+      endTarget: { x: 100, y: 0 },
+      text: ['line1', 'line2'],
+    })
+    expect(result.type).toBe('arrow')
+    expect(result.labelId).toBeDefined()
+    const els = doc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+    const labelEl = els.find((e) => e.id === result.labelId)
+    expect((labelEl as { text?: string } | undefined)?.text).toBe('line1\nline2')
+  })
+
+  it('case 342d — arrow with neither text nor label: no labelId (no regression)', async () => {
+    const { appendAnnotationToDoc } = await import('./annotate.js')
+    const doc = new LoroDoc()
+    const result = appendAnnotationToDoc(doc, {
+      type: 'arrow',
+      coords: 'absolute',
+      target: { x: 0, y: 0 },
+      endTarget: { x: 100, y: 0 },
+    })
+    expect(result.type).toBe('arrow')
+    expect(result.arrowId).toBeDefined()
+    expect(result.labelId).toBeUndefined()
+  })
+})
+
 describe('box_with_label — height optional with autoFit', () => {
   it('succeeds without height when autoFit is on (default)', async () => {
     const { appendAnnotationToDoc } = await import('./annotate.js')

--- a/packages/mcp-server/src/server/mcp/tools/annotate.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.ts
@@ -400,24 +400,20 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
   }
 
   if (spec.type !== 'box_with_label') {
+    const primitiveSpec = spec as AnnotationSpec & { type: AnnotationType }
     // For arrow specs, `text` is an alias for `label` (midpoint label text node).
-    // `label` takes precedence when both are supplied. We resolve the effective
-    // label here and pass `text: undefined` to appendSingleAnnotation so that
-    // buildAnnotationFields does not simultaneously write the inline arrow body
-    // label field (annotation-fields.ts line 114-116) alongside the midpoint
-    // text node created below.
+    // `label` takes precedence when both are supplied. Resolve the effective
+    // label here and pass `text: undefined` so buildAnnotationFields does not
+    // simultaneously write the inline arrow body label field alongside the
+    // midpoint text node created below.
     const arrowSpec =
       spec.type === 'arrow'
-        ? (() => {
-            const effectiveLabel =
-              spec.label ?? (Array.isArray(spec.text) ? spec.text.join('\n') : spec.text)
-            return {
-              ...(spec as AnnotationSpec & { type: AnnotationType }),
-              text: undefined,
-              label: effectiveLabel,
-            }
-          })()
-        : (spec as AnnotationSpec & { type: AnnotationType })
+        ? {
+            ...primitiveSpec,
+            text: undefined,
+            label: spec.label ?? (Array.isArray(spec.text) ? spec.text.join('\n') : spec.text),
+          }
+        : primitiveSpec
     const { elementId, snappedStart, snappedEnd } = appendSingleAnnotation(doc, arrowSpec)
     // When arrow.label is set, add a separate midpoint label text element.
     if (spec.type === 'arrow' && arrowSpec.label && snappedEnd) {

--- a/packages/mcp-server/src/server/mcp/tools/annotate.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.ts
@@ -400,12 +400,27 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
   }
 
   if (spec.type !== 'box_with_label') {
-    const { elementId, snappedStart, snappedEnd } = appendSingleAnnotation(
-      doc,
-      spec as AnnotationSpec & { type: AnnotationType },
-    )
+    // For arrow specs, `text` is an alias for `label` (midpoint label text node).
+    // `label` takes precedence when both are supplied. We resolve the effective
+    // label here and pass `text: undefined` to appendSingleAnnotation so that
+    // buildAnnotationFields does not simultaneously write the inline arrow body
+    // label field (annotation-fields.ts line 114-116) alongside the midpoint
+    // text node created below.
+    const arrowSpec =
+      spec.type === 'arrow'
+        ? (() => {
+            const effectiveLabel =
+              spec.label ?? (Array.isArray(spec.text) ? spec.text.join('\n') : spec.text)
+            return {
+              ...(spec as AnnotationSpec & { type: AnnotationType }),
+              text: undefined,
+              label: effectiveLabel,
+            }
+          })()
+        : (spec as AnnotationSpec & { type: AnnotationType })
+    const { elementId, snappedStart, snappedEnd } = appendSingleAnnotation(doc, arrowSpec)
     // When arrow.label is set, add a separate midpoint label text element.
-    if (spec.type === 'arrow' && spec.label && snappedEnd) {
+    if (spec.type === 'arrow' && arrowSpec.label && snappedEnd) {
       // Avoid label collisions by increasing offset, flipping side, then trying
       // near-end positions. Exclude the arrow itself and tombstones.
       const currentElements = doc.getMovableList('elements').toJSON() as Array<ExcalidrawElement>
@@ -423,7 +438,7 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
       const labelPos = resolveArrowLabelPosition({
         start: snappedStart,
         end: snappedEnd,
-        text: spec.label,
+        text: arrowSpec.label,
         offset: spec.labelOffset,
         side: spec.labelSide,
         obstacles,
@@ -627,7 +642,7 @@ export function annotateTool() {
         },
         text: {
           description:
-            'Text content. string for single line, string[] for multi-line (joined with "\\n"). box_with_label centers multi-line vertically and does NOT auto-wrap — pre-split long text into string[] to fit within width.',
+            'Text content. string for single line, string[] for multi-line (joined with "\\n"). box_with_label centers multi-line vertically and does NOT auto-wrap — pre-split long text into string[] to fit within width. For arrow type, text is an alias for label (midpoint label text node); label takes precedence when both are supplied.',
           oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
         },
         title: {

--- a/packages/mcp-server/src/shared/canvas-backend-contract.test.ts
+++ b/packages/mcp-server/src/shared/canvas-backend-contract.test.ts
@@ -44,7 +44,7 @@ beforeAll(() => {
   if (result.status !== 0) {
     throw new Error(`tsc failed:\n${result.stderr}`)
   }
-})
+}, 60_000)
 
 describe('browser-contract subpath export', () => {
   it('package.json exports map includes ./browser-contract', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       ws:
-        specifier: ^8
-        version: 8.20.0
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1023,6 +1023,10 @@ packages:
     resolution: {integrity: sha512-I/INw4sHGlVZ/afZOckpLiDP9SmbMl1g/GCqeHjLw1Afw/0PlRs2tRFgTGWmdI0hoNuWZn3y2iHNmG1vyECyQQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@5.2.0':
     resolution: {integrity: sha512-1HJt+3fqxblp/GQjdntSyoSHYBc0e3CzXVgjFpKA6qFLd9FHBBqwN8Co0xYH6t2JVUZrtFwZ4bBiwptkiLxyOg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1041,9 +1045,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@11.2.0':
     resolution: {integrity: sha512-joR1YS2sI0us+9d0I8ViqFbrRLONO8CFTuyvBX4ZVBSch+VsZiugUABdrhBXXJR1VyEzvpz5SQCix3keETQ58g==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1080,6 +1102,10 @@ packages:
   '@inquirer/figures@2.0.6':
     resolution: {integrity: sha512-dsZgQtH2t5Q6ah3aPbZbeEZAxsD9qQu0DXf01AltuEfRTm+NoLN6+rLVbr+4edeEbNCp/wBNM6mALRWtsQpfkw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
   '@inquirer/input@5.1.0':
     resolution: {integrity: sha512-sVZCz6P6e8tW5g2bSFel1oLpa6jK/u7BexFfrgTqR8syIdnHqy+iopnlSbYBZMsCK52chLjhGNBxt0eRqhsghw==}
@@ -1147,6 +1173,15 @@ packages:
   '@inquirer/type@4.0.6':
     resolution: {integrity: sha512-J+9tdxOskuYuGjsvGaq00AamhDgjR7anhEW2dP4QdQpFCMPngCeC/bCYWQ5NsMWZRdsy53is7kAHb/+7cwDk2g==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1306,8 +1341,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mswjs/interceptors@0.41.5':
-    resolution: {integrity: sha512-Fa2HztoLlZxRN6wVC2KB7q0SvRTKjfP0328NVnSit03+0nzm62syxyT46KGbgq3Vr1A/mmLeQwu3GprB0lNTjw==}
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
   '@napi-rs/canvas-android-arm64@0.1.100':
@@ -3057,6 +3092,9 @@ packages:
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -3885,6 +3923,9 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -4006,8 +4047,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql@16.13.2:
-    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+  graphql@16.14.1:
+    resolution: {integrity: sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   hachure-fill@0.5.2:
@@ -4653,6 +4694,10 @@ packages:
   mutation-testing-report-schema@3.7.3:
     resolution: {integrity: sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   mute-stream@4.0.0:
     resolution: {integrity: sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -5071,8 +5116,8 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  rettime@0.11.8:
-    resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -5454,6 +5499,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -5479,6 +5528,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -5747,8 +5799,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6444,6 +6496,9 @@ snapshots:
 
   '@inquirer/ansi@2.0.6': {}
 
+  '@inquirer/ansi@2.0.7':
+    optional: true
+
   '@inquirer/checkbox@5.2.0(@types/node@24.12.2)':
     dependencies:
       '@inquirer/ansi': 2.0.6
@@ -6460,6 +6515,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
 
+  '@inquirer/confirm@6.1.1(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.2)
+      '@inquirer/type': 4.0.7(@types/node@24.12.2)
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
+
   '@inquirer/core@11.2.0(@types/node@24.12.2)':
     dependencies:
       '@inquirer/ansi': 2.0.6
@@ -6471,6 +6534,19 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 24.12.2
+
+  '@inquirer/core@11.2.1(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.12.2)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
 
   '@inquirer/editor@5.2.0(@types/node@24.12.2)':
     dependencies:
@@ -6495,6 +6571,9 @@ snapshots:
       '@types/node': 24.12.2
 
   '@inquirer/figures@2.0.6': {}
+
+  '@inquirer/figures@2.0.7':
+    optional: true
 
   '@inquirer/input@5.1.0(@types/node@24.12.2)':
     dependencies:
@@ -6560,6 +6639,11 @@ snapshots:
   '@inquirer/type@4.0.6(@types/node@24.12.2)':
     optionalDependencies:
       '@types/node': 24.12.2
+
+  '@inquirer/type@4.0.7(@types/node@24.12.2)':
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6662,7 +6746,7 @@ snapshots:
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
       '@types/ws': 8.18.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6741,7 +6825,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mswjs/interceptors@0.41.5':
+  '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -8457,6 +8541,11 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+    optional: true
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
@@ -8469,7 +8558,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.13.1
     optional: true
 
   '@types/statuses@2.0.6':
@@ -8517,7 +8606,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9381,6 +9470,11 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+    optional: true
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -9502,7 +9596,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.13.2:
+  graphql@16.14.1:
     optional: true
 
   hachure-fill@0.5.2: {}
@@ -9514,7 +9608,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10115,22 +10209,22 @@ snapshots:
 
   msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3):
     dependencies:
-      '@inquirer/confirm': 6.1.0(@types/node@24.12.2)
-      '@mswjs/interceptors': 0.41.5
+      '@inquirer/confirm': 6.1.1(@types/node@24.12.2)
+      '@mswjs/interceptors': 0.41.9
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.13.2
+      graphql: 16.14.1
       headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.11.8
+      rettime: 0.11.11
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
       tough-cookie: 6.0.1
-      type-fest: 5.6.0
+      type-fest: 5.7.0
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
@@ -10155,6 +10249,9 @@ snapshots:
       mutation-testing-report-schema: 3.7.3
 
   mutation-testing-report-schema@3.7.3: {}
+
+  mute-stream@3.0.0:
+    optional: true
 
   mute-stream@4.0.0: {}
 
@@ -10583,7 +10680,7 @@ snapshots:
   retry@0.12.0:
     optional: true
 
-  rettime@0.11.8:
+  rettime@0.11.11:
     optional: true
 
   robust-predicates@3.0.3: {}
@@ -11056,6 +11153,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
+    optional: true
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -11079,6 +11181,9 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@7.18.2:
+    optional: true
 
   undici@7.25.0: {}
 
@@ -11293,7 +11398,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Fixes a silent drop of the `text` field when using `type: arrow` in `annotate_batch`
- Previously, `text` on an arrow annotation was written to `fields.label` — an Excalidraw property that is silently ignored, producing an arrow with no visible label
- `text` is now treated as an alias for `label` and routed through `annotate.ts`'s midpoint text-element path, correctly producing `arrowId` + `labelId` in the response

## Root cause

`annotation-fields.ts` arrow branch set `fields.label = { text: input.text }` which is not the Excalidraw bound-text-element format. The correct path goes through `spec.label` in `annotate.ts:408` which creates a midpoint text element.

## Test plan

- [x] Red test case 341 confirmed failing before fix, green after
- [x] `pnpm test --project mcp-node` — full annotate_batch suite passes
- [x] `pnpm -r typecheck` — no new errors
- [ ] CI verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
