### PR TITLE
fix(mcp): guard StorageReportCard async setState against post-unmount crashes

### DIFF
--- a/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
-import { StorageReportCard } from './StorageReportCard.js'
+import { STATUS_CLEAR_MS, StorageReportCard } from './StorageReportCard.js'
 
 const PAYLOAD = {
   totalBytes: 4096,
@@ -207,6 +207,65 @@ describe('StorageReportCard', () => {
     }
     expect(thrown).toBeNull()
   })
+
+  it(
+    'does not call setState after unmount while the optimizeAll status-clear timer is still pending',
+    async () => {
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        if (url === '/api/runtime/storage') {
+          return Promise.resolve(jsonResponse(PAYLOAD))
+        }
+        if (url === '/api/workspaces') {
+          return Promise.resolve(jsonResponse({ workspaces: [] }))
+        }
+        return Promise.reject(new Error(`unexpected fetch: ${url}`))
+      })
+
+      // Real timers — optimizeAll's own fetch chain must actually settle
+      // before its finally-block schedules the STATUS_CLEAR_MS timer that
+      // this test unmounts underneath.
+      vi.useRealTimers()
+
+      const { container, unmount } = render(<StorageReportCard />)
+      await waitFor(() => {
+        expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+      })
+
+      const blobsActions = container.querySelector('[data-storage-actions="blobs"]')!
+      const button = blobsActions.querySelector('button')!
+      fireEvent.click(button)
+
+      // Wait for optimizeAll to settle — its finally block has now called
+      // scheduleStatusClear(), arming a pending STATUS_CLEAR_MS setTimeout.
+      await waitFor(() => {
+        expect(blobsActions.textContent ?? '').toMatch(/optimal|saved/i)
+      })
+
+      // Unmount while that setTimeout is still pending. This mirrors the
+      // refresh()-focused unmount test above but exercises
+      // scheduleStatusClear's own mountedRef branch instead of refresh()'s.
+      unmount()
+
+      // Simulate the jsdom environment being torn down before the timer
+      // fires — the same "window is not defined" hazard the refresh() test
+      // guards against, reached through a different handler this time.
+      const savedWindow = (globalThis as { window?: unknown }).window
+      delete (globalThis as { window?: unknown }).window
+      let thrown: unknown = null
+      try {
+        await new Promise((resolve) => setTimeout(resolve, STATUS_CLEAR_MS + 200))
+      } catch (err) {
+        thrown = err
+      } finally {
+        ;(globalThis as { window?: unknown }).window = savedWindow
+      }
+      expect(thrown).toBeNull()
+    },
+    STATUS_CLEAR_MS + 5000,
+  )
 
   it('humanises the "Updated …" line and ticks across humanise boundaries without per-second flicker', async () => {
     const { container } = render(<StorageReportCard />)

--- a/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
@@ -24,9 +24,7 @@ beforeEach(() => {
   vi.setSystemTime(new Date('2026-05-01T00:00:00Z'))
   vi.stubGlobal(
     'fetch',
-    vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify(PAYLOAD), { status: 200 })),
-    ),
+    vi.fn(() => Promise.resolve(new Response(JSON.stringify(PAYLOAD), { status: 200 }))),
   )
 })
 
@@ -181,6 +179,33 @@ describe('StorageReportCard', () => {
       // formatting since formatBytes may pick KiB / MiB depending on size).
       expect(filesActions!.textContent ?? '').toMatch(/Removed\s+4/i)
     })
+  })
+
+  it('does not call setState after unmount while the min-refresh delay is still pending', async () => {
+    const { unmount } = render(<StorageReportCard />)
+    // Unmount while the initial mount-time refresh() is still awaiting its
+    // fetch response and MIN_REFRESH_MS floor — this is the timing window
+    // that let a post-unmount setLoading(false) fire during jsdom teardown.
+    unmount()
+    // Simulate the jsdom environment being torn down (as Vitest does once a
+    // test file's tests finish) while refresh()'s pending setTimeout is
+    // still scheduled. React 19 silently no-ops a setState call on an
+    // already-unmounted root under a *live* jsdom window — the crash seen
+    // in CI only reproduces once `window` itself is gone by the time the
+    // timer fires, which is what actually happened: dispatchSetState
+    // touched the (now-undefined) `window` and threw
+    // "ReferenceError: window is not defined".
+    const savedWindow = (globalThis as { window?: unknown }).window
+    delete (globalThis as { window?: unknown }).window
+    let thrown: unknown = null
+    try {
+      await vi.advanceTimersByTimeAsync(500)
+    } catch (err) {
+      thrown = err
+    } finally {
+      ;(globalThis as { window?: unknown }).window = savedWindow
+    }
+    expect(thrown).toBeNull()
   })
 
   it('humanises the "Updated …" line and ticks across humanise boundaries without per-second flicker', async () => {

--- a/packages/mcp-server/src/app/components/StorageReportCard.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Eraser, HardDrive, Library, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -94,6 +94,23 @@ export function StorageReportCard() {
   const [updatedAt, setUpdatedAt] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
 
+  // Every handler below is async and resumes after an await to call
+  // setState. If the component unmounts mid-flight (a fast test teardown,
+  // or the user navigating away before a fetch/min-refresh delay settles),
+  // that resumed setState can outlive the component. Guard every
+  // post-await setState with this ref instead of relying on React to no-op
+  // the call safely — a live jsdom `window` makes an unmounted-root
+  // setState harmless, but if the environment itself is torn down before
+  // the callback resumes (e.g. end-of-test-file jsdom teardown racing a
+  // pending setTimeout), the same call throws.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
   // Coarse tick so the "Updated …" / "Auto-optimised …" lines stay live
   // without flickering second-by-second. Humanized strings only change at
   // 30s / 1m / 1h boundaries, so a 30s re-render is plenty.
@@ -108,22 +125,28 @@ export function StorageReportCard() {
     const start = Date.now()
     try {
       const res = await apiFetch('/api/runtime/storage')
+      if (!mountedRef.current) return
       if (!res.ok) {
         setError(`HTTP ${res.status}`)
         return
       }
       const json = storageReportPayloadSchema.parse(await res.json())
+      if (!mountedRef.current) return
       setReport(json)
       setUpdatedAt(Date.now())
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
     } finally {
       const elapsed = Date.now() - start
       const remaining = MIN_REFRESH_MS - elapsed
       if (remaining > 0) {
         await new Promise((resolve) => setTimeout(resolve, remaining))
       }
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
   }, [])
 
@@ -142,6 +165,7 @@ export function StorageReportCard() {
     setOptimizeStatus('Optimizing…')
     try {
       const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
       if (!wsRes.ok) {
         setOptimizeStatus('Optimize failed')
         return
@@ -161,13 +185,18 @@ export function StorageReportCard() {
         }
         savings += body.totalBeforeBytes - body.totalAfterBytes
       }
+      if (!mountedRef.current) return
       setOptimizeStatus(savings > 0 ? `Saved ${formatBytes(savings)}` : 'Already optimal')
       void refresh()
     } catch {
-      setOptimizeStatus('Optimize failed')
+      if (mountedRef.current) setOptimizeStatus('Optimize failed')
     } finally {
-      setOptimizing(false)
-      window.setTimeout(() => setOptimizeStatus(null), 3000)
+      if (mountedRef.current) {
+        setOptimizing(false)
+        window.setTimeout(() => {
+          if (mountedRef.current) setOptimizeStatus(null)
+        }, 3000)
+      }
     }
   }, [refresh])
 
@@ -183,16 +212,20 @@ export function StorageReportCard() {
     setLibsError(null)
     try {
       const res = await apiFetch('/api/user-libraries')
+      if (!mountedRef.current) return
       if (!res.ok) {
         setLibsError(`HTTP ${res.status}`)
         return
       }
       const json = (await res.json()) as { libraries: UserLibraryRow[] }
+      if (!mountedRef.current) return
       setLibs(json.libraries)
     } catch (err) {
-      setLibsError(err instanceof Error ? err.message : String(err))
+      if (mountedRef.current) {
+        setLibsError(err instanceof Error ? err.message : String(err))
+      }
     } finally {
-      setLibsLoading(false)
+      if (mountedRef.current) setLibsLoading(false)
     }
   }, [])
   const removeLib = useCallback(
@@ -200,6 +233,7 @@ export function StorageReportCard() {
       const res = await apiFetch(`/api/user-libraries/${encodeURIComponent(name)}`, {
         method: 'DELETE',
       })
+      if (!mountedRef.current) return
       if (!res.ok) {
         setLibsError(`Remove failed: HTTP ${res.status}`)
         return
@@ -224,11 +258,13 @@ export function StorageReportCard() {
     setPruneLogsStatus('Pruning…')
     try {
       const res = await apiFetch('/api/runtime/logs/prune', { method: 'POST' })
+      if (!mountedRef.current) return
       if (!res.ok) {
         setPruneLogsStatus('Prune failed')
         return
       }
       const body = (await res.json()) as { purgedCount: number; purgedBytes: number }
+      if (!mountedRef.current) return
       setPruneLogsStatus(
         body.purgedCount > 0
           ? `Removed ${body.purgedCount} (${formatBytes(body.purgedBytes)})`
@@ -236,10 +272,14 @@ export function StorageReportCard() {
       )
       void refresh()
     } catch {
-      setPruneLogsStatus('Prune failed')
+      if (mountedRef.current) setPruneLogsStatus('Prune failed')
     } finally {
-      setPruningLogs(false)
-      window.setTimeout(() => setPruneLogsStatus(null), 3000)
+      if (mountedRef.current) {
+        setPruningLogs(false)
+        window.setTimeout(() => {
+          if (mountedRef.current) setPruneLogsStatus(null)
+        }, 3000)
+      }
     }
   }, [refresh])
 
@@ -253,6 +293,7 @@ export function StorageReportCard() {
     setPruneVersionsStatus('Cleaning…')
     try {
       const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
       if (!wsRes.ok) {
         setPruneVersionsStatus('Cleanup failed')
         return
@@ -269,15 +310,20 @@ export function StorageReportCard() {
         const body = (await res.json()) as { totalDeleted: number }
         totalDeleted += body.totalDeleted
       }
+      if (!mountedRef.current) return
       setPruneVersionsStatus(
         totalDeleted > 0 ? `Removed ${totalDeleted} auto-version(s)` : 'Nothing to clean',
       )
       void refresh()
     } catch {
-      setPruneVersionsStatus('Cleanup failed')
+      if (mountedRef.current) setPruneVersionsStatus('Cleanup failed')
     } finally {
-      setPruningVersions(false)
-      window.setTimeout(() => setPruneVersionsStatus(null), 3000)
+      if (mountedRef.current) {
+        setPruningVersions(false)
+        window.setTimeout(() => {
+          if (mountedRef.current) setPruneVersionsStatus(null)
+        }, 3000)
+      }
     }
   }, [refresh])
 
@@ -291,6 +337,7 @@ export function StorageReportCard() {
     setCleanFilesStatus('Cleaning…')
     try {
       const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
       if (!wsRes.ok) {
         setCleanFilesStatus('Cleanup failed')
         return
@@ -309,6 +356,7 @@ export function StorageReportCard() {
         purgedBytes += body.purgedBytes
         purgedCount += body.purgedCount
       }
+      if (!mountedRef.current) return
       setCleanFilesStatus(
         purgedCount > 0
           ? `Removed ${purgedCount} (${formatBytes(purgedBytes)})`
@@ -316,10 +364,14 @@ export function StorageReportCard() {
       )
       void refresh()
     } catch {
-      setCleanFilesStatus('Cleanup failed')
+      if (mountedRef.current) setCleanFilesStatus('Cleanup failed')
     } finally {
-      setCleaningFiles(false)
-      window.setTimeout(() => setCleanFilesStatus(null), 3000)
+      if (mountedRef.current) {
+        setCleaningFiles(false)
+        window.setTimeout(() => {
+          if (mountedRef.current) setCleanFilesStatus(null)
+        }, 3000)
+      }
     }
   }, [refresh])
 

--- a/packages/mcp-server/src/app/components/StorageReportCard.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.tsx
@@ -67,6 +67,10 @@ const CATEGORIES: CategoryDescriptor[] = [
 // otherwise on a fast network the click is invisible.
 const MIN_REFRESH_MS = 400
 
+// How long a transient action status ("Saved 2 KiB", "Nothing to prune")
+// lingers on its row before clearing.
+const STATUS_CLEAR_MS = 3000
+
 // Coarse-grained interval. We do not need second-by-second updates because
 // the humanized string only changes at 30s / 1m / 1h boundaries; a 30s
 // re-render is enough to keep the display fresh without flickering.
@@ -109,6 +113,14 @@ export function StorageReportCard() {
     return () => {
       mountedRef.current = false
     }
+  }, [])
+
+  // Clear a transient action status after STATUS_CLEAR_MS, skipping the
+  // setState if the component unmounted while the timer was pending.
+  const scheduleStatusClear = useCallback((clear: () => void) => {
+    window.setTimeout(() => {
+      if (mountedRef.current) clear()
+    }, STATUS_CLEAR_MS)
   }, [])
 
   // Coarse tick so the "Updated …" / "Auto-optimised …" lines stay live
@@ -193,12 +205,10 @@ export function StorageReportCard() {
     } finally {
       if (mountedRef.current) {
         setOptimizing(false)
-        window.setTimeout(() => {
-          if (mountedRef.current) setOptimizeStatus(null)
-        }, 3000)
+        scheduleStatusClear(() => setOptimizeStatus(null))
       }
     }
-  }, [refresh])
+  }, [refresh, scheduleStatusClear])
 
   // User libraries management dialog. Surfaces installed libraries with
   // per-pack size and item count, plus a per-row Remove that maps to the
@@ -276,12 +286,10 @@ export function StorageReportCard() {
     } finally {
       if (mountedRef.current) {
         setPruningLogs(false)
-        window.setTimeout(() => {
-          if (mountedRef.current) setPruneLogsStatus(null)
-        }, 3000)
+        scheduleStatusClear(() => setPruneLogsStatus(null))
       }
     }
-  }, [refresh])
+  }, [refresh, scheduleStatusClear])
 
   // Sandwiched auto-version prune. Manual versions are explicit user
   // save-points; autos between any two manuals add no rollback value and
@@ -320,12 +328,10 @@ export function StorageReportCard() {
     } finally {
       if (mountedRef.current) {
         setPruningVersions(false)
-        window.setTimeout(() => {
-          if (mountedRef.current) setPruneVersionsStatus(null)
-        }, 3000)
+        scheduleStatusClear(() => setPruneVersionsStatus(null))
       }
     }
-  }, [refresh])
+  }, [refresh, scheduleStatusClear])
 
   // Dangling-files cleanup. Same workspace-iterating pattern as Optimize
   // all — call the per-workspace purge endpoint, sum the freed bytes, and
@@ -368,12 +374,10 @@ export function StorageReportCard() {
     } finally {
       if (mountedRef.current) {
         setCleaningFiles(false)
-        window.setTimeout(() => {
-          if (mountedRef.current) setCleanFilesStatus(null)
-        }, 3000)
+        scheduleStatusClear(() => setCleanFilesStatus(null))
       }
     }
-  }, [refresh])
+  }, [refresh, scheduleStatusClear])
 
   const ageSeconds = updatedAt === null ? null : Math.max(0, Math.floor((now - updatedAt) / 1000))
 

--- a/packages/mcp-server/src/app/components/StorageReportCard.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.tsx
@@ -68,8 +68,9 @@ const CATEGORIES: CategoryDescriptor[] = [
 const MIN_REFRESH_MS = 400
 
 // How long a transient action status ("Saved 2 KiB", "Nothing to prune")
-// lingers on its row before clearing.
-const STATUS_CLEAR_MS = 3000
+// lingers on its row before clearing. Exported so tests can size their
+// unmount-during-pending-timer waits without duplicating the constant.
+export const STATUS_CLEAR_MS = 3000
 
 // Coarse-grained interval. We do not need second-by-second updates because
 // the humanized string only changes at 30s / 1m / 1h boundaries; a 30s


### PR DESCRIPTION
## Summary

The v0.0.10 `publish-mcp` job failed its Release candidate gate with all 3182 tests passing but `Errors 1 error` (exit 1): a pending timer from `StorageReportCard` fired after jsdom environment teardown, and React's `dispatchSetState` dereferenced the missing `window` (`ReferenceError: window is not defined`), surfacing as a Vitest unhandled error during `IndexPage.test.tsx`.

React 19 silently no-ops setState on unmounted roots **while jsdom is alive** — the crash only happens when the whole environment is torn down with timers still scheduled (the `MIN_REFRESH_MS` floor delay and the 3s status-clear timers).

### Fix (dev-loop in an isolated worktree)

- `mountedRef` guard applied to **all six async handlers** (`refresh`, `optimizeAll`, `fetchLibs`, `removeLib`, prune/cleanup handlers) and the deferred status-clear timers
- Simplify pass: the four duplicated guarded-timer blocks extracted into one `scheduleStatusClear` helper with a named `STATUS_CLEAR_MS`
- The RED test reproduces the exact CI stack: render → unmount mid-refresh → `delete globalThis.window` → advance fake timers → previously threw the same `dispatchSetState` error at `StorageReportCard.tsx:126`, now clean. A follow-up test covers the `scheduleStatusClear` unmount guard.

## Verification

- [x] Red-first: regression test failed against unpatched code with the CI-identical stack
- [x] Targeted suite 5/5 ×3 repeats — flake gone
- [x] mcp-jsdom 282 tests / mcp-node 2654 tests / typecheck all pass
- [x] Multi-dimension review + adversarial verify: 0 CRITICAL/HIGH (2 LOW test-coverage notes on mechanical guard copies of the tested pattern)