### PR TITLE
chore(deps-dev): bump @tanstack/intent from 0.0.29 to 0.0.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@cyclonedx/cyclonedx-npm": "^4",
     "@secretlint/secretlint-rule-pattern": "13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "13.0.2",
-    "@tanstack/intent": "^0.0.29",
+    "@tanstack/intent": "^0.0.40",
     "lefthook": "^2.1.9",
     "secretlint": "13.0.2",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: 13.0.2
         version: 13.0.2
       '@tanstack/intent':
-        specifier: ^0.0.29
-        version: 0.0.29
+        specifier: ^0.0.40
+        version: 0.0.40
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
@@ -2996,6 +2996,10 @@ packages:
     resolution: {integrity: sha512-tJcWapEkXGRLHE7mQYvQS0xIWrzKm2n7fQ/lOy4LCdR1hX0Yxb9QnwRwd0oqmmr54ObP9/5sfiD8vELxL/r30g==}
     hasBin: true
 
+  '@tanstack/intent@0.0.40':
+    resolution: {integrity: sha512-ZuUTzr4QrjNuWdv+DfTv0///uONz5+Sw3mR+2xOXHpob6vWsUXnSk3Ht7X9Rpu6zZdQYZlZnJCwN50CAZ21GCw==}
+    hasBin: true
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -4378,6 +4382,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
@@ -8497,6 +8504,13 @@ snapshots:
       cac: 6.7.14
       yaml: 2.8.3
 
+  '@tanstack/intent@0.0.40':
+    dependencies:
+      cac: 6.7.14
+      jsonc-parser: 3.3.1
+      semver: 7.7.4
+      yaml: 2.8.3
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -10047,6 +10061,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   katex@0.16.45:
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps `@tanstack/intent` from `^0.0.29` to `^0.0.40`
- Dev-only dependency (skill validation tooling)
- Supersedes #50

## Test plan

- [ ] CI `verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)