### PR TITLE
fix(release): extend daemon startup timeout on CI publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
     permissions:
       contents: read
       id-token: write  # npm provenance (OIDC) for signed publish on npm v9.5+
+    env:
+      # Packaged daemon cold-start exceeds the 10s default on CI runners
+      # (smoke:tarball "Daemon startup timeout" broke the v0.0.9 publish).
+      WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000'
     defaults:
       run:
         working-directory: packages/mcp-server
@@ -191,6 +195,10 @@ jobs:
       contents: read
       id-token: write   # cosign keyless signing (OIDC)
       packages: write   # GHCR push
+    env:
+      # Packaged daemon cold-start exceeds the 10s default on CI runners
+      # (smoke:tarball "Daemon startup timeout" broke the v0.0.9 publish).
+      WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000'
     steps:
       - name: Validate tag shape
         env:

--- a/packages/mcp-server/src/daemon/ensure-daemon.startup-timeout.test.ts
+++ b/packages/mcp-server/src/daemon/ensure-daemon.startup-timeout.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { resolveStartupTimeoutMs } from './ensure-daemon.js'
+
+// The packaged daemon cold-start (native modules, WASM, first-run migrations)
+// can exceed the 10s default on slow CI runners; the env override lets the
+// release gate wait longer without changing local/production behavior.
+describe('resolveStartupTimeoutMs', () => {
+  it('defaults to 10s when no override or env var is set', () => {
+    expect(resolveStartupTimeoutMs({})).toBe(10_000)
+  })
+
+  it('prefers the explicit option override over the env var', () => {
+    expect(resolveStartupTimeoutMs({ WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000' }, 5_000)).toBe(
+      5_000,
+    )
+  })
+
+  it('reads WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS from env', () => {
+    expect(resolveStartupTimeoutMs({ WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000' })).toBe(60_000)
+  })
+
+  it.each([
+    ['non-numeric', 'abc'],
+    ['zero', '0'],
+    ['negative', '-5000'],
+    ['fractional', '1000.5'],
+    ['empty', ''],
+  ])('falls back to the default for %s env value', (_label, value) => {
+    expect(resolveStartupTimeoutMs({ WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: value })).toBe(10_000)
+  })
+})

--- a/packages/mcp-server/src/daemon/ensure-daemon.ts
+++ b/packages/mcp-server/src/daemon/ensure-daemon.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path'
 import { nanoid } from 'nanoid'
 import { WHITEBOARD_ROOT, DATA_DIR } from '../shared/data-dir-secure.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
-import { loadDaemonRecord, deleteDaemonRecord, isPidAlive, type DaemonRecord } from './daemon-registry.js'
+import {
+  loadDaemonRecord,
+  deleteDaemonRecord,
+  isPidAlive,
+  type DaemonRecord,
+} from './daemon-registry.js'
 import { withDaemonStartupLock } from './daemon-lock.js'
 import { purgeOldDaemonLogs } from './log-rotation.js'
 
@@ -66,7 +71,9 @@ async function findAvailablePort(start = 3099): Promise<number> {
     })
     server.on('error', (error: NodeJS.ErrnoException) => {
       if (error.code === 'EADDRINUSE') {
-        void findAvailablePort(start + 1).then(resolve).catch(reject)
+        void findAvailablePort(start + 1)
+          .then(resolve)
+          .catch(reject)
         return
       }
       reject(
@@ -97,7 +104,13 @@ function buildDaemonSpawnArgs(options: {
   if (env.WHITEBOARD_DEV === '1') {
     return {
       command: 'node',
-      args: ['--watch', '--import', 'tsx/esm', join(WHITEBOARD_ROOT, 'src/server/index.ts'), ...baseArgs],
+      args: [
+        '--watch',
+        '--import',
+        'tsx/esm',
+        join(WHITEBOARD_ROOT, 'src/server/index.ts'),
+        ...baseArgs,
+      ],
     }
   }
 
@@ -116,6 +129,20 @@ async function pingDaemon(port: number, host: string): Promise<boolean> {
   }
 }
 
+// Packaged daemon cold-start (native modules, WASM, first-run migrations) can
+// exceed the 10s default on slow CI runners. WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS
+// lets such environments wait longer; an explicit option always wins, and
+// invalid values fall back to the default.
+export function resolveStartupTimeoutMs(env: NodeJS.ProcessEnv, override?: number): number {
+  if (override !== undefined) return override
+  const raw = env.WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS
+  if (raw !== undefined && /^\d+$/.test(raw)) {
+    const parsed = Number(raw)
+    if (parsed > 0) return parsed
+  }
+  return 10_000
+}
+
 async function waitForDaemon(port: number, host: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -130,7 +157,7 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
   const env = options.env ?? process.env
   const host = options.host ?? '127.0.0.1'
   const idleTimeoutMs = options.idleTimeoutMs ?? 15 * 60_000
-  const startupTimeoutMs = options.startupTimeoutMs ?? 10_000
+  const startupTimeoutMs = resolveStartupTimeoutMs(env, options.startupTimeoutMs)
   if (
     options.startPort !== undefined &&
     (!Number.isInteger(options.startPort) || options.startPort < 0 || options.startPort > 65535)
@@ -139,7 +166,7 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
   }
   const existing = await loadDaemonRecord(dataDir)
 
-  if (existing && isPidAlive(existing.pid) && await pingDaemon(existing.port, host)) {
+  if (existing && isPidAlive(existing.pid) && (await pingDaemon(existing.port, host))) {
     return {
       ...existing,
       baseUrl: `http://${host}:${existing.port}`,
@@ -150,7 +177,7 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
     dataDir,
     async () => {
       const fresh = await loadDaemonRecord(dataDir)
-      if (fresh && isPidAlive(fresh.pid) && await pingDaemon(fresh.port, host)) {
+      if (fresh && isPidAlive(fresh.pid) && (await pingDaemon(fresh.port, host))) {
         return {
           ...fresh,
           baseUrl: `http://${host}:${fresh.port}`,
@@ -159,7 +186,7 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
 
       await deleteDaemonRecord(dataDir)
 
-      const port = options.startPort ?? await findAvailablePort(3099)
+      const port = options.startPort ?? (await findAvailablePort(3099))
       const token = nanoid(32)
       const { command, args } = buildDaemonSpawnArgs({
         env,

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -429,6 +429,23 @@ describe('release.yml publish job step ordering hazards', () => {
       ).toMatch(/working-directory:\s*\.\s*$/m)
     }
   })
+
+  it('publish jobs extend the daemon startup timeout for CI cold starts', () => {
+    // Packaged daemon cold-start (native modules, WASM, first-run migrations)
+    // exceeds the 10s default on CI runners and killed the tarball smoke.
+    const releaseYml = readFile('.github/workflows/release.yml')
+    for (const [jobId, nextJobId] of [
+      ['publish-mcp', 'docker-publish-sign'],
+      ['docker-publish-sign', 'deploy-web'],
+    ] as const) {
+      const section = jobSection(releaseYml, jobId, nextJobId)
+      expect(section, `${jobId} job must exist`).not.toBe('')
+      expect(
+        section,
+        `${jobId} must set WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS for slow CI cold starts`,
+      ).toContain('WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS')
+    }
+  })
 })
 
 describe('generate-npm-sbom.mjs pnpm-run environment', () => {


### PR DESCRIPTION
## Summary

The v0.0.9 `publish-mcp` / `docker-publish-sign` jobs failed **twice deterministically** at `smoke:tarball` with `Daemon startup timeout`, while the same smoke passes locally. The packaged daemon cold-start (native modules, WASM, first-run migrations) exceeds ensureDaemon's 10s default on GitHub runners.

- `ensure-daemon.ts`: new `WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS` env override via `resolveStartupTimeoutMs()` — an explicit option always wins, invalid values (non-numeric, zero, negative, fractional) fall back to the 10s default. Local/production behavior unchanged.
- `release.yml`: `publish-mcp` and `docker-publish-sign` set the override to 60s at job level, with a sbom-policy drift test asserting both jobs keep it.

## Test plan

- [x] Red-first: `resolveStartupTimeoutMs` unit tests failed before the export existed
- [x] `smoke:tarball` passes locally
- [x] mcp-node: 46 passed (timeout + sbom-policy suites)
- [ ] After merge + next release: publish-mcp / docker-publish-sign complete past the tarball smoke