### PR TITLE
fix(web): give BrowserLocalCanvasPage a real layout — editor area was 0px

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import { IndexedDBStore } from '../lib/browser-local-store.js'
+// Real app styles so layout assertions measure the shipped geometry.
+import '../index.css'
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
@@ -25,6 +27,20 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
     await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
       timeout: 5000,
     })
+  })
+
+  it('layout: excalidraw container fills the viewport below the header', async () => {
+    // An unsized height chain collapses the container to 0px and the whiteboard
+    // becomes invisible. The page must own its viewport height so the editor
+    // area gets real geometry.
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const container = screen.getByTestId('excalidraw-container')
+    // Viewport is 1280x900; the editor area must occupy most of it.
+    expect(container.clientHeight).toBeGreaterThan(300)
+    expect(container.clientWidth).toBeGreaterThan(600)
   })
 
   it('cleanup: delete canvas shows cleanup-completed', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -34,9 +34,17 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
 
   if (pageState.kind === 'load-degraded') {
     return (
-      <div role="alert" aria-live="assertive">
-        <p>{pageState.message}</p>
-        <button type="button" onClick={() => void startFresh()}>
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="flex h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+      >
+        <p className="max-w-md text-sm text-destructive">{pageState.message}</p>
+        <button
+          type="button"
+          onClick={() => void startFresh()}
+          className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+        >
           Start fresh
         </button>
       </div>
@@ -45,9 +53,16 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
 
   if (pageState.kind === 'cleanup-completed') {
     return (
-      <div data-testid="cleanup-completed">
-        <p>Canvas removed.</p>
-        <button type="button" onClick={() => void startFresh()}>
+      <div
+        data-testid="cleanup-completed"
+        className="flex h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+      >
+        <p className="text-sm text-muted-foreground">Canvas removed.</p>
+        <button
+          type="button"
+          onClick={() => void startFresh()}
+          className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+        >
           Start fresh
         </button>
       </div>
@@ -56,7 +71,11 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
 
   if (pageState.kind === 'loading') {
     return (
-      <div role="status" aria-live="polite">
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex h-dvh items-center justify-center text-sm text-muted-foreground"
+      >
         Loading…
       </div>
     )
@@ -75,20 +94,27 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
           : status.message
 
   return (
-    <main>
-      <header>
-        <h1>{pageState.snapshot.name}</h1>
-        <span>{persistenceLabel}</span>
+    // h-dvh makes the page own its viewport height: without it the flex chain
+    // has no sized ancestor and the editor area collapses to 0px.
+    <main className="flex h-dvh w-full flex-col">
+      <header className="flex shrink-0 items-center gap-3 border-b bg-background px-4 py-2">
+        <h1 className="truncate text-sm font-semibold">{pageState.snapshot.name}</h1>
+        <span className="text-xs text-muted-foreground">{persistenceLabel}</span>
         {cleanupError && (
-          <div role="alert" aria-live="assertive">
+          <div role="alert" aria-live="assertive" className="text-xs text-destructive">
             {cleanupError}
           </div>
         )}
-        <button type="button" onClick={() => void triggerCleanup()} aria-label="Delete canvas">
+        <button
+          type="button"
+          onClick={() => void triggerCleanup()}
+          aria-label="Delete canvas"
+          className="ml-auto rounded-md border px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+        >
           Delete
         </button>
       </header>
-      <div data-testid="excalidraw-container" style={{ height: '100%', width: '100%' }}>
+      <div data-testid="excalidraw-container" className="min-h-0 flex-1">
         <Excalidraw excalidrawAPI={setExcalidrawAPI} onChange={onChange} />
       </div>
     </main>

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { playwright } from '@vitest/browser-playwright'
 import wasm from 'vite-plugin-wasm'
@@ -19,7 +20,9 @@ export default defineConfig({
       ),
     },
   },
-  plugins: [react(), wasm(), topLevelAwait()],
+  // tailwindcss: layout browser tests import src/index.css to assert real
+  // computed geometry (e.g. the Excalidraw container filling the viewport).
+  plugins: [tailwindcss(), react(), wasm(), topLevelAwait()],
   test: {
     name: 'web-browser',
     include: ['src/**/*.browser.test.tsx'],


### PR DESCRIPTION
## Summary

The deployed page looked unstyled and the whiteboard itself was invisible. CSS was loading fine (Tailwind preflight active, 1088 rules) — the page component simply rendered skeleton markup with **no classes and no sized height chain**: `main` had no height, so the Excalidraw container collapsed to `0px` (`canvas.clientHeight === 0`, `body.clientHeight === 48` in production).

- `main` now owns the viewport (`h-dvh flex-col`); the header is `shrink-0` and the editor area is `min-h-0 flex-1`
- Header, loading, load-degraded, and cleanup states styled with the repo's Tailwind idiom (matching the mcp-server app's `h-screen flex-col` / `flex-1` pattern)
- Red-first `web-browser` layout test asserts the container gets real viewport geometry; `vitest.browser.config.ts` now loads the `@tailwindcss/vite` plugin so browser tests can import `src/index.css` and measure shipped styles

## Verification

- [x] Red-first: layout test failed against the unstyled page (container 0px), passes now
- [x] apps/web: 6 web-browser tests + 157 jsdom tests pass, typecheck + build pass
- [x] Manual: `wrangler pages dev` serve of dist — container/canvas 758px, Excalidraw toolbar visible and interactive

## Visual repro

Before (production v0.0.9 — header text only, whiteboard invisible):

![prod-v009-verify.png](https://github.com/user-attachments/assets/ad68fafd-103b-4d78-83f8-af64ec7abb26)

After (same dist served locally with production headers):

![layout-fix-after.png](https://github.com/user-attachments/assets/a48a08e9-88a2-44b4-9e1e-adc6e0e62821)