### PR TITLE
chore(ci): remove wrangler-action deploy, switch to Cloudflare Pages Git integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       mcp_tag_name: ${{ steps.release.outputs['packages/mcp-server--tag_name'] }}
       root_release_created: ${{ steps.release.outputs['--release_created'] }}
       root_tag_name: ${{ steps.release.outputs['--tag_name'] }}
-      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
@@ -246,41 +245,3 @@ jobs:
           DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REPO: ghcr.io/${{ github.repository }}
         run: cosign sign --yes $IMAGE_REPO@$DIGEST
-
-  deploy-web:
-    needs: release-please
-    runs-on: ubuntu-latest
-    # Deploy apps/web to Cloudflare Pages when a project release is created.
-    # Skipped when no release happened (e.g. mid-cycle pushes).
-    # The Deploy step skips itself when Cloudflare secrets are not yet configured.
-    # Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID secrets.
-    if: needs.release-please.outputs.releases_created == 'true'
-    permissions:
-      contents: read
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build apps/web
-        run: pnpm --filter @kamiazya/whiteboard-web build
-
-      - name: Deploy to Cloudflare Pages
-        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/web
-          command: pages deploy dist --project-name=whiteboard

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -564,13 +564,13 @@ describe('apps/web Cloudflare Pages config (wrangler.toml)', () => {
 })
 
 // ── Cloudflare deploy secrets drift guard ─────────────────────────────────────
-// Production Cloudflare Pages deploy secrets are allowed only in release.yml
-// (the deploy-web job). All other workflow files and apps/web config files must
-// not embed these secrets — add to the allowlist below if a second deploy path
-// is introduced intentionally.
+// apps/web is deployed via Cloudflare Pages Git integration (not wrangler-action),
+// so Cloudflare production secrets must NOT appear in any workflow file or
+// apps/web config. If a second CI-driven deploy path is introduced intentionally,
+// add it to CF_SECRET_WORKFLOW_ALLOWLIST and add a positive assertion below.
 
 const CF_SECRETS = ['CLOUDFLARE_API_TOKEN', 'CF_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID'] as const
-const CF_SECRET_WORKFLOW_ALLOWLIST = new Set(['release.yml'])
+const CF_SECRET_WORKFLOW_ALLOWLIST = new Set<string>()
 
 describe('apps/web Cloudflare deploy secrets guard', () => {
   const configFiles = [
@@ -597,7 +597,7 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     )
   })
 
-  it('only allowlisted workflow files deploy apps/web using Cloudflare production secrets', () => {
+  it('no workflow file deploys apps/web using Cloudflare production secrets', () => {
     const workflowsDir = resolve(REPO_ROOT, '.github/workflows')
     if (!existsSync(workflowsDir)) return
     const violations: string[] = []
@@ -613,20 +613,7 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     }
     expect(
       violations,
-      'Cloudflare production secrets found in a non-allowlisted workflow — add to CF_SECRET_WORKFLOW_ALLOWLIST if intentional',
+      'Cloudflare production secrets found in a workflow — deployment should use Cloudflare Pages Git integration instead',
     ).toEqual([])
-  })
-
-  it('release.yml deploy-web job uses Cloudflare secrets for apps/web deploy', () => {
-    const releaseYml = resolve(REPO_ROOT, '.github/workflows/release.yml')
-    if (!existsSync(releaseYml)) return
-    const content = readFileSync(releaseYml, 'utf-8')
-    expect(content, 'release.yml must contain deploy-web job').toContain('deploy-web:')
-    expect(content, 'release.yml deploy-web must reference CLOUDFLARE_API_TOKEN').toContain(
-      'CLOUDFLARE_API_TOKEN',
-    )
-    expect(content, 'release.yml deploy-web must reference CLOUDFLARE_ACCOUNT_ID').toContain(
-      'CLOUDFLARE_ACCOUNT_ID',
-    )
   })
 })


### PR DESCRIPTION
## Summary

- Remove `deploy-web` job from `release.yml` — `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` no longer stored in GitHub Secrets
- Remove `releases_created` output (was only used by the removed job)
- Update `web-app-boundary.test.ts` drift guard: allowlist is now empty; negative check ensures no workflow accidentally introduces CF secrets

## Why Git integration over wrangler-action

| | wrangler-action (old) | Git integration (new) |
|---|---|---|
| CF secrets in GitHub | ✓ (`CLOUDFLARE_API_TOKEN`) | ✗ none |
| PR preview URLs | なし | 自動生成 (`pr-N.whiteboard.pages.dev`) |
| Fork PR previews | blocked (secrets unavailable) | Cloudflare ダッシュボードで制御 |

## Setup required (tracked in `tmp/issues/cloudflare-pages-setup.md`)

1. Cloudflare Pages → Create project → **Connect to Git** → `kamiazya/whiteboard`
2. Build command: `pnpm --filter @kamiazya/whiteboard-web build`
3. Output directory: `apps/web/dist`
4. Root directory: `/`

## Test plan

- [x] `pnpm test --project mcp-node` — `web-app-boundary` tests pass with empty allowlist
- [x] `pnpm typecheck` passes
- [ ] After merge: connect Cloudflare Pages to repo and verify PR preview URL generates
