### PR TITLE
fix(ci): cache Docker dry-run build, reuse mcp-server dist artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # dry-run-npm reuses this dist instead of rebuilding from scratch.
+      - name: Upload mcp-server dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-server-dist-${{ github.run_id }}
+          path: packages/mcp-server/dist/
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Web app artifact smoke
         run: pnpm --filter @kamiazya/whiteboard-web smoke:artifact
 
@@ -205,8 +214,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
+      # Reuse the dist already built and verified by the `verify` job instead
+      # of rebuilding from scratch.
+      - name: Download mcp-server dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-server-dist-${{ github.run_id }}
+          path: packages/mcp-server/dist/
 
       - name: npm publish dry-run
         run: pnpm publish:dry-run:npm
@@ -233,6 +247,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # docker-container driver is required for the GHA cache backend used by
+      # publish-dry-run-docker.mjs; the default docker driver can't export it.
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Docker build dry-run
         run: pnpm publish:dry-run:docker

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -66,6 +66,9 @@ const buildResult = spawnSync('docker', buildArgs, {
 })
 
 if (buildResult.status !== 0 || buildResult.error) {
+  if (buildResult.stderr) {
+    process.stderr.write(buildResult.stderr)
+  }
   fail('docker build')
 }
 

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -27,9 +27,7 @@ const dockerCheck = spawnSync('docker', ['info'], {
   stdio: ['ignore', 'ignore', 'ignore'],
 })
 if (dockerCheck.status !== 0 || dockerCheck.error) {
-  process.stderr.write(
-    '[publish-dry-run:docker] Docker daemon not available; skipping dry-run.\n',
-  )
+  process.stderr.write('[publish-dry-run:docker] Docker daemon not available; skipping dry-run.\n')
   process.exit(0)
 }
 
@@ -37,15 +35,35 @@ mkdirSync(OUT_DIR, { recursive: true })
 
 // Step 1: docker build (no push). Build logs go to the pipe but are not
 // forwarded to stdout — only the safe JSON summary is printed.
-const buildResult = spawnSync(
-  'docker',
-  ['build', '-f', DOCKERFILE, '-t', IMAGE_TAG, '--progress=plain', '.'],
-  {
-    cwd: REPO_ROOT,
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  },
-)
+//
+// In GitHub Actions, build through buildx with the GHA cache backend so the
+// dependency-install and compile layers survive between runs (the plain
+// `docker build` engine and the ACTIONS_CACHE_URL credentials it needs are
+// only available inside a runner, not on a local dev machine).
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+const buildArgs = isGitHubActions
+  ? [
+      'buildx',
+      'build',
+      '--cache-from',
+      'type=gha',
+      '--cache-to',
+      'type=gha,mode=max',
+      '--load',
+      '-f',
+      DOCKERFILE,
+      '-t',
+      IMAGE_TAG,
+      '--progress=plain',
+      '.',
+    ]
+  : ['build', '-f', DOCKERFILE, '-t', IMAGE_TAG, '--progress=plain', '.']
+
+const buildResult = spawnSync('docker', buildArgs, {
+  cwd: REPO_ROOT,
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
 
 if (buildResult.status !== 0 || buildResult.error) {
   fail('docker build')
@@ -53,15 +71,11 @@ if (buildResult.status !== 0 || buildResult.error) {
 
 // Step 2: capture locally-built image ID (sha256 digest of the image config).
 // RepoDigests are only populated after a registry push; use .Id for local builds.
-const inspectResult = spawnSync(
-  'docker',
-  ['image', 'inspect', IMAGE_TAG, '--format', '{{.Id}}'],
-  {
-    cwd: REPO_ROOT,
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  },
-)
+const inspectResult = spawnSync('docker', ['image', 'inspect', IMAGE_TAG, '--format', '{{.Id}}'], {
+  cwd: REPO_ROOT,
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
 
 if (inspectResult.status !== 0 || inspectResult.error) {
   fail('docker image inspect')


### PR DESCRIPTION
## Summary
- Docker dry-run (`dry-run-docker`) rebuilt node_modules and tsc output from scratch every run, ~1m35s of cold `docker build` with no layer cache. Added `docker/setup-buildx-action` and switched the build to `docker buildx build --cache-from/--cache-to type=gha` (GitHub Actions only; local dev keeps the plain `docker build` fallback).
- `dry-run-npm` duplicated the same `pnpm build` the `verify` job had already run and validated (~34s wasted). `verify` now uploads `packages/mcp-server/dist` as an artifact and `dry-run-npm` downloads it instead of rebuilding.

## Test plan
- [x] `node --check` on the edited script
- [x] Local `pnpm build` + `pnpm publish:dry-run:npm` against the produced dist — succeeds using only the existing dist, confirming the artifact-reuse path works
- [x] Local run of `publish-dry-run-docker.mjs` with no Docker daemon — confirms the graceful-skip fallback (non-CI path) still works
- [ ] Confirm in the real PR run that `dry-run-docker`/`dry-run-npm` wall time drops