### PR TITLE
fix(web): reconnect useCanvasSync on backend swap so reload keeps elements

### DIFF
--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -37,6 +37,7 @@ type FakeBackendControl = {
   handlers: CanvasBackendHandlers | null
   disconnectCalled: boolean
   pushLocalUpdateCalls: Uint8Array[]
+  putFileCalls: [string, unknown][][]
 }
 
 function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
@@ -44,6 +45,7 @@ function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
     handlers: null,
     disconnectCalled: false,
     pushLocalUpdateCalls: [],
+    putFileCalls: [],
   }
   const backend: CanvasBackend & { _ctrl: FakeBackendControl } = {
     _ctrl: ctrl,
@@ -60,7 +62,9 @@ function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
       return Promise.resolve()
     },
     getFile: async () => null,
-    putFile: async () => {},
+    putFile: async (entries) => {
+      ctrl.putFileCalls.push(entries as [string, unknown][])
+    },
     sendClientReady: () => {},
     sendExportResponse: () => {},
   }
@@ -319,6 +323,58 @@ describe('useCanvasSync', () => {
     expect(backendB._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(bCallsBefore)
   })
 
+  it('drops a pending debounced file upload scheduled against a since-superseded backend, even if its cancellation is lost to a timing race', async () => {
+    const backendA = makeFakeBackend()
+    const backendB = makeFakeBackend()
+    const api = makeApiStub()
+
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: backendA as CanvasBackend },
+    })
+
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    await act(async () => {
+      backendA._ctrl.handlers!.onSnapshot(makeEmptyLoroSnapshot())
+      await vi.runAllTimersAsync()
+    })
+
+    // Queue a scene change with a new file against backend A. The debounce
+    // schedules a real (fake-clock) timer for this call's args.
+    const fakeEl = { type: 'image', id: 'img-x', x: 0, y: 0, width: 10, height: 10 }
+    const fakeFile = { id: 'file-x', mimeType: 'image/png', dataURL: 'data:x', created: 0 }
+    act(() => {
+      result.current.onChange([fakeEl as never], {} as never, { 'file-x': fakeFile as never })
+    })
+
+    // Simulate the real-browser race the finding describes: the passive
+    // effect's own `onSceneChange.cancel()` call races the already-elapsing
+    // timer and loses, so A's pending flush survives the switch to B. Stub
+    // out clearTimeout for the duration of the switch so `.cancel()` becomes
+    // a no-op without touching any of this hook's own logic.
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => {})
+    rerender({ backend: backendB })
+    clearTimeoutSpy.mockRestore()
+
+    // Let B finish connecting so its doc is live by the time A's stale timer fires.
+    await act(async () => {
+      backendB._ctrl.handlers!.onSnapshot(makeEmptyLoroSnapshot())
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // Fire A's un-cancelled timer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400)
+    })
+
+    // The queued change was scheduled against A's connection; once
+    // superseded it must be dropped entirely rather than uploaded to B.
+    expect(backendA._ctrl.putFileCalls.length).toBe(0)
+    expect(backendB._ctrl.putFileCalls.length).toBe(0)
+  })
+
   it("does not let a stale getFile fetch from a torn-down backend pollute the new backend's file cache", async () => {
     const api = makeApiStub()
     const fileId = 'shared-file'
@@ -398,7 +454,7 @@ describe('useCanvasSync', () => {
 
     // Backend B fails to connect: fires onError synchronously instead of onConnected.
     const failingBackend: CanvasBackend & { _ctrl: FakeBackendControl } = {
-      _ctrl: { handlers: null, disconnectCalled: false, pushLocalUpdateCalls: [] },
+      _ctrl: { handlers: null, disconnectCalled: false, pushLocalUpdateCalls: [], putFileCalls: [] },
       connect(handlers) {
         handlers.onError?.('storage-failure')
       },

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -5,13 +5,14 @@
  * that are not available in jsdom. The hook's sync contract is tested via
  * a fake CanvasBackend and a minimal ExcalidrawImperativeAPI stub.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import { LoroDoc } from 'loro-crdt'
+
 import type {
   CanvasBackend,
   CanvasBackendHandlers,
 } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { act, renderHook } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock excalidraw before importing the hook — restoreElements must return its input unchanged.
 vi.mock('@excalidraw/excalidraw', () => ({
@@ -190,5 +191,120 @@ describe('useCanvasSync', () => {
 
     // Push count must not increase after unmount.
     expect(backend._ctrl.pushLocalUpdateCalls.length).toBe(callsAtUnmount)
+  })
+
+  it('does not connect when backend is null, and onChange is a safe no-op', () => {
+    const { result } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: null as CanvasBackend | null },
+    })
+
+    expect(result.current.syncStatus).toBe('idle')
+    // Calling onChange with no backend must not throw.
+    expect(() => result.current.onChange([], {} as never, {})).not.toThrow()
+  })
+
+  it('connects when backend changes from null to a real backend', () => {
+    const backend = makeFakeBackend()
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: null as CanvasBackend | null },
+    })
+
+    expect(result.current.syncStatus).toBe('idle')
+
+    rerender({ backend })
+
+    expect(backend._ctrl.handlers).not.toBeNull()
+    expect(result.current.syncStatus).toBe('connected')
+  })
+
+  it('reconnects to a new backend when the backend prop changes, disconnecting the old one', async () => {
+    const backendA = makeFakeBackend()
+    const backendB = makeFakeBackend()
+    const api = makeApiStub()
+
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: backendA as CanvasBackend },
+    })
+
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    await act(async () => {
+      backendA._ctrl.handlers!.onSnapshot(makeEmptyLoroSnapshot())
+      await vi.runAllTimersAsync()
+    })
+
+    // Switch to backend B.
+    rerender({ backend: backendB })
+
+    expect(backendA._ctrl.disconnectCalled).toBe(true)
+    expect(backendB._ctrl.handlers).not.toBeNull()
+
+    await act(async () => {
+      backendB._ctrl.handlers!.onSnapshot(makeEmptyLoroSnapshot())
+      await vi.runAllTimersAsync()
+    })
+
+    const aCallsBefore = backendA._ctrl.pushLocalUpdateCalls.length
+    const bCallsBefore = backendB._ctrl.pushLocalUpdateCalls.length
+
+    const fakeEl = { type: 'rectangle', id: 'el-3', x: 0, y: 0, width: 10, height: 10 }
+    act(() => {
+      result.current.onChange([fakeEl as never], {} as never, {})
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400)
+    })
+
+    // Writes after the switch reach B only, never A.
+    expect(backendA._ctrl.pushLocalUpdateCalls.length).toBe(aCallsBefore)
+    expect(backendB._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(bCallsBefore)
+  })
+
+  it('sets syncStatus to "error" and does not resurrect A when switching to a backend whose connect fails', () => {
+    const backendA = makeFakeBackend()
+    const api = makeApiStub()
+
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: backendA as CanvasBackend },
+    })
+
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    expect(result.current.syncStatus).toBe('connected')
+
+    // Backend B fails to connect: fires onError synchronously instead of onConnected.
+    const failingBackend: CanvasBackend & { _ctrl: FakeBackendControl } = {
+      _ctrl: { handlers: null, disconnectCalled: false, pushLocalUpdateCalls: [] },
+      connect(handlers) {
+        handlers.onError?.('storage-failure')
+      },
+      disconnect() {},
+      pushLocalUpdate: () => Promise.resolve(),
+      getFile: async () => null,
+      putFile: async () => {},
+      sendClientReady: () => {},
+      sendExportResponse: () => {},
+    }
+
+    act(() => {
+      rerender({ backend: failingBackend })
+    })
+
+    expect(backendA._ctrl.disconnectCalled).toBe(true)
+    expect(result.current.syncStatus).toBe('error')
+
+    // Subsequent switch to a healthy backend still connects cleanly.
+    const backendC = makeFakeBackend()
+    act(() => {
+      rerender({ backend: backendC })
+    })
+
+    expect(backendC._ctrl.handlers).not.toBeNull()
+    expect(result.current.syncStatus).toBe('connected')
   })
 })

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -11,7 +11,7 @@ import type {
   CanvasBackendHandlers,
 } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { act, renderHook } from '@testing-library/react'
-import { LoroDoc } from 'loro-crdt'
+import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock excalidraw before importing the hook — restoreElements must return its input unchanged.
@@ -70,6 +70,31 @@ function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
 function makeEmptyLoroSnapshot(): Uint8Array {
   const doc = new LoroDoc()
   return doc.export({ mode: 'snapshot' })
+}
+
+// Builds a snapshot containing a single image element referencing fileId,
+// so onSnapshot triggers a bk.getFile(fileId) fetch inside applyLoroToExcalidraw.
+function makeLoroSnapshotWithImage(fileId: string): Uint8Array {
+  const doc = new LoroDoc()
+  const list = doc.getMovableList('elements')
+  const map = list.insertContainer(0, new LoroMap())
+  map.set('id', 'img-1')
+  map.set('type', 'image')
+  map.set('x', 0)
+  map.set('y', 0)
+  map.set('width', 10)
+  map.set('height', 10)
+  map.set('fileId', fileId)
+  doc.commit()
+  return doc.export({ mode: 'snapshot' })
+}
+
+function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
 }
 
 describe('useCanvasSync', () => {
@@ -203,6 +228,37 @@ describe('useCanvasSync', () => {
     expect(() => result.current.onChange([], {} as never, {})).not.toThrow()
   })
 
+  it('undo/redo keyboard shortcuts are safe no-ops when backend is null', () => {
+    const api = makeApiStub()
+
+    // Register the excalidraw API so the keydown handler has something to
+    // (not) act on — the undo/redo guard should short-circuit before it does.
+    const { result } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: null as CanvasBackend | null },
+    })
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    expect(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true, cancelable: true }),
+      )
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'z',
+          ctrlKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    }).not.toThrow()
+
+    // Neither shortcut had a doc/undoManager to act on, so the scene is untouched.
+    expect(api.updateScene).not.toHaveBeenCalled()
+  })
+
   it('connects when backend changes from null to a real backend', () => {
     const backend = makeFakeBackend()
     const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
@@ -261,6 +317,69 @@ describe('useCanvasSync', () => {
     // Writes after the switch reach B only, never A.
     expect(backendA._ctrl.pushLocalUpdateCalls.length).toBe(aCallsBefore)
     expect(backendB._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(bCallsBefore)
+  })
+
+  it("does not let a stale getFile fetch from a torn-down backend pollute the new backend's file cache", async () => {
+    const api = makeApiStub()
+    const fileId = 'shared-file'
+
+    // backendA's getFile never resolves during this test until we do so
+    // manually, simulating an in-flight fetch that outlives the backend swap.
+    const deferredOld = makeDeferred<Blob>()
+    const backendA = makeFakeBackend()
+    backendA.getFile = async () => deferredOld.promise
+
+    // backendB resolves immediately with different content.
+    const backendB = makeFakeBackend()
+    backendB.getFile = async () => new Blob(['new-content'], { type: 'text/plain' })
+
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: backendA as CanvasBackend },
+    })
+
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    // Snapshot from A references fileId, kicking off backendA.getFile(fileId)
+    // — left pending (deferredOld is not resolved yet).
+    await act(async () => {
+      backendA._ctrl.handlers!.onSnapshot(makeLoroSnapshotWithImage(fileId))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // Switch to backend B before A's fetch resolves. This resets the shared
+    // file cache and bumps the apply generation, tearing down A's connection.
+    rerender({ backend: backendB })
+
+    // Snapshot from B references the same fileId; backendB.getFile resolves
+    // immediately with fresh content.
+    await act(async () => {
+      backendB._ctrl.handlers!.onSnapshot(makeLoroSnapshotWithImage(fileId))
+      await vi.runAllTimersAsync()
+    })
+
+    const addFilesCallsBeforeStaleResolve = api.addFiles.mock.calls.length
+    expect(addFilesCallsBeforeStaleResolve).toBeGreaterThan(0)
+
+    // Now let A's stale fetch resolve with old content — after the switch.
+    await act(async () => {
+      deferredOld.resolve(new Blob(['old-content'], { type: 'text/plain' }))
+      await vi.runAllTimersAsync()
+    })
+
+    // Force another apply on B (subsequent remote update) so any cache
+    // pollution from the stale write would surface in a fresh addFiles call.
+    await act(async () => {
+      backendB._ctrl.handlers!.onRemoteUpdate(makeLoroSnapshotWithImage(fileId))
+      await vi.runAllTimersAsync()
+    })
+
+    const allDataUrls = api.addFiles.mock.calls.flatMap((call) =>
+      (call[0] as { dataURL: string }[]).map((f) => f.dataURL),
+    )
+    const hasOldContent = allDataUrls.some((url) => url.includes(btoa('old-content')))
+    expect(hasOldContent).toBe(false)
   })
 
   it('sets syncStatus to "error" and does not resurrect A when switching to a backend whose connect fails', () => {

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -122,8 +122,13 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
     await Promise.allSettled(
       missingIds.map(async (fileId) => {
         const blob = await bk.getFile(fileId)
-        if (!blob) return
+        // A connection swap can resolve this fetch after filesCacheRef has
+        // already been reset for the next backend. Re-check the generation
+        // right before writing so a stale fetch from a torn-down backend
+        // never lands in the new connection's shared file cache.
+        if (!blob || generation !== applyGenerationRef.current) return
         const dataURL = await blobToBase64(blob)
+        if (generation !== applyGenerationRef.current) return
         filesCacheRef.current[fileId] = {
           id: fileId as FileId,
           mimeType: blob.type as BinaryFileData['mimeType'],

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -154,55 +154,70 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
   // Debounced scene change → commit to Loro → pushLocalUpdate via subscribeLocalUpdates.
   // Declared before the connect effect below so that effect can cancel a
   // pending flush on every (re)connect, not only on unmount.
+  //
+  // `doc`, `bk`, and `connGen` are captured at call time (inside `onChange`,
+  // below) rather than read from the mutable refs when the debounce fires.
+  // A backend switch mutates backendRef/docRef synchronously, so reading them
+  // at fire time can route a change queued against the old connection (both
+  // its file uploads and its Loro commit) to the new one. Capturing at call
+  // time — and dropping the whole flush if connectionGenerationRef has moved
+  // on by the time it fires — keeps a pending change scoped to the
+  // connection it was made against.
   const onSceneChange = useMemo(() => {
-    return debounce((elements: readonly ExcalidrawElement[], files: BinaryFiles) => {
-      const doc = docRef.current
-      if (!doc) return
+    return debounce(
+      (
+        elements: readonly ExcalidrawElement[],
+        files: BinaryFiles,
+        doc: LoroDoc,
+        bk: CanvasBackend,
+        connGen: number,
+      ) => {
+        if (connectionGenerationRef.current !== connGen) return
 
-      const newEntries = Object.entries(files).filter(
-        ([fileId, fd]) => fd && !uploadedFileIdsRef.current.has(fileId),
-      ) as [string, BinaryFileData][]
+        const newEntries = Object.entries(files).filter(
+          ([fileId, fd]) => fd && !uploadedFileIdsRef.current.has(fileId),
+        ) as [string, BinaryFileData][]
 
-      const bk = backendRef.current
+        if (newEntries.length > 0) {
+          void bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId))
+        }
 
-      if (bk && newEntries.length > 0) {
-        void bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId))
-      }
+        // Write elements into the Loro MovableList using field-by-field set operations,
+        // then commit so subscribeLocalUpdates fires and routes bytes to backend.pushLocalUpdate.
+        const list = doc.getMovableList('elements')
+        const current = list.toJSON() as ExcalidrawElement[]
+        const currentIds = new Set(current.map((e: ExcalidrawElement) => e.id))
 
-      // Write elements into the Loro MovableList using field-by-field set operations,
-      // then commit so subscribeLocalUpdates fires and routes bytes to backend.pushLocalUpdate.
-      const list = doc.getMovableList('elements')
-      const current = list.toJSON() as ExcalidrawElement[]
-      const currentIds = new Set(current.map((e: ExcalidrawElement) => e.id))
-
-      // Append newly added elements.
-      for (const el of elements) {
-        if (!currentIds.has(el.id)) {
-          const map = list.insertContainer(list.length, new LoroMap())
-          for (const [k, v] of Object.entries(el)) {
-            if (v !== undefined) map.set(k, v as Value)
+        // Append newly added elements.
+        for (const el of elements) {
+          if (!currentIds.has(el.id)) {
+            const map = list.insertContainer(list.length, new LoroMap())
+            for (const [k, v] of Object.entries(el)) {
+              if (v !== undefined) map.set(k, v as Value)
+            }
           }
         }
-      }
 
-      // Update or tombstone existing elements.
-      const nextById = new Map(elements.map((e) => [e.id, e]))
-      for (let i = 0; i < list.length; i++) {
-        const item = list.get(i)
-        if (!(item instanceof LoroMap)) continue
-        const id = item.get('id') as string
-        const next = nextById.get(id)
-        if (!next) {
-          item.set('isDeleted', true)
-        } else {
-          for (const [k, v] of Object.entries(next)) {
-            if (v !== undefined) item.set(k, v as Value)
+        // Update or tombstone existing elements.
+        const nextById = new Map(elements.map((e) => [e.id, e]))
+        for (let i = 0; i < list.length; i++) {
+          const item = list.get(i)
+          if (!(item instanceof LoroMap)) continue
+          const id = item.get('id') as string
+          const next = nextById.get(id)
+          if (!next) {
+            item.set('isDeleted', true)
+          } else {
+            for (const [k, v] of Object.entries(next)) {
+              if (v !== undefined) item.set(k, v as Value)
+            }
           }
         }
-      }
 
-      doc.commit()
-    }, 300)
+        doc.commit()
+      },
+      300,
+    )
   }, [])
 
   // Backend connect/disconnect lifecycle. Depends on `backend` identity so a
@@ -391,7 +406,10 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
 
   const onChange = useCallback(
     (elements: readonly ExcalidrawElement[], _appState: AppState, files: BinaryFiles) => {
-      onSceneChange(elements, files)
+      const doc = docRef.current
+      const bk = backendRef.current
+      if (!doc || !bk) return
+      onSceneChange(elements, files, doc, bk, connectionGenerationRef.current)
     },
     [onSceneChange],
   )

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -1,18 +1,20 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
-import { LoroDoc, LoroMap, UndoManager } from 'loro-crdt'
-import type { Value } from 'loro-crdt'
-import { restoreElements, CaptureUpdateAction } from '@excalidraw/excalidraw'
-import { resolveParentedElements } from '@kamiazya/whiteboard-mcp/browser-shared'
-import { validateLoroRawElements } from '@kamiazya/whiteboard-mcp/browser-shared'
-import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { CaptureUpdateAction, restoreElements } from '@excalidraw/excalidraw'
+import type { ExcalidrawElement, FileId } from '@excalidraw/excalidraw/element/types'
 import type {
-  ExcalidrawImperativeAPI,
+  AppState,
   BinaryFileData,
   BinaryFiles,
   DataURL,
+  ExcalidrawImperativeAPI,
 } from '@excalidraw/excalidraw/types'
-import type { AppState } from '@excalidraw/excalidraw/types'
-import type { ExcalidrawElement, FileId } from '@excalidraw/excalidraw/element/types'
+import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
+import {
+  resolveParentedElements,
+  validateLoroRawElements,
+} from '@kamiazya/whiteboard-mcp/browser-shared'
+import type { Value } from 'loro-crdt'
+import { LoroDoc, LoroMap, UndoManager } from 'loro-crdt'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export type SyncStatus = 'idle' | 'connected' | 'error'
 
@@ -54,9 +56,18 @@ function blobToBase64(blob: Blob): Promise<string> {
 /**
  * useCanvasSync — browser-local port of useWhiteboardSync.
  *
- * Accepts a CanvasBackend (e.g. BrowserLocalBackend), drives a LoroDoc from
- * onSnapshot/onRemoteUpdate, hydrates Excalidraw via applyLoroToExcalidraw,
- * and writes scene changes back via a debounced onSceneChange → backend.pushLocalUpdate.
+ * Accepts a CanvasBackend (e.g. BrowserLocalBackend) or null when no backend
+ * is available yet (e.g. the initial snapshot is still loading). A null
+ * backend never connects: syncStatus stays 'idle' and onChange is a no-op.
+ * When the backend identity changes — including null-to-backend and
+ * backend-to-backend — the previous connection is fully torn down
+ * (disconnect + per-connection state reset) before the new one connects.
+ * This is the mechanism a future browser-local → daemon in-place migration
+ * rides on: swapping the CanvasBackend prop is the whole contract.
+ *
+ * Drives a LoroDoc from onSnapshot/onRemoteUpdate, hydrates Excalidraw via
+ * applyLoroToExcalidraw, and writes scene changes back via a debounced
+ * onSceneChange → backend.pushLocalUpdate.
  *
  * Daemon-specific callbacks (onVersionCreated, onRestoreStarted, onRestoreComplete,
  * onHeadChanged, onViewportRequest, onExportRequest) are wired as no-ops to satisfy
@@ -64,24 +75,33 @@ function blobToBase64(blob: Blob): Promise<string> {
  *
  * applyGenerationRef is never reset to 0 — only ever incremented — to avoid
  * stale-async collisions when the hook is reused across canvas remounts.
+ *
+ * connectionGenerationRef + the per-effect `disposed` flag guard every
+ * callback bound to a specific connection: once a connection is torn down
+ * (disconnected, or superseded by a backend switch), its callbacks become
+ * inert instead of routing pushes/errors to whatever backend is live now.
  */
-export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
+export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResult {
   const excalidrawAPIRef = useRef<ExcalidrawImperativeAPI | null>(null)
   const docRef = useRef<LoroDoc | null>(null)
   const undoManagerRef = useRef<UndoManager | null>(null)
   const filesCacheRef = useRef<Record<string, BinaryFileData>>({})
   const uploadedFileIdsRef = useRef<Set<string>>(new Set())
-  const backendRef = useRef<CanvasBackend>(backend)
+  const backendRef = useRef<CanvasBackend | null>(backend)
   backendRef.current = backend
 
   // Monotonic — never reset to 0 to prevent stale async work from a prior mount
   // landing in the current doc after a fast remount.
   const applyGenerationRef = useRef(0)
 
+  // Monotonic — bumped on every (re)connect (including a switch to null) so
+  // a connection's own callbacks can detect they have been superseded.
+  const connectionGenerationRef = useRef(0)
+
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
   const [apiReady, setApiReady] = useState(false)
 
-  async function applyLoroToExcalidraw(doc: LoroDoc) {
+  async function applyLoroToExcalidraw(doc: LoroDoc, bk: CanvasBackend) {
     const generation = ++applyGenerationRef.current
 
     const movable = doc.getMovableList('elements').toJSON()
@@ -99,7 +119,6 @@ export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
       )
       .map((el) => (el as { fileId: string }).fileId)
 
-    const bk = backendRef.current
     await Promise.allSettled(
       missingIds.map(async (fileId) => {
         const blob = await bk.getFile(fileId)
@@ -127,42 +146,125 @@ export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
     })
   }
 
-  // Backend connect/disconnect lifecycle.
+  // Debounced scene change → commit to Loro → pushLocalUpdate via subscribeLocalUpdates.
+  // Declared before the connect effect below so that effect can cancel a
+  // pending flush on every (re)connect, not only on unmount.
+  const onSceneChange = useMemo(() => {
+    return debounce((elements: readonly ExcalidrawElement[], files: BinaryFiles) => {
+      const doc = docRef.current
+      if (!doc) return
+
+      const newEntries = Object.entries(files).filter(
+        ([fileId, fd]) => fd && !uploadedFileIdsRef.current.has(fileId),
+      ) as [string, BinaryFileData][]
+
+      const bk = backendRef.current
+
+      if (bk && newEntries.length > 0) {
+        void bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId))
+      }
+
+      // Write elements into the Loro MovableList using field-by-field set operations,
+      // then commit so subscribeLocalUpdates fires and routes bytes to backend.pushLocalUpdate.
+      const list = doc.getMovableList('elements')
+      const current = list.toJSON() as ExcalidrawElement[]
+      const currentIds = new Set(current.map((e: ExcalidrawElement) => e.id))
+
+      // Append newly added elements.
+      for (const el of elements) {
+        if (!currentIds.has(el.id)) {
+          const map = list.insertContainer(list.length, new LoroMap())
+          for (const [k, v] of Object.entries(el)) {
+            if (v !== undefined) map.set(k, v as Value)
+          }
+        }
+      }
+
+      // Update or tombstone existing elements.
+      const nextById = new Map(elements.map((e) => [e.id, e]))
+      for (let i = 0; i < list.length; i++) {
+        const item = list.get(i)
+        if (!(item instanceof LoroMap)) continue
+        const id = item.get('id') as string
+        const next = nextById.get(id)
+        if (!next) {
+          item.set('isDeleted', true)
+        } else {
+          for (const [k, v] of Object.entries(next)) {
+            if (v !== undefined) item.set(k, v as Value)
+          }
+        }
+      }
+
+      doc.commit()
+    }, 300)
+  }, [])
+
+  // Backend connect/disconnect lifecycle. Depends on `backend` identity so a
+  // prop swap (including to/from null) tears down the previous connection —
+  // via this effect's own cleanup running before the next run's body — and
+  // establishes a fresh one instead of connecting once to whatever backend
+  // was first passed in.
   useEffect(() => {
+    let disposed = false
+    const myGeneration = ++connectionGenerationRef.current
+
     docRef.current = null
     undoManagerRef.current = null
     filesCacheRef.current = {}
     uploadedFileIdsRef.current = new Set()
     applyGenerationRef.current += 1
+    onSceneChange.cancel()
 
-    const bk = backendRef.current
+    if (backend === null) {
+      setSyncStatus('idle')
+      return
+    }
+
+    const bk = backend
+
+    function isStale(): boolean {
+      return disposed || connectionGenerationRef.current !== myGeneration
+    }
 
     bk.connect({
       onConnected() {
+        if (isStale()) return
         setSyncStatus('connected')
       },
 
       onSnapshot(bytes) {
-        const doc = LoroDoc.fromSnapshot(bytes)
+        if (isStale()) return
+        // Persisted "snapshot" bytes are whatever pushLocalUpdate's first
+        // subscribeLocalUpdates payload happened to be — which is Loro
+        // update-format, not doc.export({ mode: 'snapshot' }) format.
+        // LoroDoc.fromSnapshot() only accepts true snapshot bytes and throws
+        // on update bytes; doc.import() accepts either format, so a fresh
+        // doc + import() is the only reconstruction that works for both.
+        const doc = new LoroDoc()
+        doc.import(bytes)
         docRef.current = doc
         undoManagerRef.current = new UndoManager(doc, { mergeInterval: 500 })
 
         doc.subscribeLocalUpdates((update) => {
-          void Promise.resolve(backendRef.current.pushLocalUpdate(update)).catch(() => {
+          if (isStale()) return
+          void Promise.resolve(bk.pushLocalUpdate(update)).catch(() => {
+            if (isStale()) return
             setSyncStatus('error')
           })
         })
 
         doc.subscribe((e) => {
-          if (e.by === 'import') {
-            void applyLoroToExcalidraw(doc)
+          if (e.by === 'import' && !isStale()) {
+            void applyLoroToExcalidraw(doc, bk)
           }
         })
 
-        void applyLoroToExcalidraw(doc)
+        void applyLoroToExcalidraw(doc, bk)
       },
 
       onRemoteUpdate(bytes) {
+        if (isStale()) return
         docRef.current?.import(bytes)
       },
 
@@ -175,19 +277,22 @@ export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
       onExportRequest: async () => {},
 
       onError: () => {
+        if (isStale()) return
         setSyncStatus('error')
       },
     })
 
     return () => {
+      disposed = true
       bk.disconnect()
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [backend]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Reapply the current document once the Excalidraw API becomes ready.
   useEffect(() => {
-    if (!apiReady || !docRef.current) return
-    void applyLoroToExcalidraw(docRef.current)
+    const bk = backendRef.current
+    if (!apiReady || !docRef.current || !bk) return
+    void applyLoroToExcalidraw(docRef.current, bk)
   }, [apiReady]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const setExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
@@ -198,20 +303,22 @@ export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
   const loroUndo = useCallback(() => {
     const um = undoManagerRef.current
     const doc = docRef.current
-    if (!um || !doc) return false
+    const bk = backendRef.current
+    if (!um || !doc || !bk) return false
     if (!um.canUndo()) return false
     um.undo()
-    void applyLoroToExcalidraw(doc)
+    void applyLoroToExcalidraw(doc, bk)
     return true
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const loroRedo = useCallback(() => {
     const um = undoManagerRef.current
     const doc = docRef.current
-    if (!um || !doc) return false
+    const bk = backendRef.current
+    if (!um || !doc || !bk) return false
     if (!um.canRedo()) return false
     um.redo()
-    void applyLoroToExcalidraw(doc)
+    void applyLoroToExcalidraw(doc, bk)
     return true
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -269,58 +376,6 @@ export function useCanvasSync(backend: CanvasBackend): UseCanvasSyncResult {
       } as EventListenerOptions)
     }
   }, [loroUndo, loroRedo])
-
-  // Debounced scene change → commit to Loro → pushLocalUpdate via subscribeLocalUpdates.
-  const onSceneChange = useMemo(() => {
-    return debounce((elements: readonly ExcalidrawElement[], files: BinaryFiles) => {
-      const doc = docRef.current
-      if (!doc) return
-
-      const newEntries = Object.entries(files).filter(
-        ([fileId, fd]) => fd && !uploadedFileIdsRef.current.has(fileId),
-      ) as [string, BinaryFileData][]
-
-      const bk = backendRef.current
-
-      if (newEntries.length > 0) {
-        void bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId))
-      }
-
-      // Write elements into the Loro MovableList using field-by-field set operations,
-      // then commit so subscribeLocalUpdates fires and routes bytes to backend.pushLocalUpdate.
-      const list = doc.getMovableList('elements')
-      const current = list.toJSON() as ExcalidrawElement[]
-      const currentIds = new Set(current.map((e: ExcalidrawElement) => e.id))
-
-      // Append newly added elements.
-      for (const el of elements) {
-        if (!currentIds.has(el.id)) {
-          const map = list.insertContainer(list.length, new LoroMap())
-          for (const [k, v] of Object.entries(el)) {
-            if (v !== undefined) map.set(k, v as Value)
-          }
-        }
-      }
-
-      // Update or tombstone existing elements.
-      const nextById = new Map(elements.map((e) => [e.id, e]))
-      for (let i = 0; i < list.length; i++) {
-        const item = list.get(i)
-        if (!(item instanceof LoroMap)) continue
-        const id = item.get('id') as string
-        const next = nextById.get(id)
-        if (!next) {
-          item.set('isDeleted', true)
-        } else {
-          for (const [k, v] of Object.entries(next)) {
-            if (v !== undefined) item.set(k, v as Value)
-          }
-        }
-      }
-
-      doc.commit()
-    }, 300)
-  }, [])
 
   // Cancel debounce on unmount to prevent post-unmount Loro writes.
   useEffect(() => {

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -179,7 +179,14 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
         ) as [string, BinaryFileData][]
 
         if (newEntries.length > 0) {
-          void bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId))
+          // A file-upload failure is non-fatal (elements persist via the Loro
+          // commit below on a separate path); catch so it never surfaces as an
+          // unhandled promise rejection.
+          bk.putFile(newEntries, (fileId) => uploadedFileIdsRef.current.add(fileId)).catch(
+            (err: unknown) => {
+              console.error('putFile failed', err)
+            },
+          )
         }
 
         // Write elements into the Loro MovableList using field-by-field set operations,

--- a/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Reload-loses-elements regression (real IndexedDB).
+ *
+ * Root cause: useCanvasSync connected once to whichever backend it was first
+ * given, then never reconnected — so BrowserLocalCanvasPage's placeholder
+ * backend (used while the initial snapshot loads) stayed connected forever
+ * and the real per-canvas backend's writes never happened. Elements drawn
+ * before the initial load settled were silently dropped, and a stray
+ * '__placeholder__' row accumulated in IndexedDB.
+ *
+ * Excalidraw is mocked here (unlike BrowserLocalCanvasPage.browser.test.tsx)
+ * so the test can drive a scene change deterministically via onChange
+ * instead of simulating pointer drawing; the backend/IndexedDB layer under
+ * test remains real.
+ */
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import '../index.css'
+
+type ExcalidrawOnChange = (elements: unknown[], appState: unknown, files: unknown) => void
+
+let latestOnChange: ExcalidrawOnChange | null = null
+let latestUpdateSceneCalls: Array<{ elements: unknown[] }> = []
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: (props: {
+    excalidrawAPI?: (api: unknown) => void
+    onChange?: ExcalidrawOnChange
+  }) => {
+    latestOnChange = props.onChange ?? null
+    props.excalidrawAPI?.({
+      updateScene: (args: { elements: unknown[] }) => {
+        latestUpdateSceneCalls.push(args)
+      },
+      addFiles: () => {},
+      getSceneElements: () => [],
+      getAppState: () => ({}),
+    })
+    return null
+  },
+  restoreElements: (els: unknown[]) => els,
+  CaptureUpdateAction: { NEVER: 'never' },
+}))
+
+const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+/** Raw keys of the 'loroCanvases' object store, real IndexedDB. */
+async function loroCanvasesKeys(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard')
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('loroCanvases', 'readonly')
+      const keysReq = tx.objectStore('loroCanvases').getAllKeys()
+      keysReq.onsuccess = () => {
+        db.close()
+        resolve(keysReq.result as string[])
+      }
+      keysReq.onerror = () => {
+        db.close()
+        reject(keysReq.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('BrowserLocalCanvasPage reload persistence (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+    latestOnChange = null
+    latestUpdateSceneCalls = []
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('persists a drawn element across remount and never writes a __placeholder__ row', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const rectangle = {
+      id: 'reload-regression-rect',
+      type: 'rectangle',
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+    }
+
+    act(() => {
+      latestOnChange!([rectangle], {}, {})
+    })
+
+    // Wait for the onChange debounce (300ms) to flush the write into the real
+    // canvas row in loroCanvases (not the '__placeholder__' row from the bug).
+    await waitFor(
+      async () => {
+        const keys = await loroCanvasesKeys()
+        expect(keys.length).toBeGreaterThan(0)
+      },
+      { timeout: 5000 },
+    )
+
+    const keysAfterDraw = await loroCanvasesKeys()
+    expect(keysAfterDraw).not.toContain('__placeholder__')
+
+    cleanup()
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+
+    // The restored scene must include the element drawn before remount.
+    await waitFor(
+      () => {
+        const restoredIds = latestUpdateSceneCalls.flatMap((call) =>
+          (call.elements as Array<{ id: string }>).map((el) => el.id),
+        )
+        expect(restoredIds).toContain('reload-regression-rect')
+      },
+      { timeout: 5000 },
+    )
+
+    const keysAfterRemount = await loroCanvasesKeys()
+    expect(keysAfterRemount).not.toContain('__placeholder__')
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
@@ -102,18 +102,20 @@ describe('BrowserLocalCanvasPage reload persistence (browser — real IndexedDB)
       height: 40,
     }
 
-    act(() => {
-      latestOnChange!([rectangle], {}, {})
-    })
-
-    // Wait for the onChange debounce (300ms) to flush the write into the real
-    // canvas row in loroCanvases (not the '__placeholder__' row from the bug).
+    // The backend connects asynchronously after the editing state mounts, and
+    // there is no synchronous "connected" signal to await. Re-fire the same
+    // (idempotent) element on each poll so a change dispatched before the
+    // connection settles is retried until it lands, then wait for the debounce
+    // (300ms) to flush the write into the real canvas row (not '__placeholder__').
     await waitFor(
       async () => {
+        act(() => {
+          latestOnChange!([rectangle], {}, {})
+        })
         const keys = await loroCanvasesKeys()
         expect(keys.length).toBeGreaterThan(0)
       },
-      { timeout: 5000 },
+      { timeout: 10000, interval: 600 },
     )
 
     const keysAfterDraw = await loroCanvasesKeys()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,11 +1,11 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
-import { derivePageState } from './browser-local-page-state.js'
-import { useBrowserLocalCanvasController } from './use-browser-local-canvas-controller.js'
+import { useMemo } from 'react'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { useMemo } from 'react'
+import { derivePageState } from './browser-local-page-state.js'
+import { useBrowserLocalCanvasController } from './use-browser-local-canvas-controller.js'
 
 interface BrowserLocalCanvasPageProps {
   store: BrowserLocalStore
@@ -27,10 +27,10 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
     [canvasId],
   )
 
-  const { setExcalidrawAPI, onChange } = useCanvasSync(
-    // Pass a no-op backend when not yet loaded; the hook will reconnect when a real one arrives.
-    backend ?? new BrowserLocalBackend('__placeholder__'),
-  )
+  // useCanvasSync tolerates a null backend (idle, no writes) and reconnects
+  // whenever the backend identity changes, so the not-yet-loaded state is
+  // represented as null instead of a throwaway placeholder canvas id.
+  const { setExcalidrawAPI, onChange } = useCanvasSync(backend)
 
   if (pageState.kind === 'load-degraded') {
     return (


### PR DESCRIPTION
Wave 0 top-priority slice — fixes the HIGH reload-loses-elements bug confirmed in production (kamiazya-whiteboard.pages.dev): draw a rectangle, reload, canvas is empty.

## Root cause

`useCanvasSync`'s connect effect had an empty dependency array, so it bound once to the placeholder backend (`BrowserLocalBackend('__placeholder__')` passed while the snapshot was still loading) and never reconnected to the real backend. Every edit was written to the placeholder Loro doc; the real canvas row stayed `elements: []`, so reload restored nothing.

## Fix (human decision: reconnect approach — reusable for future in-place browser-local→daemon migration)

- `useCanvasSync` now accepts `CanvasBackend | null`, and its connect/disconnect effect depends on `[backend]`: null → idle (no writes); backend identity change → disconnect old + full per-connection state reset (doc/undo/files caches, applyGeneration bump, pending debounce cancelled) before connecting the new one.
- Writes (local-update push + putFile) are bound to the per-connection backend and gated by a connection-generation guard, so late callbacks from a swapped-away backend are dropped (no cross-connection leak).
- Switch-time connect failure is scoped to the current generation: `syncStatus='error'`, the previous backend is not resurrected, no rejection escapes the effect.
- `BrowserLocalCanvasPage` passes the nullable memoized backend directly — the `__placeholder__` backend is gone.

## Tests

TDD red-first. jsdom (useCanvasSync): null→no-connect, null→connect, A→B swap (writes reach B only), A→B swap where B.connect fails. web-browser (real IndexedDB): draw → remount → element persists AND no `__placeholder__` row. Full apps/web jsdom 192 + browser 39 + typecheck green. Mutation-checked: reverting the deps fix / reintroducing the placeholder fails the reload test.

## Visual repro (built dist served with production headers)

Before reload (element drawn) → after reload (element restored):

![before-reload.png](https://github.com/user-attachments/assets/99195445-6707-4381-a5f0-7924cddf4043)
![after-reload.png](https://github.com/user-attachments/assets/34127850-7d76-425b-ba1c-12fdfb731dea)