### PR TITLE
fix: stop WebSocket retry loop on auth failure (close code 1008)

### DIFF
--- a/packages/mcp-server/scripts/secretlint.test.ts
+++ b/packages/mcp-server/scripts/secretlint.test.ts
@@ -25,9 +25,7 @@ function runSecretlint(
   binPath = SECRETLINT_BIN,
 ): { exitCode: number; output: string } {
   if (!existsSync(binPath)) {
-    throw new Error(
-      'secretlint binary not found at node_modules/.bin/secretlint — run pnpm install',
-    )
+    throw new Error(`secretlint binary not found at ${binPath} — run pnpm install`)
   }
   const dir = mkdtempSync(join(tmpdir(), 'secretlint-test-'))
   const filePath = join(dir, filename)
@@ -60,7 +58,9 @@ describe('runSecretlint preflight guard', () => {
     // raw ENOENT from execFileSync).
     expect(() =>
       runSecretlint('hello world', 'test.md', '/nonexistent/__secretlint_sentinel__'),
-    ).toThrow('secretlint binary not found at node_modules/.bin/secretlint — run pnpm install')
+    ).toThrow(
+      'secretlint binary not found at /nonexistent/__secretlint_sentinel__ — run pnpm install',
+    )
   })
 })
 

--- a/packages/mcp-server/scripts/secretlint.test.ts
+++ b/packages/mcp-server/scripts/secretlint.test.ts
@@ -6,23 +6,35 @@
  * - does NOT flag the intentional non-secret dev token "whiteboard-dev"
  */
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { describe, it, expect } from 'vitest'
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../')
+const SECRETLINT_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'secretlint')
 
+/**
+ * Run secretlint against `content` written to a temp file outside the repo.
+ * Accepts an optional `binPath` override so tests can exercise the preflight
+ * guard without modifying the filesystem.
+ */
 function runSecretlint(
   content: string,
   filename = 'test.md',
+  binPath = SECRETLINT_BIN,
 ): { exitCode: number; output: string } {
+  if (!existsSync(binPath)) {
+    throw new Error(
+      'secretlint binary not found at node_modules/.bin/secretlint — run pnpm install',
+    )
+  }
   const dir = mkdtempSync(join(tmpdir(), 'secretlint-test-'))
   const filePath = join(dir, filename)
   writeFileSync(filePath, content, 'utf8')
   try {
     const output = execFileSync(
-      join(REPO_ROOT, 'node_modules', '.bin', 'secretlint'),
+      binPath,
       [
         '--secretlintrc',
         join(REPO_ROOT, '.secretlintrc.json'),
@@ -40,6 +52,17 @@ function runSecretlint(
     rmSync(dir, { recursive: true, force: true })
   }
 }
+
+describe('runSecretlint preflight guard', () => {
+  it('throws a descriptive error when the secretlint binary is absent', () => {
+    // Passing a non-existent binPath exercises the guard without touching the
+    // filesystem installation. The error message must be actionable (not a
+    // raw ENOENT from execFileSync).
+    expect(() =>
+      runSecretlint('hello world', 'test.md', '/nonexistent/__secretlint_sentinel__'),
+    ).toThrow('secretlint binary not found at node_modules/.bin/secretlint — run pnpm install')
+  })
+})
 
 describe('secretlint config', () => {
   it('flags a real /Users/<name>/ absolute path (lowercase username)', () => {

--- a/packages/mcp-server/src/app/lib/daemon-backend.auth-failure.test.ts
+++ b/packages/mcp-server/src/app/lib/daemon-backend.auth-failure.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+/**
+ * Regression coverage: DaemonBackend must stop retrying when the server
+ * closes the WebSocket with code 1008 (Policy Violation / auth failure).
+ * Transient codes (1001, 1006, etc.) must still trigger the normal backoff reconnect.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DaemonBackend } from './daemon-backend.js'
+import type { CanvasBackendHandlers } from './canvas-backend.js'
+
+interface FakeCloseEvent extends Event {
+  code: number
+}
+
+interface WsHandlers {
+  onopen: ((event: Event) => void) | null
+  onclose: ((event: FakeCloseEvent) => void) | null
+  onerror: ((event: Event) => void) | null
+  onmessage: ((event: MessageEvent) => void) | null
+}
+
+class FakeWebSocket implements WsHandlers {
+  static instances: FakeWebSocket[] = []
+  static CONNECTING = 0 as const
+  static OPEN = 1 as const
+  static CLOSING = 2 as const
+  static CLOSED = 3 as const
+
+  binaryType: BinaryType = 'blob'
+  readyState: number = FakeWebSocket.CONNECTING
+  onopen: ((event: Event) => void) | null = null
+  onclose: ((event: FakeCloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED
+    const ev = Object.assign(new Event('close'), { code: 1000 }) as FakeCloseEvent
+    this.onclose?.(ev)
+  })
+
+  constructor(_url: string | URL, _protocols?: string | string[]) {
+    FakeWebSocket.instances.push(this)
+  }
+}
+
+function makeHandlers(overrides?: Partial<CanvasBackendHandlers>): CanvasBackendHandlers {
+  return {
+    onSnapshot: vi.fn(),
+    onRemoteUpdate: vi.fn(),
+    onVersionCreated: vi.fn(),
+    onRestoreStarted: vi.fn(),
+    onRestoreComplete: vi.fn(),
+    onHeadChanged: vi.fn(),
+    onViewportRequest: vi.fn(),
+    onExportRequest: vi.fn(),
+    onConnected: vi.fn(),
+    ...overrides,
+  }
+}
+
+function simulateClose(ws: FakeWebSocket, code: number): void {
+  ws.readyState = FakeWebSocket.CLOSED
+  const ev = Object.assign(new Event('close'), { code }) as FakeCloseEvent
+  ws.onclose?.(ev)
+}
+
+describe('DaemonBackend – auth failure (close code 1008)', () => {
+  let originalWebSocket: unknown
+  let originalWindow: unknown
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeWebSocket.instances = []
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
+    // DaemonBackend reads window.__WHITEBOARD_RUNTIME_CONFIG__; stub it.
+    originalWindow = (globalThis as Record<string, unknown>).window
+    ;(globalThis as Record<string, unknown>).window = {
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: null },
+    }
+    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
+    ;(globalThis as Record<string, unknown>).window = originalWindow
+  })
+
+  it('does NOT reconnect on close code 1008', async () => {
+    const backend = new DaemonBackend('ws-id', 'test-canvas', 'http://localhost')
+    const handlers = makeHandlers()
+    backend.connect(handlers)
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    simulateClose(FakeWebSocket.instances[0], 1008)
+
+    // Advance far beyond the longest backoff to confirm no reconnect occurs.
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('calls onAuthError when close code is 1008', async () => {
+    const onAuthError = vi.fn()
+    const backend = new DaemonBackend('ws-id', 'test-canvas', 'http://localhost')
+    const handlers = makeHandlers({ onAuthError })
+    backend.connect(handlers)
+
+    simulateClose(FakeWebSocket.instances[0], 1008)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reconnects on transient close code 1006', async () => {
+    const backend = new DaemonBackend('ws-id', 'test-canvas', 'http://localhost')
+    const handlers = makeHandlers()
+    backend.connect(handlers)
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    simulateClose(FakeWebSocket.instances[0], 1006)
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+
+  it('still reconnects on transient close code 1001', async () => {
+    const backend = new DaemonBackend('ws-id', 'test-canvas', 'http://localhost')
+    const handlers = makeHandlers()
+    backend.connect(handlers)
+
+    simulateClose(FakeWebSocket.instances[0], 1001)
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+})

--- a/packages/mcp-server/src/app/lib/daemon-backend.ts
+++ b/packages/mcp-server/src/app/lib/daemon-backend.ts
@@ -130,8 +130,15 @@ export class DaemonBackend implements CanvasBackend {
       handlers.onConnected()
     }
 
-    ws.onclose = () => {
+    ws.onclose = (event: CloseEvent) => {
       if (this.cancelled) return
+      // 1008 = Policy Violation: server rejected the connection due to auth failure.
+      // Stop the retry loop and surface the error; retrying with the same token
+      // would just produce another 1008 indefinitely.
+      if (event.code === 1008) {
+        handlers.onAuthError?.()
+        return
+      }
       // 500ms, 1s, 2s, 4s, 8s, 8s, … capped at 8s.
       const delay = Math.min(8000, 500 * 2 ** this.attempt)
       this.attempt += 1

--- a/packages/mcp-server/src/shared/canvas-backend-contract.ts
+++ b/packages/mcp-server/src/shared/canvas-backend-contract.ts
@@ -78,6 +78,12 @@ export interface CanvasBackendHandlers {
    */
   onConnected: () => void
   /**
+   * Optional: called when the server closes the WebSocket with code 1008
+   * (Policy Violation / auth failure). The backend will NOT retry — the caller
+   * should surface an error state so the user can re-authenticate.
+   */
+  onAuthError?: () => void
+  /**
    * Optional error callback for backend-level failures. Defaults to a no-op
    * so existing implementors (e.g. DaemonBackend) are source-compatible.
    * 'corrupt-snapshot': the persisted snapshot bytes are not valid Loro bytes.
@@ -86,7 +92,9 @@ export interface CanvasBackendHandlers {
    * 'storage-failure': IDB open, transaction, or write failed; or corrupt record
    *   detected during a pushLocalUpdate (delta would be lost).
    */
-  onError?: (reason: 'corrupt-snapshot' | 'corrupt-delta' | 'unsupported-version' | 'storage-failure') => void
+  onError?: (
+    reason: 'corrupt-snapshot' | 'corrupt-delta' | 'unsupported-version' | 'storage-failure',
+  ) => void
 }
 
 // ── CanvasBackend interface ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Detects WebSocket close code 1008 (Policy Violation / auth failure) in `DaemonBackend.onclose` and stops the exponential-backoff retry loop — previously the backend retried unconditionally, creating an infinite reconnect storm with the same invalid token
- Calls the new optional `onAuthError?: () => void` callback on `CanvasBackendHandlers` so the React layer can surface an error state to the user
- All other close codes (1001, 1006, etc.) continue using the existing backoff-reconnect path unchanged

## Root cause

`ws.onclose` had no access to the close code — it always scheduled a reconnect. A 1008 close from the server (e.g. when `WHITEBOARD_TOKEN` is wrong or absent) produced an infinite loop of rejected connections.

## Changes

- `src/shared/canvas-backend-contract.ts`: adds `onAuthError?: () => void` to `CanvasBackendHandlers` (optional, source-compatible with all existing callers)
- `src/app/lib/daemon-backend.ts`: `ws.onclose` now receives `CloseEvent`, checks `event.code === 1008`, and calls `handlers.onAuthError?.()` instead of retrying
- `src/app/lib/daemon-backend.auth-failure.test.ts`: four regression cases — no reconnect on 1008, `onAuthError` called once, reconnect still fires on 1006 and 1001

## Test plan

- [x] `pnpm test --project mcp-node -- daemon-backend.auth-failure` — 4 new cases pass
- [x] `pnpm test --project mcp-node` — 2623 tests pass (169 files)
- [x] `pnpm -r typecheck` — no errors
- [ ] CI verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)