### PR TITLE
fix(release): gate git-based plugin distribution behind releases via stable branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,11 @@
   "plugins": [
     {
       "name": "whiteboard",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "kamiazya/whiteboard",
+        "ref": "stable"
+      },
       "description": "Collaborative Excalidraw canvas for Claude Code. Wraps the @kamiazya/whiteboard-mcp server and exposes the bundled /drawing-visuals, /coauthoring-visuals, and /auditing-workspaces skills.",
       "version": "0.0.10",
       "author": {
@@ -21,21 +25,9 @@
       "homepage": "https://github.com/kamiazya/whiteboard",
       "repository": "https://github.com/kamiazya/whiteboard",
       "license": "MIT",
-      "keywords": [
-        "excalidraw",
-        "diagramming",
-        "mcp",
-        "whiteboard",
-        "claude-code",
-        "codex"
-      ],
+      "keywords": ["excalidraw", "diagramming", "mcp", "whiteboard", "claude-code", "codex"],
       "category": "productivity",
-      "tags": [
-        "diagramming",
-        "mcp",
-        "excalidraw",
-        "visualization"
-      ]
+      "tags": ["diagramming", "mcp", "excalidraw", "visualization"]
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,32 @@ jobs:
           # GITHUB_TOKEN-driven actions cannot trigger workflows on other workflows.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
+  # Fast-forward the `stable` branch to the root (plugin) release tag.
+  # Git-based plugin consumers (Claude Code marketplace source ref, Codex
+  # `@stable` marketplaces) resolve `stable`, so plugin content ships on
+  # release-PR merge instead of on every push to main.
+  advance-stable:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.root_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Fast-forward stable to the release tag
+        env:
+          TAG: ${{ needs.release-please.outputs.root_tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --no-tags || true
+          git rev-parse --verify "refs/tags/${TAG}^{commit}" >/dev/null
+          # No force flag: a non-fast-forward means history was rewritten — fail loudly.
+          git push origin "refs/tags/${TAG}^{commit}:refs/heads/stable"
+
   publish-mcp:
     needs: release-please
     if: ${{ needs.release-please.outputs.mcp_release_created == 'true' || inputs.force_publish_tag != '' }}

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ claude mcp add whiteboard -- npx -y @kamiazya/whiteboard-mcp@latest
 In a Codex session, run:
 
 ```
-codex plugin marketplace add kamiazya/whiteboard
+codex plugin marketplace add kamiazya/whiteboard@stable
 ```
+
+The `@stable` pin tracks the latest release instead of the development branch.
 
 Then open `/plugins`, choose **kamiazya Whiteboard → whiteboard → Install plugin**, and restart Codex. This installs the MCP server **and** the bundled skills in one step.
 

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -171,11 +171,20 @@ describe('publish contract', () => {
       'node_modules/@kamiazya/whiteboard-mcp/dist/server/mcp/index.js',
     )
 
-    // The marketplace plugin manifest points at the existing .claude-plugin/plugin.json
-    // and the marketplace name in README must match the marketplace.json declaration.
+    // The marketplace plugin manifest points at the release-gated stable branch
+    // (advance-stable in release.yml fast-forwards it on each root release) so
+    // merging to main does not immediately ship plugin content. The marketplace
+    // name in README must match the marketplace.json declaration.
     expect(claudeMarketplace.name).toBe('whiteboard-marketplace')
     expect(claudeMarketplace.plugins[0].name).toBe('whiteboard')
-    expect(claudeMarketplace.plugins[0].source).toBe('./')
+    expect(claudeMarketplace.plugins[0].source).toEqual({
+      source: 'github',
+      repo: 'kamiazya/whiteboard',
+      ref: 'stable',
+    })
+    // Codex ref pinning is user-side opt-in, so the README install command must
+    // carry the @stable pin to keep Codex installs release-gated too.
+    expect(rootReadme).toContain('codex plugin marketplace add kamiazya/whiteboard@stable')
     // marketplace.json versions must stay aligned with the published mcp-server package
     // (release-please-config.json tracks both jsonpaths in extra-files).
     expect(claudeMarketplace.metadata.version).toBe(mcpPackage.version)


### PR DESCRIPTION
# Why

Merging to `main` currently ships Claude Code plugin content (skills, manifests) to users immediately: the marketplace plugin `source` is `"./"`, which resolves the repository default branch on install/update. This bypasses the release gate that release-please already provides for the npm package and the MCP registry entry.

Per-ecosystem status before this PR:

| Surface | Gated by releases? |
|---|---|
| npm / MCP Registry | ✅ `npm publish` runs only on release-PR merge |
| Gemini CLI extension | ✅ resolves the latest GitHub Release when releases exist |
| Claude Code plugin | ❌ tracks default-branch HEAD |
| Codex plugin | ❌ unpinned marketplaces track default-branch HEAD |

# What

- **`.claude-plugin/marketplace.json`**: pin the plugin source to the release-gated branch — `{"source": "github", "repo": "kamiazya/whiteboard", "ref": "stable"}` (ref pinning per the [plugin marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces)).
- **`.github/workflows/release.yml`**: new `advance-stable` job — when release-please creates the root (plugin) release, fast-forward `stable` to the release tag. No force push; a non-fast-forward fails loudly.
- **`README.md`**: Codex install command becomes `codex plugin marketplace add kamiazya/whiteboard@stable`. Codex ref pinning is user-side opt-in, so the README pin is the strongest gate available there.
- **`publish-contract.test.ts`**: locks the new source shape and the README `@stable` pin (this test is what caught the old `"./"` contract on the first commit attempt).

The `stable` branch has been created at `whiteboard-plugin-v0.0.10` (the latest root release), so the pinned source resolves as soon as this merges.

# Verification

- `claude plugin validate .` → Validation passed
- `pnpm test --project mcp-node` (pre-push hook) → green, including the updated publish-contract test
- YAML/JSON syntax validated

# Notes

- Gemini CLI and the MCP registry need no change; they were already release-gated.
- Existing Codex users who added the marketplace without `@stable` keep tracking `main` — this is a documented limitation of Codex's user-side pinning; fully closing it would require making the default branch itself release-tracking.
