### PR TITLE
fix(web): unblank the deployed app — CSP wasm-unsafe-eval + self-hosted Excalidraw fonts

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,1 @@
+.wrangler/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,6 @@
     "tailwindcss": "^4",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vite-plugin-static-copy": "^4.1.1",
     "vite-plugin-top-level-await": "^1",
     "vite-plugin-wasm": "^3",
     "vitest": "catalog:",

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,4 +3,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*

--- a/apps/web/scripts/smoke-artifact.mjs
+++ b/apps/web/scripts/smoke-artifact.mjs
@@ -72,11 +72,16 @@ if (headers !== null) {
   assert(csp.includes("base-uri 'none'"), "CSP: base-uri 'none'")
   assert(csp.includes("object-src 'none'"), "CSP: object-src 'none'")
   assert(csp.includes("script-src 'self'"), "CSP: script-src 'self'")
+  // loro-crdt is WASM; without 'wasm-unsafe-eval' the app dies at bootstrap (blank page).
+  assert(
+    /script-src[^;]*'wasm-unsafe-eval'/.test(csp),
+    "CSP: 'wasm-unsafe-eval' for loro-crdt WASM",
+  )
 
   // No wildcard sources that would defeat the CSP
-  assert(!csp.includes("script-src *"), 'CSP: no wildcard script-src')
-  assert(!csp.includes("default-src *"), 'CSP: no wildcard default-src')
-  assert(!csp.includes("connect-src *"), 'CSP: no wildcard connect-src')
+  assert(!csp.includes('script-src *'), 'CSP: no wildcard script-src')
+  assert(!csp.includes('default-src *'), 'CSP: no wildcard default-src')
+  assert(!csp.includes('connect-src *'), 'CSP: no wildcard connect-src')
   assert(!csp.match(/script-src[^;]*'unsafe-eval'/), "CSP: no 'unsafe-eval' in script-src")
 }
 

--- a/apps/web/scripts/smoke-artifact.mjs
+++ b/apps/web/scripts/smoke-artifact.mjs
@@ -44,6 +44,15 @@ console.log('\n[smoke-artifact] dist/ structure')
 assert(existsSync(DIST), 'dist/ directory exists')
 assert(existsSync(resolve(DIST, 'index.html')), 'dist/index.html exists')
 
+// Self-hosted Excalidraw fonts: Excalidraw resolves
+// `${EXCALIDRAW_ASSET_PATH}fonts/<Family>/…` and the CSP blocks the esm.sh
+// fallback, so the fonts must land at dist/fonts/<Family>/ exactly.
+assert(existsSync(resolve(DIST, 'fonts/Excalifont')), 'dist/fonts/Excalifont/ exists (self-hosted)')
+assert(
+  !existsSync(resolve(DIST, 'fonts/node_modules')),
+  'dist/fonts has no node_modules path prefix (copy structure regression)',
+)
+
 // ── _headers copied ───────────────────────────────────────────────────────────
 console.log('\n[smoke-artifact] _headers')
 const headers = readDist('_headers')

--- a/apps/web/src/excalidraw-asset-path.ts
+++ b/apps/web/src/excalidraw-asset-path.ts
@@ -1,0 +1,18 @@
+// Point Excalidraw's lazy asset loading (fonts) at our own origin instead of the
+// esm.sh CDN default. vite.config.ts copies @excalidraw/excalidraw/dist/prod/fonts
+// into dist/fonts, and the CSP (default-src 'self') blocks cross-origin font
+// fetches — so self-hosting is not just offline-friendliness, it is required.
+//
+// This module must be imported before anything that pulls in @excalidraw/excalidraw
+// (see the import order in main.tsx): Excalidraw reads the global when it registers
+// fonts.
+
+declare global {
+  interface Window {
+    EXCALIDRAW_ASSET_PATH?: string
+  }
+}
+
+window.EXCALIDRAW_ASSET_PATH = '/'
+
+export {}

--- a/apps/web/src/lib/excalidraw-asset-path.test.ts
+++ b/apps/web/src/lib/excalidraw-asset-path.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import '../excalidraw-asset-path.js'
+
+// vite.config.ts copies @excalidraw/excalidraw/dist/prod/fonts → dist/fonts so the
+// app is self-contained. Without window.EXCALIDRAW_ASSET_PATH Excalidraw fetches
+// fonts from esm.sh instead, which the CSP (default-src 'self') blocks — every
+// lazy font load fails and text falls back to system fonts.
+describe('excalidraw asset path', () => {
+  it('pins Excalidraw asset loading to the self-hosted origin', () => {
+    expect(window.EXCALIDRAW_ASSET_PATH).toBe('/')
+  })
+})

--- a/apps/web/src/lib/headers-policy.test.ts
+++ b/apps/web/src/lib/headers-policy.test.ts
@@ -40,6 +40,22 @@ describe('Content-Security-Policy directives', () => {
     expect(extractCsp(headersContent)).toContain("frame-ancestors 'none'")
   })
 
+  it("script-src allows WebAssembly compilation via 'wasm-unsafe-eval'", () => {
+    // loro-crdt ships as a WebAssembly module. Under script-src 'self' the browser
+    // rejects WebAssembly.Module() (CompileError) and the app renders a blank page.
+    // 'wasm-unsafe-eval' permits WASM compilation WITHOUT allowing JS eval().
+    const csp = extractCsp(headersContent)
+    expect(csp).toMatch(/script-src[^;]*'wasm-unsafe-eval'/)
+  })
+
+  it("script-src does not contain full 'unsafe-eval'", () => {
+    // 'wasm-unsafe-eval' is the narrow carve-out; plain 'unsafe-eval' (JS eval)
+    // must never be introduced. The leading quote in the pattern prevents a
+    // false match against 'wasm-unsafe-eval'.
+    const csp = extractCsp(headersContent)
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-eval'/)
+  })
+
   it('connect-src does not contain bare wildcard *', () => {
     const csp = extractCsp(headersContent)
     const connectSrcMatch = /connect-src\s+([^;]*)/.exec(csp)

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,5 @@
+// Must run before any module that pulls in @excalidraw/excalidraw.
+import './excalidraw-asset-path.js'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App.js'

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,13 +1,55 @@
-import { dirname, resolve, sep } from 'node:path'
+import { cpSync, existsSync } from 'node:fs'
+import { createReadStream } from 'node:fs'
+import { dirname, extname, join, normalize, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
-import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { defineConfig, type Plugin } from 'vite'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const EXCALIDRAW_FONTS_DIR = resolve(
+  __dirname,
+  'node_modules/@excalidraw/excalidraw/dist/prod/fonts',
+)
+
+// Self-host the Excalidraw fonts so the app works offline and the CSP
+// (default-src 'self') does not block lazy font loading. Excalidraw resolves
+// font URLs as `${window.EXCALIDRAW_ASSET_PATH}fonts/<Family>/<file>.woff2`
+// (asset path is set in src/excalidraw-asset-path.ts), so both build output
+// and the dev server must expose the fonts at /fonts/<Family>/….
+// cpSync (dereference) instead of a glob copy plugin: pnpm symlinks plus
+// fast-glob base-path inference kept reproducing the node_modules prefix in
+// the destination.
+function excalidrawFontsPlugin(): Plugin {
+  return {
+    name: 'excalidraw-self-hosted-fonts',
+    closeBundle() {
+      cpSync(EXCALIDRAW_FONTS_DIR, resolve(__dirname, 'dist/fonts'), {
+        recursive: true,
+        dereference: true,
+      })
+    },
+    configureServer(server) {
+      server.middlewares.use('/fonts', (req, res, next) => {
+        const relPath = normalize(decodeURIComponent(req.url ?? '')).replace(/^([/\\])+/, '')
+        const filePath = join(EXCALIDRAW_FONTS_DIR, relPath)
+        // join+normalize keeps traversal inside the fonts dir; double-check anyway.
+        if (!filePath.startsWith(EXCALIDRAW_FONTS_DIR) || !existsSync(filePath)) {
+          next()
+          return
+        }
+        res.setHeader(
+          'Content-Type',
+          extname(filePath) === '.woff2' ? 'font/woff2' : 'application/octet-stream',
+        )
+        createReadStream(filePath).pipe(res)
+      })
+    },
+  }
+}
 
 export default defineConfig({
   resolve: {
@@ -31,21 +73,6 @@ export default defineConfig({
     // Required for the browser bundle that includes the Loro CRDT WASM build.
     wasm(),
     topLevelAwait(),
-    viteStaticCopy({
-      targets: [
-        {
-          // Self-host the Excalidraw fonts so the app works offline.
-          // The glob pattern starts after the fonts/ directory so the
-          // dest only contains the font family subdirectories, not the
-          // full node_modules path prefix.
-          // fast-glob (used by vite-plugin-static-copy) requires forward
-          // slashes even on Windows; replace OS separators before appending.
-          src: `${resolve(__dirname, 'node_modules/@excalidraw/excalidraw/dist/prod/fonts')
-            .split(sep)
-            .join('/')}/**/*`,
-          dest: 'fonts',
-        },
-      ],
-    }),
+    excalidrawFontsPlugin(),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-static-copy:
-        specifier: ^4.1.1
-        version: 4.1.1(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-top-level-await:
         specifier: ^1
         version: 1.6.0(rollup@4.60.1)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -12124,14 +12121,6 @@ snapshots:
       picocolors: 1.1.1
       tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  vite-plugin-static-copy@4.1.1(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      chokidar: 3.6.0
-      p-map: 7.0.4
-      picocolors: 1.1.1
-      tinyglobby: 0.2.17
-      vite: 8.0.16(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-plugin-top-level-await@1.6.0(rollup@4.60.1)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

The deployed app at kamiazya-whiteboard.pages.dev returned 200 but rendered a **blank page**. Chrome debugging found two CSP-related failures; both are fixed red-first.

### 1. CSP blocked WebAssembly compilation (the blank page)

Console: `CompileError: WebAssembly.Module(): ... 'unsafe-eval' is not an allowed source ... "script-src 'self'"`.

loro-crdt ships as a WASM module and the bundle dies at bootstrap. Added `'wasm-unsafe-eval'` to `script-src` in `apps/web/public/_headers` — this permits WASM compilation **without** allowing JS `eval()`. Guards: headers-policy tests (positive `'wasm-unsafe-eval'`, negative plain `'unsafe-eval'`) + smoke-artifact assertion.

### 2. Excalidraw fonts resolved from esm.sh (blocked by CSP)

After the WASM fix, 200 console errors remained: every lazy font fetch went to the esm.sh CDN, blocked by `default-src 'self'`.

- `vite.config.ts` already copied the fonts into `dist/fonts`, but `window.EXCALIDRAW_ASSET_PATH` was never set, so Excalidraw never looked locally. Now set to `/` in `src/excalidraw-asset-path.ts`, imported first in `main.tsx`.
- The copy itself was also broken: the static-copy glob emitted `dist/fonts/node_modules/@excalidraw/…` instead of `dist/fonts/<Family>/`. Replaced with a small `cpSync` plugin (dereferences pnpm symlinks) plus a dev-server middleware serving the same layout; dropped the now-unused `vite-plugin-static-copy` dependency from apps/web.

Known cosmetic leftover: Excalidraw always appends its esm.sh fallback to FontFace src lists, and Chrome logs a CSP violation per blocked candidate even though the local source wins. Functionally fonts load from `/fonts/<Family>/` (verified).

## Verification (wrangler pages dev serving dist with _headers)

- [x] No `CompileError` — app boots, Excalidraw mounts (2 canvases), CSS applied
- [x] `document.fonts` has all 234 faces; `document.fonts.load('20px Excalifont')` loads from the local origin on demand
- [x] Red-first: headers-policy wasm test and excalidraw-asset-path test failed pre-fix
- [x] apps/web: 157 tests pass, typecheck pass, `smoke:artifact` all checks pass (incl. new fonts-structure guard)

## Visual repro

After (local dist serve with production headers — app renders instead of a blank page):

![csp-fix-local-verify.png](https://github.com/user-attachments/assets/67dbb663-c983-48ad-8ad2-1f3e75620cd5)

Before: the production page was fully blank (no DOM painted) with the CompileError above in console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Excalidraw fonts are now loaded from the app’s own domain, improving self-hosted asset delivery.
  * Development and build setups now include direct font handling for smoother local and production use.

* **Bug Fixes**
  * Updated security settings to support WebAssembly execution needed by the app while keeping stricter CSP rules.
  * Added checks to prevent broken font paths and unintended external asset loading.

* **Tests**
  * Expanded automated checks for security policy and font asset placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->