### PR TITLE
refactor(web): make Loro the single source of truth for canvas elements

### DIFF
--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -135,6 +135,39 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     expect(await metaStore.getDefaultCanvasId()).toBe(canvasId)
   })
 
+  it('upgrades without aborting when a legacy canvases row is a non-object (corrupt data)', async () => {
+    // A null / non-object row must not throw a TypeError from `'scene' in value`
+    // inside the upgrade cursor — that would abort the transaction and brick the
+    // DB open for the user.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('whiteboard', 2)
+      req.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result
+        if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+        if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
+        if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('canvases', 'readwrite')
+        // A corrupt non-object value stored under a key.
+        tx.objectStore('canvases').put(null, 'corrupt-row')
+        tx.oncomplete = () => {
+          db.close()
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+
+    // Opening through the shared opener at v3 must complete (guard prevents the
+    // `in` TypeError from aborting the upgrade).
+    const db = await openWhiteboardDb()
+    expect(db.version).toBe(DB_VERSION)
+    db.close()
+  })
+
   it('mutation-check: reverting DB_VERSION to 2 makes the seeded v2 fixture fail to strip scene', async () => {
     // This test documents the guard rather than actually reverting production
     // code (that is done manually per the zod-schema-discipline mutation-check

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * v2 -> v3 upgrade migration (real IndexedDB): the persisted JSON 'canvases'
+ * row is demoted to metadata-only. Elements are canonical in the Loro doc
+ * ('loroCanvases'), so a legacy 'scene' field on a v2 'canvases' row must be
+ * stripped on upgrade without ever touching 'loroCanvases'.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Loro } from 'loro-crdt'
+import { openWhiteboardDb, DB_VERSION } from './browser-idb.js'
+import { IndexedDBStore } from './browser-local-store.js'
+import { LoroStore } from './loro-store.js'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+/** Seed a pre-v3 ("v2 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
+async function seedV2Fixture(canvasId: string, loroSnapshot: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard', 2)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
+      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction(['meta', 'canvases', 'loroCanvases'], 'readwrite')
+      tx.objectStore('meta').put(canvasId, 'defaultCanvasId')
+      tx.objectStore('canvases').put(
+        {
+          id: canvasId,
+          name: 'Pre-migration canvas',
+          scene: { elements: [{ id: 'legacy-el', type: 'rectangle' }] },
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        canvasId,
+      )
+      tx.objectStore('loroCanvases').put(
+        {
+          v: 1,
+          snapshot: loroSnapshot,
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        canvasId,
+      )
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+/** Reads a 'canvases' row directly via raw IDB, bypassing canvasSnapshotSchema. */
+async function readRawCanvasesRow(canvasId: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard')
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('canvases', 'readonly')
+      const getReq = tx.objectStore('canvases').get(canvasId)
+      getReq.onsuccess = () => resolve(getReq.result)
+      getReq.onerror = () => reject(getReq.error)
+      tx.oncomplete = () => db.close()
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('current DB_VERSION is 3 or higher (guards against reverting the bump alone)', () => {
+    expect(DB_VERSION).toBeGreaterThanOrEqual(3)
+  })
+
+  it('opens a seeded v2 fixture at the current version without VersionError, strips scene, and keeps loroCanvases canonical', async () => {
+    const canvasId = 'canvas-migrate-1'
+    const doc = new Loro()
+    doc.getList('elements').push({ id: 'canonical-el' })
+    const loroSnapshot = doc.export({ mode: 'snapshot' })
+    await seedV2Fixture(canvasId, loroSnapshot)
+
+    // (a) Open through the shared opener at the current DB_VERSION — must not VersionError.
+    const db = await openWhiteboardDb()
+    db.close()
+
+    // (b) The loroCanvases record survives and its elements are canonical after load.
+    const loroStore = new LoroStore()
+    const loroResult = await loroStore.load(canvasId)
+    expect(loroResult.kind).toBe('ok')
+    if (loroResult.kind === 'ok') {
+      const restored = new Loro()
+      restored.import(loroResult.snapshot)
+      expect(restored.getList('elements').toArray()).toEqual([{ id: 'canonical-el' }])
+    }
+
+    // (c) The 'canvases' row has no scene / no old-schema orphan remains.
+    // Checked against the RAW stored row (not the parsed load() result): Zod's
+    // z.object() silently strips unrecognized keys from its parsed OUTPUT even
+    // when the underlying row still carries them, so asserting only against
+    // loadResult.snapshot would pass even if the upgrade never ran.
+    const rawRow = await readRawCanvasesRow(canvasId)
+    expect(rawRow).not.toHaveProperty('scene')
+    expect(rawRow).toEqual({
+      id: canvasId,
+      name: 'Pre-migration canvas',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    const metaStore = new IndexedDBStore()
+    const loadResult = await metaStore.load(canvasId)
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot).toEqual({
+        id: canvasId,
+        name: 'Pre-migration canvas',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      })
+    }
+
+    // (d) The default pointer/id is intact.
+    expect(await metaStore.getDefaultCanvasId()).toBe(canvasId)
+  })
+
+  it('mutation-check: reverting DB_VERSION to 2 makes the seeded v2 fixture fail to strip scene', async () => {
+    // This test documents the guard rather than actually reverting production
+    // code (that is done manually per the zod-schema-discipline mutation-check
+    // step). It re-asserts the invariant the real mutation-check depends on:
+    // opening at version 2 must NOT run the v2->v3 upgrade at all.
+    const canvasId = 'canvas-migrate-2'
+    const doc = new Loro()
+    doc.getList('elements').push({ id: 'el' })
+    await seedV2Fixture(canvasId, doc.export({ mode: 'snapshot' }))
+
+    // Opening at the (hypothetically reverted) old version 2 does not run
+    // onupgradeneeded at all, so the legacy 'scene' field is still present.
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('whiteboard', 2)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    const raw = await new Promise<unknown>((resolve, reject) => {
+      const tx = rawDb.transaction('canvases', 'readonly')
+      const getReq = tx.objectStore('canvases').get(canvasId)
+      getReq.onsuccess = () => resolve(getReq.result)
+      getReq.onerror = () => reject(getReq.error)
+      tx.oncomplete = () => rawDb.close()
+    })
+    expect(raw).toHaveProperty('scene')
+  })
+})

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -23,9 +23,11 @@ function stripLegacySceneField(tx: IDBTransaction): void {
   cursorReq.onsuccess = () => {
     const cursor = cursorReq.result
     if (!cursor) return
-    const value = cursor.value as Record<string, unknown>
-    if ('scene' in value) {
-      const { scene: _scene, ...metadataOnly } = value
+    const value = cursor.value as unknown
+    // Guard the `in` check: a corrupt/non-object row would otherwise throw a
+    // TypeError, aborting the upgrade transaction and bricking the DB open.
+    if (typeof value === 'object' && value !== null && 'scene' in value) {
+      const { scene: _scene, ...metadataOnly } = value as Record<string, unknown>
       cursor.update(metadataOnly)
     }
     cursor.continue()
@@ -41,8 +43,12 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
       if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
 
+      // oldVersion === 0 is a fresh install (empty 'canvases' store), so the
+      // scene-strip is a pure no-op there — only run it for a real v1/v2 upgrade.
       // req.transaction is always non-null inside onupgradeneeded; narrowed for TS.
-      if (event.oldVersion < 3 && req.transaction) stripLegacySceneField(req.transaction)
+      if (event.oldVersion > 0 && event.oldVersion < 3 && req.transaction) {
+        stripLegacySceneField(req.transaction)
+      }
     }
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -1,0 +1,53 @@
+/**
+ * Single opener for the shared 'whiteboard' IndexedDB, used by both
+ * browser-local-store.ts (legacy JSON 'canvases' metadata) and loro-store.ts
+ * (canonical 'loroCanvases' CRDT records). Both stores live in the same
+ * database, so a version bump or upgrade change to one that isn't mirrored in
+ * the other produces a VersionError the next time the stale opener runs.
+ * Owning DB_VERSION and onupgradeneeded in one place makes that impossible by
+ * construction instead of relying on a hand-synced comment.
+ */
+export const DB_NAME = 'whiteboard'
+
+/**
+ * v2 -> v3: elements are canonical in the Loro doc ('loroCanvases'); the JSON
+ * 'canvases' row is demoted to metadata only (id/name/updatedAt). Any legacy
+ * 'scene' field left over from a pre-v3 row is stripped during upgrade so no
+ * old-schema shape survives to fail canvasSnapshotSchema.parse.
+ */
+export const DB_VERSION = 3
+
+function stripLegacySceneField(tx: IDBTransaction): void {
+  const store = tx.objectStore('canvases')
+  const cursorReq = store.openCursor()
+  cursorReq.onsuccess = () => {
+    const cursor = cursorReq.result
+    if (!cursor) return
+    const value = cursor.value as Record<string, unknown>
+    if ('scene' in value) {
+      const { scene: _scene, ...metadataOnly } = value
+      cursor.update(metadataOnly)
+    }
+    cursor.continue()
+  }
+}
+
+export function openWhiteboardDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
+      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+
+      if (event.oldVersion < 3) {
+        const tx = (event.target as IDBOpenDBRequest).transaction
+        // tx is always non-null inside onupgradeneeded; narrowed for TS.
+        if (tx) stripLegacySceneField(tx)
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -36,16 +36,13 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION)
     req.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
+      const db = req.result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
       if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
       if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
 
-      if (event.oldVersion < 3) {
-        const tx = (event.target as IDBOpenDBRequest).transaction
-        // tx is always non-null inside onupgradeneeded; narrowed for TS.
-        if (tx) stripLegacySceneField(tx)
-      }
+      // req.transaction is always non-null inside onupgradeneeded; narrowed for TS.
+      if (event.oldVersion < 3 && req.transaction) stripLegacySceneField(req.transaction)
     }
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)

--- a/apps/web/src/lib/browser-local-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-local-backend.browser.test.tsx
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Loro } from 'loro-crdt'
 import { BrowserLocalBackend } from './browser-local-backend.js'
+import { DB_VERSION } from './browser-idb.js'
 import type { CanvasBackendHandlers } from '@kamiazya/whiteboard-mcp/browser-contract'
 
 async function clearDb(): Promise<void> {
@@ -277,7 +278,7 @@ describe('BrowserLocalBackend', () => {
 
 async function forceInvalidLoroRecord(canvasId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 2)
+    const req = indexedDB.open('whiteboard', DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -311,7 +312,7 @@ async function forceInvalidLoroRecord(canvasId: string): Promise<void> {
 
 async function forceRecordWithBadDelta(canvasId: string, snapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 2)
+    const req = indexedDB.open('whiteboard', DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -346,7 +347,7 @@ async function forceRecordWithBadDelta(canvasId: string, snapshot: Uint8Array): 
 
 async function forceCorruptRecord(canvasId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 2)
+    const req = indexedDB.open('whiteboard', DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')

--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -6,7 +6,6 @@ import type { CanvasSnapshot } from './whiteboard-client.js'
 const snap: CanvasSnapshot = {
   id: 'c1',
   name: 'untitled',
-  scene: { elements: [] },
   updatedAt: '2026-05-24T00:00:00.000Z',
 }
 
@@ -131,7 +130,10 @@ describe('IndexedDBStore', () => {
         const db = req.result
         const tx = db.transaction('canvases', 'readwrite')
         tx.objectStore('canvases').put({ broken: true }, 'c1')
-        tx.oncomplete = () => { db.close(); resolve() }
+        tx.oncomplete = () => {
+          db.close()
+          resolve()
+        }
         tx.onerror = () => reject(tx.error)
       }
       req.onerror = () => reject(req.error)

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -85,6 +85,12 @@ export class IndexedDBStore implements BrowserLocalStore {
         resolve()
       }
       tx.onerror = () => reject(tx.error)
+      // Without onabort a mid-write abort (e.g. QuotaExceeded) leaves the promise
+      // unsettled — the caller's await would hang forever.
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
+      }
     })
   }
 
@@ -116,6 +122,10 @@ export class IndexedDBStore implements BrowserLocalStore {
         resolve()
       }
       tx.onerror = () => reject(tx.error)
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
+      }
     })
   }
 
@@ -173,6 +183,10 @@ export class IndexedDBStore implements BrowserLocalStore {
       tx.onerror = () => {
         db.close()
         reject(tx.error)
+      }
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
       }
     })
   }

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -1,12 +1,6 @@
-import { z } from 'zod'
+import { openWhiteboardDb } from './browser-idb.js'
+import { canvasSnapshotSchema } from './whiteboard-client.js'
 import type { CanvasSnapshot } from './whiteboard-client.js'
-
-const canvasSnapshotSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  scene: z.object({ elements: z.array(z.unknown()) }),
-  updatedAt: z.string(),
-})
 
 export type LoadResult =
   | { kind: 'ok'; snapshot: CanvasSnapshot }
@@ -69,29 +63,9 @@ export class MemoryStore implements BrowserLocalStore {
   }
 }
 
-const DB_NAME = 'whiteboard'
-// Both stores (legacy JSON canvases and Loro CRDT loroCanvases) share the same
-// IndexedDB database. Opening at v1 after a v2 upgrade causes a VersionError, so
-// this opener must stay in sync with loro-store.ts which opens at DB_VERSION 2.
-const DB_VERSION = 2
-
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION)
-    req.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
-      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
-      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
-    }
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
-}
-
 export class IndexedDBStore implements BrowserLocalStore {
   async getDefaultCanvasId(): Promise<string | null> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('meta', 'readonly')
       const req = tx.objectStore('meta').get('defaultCanvasId')
@@ -102,22 +76,28 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async setDefaultCanvasId(id: string): Promise<void> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('meta', 'readwrite')
       tx.objectStore('meta').put(id, 'defaultCanvasId')
-      tx.oncomplete = () => { db.close(); resolve() }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
       tx.onerror = () => reject(tx.error)
     })
   }
 
   async load(id: string): Promise<LoadResult> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve) => {
       const tx = db.transaction('canvases', 'readonly')
       const req = tx.objectStore('canvases').get(id)
       req.onsuccess = () => {
-        if (req.result === undefined) { resolve({ kind: 'not-found' }); return }
+        if (req.result === undefined) {
+          resolve({ kind: 'not-found' })
+          return
+        }
         const parsed = canvasSnapshotSchema.safeParse(req.result)
         resolve(parsed.success ? { kind: 'ok', snapshot: parsed.data } : { kind: 'corrupted' })
       }
@@ -127,17 +107,20 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async save(snapshot: CanvasSnapshot): Promise<void> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('canvases', 'readwrite')
       tx.objectStore('canvases').put(snapshot, snapshot.id)
-      tx.oncomplete = () => { db.close(); resolve() }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
       tx.onerror = () => reject(tx.error)
     })
   }
 
   async del(expectedId: string): Promise<DeleteResult> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction(['meta', 'canvases'], 'readwrite')
       const metaStore = tx.objectStore('meta')
@@ -160,7 +143,10 @@ export class IndexedDBStore implements BrowserLocalStore {
         metaStore.delete('defaultCanvasId')
         canvasStore.delete(expectedId)
       }
-      tx.oncomplete = () => { db.close(); resolve({ deleted: true }) }
+      tx.oncomplete = () => {
+        db.close()
+        resolve({ deleted: true })
+      }
       tx.onabort = () => {
         db.close()
         // earlyResult is set only when our code calls tx.abort() (pointer-mismatch / not-found).
@@ -168,17 +154,26 @@ export class IndexedDBStore implements BrowserLocalStore {
         if (earlyResult !== null) resolve(earlyResult)
         else reject(tx.error ?? new DOMException('Transaction aborted unexpectedly', 'AbortError'))
       }
-      tx.onerror = () => { db.close(); reject(tx.error) }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
     })
   }
 
   async removeCanvas(id: string): Promise<void> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('canvases', 'readwrite')
       tx.objectStore('canvases').delete(id)
-      tx.oncomplete = () => { db.close(); resolve() }
-      tx.onerror = () => { db.close(); reject(tx.error) }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
     })
   }
 

--- a/apps/web/src/lib/loro-store.browser.test.tsx
+++ b/apps/web/src/lib/loro-store.browser.test.tsx
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Loro } from 'loro-crdt'
 import { LoroStore, loroRecordEnvelopeSchema } from './loro-store.js'
+import { DB_VERSION } from './browser-idb.js'
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
@@ -55,8 +56,12 @@ describe('loroRecordEnvelopeSchema', () => {
 })
 
 describe('LoroStore (real IndexedDB)', () => {
-  beforeEach(async () => { await clearDb() })
-  afterEach(async () => { await clearDb() })
+  beforeEach(async () => {
+    await clearDb()
+  })
+  afterEach(async () => {
+    await clearDb()
+  })
 
   it('load returns not-found for unknown canvasId', async () => {
     const store = new LoroStore()
@@ -104,9 +109,7 @@ describe('LoroStore (real IndexedDB)', () => {
       const fresh = new Loro()
       fresh.import(result.snapshot)
       for (const d of result.deltas ?? []) fresh.import(d)
-      expect(fresh.getList('elements').toJSON()).toEqual([
-        { id: 'a' }, { id: 'b' }, { id: 'c' },
-      ])
+      expect(fresh.getList('elements').toJSON()).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
     }
   })
 
@@ -199,7 +202,7 @@ describe('LoroStore (real IndexedDB)', () => {
 function openLoroDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     // Open at the CURRENT DB_VERSION so upgrade runs if needed
-    const req = indexedDB.open('whiteboard', 2)
+    const req = indexedDB.open('whiteboard', DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -139,6 +139,10 @@ export class LoroStore {
         db.close()
         reject(tx.error)
       }
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
+      }
     })
   }
 

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -1,5 +1,6 @@
 import { Loro } from 'loro-crdt'
 import { z } from 'zod'
+import { openWhiteboardDb } from './browser-idb.js'
 
 /**
  * Versioned envelope for Loro records persisted in IndexedDB.
@@ -30,28 +31,6 @@ export type LoroLoadResult =
   | { kind: 'corrupt-delta' }
   | { kind: 'unsupported-version' }
 
-const DB_NAME = 'whiteboard'
-/**
- * DB_VERSION 2 adds the 'loroCanvases' object store for Loro CRDT records.
- * The v1 'canvases' and 'meta' stores are preserved untouched by the upgrade.
- */
-const DB_VERSION = 2
-
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION)
-    req.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      // Preserve v1 stores; only add the new Loro store.
-      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
-      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
-      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
-    }
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
-}
-
 /**
  * Try importing bytes into a throwaway LoroDoc to confirm they are valid Loro
  * bytes (snapshot or update). Returns false if the import throws.
@@ -68,7 +47,7 @@ function isValidLoroBytes(bytes: Uint8Array): boolean {
 
 /**
  * LoroStore: persists Loro CRDT snapshot+delta records in the 'loroCanvases'
- * IndexedDB object store (DB v2). Isolated from the v1 'canvases' JSON store
+ * IndexedDB object store. Isolated from the 'canvases' JSON metadata store
  * so legacy records are never misread as Loro bytes.
  *
  * load() deep-validates bytes by importing them into a throwaway LoroDoc so
@@ -77,7 +56,7 @@ function isValidLoroBytes(bytes: Uint8Array): boolean {
  */
 export class LoroStore {
   async load(canvasId: string): Promise<LoroLoadResult> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve) => {
       const tx = db.transaction('loroCanvases', 'readonly')
       const req = tx.objectStore('loroCanvases').get(canvasId)
@@ -122,18 +101,28 @@ export class LoroStore {
       }
       // req.onerror fires when the get request itself fails; close db and resolve
       // so the IDB connection is not leaked. Prevent the error from propagating to tx.onerror.
-      req.onerror = (e) => { e.preventDefault(); db.close(); resolve({ kind: 'corrupt-snapshot' }) }
+      req.onerror = (e) => {
+        e.preventDefault()
+        db.close()
+        resolve({ kind: 'corrupt-snapshot' })
+      }
       // tx.onerror/tx.onabort fire when the transaction errors before req completes
       // (e.g. quota exceeded, database closing mid-read). Without these the promise
       // never settles and loadAndDeliver stalls permanently.
-      tx.onerror = () => { db.close(); resolve({ kind: 'corrupt-snapshot' }) }
-      tx.onabort = () => { db.close(); resolve({ kind: 'corrupt-snapshot' }) }
+      tx.onerror = () => {
+        db.close()
+        resolve({ kind: 'corrupt-snapshot' })
+      }
+      tx.onabort = () => {
+        db.close()
+        resolve({ kind: 'corrupt-snapshot' })
+      }
       tx.oncomplete = () => db.close()
     })
   }
 
   async save(canvasId: string, snapshot: Uint8Array): Promise<void> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const envelope: LoroRecordEnvelope = {
         v: 1,
@@ -142,8 +131,14 @@ export class LoroStore {
       }
       const tx = db.transaction('loroCanvases', 'readwrite')
       tx.objectStore('loroCanvases').put(envelope, canvasId)
-      tx.oncomplete = () => { db.close(); resolve() }
-      tx.onerror = () => { db.close(); reject(tx.error) }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
     })
   }
 
@@ -156,7 +151,7 @@ export class LoroStore {
    * If no record exists yet, this is a no-op (snapshot must be saved first).
    */
   async appendDelta(canvasId: string, delta: Uint8Array): Promise<void> {
-    const db = await openDb()
+    const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('loroCanvases', 'readwrite')
       const store = tx.objectStore('loroCanvases')
@@ -181,10 +176,19 @@ export class LoroStore {
         }
         store.put(updated, canvasId)
       }
-      tx.oncomplete = () => { db.close(); resolve() }
-      tx.onerror = () => { db.close(); reject(tx.error) }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
       // tx.onabort fires when our code calls tx.abort() (corrupt envelope branch above).
-      tx.onabort = () => { db.close(); reject(new DOMException('Corrupt envelope; delta not appended', 'AbortError')) }
+      tx.onabort = () => {
+        db.close()
+        reject(new DOMException('Corrupt envelope; delta not appended', 'AbortError'))
+      }
     })
   }
 }

--- a/apps/web/src/lib/migration-export.test.ts
+++ b/apps/web/src/lib/migration-export.test.ts
@@ -2,42 +2,49 @@ import { describe, expect, it } from 'vitest'
 import { migrationBundleSchema } from '@kamiazya/whiteboard-mcp/migration-bundle'
 
 import type { CanvasSnapshot } from './whiteboard-client.js'
-import { buildMigrationBundle } from './migration-export.js'
+import { buildMigrationBundle, type MigrationCanvasInput } from './migration-export.js'
 
 function makeSnapshot(overrides: Partial<CanvasSnapshot> = {}): CanvasSnapshot {
   return {
     id: 'canvas-1',
     name: 'My Canvas',
-    scene: { elements: [{ id: 'el-1', type: 'rectangle' }] },
     updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeInput(overrides: Partial<MigrationCanvasInput> = {}): MigrationCanvasInput {
+  return {
+    snapshot: makeSnapshot(),
+    elements: [{ id: 'el-1', type: 'rectangle' }],
     ...overrides,
   }
 }
 
 describe('buildMigrationBundle', () => {
   it('returns a bundle that satisfies migrationBundleSchema', () => {
-    const bundle = buildMigrationBundle([makeSnapshot()])
+    const bundle = buildMigrationBundle([makeInput()])
     expect(() => migrationBundleSchema.parse(bundle)).not.toThrow()
   })
 
   it('sets the correct format/version/sourceProvider literals', () => {
-    const bundle = buildMigrationBundle([makeSnapshot()])
+    const bundle = buildMigrationBundle([makeInput()])
     expect(bundle.format).toBe('whiteboard-migration')
     expect(bundle.version).toBe(1)
     expect(bundle.sourceProvider).toBe('browser-local')
   })
 
-  it('carries over id, name, and scene.elements from the snapshot', () => {
-    const snapshot = makeSnapshot({ id: 'abc', name: 'Roadmap' })
-    const bundle = buildMigrationBundle([snapshot])
+  it('carries over id, name, and elements from the input', () => {
+    const input = makeInput({ snapshot: makeSnapshot({ id: 'abc', name: 'Roadmap' }) })
+    const bundle = buildMigrationBundle([input])
     expect(bundle.canvases).toEqual([
-      { id: 'abc', name: 'Roadmap', scene: { elements: snapshot.scene.elements } },
+      { id: 'abc', name: 'Roadmap', scene: { elements: input.elements } },
     ])
   })
 
   it('produces an ISO createdAt from an injected clock', () => {
     const now = () => new Date('2026-01-01T12:00:00.000Z')
-    const bundle = buildMigrationBundle([makeSnapshot()], now)
+    const bundle = buildMigrationBundle([makeInput()], now)
     expect(bundle.createdAt).toBe('2026-01-01T12:00:00.000Z')
   })
 
@@ -47,11 +54,11 @@ describe('buildMigrationBundle', () => {
     expect(() => migrationBundleSchema.parse(bundle)).not.toThrow()
   })
 
-  it('does not mutate the input snapshots array or its entries', () => {
-    const snapshots = [makeSnapshot()]
-    const frozenElements = snapshots[0].scene.elements
-    buildMigrationBundle(snapshots)
-    expect(snapshots).toHaveLength(1)
-    expect(snapshots[0].scene.elements).toBe(frozenElements)
+  it('does not mutate the input array or its entries', () => {
+    const inputs = [makeInput()]
+    const frozenElements = inputs[0].elements
+    buildMigrationBundle(inputs)
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].elements).toBe(frozenElements)
   })
 })

--- a/apps/web/src/lib/migration-export.ts
+++ b/apps/web/src/lib/migration-export.ts
@@ -2,13 +2,22 @@
  * Builds a MigrationBundle from browser-local canvas snapshots so a user can
  * export their data and import it into a daemon-backed workspace (or another
  * browser-local instance). Pure function — no UI wiring here.
+ *
+ * CanvasSnapshot (the persisted JSON 'canvases' row) is metadata-only —
+ * elements are canonical in the Loro doc, not the JSON row — so the caller
+ * must supply each canvas's current elements alongside its snapshot.
  */
 import type { MigrationBundle } from '@kamiazya/whiteboard-mcp/migration-bundle'
 
 import type { CanvasSnapshot } from './whiteboard-client.js'
 
+export interface MigrationCanvasInput {
+  snapshot: CanvasSnapshot
+  elements: unknown[]
+}
+
 export function buildMigrationBundle(
-  canvases: readonly CanvasSnapshot[],
+  canvases: readonly MigrationCanvasInput[],
   now: () => Date = () => new Date(),
 ): MigrationBundle {
   return {
@@ -16,10 +25,10 @@ export function buildMigrationBundle(
     version: 1,
     sourceProvider: 'browser-local',
     createdAt: now().toISOString(),
-    canvases: canvases.map((snapshot) => ({
+    canvases: canvases.map(({ snapshot, elements }) => ({
       id: snapshot.id,
       name: snapshot.name,
-      scene: { elements: snapshot.scene.elements },
+      scene: { elements },
     })),
   }
 }

--- a/apps/web/src/lib/whiteboard-client.ts
+++ b/apps/web/src/lib/whiteboard-client.ts
@@ -1,6 +1,14 @@
-export interface CanvasSnapshot {
-  id: string
-  name: string
-  scene: { elements: unknown[] }
-  updatedAt: string
-}
+import { z } from 'zod'
+
+/**
+ * Persisted JSON 'canvases' row: metadata only. Elements are canonical in the
+ * Loro doc ('loroCanvases' store); this schema must never grow a scene/elements
+ * field again or the two stores drift out of sync.
+ */
+export const canvasSnapshotSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  updatedAt: z.string(),
+})
+
+export type CanvasSnapshot = z.infer<typeof canvasSnapshotSchema>

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -52,7 +52,6 @@ vi.mock('../lib/browser-local-backend.js', () => ({
 const snap: CanvasSnapshot = {
   id: 'c1',
   name: 'untitled',
-  scene: { elements: [] },
   updatedAt: '2026-05-24T00:00:00.000Z',
 }
 

--- a/apps/web/src/pages/browser-local-page-state.test.ts
+++ b/apps/web/src/pages/browser-local-page-state.test.ts
@@ -6,7 +6,6 @@ import type { BrowserLocalPersistenceState } from './use-browser-local-canvas-co
 const snapshot: CanvasSnapshot = {
   id: 'canvas-A',
   name: 'untitled',
-  scene: { elements: [] },
   updatedAt: '2026-05-04T00:00:00.000Z',
 }
 
@@ -30,18 +29,21 @@ describe('derivePageState', () => {
     // Defence-in-depth — the controller never sets cleanupCompleted
     // while persistence is degraded (cleanup runs from the editor),
     // but if both flags somehow flipped on, the safer banner wins.
-    expect(derivePageState({ snapshot: null, persistence: degraded, cleanupCompleted: true }))
-      .toEqual({ kind: 'load-degraded', message: 'Save failed.' })
+    expect(
+      derivePageState({ snapshot: null, persistence: degraded, cleanupCompleted: true }),
+    ).toEqual({ kind: 'load-degraded', message: 'Save failed.' })
   })
 
   it('snapshot=null + cleanupCompleted=true (and persistence not degraded) → cleanup-completed', () => {
-    expect(derivePageState({ snapshot: null, persistence: saved, cleanupCompleted: true }))
-      .toEqual({ kind: 'cleanup-completed' })
+    expect(derivePageState({ snapshot: null, persistence: saved, cleanupCompleted: true })).toEqual(
+      { kind: 'cleanup-completed' },
+    )
   })
 
   it('snapshot=null + cleanupCompleted=false + persistence not degraded → loading', () => {
-    expect(derivePageState({ snapshot: null, persistence: saved, cleanupCompleted: false }))
-      .toEqual({ kind: 'loading' })
+    expect(
+      derivePageState({ snapshot: null, persistence: saved, cleanupCompleted: false }),
+    ).toEqual({ kind: 'loading' })
   })
 
   it('snapshot present → editing (regardless of persistence kind), and the persistence flows through unchanged', () => {

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -8,7 +8,6 @@ import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 const snap: CanvasSnapshot = {
   id: 'c1',
   name: 'untitled',
-  scene: { elements: [] },
   updatedAt: '2026-05-24T00:00:00.000Z',
 }
 
@@ -43,7 +42,7 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     expect(result.current.snapshot).not.toBeNull()
-    expect(result.current.snapshot?.scene.elements).toEqual([])
+    expect(result.current.snapshot?.name).toBe('untitled')
   })
 
   it('loads existing canvas from store on mount', async () => {
@@ -55,30 +54,20 @@ describe('useBrowserLocalCanvasController', () => {
     expect(result.current.snapshot).toEqual(snap)
   })
 
-  it('updateScene sets persistence to pending', async () => {
+  it('renameCanvas transitions persistence pending -> saved via an immediate flush (no debounce)', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     act(() => {
-      result.current.updateScene([{ type: 'rectangle' }])
+      result.current.renameCanvas('Renamed')
     })
-    expect(result.current.persistence.kind).toBe('pending')
-  })
-
-  it('persistence becomes saved after debounce timer fires', async () => {
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
-    await act(async () => {})
-    act(() => {
-      result.current.updateScene([{ type: 'rectangle' }])
-    })
-    expect(result.current.persistence.kind).toBe('pending')
+    // renameCanvas flushes immediately (no setTimeout), so a microtask flush
+    // settles it back to 'saved' without advancing any timers.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await Promise.resolve()
+      await Promise.resolve()
     })
     expect(result.current.persistence.kind).toBe('saved')
   })
@@ -100,11 +89,8 @@ describe('useBrowserLocalCanvasController', () => {
     }
     const { result } = renderHook(() => useBrowserLocalCanvasController(failingStore))
     await act(async () => {})
-    act(() => {
-      result.current.updateScene([{ type: 'rectangle' }])
-    })
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      result.current.renameCanvas('Renamed')
     })
     expect(result.current.persistence.kind).toBe('degraded')
     if (result.current.persistence.kind === 'degraded') {
@@ -122,7 +108,7 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     act(() => {
-      result.current.updateScene([{ type: 'line' }])
+      result.current.renameCanvas('Renamed before cleanup')
     })
     await act(async () => {
       await result.current.triggerCleanup()
@@ -152,9 +138,14 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     shouldFailSave = true
-    act(() => {
-      result.current.updateScene([{ type: 'circle' }])
+    // renameCanvas flushes immediately; let that failing save settle to 'degraded'
+    // before triggerCleanup runs, matching how a real prior save failure lingers.
+    await act(async () => {
+      result.current.renameCanvas('Renamed')
+      await Promise.resolve()
+      await Promise.resolve()
     })
+    expect(result.current.persistence.kind).toBe('degraded')
     await act(async () => {
       await result.current.triggerCleanup()
     })
@@ -195,10 +186,14 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     shouldFailSave = true
-    act(() => {
-      result.current.updateScene([{ type: 'circle' }]) // sets pendingSnapshotRef
+    // renameCanvas flushes immediately and fails; let it settle to 'degraded'
+    // before triggerCleanup runs, so triggerCleanup's own degraded-guard aborts.
+    await act(async () => {
+      result.current.renameCanvas('Renamed')
+      await Promise.resolve()
+      await Promise.resolve()
     })
-    // triggerCleanup triggers flushSave with pending data; save fails → abort
+    expect(result.current.persistence.kind).toBe('degraded')
     await act(async () => {
       await result.current.triggerCleanup()
     })
@@ -228,40 +223,6 @@ describe('useBrowserLocalCanvasController', () => {
     expect(result.current.snapshot).toEqual(snap)
   })
 
-  it('rapid updateScene calls within debounce window coalesce into a single save', async () => {
-    const base = new MemoryStore()
-    await base.setDefaultCanvasId('c1')
-    await base.save(snap)
-    let saveCount = 0
-    const trackingStore: BrowserLocalStore = {
-      getDefaultCanvasId: base.getDefaultCanvasId.bind(base),
-      setDefaultCanvasId: base.setDefaultCanvasId.bind(base),
-      load: base.load.bind(base),
-      del: base.del.bind(base),
-      generateId: base.generateId.bind(base),
-      save: async (s) => {
-        saveCount++
-        return base.save(s)
-      },
-    }
-    const { result } = renderHook(() => useBrowserLocalCanvasController(trackingStore))
-    await act(async () => {})
-    saveCount = 0 // ignore initial load (no save triggered on load)
-    act(() => {
-      result.current.updateScene([{ type: 'a' }])
-    })
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(500)
-    }) // halfway
-    act(() => {
-      result.current.updateScene([{ type: 'b' }])
-    }) // resets debounce
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500)
-    }) // past second debounce
-    expect(saveCount).toBe(1)
-  })
-
   it('no phantom save re-populates store after triggerCleanup', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
@@ -269,12 +230,12 @@ describe('useBrowserLocalCanvasController', () => {
     const { result } = renderHook(() => useBrowserLocalCanvasController(store))
     await act(async () => {})
     act(() => {
-      result.current.updateScene([{ type: 'line' }])
+      result.current.renameCanvas('Renamed')
     })
     await act(async () => {
       await result.current.triggerCleanup()
     })
-    // Advance past the debounce window — any un-flushed timer would save phantom data
+    // Advance past any timer window — no un-flushed timer should save phantom data.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000)
     })
@@ -406,49 +367,6 @@ describe('useBrowserLocalCanvasController', () => {
     expect(result.current.snapshot?.name).toBe('untitled')
   })
 
-  it('renameCanvas merges with a concurrently-pending scene edit (updateScene then renameCanvas)', async () => {
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
-    await act(async () => {})
-    act(() => {
-      result.current.updateScene([{ type: 'rectangle' }])
-    })
-    await act(async () => {
-      result.current.renameCanvas('Renamed')
-    })
-    const loadResult = await store.load('c1')
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Renamed')
-      expect(loadResult.snapshot.scene.elements).toEqual([{ type: 'rectangle' }])
-    }
-  })
-
-  it('renameCanvas merges with a concurrently-pending scene edit (renameCanvas then updateScene)', async () => {
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
-    await act(async () => {})
-    act(() => {
-      result.current.renameCanvas('Renamed')
-    })
-    act(() => {
-      result.current.updateScene([{ type: 'rectangle' }])
-    })
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
-    })
-    const loadResult = await store.load('c1')
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Renamed')
-      expect(loadResult.snapshot.scene.elements).toEqual([{ type: 'rectangle' }])
-    }
-  })
-
   it('renameCanvas before the initial load resolves is a safe no-op', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
@@ -498,24 +416,5 @@ describe('useBrowserLocalCanvasController', () => {
     })
     expect(result.current.snapshot?.updatedAt).not.toBe(snap.updatedAt)
     expect(result.current.persistence.kind).toBe('saved')
-  })
-
-  it('save/reload roundtrip: saved elements persist in store', async () => {
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    const { result } = renderHook(() => useBrowserLocalCanvasController(store))
-    await act(async () => {})
-    act(() => {
-      result.current.updateScene([{ type: 'ellipse' }])
-    })
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
-    })
-    const loadResult = await store.load('c1')
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.scene.elements).toEqual([{ type: 'ellipse' }])
-    }
   })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -13,13 +13,10 @@ export interface BrowserLocalCanvasController {
   persistence: BrowserLocalPersistenceState
   cleanupCompleted: boolean
   cleanupError: string | null
-  updateScene(elements: unknown[]): void
   renameCanvas(name: string): void
   triggerCleanup(): Promise<void>
   startFresh(): Promise<void>
 }
-
-const DEBOUNCE_MS = 1000
 
 export function useBrowserLocalCanvasController(
   store: BrowserLocalStore,
@@ -42,16 +39,11 @@ export function useBrowserLocalCanvasController(
   const snapshotRef = useRef(snapshot)
   snapshotRef.current = snapshot
   const pendingSnapshotRef = useRef<CanvasSnapshot | null>(null)
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Returns true if there was nothing to flush or the flush succeeded.
   // Returns false if a pending save failed — callers that depend on data
   // integrity (e.g. triggerCleanup) must abort when this returns false.
   const flushSave = useCallback(async (): Promise<boolean> => {
-    if (saveTimerRef.current !== null) {
-      clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = null
-    }
     const snap = pendingSnapshotRef.current
     if (snap === null) return true
     pendingSnapshotRef.current = null
@@ -84,7 +76,6 @@ export function useBrowserLocalCanvasController(
         const newSnapshot: CanvasSnapshot = {
           id,
           name: 'untitled',
-          scene: { elements: [] },
           updatedAt: new Date().toISOString(),
         }
         await storeRef.current.setDefaultCanvasId(id)
@@ -124,33 +115,12 @@ export function useBrowserLocalCanvasController(
     }
   }, []) // store identity is stable; storeRef tracks current value
 
-  const updateScene = useCallback(
-    (elements: unknown[]) => {
-      setSnapshot((prev) => {
-        if (prev === null) return prev
-        const updated: CanvasSnapshot = {
-          ...prev,
-          scene: { elements },
-          updatedAt: new Date().toISOString(),
-        }
-        pendingSnapshotRef.current = updated
-        return updated
-      })
-      setPersistenceRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt ?? null }))
-      if (saveTimerRef.current !== null) clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = setTimeout(() => {
-        void flushSave()
-      }, DEBOUNCE_MS)
-    },
-    [flushSave],
-  )
-
-  // Discrete edit — flush immediately instead of the scene debounce so a rename
+  // Discrete edit — flush immediately (no debounce) so a rename
   // never lingers as "Unsaved changes" and survives a fast reload.
   const renameCanvas = useCallback(
     (name: string) => {
-      // Merge with the freshest pending snapshot (e.g. a concurrent updateScene)
-      // instead of committed state, so neither edit clobbers the other. Computed
+      // Merge with the freshest pending snapshot instead of committed state, so
+      // a concurrent edit in flight is never clobbered. Computed
       // from refs (not a setState updater) so pendingSnapshotRef is guaranteed
       // current before the immediate flushSave below reads it.
       const base = pendingSnapshotRef.current ?? snapshotRef.current
@@ -206,7 +176,6 @@ export function useBrowserLocalCanvasController(
     const fresh: CanvasSnapshot = {
       id,
       name: 'untitled',
-      scene: { elements: [] },
       updatedAt: new Date().toISOString(),
     }
     try {
@@ -249,18 +218,11 @@ export function useBrowserLocalCanvasController(
     setCleanupCompleted(false)
   }, [])
 
-  useEffect(() => {
-    return () => {
-      if (saveTimerRef.current !== null) clearTimeout(saveTimerRef.current)
-    }
-  }, [])
-
   return {
     snapshot,
     persistence,
     cleanupCompleted,
     cleanupError,
-    updateScene,
     renameCanvas,
     triggerCleanup,
     startFresh,

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -18,6 +18,10 @@ export interface BrowserLocalCanvasController {
   startFresh(): Promise<void>
 }
 
+function createUntitledSnapshot(id: string): CanvasSnapshot {
+  return { id, name: 'untitled', updatedAt: new Date().toISOString() }
+}
+
 export function useBrowserLocalCanvasController(
   store: BrowserLocalStore,
 ): BrowserLocalCanvasController {
@@ -73,11 +77,7 @@ export function useBrowserLocalCanvasController(
 
       if (id === null) {
         id = storeRef.current.generateId()
-        const newSnapshot: CanvasSnapshot = {
-          id,
-          name: 'untitled',
-          updatedAt: new Date().toISOString(),
-        }
+        const newSnapshot = createUntitledSnapshot(id)
         await storeRef.current.setDefaultCanvasId(id)
         await storeRef.current.save(newSnapshot)
         if (!cancelled) setSnapshot(newSnapshot)
@@ -173,11 +173,7 @@ export function useBrowserLocalCanvasController(
   const startFresh = useCallback(async () => {
     setCleanupError(null)
     const id = storeRef.current.generateId()
-    const fresh: CanvasSnapshot = {
-      id,
-      name: 'untitled',
-      updatedAt: new Date().toISOString(),
-    }
+    const fresh = createUntitledSnapshot(id)
     try {
       // Save the new canvas BEFORE repointing the default id, so a failed write never
       // leaves the pointer aimed at an unsaved canvas (which would reload as degraded).


### PR DESCRIPTION
Wave 1 slice S-Data of the apps/web completion plan. Removes the element double-write between the JSON `canvases` row and the Loro doc: elements are now canonical **only** in `loroCanvases`, and the JSON row is demoted to metadata.

## Change

- `canvasSnapshotSchema` / `CanvasSnapshot` narrowed to metadata-only `{ id, name, updatedAt }` — `scene` dropped. `CanvasSnapshot` is now `z.infer<typeof canvasSnapshotSchema>` so the previously hand-written parallel interface can't drift.
- Extracted the duplicated IDB opener + `DB_VERSION` + `onupgradeneeded` into one shared `apps/web/src/lib/browser-idb.ts`, consumed by both `browser-local-store` and `loro-store`. This makes "bump both together" **structural** (one `DB_VERSION`) instead of a hand-synced comment — a single opener can't drift into a VersionError.
- `DB_VERSION` 2→3 with a v2→v3 migration that strips the legacy `scene` field from existing `canvases` rows; `loroCanvases` (the element source of truth) is untouched.
- Removed the dead `controller.updateScene` JSON-element write path (the page never called it; elements flow through Loro via useCanvasSync). The pending→saving→saved persistence machine + metadata save path are intact.
- Reconciled `buildMigrationBundle` (S-K'): since the snapshot no longer carries `scene`, it now takes `{ snapshot, elements }` pairs where the caller supplies elements from Loro — the bundle contract shape (`scene:{elements}`) is unchanged.

## Verification

- apps/web jsdom 206 + web-browser 46 + typecheck all pass. The web-browser suite includes a **real-IndexedDB v2→v3 migration test** (seed a v2 fixture with `scene` on the JSON row + a populated loro envelope → open at v3 → no VersionError, scene stripped, loroCanvases canonical, no orphan rows) and the existing draw→reload element-persistence + loro-store-is-source-of-truth guards.
- **mutation-checked**: reverting `DB_VERSION` 3→2 fails the migration test.
- Manual (wrangler pages dev): confirmed the persisted `canvases` row is metadata-only (`id,name,updatedAt`, no `scene`) and the DB opens at version 3. (Element round-trip is proven by the deterministic browser regression tests rather than a headless pointer draw.)

Review: 0 CRITICAL/HIGH/QA-fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas data now uses a simpler snapshot format, with canvas contents handled separately for more reliable saves and exports.
  * Editing changes are saved immediately for actions like renaming, reducing delays before updates persist.

* **Bug Fixes**
  * Improved browser database upgrades so older saved data is migrated safely without showing legacy content.
  * Fixed several IndexedDB edge cases to better detect missing, corrupted, or outdated local data.
  * Prevented cleanup flows from accidentally restoring removed canvas data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->