### PR TITLE
feat(web): editable canvas title with browser-local persistence

### DIFF
--- a/apps/web/src/components/canvas-title/CanvasTitle.test.tsx
+++ b/apps/web/src/components/canvas-title/CanvasTitle.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { CanvasTitle } from './CanvasTitle.js'
+
+describe('CanvasTitle', () => {
+  afterEach(() => cleanup())
+
+  it('renders the current name in a labeled textbox', () => {
+    render(<CanvasTitle value="My canvas" onRename={vi.fn()} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement
+    expect(input.value).toBe('My canvas')
+  })
+
+  it('typing then pressing Enter commits the rename with the typed value', () => {
+    const onRename = vi.fn()
+    render(<CanvasTitle value="My canvas" onRename={onRename} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i })
+    fireEvent.change(input, { target: { value: 'Renamed via Enter' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onRename).toHaveBeenCalledWith('Renamed via Enter')
+  })
+
+  it('typing then blurring commits the rename with the typed value', () => {
+    const onRename = vi.fn()
+    render(<CanvasTitle value="My canvas" onRename={onRename} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i })
+    fireEvent.change(input, { target: { value: 'Renamed via blur' } })
+    fireEvent.blur(input)
+    expect(onRename).toHaveBeenCalledWith('Renamed via blur')
+  })
+
+  it('pressing Escape reverts to the last committed name and does not call onRename', () => {
+    const onRename = vi.fn()
+    render(<CanvasTitle value="My canvas" onRename={onRename} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Should be discarded' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onRename).not.toHaveBeenCalled()
+    expect(input.value).toBe('My canvas')
+  })
+
+  it('clearing the input and blurring falls back to "untitled" and still calls onRename', () => {
+    const onRename = vi.fn()
+    render(<CanvasTitle value="My canvas" onRename={onRename} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i })
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+    expect(onRename).toHaveBeenCalledWith('untitled')
+  })
+
+  it('keydown and keyup do not bubble to document listeners while editing', () => {
+    const documentKeyDown = vi.fn()
+    const documentKeyUp = vi.fn()
+    document.addEventListener('keydown', documentKeyDown)
+    document.addEventListener('keyup', documentKeyUp)
+    try {
+      render(<CanvasTitle value="My canvas" onRename={vi.fn()} />)
+      const input = screen.getByRole('textbox', { name: /canvas title/i })
+      fireEvent.keyDown(input, { key: 'Delete' })
+      fireEvent.keyUp(input, { key: 'Delete' })
+      expect(documentKeyDown).not.toHaveBeenCalled()
+      expect(documentKeyUp).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', documentKeyDown)
+      document.removeEventListener('keyup', documentKeyUp)
+    }
+  })
+})

--- a/apps/web/src/components/canvas-title/CanvasTitle.test.tsx
+++ b/apps/web/src/components/canvas-title/CanvasTitle.test.tsx
@@ -11,6 +11,25 @@ describe('CanvasTitle', () => {
     expect(input.value).toBe('My canvas')
   })
 
+  it('shows the normalized "untitled" in the field after committing an empty title', () => {
+    render(<CanvasTitle value="My canvas" onRename={vi.fn()} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+    // The input must not stay blank while the canvas is actually named 'untitled'.
+    expect(input.value).toBe('untitled')
+  })
+
+  it('does not clobber in-progress typing when the value prop changes (async load)', () => {
+    // The snapshot loads asynchronously and can push a new `value` while the user
+    // is mid-edit; the draft must win until the user commits.
+    const { rerender } = render(<CanvasTitle value="" onRename={vi.fn()} />)
+    const input = screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Typing in progress' } })
+    rerender(<CanvasTitle value="untitled" onRename={vi.fn()} />)
+    expect(input.value).toBe('Typing in progress')
+  })
+
   it('typing then pressing Enter commits the rename with the typed value', () => {
     const onRename = vi.fn()
     render(<CanvasTitle value="My canvas" onRename={onRename} />)

--- a/apps/web/src/components/canvas-title/CanvasTitle.tsx
+++ b/apps/web/src/components/canvas-title/CanvasTitle.tsx
@@ -1,0 +1,61 @@
+import { useRef, useState, type KeyboardEvent } from 'react'
+
+interface CanvasTitleProps {
+  value: string
+  onRename: (name: string) => void
+}
+
+// Excalidraw registers document-level keydown/keyup handlers for its shortcuts
+// (delete selection, clear, etc). Without stopPropagation here, typing Enter/
+// Escape/Backspace/Delete into this field would also trigger those canvas
+// shortcuts.
+function stopPropagation(event: KeyboardEvent<HTMLInputElement>): void {
+  event.stopPropagation()
+}
+
+export function CanvasTitle({ value, onRename }: CanvasTitleProps) {
+  // Initialized once from the incoming value. CanvasTitle is remounted
+  // whenever the underlying canvas identity changes (load-degraded /
+  // cleanup-completed / startFresh all unmount this component), so there is
+  // no live external-rename case that requires re-syncing draft from a
+  // changed `value` prop while mounted — Escape below covers the only
+  // in-place revert this component needs.
+  const [draft, setDraft] = useState(value)
+  // Escape reverts without committing; the ensuing blur() call must not also
+  // fire the blur-commit handler, so suppress exactly the next blur.
+  const suppressNextBlurRef = useRef(false)
+
+  function commit() {
+    if (suppressNextBlurRef.current) {
+      suppressNextBlurRef.current = false
+      return
+    }
+    const normalized = draft.trim() || 'untitled'
+    onRename(normalized)
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    stopPropagation(event)
+    if (event.key === 'Enter') {
+      commit()
+      event.currentTarget.blur()
+    } else if (event.key === 'Escape') {
+      suppressNextBlurRef.current = true
+      setDraft(value)
+      event.currentTarget.blur()
+    }
+  }
+
+  return (
+    <input
+      type="text"
+      aria-label="Canvas title"
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onKeyDown={handleKeyDown}
+      onKeyUp={stopPropagation}
+      onBlur={commit}
+      className="min-w-0 flex-1 truncate rounded-md border border-transparent bg-transparent px-1.5 py-1 text-sm font-semibold outline-none transition-colors hover:border-border focus:border-border focus:bg-background"
+    />
+  )
+}

--- a/apps/web/src/components/canvas-title/CanvasTitle.tsx
+++ b/apps/web/src/components/canvas-title/CanvasTitle.tsx
@@ -14,12 +14,10 @@ function stopPropagation(event: KeyboardEvent<HTMLInputElement>): void {
 }
 
 export function CanvasTitle({ value, onRename }: CanvasTitleProps) {
-  // Initialized once from the incoming value. CanvasTitle is remounted
-  // whenever the underlying canvas identity changes (load-degraded /
-  // cleanup-completed / startFresh all unmount this component), so there is
-  // no live external-rename case that requires re-syncing draft from a
-  // changed `value` prop while mounted — Escape below covers the only
-  // in-place revert this component needs.
+  // Initialized once from the incoming value; CanvasTitle is remounted whenever
+  // the canvas identity changes, so no live external-rename re-sync is needed.
+  // (A useEffect syncing draft←value would clobber the user's in-progress typing
+  // when the snapshot loads asynchronously and pushes a new `value`.)
   const [draft, setDraft] = useState(value)
   // Escape reverts without committing; the ensuing blur() call must not also
   // fire the blur-commit handler, so suppress exactly the next blur.
@@ -31,6 +29,10 @@ export function CanvasTitle({ value, onRename }: CanvasTitleProps) {
       return
     }
     const normalized = draft.trim() || 'untitled'
+    // Reflect the normalization back into the field so an empty/whitespace commit
+    // shows 'untitled' instead of leaving the input blank while the canvas is
+    // actually named 'untitled'.
+    setDraft(normalized)
     onRename(normalized)
   }
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+// Real app styles so layout assertions measure the shipped geometry.
+import '../index.css'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('reload: edited title survives an unmount + fresh-store remount', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Reloaded title' } })
+    titleInput.blur()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Reloaded title'),
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+
+    cleanup()
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Reloaded title'),
+      { timeout: 5000 },
+    )
+  })
+
+  it('layout: excalidraw container still fills the viewport after editing the title', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Layout check' } })
+    titleInput.blur()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Layout check'),
+      { timeout: 5000 },
+    )
+    const container = screen.getByTestId('excalidraw-container')
+    expect(container.clientHeight).toBeGreaterThan(300)
+    expect(container.clientWidth).toBeGreaterThan(600)
+  })
+
+  it("keyboard isolation: Enter/Escape/Backspace/Delete typed in the title do not reach Excalidraw's document-level shortcut handlers", async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const documentKeyDown = vi.fn()
+    document.addEventListener('keydown', documentKeyDown)
+    try {
+      const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+      titleInput.focus()
+      fireEvent.change(titleInput, { target: { value: 'Typing in title' } })
+      for (const key of ['Enter', 'Escape', 'Backspace', 'Delete']) {
+        fireEvent.keyDown(titleInput, { key })
+      }
+      expect(documentKeyDown).not.toHaveBeenCalled()
+      // The canvas editor is still mounted and unaffected.
+      expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument()
+    } finally {
+      document.removeEventListener('keydown', documentKeyDown)
+    }
+  })
+
+  it('network-negative: editing the title triggers no fetch to /api/ or daemon endpoints', async () => {
+    const calls: string[] = []
+    const original = window.fetch.bind(window)
+    const spy = vi.spyOn(window, 'fetch').mockImplementation((...args) => {
+      const url =
+        typeof args[0] === 'string'
+          ? args[0]
+          : args[0] instanceof URL
+            ? args[0].href
+            : (args[0] as Request).url
+      calls.push(url)
+      return original(...args)
+    })
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Network check' } })
+    titleInput.blur()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Network check'),
+      { timeout: 5000 },
+    )
+    const daemonCalls = calls.filter(
+      (url) => url.includes('/api/') || url.includes('localhost:3') || url.includes('127.0.0.1'),
+    )
+    expect(daemonCalls).toHaveLength(0)
+    spy.mockRestore()
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, act, cleanup } from '@testing-library/react'
+import { render, screen, act, cleanup, fireEvent } from '@testing-library/react'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
@@ -235,6 +235,42 @@ describe('BrowserLocalCanvasPage', () => {
     })
     expect(fetchSpy).not.toHaveBeenCalled()
     fetchSpy.mockRestore()
+  })
+
+  it('keeps a heading landmark and a distinct title textbox after adding the editable title', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.textContent).toBe('untitled')
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    expect(titleInput).toBeTruthy()
+    // Distinct from the Delete button's accessible name.
+    expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+  })
+
+  it('renaming via the title control updates the heading and flushes a save', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
+    await act(async () => {
+      fireEvent.blur(titleInput)
+      await vi.runAllTimersAsync()
+    })
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Renamed canvas')
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('Renamed canvas')
+    }
   })
 
   it('does not render an "Add rectangle" button — scene writes flow through Excalidraw onChange', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,6 +1,7 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import { useMemo } from 'react'
+import { CanvasTitle } from '../components/canvas-title/CanvasTitle.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
@@ -12,8 +13,15 @@ interface BrowserLocalCanvasPageProps {
 }
 
 export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
-  const { snapshot, persistence, cleanupCompleted, cleanupError, triggerCleanup, startFresh } =
-    useBrowserLocalCanvasController(store)
+  const {
+    snapshot,
+    persistence,
+    cleanupCompleted,
+    cleanupError,
+    triggerCleanup,
+    startFresh,
+    renameCanvas,
+  } = useBrowserLocalCanvasController(store)
 
   const pageState = derivePageState({ snapshot, persistence, cleanupCompleted })
 
@@ -98,7 +106,10 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
     // has no sized ancestor and the editor area collapses to 0px.
     <main className="flex h-dvh w-full flex-col">
       <header className="flex shrink-0 items-center gap-3 border-b bg-background px-4 py-2">
-        <h1 className="truncate text-sm font-semibold">{pageState.snapshot.name}</h1>
+        {/* Visually-hidden heading landmark: the editable control below is the
+            visible title, but the page keeps a real <h1> for accessibility trees. */}
+        <h1 className="sr-only">{pageState.snapshot.name}</h1>
+        <CanvasTitle value={pageState.snapshot.name} onRename={renameCanvas} />
         <span className="text-xs text-muted-foreground">{persistenceLabel}</span>
         {cleanupError && (
           <div role="alert" aria-live="assertive" className="text-xs text-destructive">

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -6,10 +6,28 @@ import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { derivePageState } from './browser-local-page-state.js'
-import { useBrowserLocalCanvasController } from './use-browser-local-canvas-controller.js'
+import {
+  type BrowserLocalPersistenceState,
+  useBrowserLocalCanvasController,
+} from './use-browser-local-canvas-controller.js'
 
 interface BrowserLocalCanvasPageProps {
   store: BrowserLocalStore
+}
+
+// Map the persistence state machine to user-facing copy. `degraded` carries its
+// own message; the other states are not shown as raw enum tokens.
+function persistenceLabel(status: BrowserLocalPersistenceState): string {
+  switch (status.kind) {
+    case 'saved':
+      return 'Saved'
+    case 'saving':
+      return 'Saving…'
+    case 'pending':
+      return 'Unsaved changes'
+    case 'degraded':
+      return status.message
+  }
 }
 
 export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
@@ -89,18 +107,6 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
     )
   }
 
-  // Map the persistence state machine to user-facing copy. `degraded` carries its own
-  // message; the other states are not shown as raw enum tokens.
-  const status = pageState.persistence
-  const persistenceLabel =
-    status.kind === 'saved'
-      ? 'Saved'
-      : status.kind === 'saving'
-        ? 'Saving…'
-        : status.kind === 'pending'
-          ? 'Unsaved changes'
-          : status.message
-
   return (
     // h-dvh makes the page own its viewport height: without it the flex chain
     // has no sized ancestor and the editor area collapses to 0px.
@@ -110,7 +116,9 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
             visible title, but the page keeps a real <h1> for accessibility trees. */}
         <h1 className="sr-only">{pageState.snapshot.name}</h1>
         <CanvasTitle value={pageState.snapshot.name} onRename={renameCanvas} />
-        <span className="text-xs text-muted-foreground">{persistenceLabel}</span>
+        <span className="text-xs text-muted-foreground">
+          {persistenceLabel(pageState.persistence)}
+        </span>
         {cleanupError && (
           <div role="alert" aria-live="assertive" className="text-xs text-destructive">
             {cleanupError}

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -449,6 +449,44 @@ describe('useBrowserLocalCanvasController', () => {
     }
   })
 
+  it('renameCanvas before the initial load resolves is a safe no-op', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    // No awaited act() yet — the async load hasn't populated snapshotRef/pendingSnapshotRef.
+    expect(result.current.snapshot).toBeNull()
+    act(() => {
+      result.current.renameCanvas('Too early')
+    })
+    expect(result.current.snapshot).toBeNull()
+    expect(result.current.persistence.kind).toBe('saved')
+    // Let the load finish and confirm the store was never touched by the no-op call.
+    await act(async () => {})
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe(snap.name)
+    }
+  })
+
+  it('renameCanvas after cleanup cleared the snapshot is a safe no-op', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    await act(async () => {
+      await result.current.triggerCleanup()
+    })
+    expect(result.current.snapshot).toBeNull()
+    act(() => {
+      result.current.renameCanvas('After cleanup')
+    })
+    expect(result.current.snapshot).toBeNull()
+    expect(await store.getDefaultCanvasId()).toBeNull()
+  })
+
   it('renameCanvas refreshes updatedAt and transitions persistence to saved', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -109,7 +109,9 @@ describe('useBrowserLocalCanvasController', () => {
     expect(result.current.persistence.kind).toBe('degraded')
     if (result.current.persistence.kind === 'degraded') {
       expect(result.current.persistence.message).not.toMatch(/secret-key|abc123/i)
-      expect(result.current.persistence.message).not.toMatch(/\btoken\b|\bAuthorization\b|\bBearer\b/i)
+      expect(result.current.persistence.message).not.toMatch(
+        /\btoken\b|\bAuthorization\b|\bBearer\b/i,
+      )
     }
   })
 
@@ -150,8 +152,12 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     shouldFailSave = true
-    act(() => { result.current.updateScene([{ type: 'circle' }]) })
-    await act(async () => { await result.current.triggerCleanup() })
+    act(() => {
+      result.current.updateScene([{ type: 'circle' }])
+    })
+    await act(async () => {
+      await result.current.triggerCleanup()
+    })
     expect(result.current.cleanupError).not.toBeNull()
     expect(result.current.cleanupError).not.toMatch(/secret-credential-xyz/i)
     expect(result.current.cleanupError).not.toMatch(/\btoken\b|\bAuthorization\b|\bBearer\b/i)
@@ -163,7 +169,9 @@ describe('useBrowserLocalCanvasController', () => {
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
-    await act(async () => { await result.current.triggerCleanup() })
+    await act(async () => {
+      await result.current.triggerCleanup()
+    })
     expect(result.current.cleanupError).toBeNull()
     expect(result.current.cleanupCompleted).toBe(true)
   })
@@ -231,15 +239,26 @@ describe('useBrowserLocalCanvasController', () => {
       load: base.load.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
-      save: async (s) => { saveCount++; return base.save(s) },
+      save: async (s) => {
+        saveCount++
+        return base.save(s)
+      },
     }
     const { result } = renderHook(() => useBrowserLocalCanvasController(trackingStore))
     await act(async () => {})
     saveCount = 0 // ignore initial load (no save triggered on load)
-    act(() => { result.current.updateScene([{ type: 'a' }]) })
-    await act(async () => { await vi.advanceTimersByTimeAsync(500) }) // halfway
-    act(() => { result.current.updateScene([{ type: 'b' }]) }) // resets debounce
-    await act(async () => { await vi.advanceTimersByTimeAsync(1500) }) // past second debounce
+    act(() => {
+      result.current.updateScene([{ type: 'a' }])
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    }) // halfway
+    act(() => {
+      result.current.updateScene([{ type: 'b' }])
+    }) // resets debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    }) // past second debounce
     expect(saveCount).toBe(1)
   })
 
@@ -311,6 +330,136 @@ describe('useBrowserLocalCanvasController', () => {
     expect((await base.load('c1')).kind).toBe('not-found')
     expect((await base.load('fresh-1')).kind).toBe('not-found')
     expect(await base.getDefaultCanvasId()).toBeNull()
+  })
+
+  it('renameCanvas updates snapshot.name and persists it', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    await act(async () => {
+      result.current.renameCanvas('New name')
+    })
+    expect(result.current.snapshot?.name).toBe('New name')
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('New name')
+    }
+  })
+
+  it('renameCanvas racing with unmount does not warn or clobber a later mount', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result, unmount } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    act(() => {
+      result.current.renameCanvas('Racing name')
+    })
+    unmount()
+    // Let the in-flight save promise resolve after unmount.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('act(...)'))).toBe(false)
+    warnSpy.mockRestore()
+
+    // A subsequently-mounted controller must see the persisted rename, not a clobbered value.
+    const { result: result2 } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    expect(result2.current.snapshot?.name).toBe('Racing name')
+  })
+
+  it('renameCanvas with whitespace-only input falls back to "untitled" and persists that, not empty', async () => {
+    const named: CanvasSnapshot = { ...snap, name: 'My canvas' }
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(named)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    await act(async () => {
+      result.current.renameCanvas('   ')
+    })
+    expect(result.current.snapshot?.name).toBe('untitled')
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('untitled')
+      expect(loadResult.snapshot.name).not.toBe('')
+    }
+  })
+
+  it('renameCanvas with empty string also falls back to "untitled"', async () => {
+    const named: CanvasSnapshot = { ...snap, name: 'My canvas' }
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(named)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    await act(async () => {
+      result.current.renameCanvas('')
+    })
+    expect(result.current.snapshot?.name).toBe('untitled')
+  })
+
+  it('renameCanvas merges with a concurrently-pending scene edit (updateScene then renameCanvas)', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    act(() => {
+      result.current.updateScene([{ type: 'rectangle' }])
+    })
+    await act(async () => {
+      result.current.renameCanvas('Renamed')
+    })
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('Renamed')
+      expect(loadResult.snapshot.scene.elements).toEqual([{ type: 'rectangle' }])
+    }
+  })
+
+  it('renameCanvas merges with a concurrently-pending scene edit (renameCanvas then updateScene)', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    act(() => {
+      result.current.renameCanvas('Renamed')
+    })
+    act(() => {
+      result.current.updateScene([{ type: 'rectangle' }])
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    const loadResult = await store.load('c1')
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('Renamed')
+      expect(loadResult.snapshot.scene.elements).toEqual([{ type: 'rectangle' }])
+    }
+  })
+
+  it('renameCanvas refreshes updatedAt and transitions persistence to saved', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
+    await act(async () => {})
+    await act(async () => {
+      result.current.renameCanvas('New name')
+    })
+    expect(result.current.snapshot?.updatedAt).not.toBe(snap.updatedAt)
+    expect(result.current.persistence.kind).toBe('saved')
   })
 
   it('save/reload roundtrip: saved elements persist in store', async () => {

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -162,6 +162,11 @@ export function useBrowserLocalCanvasController(
         updatedAt: new Date().toISOString(),
       }
       pendingSnapshotRef.current = updated
+      // Also advance snapshotRef synchronously: it is the fallback merge base
+      // (read above when pendingSnapshotRef is null after a flush clears it), so
+      // leaving it stale until the next render could let a follow-up edit merge
+      // onto a pre-rename base.
+      snapshotRef.current = updated
       setSnapshot(updated)
       setPersistenceRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt ?? null }))
       void flushSave()

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -14,6 +14,7 @@ export interface BrowserLocalCanvasController {
   cleanupCompleted: boolean
   cleanupError: string | null
   updateScene(elements: unknown[]): void
+  renameCanvas(name: string): void
   triggerCleanup(): Promise<void>
   startFresh(): Promise<void>
 }
@@ -38,6 +39,8 @@ export function useBrowserLocalCanvasController(
   setPersistenceRef.current = setPersistence
   const persistenceRef = useRef(persistence)
   persistenceRef.current = persistence
+  const snapshotRef = useRef(snapshot)
+  snapshotRef.current = snapshot
   const pendingSnapshotRef = useRef<CanvasSnapshot | null>(null)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -121,23 +124,50 @@ export function useBrowserLocalCanvasController(
     }
   }, []) // store identity is stable; storeRef tracks current value
 
-  const updateScene = useCallback((elements: unknown[]) => {
-    setSnapshot((prev) => {
-      if (prev === null) return prev
+  const updateScene = useCallback(
+    (elements: unknown[]) => {
+      setSnapshot((prev) => {
+        if (prev === null) return prev
+        const updated: CanvasSnapshot = {
+          ...prev,
+          scene: { elements },
+          updatedAt: new Date().toISOString(),
+        }
+        pendingSnapshotRef.current = updated
+        return updated
+      })
+      setPersistenceRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt ?? null }))
+      if (saveTimerRef.current !== null) clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = setTimeout(() => {
+        void flushSave()
+      }, DEBOUNCE_MS)
+    },
+    [flushSave],
+  )
+
+  // Discrete edit — flush immediately instead of the scene debounce so a rename
+  // never lingers as "Unsaved changes" and survives a fast reload.
+  const renameCanvas = useCallback(
+    (name: string) => {
+      // Merge with the freshest pending snapshot (e.g. a concurrent updateScene)
+      // instead of committed state, so neither edit clobbers the other. Computed
+      // from refs (not a setState updater) so pendingSnapshotRef is guaranteed
+      // current before the immediate flushSave below reads it.
+      const base = pendingSnapshotRef.current ?? snapshotRef.current
+      if (base === null) return
+      const normalized = name.trim() || 'untitled'
       const updated: CanvasSnapshot = {
-        ...prev,
-        scene: { elements },
+        ...base,
+        name: normalized,
         updatedAt: new Date().toISOString(),
       }
       pendingSnapshotRef.current = updated
-      return updated
-    })
-    setPersistenceRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt ?? null }))
-    if (saveTimerRef.current !== null) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(() => {
+      setSnapshot(updated)
+      setPersistenceRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt ?? null }))
       void flushSave()
-    }, DEBOUNCE_MS)
-  }, [flushSave])
+    },
+    [flushSave],
+  )
 
   const triggerCleanup = useCallback(async () => {
     setCleanupError(null)
@@ -156,7 +186,7 @@ export function useBrowserLocalCanvasController(
     if (id === null) return
     try {
       const result = await storeRef.current.del(id)
-      if (!result.deleted) return  // pointer-mismatch or not-found: silent no-op
+      if (!result.deleted) return // pointer-mismatch or not-found: silent no-op
       setSnapshot(null)
       setCleanupCompleted(true)
     } catch {
@@ -220,5 +250,14 @@ export function useBrowserLocalCanvasController(
     }
   }, [])
 
-  return { snapshot, persistence, cleanupCompleted, cleanupError, updateScene, triggerCleanup, startFresh }
+  return {
+    snapshot,
+    persistence,
+    cleanupCompleted,
+    cleanupError,
+    updateScene,
+    renameCanvas,
+    triggerCleanup,
+    startFresh,
+  }
 }


### PR DESCRIPTION
Wave 1 slice S-B of the apps/web completion plan. The canvas title was a static `<h1>`; now it is editable and the rename persists through the browser-local store, surviving reload.

## Change

- New `CanvasTitle` component: a real `<input aria-label="Canvas title">` for editing plus a visually-hidden `<h1>` mirror so the page keeps a heading landmark. Enter commits, Escape reverts, blur commits. Keyboard events are `stopPropagation`-guarded so Enter/Escape/Backspace/Delete typed into the title never reach Excalidraw's document-level shortcuts (e.g. Delete won't nuke elements).
- `renameCanvas(name)` on the browser-local controller writes through the **same** pendingSnapshot/flushSave state machine as scene edits (no parallel storage path), merging with any pending scene edit, and flushes immediately so a rename never lingers as "Unsaved changes".
- Empty / whitespace-only input normalizes to `untitled` before it reaches the store — a blank name is never persisted.
- Existing header layout (flex column, beta banner, BackendConfigChip, Delete button, save-status) intact; the title's accessible name (`/canvas title/i`) is kept distinct from Delete (`/delete/i`) so existing role queries don't collide.

## Tests (TDD red-first)

jsdom 209 + web-browser 43 + typecheck all pass. Coverage: controller rename (persist, whitespace→`untitled`, no empty write, concurrent scene+rename merge, flush-races-unmount), CanvasTitle interaction (Enter/Escape/blur/fallback/heading-present), and a real-IndexedDB `.rename.browser.test.tsx` proving reload persistence + keyboard-isolation-doesn't-delete-elements. Review: 0 CRITICAL/HIGH/QA-fail.

## Visual repro (built dist served with production headers)

Edited title (Saved) → after reload (retained):

![title-edited.png](https://github.com/user-attachments/assets/159d5085-db17-443c-9885-ce6469406d24)
![title-after-reload.png](https://github.com/user-attachments/assets/1b4f1c7d-7b31-499f-9109-82bf04bf97f2)