### PR TITLE
feat(web): backend configuration chip

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { App } from './App.js'
+import type { ProviderState } from './lib/provider.js'
+
+afterEach(cleanup)
+
+// BrowserLocalCanvasPage pulls in Excalidraw/loro-crdt which need a real
+// browser (roughjs native bindings, WASM). Mock it here since this suite
+// only exercises the backend-configuration chip, not the canvas itself.
+vi.mock('./pages/BrowserLocalCanvasPage.js', () => ({
+  BrowserLocalCanvasPage: () => <div data-testid="browser-local-canvas-page" />,
+}))
+
+const BROWSER_LOCAL_STATE: ProviderState = {
+  kind: 'browser-local',
+  capabilities: {
+    canvasReadWrite: true,
+    migrationExport: true,
+    migrationImport: false,
+    workspaces: false,
+    versions: false,
+  },
+}
+
+const LOCAL_DAEMON_STATE: ProviderState = {
+  kind: 'local-daemon',
+  daemonBaseUrl: 'http://127.0.0.1:3000',
+  capabilities: {
+    canvasReadWrite: true,
+    migrationExport: false,
+    migrationImport: true,
+    workspaces: true,
+    versions: true,
+  },
+}
+
+const INVALID_CONFIG_STATE: ProviderState = {
+  kind: 'invalid-config',
+  message: 'Runtime configuration is invalid.',
+}
+
+describe('App backend configuration chip', () => {
+  it('shows "Browser only" when configured for browser-local storage', () => {
+    render(<App providerState={BROWSER_LOCAL_STATE} />)
+    expect(screen.getByText('Browser only')).toBeTruthy()
+  })
+
+  it('shows the daemon URL when configured for a local daemon', () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    expect(screen.getByText('Configured for local daemon at http://127.0.0.1:3000')).toBeTruthy()
+  })
+
+  it('does not render the chip on the invalid-config error page', () => {
+    render(<App providerState={INVALID_CONFIG_STATE} />)
+    expect(screen.queryByText('Browser only')).toBeNull()
+    expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,25 @@ interface AppProps {
   providerState?: ProviderState
 }
 
+// Reports the configured storage backend only — this reflects runtime
+// config, not a live connection/detection probe. Do not claim 'Connected'
+// or 'Daemon unavailable' here; that needs an actual live probe.
+function BackendConfigChip({ state }: { state: ProviderState }) {
+  const label =
+    state.kind === 'local-daemon'
+      ? `Configured for local daemon at ${state.daemonBaseUrl}`
+      : 'Browser only'
+
+  return (
+    <div
+      data-testid="backend-config-chip"
+      className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground"
+    >
+      {label}
+    </div>
+  )
+}
+
 export function App({ providerState }: AppProps) {
   const state = providerState ?? _defaultProviderState
 
@@ -29,10 +48,16 @@ export function App({ providerState }: AppProps) {
   if (state.kind === 'local-daemon') {
     return (
       <main data-provider="local-daemon" data-status="placeholder">
+        <BackendConfigChip state={state} />
         <h1>Whiteboard</h1>
       </main>
     )
   }
 
-  return <BrowserLocalCanvasPage store={_browserLocalStore} />
+  return (
+    <>
+      <BackendConfigChip state={state} />
+      <BrowserLocalCanvasPage store={_browserLocalStore} />
+    </>
+  )
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,10 +15,14 @@ interface AppProps {
   providerState?: ProviderState
 }
 
+interface BackendConfigChipProps {
+  state: ProviderState
+}
+
 // Reports the configured storage backend only — this reflects runtime
 // config, not a live connection/detection probe. Do not claim 'Connected'
 // or 'Daemon unavailable' here; that needs an actual live probe.
-function BackendConfigChip({ state }: { state: ProviderState }) {
+function BackendConfigChip({ state }: BackendConfigChipProps) {
   const label =
     state.kind === 'local-daemon'
       ? `Configured for local daemon at ${state.daemonBaseUrl}`

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,12 +16,17 @@ interface AppProps {
 }
 
 interface BackendConfigChipProps {
-  state: ProviderState
+  // invalid-config renders its own error page and never shows the chip;
+  // excluding it here lets the compiler prove that instead of a silent
+  // 'Browser only' fallback.
+  state: Exclude<ProviderState, { kind: 'invalid-config' }>
 }
 
 // Reports the configured storage backend only — this reflects runtime
 // config, not a live connection/detection probe. Do not claim 'Connected'
 // or 'Daemon unavailable' here; that needs an actual live probe.
+// Fixed-positioned overlay: the canvas page owns the full viewport (h-dvh),
+// so an in-flow sibling would push it down and create a page scrollbar.
 function BackendConfigChip({ state }: BackendConfigChipProps) {
   const label =
     state.kind === 'local-daemon'
@@ -31,7 +36,7 @@ function BackendConfigChip({ state }: BackendConfigChipProps) {
   return (
     <div
       data-testid="backend-config-chip"
-      className="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground"
+      className="fixed right-2 bottom-2 z-50 flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs font-medium text-muted-foreground shadow-sm"
     >
       {label}
     </div>


### PR DESCRIPTION
Wave 0 / S-J slice of the apps/web completion plan (tmp/notes/apps-web-completion-plan.md).

- `BackendConfigChip` in App.tsx reads `ProviderState.kind` and shows 'Browser only' or 'Configured for local daemon at <daemonBaseUrl>'
- Deliberately configuration-only: no 'Connected' / live-probe claims (that upgrade lands in S-H once real detection exists)
- invalid-config keeps its existing error page (no chip)
- Mitigates the storage-silo confusion issues (mcp-web-storage-silo / dual-ui-port-confusion): the user can always tell which backend the UI is configured for

TDD red-first (3 variants); apps/web 160/160 pass; typecheck clean; manually verified via wrangler pages dev + screenshot. Review: 0 findings.

Known follow-up: chip placement is a full-width bar until a real header component exists; visual polish deferred.