### PR TITLE
feat(web): id-addressed multi-canvas foundation for browser-local storage

### DIFF
--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, beforeEach } from 'vitest'
 import { IDBFactory } from 'fake-indexeddb'
-import { MemoryStore, IndexedDBStore } from './browser-local-store.js'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { IndexedDBStore, MemoryStore } from './browser-local-store.js'
 import type { CanvasSnapshot } from './whiteboard-client.js'
 
 const snap: CanvasSnapshot = {
@@ -87,6 +87,22 @@ describe('MemoryStore', () => {
     expect(a.length).toBeGreaterThan(0)
     expect(a).not.toBe(b)
   })
+
+  it('listCanvases returns empty array when store is empty', async () => {
+    const store = new MemoryStore()
+    expect(await store.listCanvases()).toEqual([])
+  })
+
+  it('listCanvases returns all saved snapshots by id', async () => {
+    const store = new MemoryStore()
+    const a: CanvasSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
+    const b: CanvasSnapshot = { ...snap, id: 'c2', name: 'Canvas B' }
+    await store.save(a)
+    await store.save(b)
+    const list = await store.listCanvases()
+    expect(list).toHaveLength(2)
+    expect(list).toEqual(expect.arrayContaining([a, b]))
+  })
 })
 
 describe('IndexedDBStore', () => {
@@ -161,5 +177,44 @@ describe('IndexedDBStore', () => {
   it('del when no default id returns not-found', async () => {
     const store = new IndexedDBStore()
     expect(await store.del('c1')).toEqual({ deleted: false, reason: 'not-found' })
+  })
+
+  it('listCanvases returns empty array when store is empty', async () => {
+    const store = new IndexedDBStore()
+    expect(await store.listCanvases()).toEqual([])
+  })
+
+  it('listCanvases returns all saved snapshots by id', async () => {
+    const store = new IndexedDBStore()
+    const a: CanvasSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
+    const b: CanvasSnapshot = { ...snap, id: 'c2', name: 'Canvas B' }
+    await store.save(a)
+    await store.save(b)
+    const list = await store.listCanvases()
+    expect(list).toHaveLength(2)
+    expect(list).toEqual(expect.arrayContaining([a, b]))
+  })
+
+  it('listCanvases skips a corrupt row instead of throwing or blanking the list', async () => {
+    const store = new IndexedDBStore()
+    const a: CanvasSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
+    await store.save(a)
+    // Write a malformed row directly via raw IDB (bypasses canvasSnapshotSchema).
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('whiteboard', 3)
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('canvases', 'readwrite')
+        tx.objectStore('canvases').put({ broken: true }, 'corrupt')
+        tx.oncomplete = () => {
+          db.close()
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+    const list = await store.listCanvases()
+    expect(list).toEqual([a])
   })
 })

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -224,6 +224,10 @@ export class IndexedDBStore implements BrowserLocalStore {
         db.close()
         reject(tx.error)
       }
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
+      }
     })
   }
 }

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -1,6 +1,6 @@
 import { openWhiteboardDb } from './browser-idb.js'
-import { canvasSnapshotSchema } from './whiteboard-client.js'
 import type { CanvasSnapshot } from './whiteboard-client.js'
+import { canvasSnapshotSchema } from './whiteboard-client.js'
 
 export type LoadResult =
   | { kind: 'ok'; snapshot: CanvasSnapshot }
@@ -22,6 +22,7 @@ export interface BrowserLocalStore {
   // (it only removes the canvas the default pointer currently aims at).
   removeCanvas?(id: string): Promise<void>
   generateId(): string
+  listCanvases(): Promise<CanvasSnapshot[]>
 }
 
 export class MemoryStore implements BrowserLocalStore {
@@ -60,6 +61,10 @@ export class MemoryStore implements BrowserLocalStore {
 
   generateId(): string {
     return crypto.randomUUID()
+  }
+
+  async listCanvases(): Promise<CanvasSnapshot[]> {
+    return [...this.canvases.values()]
   }
 }
 
@@ -193,5 +198,32 @@ export class IndexedDBStore implements BrowserLocalStore {
 
   generateId(): string {
     return crypto.randomUUID()
+  }
+
+  async listCanvases(): Promise<CanvasSnapshot[]> {
+    const db = await openWhiteboardDb()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('canvases', 'readonly')
+      const cursorReq = tx.objectStore('canvases').openCursor()
+      const results: CanvasSnapshot[] = []
+      cursorReq.onsuccess = () => {
+        const cursor = cursorReq.result
+        if (!cursor) return
+        // Hydrate through the single parse boundary; skip a corrupt/legacy row
+        // instead of throwing so it cannot blank the whole list.
+        const parsed = canvasSnapshotSchema.safeParse(cursor.value)
+        if (parsed.success) results.push(parsed.data)
+        cursor.continue()
+      }
+      cursorReq.onerror = () => reject(cursorReq.error)
+      tx.oncomplete = () => {
+        db.close()
+        resolve(results)
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    })
   }
 }

--- a/apps/web/src/lib/loro-store.browser.test.tsx
+++ b/apps/web/src/lib/loro-store.browser.test.tsx
@@ -69,6 +69,22 @@ describe('LoroStore (real IndexedDB)', () => {
     expect(result).toEqual({ kind: 'not-found' })
   })
 
+  it('createEmptySnapshot returns bytes that import into a fresh Loro doc without throwing', () => {
+    const store = new LoroStore()
+    const bytes = store.createEmptySnapshot()
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    const doc = new Loro()
+    expect(() => doc.import(bytes)).not.toThrow()
+    expect(doc.getList('elements').length).toBe(0)
+  })
+
+  it('createEmptySnapshot bytes round-trip through save/load', async () => {
+    const store = new LoroStore()
+    await store.save('empty-canvas', store.createEmptySnapshot())
+    const result = await store.load('empty-canvas')
+    expect(result.kind).toBe('ok')
+  })
+
   it('save then load returns ok with the snapshot bytes', async () => {
     const store = new LoroStore()
     const snapshot = makeSnapshot([{ id: 'a', type: 'rect' }])

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -55,6 +55,16 @@ function isValidLoroBytes(bytes: Uint8Array): boolean {
  * rather than surfacing as throws inside the hook's onSnapshot/onRemoteUpdate.
  */
 export class LoroStore {
+  /**
+   * Bytes for a brand-new, empty Loro document snapshot. Callers that only
+   * need to seed a fresh canvas (e.g. the page-layer create-canvas flow) use
+   * this instead of importing `loro-crdt` themselves, keeping CRDT-library
+   * knowledge (the `{ mode: 'snapshot' }` export API) confined to this file.
+   */
+  createEmptySnapshot(): Uint8Array {
+    return new Loro().export({ mode: 'snapshot' })
+  }
+
   async load(canvasId: string): Promise<LoroLoadResult> {
     const db = await openWhiteboardDb()
     return new Promise((resolve) => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, act, cleanup, fireEvent } from '@testing-library/react'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import { MemoryStore } from '../lib/browser-local-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 
 // Excalidraw requires a real browser (roughjs native bindings). Mock it in jsdom.
 vi.mock('@excalidraw/excalidraw', () => ({
@@ -87,6 +87,7 @@ describe('BrowserLocalCanvasPage', () => {
       save: base.save.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
     }
     await act(async () => {
       render(<BrowserLocalCanvasPage store={failingStore} />)
@@ -107,6 +108,7 @@ describe('BrowserLocalCanvasPage', () => {
       save: base.save.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
     }
     await act(async () => {
       render(<BrowserLocalCanvasPage store={failingStore} />)
@@ -131,6 +133,7 @@ describe('BrowserLocalCanvasPage', () => {
       },
       del: base.del.bind(base),
       generateId: () => 'fresh-id',
+      listCanvases: async () => [],
     }
     await act(async () => {
       render(<BrowserLocalCanvasPage store={failingFreshStore} />)
@@ -187,6 +190,7 @@ describe('BrowserLocalCanvasPage', () => {
       },
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
     }
     await act(async () => {
       render(<BrowserLocalCanvasPage store={failingSaveStore} />)

--- a/apps/web/src/pages/use-browser-local-canvas-controller.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.multi-canvas.browser.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * S-C1 multi-canvas foundation (real IndexedDB): listCanvases / createCanvas /
+ * switchCanvas against the real IndexedDBStore + LoroStore, proving id-addressed
+ * isolation between canvases rather than relying on the fake-indexeddb node tests.
+ */
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { LoroStore } from '../lib/loro-store.js'
+import { useBrowserLocalCanvasController } from './use-browser-local-canvas-controller.js'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+function snapshotWithElements(elements: unknown[]): Uint8Array {
+  const doc = new Loro()
+  const list = doc.getList('elements')
+  for (const el of elements) list.push(el)
+  return doc.export({ mode: 'snapshot' })
+}
+
+describe('multi-canvas foundation (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+  })
+
+  afterEach(async () => {
+    cleanup()
+    await clearDb()
+  })
+
+  it('createCanvas twice persists both, and listCanvases returns both by their real id', async () => {
+    const store = new IndexedDBStore()
+    const loro = new LoroStore()
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+    await act(async () => {})
+
+    let idA = ''
+    let idB = ''
+    await act(async () => {
+      idA = (await result.current.createCanvas('Canvas A')).id
+    })
+    await act(async () => {
+      idB = (await result.current.createCanvas('Canvas B')).id
+    })
+
+    const list = await result.current.listCanvases()
+    const ids = list.map((c) => c.id)
+    expect(ids).toContain(idA)
+    expect(ids).toContain(idB)
+    expect(list.find((c) => c.id === idA)?.name).toBe('Canvas A')
+    expect(list.find((c) => c.id === idB)?.name).toBe('Canvas B')
+
+    // createCanvas seeds an empty Loro doc so a switch onto a never-edited
+    // canvas delivers a valid empty doc rather than not-found.
+    expect((await loro.load(idA)).kind).toBe('ok')
+    expect((await loro.load(idB)).kind).toBe('ok')
+  })
+
+  it('two canvases hold independent elements in loroCanvases — writing to one never leaks into the other', async () => {
+    const store = new IndexedDBStore()
+    const loro = new LoroStore()
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+    await act(async () => {})
+
+    let idA = ''
+    let idB = ''
+    await act(async () => {
+      idA = (await result.current.createCanvas('Canvas A')).id
+    })
+    await act(async () => {
+      idB = (await result.current.createCanvas('Canvas B')).id
+    })
+
+    await loro.save(idA, snapshotWithElements([{ id: 'rect-a', type: 'rectangle' }]))
+    await loro.save(idB, snapshotWithElements([{ id: 'rect-b', type: 'rectangle' }]))
+
+    const loadedA = await loro.load(idA)
+    const loadedB = await loro.load(idB)
+    expect(loadedA.kind).toBe('ok')
+    expect(loadedB.kind).toBe('ok')
+    if (loadedA.kind === 'ok' && loadedB.kind === 'ok') {
+      const docA = new Loro()
+      docA.import(loadedA.snapshot)
+      const docB = new Loro()
+      docB.import(loadedB.snapshot)
+      expect(docA.getList('elements').toJSON()).toEqual([{ id: 'rect-a', type: 'rectangle' }])
+      expect(docB.getList('elements').toJSON()).toEqual([{ id: 'rect-b', type: 'rectangle' }])
+    }
+  })
+
+  it('switchCanvas swaps the current snapshot and the persisted default pointer, A -> B -> A', async () => {
+    const store = new IndexedDBStore()
+    const loro = new LoroStore()
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+    await waitFor(() => expect(result.current.snapshot).not.toBeNull())
+    const idA = result.current.snapshot!.id
+
+    let idB = ''
+    await act(async () => {
+      idB = (await result.current.createCanvas('Canvas B')).id
+    })
+
+    await act(async () => {
+      await result.current.switchCanvas(idB)
+    })
+    expect(result.current.snapshot?.id).toBe(idB)
+    expect(await store.getDefaultCanvasId()).toBe(idB)
+
+    await act(async () => {
+      await result.current.switchCanvas(idA)
+    })
+    expect(result.current.snapshot?.id).toBe(idA)
+    expect(await store.getDefaultCanvasId()).toBe(idA)
+  })
+})

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -16,6 +16,12 @@ class FakeLoroStore implements LoroStoreLike {
     if (this.shouldThrow) throw new Error('loro save failed')
     this.saved.push({ id, bytes })
   }
+
+  createEmptySnapshot(): Uint8Array {
+    // Fake in-memory bytes — the fake never touches real loro-crdt, matching
+    // the isolation LoroStoreLike is meant to provide to this test file.
+    return new Uint8Array([1, 2, 3])
+  }
 }
 
 const snap: CanvasSnapshot = {

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -557,7 +557,7 @@ describe('useBrowserLocalCanvasController', () => {
       })
     })
 
-    it('switchCanvas to an unknown id is a safe no-op', async () => {
+    it('switchCanvas to an unknown id degrades persistence with feedback and leaves current snapshot untouched', async () => {
       const store = new MemoryStore()
       await store.setDefaultCanvasId('c1')
       await store.save(snap)
@@ -570,8 +570,38 @@ describe('useBrowserLocalCanvasController', () => {
         await result.current.switchCanvas('does-not-exist')
       })
 
+      // A missing/corrupted target record must surface the same way a failed
+      // load does — silently doing nothing leaves the user with no explanation.
+      expect(result.current.persistence.kind).toBe('degraded')
       expect(result.current.snapshot).toEqual(before)
       expect(await store.getDefaultCanvasId()).toBe('c1')
+    })
+
+    it('switchCanvas clears a stale degraded banner from the previous canvas on a successful switch', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      // Leave a stale degraded banner behind, as a prior failed switch would.
+      await act(async () => {
+        await result.current.switchCanvas('does-not-exist')
+      })
+      expect(result.current.persistence.kind).toBe('degraded')
+
+      await act(async () => {
+        await result.current.switchCanvas(created!.id)
+      })
+
+      expect(result.current.persistence.kind).toBe('saved')
+      expect(result.current.snapshot?.id).toBe(created!.id)
     })
 
     it('switchCanvas degrades persistence instead of rejecting when load() throws', async () => {

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -1,9 +1,22 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { useBrowserLocalCanvasController } from './use-browser-local-canvas-controller.js'
+import { MemoryStore } from '../lib/browser-local-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+import {
+  type LoroStoreLike,
+  useBrowserLocalCanvasController,
+} from './use-browser-local-canvas-controller.js'
+
+class FakeLoroStore implements LoroStoreLike {
+  saved: Array<{ id: string; bytes: Uint8Array }> = []
+  shouldThrow = false
+
+  async save(id: string, bytes: Uint8Array): Promise<void> {
+    if (this.shouldThrow) throw new Error('loro save failed')
+    this.saved.push({ id, bytes })
+  }
+}
 
 const snap: CanvasSnapshot = {
   id: 'c1',
@@ -83,6 +96,7 @@ describe('useBrowserLocalCanvasController', () => {
       load: base.load.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
       save: async () => {
         throw new Error('IndexedDB: secret-key=abc123 transaction aborted')
       },
@@ -130,6 +144,7 @@ describe('useBrowserLocalCanvasController', () => {
       load: base.load.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
       save: async (s) => {
         if (shouldFailSave) throw new Error('secret-credential-xyz leaked error')
         return base.save(s)
@@ -178,6 +193,7 @@ describe('useBrowserLocalCanvasController', () => {
       load: base.load.bind(base),
       del: base.del.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
       save: async (s) => {
         if (shouldFailSave) throw new Error('disk full')
         return base.save(s)
@@ -211,6 +227,7 @@ describe('useBrowserLocalCanvasController', () => {
       setDefaultCanvasId: base.setDefaultCanvasId.bind(base),
       load: base.load.bind(base),
       generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
       save: base.save.bind(base),
       del: async () => ({ deleted: false, reason: 'pointer-mismatch' }),
     }
@@ -272,6 +289,7 @@ describe('useBrowserLocalCanvasController', () => {
       del: base.del.bind(base),
       removeCanvas: base.removeCanvas.bind(base),
       generateId: () => 'fresh-1',
+      listCanvases: async () => [],
       setDefaultCanvasId: async () => {
         throw new Error('IndexedDB: meta write aborted')
       },
@@ -416,5 +434,138 @@ describe('useBrowserLocalCanvasController', () => {
     })
     expect(result.current.snapshot?.updatedAt).not.toBe(snap.updatedAt)
     expect(result.current.persistence.kind).toBe('saved')
+  })
+
+  describe('multi-canvas: listCanvases / createCanvas / switchCanvas', () => {
+    it('listCanvases reflects the auto-created canvas on first mount', async () => {
+      const store = new MemoryStore()
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+      const list = await result.current.listCanvases()
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe(result.current.snapshot?.id)
+    })
+
+    it('createCanvas returns a fresh snapshot, persists metadata, writes an empty Loro doc, and does not change current snapshot', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+      const currentBefore = result.current.snapshot
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      expect(created).toBeDefined()
+      expect(created?.id).not.toBe('c1')
+      expect(created?.name).toBe('Second canvas')
+      expect(result.current.snapshot).toEqual(currentBefore)
+      expect(await store.getDefaultCanvasId()).toBe('c1')
+
+      const persisted = await store.load(created!.id)
+      expect(persisted).toEqual({ kind: 'ok', snapshot: created })
+      expect(loro.saved.some((s) => s.id === created!.id)).toBe(true)
+    })
+
+    it('createCanvas defaults the name to "untitled" when none is given', async () => {
+      const store = new MemoryStore()
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas()
+      })
+      expect(created?.name).toBe('untitled')
+    })
+
+    it('createCanvas rolls back the metadata row when the Loro write fails', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      loro.shouldThrow = true
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let thrown: unknown
+      await act(async () => {
+        try {
+          await result.current.createCanvas('Doomed')
+        } catch (err) {
+          thrown = err
+        }
+      })
+      expect(thrown).toBeDefined()
+
+      const list = await store.listCanvases()
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe('c1')
+    })
+
+    it('listCanvases includes canvases created via createCanvas', async () => {
+      const store = new MemoryStore()
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+      await act(async () => {
+        await result.current.createCanvas('Second canvas')
+      })
+      const list = await result.current.listCanvases()
+      expect(list).toHaveLength(2)
+    })
+
+    it('switchCanvas flushes a pending edit on the current canvas, then sets the target as current and updates the default pointer', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      act(() => {
+        result.current.renameCanvas('Renamed before switch')
+      })
+
+      await act(async () => {
+        await result.current.switchCanvas(created!.id)
+      })
+
+      expect(result.current.snapshot?.id).toBe(created!.id)
+      expect(await store.getDefaultCanvasId()).toBe(created!.id)
+
+      const flushed = await store.load('c1')
+      expect(flushed).toEqual({
+        kind: 'ok',
+        snapshot: { ...snap, name: 'Renamed before switch', updatedAt: expect.any(String) },
+      })
+    })
+
+    it('switchCanvas to an unknown id is a safe no-op', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+      const before = result.current.snapshot
+
+      await act(async () => {
+        await result.current.switchCanvas('does-not-exist')
+      })
+
+      expect(result.current.snapshot).toEqual(before)
+      expect(await store.getDefaultCanvasId()).toBe('c1')
+    })
   })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -567,5 +567,131 @@ describe('useBrowserLocalCanvasController', () => {
       expect(result.current.snapshot).toEqual(before)
       expect(await store.getDefaultCanvasId()).toBe('c1')
     })
+
+    it('switchCanvas degrades persistence instead of rejecting when load() throws', async () => {
+      const base = new MemoryStore()
+      await base.setDefaultCanvasId('c1')
+      await base.save(snap)
+      const throwingStore: BrowserLocalStore = {
+        getDefaultCanvasId: base.getDefaultCanvasId.bind(base),
+        setDefaultCanvasId: base.setDefaultCanvasId.bind(base),
+        save: base.save.bind(base),
+        del: base.del.bind(base),
+        generateId: base.generateId.bind(base),
+        listCanvases: base.listCanvases.bind(base),
+        load: async (id: string) => {
+          if (id === 'boom') throw new Error('IndexedDB: read aborted')
+          return base.load(id)
+        },
+      }
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(throwingStore, loro))
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.switchCanvas('boom')
+      })
+
+      expect(result.current.persistence.kind).toBe('degraded')
+      // Current snapshot and default pointer must stay untouched by the failed switch.
+      expect(result.current.snapshot).toEqual(snap)
+      expect(await throwingStore.getDefaultCanvasId()).toBe('c1')
+    })
+
+    it('switchCanvas degrades persistence instead of rejecting when setDefaultCanvasId() throws', async () => {
+      const base = new MemoryStore()
+      await base.setDefaultCanvasId('c1')
+      await base.save(snap)
+      const throwingStore: BrowserLocalStore = {
+        getDefaultCanvasId: base.getDefaultCanvasId.bind(base),
+        setDefaultCanvasId: async () => {
+          throw new Error('IndexedDB: meta write aborted')
+        },
+        save: base.save.bind(base),
+        del: base.del.bind(base),
+        generateId: base.generateId.bind(base),
+        listCanvases: base.listCanvases.bind(base),
+        load: base.load.bind(base),
+      }
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(throwingStore, loro))
+      await act(async () => {})
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      await act(async () => {
+        await result.current.switchCanvas(created!.id)
+      })
+
+      expect(result.current.persistence.kind).toBe('degraded')
+      expect(result.current.snapshot).toEqual(snap)
+      expect(await base.getDefaultCanvasId()).toBe('c1')
+    })
+
+    it('switchCanvas waits for an in-flight fire-and-forget rename flush before switching, and aborts the switch if that flush fails', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      // Intercept the next save() (the one renameCanvas's fire-and-forget
+      // flushSave triggers) so the test controls exactly when it settles.
+      let rejectFirstSave!: (err: unknown) => void
+      let firstSaveStarted = false
+      const originalSave = store.save.bind(store)
+      let interceptNext = true
+      store.save = (s: CanvasSnapshot) => {
+        if (interceptNext) {
+          interceptNext = false
+          firstSaveStarted = true
+          return new Promise<void>((_resolve, reject) => {
+            rejectFirstSave = reject
+          })
+        }
+        return originalSave(s)
+      }
+
+      // Fire-and-forget flush, exactly like renameCanvas triggers internally.
+      act(() => {
+        result.current.renameCanvas('Renamed before switch')
+      })
+      expect(firstSaveStarted).toBe(true)
+
+      let switchSettled = false
+      const switchPromise = result.current.switchCanvas(created!.id).then(() => {
+        switchSettled = true
+      })
+
+      // Let pending microtasks run without resolving the intercepted save —
+      // switchCanvas must still be waiting on it, not racing past it.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(switchSettled).toBe(false)
+      expect(await store.getDefaultCanvasId()).toBe('c1')
+
+      await act(async () => {
+        rejectFirstSave(new Error('save failed'))
+        await switchPromise
+      })
+
+      expect(switchSettled).toBe(true)
+      expect(result.current.persistence.kind).toBe('degraded')
+      // The failed flush must abort the switch: default pointer stays on the
+      // original canvas instead of silently losing the rename.
+      expect(await store.getDefaultCanvasId()).toBe('c1')
+      expect(result.current.snapshot?.id).toBe('c1')
+    })
   })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -699,5 +699,94 @@ describe('useBrowserLocalCanvasController', () => {
       expect(await store.getDefaultCanvasId()).toBe('c1')
       expect(result.current.snapshot?.id).toBe('c1')
     })
+
+    it('two concurrent flush waiters both observe the second save that starts once the first settles', async () => {
+      // Regression: flushSave used to check pendingSnapshotRef only once right
+      // after awaiting the prior save. If two callers were waiting on that
+      // same prior save, the first to resume could consume pendingSnapshotRef
+      // and kick off a second save while the other observed an already-null
+      // pendingSnapshotRef and returned true before the second save settled.
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let created: CanvasSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createCanvas('Second canvas')
+      })
+
+      // Intercept store.save so the test controls exactly when each of the
+      // two successive saves (first rename, then second rename) settles.
+      const originalSave = store.save.bind(store)
+      let resolveFirstSave!: () => void
+      let resolveSecondSave!: () => void
+      let saveCallCount = 0
+      store.save = (s: CanvasSnapshot) => {
+        saveCallCount += 1
+        if (saveCallCount === 1) {
+          return new Promise<void>((resolve) => {
+            resolveFirstSave = () => {
+              originalSave(s).then(resolve)
+            }
+          })
+        }
+        if (saveCallCount === 2) {
+          return new Promise<void>((resolve) => {
+            resolveSecondSave = () => {
+              originalSave(s).then(resolve)
+            }
+          })
+        }
+        return originalSave(s)
+      }
+
+      // First rename starts save #1 (fire-and-forget, exactly like the real hook).
+      act(() => {
+        result.current.renameCanvas('First rename')
+      })
+      expect(saveCallCount).toBe(1)
+
+      // Second rename queues a new pending snapshot and starts a second
+      // flush waiter that awaits the still-in-flight save #1.
+      act(() => {
+        result.current.renameCanvas('Second rename')
+      })
+
+      // A concurrent switchCanvas call is a third waiter on the same save #1.
+      let switchSettled = false
+      const switchPromise = result.current.switchCanvas(created!.id).then(() => {
+        switchSettled = true
+      })
+
+      // Settle save #1. This lets save #2 (carrying "Second rename") start.
+      await act(async () => {
+        resolveFirstSave()
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(saveCallCount).toBe(2)
+      // switchCanvas must still be waiting — save #2 has not settled yet.
+      expect(switchSettled).toBe(false)
+      expect(await store.getDefaultCanvasId()).toBe('c1')
+
+      // Now let save #2 settle and confirm switchCanvas only proceeds after it does.
+      await act(async () => {
+        resolveSecondSave()
+        await switchPromise
+      })
+      expect(switchSettled).toBe(true)
+      expect(result.current.persistence.kind).toBe('saved')
+      expect(result.current.snapshot?.id).toBe(created!.id)
+      expect(await store.getDefaultCanvasId()).toBe(created!.id)
+      const flushed = await store.load('c1')
+      expect(flushed).toEqual({
+        kind: 'ok',
+        snapshot: { ...snap, name: 'Second rename', updatedAt: expect.any(String) },
+      })
+    })
   })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -1,6 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { Loro } from 'loro-crdt'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { LoroStore } from '../lib/loro-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+
+// Narrow surface used by the controller to seed a new canvas's Loro doc.
+// Injectable so node/jsdom tests can supply an in-memory fake instead of
+// touching real IndexedDB.
+export interface LoroStoreLike {
+  save(canvasId: string, snapshot: Uint8Array): Promise<void>
+}
 
 export type BrowserLocalPersistenceState =
   | { kind: 'saved'; lastSavedAt: null | string }
@@ -16,6 +25,9 @@ export interface BrowserLocalCanvasController {
   renameCanvas(name: string): void
   triggerCleanup(): Promise<void>
   startFresh(): Promise<void>
+  listCanvases(): Promise<CanvasSnapshot[]>
+  createCanvas(name?: string): Promise<CanvasSnapshot>
+  switchCanvas(id: string): Promise<void>
 }
 
 function createUntitledSnapshot(id: string): CanvasSnapshot {
@@ -24,6 +36,7 @@ function createUntitledSnapshot(id: string): CanvasSnapshot {
 
 export function useBrowserLocalCanvasController(
   store: BrowserLocalStore,
+  loro: LoroStoreLike = new LoroStore(),
 ): BrowserLocalCanvasController {
   const [snapshot, setSnapshot] = useState<CanvasSnapshot | null>(null)
   const [persistence, setPersistence] = useState<BrowserLocalPersistenceState>({
@@ -36,6 +49,8 @@ export function useBrowserLocalCanvasController(
   // Stable refs so timer callbacks always see current state without re-creating
   const storeRef = useRef(store)
   storeRef.current = store
+  const loroRef = useRef(loro)
+  loroRef.current = loro
   const setPersistenceRef = useRef(setPersistence)
   setPersistenceRef.current = setPersistence
   const persistenceRef = useRef(persistence)
@@ -214,6 +229,49 @@ export function useBrowserLocalCanvasController(
     setCleanupCompleted(false)
   }, [])
 
+  const listCanvases = useCallback((): Promise<CanvasSnapshot[]> => {
+    return storeRef.current.listCanvases()
+  }, [])
+
+  const createCanvas = useCallback(async (name?: string): Promise<CanvasSnapshot> => {
+    const id = storeRef.current.generateId()
+    const fresh: CanvasSnapshot = {
+      id,
+      name: name?.trim() || 'untitled',
+      updatedAt: new Date().toISOString(),
+    }
+    // Metadata first, then the Loro doc: if the Loro write fails, the
+    // metadata row is rolled back so a failed create never leaves an
+    // orphan metadata row with no backing Loro doc.
+    await storeRef.current.save(fresh)
+    try {
+      await loroRef.current.save(id, new Loro().export({ mode: 'snapshot' }))
+    } catch (err) {
+      try {
+        await storeRef.current.removeCanvas?.(id)
+      } catch {
+        // Orphan cleanup is best-effort; leaving a stray metadata row is harmless.
+      }
+      throw err
+    }
+    return fresh
+  }, [])
+
+  const switchCanvas = useCallback(
+    async (id: string): Promise<void> => {
+      // Flush any pending edit on the current canvas before switching away
+      // from it, so a fast switch never drops an in-flight rename.
+      const flushed = await flushSave()
+      if (!flushed) return
+      const result = await storeRef.current.load(id)
+      if (result.kind !== 'ok') return // unknown id: safe no-op, current snapshot untouched
+      await storeRef.current.setDefaultCanvasId(id)
+      snapshotRef.current = result.snapshot
+      setSnapshot(result.snapshot)
+    },
+    [flushSave],
+  )
+
   return {
     snapshot,
     persistence,
@@ -222,5 +280,8 @@ export function useBrowserLocalCanvasController(
     renameCanvas,
     triggerCleanup,
     startFresh,
+    listCanvases,
+    createCanvas,
+    switchCanvas,
   }
 }

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -58,29 +58,44 @@ export function useBrowserLocalCanvasController(
   const snapshotRef = useRef(snapshot)
   snapshotRef.current = snapshot
   const pendingSnapshotRef = useRef<CanvasSnapshot | null>(null)
+  // Tracks the currently in-flight flush so overlapping callers (renameCanvas's
+  // fire-and-forget flush racing with switchCanvas's own awaited flush) serialize
+  // on the real outcome instead of the second caller observing an already-cleared
+  // pendingSnapshotRef and returning true before the first save actually settles.
+  const savePromiseRef = useRef<Promise<boolean> | null>(null)
 
   // Returns true if there was nothing to flush or the flush succeeded.
   // Returns false if a pending save failed — callers that depend on data
-  // integrity (e.g. triggerCleanup) must abort when this returns false.
+  // integrity (e.g. triggerCleanup, switchCanvas) must abort when this returns false.
   const flushSave = useCallback(async (): Promise<boolean> => {
+    if (savePromiseRef.current !== null) {
+      const priorOk = await savePromiseRef.current
+      if (!priorOk) return false
+    }
     const snap = pendingSnapshotRef.current
     if (snap === null) return true
     pendingSnapshotRef.current = null
     setPersistenceRef.current((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt ?? null }))
-    try {
-      await storeRef.current.save(snap)
-      setPersistenceRef.current({ kind: 'saved', lastSavedAt: new Date().toISOString() })
-      return true
-    } catch {
-      // Generic safe copy — do not expose raw IndexedDB error
-      setPersistenceRef.current((p) => ({
-        kind: 'degraded',
-        reason: 'save-failed',
-        message: 'Changes could not be saved.',
-        lastSavedAt: p.lastSavedAt ?? null,
-      }))
-      return false
-    }
+    const promise = (async (): Promise<boolean> => {
+      try {
+        await storeRef.current.save(snap)
+        setPersistenceRef.current({ kind: 'saved', lastSavedAt: new Date().toISOString() })
+        return true
+      } catch {
+        // Generic safe copy — do not expose raw IndexedDB error
+        setPersistenceRef.current((p) => ({
+          kind: 'degraded',
+          reason: 'save-failed',
+          message: 'Changes could not be saved.',
+          lastSavedAt: p.lastSavedAt ?? null,
+        }))
+        return false
+      } finally {
+        savePromiseRef.current = null
+      }
+    })()
+    savePromiseRef.current = promise
+    return promise
   }, [])
 
   useEffect(() => {
@@ -259,11 +274,23 @@ export function useBrowserLocalCanvasController(
       // from it, so a fast switch never drops an in-flight rename.
       const flushed = await flushSave()
       if (!flushed) return
-      const result = await storeRef.current.load(id)
-      if (result.kind !== 'ok') return // unknown id: safe no-op, current snapshot untouched
-      await storeRef.current.setDefaultCanvasId(id)
-      snapshotRef.current = result.snapshot
-      setSnapshot(result.snapshot)
+      try {
+        const result = await storeRef.current.load(id)
+        if (result.kind !== 'ok') return // unknown id: safe no-op, current snapshot untouched
+        await storeRef.current.setDefaultCanvasId(id)
+        snapshotRef.current = result.snapshot
+        setSnapshot(result.snapshot)
+      } catch {
+        // Generic safe copy — do not expose raw IndexedDB error. Current
+        // snapshot and default pointer are left untouched: a failed switch
+        // must not corrupt the still-current canvas view.
+        setPersistenceRef.current((p) => ({
+          kind: 'degraded',
+          reason: 'switch-failed',
+          message: 'The canvas could not be switched.',
+          lastSavedAt: p.lastSavedAt ?? null,
+        }))
+      }
     },
     [flushSave],
   )

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -290,10 +290,26 @@ export function useBrowserLocalCanvasController(
       if (!flushed) return
       try {
         const result = await storeRef.current.load(id)
-        if (result.kind !== 'ok') return // unknown id: safe no-op, current snapshot untouched
+        if (result.kind !== 'ok') {
+          // Target record is missing or unreadable: surface it the same way the
+          // initial-mount load does, instead of leaving the user with no feedback
+          // for why the switch silently did nothing. Current snapshot and default
+          // pointer are left untouched — the still-current canvas view is not corrupted.
+          setPersistenceRef.current((p) => ({
+            kind: 'degraded',
+            reason: 'switch-failed',
+            message: 'The canvas could not be switched.',
+            lastSavedAt: p.lastSavedAt ?? null,
+          }))
+          return
+        }
         await storeRef.current.setDefaultCanvasId(id)
         snapshotRef.current = result.snapshot
         setSnapshot(result.snapshot)
+        // Clear any stale degraded banner left over from the previous canvas —
+        // a successful switch to a freshly-loaded, in-sync canvas should not keep
+        // showing an error from before the switch.
+        setPersistenceRef.current({ kind: 'saved', lastSavedAt: new Date().toISOString() })
       } catch {
         // Generic safe copy — do not expose raw IndexedDB error. Current
         // snapshot and default pointer are left untouched: a failed switch

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -30,8 +30,8 @@ export interface BrowserLocalCanvasController {
   switchCanvas(id: string): Promise<void>
 }
 
-function createUntitledSnapshot(id: string): CanvasSnapshot {
-  return { id, name: 'untitled', updatedAt: new Date().toISOString() }
+function createCanvasSnapshot(id: string, name?: string): CanvasSnapshot {
+  return { id, name: name?.trim() || 'untitled', updatedAt: new Date().toISOString() }
 }
 
 export function useBrowserLocalCanvasController(
@@ -92,7 +92,7 @@ export function useBrowserLocalCanvasController(
 
       if (id === null) {
         id = storeRef.current.generateId()
-        const newSnapshot = createUntitledSnapshot(id)
+        const newSnapshot = createCanvasSnapshot(id)
         await storeRef.current.setDefaultCanvasId(id)
         await storeRef.current.save(newSnapshot)
         if (!cancelled) setSnapshot(newSnapshot)
@@ -188,7 +188,7 @@ export function useBrowserLocalCanvasController(
   const startFresh = useCallback(async () => {
     setCleanupError(null)
     const id = storeRef.current.generateId()
-    const fresh = createUntitledSnapshot(id)
+    const fresh = createCanvasSnapshot(id)
     try {
       // Save the new canvas BEFORE repointing the default id, so a failed write never
       // leaves the pointer aimed at an unsaved canvas (which would reload as degraded).
@@ -235,11 +235,7 @@ export function useBrowserLocalCanvasController(
 
   const createCanvas = useCallback(async (name?: string): Promise<CanvasSnapshot> => {
     const id = storeRef.current.generateId()
-    const fresh: CanvasSnapshot = {
-      id,
-      name: name?.trim() || 'untitled',
-      updatedAt: new Date().toISOString(),
-    }
+    const fresh = createCanvasSnapshot(id, name)
     // Metadata first, then the Loro doc: if the Loro write fails, the
     // metadata row is rolled back so a failed create never leaves an
     // orphan metadata row with no backing Loro doc.

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -67,35 +67,49 @@ export function useBrowserLocalCanvasController(
   // Returns true if there was nothing to flush or the flush succeeded.
   // Returns false if a pending save failed — callers that depend on data
   // integrity (e.g. triggerCleanup, switchCanvas) must abort when this returns false.
+  //
+  // Loops instead of awaiting the in-flight save once: two concurrent callers
+  // both awaiting the same prior save wake up in the same microtask batch, and
+  // the first to resume can consume pendingSnapshotRef and start the next save
+  // before the second checks it. Looping back after every await re-reads
+  // savePromiseRef/pendingSnapshotRef so the second caller picks up and awaits
+  // that newly-started save instead of returning true while it is still
+  // in flight.
   const flushSave = useCallback(async (): Promise<boolean> => {
-    if (savePromiseRef.current !== null) {
-      const priorOk = await savePromiseRef.current
-      if (!priorOk) return false
-    }
-    const snap = pendingSnapshotRef.current
-    if (snap === null) return true
-    pendingSnapshotRef.current = null
-    setPersistenceRef.current((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt ?? null }))
-    const promise = (async (): Promise<boolean> => {
-      try {
-        await storeRef.current.save(snap)
-        setPersistenceRef.current({ kind: 'saved', lastSavedAt: new Date().toISOString() })
-        return true
-      } catch {
-        // Generic safe copy — do not expose raw IndexedDB error
-        setPersistenceRef.current((p) => ({
-          kind: 'degraded',
-          reason: 'save-failed',
-          message: 'Changes could not be saved.',
-          lastSavedAt: p.lastSavedAt ?? null,
-        }))
-        return false
-      } finally {
-        savePromiseRef.current = null
+    for (;;) {
+      if (savePromiseRef.current !== null) {
+        const priorOk = await savePromiseRef.current
+        if (!priorOk) return false
+        continue
       }
-    })()
-    savePromiseRef.current = promise
-    return promise
+      const snap = pendingSnapshotRef.current
+      if (snap === null) return true
+      pendingSnapshotRef.current = null
+      setPersistenceRef.current((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt ?? null }))
+      const promise = (async (): Promise<boolean> => {
+        try {
+          await storeRef.current.save(snap)
+          setPersistenceRef.current({ kind: 'saved', lastSavedAt: new Date().toISOString() })
+          return true
+        } catch {
+          // Generic safe copy — do not expose raw IndexedDB error
+          setPersistenceRef.current((p) => ({
+            kind: 'degraded',
+            reason: 'save-failed',
+            message: 'Changes could not be saved.',
+            lastSavedAt: p.lastSavedAt ?? null,
+          }))
+          return false
+        } finally {
+          savePromiseRef.current = null
+        }
+      })()
+      savePromiseRef.current = promise
+      const ok = await promise
+      if (!ok) return false
+      // Loop again: another edit may have queued a new pending snapshot
+      // while this save was in flight.
+    }
   }, [])
 
   useEffect(() => {

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -1,4 +1,3 @@
-import { Loro } from 'loro-crdt'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { LoroStore } from '../lib/loro-store.js'
@@ -6,9 +5,10 @@ import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 
 // Narrow surface used by the controller to seed a new canvas's Loro doc.
 // Injectable so node/jsdom tests can supply an in-memory fake instead of
-// touching real IndexedDB.
+// touching real IndexedDB or the loro-crdt library directly.
 export interface LoroStoreLike {
   save(canvasId: string, snapshot: Uint8Array): Promise<void>
+  createEmptySnapshot(): Uint8Array
 }
 
 export type BrowserLocalPersistenceState =
@@ -256,7 +256,7 @@ export function useBrowserLocalCanvasController(
     // orphan metadata row with no backing Loro doc.
     await storeRef.current.save(fresh)
     try {
-      await loroRef.current.save(id, new Loro().export({ mode: 'snapshot' }))
+      await loroRef.current.save(id, loroRef.current.createEmptySnapshot())
     } catch (err) {
       try {
         await storeRef.current.removeCanvas?.(id)


### PR DESCRIPTION
Wave 1 slice S-C1 of the apps/web completion plan. Extends the browser-local persistence layer from a single-default-pointer model to an id-addressed multi-canvas foundation. **API-layer only — no UI** (canvas list / switcher is S-C2).

## Change

- `listCanvases()` / `createCanvas(name?)` / `switchCanvas(id)` added to `BrowserLocalStore` (both MemoryStore + IndexedDBStore) and the controller.
  - `listCanvases` openCursors the `canvases` store and hydrates each row through `canvasSnapshotSchema.safeParse`, skipping corrupt rows (one parse boundary, one bad row can't blank the whole list).
  - `createCanvas` issues a fresh id, writes the metadata row AND seeds an empty Loro doc for that id; on Loro-write failure it rolls back the orphan metadata row (mirrors `startFresh`).
  - `switchCanvas` flushes the current canvas first, then loads the target by id; unknown id is a safe no-op.
- `defaultCanvasId` demoted to a "last-opened" hint; all element/metadata access is by explicit id. **No workspace/slug identity** (YAGNI, per plan).
- **No DB_VERSION bump**: `canvases` / `loroCanvases` are already id-keyed maps, so holding many canvases needs no schema change. S-Data's v3 schema + migration are untouched.

## Verification

- apps/web jsdom 223 + web-browser 52 + typecheck all pass. The web-browser suite adds a real-IndexedDB multi-canvas test proving: createCanvas×2 → listCanvases returns both by real id, and two canvases hold **independent** elements in `loroCanvases` (writing to A never leaks into B). S-Data's v2→v3 migration test still passes unchanged.
- Review: 0 CRITICAL/HIGH/QA-fail; the dev-loop's triage/fix loop already hardened switchCanvas failure/degraded handling and a flush-waiter race.

This is invisible to end users (no UI yet), so test output is the evidence; the switcher UI + live switch flow land in S-C2 (Wave 1 final slice).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing existing canvases, creating new canvases, and switching between canvases.
  * New canvases now start as empty documents and can be saved and reopened reliably.

* **Bug Fixes**
  * Improved handling of damaged or outdated saved canvas data so it’s skipped instead of breaking the canvas list.
  * Made canvas switching more reliable when saves are in progress or storage temporarily fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->