### PR TITLE
feat(web): add UserSettingsStore for non-secret UI prefs

### DIFF
--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createUserSettingsStore, defaultUserSettings, STORAGE_KEY } from './user-settings-store.js'
+
+describe('createUserSettingsStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('load() returns defaults when nothing is stored', () => {
+    const store = createUserSettingsStore()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  it('save() then a fresh instance load() returns the persisted value (reload simulation)', () => {
+    const store = createUserSettingsStore()
+    store.save({
+      ...defaultUserSettings(),
+      storage: { preferredProvider: 'browser-local', lastBrowserLocalCanvasId: 'canvas-1' },
+    })
+
+    const reloaded = createUserSettingsStore()
+    expect(reloaded.load().storage).toMatchObject({
+      preferredProvider: 'browser-local',
+      lastBrowserLocalCanvasId: 'canvas-1',
+    })
+  })
+
+  it('update() applies fn to current settings and persists the result', () => {
+    const store = createUserSettingsStore()
+    store.update((current) => ({
+      ...current,
+      storage: { ...current.storage, dismissedPersistenceWarningAt: '2026-07-05T00:00:00.000Z' },
+    }))
+
+    expect(createUserSettingsStore().load().storage.dismissedPersistenceWarningAt).toBe(
+      '2026-07-05T00:00:00.000Z',
+    )
+  })
+
+  it('reset() clears stored settings back to defaults', () => {
+    const store = createUserSettingsStore()
+    store.save({
+      ...defaultUserSettings(),
+      storage: { preferredProvider: 'local-daemon' },
+    })
+    store.reset()
+
+    expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
+  })
+
+  it('falls back to defaults when stored JSON is corrupted', () => {
+    localStorage.setItem(STORAGE_KEY, '{not valid json')
+    const store = createUserSettingsStore()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  it('falls back to defaults when stored version is unknown', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 999, storage: {} }))
+    const store = createUserSettingsStore()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  it('rejects a stored payload carrying a daemonToken-shaped key and falls back to defaults', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: { preferredProvider: 'browser-local', daemonToken: 'super-secret' },
+        migration: {},
+        capabilities: {},
+      }),
+    )
+    const store = createUserSettingsStore()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  it('does not persist an update() result that injects an unknown token-shaped key', () => {
+    const store = createUserSettingsStore()
+    type SettingsWithToken = ReturnType<typeof defaultUserSettings> & {
+      storage: { daemonToken?: string }
+    }
+    store.update(
+      (current) =>
+        ({
+          ...current,
+          storage: { ...current.storage, daemonToken: 'x' },
+        }) as SettingsWithToken,
+    )
+
+    expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
+  })
+})

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createUserSettingsStore, defaultUserSettings, STORAGE_KEY } from './user-settings-store.js'
 
 describe('createUserSettingsStore', () => {
@@ -88,5 +88,37 @@ describe('createUserSettingsStore', () => {
     )
 
     expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
+  })
+})
+
+describe('createUserSettingsStore — blocked storage (SecurityError)', () => {
+  // Browsers can throw from localStorage access itself when storage is blocked
+  // by privacy settings. The store's contract is "never throws".
+  it('load() returns defaults when localStorage.getItem throws', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    try {
+      expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('save() and reset() do not throw when localStorage writes throw', () => {
+    const setSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    const removeSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    try {
+      const store = createUserSettingsStore()
+      expect(() => store.save(defaultUserSettings())).not.toThrow()
+      expect(() => store.reset()).not.toThrow()
+    } finally {
+      setSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
   })
 })

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -2,7 +2,38 @@ import { z } from 'zod'
 
 // Namespaced + version-suffixed so a future schema bump can migrate without
 // colliding with the V1 key still read by older tabs during a rollout.
+// Because the schemas below are `.strict()`, ANY field addition or change MUST
+// bump both this key suffix and the `version` literal: an older tab would
+// safeParse-fail on a newer payload, fall back to defaults, and then clobber
+// the newer fields if both versions shared one key.
 export const STORAGE_KEY = 'whiteboard:user-settings:v1'
+
+// localStorage access itself can throw (SecurityError when the browser blocks
+// storage via privacy settings or embedded contexts). The store's contract is
+// "never throws" — treat a throwing storage like an empty one.
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // Contract: never throws; an unwritable storage degrades to in-memory-only.
+  }
+}
+
+function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // Contract: never throws.
+  }
+}
 
 // `.strict()` at every level is the enforcement point for "no daemon/cloud
 // token in UserSettings": an unknown key (e.g. a token-shaped field) makes
@@ -67,7 +98,7 @@ export interface UserSettingsStore {
 
 export function createUserSettingsStore(): UserSettingsStore {
   function load(): UserSettings {
-    const raw = localStorage.getItem(STORAGE_KEY)
+    const raw = safeGetItem(STORAGE_KEY)
     if (raw === null) return defaultUserSettings()
 
     let parsedJson: unknown
@@ -84,7 +115,7 @@ export function createUserSettingsStore(): UserSettingsStore {
   function save(next: UserSettings): void {
     const result = userSettingsSchema.safeParse(next)
     if (!result.success) return
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(result.data))
+    safeSetItem(STORAGE_KEY, JSON.stringify(result.data))
   }
 
   function update(fn: (current: UserSettings) => UserSettings): void {
@@ -92,7 +123,7 @@ export function createUserSettingsStore(): UserSettingsStore {
   }
 
   function reset(): void {
-    localStorage.removeItem(STORAGE_KEY)
+    safeRemoveItem(STORAGE_KEY)
   }
 
   return { load, save, update, reset }

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod'
+
+// Namespaced + version-suffixed so a future schema bump can migrate without
+// colliding with the V1 key still read by older tabs during a rollout.
+export const STORAGE_KEY = 'whiteboard:user-settings:v1'
+
+// `.strict()` at every level is the enforcement point for "no daemon/cloud
+// token in UserSettings": an unknown key (e.g. a token-shaped field) makes
+// safeParse fail, and callers fall back to defaults rather than persisting it.
+const storageSettingsSchema = z
+  .object({
+    preferredProvider: z.enum(['browser-local', 'local-daemon']).optional(),
+    lastBrowserLocalCanvasId: z.string().optional(),
+    localDaemonBaseUrl: z.string().optional(),
+    dismissedPersistenceWarningAt: z.string().optional(),
+  })
+  .strict()
+
+const migrationSettingsSchema = z
+  .object({
+    browserLocalToDaemon: z
+      .object({
+        lastExportedAt: z.string().optional(),
+        lastImportedAt: z.string().optional(),
+        lastImportedCanvasId: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const capabilitySettingsSchema = z
+  .object({
+    webMcpEnabled: z.boolean().optional(),
+    webMcpMaxTier: z
+      .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)])
+      .optional(),
+  })
+  .strict()
+
+const userSettingsSchema = z
+  .object({
+    version: z.literal(1),
+    storage: storageSettingsSchema,
+    migration: migrationSettingsSchema,
+    capabilities: capabilitySettingsSchema,
+  })
+  .strict()
+
+export type UserSettings = z.infer<typeof userSettingsSchema>
+
+export function defaultUserSettings(): UserSettings {
+  return {
+    version: 1,
+    storage: {},
+    migration: {},
+    capabilities: {},
+  }
+}
+
+export interface UserSettingsStore {
+  load(): UserSettings
+  save(next: UserSettings): void
+  update(fn: (current: UserSettings) => UserSettings): void
+  reset(): void
+}
+
+export function createUserSettingsStore(): UserSettingsStore {
+  function load(): UserSettings {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return defaultUserSettings()
+
+    let parsedJson: unknown
+    try {
+      parsedJson = JSON.parse(raw)
+    } catch {
+      return defaultUserSettings()
+    }
+
+    const result = userSettingsSchema.safeParse(parsedJson)
+    return result.success ? result.data : defaultUserSettings()
+  }
+
+  function save(next: UserSettings): void {
+    const result = userSettingsSchema.safeParse(next)
+    if (!result.success) return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(result.data))
+  }
+
+  function update(fn: (current: UserSettings) => UserSettings): void {
+    save(fn(load()))
+  }
+
+  function reset(): void {
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  return { load, save, update, reset }
+}


### PR DESCRIPTION
Wave 0 / S-D slice of the apps/web completion plan (tmp/notes/apps-web-completion-plan.md).

- New `apps/web/src/lib/user-settings-store.ts`: localStorage-backed, schema-versioned store for non-secret UI prefs (preferredProvider, lastBrowserLocalCanvasId, persistence-warning dismissal, migration markers, capability flags)
- Zod single source of truth: `.strict()` at every nesting level, `z.infer` types — token-shaped keys (e.g. daemonToken) fail safeParse and fall back to defaults, enforcing the 'no daemon/cloud tokens in settings' security boundary from the First Step design
- Corrupt JSON / unknown version → silent fallback to defaults (never throws)

TDD red-first; 8 new tests; apps/web 165/165 pass; typecheck clean. Review: 0 CRITICAL/HIGH (1 LOW: nested sub-schema round-trip coverage, tracked for follow-up). No UI wiring in this slice by design.