### PR TITLE
feat(shared): MigrationBundle contract + package export

### DIFF
--- a/apps/web/src/lib/migration-export.test.ts
+++ b/apps/web/src/lib/migration-export.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { migrationBundleSchema } from '@kamiazya/whiteboard-mcp/migration-bundle'
+
+import type { CanvasSnapshot } from './whiteboard-client.js'
+import { buildMigrationBundle } from './migration-export.js'
+
+function makeSnapshot(overrides: Partial<CanvasSnapshot> = {}): CanvasSnapshot {
+  return {
+    id: 'canvas-1',
+    name: 'My Canvas',
+    scene: { elements: [{ id: 'el-1', type: 'rectangle' }] },
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('buildMigrationBundle', () => {
+  it('returns a bundle that satisfies migrationBundleSchema', () => {
+    const bundle = buildMigrationBundle([makeSnapshot()])
+    expect(() => migrationBundleSchema.parse(bundle)).not.toThrow()
+  })
+
+  it('sets the correct format/version/sourceProvider literals', () => {
+    const bundle = buildMigrationBundle([makeSnapshot()])
+    expect(bundle.format).toBe('whiteboard-migration')
+    expect(bundle.version).toBe(1)
+    expect(bundle.sourceProvider).toBe('browser-local')
+  })
+
+  it('carries over id, name, and scene.elements from the snapshot', () => {
+    const snapshot = makeSnapshot({ id: 'abc', name: 'Roadmap' })
+    const bundle = buildMigrationBundle([snapshot])
+    expect(bundle.canvases).toEqual([
+      { id: 'abc', name: 'Roadmap', scene: { elements: snapshot.scene.elements } },
+    ])
+  })
+
+  it('produces an ISO createdAt from an injected clock', () => {
+    const now = () => new Date('2026-01-01T12:00:00.000Z')
+    const bundle = buildMigrationBundle([makeSnapshot()], now)
+    expect(bundle.createdAt).toBe('2026-01-01T12:00:00.000Z')
+  })
+
+  it('produces an empty canvases array that still parses when given no snapshots', () => {
+    const bundle = buildMigrationBundle([])
+    expect(bundle.canvases).toEqual([])
+    expect(() => migrationBundleSchema.parse(bundle)).not.toThrow()
+  })
+
+  it('does not mutate the input snapshots array or its entries', () => {
+    const snapshots = [makeSnapshot()]
+    const frozenElements = snapshots[0].scene.elements
+    buildMigrationBundle(snapshots)
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0].scene.elements).toBe(frozenElements)
+  })
+})

--- a/apps/web/src/lib/migration-export.ts
+++ b/apps/web/src/lib/migration-export.ts
@@ -1,7 +1,7 @@
 /**
  * Builds a MigrationBundle from browser-local canvas snapshots so a user can
  * export their data and import it into a daemon-backed workspace (or another
- * browser-local instance). Pure function — no UI wiring here (see S-M).
+ * browser-local instance). Pure function — no UI wiring here.
  */
 import type { MigrationBundle } from '@kamiazya/whiteboard-mcp/migration-bundle'
 

--- a/apps/web/src/lib/migration-export.ts
+++ b/apps/web/src/lib/migration-export.ts
@@ -1,0 +1,25 @@
+/**
+ * Builds a MigrationBundle from browser-local canvas snapshots so a user can
+ * export their data and import it into a daemon-backed workspace (or another
+ * browser-local instance). Pure function — no UI wiring here (see S-M).
+ */
+import type { MigrationBundle } from '@kamiazya/whiteboard-mcp/migration-bundle'
+
+import type { CanvasSnapshot } from './whiteboard-client.js'
+
+export function buildMigrationBundle(
+  canvases: readonly CanvasSnapshot[],
+  now: () => Date = () => new Date(),
+): MigrationBundle {
+  return {
+    format: 'whiteboard-migration',
+    version: 1,
+    sourceProvider: 'browser-local',
+    createdAt: now().toISOString(),
+    canvases: canvases.map((snapshot) => ({
+      id: snapshot.id,
+      name: snapshot.name,
+      scene: { elements: snapshot.scene.elements },
+    })),
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -78,6 +78,10 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/browser-shared-index.ts',
       ),
+      '@kamiazya/whiteboard-mcp/migration-bundle': resolve(
+        __dirname,
+        '../../packages/mcp-server/src/shared/migration-bundle.ts',
+      ),
     },
   },
   build: {

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/browser-shared-index.ts',
       ),
+      '@kamiazya/whiteboard-mcp/migration-bundle': resolve(
+        __dirname,
+        '../../packages/mcp-server/src/shared/migration-bundle.ts',
+      ),
     },
   },
   // tailwindcss: layout browser tests import src/index.css to assert real

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/browser-shared-index.ts',
       ),
+      '@kamiazya/whiteboard-mcp/migration-bundle': resolve(
+        __dirname,
+        '../../packages/mcp-server/src/shared/migration-bundle.ts',
+      ),
     },
   },
   test: {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -38,6 +38,10 @@
       "types": "./src/shared/browser-shared-index.ts",
       "import": "./dist/shared/browser-shared-index.js"
     },
+    "./migration-bundle": {
+      "types": "./src/shared/migration-bundle.ts",
+      "import": "./dist/shared/migration-bundle.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -72,6 +76,10 @@
       "./browser-shared": {
         "types": "./dist/shared/browser-shared-index.d.ts",
         "import": "./dist/shared/browser-shared-index.js"
+      },
+      "./migration-bundle": {
+        "types": "./dist/shared/migration-bundle.d.ts",
+        "import": "./dist/shared/migration-bundle.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -87,6 +87,10 @@ describe('publish contract', () => {
         types: './src/shared/browser-shared-index.ts',
         import: './dist/shared/browser-shared-index.js',
       },
+      './migration-bundle': {
+        types: './src/shared/migration-bundle.ts',
+        import: './dist/shared/migration-bundle.js',
+      },
       './package.json': './package.json',
     })
     // publishConfig.exports is the shape pnpm substitutes on npm publish,
@@ -103,6 +107,10 @@ describe('publish contract', () => {
       './browser-shared': {
         types: './dist/shared/browser-shared-index.d.ts',
         import: './dist/shared/browser-shared-index.js',
+      },
+      './migration-bundle': {
+        types: './dist/shared/migration-bundle.d.ts',
+        import: './dist/shared/migration-bundle.js',
       },
       './package.json': './package.json',
     })

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -91,6 +91,7 @@ const ALLOWED_SHARED_EXACT = new Set([
   'canvas-backend-contract.js', // transport/callback seam — types + Zod re-exports only, no Node APIs
   'external-url-policy.js', // pure URL validation, no Node APIs
   'loro-raw-element.js', // Zod schema for Loro-stored element shape — zod-only, no Node APIs
+  'migration-bundle.js', // MigrationBundle Zod contract — zod-only, no Node APIs
   'resolve-parented-elements.js', // pure data transformation
   'ws-messages.js', // WebSocket protocol types/constants
   'ws-protocol.js', // WebSocket protocol helpers

--- a/packages/mcp-server/src/shared/migration-bundle.test.ts
+++ b/packages/mcp-server/src/shared/migration-bundle.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import { migrationBundleSchema } from './migration-bundle.js'
+
+function validBundle() {
+  return {
+    format: 'whiteboard-migration' as const,
+    version: 1 as const,
+    sourceProvider: 'browser-local' as const,
+    createdAt: '2026-07-05T00:00:00.000Z',
+    canvases: [
+      {
+        id: 'canvas-1',
+        name: 'My Canvas',
+        scene: { elements: [{ id: 'el-1', type: 'rectangle' }] },
+      },
+    ],
+  }
+}
+
+describe('migrationBundleSchema', () => {
+  it('parses a valid v1 bundle with one canvas and round-trips deeply equal', () => {
+    const bundle = validBundle()
+    const parsed = migrationBundleSchema.parse(bundle)
+    expect(parsed).toEqual(bundle)
+  })
+
+  it('parses a bundle with multiple canvases (array form is the schema contract)', () => {
+    const bundle = validBundle()
+    const multi = {
+      ...bundle,
+      canvases: [...bundle.canvases, { ...bundle.canvases[0], id: 'canvas-2' }],
+    }
+    expect(() => migrationBundleSchema.parse(multi)).not.toThrow()
+  })
+
+  it('parses scene without optional appState/files', () => {
+    const bundle = validBundle()
+    expect(bundle.canvases[0].scene).not.toHaveProperty('appState')
+    expect(() => migrationBundleSchema.parse(bundle)).not.toThrow()
+  })
+
+  it('parses scene with appState and files present', () => {
+    const bundle = validBundle()
+    const withExtras = {
+      ...bundle,
+      canvases: [
+        {
+          ...bundle.canvases[0],
+          scene: {
+            ...bundle.canvases[0].scene,
+            appState: { viewBackgroundColor: '#fff' },
+            files: { 'file-1': { mimeType: 'image/png' } },
+          },
+        },
+      ],
+    }
+    expect(() => migrationBundleSchema.parse(withExtras)).not.toThrow()
+  })
+
+  it('rejects an unknown top-level key (strict)', () => {
+    const bundle = { ...validBundle(), extra: 'nope' }
+    expect(() => migrationBundleSchema.parse(bundle)).toThrow()
+  })
+
+  it('rejects an unknown key inside a canvas entry (strict)', () => {
+    const bundle = validBundle()
+    const withExtra = {
+      ...bundle,
+      canvases: [{ ...bundle.canvases[0], extra: 'nope' }],
+    }
+    expect(() => migrationBundleSchema.parse(withExtra)).toThrow()
+  })
+
+  it('rejects an unknown key inside scene (strict)', () => {
+    const bundle = validBundle()
+    const withExtra = {
+      ...bundle,
+      canvases: [{ ...bundle.canvases[0], scene: { ...bundle.canvases[0].scene, extra: 'nope' } }],
+    }
+    expect(() => migrationBundleSchema.parse(withExtra)).toThrow()
+  })
+
+  it('rejects the wrong format string', () => {
+    const bundle = { ...validBundle(), format: 'something-else' }
+    expect(() => migrationBundleSchema.parse(bundle)).toThrow()
+  })
+
+  it('rejects version other than the literal 1', () => {
+    expect(() => migrationBundleSchema.parse({ ...validBundle(), version: 2 })).toThrow()
+    expect(() => migrationBundleSchema.parse({ ...validBundle(), version: '1' })).toThrow()
+  })
+
+  it('rejects a sourceProvider other than browser-local', () => {
+    const bundle = { ...validBundle(), sourceProvider: 'daemon' }
+    expect(() => migrationBundleSchema.parse(bundle)).toThrow()
+  })
+
+  it('rejects a missing createdAt or canvases field', () => {
+    const bundle = validBundle() as Record<string, unknown>
+    const { createdAt: _createdAt, ...withoutCreatedAt } = bundle
+    expect(() => migrationBundleSchema.parse(withoutCreatedAt)).toThrow()
+    const { canvases: _canvases, ...withoutCanvases } = bundle
+    expect(() => migrationBundleSchema.parse(withoutCanvases)).toThrow()
+  })
+
+  it('rejects non-array elements in scene', () => {
+    const bundle = validBundle()
+    const invalid = {
+      ...bundle,
+      canvases: [{ ...bundle.canvases[0], scene: { elements: 'not-an-array' } }],
+    }
+    expect(() => migrationBundleSchema.parse(invalid)).toThrow()
+  })
+})

--- a/packages/mcp-server/src/shared/migration-bundle.test.ts
+++ b/packages/mcp-server/src/shared/migration-bundle.test.ts
@@ -104,6 +104,15 @@ describe('migrationBundleSchema', () => {
     expect(() => migrationBundleSchema.parse(withoutCanvases)).toThrow()
   })
 
+  it('rejects a createdAt that is not an ISO 8601 datetime', () => {
+    expect(() =>
+      migrationBundleSchema.parse({ ...validBundle(), createdAt: 'yesterday' }),
+    ).toThrow()
+    expect(() =>
+      migrationBundleSchema.parse({ ...validBundle(), createdAt: '2026-07-05' }),
+    ).toThrow()
+  })
+
   it('rejects non-array elements in scene', () => {
     const bundle = validBundle()
     const invalid = {

--- a/packages/mcp-server/src/shared/migration-bundle.ts
+++ b/packages/mcp-server/src/shared/migration-bundle.ts
@@ -1,0 +1,46 @@
+/**
+ * MigrationBundle: the JSON contract exported by browser-local canvases so
+ * they can be re-imported into a daemon-backed workspace (or another
+ * browser-local instance). Zod is the single source of truth per
+ * zod-schema-discipline; MigrationBundle is derived via z.infer, never a
+ * parallel hand-written interface.
+ *
+ * This module imports only 'zod' — no Node builtins, no src/server|cli|daemon
+ * imports — so it stays safe to bundle into the browser app.
+ *
+ * v1 keeps `canvases` as an array even though the current export/import flow
+ * only ever produces/accepts exactly one canvas; enforcing length === 1 is a
+ * consumer-side (import route) concern, not a schema-shape concern.
+ */
+import { z } from 'zod'
+
+const migrationSceneSchema = z
+  .object({
+    elements: z.array(z.unknown()),
+    // Excalidraw's appState/files shapes are vendor-owned and evolve outside
+    // this repo's control; z.record(z.unknown()) is deliberately loose here
+    // rather than a gap in the schema.
+    appState: z.record(z.string(), z.unknown()).optional(),
+    files: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict()
+
+const migrationCanvasSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    scene: migrationSceneSchema,
+  })
+  .strict()
+
+export const migrationBundleSchema = z
+  .object({
+    format: z.literal('whiteboard-migration'),
+    version: z.literal(1),
+    sourceProvider: z.literal('browser-local'),
+    createdAt: z.string(),
+    canvases: z.array(migrationCanvasSchema),
+  })
+  .strict()
+
+export type MigrationBundle = z.infer<typeof migrationBundleSchema>

--- a/packages/mcp-server/src/shared/migration-bundle.ts
+++ b/packages/mcp-server/src/shared/migration-bundle.ts
@@ -16,10 +16,12 @@ import { z } from 'zod'
 
 const migrationSceneSchema = z
   .object({
+    // Excalidraw element shapes are vendor-owned and evolve outside this
+    // repo's control; z.unknown() per element is deliberately loose here
+    // rather than a gap in the schema. The import side revalidates elements
+    // against its own persistence contract before storing them.
     elements: z.array(z.unknown()),
-    // Excalidraw's appState/files shapes are vendor-owned and evolve outside
-    // this repo's control; z.record(z.unknown()) is deliberately loose here
-    // rather than a gap in the schema.
+    // Same rationale as elements: appState/files are vendor-owned shapes.
     appState: z.record(z.string(), z.unknown()).optional(),
     files: z.record(z.string(), z.unknown()).optional(),
   })
@@ -38,7 +40,7 @@ export const migrationBundleSchema = z
     format: z.literal('whiteboard-migration'),
     version: z.literal(1),
     sourceProvider: z.literal('browser-local'),
-    createdAt: z.string(),
+    createdAt: z.iso.datetime(),
     canvases: z.array(migrationCanvasSchema),
   })
   .strict()


### PR DESCRIPTION
Wave 0 / S-K' slice of the apps/web completion plan (plan gate must-fix applied: defines a NEW contract, not a move — no migrationBundleSchema previously existed).

- New \`packages/mcp-server/src/shared/migration-bundle.ts\`: \`migrationBundleSchema\` (Zod, \`.strict()\` at every level), \`MigrationBundle = z.infer\`. Shape: format/version/sourceProvider literals, \`createdAt\` (ISO datetime), \`canvases[]\` with per-canvas scene. Array form kept; length===1 enforcement is S-L's job.
- Exported as \`@kamiazya/whiteboard-mcp/migration-bundle\` — both the workspace \`exports\` and \`publishConfig.exports\` blocks updated, with \`publish-contract.test.ts\` expectations updated red-first.
- Browser-safe: zod-only imports; added to the \`web-app-boundary\` shared allowlist.
- apps/web: source-resolving alias in vite/vitest/vitest.browser configs + \`buildMigrationBundle()\` pure function (injectable clock) — UI wiring is S-M.

TDD red-first at each layer. mcp-node 69 tests + apps/web 176 tests + typecheck + build all pass. Review: 0 CRITICAL/HIGH; 2 LOW (createdAt now ISO-validated, elements comment) fixed in follow-up.