### PR TITLE
fix(release): honour SMOKE_RPC_TIMEOUT in the tarball smoke path too

### DIFF
--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -56,6 +56,13 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
     }
   })
 
+  // The first tools/call spawns the packaged daemon, so its latency includes the
+  // full cold-start. CI runners exceed the 20s default; the env override lets the
+  // release publish jobs wait longer without slowing local runs.
+  const rpcTimeoutMs = /^\d+$/.test(process.env.WHITEBOARD_SMOKE_RPC_TIMEOUT_MS ?? '')
+    ? Number(process.env.WHITEBOARD_SMOKE_RPC_TIMEOUT_MS)
+    : 20_000
+
   let nextId = 1
 
   function rpc(method: string, params: unknown): Promise<unknown> {
@@ -78,7 +85,7 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
           pending.delete(id)
           reject(new Error(`RPC ${method} (#${id}) timed out`))
         }
-      }, 20_000)
+      }, rpcTimeoutMs)
     })
   }
 
@@ -105,9 +112,7 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
       await promise
     } catch (err) {
       if (err instanceof Error && pattern.test(err.message)) return
-      throw new Error(
-        `${label}: wrong error: ${err instanceof Error ? err.message : String(err)}`,
-      )
+      throw new Error(`${label}: wrong error: ${err instanceof Error ? err.message : String(err)}`)
     }
     throw new Error(`${label}: expected rejection but resolved`)
   }
@@ -176,7 +181,9 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
       (n, ws) => n + (Array.isArray(ws.canvases) ? ws.canvases.length : 0),
       0,
     )
-    console.log(`[e2e] canvas_list → ${(listed.workspaces as unknown[]).length} workspaces, ${totalCanvases} canvases`)
+    console.log(
+      `[e2e] canvas_list → ${(listed.workspaces as unknown[]).length} workspaces, ${totalCanvases} canvases`,
+    )
 
     const palette = await callTool('palette_get', { workspaceId })
     if (typeof palette.palette !== 'object' || palette.palette === null) {
@@ -186,9 +193,13 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
 
     const libsInstalled = await callTool('library_list_installed', {})
     if (!Array.isArray(libsInstalled.installedUrls)) {
-      throw new Error(`library_list_installed returned unexpected shape: ${JSON.stringify(libsInstalled)}`)
+      throw new Error(
+        `library_list_installed returned unexpected shape: ${JSON.stringify(libsInstalled)}`,
+      )
     }
-    console.log(`[e2e] library_list_installed → ${(libsInstalled.installedUrls as unknown[]).length} urls`)
+    console.log(
+      `[e2e] library_list_installed → ${(libsInstalled.installedUrls as unknown[]).length} urls`,
+    )
 
     // library_uninstall with a never-installed URL. removeInstalledLibrary is an idempotent SQL DELETE
     // that returns the current installed list, so this succeeds offline without any HTTPS fetch.
@@ -196,7 +207,9 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
       libraryUrl: 'https://smoke-test.example.com/never-installed.excalidrawlib',
     })
     if (!Array.isArray(libUninstalled.installedUrls)) {
-      throw new Error(`library_uninstall returned unexpected shape: ${JSON.stringify(libUninstalled)}`)
+      throw new Error(
+        `library_uninstall returned unexpected shape: ${JSON.stringify(libUninstalled)}`,
+      )
     }
     console.log('[e2e] library_uninstall (idempotent) → OK')
 
@@ -331,7 +344,9 @@ export async function runE2eCheckpointSmoke({ entry, root }: RunOptions): Promis
     // export_png now falls back to headless rendering when no browser is connected.
     // Verify it succeeds (headless path is active after the #45 merge).
     const pngResult = await callTool('export_png', { canvasId: created.id })
-    console.log(`[e2e] export_png → headless render OK (pngDataUrl=${typeof (pngResult as Record<string, unknown>).pngDataUrl !== 'undefined' ? 'present' : 'not present'})`)
+    console.log(
+      `[e2e] export_png → headless render OK (pngDataUrl=${typeof (pngResult as Record<string, unknown>).pngDataUrl !== 'undefined' ? 'present' : 'not present'})`,
+    )
 
     const exported = await callTool('canvas_export_json', { canvasId: created.id })
     if (!exported.filePath || !(exported.filePath as string).endsWith('.excalidraw')) {

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -451,15 +451,23 @@ describe('release.yml publish job step ordering hazards', () => {
     }
   })
 
-  it('e2e smoke honours WHITEBOARD_SMOKE_RPC_TIMEOUT_MS (first tools/call includes daemon spawn)', () => {
-    // The packaged tarball smoke's first tools/call spawns the daemon; under CI
-    // cold-start the hardcoded RPC deadline expired ("RPC tools/call timed out")
-    // even after the daemon-startup timeout itself was extended.
-    const smoke = readFile('packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs')
-    expect(
-      smoke,
-      'mcp-e2e-smoke.mjs must read WHITEBOARD_SMOKE_RPC_TIMEOUT_MS instead of hardcoding the RPC deadline',
-    ).toContain('WHITEBOARD_SMOKE_RPC_TIMEOUT_MS')
+  it('every smoke RPC path honours WHITEBOARD_SMOKE_RPC_TIMEOUT_MS (first tools/call includes daemon spawn)', () => {
+    // Each smoke that RPCs a freshly-spawned daemon has its own rpc() with a
+    // deadline; under CI cold-start a hardcoded 20s expired ("RPC tools/call
+    // timed out") even after the daemon-startup timeout was extended. Both the
+    // standalone smoke:e2e AND the packaged tarball smoke (which runs through
+    // mcp-e2e-checkpoint.smoke-impl.ts, NOT mcp-e2e-smoke.mjs) must read the
+    // override — the tarball path being missed is exactly what broke v0.0.10/11.
+    const rpcSmokeFiles = [
+      'packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs',
+      'packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts',
+    ]
+    for (const rel of rpcSmokeFiles) {
+      expect(
+        readFile(rel),
+        `${rel} must read WHITEBOARD_SMOKE_RPC_TIMEOUT_MS instead of hardcoding the RPC deadline`,
+      ).toContain('WHITEBOARD_SMOKE_RPC_TIMEOUT_MS')
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

The v0.0.10 and v0.0.11 publish jobs (publish-mcp / docker-publish-sign) kept failing at the tarball smoke with `RPC tools/call (#3) timed out`, even though PR #110 added `WHITEBOARD_SMOKE_RPC_TIMEOUT_MS=90000` to those jobs.

Root cause: #110 patched the wrong file. `mcp-e2e-smoke.mjs` (the standalone `smoke:e2e`) got the env override, but the **packaged tarball smoke** runs through a *separate* `rpc()` in `src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts` (via `runPackedTarballSmoke` → `runE2eCheckpointSmoke`), which still hardcoded `20_000`. Its first `tools/call` spawns the packaged daemon, so on a cold CI runner the 20s deadline expired before the daemon was ready.

- The checkpoint smoke `rpc()` now reads `WHITEBOARD_SMOKE_RPC_TIMEOUT_MS` (digits-only, fallback 20s) — local runs unchanged; the 90s override in release.yml now actually reaches this path.
- Extended the `sbom-policy` drift guard to assert **both** RPC smoke files honour the override, so a third path can't silently regress this again.

## Verification

- [x] typecheck clean
- [x] sbom-policy drift guard passes; **mutation-checked** — reverting the impl makes the guard go RED (proves it would have caught the tarball-path miss)
- [ ] After merge + next release: publish-mcp / docker-publish-sign complete past the tarball smoke → npm + GHCR publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smoke RPC timeout is now configurable through an environment variable, with validation and a safe default if unset or invalid.
* **Bug Fixes**
  * Pending RPC requests now use the configured timeout consistently instead of a fixed value.
* **Tests**
  * Updated release checks to verify the timeout setting works in both smoke execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->