### PR TITLE
fix(ci): unbreak publish jobs — validate-step cwd and SBOM generation under pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
         working-directory: packages/mcp-server
     steps:
       - name: Validate tag shape
+        # Runs before checkout: the job-default working-directory does not exist yet,
+        # so this step must override it or bash fails to start.
+        working-directory: .
         env:
           TAG: ${{ inputs.force_publish_tag || needs.release-please.outputs.mcp_tag_name }}
         run: |

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
-    "@cyclonedx/cyclonedx-npm": "^5",
+    "@cyclonedx/cyclonedx-npm": "^4.2.1",
     "@secretlint/secretlint-rule-pattern": "13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "13.0.2",
     "@tanstack/intent": "^0.0.40",

--- a/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
+++ b/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
@@ -52,7 +52,11 @@ function safeHint(result) {
 // Ensure output directory exists; clean up any previous temp dir.
 // pnpm deploy creates TMP_DIR itself — do not mkdir it here.
 mkdirSync(OUT_DIR, { recursive: true })
-try { rmSync(TMP_DIR, { recursive: true, force: true }) } catch { /* ok */ }
+try {
+  rmSync(TMP_DIR, { recursive: true, force: true })
+} catch {
+  /* ok */
+}
 
 // Deploy production-only dependencies into an isolated temp directory.
 // pnpm deploy reads pnpm-lock.yaml from the workspace root so dependency
@@ -62,8 +66,12 @@ try { rmSync(TMP_DIR, { recursive: true, force: true }) } catch { /* ok */ }
 const deployResult = spawnSync(
   'pnpm',
   [
-    '--filter', '@kamiazya/whiteboard-mcp',
-    'deploy', '--legacy', '--prod', '--ignore-scripts',
+    '--filter',
+    '@kamiazya/whiteboard-mcp',
+    'deploy',
+    '--legacy',
+    '--prod',
+    '--ignore-scripts',
     TMP_DIR,
   ],
   {
@@ -81,6 +89,17 @@ if (deployResult.status !== 0 || deployResult.error) {
 // Use the lockfile-pinned binary from the workspace.
 const cyclonedxBin = resolve(WORKSPACE_ROOT, 'node_modules', '.bin', 'cyclonedx-npm')
 
+// Strip package-manager lifecycle env before invoking cyclonedx-npm.
+// Under `pnpm run`, npm_execpath points at pnpm's own CLI; cyclonedx-npm uses
+// npm_execpath to locate "npm", so it would silently run `pnpm ls` instead of
+// `npm ls` and die with an option-parse error (exit 254, empty stdout).
+const cleanEnv = { ...process.env }
+for (const key of Object.keys(cleanEnv)) {
+  if (key === 'npm_execpath' || key.startsWith('npm_config_') || key.startsWith('npm_lifecycle_')) {
+    delete cleanEnv[key]
+  }
+}
+
 // Generate the SBOM from the isolated production deploy.
 // --ignore-npm-errors: npm ls reports ELSPROBLEMS for devDependencies listed
 //   in package.json but absent from node_modules (deployed prod-only).
@@ -90,15 +109,19 @@ const sbomResult = spawnSync(
   cyclonedxBin,
   [
     '--ignore-npm-errors',
-    '--output-format', 'JSON',
-    '--output-file', SBOM_FILE,
-    '--output-reproducible',  // omit timestamps for deterministic output
-    '--spec-version', '1.4',  // CycloneDX 1.4 — stable spec
+    '--output-format',
+    'JSON',
+    '--output-file',
+    SBOM_FILE,
+    '--output-reproducible', // omit timestamps for deterministic output
+    '--spec-version',
+    '1.4', // CycloneDX 1.4 — stable spec
   ],
   {
     cwd: TMP_DIR,
+    env: cleanEnv,
     encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],  // never relay tool output to our stdout
+    stdio: ['ignore', 'pipe', 'pipe'], // never relay tool output to our stdout
   },
 )
 

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -294,7 +294,9 @@ describe('generated SBOM content regression', () => {
       'pkg:npm/jsdom@', // jsdom
       'pkg:npm/fast-check@', // fast-check core
       '%40fast-check/', // @fast-check/* scoped
-      '%40excalidraw/', // @excalidraw/* (bundled into dist, not a prod dep)
+      // @excalidraw/* is intentionally NOT listed: @excalidraw/utils is a runtime
+      // dependency of the server-side headless export, so it (and its transitive
+      // @excalidraw/* deps) legitimately appear in the production SBOM.
       '%40stryker-mutator/', // @stryker-mutator/* mutation testing
       'pkg:npm/playwright@', // playwright core
       '%40playwright/', // @playwright/* scoped
@@ -308,7 +310,13 @@ describe('generated SBOM content regression', () => {
 
   it.runIf(sbomExists)('generated SBOM contains expected production packages', () => {
     const purls = loadSbomPurls()
-    const prodPatterns = ['pkg:npm/hono@', 'pkg:npm/jose@', 'pkg:npm/zod@', 'pkg:npm/nanoid@']
+    const prodPatterns = [
+      'pkg:npm/hono@',
+      'pkg:npm/jose@',
+      'pkg:npm/zod@',
+      'pkg:npm/nanoid@',
+      '%40excalidraw/utils@', // runtime dep of server-side headless export
+    ]
     for (const pattern of prodPatterns) {
       expect(
         purls.some((p) => p.includes(pattern)),
@@ -392,5 +400,57 @@ describe('validateSbomSummary PBT', () => {
     withDefaults(),
   )('non-object summary always fails validation', (summary) => {
     expect(validateSbomSummary(summary).ok).toBe(false)
+  })
+})
+
+describe('release.yml publish job step ordering hazards', () => {
+  it('publish-mcp pre-checkout steps must not inherit the packages/mcp-server default cwd', () => {
+    // publish-mcp sets defaults.run.working-directory: packages/mcp-server, but that
+    // directory only exists after actions/checkout runs. Any run step placed before
+    // checkout (e.g. Validate tag shape) must override with working-directory: .
+    // or bash fails to start ("No such file or directory") — broke the v0.0.8 release.
+    const releaseYml = readFile('.github/workflows/release.yml')
+    const publishMcp = jobSection(releaseYml, 'publish-mcp', 'docker-publish-sign')
+    expect(publishMcp, 'publish-mcp job must exist in release.yml').not.toBe('')
+    const checkoutIdx = publishMcp.indexOf('actions/checkout@')
+    expect(checkoutIdx, 'publish-mcp must have a checkout step').toBeGreaterThan(-1)
+    const preCheckout = publishMcp.slice(0, checkoutIdx)
+    // Every `run:` step before checkout needs an explicit working-directory override.
+    const runSteps = preCheckout.match(/^      - name: .*$/gm) ?? []
+    for (const step of runSteps) {
+      expect(
+        preCheckout,
+        `pre-checkout step "${step.trim()}" must set working-directory: . (job default dir does not exist yet)`,
+      ).toMatch(/working-directory:\s*\.\s*$/m)
+    }
+  })
+})
+
+describe('generate-npm-sbom.mjs pnpm-run environment', () => {
+  it('strips package-manager lifecycle env before spawning cyclonedx-npm', () => {
+    // Under `pnpm run`, npm_execpath points at pnpm's CLI. cyclonedx-npm resolves
+    // "npm" through npm_execpath, so without sanitization it runs `pnpm ls` and
+    // fails (exit 254). The script must spawn cyclonedx-npm with a cleaned env.
+    const script = readFile('packages/mcp-server/scripts/release/generate-npm-sbom.mjs')
+    expect(script, 'script must strip npm_execpath from the spawn env').toContain('npm_execpath')
+    expect(script, 'cyclonedx spawn must use the sanitized env').toMatch(/env:\s*cleanEnv/)
+  })
+})
+
+describe('cyclonedx-npm version policy', () => {
+  it('stays on v4 until the v5 --ignore-npm-errors regression is fixed', () => {
+    // @cyclonedx/cyclonedx-npm@5.0.0 treats npm ls ELSPROBLEMS as fatal even with
+    // --ignore-npm-errors, so SBOM generation fails on the pnpm-deployed prod tree
+    // (devDependencies are intentionally absent there). v4 honours the flag.
+    // Remove this pin guard once an upstream release honours --ignore-npm-errors again.
+    const rootPkg = JSON.parse(readFile('package.json')) as {
+      devDependencies?: Record<string, string>
+    }
+    const version = rootPkg.devDependencies?.['@cyclonedx/cyclonedx-npm']
+    expect(version, '@cyclonedx/cyclonedx-npm must be a root devDependency').toBeTruthy()
+    expect(
+      version,
+      'must stay on ^4.x — v5.0.0 --ignore-npm-errors regression breaks generate:sbom:npm',
+    ).toMatch(/^\^?4\./)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^2.0.0
         version: 2.4.13
       '@cyclonedx/cyclonedx-npm':
-        specifier: ^5
-        version: 5.0.0
+        specifier: ^4.2.1
+        version: 4.2.1
       '@secretlint/secretlint-rule-pattern':
         specifier: 13.0.2
         version: 13.0.2
@@ -818,8 +818,8 @@ packages:
       xmlbuilder2:
         optional: true
 
-  '@cyclonedx/cyclonedx-npm@5.0.0':
-    resolution: {integrity: sha512-pEz/pqYJHQ0ZvY5xFJa+GQ5AjNL7JOEJCXCHymvKo2N1VnzKE1ROpkumduJt8a0DukQjQfBGRXouGQ9xqJtJaQ==}
+  '@cyclonedx/cyclonedx-npm@4.2.1':
+    resolution: {integrity: sha512-SOA/96sf0wsgUYCRtFkLFm6WoFhG+q1BxdC84hPSn9J3xWlH1e7OnTPJT+WNUzTqzX1nSm5JhjRX4krozu2X+g==}
     engines: {node: '>=20.18.0', npm: '>=9'}
     hasBin: true
 
@@ -6723,7 +6723,7 @@ snapshots:
       spdx-expression-parse: 4.0.0
       xmlbuilder2: 4.0.3
 
-  '@cyclonedx/cyclonedx-npm@5.0.0':
+  '@cyclonedx/cyclonedx-npm@4.2.1':
     dependencies:
       '@cyclonedx/cyclonedx-library': 10.0.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(libxmljs2@0.37.0)(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@4.0.3)
       commander: 14.0.3
@@ -11885,7 +11885,7 @@ snapshots:
 
   table@6.9.0:
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3


### PR DESCRIPTION
## Summary

The v0.0.8 release run (28736114626) succeeded for `deploy-web` 🎉 but `publish-mcp` and `docker-publish-sign` failed. This PR fixes both root causes. All changes are red-first guarded.

### publish-mcp — Validate tag shape ran in a nonexistent cwd

The step runs before `actions/checkout`, but the job default `working-directory: packages/mcp-server` only exists after checkout — bash failed to start (`No such file or directory`). Fixed with `working-directory: .` on the step; a new policy test asserts every pre-checkout step overrides the default cwd.

### docker-publish-sign — generate:sbom:npm failed (two independent bugs)

1. **`npm_execpath` under `pnpm run`**: pnpm sets `npm_execpath` to its own CLI; cyclonedx-npm resolves "npm" through it and silently ran `pnpm ls --json --long --all` (exit 254, empty stdout). The script now strips package-manager lifecycle env (`npm_execpath`, `npm_config_*`, `npm_lifecycle_*`) before spawning cyclonedx-npm.
2. **cyclonedx-npm 5.0.0 regression**: v5 treats `npm ls` ELSPROBLEMS as fatal even with `--ignore-npm-errors` (reproduced outside pnpm too). Pinned back to `^4.2.1`; a version-policy test documents the removal criteria.

Also corrected the SBOM dev-only pattern list: `@excalidraw/utils` is a runtime dependency of server-side headless export, so `@excalidraw/*` legitimately appears in the production SBOM (it is now asserted as an expected production package instead).

## Verification

- [x] Red-first: pre-checkout cwd test and version-policy test both failed against the pre-fix tree
- [x] `pnpm --filter @kamiazya/whiteboard-mcp generate:sbom:npm` succeeds locally via `pnpm run` (toolVersion 4.2.1)
- [x] `pnpm test --project mcp-node` — 2646 passed
- [ ] After merge: `workflow_dispatch` with `force_publish_tag=mcp-server-v0.0.8` to re-publish npm + Docker for the existing release (deploy-web already succeeded; no new release needed)