### PR TITLE
fix(web): address AI review follow-ups from #100 and #102

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,5 @@
-import { cpSync, existsSync } from 'node:fs'
-import { createReadStream } from 'node:fs'
-import { dirname, extname, join, normalize, resolve } from 'node:path'
+import { cpSync, createReadStream, statSync } from 'node:fs'
+import { dirname, extname, join, normalize, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
@@ -36,8 +35,19 @@ function excalidrawFontsPlugin(): Plugin {
       server.middlewares.use('/fonts', (req, res, next) => {
         const relPath = normalize(decodeURIComponent(req.url ?? '')).replace(/^([/\\])+/, '')
         const filePath = join(EXCALIDRAW_FONTS_DIR, relPath)
-        // join+normalize keeps traversal inside the fonts dir; double-check anyway.
-        if (!filePath.startsWith(EXCALIDRAW_FONTS_DIR) || !existsSync(filePath)) {
+        // Terminate the base with a separator: a bare prefix check would accept
+        // sibling directories (e.g. fonts-backup). Serve regular files only so a
+        // directory request cannot reach createReadStream (EISDIR crash).
+        const safeBase = EXCALIDRAW_FONTS_DIR.endsWith(sep)
+          ? EXCALIDRAW_FONTS_DIR
+          : EXCALIDRAW_FONTS_DIR + sep
+        let isFile = false
+        try {
+          isFile = filePath.startsWith(safeBase) && statSync(filePath).isFile()
+        } catch {
+          // missing file → fall through to next()
+        }
+        if (!isFile) {
           next()
           return
         }
@@ -45,7 +55,14 @@ function excalidrawFontsPlugin(): Plugin {
           'Content-Type',
           extname(filePath) === '.woff2' ? 'font/woff2' : 'application/octet-stream',
         )
-        createReadStream(filePath).pipe(res)
+        const stream = createReadStream(filePath)
+        stream.on('error', () => {
+          // Without this, a read error crashes the dev server via an
+          // unhandled 'error' event on the stream.
+          if (!res.headersSent) res.statusCode = 500
+          res.end()
+        })
+        stream.pipe(res)
       })
     },
   }

--- a/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
+++ b/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
@@ -93,9 +93,16 @@ const cyclonedxBin = resolve(WORKSPACE_ROOT, 'node_modules', '.bin', 'cyclonedx-
 // Under `pnpm run`, npm_execpath points at pnpm's own CLI; cyclonedx-npm uses
 // npm_execpath to locate "npm", so it would silently run `pnpm ls` instead of
 // `npm ls` and die with an option-parse error (exit 254, empty stdout).
+// Compare case-insensitively: Windows env var keys are case-insensitive and
+// may surface with different casing than the lowercase names pnpm sets.
 const cleanEnv = { ...process.env }
 for (const key of Object.keys(cleanEnv)) {
-  if (key === 'npm_execpath' || key.startsWith('npm_config_') || key.startsWith('npm_lifecycle_')) {
+  const lowerKey = key.toLowerCase()
+  if (
+    lowerKey === 'npm_execpath' ||
+    lowerKey.startsWith('npm_config_') ||
+    lowerKey.startsWith('npm_lifecycle_')
+  ) {
     delete cleanEnv[key]
   }
 }

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -415,12 +415,17 @@ describe('release.yml publish job step ordering hazards', () => {
     const checkoutIdx = publishMcp.indexOf('actions/checkout@')
     expect(checkoutIdx, 'publish-mcp must have a checkout step').toBeGreaterThan(-1)
     const preCheckout = publishMcp.slice(0, checkoutIdx)
-    // Every `run:` step before checkout needs an explicit working-directory override.
-    const runSteps = preCheckout.match(/^      - name: .*$/gm) ?? []
+    // Every `run:` step before checkout needs an explicit working-directory
+    // override. Assert PER STEP — matching against the whole pre-checkout block
+    // would let one compliant step mask another step's missing override.
+    const steps = preCheckout.split(/^      - /m).slice(1)
+    const runSteps = steps.filter((step) => /^\s*run:/m.test(step))
+    expect(runSteps.length, 'expected at least one pre-checkout run step').toBeGreaterThan(0)
     for (const step of runSteps) {
+      const stepName = step.match(/name:\s*(.*)/)?.[1] ?? step.slice(0, 40)
       expect(
-        preCheckout,
-        `pre-checkout step "${step.trim()}" must set working-directory: . (job default dir does not exist yet)`,
+        step,
+        `pre-checkout step "${stepName.trim()}" must set working-directory: . (job default dir does not exist yet)`,
       ).toMatch(/working-directory:\s*\.\s*$/m)
     }
   })


### PR DESCRIPTION
## Summary

Applies the valid findings from Gemini's reviews on PR #100 ([review 4631088535](https://github.com/kamiazya/whiteboard/pull/100#pullrequestreview-4631088535)) and PR #102, both merged before the reviews landed.

### From #100

- **[HIGH — test logic bug] per-step working-directory assertion**: the pre-checkout cwd guard in `sbom-policy.test.ts` matched against the whole pre-checkout block, so one compliant step masked violations in any other step. Now split into per-step assertions (with a non-empty-steps sanity check).
- **[MEDIUM] case-insensitive env strip** in `generate-npm-sbom.mjs`: Windows env keys are case-insensitive; compare lowercased keys when stripping `npm_execpath` / `npm_config_*` / `npm_lifecycle_*`.

### From #102 (dev-only fonts middleware in `apps/web/vite.config.ts`)

- **[HIGH] sibling-prefix traversal**: terminate the base-dir prefix check with a path separator so `/fonts/../fonts-backup/…` style paths can never match.
- **[HIGH] EISDIR crash**: serve regular files only (`statSync().isFile()`); directory requests fall through to `next()`.
- **[MEDIUM] stream error handling**: a read error on the stream no longer takes down the dev server via an unhandled `'error'` event.

### Skipped (with reason)

- `typeof window !== 'undefined'` guard in `excalidraw-asset-path.ts`: the module is imported only from the browser entry (`main.tsx`) and its own jsdom test — there is no SSR or bare-Node import path, so the guard would be dead code.

## Verification

- [x] `sbom-policy.test.ts` — 39 tests pass (per-step assertion verified against current release.yml)
- [x] `generate:sbom:npm` succeeds after the env change
- [x] apps/web build + typecheck pass
- [x] Live vite dev server check: valid font → `200 font/woff2`; directory (`/fonts/Excalifont`), trailing-slash, and traversal requests all fall through to the SPA fallback; server stays alive throughout