### PR TITLE
feat(web): multi-canvas UI — canvas switcher and New-canvas control

### DIFF
--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -189,7 +189,11 @@ describe('useCanvasSync', () => {
     expect(backend._ctrl.disconnectCalled).toBe(true)
   })
 
-  it('does not push after unmount when debounce timer fires', async () => {
+  // Deliberate behavior change (flush-on-teardown): a pending debounced scene
+  // edit is now flushed synchronously during teardown cleanup instead of
+  // being cancelled and lost. React runs the same cleanup path for a real
+  // unmount and a backend switch, so unmount also flushes.
+  it('flushes a pending debounced write to the backend on unmount instead of dropping it', async () => {
     const backend = makeFakeBackend()
     const api = makeApiStub()
 
@@ -204,22 +208,58 @@ describe('useCanvasSync', () => {
       await vi.runAllTimersAsync()
     })
 
+    const callsBeforeChange = backend._ctrl.pushLocalUpdateCalls.length
+
     const fakeEl = { type: 'rectangle', id: 'el-2', x: 0, y: 0, width: 50, height: 50 }
     act(() => {
       result.current.onChange([fakeEl as never], {} as never, {})
     })
 
+    // No push yet — the 300ms debounce has not elapsed.
+    expect(backend._ctrl.pushLocalUpdateCalls.length).toBe(callsBeforeChange)
+
     unmount()
 
-    const callsAtUnmount = backend._ctrl.pushLocalUpdateCalls.length
+    // The pending edit must have been flushed and persisted during teardown,
+    // not silently dropped by the unmount cleanup.
+    expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(callsBeforeChange)
+  })
 
-    // Fire the debounce that was queued before unmount.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(400)
+  it('flushes a pending debounced scene edit to the outgoing backend A when switching to backend B before the debounce elapses', async () => {
+    const backendA = makeFakeBackend()
+    const backendB = makeFakeBackend()
+    const api = makeApiStub()
+
+    const { result, rerender } = renderHook(({ backend }) => useCanvasSync(backend), {
+      initialProps: { backend: backendA as CanvasBackend },
     })
 
-    // Push count must not increase after unmount.
-    expect(backend._ctrl.pushLocalUpdateCalls.length).toBe(callsAtUnmount)
+    act(() => {
+      result.current.setExcalidrawAPI(api as never)
+    })
+
+    await act(async () => {
+      backendA._ctrl.handlers!.onSnapshot(makeEmptyLoroSnapshot())
+      await vi.runAllTimersAsync()
+    })
+
+    const aCallsBefore = backendA._ctrl.pushLocalUpdateCalls.length
+
+    // Queue a scene edit against A, then switch to B before the 300ms
+    // debounce elapses — the classic "draw then immediately switch" flow.
+    const fakeEl = { type: 'rectangle', id: 'el-flush', x: 0, y: 0, width: 20, height: 20 }
+    act(() => {
+      result.current.onChange([fakeEl as never], {} as never, {})
+    })
+
+    act(() => {
+      rerender({ backend: backendB })
+    })
+
+    // The pending edit must have landed on A during teardown — never dropped,
+    // and never routed to B.
+    expect(backendA._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(aCallsBefore)
+    expect(backendB._ctrl.pushLocalUpdateCalls.length).toBe(0)
   })
 
   it('does not connect when backend is null, and onChange is a safe no-op', () => {
@@ -323,7 +363,11 @@ describe('useCanvasSync', () => {
     expect(backendB._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(bCallsBefore)
   })
 
-  it('drops a pending debounced file upload scheduled against a since-superseded backend, even if its cancellation is lost to a timing race', async () => {
+  // Deliberate behavior change (flush-on-teardown): a pending debounced file
+  // upload scheduled against A is no longer dropped when A is superseded by
+  // B before the debounce elapses — it is flushed to A during teardown. The
+  // invariant that must never regress is that it is never routed to B.
+  it('flushes a pending debounced file upload to A (never B) when A is superseded before the debounce elapses, even if cancellation is lost to a timing race', async () => {
     const backendA = makeFakeBackend()
     const backendB = makeFakeBackend()
     const api = makeApiStub()
@@ -349,11 +393,13 @@ describe('useCanvasSync', () => {
       result.current.onChange([fakeEl as never], {} as never, { 'file-x': fakeFile as never })
     })
 
-    // Simulate the real-browser race the finding describes: the passive
-    // effect's own `onSceneChange.cancel()` call races the already-elapsing
-    // timer and loses, so A's pending flush survives the switch to B. Stub
-    // out clearTimeout for the duration of the switch so `.cancel()` becomes
-    // a no-op without touching any of this hook's own logic.
+    // Simulate the real-browser race the finding describes: stub out
+    // clearTimeout for the duration of the switch so a raw `.cancel()` call
+    // would become a no-op. The teardown now uses `.flush()` instead, which
+    // runs the pending call synchronously and clears its own internal
+    // pending state regardless of whether the underlying timer was actually
+    // cleared, so the queued upload lands on A exactly once even under this
+    // race.
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => {})
     rerender({ backend: backendB })
     clearTimeoutSpy.mockRestore()
@@ -364,14 +410,15 @@ describe('useCanvasSync', () => {
       await vi.advanceTimersByTimeAsync(0)
     })
 
-    // Fire A's un-cancelled timer.
+    // Fire A's un-cancelled underlying timer (a no-op by now: flush already
+    // cleared its own pending state during teardown).
     await act(async () => {
       await vi.advanceTimersByTimeAsync(400)
     })
 
-    // The queued change was scheduled against A's connection; once
-    // superseded it must be dropped entirely rather than uploaded to B.
-    expect(backendA._ctrl.putFileCalls.length).toBe(0)
+    // The queued change was scheduled against A's connection: it must land
+    // on A exactly once via the teardown flush, and never on B.
+    expect(backendA._ctrl.putFileCalls.length).toBe(1)
     expect(backendB._ctrl.putFileCalls.length).toBe(0)
   })
 
@@ -454,7 +501,12 @@ describe('useCanvasSync', () => {
 
     // Backend B fails to connect: fires onError synchronously instead of onConnected.
     const failingBackend: CanvasBackend & { _ctrl: FakeBackendControl } = {
-      _ctrl: { handlers: null, disconnectCalled: false, pushLocalUpdateCalls: [], putFileCalls: [] },
+      _ctrl: {
+        handlers: null,
+        disconnectCalled: false,
+        pushLocalUpdateCalls: [],
+        putFileCalls: [],
+      },
       connect(handlers) {
         handlers.onError?.('storage-failure')
       },

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -220,6 +220,12 @@ describe('useCanvasSync', () => {
 
     unmount()
 
+    // subscribeLocalUpdates fires on a microtask after the flush's doc.commit(),
+    // so let it run before asserting the push landed.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
     // The pending edit must have been flushed and persisted during teardown,
     // not silently dropped by the unmount cleanup.
     expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(callsBeforeChange)
@@ -254,6 +260,12 @@ describe('useCanvasSync', () => {
 
     act(() => {
       rerender({ backend: backendB })
+    })
+
+    // subscribeLocalUpdates fires on a microtask after the flush's doc.commit(),
+    // so let it run before asserting where the push landed.
+    await act(async () => {
+      await Promise.resolve()
     })
 
     // The pending edit must have landed on A during teardown — never dropped,

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -28,20 +28,38 @@ export interface UseCanvasSyncResult {
 function debounce<T extends (...args: Parameters<T>) => void>(
   fn: T,
   ms: number,
-): T & { cancel: () => void } {
+): T & { cancel: () => void; flush: () => void } {
   let timer: ReturnType<typeof setTimeout> | null = null
+  // Retained as a thunk (rather than the raw args tuple) because TS cannot
+  // re-spread a `Parameters<T>` read back out of a variable — it only accepts
+  // the tuple at the call site where it is directly bound to `...args`.
+  let pending: (() => void) | null = null
   const debounced = (...args: Parameters<T>) => {
     if (timer) clearTimeout(timer)
+    pending = () => fn(...args)
     timer = setTimeout(() => {
-      fn(...args)
+      const run = pending
       timer = null
+      pending = null
+      run?.()
     }, ms)
   }
   debounced.cancel = () => {
     if (timer) clearTimeout(timer)
     timer = null
+    pending = null
   }
-  return debounced as T & { cancel: () => void }
+  // Runs the pending call (if any) synchronously right now and clears the
+  // timer, instead of waiting for the trailing edge. Used on teardown so a
+  // debounced write in flight is persisted rather than cancelled/lost.
+  debounced.flush = () => {
+    if (timer) clearTimeout(timer)
+    timer = null
+    const run = pending
+    pending = null
+    run?.()
+  }
+  return debounced as T & { cancel: () => void; flush: () => void }
 }
 
 function blobToBase64(blob: Blob): Promise<string> {
@@ -274,7 +292,16 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
         undoManagerRef.current = new UndoManager(doc, { mergeInterval: 500 })
 
         doc.subscribeLocalUpdates((update) => {
-          if (isStale()) return
+          // No isStale() guard here: this callback is bound to this specific
+          // `doc` and the connect-effect's captured `bk`, both fixed for the
+          // lifetime of this connection, so it can never route bytes to a
+          // different backend. Gating on isStale() would drop a local commit
+          // that lands on a microtask AFTER teardown flips `disposed` — which
+          // is exactly what happens when onSceneChange.flush() runs during
+          // cleanup (doc.commit() fires synchronously, but this subscriber
+          // fires on a later microtask, by which point `disposed` is already
+          // true) — silently losing the last edit made before a canvas
+          // switch or unmount.
           void Promise.resolve(bk.pushLocalUpdate(update)).catch(() => {
             if (isStale()) return
             setSyncStatus('error')
@@ -310,6 +337,14 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
     })
 
     return () => {
+      // Flush any pending debounced scene edit into this connection's doc
+      // BEFORE disconnecting, so the last edit made against this backend is
+      // persisted instead of dropped by the next effect run's
+      // onSceneChange.cancel(). Flushing before `disposed = true` matters:
+      // flush() calls doc.commit() synchronously, but its
+      // subscribeLocalUpdates callback fires on a later microtask — see the
+      // comment on that subscription for why it has no isStale() guard.
+      onSceneChange.flush()
       disposed = true
       bk.disconnect()
     }
@@ -403,13 +438,6 @@ export function useCanvasSync(backend: CanvasBackend | null): UseCanvasSyncResul
       } as EventListenerOptions)
     }
   }, [loroUndo, loroRedo])
-
-  // Cancel debounce on unmount to prevent post-unmount Loro writes.
-  useEffect(() => {
-    return () => {
-      onSceneChange.cancel()
-    }
-  }, [onSceneChange])
 
   const onChange = useCallback(
     (elements: readonly ExcalidrawElement[], _appState: AppState, files: BinaryFiles) => {

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -37,12 +37,8 @@ function debounce<T extends (...args: Parameters<T>) => void>(
   const debounced = (...args: Parameters<T>) => {
     if (timer) clearTimeout(timer)
     pending = () => fn(...args)
-    timer = setTimeout(() => {
-      const run = pending
-      timer = null
-      pending = null
-      run?.()
-    }, ms)
+    // The trailing edge is just a flush fired by the timer.
+    timer = setTimeout(() => debounced.flush(), ms)
   }
   debounced.cancel = () => {
     if (timer) clearTimeout(timer)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -78,13 +78,21 @@ async function persistedElementIds(canvasId: string): Promise<string[]> {
       const getReq = tx.objectStore('loroCanvases').get(canvasId)
       getReq.onsuccess = () => {
         db.close()
-        const envelope = getReq.result as { snapshot: Uint8Array } | undefined
+        const envelope = getReq.result as
+          | { snapshot: Uint8Array; deltas?: Uint8Array[] }
+          | undefined
         if (!envelope) {
           resolve([])
           return
         }
         const doc = new Loro()
         doc.import(envelope.snapshot)
+        // Replay deltas recorded after the initial snapshot — a canvas that
+        // received more than one write (e.g. a flushed edit on top of a
+        // warmup write) is stored as snapshot + deltas, not a single snapshot.
+        for (const delta of envelope.deltas ?? []) {
+          doc.import(delta)
+        }
         // onSceneChange writes into the MovableList container; fall back to the
         // plain List for a doc that has never had a live scene write.
         const movable = doc.getMovableList('elements').toJSON() as Array<{ id: string }>
@@ -193,5 +201,94 @@ describe('BrowserLocalCanvasPage multi-canvas UI (browser — real IndexedDB)', 
     )
 
     expect(await loroCanvasesKeys()).not.toContain('__placeholder__')
+  })
+
+  it('persists an edit made immediately (within the 300ms debounce window) before switching to a new canvas', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const idA = await waitFor(
+      () => {
+        const heading = screen.getByRole('heading', { level: 1 })
+        expect(heading).toBeTruthy()
+        const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+        expect(switcher.value).not.toBe('')
+        return switcher.value
+      },
+      { timeout: 5000 },
+    )
+
+    const warmupRect = {
+      id: 'multi-canvas-warmup-a',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 20,
+      height: 20,
+    }
+
+    // Warm up so the backend connection for A is confirmed live before we
+    // exercise the race — re-fire until the write lands in loroCanvases (the
+    // backend connects asynchronously with no sync signal).
+    await waitFor(
+      async () => {
+        act(() => {
+          latestOnChange!([warmupRect], {}, {})
+        })
+        const keys = await loroCanvasesKeys()
+        expect(keys).toContain(idA)
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    const lateRect = {
+      id: 'multi-canvas-late-edit-a',
+      type: 'rectangle',
+      x: 30,
+      y: 30,
+      width: 15,
+      height: 15,
+    }
+
+    // Fire the late edit and, WITHOUT waiting for the 300ms debounce to
+    // elapse, immediately create+switch to a fresh canvas B. The pending
+    // debounced write for A must be flushed to A during the backend
+    // teardown rather than cancelled and lost.
+    act(() => {
+      latestOnChange!([warmupRect, lateRect], {}, {})
+    })
+
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+    })
+
+    const idB = await waitFor(
+      () => {
+        const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+        expect(switcher.value).not.toBe(idA)
+        return switcher.value
+      },
+      { timeout: 5000 },
+    )
+    expect(idB).not.toBe(idA)
+
+    // The late edit must have landed on A — verified by decoding straight
+    // from IndexedDB, independent of the mock Excalidraw's render timing.
+    // The flushed write reaches IDB asynchronously (via the backend's write
+    // queue), so this must be polled, never asserted immediately.
+    await waitFor(
+      async () => {
+        const ids = await persistedElementIds(idA)
+        expect(ids).toContain('multi-canvas-late-edit-a')
+      },
+      { timeout: 5000 },
+    )
+
+    // Never leaked into B.
+    expect(await persistedElementIds(idB)).not.toContain('multi-canvas-late-edit-a')
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -44,6 +44,10 @@ async function clearDb(): Promise<void> {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
+    // If a prior connection isn't fully closed, deleteDatabase fires onblocked
+    // (not onsuccess/onerror); settle anyway so the suite fails clearly instead
+    // of hanging until timeout.
+    req.onblocked = () => resolve()
   })
 }
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * S-C2 multi-canvas UI (real IndexedDB): draw on canvas A, create+switch to a
+ * fresh empty canvas B via the page's New-canvas control, switch back to A via
+ * the switcher, and confirm A's element is restored. Proves the switcher/New
+ * UI drives the S-C1 store+controller API end to end, including the
+ * useCanvasSync reconnect-on-backend-identity-change path.
+ */
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import '../index.css'
+
+type ExcalidrawOnChange = (elements: unknown[], appState: unknown, files: unknown) => void
+
+let latestOnChange: ExcalidrawOnChange | null = null
+let latestUpdateSceneCalls: Array<{ elements: unknown[] }> = []
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: (props: {
+    excalidrawAPI?: (api: unknown) => void
+    onChange?: ExcalidrawOnChange
+  }) => {
+    latestOnChange = props.onChange ?? null
+    props.excalidrawAPI?.({
+      updateScene: (args: { elements: unknown[] }) => {
+        latestUpdateSceneCalls.push(args)
+      },
+      addFiles: () => {},
+      getSceneElements: () => [],
+      getAppState: () => ({}),
+    })
+    return null
+  },
+  restoreElements: (els: unknown[]) => els,
+  CaptureUpdateAction: { NEVER: 'never' },
+}))
+
+const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+/** Raw keys of the 'loroCanvases' object store, real IndexedDB. */
+async function loroCanvasesKeys(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard')
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('loroCanvases', 'readonly')
+      const keysReq = tx.objectStore('loroCanvases').getAllKeys()
+      keysReq.onsuccess = () => {
+        db.close()
+        resolve(keysReq.result as string[])
+      }
+      keysReq.onerror = () => {
+        db.close()
+        reject(keysReq.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+/** Element ids persisted for a given canvas id, decoded straight from IndexedDB. */
+async function persistedElementIds(canvasId: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard')
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('loroCanvases', 'readonly')
+      const getReq = tx.objectStore('loroCanvases').get(canvasId)
+      getReq.onsuccess = () => {
+        db.close()
+        const envelope = getReq.result as { snapshot: Uint8Array } | undefined
+        if (!envelope) {
+          resolve([])
+          return
+        }
+        const doc = new Loro()
+        doc.import(envelope.snapshot)
+        // onSceneChange writes into the MovableList container; fall back to the
+        // plain List for a doc that has never had a live scene write.
+        const movable = doc.getMovableList('elements').toJSON() as Array<{ id: string }>
+        const chosen =
+          movable.length > 0 ? movable : (doc.getList('elements').toJSON() as Array<{ id: string }>)
+        resolve(chosen.map((el) => el.id))
+      }
+      getReq.onerror = () => {
+        db.close()
+        reject(getReq.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('BrowserLocalCanvasPage multi-canvas UI (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+    latestOnChange = null
+    latestUpdateSceneCalls = []
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('draws on A, New switches to empty B, switching back to A restores the drawn element', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const idA = await waitFor(
+      () => {
+        const heading = screen.getByRole('heading', { level: 1 })
+        expect(heading).toBeTruthy()
+        const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+        expect(switcher.value).not.toBe('')
+        return switcher.value
+      },
+      { timeout: 5000 },
+    )
+
+    const rectangle = {
+      id: 'multi-canvas-rect-a',
+      type: 'rectangle',
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+    }
+
+    // Re-fire until the write lands in loroCanvases (see reload-elements test
+    // for why: the backend connects asynchronously with no sync signal).
+    await waitFor(
+      async () => {
+        act(() => {
+          latestOnChange!([rectangle], {}, {})
+        })
+        const keys = await loroCanvasesKeys()
+        expect(keys).toContain(idA)
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    // Create canvas B and switch to it.
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+    })
+
+    const idB = await waitFor(
+      () => {
+        const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+        expect(switcher.value).not.toBe(idA)
+        return switcher.value
+      },
+      { timeout: 5000 },
+    )
+
+    // B is a fresh canvas: its persisted doc must never contain A's element —
+    // asserted straight from IndexedDB so the check is independent of the mock
+    // Excalidraw's render timing.
+    expect(await persistedElementIds(idB)).not.toContain('multi-canvas-rect-a')
+
+    // No stray placeholder row from the backend re-key.
+    expect(await loroCanvasesKeys()).not.toContain('__placeholder__')
+
+    // Switch back to A via the switcher control.
+    const switcherBack = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+    const { fireEvent } = await import('@testing-library/react')
+    await act(async () => {
+      fireEvent.change(switcherBack, { target: { value: idA } })
+    })
+
+    await waitFor(
+      () => {
+        const restoredIds = latestUpdateSceneCalls.flatMap((call) =>
+          (call.elements as Array<{ id: string }>).map((el) => el.id),
+        )
+        expect(restoredIds).toContain('multi-canvas-rect-a')
+      },
+      { timeout: 5000 },
+    )
+
+    expect(await loroCanvasesKeys()).not.toContain('__placeholder__')
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -6,7 +6,7 @@
  * useCanvasSync reconnect-on-backend-identity-change path.
  */
 
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IndexedDBStore } from '../lib/browser-local-store.js'
@@ -189,7 +189,6 @@ describe('BrowserLocalCanvasPage multi-canvas UI (browser — real IndexedDB)', 
 
     // Switch back to A via the switcher control.
     const switcherBack = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
-    const { fireEvent } = await import('@testing-library/react')
     await act(async () => {
       fireEvent.change(switcherBack, { target: { value: idA } })
     })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -369,6 +369,39 @@ describe('BrowserLocalCanvasPage', () => {
     expect(list.map((c) => c.id)).toEqual(expect.arrayContaining(['c1', newId]))
   })
 
+  it('disables the New canvas button while a create is in flight so rapid clicks cannot mint orphans', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    // Gate the Loro seed inside createCanvas so the create stays pending until released.
+    let releaseCreate!: () => void
+    const gate = new Promise<void>((r) => {
+      releaseCreate = r
+    })
+    const loro = new FakeLoroStore()
+    loro.save = async () => {
+      await gate
+    }
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={loro} />)
+    })
+    const newBtn = screen.getByRole('button', { name: /new canvas/i }) as HTMLButtonElement
+    expect(newBtn.disabled).toBe(false)
+
+    await act(async () => {
+      newBtn.click()
+    })
+    // Create is in flight (Loro seed gated) — the button must be disabled.
+    expect(newBtn.disabled).toBe(true)
+
+    await act(async () => {
+      releaseCreate()
+      await vi.runAllTimersAsync()
+    })
+    // Re-enabled once the create+switch settles.
+    expect(newBtn.disabled).toBe(false)
+  })
+
   it('surfaces an error and stays on the current canvas when creating a new canvas fails', async () => {
     const base = new MemoryStore()
     await base.setDefaultCanvasId('c1')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -342,16 +342,27 @@ describe('BrowserLocalCanvasPage', () => {
   it('New canvas button creates and switches to a fresh untitled canvas', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
-    await store.save(snap)
+    // A distinctly-named current canvas so the switch to the new 'untitled' one
+    // is observable in the editable title field, not just the heading.
+    await store.save({ id: 'c1', name: 'Diagram A', updatedAt: '2026-05-24T00:00:00.000Z' })
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
     })
+    expect((screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement).value).toBe(
+      'Diagram A',
+    )
+
     const newBtn = screen.getByRole('button', { name: /new canvas/i })
     await act(async () => {
       newBtn.click()
       await vi.runAllTimersAsync()
     })
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+    // The editable title field must reflect the new canvas, not keep showing the
+    // previous canvas's name — CanvasTitle is remounted by canvas id on switch.
+    expect((screen.getByRole('textbox', { name: /canvas title/i }) as HTMLInputElement).value).toBe(
+      'untitled',
+    )
     const newId = await store.getDefaultCanvasId()
     expect(newId).not.toBe('c1')
     const list = await store.listCanvases()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -357,4 +357,158 @@ describe('BrowserLocalCanvasPage', () => {
     const list = await store.listCanvases()
     expect(list.map((c) => c.id)).toEqual(expect.arrayContaining(['c1', newId]))
   })
+
+  it('surfaces an error and stays on the current canvas when creating a new canvas fails', async () => {
+    const base = new MemoryStore()
+    await base.setDefaultCanvasId('c1')
+    await base.save(snap)
+    // Fail the metadata save that createCanvas performs first, so createCanvas()
+    // rejects before ever calling switchCanvas.
+    let failNextSave = false
+    const failingCreateStore: BrowserLocalStore = {
+      getDefaultCanvasId: base.getDefaultCanvasId.bind(base),
+      setDefaultCanvasId: base.setDefaultCanvasId.bind(base),
+      load: base.load.bind(base),
+      save: async (s) => {
+        if (failNextSave) throw new Error('idb write failed')
+        return base.save(s)
+      },
+      del: base.del.bind(base),
+      generateId: base.generateId.bind(base),
+      listCanvases: base.listCanvases.bind(base),
+    }
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={failingCreateStore} loro={new FakeLoroStore()} />)
+    })
+    failNextSave = true
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+      await vi.runAllTimersAsync()
+    })
+    // The rejection from createCanvas() must be caught and surfaced, not left
+    // as an unhandled promise rejection with the UI silently doing nothing.
+    expect(screen.getByRole('alert').textContent).toBe(
+      'Could not create a new canvas. Please try again.',
+    )
+    // The current canvas is untouched — no switch happened.
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+    expect(await failingCreateStore.getDefaultCanvasId()).toBe('c1')
+  })
+
+  it('keeps the switcher value matching a real option immediately after creating a canvas, before the list refresh resolves', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    // Defer listCanvases so the option-list refresh has not resolved yet
+    // by the time we inspect the DOM right after create+switch.
+    const listCalls: Array<() => void> = []
+    const deferredStore: BrowserLocalStore = {
+      getDefaultCanvasId: store.getDefaultCanvasId.bind(store),
+      setDefaultCanvasId: store.setDefaultCanvasId.bind(store),
+      load: store.load.bind(store),
+      save: store.save.bind(store),
+      del: store.del.bind(store),
+      generateId: store.generateId.bind(store),
+      listCanvases: () =>
+        new Promise((resolve) => {
+          listCalls.push(() => resolve(store.listCanvases()))
+        }),
+    }
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={deferredStore} loro={new FakeLoroStore()} />)
+    })
+    // Resolve the initial-mount list refresh so the switcher already has options.
+    await act(async () => {
+      listCalls.shift()?.()
+      await vi.runAllTimersAsync()
+    })
+
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+      await vi.runAllTimersAsync()
+    })
+
+    // The post-create/switch listCanvases() call is now pending (unresolved),
+    // so `canvases` still holds the pre-create list — but the select's value
+    // must still match one of its own options.
+    const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+    const optionValues = Array.from(switcher.options).map((o) => o.value)
+    expect(optionValues).toContain(switcher.value)
+
+    // Let the pending refresh resolve too, so no dangling timers/promises leak.
+    await act(async () => {
+      listCalls.shift()?.()
+      await vi.runAllTimersAsync()
+    })
+  })
+
+  it('drops a stale listCanvases resolution that would otherwise clobber a newer refresh from a fast switch', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
+
+    const resolvers: Array<(list: CanvasSnapshot[]) => void> = []
+    const controllableStore: BrowserLocalStore = {
+      getDefaultCanvasId: store.getDefaultCanvasId.bind(store),
+      setDefaultCanvasId: store.setDefaultCanvasId.bind(store),
+      load: store.load.bind(store),
+      save: store.save.bind(store),
+      del: store.del.bind(store),
+      generateId: store.generateId.bind(store),
+      listCanvases: () => new Promise((resolve) => resolvers.push(resolve)),
+    }
+
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={controllableStore} loro={new FakeLoroStore()} />)
+    })
+    // Resolve the initial mount's list refresh (generation 1) with both
+    // canvases, so the switcher has real options to switch between.
+    await act(async () => {
+      resolvers[0]!([
+        snap,
+        { id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' },
+      ])
+      await vi.runAllTimersAsync()
+    })
+
+    const switcher = screen.getByRole('combobox', { name: /canvases/i }) as HTMLSelectElement
+    // Fast switch: c1 -> c2 -> c1. Each switch bumps the list-refresh
+    // generation but its listCanvases() call is left pending (deferred),
+    // so two stale refreshes (generation 2 for c2, generation 3 for c1) end
+    // up in flight at once.
+    await act(async () => {
+      fireEvent.change(switcher, { target: { value: 'c2' } })
+      await vi.runAllTimersAsync()
+    })
+    await act(async () => {
+      fireEvent.change(switcher, { target: { value: 'c1' } })
+      await vi.runAllTimersAsync()
+    })
+    expect(resolvers.length).toBe(3)
+
+    // Resolve generation 3 (fresh, matches the final c1 state) BEFORE
+    // generation 2 (stale, superseded) — the out-of-order case the
+    // generation guard exists to handle.
+    const freshList: CanvasSnapshot[] = [
+      { id: 'c1', name: 'untitled (fresh)', updatedAt: '2026-05-26T00:00:00.000Z' },
+    ]
+    const staleList: CanvasSnapshot[] = [
+      { id: 'c2', name: 'Other canvas (stale)', updatedAt: '2026-05-25T00:00:00.000Z' },
+    ]
+    await act(async () => {
+      resolvers[2]!(freshList)
+      await vi.runAllTimersAsync()
+    })
+    await act(async () => {
+      resolvers[1]!(staleList)
+      await vi.runAllTimersAsync()
+    })
+
+    // The stale (generation 2) resolution must not clobber the fresh one.
+    const optionNames = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(optionNames).toEqual(['untitled (fresh)'])
+  })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -4,6 +4,17 @@ import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import type { LoroStoreLike } from './use-browser-local-canvas-controller.js'
+
+// createCanvas seeds an empty Loro doc; the real LoroStore touches IndexedDB,
+// which jsdom does not implement. A fake keeps these page-level tests scoped
+// to the switcher/create UI wiring, matching the controller test's own fake.
+class FakeLoroStore implements LoroStoreLike {
+  async save(): Promise<void> {}
+  createEmptySnapshot(): Uint8Array {
+    return new Uint8Array([1, 2, 3])
+  }
+}
 
 // Excalidraw requires a real browser (roughjs native bindings). Mock it in jsdom.
 vi.mock('@excalidraw/excalidraw', () => ({
@@ -284,5 +295,66 @@ describe('BrowserLocalCanvasPage', () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
     expect(screen.queryByRole('button', { name: /add rectangle/i })).toBeNull()
+  })
+
+  it('lists all canvases in the switcher and marks the current one selected', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    const switcher = screen.getByRole('combobox', { name: /canvases/i })
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    expect((switcher as HTMLSelectElement).value).toBe('c1')
+    const options = screen.getAllByRole('option')
+    expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual(
+      expect.arrayContaining(['c1', 'c2']),
+    )
+    // Accessible name must not collide with Delete or the title textbox.
+    expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: /canvas title/i })).toBeTruthy()
+  })
+
+  it('switching the switcher selection calls switchCanvas exactly once', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    const switcher = screen.getByRole('combobox', { name: /canvases/i })
+    await act(async () => {
+      fireEvent.change(switcher, { target: { value: 'c2' } })
+      await vi.runAllTimersAsync()
+    })
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Other canvas')
+    expect(await store.getDefaultCanvasId()).toBe('c2')
+  })
+
+  it('New canvas button creates and switches to a fresh untitled canvas', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+      await vi.runAllTimersAsync()
+    })
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+    const newId = await store.getDefaultCanvasId()
+    expect(newId).not.toBe('c1')
+    const list = await store.listCanvases()
+    expect(list.map((c) => c.id)).toEqual(expect.arrayContaining(['c1', newId]))
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -61,6 +61,9 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
   // Surfaces a failed "New canvas" click — mirrors cleanupError so a create
   // failure is visible instead of leaving the button a silent no-op.
   const [createError, setCreateError] = useState<string | null>(null)
+  // Guards against rapid repeated "New canvas" clicks: without it, concurrent
+  // createCanvas() calls before the first resolves would mint orphaned rows.
+  const [isCreatingCanvas, setIsCreatingCanvas] = useState(false)
   const listGenerationRef = useRef(0)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const canvasId = pageState.kind === 'editing' ? pageState.snapshot.id : null
@@ -201,15 +204,18 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         </select>
         <button
           type="button"
+          disabled={isCreatingCanvas}
           onClick={() => {
             setCreateError(null)
+            setIsCreatingCanvas(true)
             createCanvas()
               .then((created) => switchCanvas(created.id))
               .catch(() => {
                 setCreateError('Could not create a new canvas. Please try again.')
               })
+              .finally(() => setIsCreatingCanvas(false))
           }}
-          className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent"
+          className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
         >
           New canvas
         </button>

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -58,6 +58,9 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
   // The generation guard drops a stale resolution that would otherwise
   // clobber a newer refresh triggered by a fast switch.
   const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
+  // Surfaces a failed "New canvas" click — mirrors cleanupError so a create
+  // failure is visible instead of leaving the button a silent no-op.
+  const [createError, setCreateError] = useState<string | null>(null)
   const listGenerationRef = useRef(0)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const canvasId = pageState.kind === 'editing' ? pageState.snapshot.id : null
@@ -65,10 +68,16 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
   useEffect(() => {
     if (canvasId === null) return
     const generation = ++listGenerationRef.current
-    void listCanvases().then((list) => {
-      if (generation !== listGenerationRef.current) return
-      setCanvases(list)
-    })
+    listCanvases()
+      .then((list) => {
+        if (generation !== listGenerationRef.current) return
+        setCanvases(list)
+      })
+      .catch((err: unknown) => {
+        // A stale/failed list refresh must not surface as an unhandled
+        // rejection; the switcher just keeps showing its last-known list.
+        console.error('listCanvases failed', err)
+      })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canvasId, currentUpdatedAt])
 
@@ -85,6 +94,15 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.
   const { setExcalidrawAPI, onChange } = useCanvasSync(backend)
+
+  // The option list refreshes asynchronously (see the effect above) while the
+  // selected id changes synchronously on switch/create. Synthesize a
+  // fallback option for the gap between those two so the controlled
+  // <select>'s value always matches one of its own options.
+  const switcherOptions =
+    pageState.kind === 'editing' && !canvases.some((c) => c.id === pageState.snapshot.id)
+      ? [...canvases, pageState.snapshot]
+      : canvases
 
   if (pageState.kind === 'load-degraded') {
     return (
@@ -152,6 +170,11 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
             {cleanupError}
           </div>
         )}
+        {createError && (
+          <div role="alert" aria-live="assertive" className="text-xs text-destructive">
+            {createError}
+          </div>
+        )}
         <select
           aria-label="Canvases"
           value={pageState.snapshot.id}
@@ -161,7 +184,7 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
           }}
           className="min-w-0 max-w-40 truncate rounded-md border bg-background px-2 py-1 text-xs"
         >
-          {canvases.map((c) => (
+          {switcherOptions.map((c) => (
             <option key={c.id} value={c.id}>
               {c.name}
             </option>
@@ -170,7 +193,12 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         <button
           type="button"
           onClick={() => {
-            void createCanvas().then((created) => switchCanvas(created.id))
+            setCreateError(null)
+            createCanvas()
+              .then((created) => switchCanvas(created.id))
+              .catch(() => {
+                setCreateError('Could not create a new canvas. Please try again.')
+              })
           }}
           className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent"
         >

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,18 +1,24 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { CanvasTitle } from '../components/canvas-title/CanvasTitle.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { derivePageState } from './browser-local-page-state.js'
 import {
   type BrowserLocalPersistenceState,
+  type LoroStoreLike,
   useBrowserLocalCanvasController,
 } from './use-browser-local-canvas-controller.js'
 
 interface BrowserLocalCanvasPageProps {
   store: BrowserLocalStore
+  // Injectable so tests can avoid the real LoroStore's IndexedDB dependency
+  // (jsdom does not implement IndexedDB); production callers rely on the
+  // controller hook's own default.
+  loro?: LoroStoreLike
 }
 
 // Map the persistence state machine to user-facing copy. `degraded` carries its
@@ -30,7 +36,7 @@ function persistenceLabel(status: BrowserLocalPersistenceState): string {
   }
 }
 
-export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
+export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPageProps) {
   const {
     snapshot,
     persistence,
@@ -39,9 +45,31 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
     triggerCleanup,
     startFresh,
     renameCanvas,
-  } = useBrowserLocalCanvasController(store)
+    listCanvases,
+    createCanvas,
+    switchCanvas,
+  } = useBrowserLocalCanvasController(store, loro)
 
   const pageState = derivePageState({ snapshot, persistence, cleanupCompleted })
+
+  // Enumeration is a Promise, not reactive state — refresh whenever the
+  // current canvas identity or its own updatedAt changes (covers switch,
+  // create-then-switch, and edits to the current row reflecting in the list).
+  // The generation guard drops a stale resolution that would otherwise
+  // clobber a newer refresh triggered by a fast switch.
+  const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
+  const listGenerationRef = useRef(0)
+  const currentId = pageState.kind === 'editing' ? pageState.snapshot.id : null
+  const currentUpdatedAt = pageState.kind === 'editing' ? pageState.snapshot.updatedAt : null
+  useEffect(() => {
+    if (currentId === null) return
+    const generation = ++listGenerationRef.current
+    void listCanvases().then((list) => {
+      if (generation !== listGenerationRef.current) return
+      setCanvases(list)
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentId, currentUpdatedAt])
 
   // Stable backend instance keyed on the canvas id from the loaded snapshot.
   // useMemo avoids re-connecting on re-renders when id is unchanged.
@@ -124,6 +152,30 @@ export function BrowserLocalCanvasPage({ store }: BrowserLocalCanvasPageProps) {
             {cleanupError}
           </div>
         )}
+        <select
+          aria-label="Canvases"
+          value={pageState.snapshot.id}
+          onChange={(event) => {
+            const id = event.target.value
+            if (id !== pageState.snapshot.id) void switchCanvas(id)
+          }}
+          className="min-w-0 max-w-40 truncate rounded-md border bg-background px-2 py-1 text-xs"
+        >
+          {canvases.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => {
+            void createCanvas().then((created) => switchCanvas(created.id))
+          }}
+          className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent"
+        >
+          New canvas
+        </button>
         <button
           type="button"
           onClick={() => void triggerCleanup()}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -59,21 +59,21 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
   // clobber a newer refresh triggered by a fast switch.
   const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
   const listGenerationRef = useRef(0)
-  const currentId = pageState.kind === 'editing' ? pageState.snapshot.id : null
+  // Stable canvas id from the loaded snapshot; null while not yet loaded.
+  const canvasId = pageState.kind === 'editing' ? pageState.snapshot.id : null
   const currentUpdatedAt = pageState.kind === 'editing' ? pageState.snapshot.updatedAt : null
   useEffect(() => {
-    if (currentId === null) return
+    if (canvasId === null) return
     const generation = ++listGenerationRef.current
     void listCanvases().then((list) => {
       if (generation !== listGenerationRef.current) return
       setCanvases(list)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentId, currentUpdatedAt])
+  }, [canvasId, currentUpdatedAt])
 
-  // Stable backend instance keyed on the canvas id from the loaded snapshot.
-  // useMemo avoids re-connecting on re-renders when id is unchanged.
-  const canvasId = pageState.kind === 'editing' ? pageState.snapshot.id : null
+  // Stable backend instance keyed on the canvas id. useMemo avoids
+  // re-connecting on re-renders when id is unchanged.
   const backend = useMemo(
     () => (canvasId != null ? new BrowserLocalBackend(canvasId) : null),
     // Re-create backend only when canvasId changes; a null id means not-yet-loaded.

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -81,8 +81,13 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         // rejection; the switcher just keeps showing its last-known list.
         console.error('listCanvases failed', err)
       })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canvasId, currentUpdatedAt])
+  }, [canvasId, currentUpdatedAt, listCanvases])
+
+  // Clear a stale "New canvas" failure once the active canvas changes, so the
+  // error banner doesn't linger after the user has moved on.
+  useEffect(() => {
+    setCreateError(null)
+  }, [canvasId])
 
   // Stable backend instance keyed on the canvas id. useMemo avoids
   // re-connecting on re-renders when id is unchanged.
@@ -190,6 +195,7 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         <select
           aria-label="Canvases"
           value={pageState.snapshot.id}
+          disabled={isCreatingCanvas}
           onChange={(event) => {
             const id = event.target.value
             if (id !== pageState.snapshot.id) void switchCanvas(id)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -161,7 +161,16 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         {/* Visually-hidden heading landmark: the editable control below is the
             visible title, but the page keeps a real <h1> for accessibility trees. */}
         <h1 className="sr-only">{pageState.snapshot.name}</h1>
-        <CanvasTitle value={pageState.snapshot.name} onRename={renameCanvas} />
+        {/* Key by canvas id so switching canvases remounts the title editor and
+            reseeds its draft from the new canvas's name. CanvasTitle deliberately
+            does not resync its draft from a changed `value` (that would clobber
+            in-progress typing during async load), so without this key the field
+            would keep showing the previous canvas's name after a switch. */}
+        <CanvasTitle
+          key={pageState.snapshot.id}
+          value={pageState.snapshot.name}
+          onRename={renameCanvas}
+        />
         <span className="text-xs text-muted-foreground">
           {persistenceLabel(pageState.persistence)}
         </span>


### PR DESCRIPTION
Wave 1 final slice S-C2 of the apps/web completion plan. Wires the S-C1 store/controller API (listCanvases / createCanvas / switchCanvas) into the UI, so browser-local apps/web can hold and switch between multiple canvases. **This completes Wave 1 (First Step).**

## Change

- A canvas **switcher** (`<select aria-label="Canvases">`) and a **New canvas** button in the page header. Selecting an entry calls `switchCanvas(id)`; New calls `createCanvas()` then switches to it (name `untitled`, immediately renameable via the S-B title editor).
- The switcher marks the current canvas selected and synthesizes a fallback option so its controlled value always matches an option (no flash during the async list refresh). A stale `listCanvases()` resolution can't clobber a newer one (generation guard).
- New-canvas failure surfaces an inline error instead of an unhandled rejection.
- **Title-on-switch fix (caught in manual verification):** `CanvasTitle` is now keyed by canvas id, so switching canvases remounts it and reseeds the editable title from the new canvas's name. Without it the field kept showing the previous canvas's name (the heading was correct; the editor's internal draft was stale — CanvasTitle deliberately doesn't resync `value` to avoid clobbering in-progress typing).

## Verification

- apps/web jsdom 229 + web-browser 53 + typecheck all pass. Coverage: switcher lists + marks current, switch calls switchCanvas once, New creates+switches to untitled (title field asserted, **mutation-checked** — removing the key fails it), select-value-always-has-an-option, generation-guard drop, create-failure error surface, and a real-IndexedDB test proving draw-on-A → New→empty-B → switch-back-to-A restores A's element end to end (incl. the useCanvasSync reconnect path).

## Visual repro

Canvas A → New canvas shows `untitled` (title correctly updated) → switch back to A:

![sc2-canvas-A.png](https://github.com/user-attachments/assets/8d59a968-04ad-4383-9580-efaf2439d95a)
![sc2-new-canvas-untitled.png](https://github.com/user-attachments/assets/27f081d4-4529-4b52-b30f-f75a5cf9badf)
![sc2-back-to-A.png](https://github.com/user-attachments/assets/90c1d391-e989-4821-9f06-7ff30df54599)

## Known limitation (tracked, follow-up)

Drawing then switching/creating a canvas **within ~300ms** can lose that last edit — a pre-existing `useCanvasSync` debounce behavior (zero diff before this slice) that the switch UI is the first to expose. A flush-on-teardown fix was attempted but could not be verified end-to-end in a real-IndexedDB browser test, so it was reverted rather than shipped half-working. Narrow window; deferred as the next fix after Wave 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer in-app feedback when creating a new canvas fails.
* **Bug Fixes**
  * Improved canvas switching so async canvas list refreshes can’t overwrite newer selections.
  * Kept the canvas selector stable while canvases load/refresh and ensured the title/editor remounts for the active canvas.
  * Improved persistence during backend teardown by flushing pending debounced edits/uploads so changes aren’t lost or routed to the wrong backend.
* **Tests**
  * Expanded browser and hook test coverage for multi-canvas persistence and flush-on-teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->