### PR TITLE
ci(release): gate deploy-web on production-web GitHub Environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,4 +285,4 @@ jobs:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/web
-          command: pages deploy dist --project-name=whiteboard
+          command: pages deploy dist --project-name=kamiazya-whiteboard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,8 +253,10 @@ jobs:
     # Deploy apps/web to Cloudflare Pages when a project release is created.
     # Skipped when no release happened (e.g. mid-cycle pushes).
     # The Deploy step skips itself when Cloudflare secrets are not yet configured.
-    # Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID secrets.
+    # Secrets are scoped to the production-web environment (tag-protected in repo settings).
+    # Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID in the production-web environment.
     if: needs.release-please.outputs.releases_created == 'true'
+    environment: production-web
     permissions:
       contents: read
     env:

--- a/apps/web/src/lib/pages-origin-policy.test.ts
+++ b/apps/web/src/lib/pages-origin-policy.test.ts
@@ -7,25 +7,25 @@ import {
 
 describe('PROVISIONAL_PRODUCTION_ORIGIN', () => {
   it('is the provisional pages.dev production origin', () => {
-    expect(PROVISIONAL_PRODUCTION_ORIGIN).toBe('https://whiteboard.pages.dev')
+    expect(PROVISIONAL_PRODUCTION_ORIGIN).toBe('https://kamiazya-whiteboard.pages.dev')
   })
 })
 
 describe('classifyPagesOrigin', () => {
   it('classifies the provisional production origin as production', () => {
-    expect(classifyPagesOrigin('https://whiteboard.pages.dev')).toBe('production')
+    expect(classifyPagesOrigin('https://kamiazya-whiteboard.pages.dev')).toBe('production')
   })
 
   it('classifies a preview subdomain as preview', () => {
-    expect(classifyPagesOrigin('https://abc123.whiteboard.pages.dev')).toBe('preview')
+    expect(classifyPagesOrigin('https://abc123.kamiazya-whiteboard.pages.dev')).toBe('preview')
   })
 
   it('classifies an arbitrary hash subdomain as preview', () => {
-    expect(classifyPagesOrigin('https://evil-hash.whiteboard.pages.dev')).toBe('preview')
+    expect(classifyPagesOrigin('https://evil-hash.kamiazya-whiteboard.pages.dev')).toBe('preview')
   })
 
   it('classifies http origin as insecure', () => {
-    expect(classifyPagesOrigin('http://whiteboard.pages.dev')).toBe('insecure')
+    expect(classifyPagesOrigin('http://kamiazya-whiteboard.pages.dev')).toBe('insecure')
   })
 
   it('classifies http localhost as insecure (not localhost) since insecure takes precedence', () => {
@@ -42,19 +42,25 @@ describe('classifyPagesOrigin', () => {
   })
 
   it('classifies origin with path as non-bare-origin', () => {
-    expect(classifyPagesOrigin('https://whiteboard.pages.dev/path')).toBe('non-bare-origin')
+    expect(classifyPagesOrigin('https://kamiazya-whiteboard.pages.dev/path')).toBe(
+      'non-bare-origin',
+    )
   })
 
   it('classifies origin with query string as non-bare-origin', () => {
-    expect(classifyPagesOrigin('https://whiteboard.pages.dev?q=1')).toBe('non-bare-origin')
+    expect(classifyPagesOrigin('https://kamiazya-whiteboard.pages.dev?q=1')).toBe('non-bare-origin')
   })
 
   it('classifies origin with fragment as non-bare-origin', () => {
-    expect(classifyPagesOrigin('https://whiteboard.pages.dev#hash')).toBe('non-bare-origin')
+    expect(classifyPagesOrigin('https://kamiazya-whiteboard.pages.dev#hash')).toBe(
+      'non-bare-origin',
+    )
   })
 
   it('classifies origin with credentials as non-bare-origin', () => {
-    expect(classifyPagesOrigin('https://user:pass@whiteboard.pages.dev')).toBe('non-bare-origin')
+    expect(classifyPagesOrigin('https://user:pass@kamiazya-whiteboard.pages.dev')).toBe(
+      'non-bare-origin',
+    )
   })
 
   it('classifies wildcard hostname as non-bare-origin', () => {
@@ -80,11 +86,11 @@ describe('classifyPagesOrigin', () => {
 
 describe('isProductionPagesOrigin', () => {
   it('returns true for provisional production origin', () => {
-    expect(isProductionPagesOrigin('https://whiteboard.pages.dev')).toBe(true)
+    expect(isProductionPagesOrigin('https://kamiazya-whiteboard.pages.dev')).toBe(true)
   })
 
   it('returns false for preview origin', () => {
-    expect(isProductionPagesOrigin('https://abc123.whiteboard.pages.dev')).toBe(false)
+    expect(isProductionPagesOrigin('https://abc123.kamiazya-whiteboard.pages.dev')).toBe(false)
   })
 
   it('returns false for localhost', () => {
@@ -92,7 +98,7 @@ describe('isProductionPagesOrigin', () => {
   })
 
   it('returns false for insecure origin', () => {
-    expect(isProductionPagesOrigin('http://whiteboard.pages.dev')).toBe(false)
+    expect(isProductionPagesOrigin('http://kamiazya-whiteboard.pages.dev')).toBe(false)
   })
 })
 

--- a/apps/web/src/lib/pages-origin-policy.ts
+++ b/apps/web/src/lib/pages-origin-policy.ts
@@ -1,8 +1,8 @@
 // Provisional production origin for the hosted app.
 // Update to the confirmed canonical domain once it is assigned.
-export const PROVISIONAL_PRODUCTION_ORIGIN = 'https://whiteboard.pages.dev' as const
+export const PROVISIONAL_PRODUCTION_ORIGIN = 'https://kamiazya-whiteboard.pages.dev' as const
 
-const PAGES_DOMAIN = 'whiteboard.pages.dev'
+const PAGES_DOMAIN = 'kamiazya-whiteboard.pages.dev'
 
 // Classification of an origin candidate against the Cloudflare Pages hosting policy.
 // 'production'             — exact provisional production origin; accepted.

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { EMPTY_RUNTIME_CONFIG } from '../runtime-config.js'
-import { resolveHostedProviderStateFromRaw, resolveProviderState, resolveProviderStateFromRaw } from './provider.js'
+import {
+  resolveHostedProviderStateFromRaw,
+  resolveProviderState,
+  resolveProviderStateFromRaw,
+} from './provider.js'
 
 describe('resolveProviderState', () => {
   it('returns browser-local when daemonBaseUrl is absent', () => {
@@ -8,7 +12,9 @@ describe('resolveProviderState', () => {
   })
 
   it('returns local-daemon only when daemonBaseUrl is present', () => {
-    expect(resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe('local-daemon')
+    expect(resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe(
+      'local-daemon',
+    )
   })
 
   it('local-daemon state carries daemonBaseUrl', () => {
@@ -56,7 +62,9 @@ describe('resolveProviderStateFromRaw', () => {
   })
 
   it('valid daemonBaseUrl returns local-daemon state', () => {
-    expect(resolveProviderStateFromRaw({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe('local-daemon')
+    expect(resolveProviderStateFromRaw({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe(
+      'local-daemon',
+    )
   })
 
   it('invalid URL returns invalid-config state', () => {
@@ -106,12 +114,16 @@ describe('resolveHostedProviderStateFromRaw', () => {
   })
 
   it('production publicOrigin with no daemon returns browser-local', () => {
-    const state = resolveHostedProviderStateFromRaw({ publicOrigin: 'https://whiteboard.pages.dev' })
+    const state = resolveHostedProviderStateFromRaw({
+      publicOrigin: 'https://kamiazya-whiteboard.pages.dev',
+    })
     expect(state.kind).toBe('browser-local')
   })
 
   it('preview publicOrigin returns invalid-config', () => {
-    const state = resolveHostedProviderStateFromRaw({ publicOrigin: 'https://abc123.whiteboard.pages.dev' })
+    const state = resolveHostedProviderStateFromRaw({
+      publicOrigin: 'https://abc123.kamiazya-whiteboard.pages.dev',
+    })
     expect(state.kind).toBe('invalid-config')
   })
 
@@ -122,7 +134,7 @@ describe('resolveHostedProviderStateFromRaw', () => {
 
   it('invalid-config message does not expose the rejected publicOrigin value', () => {
     const state = resolveHostedProviderStateFromRaw({
-      publicOrigin: 'https://secret.whiteboard.pages.dev',
+      publicOrigin: 'https://secret.kamiazya-whiteboard.pages.dev',
     })
     expect(state.kind).toBe('invalid-config')
     if (state.kind === 'invalid-config') {
@@ -134,12 +146,15 @@ describe('resolveHostedProviderStateFromRaw', () => {
   // browserOrigin guard: preview browser origin is rejected even with no runtime config,
   // so a Cloudflare Pages preview deploy cannot silently enter browser-local mode.
   it('preview browserOrigin returns invalid-config even with empty runtime config', () => {
-    const state = resolveHostedProviderStateFromRaw({}, 'https://abc123.whiteboard.pages.dev')
+    const state = resolveHostedProviderStateFromRaw(
+      {},
+      'https://abc123.kamiazya-whiteboard.pages.dev',
+    )
     expect(state.kind).toBe('invalid-config')
   })
 
   it('production browserOrigin with empty runtime config returns browser-local', () => {
-    const state = resolveHostedProviderStateFromRaw({}, 'https://whiteboard.pages.dev')
+    const state = resolveHostedProviderStateFromRaw({}, 'https://kamiazya-whiteboard.pages.dev')
     expect(state.kind).toBe('browser-local')
   })
 
@@ -149,7 +164,10 @@ describe('resolveHostedProviderStateFromRaw', () => {
   })
 
   it('invalid-config from preview browserOrigin does not expose the origin value', () => {
-    const state = resolveHostedProviderStateFromRaw({}, 'https://secret-hash.whiteboard.pages.dev')
+    const state = resolveHostedProviderStateFromRaw(
+      {},
+      'https://secret-hash.kamiazya-whiteboard.pages.dev',
+    )
     expect(state.kind).toBe('invalid-config')
     if (state.kind === 'invalid-config') {
       expect(state.message).not.toContain('secret-hash')

--- a/apps/web/src/runtime-config.test.ts
+++ b/apps/web/src/runtime-config.test.ts
@@ -31,7 +31,9 @@ describe('runtimeConfigSchema', () => {
   })
 
   it('rejects publicOrigin with a query string', () => {
-    expect(() => resolveRuntimeConfig({ publicOrigin: 'https://app.example.com?token=x' })).toThrow()
+    expect(() =>
+      resolveRuntimeConfig({ publicOrigin: 'https://app.example.com?token=x' }),
+    ).toThrow()
   })
 
   it('rejects publicOrigin with a fragment', () => {
@@ -47,7 +49,9 @@ describe('runtimeConfigSchema', () => {
   })
 
   it('rejects unknown keys (credential-bearing config is fail-closed)', () => {
-    expect(() => resolveRuntimeConfig({ daemonBaseUrl: 'http://127.0.0.1:3099', token: 'secret' })).toThrow()
+    expect(() =>
+      resolveRuntimeConfig({ daemonBaseUrl: 'http://127.0.0.1:3099', token: 'secret' }),
+    ).toThrow()
   })
 
   it('rejects config with Authorization key', () => {
@@ -74,20 +78,20 @@ describe('resolveHostedRuntimeConfig', () => {
   })
 
   it('accepts production pages.dev publicOrigin', () => {
-    const config = resolveHostedRuntimeConfig({ publicOrigin: 'https://whiteboard.pages.dev' })
-    expect(config.publicOrigin).toBe('https://whiteboard.pages.dev')
+    const config = resolveHostedRuntimeConfig({
+      publicOrigin: 'https://kamiazya-whiteboard.pages.dev',
+    })
+    expect(config.publicOrigin).toBe('https://kamiazya-whiteboard.pages.dev')
   })
 
   it('rejects preview origin as publicOrigin', () => {
     expect(() =>
-      resolveHostedRuntimeConfig({ publicOrigin: 'https://abc123.whiteboard.pages.dev' }),
+      resolveHostedRuntimeConfig({ publicOrigin: 'https://abc123.kamiazya-whiteboard.pages.dev' }),
     ).toThrow()
   })
 
   it('rejects localhost as publicOrigin', () => {
-    expect(() =>
-      resolveHostedRuntimeConfig({ publicOrigin: 'https://localhost:5173' }),
-    ).toThrow()
+    expect(() => resolveHostedRuntimeConfig({ publicOrigin: 'https://localhost:5173' })).toThrow()
   })
 
   it('rejects custom domain as publicOrigin (deferred)', () => {
@@ -99,7 +103,9 @@ describe('resolveHostedRuntimeConfig', () => {
   it('error message is a safe generic copy — does not expose raw publicOrigin value', () => {
     let message = ''
     try {
-      resolveHostedRuntimeConfig({ publicOrigin: 'https://secret-preview.whiteboard.pages.dev' })
+      resolveHostedRuntimeConfig({
+        publicOrigin: 'https://secret-preview.kamiazya-whiteboard.pages.dev',
+      })
     } catch (e) {
       message = e instanceof Error ? e.message : String(e)
     }
@@ -112,17 +118,19 @@ describe('runtimeConfigSchema + pages origin policy cross-reference', () => {
   it('preview origin passes structural bare-origin schema', () => {
     // The schema validates shape only (bare origin, https, no wildcards).
     // A preview deploy URL is structurally valid but must NOT be used as publicOrigin.
-    const config = resolveRuntimeConfig({ publicOrigin: 'https://abc123.whiteboard.pages.dev' })
-    expect(config.publicOrigin).toBe('https://abc123.whiteboard.pages.dev')
+    const config = resolveRuntimeConfig({
+      publicOrigin: 'https://abc123.kamiazya-whiteboard.pages.dev',
+    })
+    expect(config.publicOrigin).toBe('https://abc123.kamiazya-whiteboard.pages.dev')
   })
 
   it('preview origin is rejected by isProductionPagesOrigin', () => {
-    expect(isProductionPagesOrigin('https://abc123.whiteboard.pages.dev')).toBe(false)
+    expect(isProductionPagesOrigin('https://abc123.kamiazya-whiteboard.pages.dev')).toBe(false)
   })
 
   it('production origin passes both schema and pages policy', () => {
-    const config = resolveRuntimeConfig({ publicOrigin: 'https://whiteboard.pages.dev' })
-    expect(config.publicOrigin).toBe('https://whiteboard.pages.dev')
-    expect(isProductionPagesOrigin('https://whiteboard.pages.dev')).toBe(true)
+    const config = resolveRuntimeConfig({ publicOrigin: 'https://kamiazya-whiteboard.pages.dev' })
+    expect(config.publicOrigin).toBe('https://kamiazya-whiteboard.pages.dev')
+    expect(isProductionPagesOrigin('https://kamiazya-whiteboard.pages.dev')).toBe(true)
   })
 })

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -1,2 +1,2 @@
-name = "whiteboard"
+name = "kamiazya-whiteboard"
 pages_build_output_dir = "dist"

--- a/docs/contributing/deployment/cloudflare-pages.md
+++ b/docs/contributing/deployment/cloudflare-pages.md
@@ -11,13 +11,13 @@
 | Build output goes to `apps/web/dist/` | `wrangler.toml` `pages_build_output_dir` |
 | Security headers (CSP, X-Frame-Options, …) are served on every route | `apps/web/public/_headers` → copied into `dist/` at build time |
 | CSP has no wildcard sources; `script-src` and `default-src` are `'self'` | `headers-policy.test.ts` + `smoke-artifact.mjs` |
-| Cloudflare Pages preview deploys (`*.whiteboard.pages.dev`) enter `invalid-config`, not browser-local | `App.tsx` passes `window.location.origin` to `resolveHostedProviderStateFromRaw`; preview origins are rejected at bootstrap |
+| Cloudflare Pages preview deploys (`*.kamiazya-whiteboard.pages.dev`) enter `invalid-config`, not browser-local | `App.tsx` passes `window.location.origin` to `resolveHostedProviderStateFromRaw`; preview origins are rejected at bootstrap |
 | No Cloudflare API tokens or account IDs in the repo | `web-app-boundary.test.ts` CF secrets drift guard |
 
 ## What is NOT decided yet
 
-- **Canonical custom domain** — `https://whiteboard.pages.dev` is provisional. A custom domain has not been chosen or registered.
-- **Passkey / WebAuthn** — `whiteboard.pages.dev` is **not** a passkey RP ID. Do not use it as one.
+- **Canonical custom domain** — `https://kamiazya-whiteboard.pages.dev` is provisional. A custom domain has not been chosen or registered.
+- **Passkey / WebAuthn** — `kamiazya-whiteboard.pages.dev` is **not** a passkey RP ID. Do not use it as one.
 - **OAuth / PKCE** — no authorization server is configured.
 - **Local dev via Wrangler** — `wrangler pages dev` is not part of the current workflow. Use `pnpm dev` (Vite) for local development.
 
@@ -34,7 +34,7 @@ npx wrangler pages deploy apps/web/dist --project-name whiteboard
 
 ## Preview origins
 
-Cloudflare automatically creates preview deploys at `https://<hash>.whiteboard.pages.dev`. These are intentionally blocked: the app returns an `invalid-config` error page on any preview origin. This prevents a misconfigured preview from silently acting as a real whiteboard.
+Cloudflare automatically creates preview deploys at `https://<hash>.kamiazya-whiteboard.pages.dev`. These are intentionally blocked: the app returns an `invalid-config` error page on any preview origin. This prevents a misconfigured preview from silently acting as a real whiteboard.
 
 ## Local development
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -342,7 +342,7 @@ Which gate enforces each hosted-app security property (entry points for `securit
 | No Cloudflare secrets / account IDs in the built artifact | `smoke:artifact` (secret scan over `dist/`) |
 | No Cloudflare secrets in `apps/web` config or `.github/workflows/` | `web-app-boundary.test.ts` (CF secrets drift guard) |
 | Preview origin is rejected at runtime (renders `invalid-config`) | `smoke:preview-origin` (behavioral) + bundle wiring check in `smoke:artifact` |
-| Production origin is an exact match (`https://whiteboard.pages.dev`), preview is a distinct class | `pages-origin-policy.test.ts` (`classifyPagesOrigin`) |
+| Production origin is an exact match (`https://kamiazya-whiteboard.pages.dev`), preview is a distinct class | `pages-origin-policy.test.ts` (`classifyPagesOrigin`) |
 | Preview origin never enters a trusted / local-daemon allowlist | `pages-origin-policy.test.ts` (preview ≠ production) + `web-app-boundary.test.ts` (no preview origin in `wrangler.toml`); local-daemon / server-mode wildcard rejection is held separately by `server-mode-exposure` |
 
 ---

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -628,5 +628,9 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     expect(content, 'release.yml deploy-web must reference CLOUDFLARE_ACCOUNT_ID').toContain(
       'CLOUDFLARE_ACCOUNT_ID',
     )
+    expect(
+      content,
+      'release.yml deploy-web must use production-web environment (secrets scoped to tag-protected env)',
+    ).toContain('environment: production-web')
   })
 })

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -535,13 +535,13 @@ describe('apps/web Cloudflare Pages config (wrangler.toml)', () => {
     )
   })
 
-  it('project name matches provisional production origin slug "whiteboard"', () => {
+  it('project name matches production origin slug "kamiazya-whiteboard"', () => {
     if (!existsSync(wranglerPath)) return
     const content = readFileSync(wranglerPath, 'utf-8')
     expect(
       content,
-      'wrangler.toml name must be "whiteboard" — matches https://whiteboard.pages.dev',
-    ).toMatch(/\bname\s*=\s*["']whiteboard["']/)
+      'wrangler.toml name must be "kamiazya-whiteboard" — matches https://kamiazya-whiteboard.pages.dev',
+    ).toMatch(/\bname\s*=\s*["']kamiazya-whiteboard["']/)
   })
 
   it('wrangler.toml does not contain account_id or Cloudflare production secrets', () => {
@@ -556,10 +556,10 @@ describe('apps/web Cloudflare Pages config (wrangler.toml)', () => {
   it('wrangler.toml does not hardcode preview origins in any allowed origin list', () => {
     if (!existsSync(wranglerPath)) return
     const content = readFileSync(wranglerPath, 'utf-8')
-    // Wildcard globs (*.whiteboard.pages.dev) and concrete preview subdomains are both preview origins.
-    expect(content).not.toMatch(/\*\.whiteboard\.pages\.dev/)
+    // Wildcard globs (*.kamiazya-whiteboard.pages.dev) and concrete preview subdomains are both preview origins.
+    expect(content).not.toMatch(/\*\.kamiazya-whiteboard\.pages\.dev/)
     expect(content).not.toMatch(/\*\.pages\.dev/)
-    expect(content).not.toMatch(/[a-z0-9-]+\.whiteboard\.pages\.dev/)
+    expect(content).not.toMatch(/[a-z0-9-]+\.kamiazya-whiteboard\.pages\.dev/)
   })
 })
 

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -622,15 +622,18 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     if (!existsSync(releaseYml)) return
     const content = readFileSync(releaseYml, 'utf-8')
     expect(content, 'release.yml must contain deploy-web job').toContain('deploy-web:')
-    expect(content, 'release.yml deploy-web must reference CLOUDFLARE_API_TOKEN').toContain(
+    // Extract just the deploy-web job block so assertions are scoped to that job only.
+    const deployWebMatch = content.match(/  deploy-web:[\s\S]*?(?=\n  [\w][\w-]*:|$)/)
+    const deployWebSection = deployWebMatch ? deployWebMatch[0] : ''
+    expect(deployWebSection, 'deploy-web job must reference CLOUDFLARE_API_TOKEN').toContain(
       'CLOUDFLARE_API_TOKEN',
     )
-    expect(content, 'release.yml deploy-web must reference CLOUDFLARE_ACCOUNT_ID').toContain(
+    expect(deployWebSection, 'deploy-web job must reference CLOUDFLARE_ACCOUNT_ID').toContain(
       'CLOUDFLARE_ACCOUNT_ID',
     )
     expect(
-      content,
-      'release.yml deploy-web must use production-web environment (secrets scoped to tag-protected env)',
+      deployWebSection,
+      'deploy-web job must declare environment: production-web (secrets scoped to tag-protected env)',
     ).toContain('environment: production-web')
   })
 })


### PR DESCRIPTION
## Summary

- Add `environment: production-web` to the `deploy-web` job in `release.yml`, scoping Cloudflare secrets to a tag-protected GitHub Environment instead of repo-level secrets
- Extend `web-app-boundary.test.ts` to assert the environment declaration is present **within the `deploy-web` job section** (not just anywhere in the file), preventing future drift

## Background

This project's release model is tag-based via Release Please. Cloudflare Pages Git integration is branch-based only and does not support tag-triggered deployments (confirmed and closed in PR #76). The wrangler-action approach is correct, but the Cloudflare secrets were previously at repo level with no environment gate.

Adding `environment: production-web` allows a deployment protection rule (tag policy) to be configured in GitHub repo settings, restricting secret access to actual release events.

## Required follow-up (user action)

1. **Create the `production-web` environment** in GitHub → Repository Settings → Environments
   - Add a deployment protection rule scoped to release tags (e.g. `v*` or `mcp-server-v*`)
2. **Add Cloudflare secrets to the `production-web` environment** (not repo-level)
   - `CLOUDFLARE_API_TOKEN`
   - `CLOUDFLARE_ACCOUNT_ID`
3. **Create the Cloudflare Pages project** `whiteboard` in Direct Upload mode via the Cloudflare dashboard

## Test plan

- [x] `pnpm test --project mcp-node` — all 2644 tests pass including updated boundary assertions
- [x] `pnpm typecheck` — all packages pass
- [ ] Verify `deploy-web` fires via `production-web` environment when a Release Please tag is created (requires secrets to be configured)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare Pages/hosted configuration to use the new `kamiazya-whiteboard` production and preview origin domains.
  * Adjusted the web deployment release workflow to target the production environment and the updated Pages project name.
* **Tests**
  * Updated origin classification, hosted/provider resolution, and runtime config tests to match the new `kamiazya-whiteboard.pages.dev` domains.
  * Strengthened drift and secret checks by scoping assertions to the web deployment job and adding an environment declaration verification.
* **Documentation**
  * Updated Cloudflare Pages deployment guidance and security review references for the new production/preview origin patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->