### PR TITLE
fix(release): extend smoke RPC deadline on CI publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
       # Packaged daemon cold-start exceeds the 10s default on CI runners
       # (smoke:tarball "Daemon startup timeout" broke the v0.0.9 publish).
       WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000'
+      # The smoke's first tools/call includes that same daemon spawn, so its
+      # RPC deadline needs headroom too ("RPC tools/call timed out", v0.0.10).
+      WHITEBOARD_SMOKE_RPC_TIMEOUT_MS: '90000'
     defaults:
       run:
         working-directory: packages/mcp-server
@@ -199,6 +202,9 @@ jobs:
       # Packaged daemon cold-start exceeds the 10s default on CI runners
       # (smoke:tarball "Daemon startup timeout" broke the v0.0.9 publish).
       WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS: '60000'
+      # The smoke's first tools/call includes that same daemon spawn, so its
+      # RPC deadline needs headroom too ("RPC tools/call timed out", v0.0.10).
+      WHITEBOARD_SMOKE_RPC_TIMEOUT_MS: '90000'
     steps:
       - name: Validate tag shape
         env:

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -81,6 +81,13 @@ child.stdout.on('data', (chunk) => {
   }
 })
 
+// The first tools/call spawns the daemon, so its latency includes the full
+// daemon cold-start. CI runners exceed the 20s default; the env override lets
+// release jobs wait longer without slowing local runs.
+const RPC_TIMEOUT_MS = /^\d+$/.test(process.env.WHITEBOARD_SMOKE_RPC_TIMEOUT_MS ?? '')
+  ? Number(process.env.WHITEBOARD_SMOKE_RPC_TIMEOUT_MS)
+  : 20_000
+
 let nextId = 1
 function rpc(method, params) {
   const id = nextId++
@@ -93,7 +100,7 @@ function rpc(method, params) {
         pending.delete(id)
         reject(new Error(`RPC ${method} (#${id}) timed out`))
       }
-    }, 20_000)
+    }, RPC_TIMEOUT_MS)
   })
 }
 

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -444,7 +444,22 @@ describe('release.yml publish job step ordering hazards', () => {
         section,
         `${jobId} must set WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS for slow CI cold starts`,
       ).toContain('WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS')
+      expect(
+        section,
+        `${jobId} must set WHITEBOARD_SMOKE_RPC_TIMEOUT_MS for slow CI cold starts`,
+      ).toContain('WHITEBOARD_SMOKE_RPC_TIMEOUT_MS')
     }
+  })
+
+  it('e2e smoke honours WHITEBOARD_SMOKE_RPC_TIMEOUT_MS (first tools/call includes daemon spawn)', () => {
+    // The packaged tarball smoke's first tools/call spawns the daemon; under CI
+    // cold-start the hardcoded RPC deadline expired ("RPC tools/call timed out")
+    // even after the daemon-startup timeout itself was extended.
+    const smoke = readFile('packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs')
+    expect(
+      smoke,
+      'mcp-e2e-smoke.mjs must read WHITEBOARD_SMOKE_RPC_TIMEOUT_MS instead of hardcoding the RPC deadline',
+    ).toContain('WHITEBOARD_SMOKE_RPC_TIMEOUT_MS')
   })
 })
 


### PR DESCRIPTION
## Summary

The v0.0.10 publish jobs got past daemon startup (the #108 60s override worked) but then failed at the tarball smoke with `RPC tools/call (#3) timed out`, twice (initial + rerun). The smoke's **first `tools/call` is what spawns the daemon**, so its hardcoded 20s RPC deadline races the same CI cold-start that #108 addressed — extending the daemon-startup timeout alone was not enough because the RPC caller gives up first.

- `mcp-e2e-smoke.mjs`: `WHITEBOARD_SMOKE_RPC_TIMEOUT_MS` env override for the RPC deadline (digits-only validation, falls back to the 20s default — local runs unchanged)
- `release.yml`: `publish-mcp` and `docker-publish-sign` set it to 90s (> the 60s daemon-startup budget), guarded by the existing publish-job drift test in `sbom-policy.test.ts`

## Test plan

- [x] Red-first: both new drift assertions failed against the pre-fix tree
- [x] `pnpm smoke:e2e` passes locally (default 20s path)
- [x] sbom-policy: 41 passed
- [ ] After merge + next release: publish jobs complete past the tarball smoke (npm / GHCR publish)