### PR TITLE
feat(web): capability-gated daemon-feature teasers in apps/web

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,15 +1,20 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App } from './App.js'
-import type { ProviderState } from './lib/provider.js'
+import type { ProviderState, WhiteboardCapabilities } from './lib/provider.js'
 
 afterEach(cleanup)
 
-// BrowserLocalCanvasPage pulls in Excalidraw/loro-crdt which need a real
-// browser (roughjs native bindings, WASM). Mock it here since this suite
-// only exercises the backend-configuration chip, not the canvas itself.
+// Records the props BrowserLocalCanvasPage receives so tests can assert
+// capabilities actually flow from App down to the page, not just that the
+// page mounts. BrowserLocalCanvasPage pulls in Excalidraw/loro-crdt which
+// need a real browser (roughjs native bindings, WASM), so it stays mocked.
+let receivedCapabilities: WhiteboardCapabilities | undefined
 vi.mock('./pages/BrowserLocalCanvasPage.js', () => ({
-  BrowserLocalCanvasPage: () => <div data-testid="browser-local-canvas-page" />,
+  BrowserLocalCanvasPage: ({ capabilities }: { capabilities?: WhiteboardCapabilities }) => {
+    receivedCapabilities = capabilities
+    return <div data-testid="browser-local-canvas-page" />
+  },
 }))
 
 const BROWSER_LOCAL_STATE: ProviderState = {
@@ -20,6 +25,8 @@ const BROWSER_LOCAL_STATE: ProviderState = {
     migrationImport: false,
     workspaces: false,
     versions: false,
+    branches: false,
+    merge: false,
   },
 }
 
@@ -32,6 +39,8 @@ const LOCAL_DAEMON_STATE: ProviderState = {
     migrationImport: true,
     workspaces: true,
     versions: true,
+    branches: true,
+    merge: true,
   },
 }
 
@@ -55,6 +64,17 @@ describe('App backend configuration chip', () => {
     render(<App providerState={INVALID_CONFIG_STATE} />)
     expect(screen.queryByText('Browser only')).toBeNull()
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
+  })
+})
+
+describe('App capability wiring', () => {
+  beforeEach(() => {
+    receivedCapabilities = undefined
+  })
+
+  it('passes the browser-local capabilities down to BrowserLocalCanvasPage', () => {
+    render(<App providerState={BROWSER_LOCAL_STATE} />)
+    expect(receivedCapabilities).toEqual(BROWSER_LOCAL_STATE.capabilities)
   })
 })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -82,7 +82,7 @@ export function App({ providerState }: AppProps) {
       />
       <BackendConfigChip state={state} />
       <div className="min-h-0 flex-1 overflow-hidden">
-        <BrowserLocalCanvasPage store={_browserLocalStore} />
+        <BrowserLocalCanvasPage store={_browserLocalStore} capabilities={state.capabilities} />
       </div>
     </div>
   )

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
@@ -42,6 +42,20 @@ describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
       .toBeVisible()
   })
 
+  it('keeps aria-describedby resolving to the guidance text while the tooltip is CLOSED', async () => {
+    // Radix TooltipTrigger asChild composes its own aria-describedby onto the
+    // child on open and may not merge a manually-set one. This asserts that in
+    // the closed (default) state the button's aria-describedby still resolves to
+    // an element carrying the guidance text — so screen-reader users get the
+    // description without having to open the tooltip.
+    render(<CapabilityTeaser label="Branches" enabled={false} />)
+    const control = screen.getByRole('button', { name: 'Branches' })
+    const describedBy = control.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    const descEl = document.getElementById(describedBy!.split(' ')[0])
+    expect(descEl?.textContent).toBe('Connect a local daemon (MCP) to enable Branches')
+  })
+
   it('does not render a Radix tooltip trigger once the capability is enabled', async () => {
     render(<CapabilityTeaser label="Merge" enabled={true} />)
     const control = screen.getByRole('button', { name: 'Merge' })

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { CapabilityTeaser } from './CapabilityTeaser.js'
+
+afterEach(cleanup)
+
+describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
+  it('opens the Radix tooltip with the guidance text on real hover', async () => {
+    render(<CapabilityTeaser label="Version history" enabled={false} />)
+    const control = screen.getByRole('button', { name: 'Version history' })
+
+    await userEvent.hover(control)
+    await expect
+      .element(
+        page.getByRole('tooltip', {
+          name: 'Connect a local daemon (MCP) to enable Version history',
+        }),
+      )
+      .toBeVisible()
+
+    await userEvent.unhover(control)
+  })
+
+  it('opens the Radix tooltip on real keyboard focus', async () => {
+    render(
+      <>
+        <button type="button">before</button>
+        <CapabilityTeaser label="Workspaces" enabled={false} />
+      </>,
+    )
+
+    await userEvent.tab() // focuses "before"
+    await userEvent.tab() // focuses the teaser control
+    const control = screen.getByRole('button', { name: 'Workspaces' })
+    expect(control).toHaveFocus()
+
+    await expect
+      .element(
+        page.getByRole('tooltip', { name: 'Connect a local daemon (MCP) to enable Workspaces' }),
+      )
+      .toBeVisible()
+  })
+
+  it('does not render a Radix tooltip trigger once the capability is enabled', async () => {
+    render(<CapabilityTeaser label="Merge" enabled={true} />)
+    const control = screen.getByRole('button', { name: 'Merge' })
+
+    await userEvent.hover(control)
+    expect(screen.queryByText('Connect a local daemon (MCP) to enable Merge')).toBeNull()
+  })
+})

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CapabilityTeaser } from './CapabilityTeaser.js'
+
+afterEach(cleanup)
+
+describe('CapabilityTeaser', () => {
+  it('renders an aria-disabled, focusable control with an accessible description when disabled', () => {
+    render(<CapabilityTeaser label="Version history" enabled={false} />)
+    const control = screen.getByRole('button', { name: 'Version history' })
+    expect(control.getAttribute('aria-disabled')).toBe('true')
+    expect(control.tabIndex).toBe(0)
+    const describedById = control.getAttribute('aria-describedby')
+    expect(describedById).toBeTruthy()
+    const description = document.getElementById(describedById as string)
+    expect(description?.textContent).toBe('Connect a local daemon (MCP) to enable Version history')
+  })
+
+  it('does not use native disabled (which would block focus and hide the tooltip)', () => {
+    render(<CapabilityTeaser label="Workspaces" enabled={false} />)
+    const control = screen.getByRole('button', { name: 'Workspaces' })
+    expect(control.hasAttribute('disabled')).toBe(false)
+  })
+
+  it('is a no-op when clicked while disabled', () => {
+    render(<CapabilityTeaser label="Branches" enabled={false} />)
+    const control = screen.getByRole('button', { name: 'Branches' })
+    control.click()
+    // No throw, no navigation side effect — the control simply does nothing.
+    expect(control.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('mutation-check: drops aria-disabled and the sr-only description once the capability is enabled', () => {
+    render(<CapabilityTeaser label="Merge" enabled={true} />)
+    const control = screen.getByRole('button', { name: 'Merge' })
+    expect(control.getAttribute('aria-disabled')).toBeNull()
+    expect(control.getAttribute('aria-describedby')).toBeNull()
+    expect(screen.queryByText('Connect a local daemon (MCP) to enable Merge')).toBeNull()
+  })
+})

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CapabilityTeaser } from './CapabilityTeaser.js'
 
 afterEach(cleanup)
@@ -28,6 +28,19 @@ describe('CapabilityTeaser', () => {
     control.click()
     // No throw, no navigation side effect — the control simply does nothing.
     expect(control.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('does not bubble its click to a clickable ancestor while disabled', () => {
+    // aria-disabled still dispatches/bubbles click; the control must stop it so
+    // it stays inert even inside a clickable container.
+    const onAncestorClick = vi.fn()
+    render(
+      <div onClick={onAncestorClick}>
+        <CapabilityTeaser label="Merge" enabled={false} />
+      </div>,
+    )
+    screen.getByRole('button', { name: 'Merge' }).click()
+    expect(onAncestorClick).not.toHaveBeenCalled()
   })
 
   it('mutation-check: drops aria-disabled and the sr-only description once the capability is enabled', () => {

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
@@ -1,0 +1,54 @@
+import { useId } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
+
+interface CapabilityTeaserProps {
+  label: string
+  enabled: boolean
+}
+
+// Daemon-only feature affordance shown while the capability is unavailable
+// (browser-local mode). Uses aria-disabled + a no-op handler instead of the
+// native `disabled` attribute: native disabled removes the control from the
+// focus order and suppresses pointer/focus events entirely, which would also
+// hide a Radix tooltip attached to it and make the guidance unreachable by
+// keyboard. The sr-only description is always rendered (not just while a
+// Radix tooltip happens to be open) so assistive tech gets it via
+// aria-describedby regardless of hover/focus timing.
+export function CapabilityTeaser({ label, enabled }: CapabilityTeaserProps) {
+  const descriptionId = useId()
+  const description = `Connect a local daemon (MCP) to enable ${label}`
+
+  const button = (
+    <button
+      type="button"
+      aria-disabled={enabled ? undefined : true}
+      aria-describedby={enabled ? undefined : descriptionId}
+      tabIndex={0}
+      onClick={(event) => {
+        if (!enabled) {
+          event.preventDefault()
+          return
+        }
+        // Daemon-mode wiring for this feature ships in a later slice; treat
+        // as a no-op affordance until then rather than a broken control.
+      }}
+      className="rounded-md border px-3 py-1 text-xs font-medium transition-colors aria-disabled:cursor-not-allowed aria-disabled:opacity-50 hover:aria-disabled:bg-transparent hover:not-aria-disabled:bg-accent"
+    >
+      {label}
+    </button>
+  )
+
+  if (enabled) {
+    return button
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{description}</TooltipContent>
+      <span id={descriptionId} className="sr-only">
+        {description}
+      </span>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
@@ -26,7 +26,11 @@ export function CapabilityTeaser({ label, enabled }: CapabilityTeaserProps) {
       tabIndex={0}
       onClick={(event) => {
         if (!enabled) {
+          // aria-disabled (unlike native `disabled`) still dispatches and bubbles
+          // click events, so stop it here to stay truly inert even inside a
+          // clickable ancestor.
           event.preventDefault()
+          event.stopPropagation()
           return
         }
         // Daemon-mode wiring for this feature ships in a later slice; treat

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -46,6 +46,22 @@ describe('resolveProviderState', () => {
     })
   })
 
+  it('browser-local capabilities: branches and merge are false', () => {
+    const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
+    expect(state).toMatchObject({
+      kind: 'browser-local',
+      capabilities: { branches: false, merge: false },
+    })
+  })
+
+  it('local-daemon capabilities: branches and merge are true', () => {
+    const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
+    expect(state).toMatchObject({
+      kind: 'local-daemon',
+      capabilities: { branches: true, merge: true },
+    })
+  })
+
   it('descriptor JSON contains no token Authorization Bearer secret fields', () => {
     const daemonState = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
     const localState = resolveProviderState(EMPTY_RUNTIME_CONFIG)

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -1,35 +1,52 @@
-import { resolveHostedRuntimeConfig, resolveRuntimeConfig, type RuntimeConfig } from '../runtime-config.js'
+import {
+  resolveHostedRuntimeConfig,
+  resolveRuntimeConfig,
+  type RuntimeConfig,
+} from '../runtime-config.js'
 import { classifyPagesOrigin } from './pages-origin-policy.js'
 
 export type ProviderKind = 'browser-local' | 'local-daemon'
 
+// Static, in-process, per-provider-kind capability map — NOT a cross-process
+// or persisted contract (no negotiation, no wire payload), so this stays a
+// plain type + const map rather than a Zod schema. Deliberate, not an oversight.
 export type WhiteboardCapabilities = {
   readonly canvasReadWrite: boolean
   readonly migrationExport: boolean
   readonly migrationImport: boolean
   readonly workspaces: boolean
   readonly versions: boolean
+  readonly branches: boolean
+  readonly merge: boolean
 }
 
 export type ProviderState =
   | { readonly kind: 'browser-local'; readonly capabilities: WhiteboardCapabilities }
-  | { readonly kind: 'local-daemon'; readonly daemonBaseUrl: string; readonly capabilities: WhiteboardCapabilities }
+  | {
+      readonly kind: 'local-daemon'
+      readonly daemonBaseUrl: string
+      readonly capabilities: WhiteboardCapabilities
+    }
   | { readonly kind: 'invalid-config'; readonly message: string }
 
-const BROWSER_LOCAL_CAPABILITIES: WhiteboardCapabilities = {
+export const BROWSER_LOCAL_CAPABILITIES: WhiteboardCapabilities = {
   canvasReadWrite: true,
   migrationExport: true,
   migrationImport: false,
   workspaces: false,
   versions: false,
+  branches: false,
+  merge: false,
 }
 
-const LOCAL_DAEMON_CAPABILITIES: WhiteboardCapabilities = {
+export const LOCAL_DAEMON_CAPABILITIES: WhiteboardCapabilities = {
   canvasReadWrite: true,
   migrationExport: false,
   migrationImport: true,
   workspaces: true,
   versions: true,
+  branches: true,
+  merge: true,
 }
 
 export function resolveProviderState(config: RuntimeConfig): ProviderState {
@@ -59,7 +76,10 @@ export function resolveProviderStateFromRaw(raw: unknown): ProviderState {
 // Hosted-production variant: rejects non-production publicOrigin values and
 // Cloudflare Pages preview browser origins so that preview deploys cannot
 // silently enter browser-local mode. localhost is allowed for local dev.
-export function resolveHostedProviderStateFromRaw(raw: unknown, browserOrigin?: string): ProviderState {
+export function resolveHostedProviderStateFromRaw(
+  raw: unknown,
+  browserOrigin?: string,
+): ProviderState {
   if (browserOrigin !== undefined && classifyPagesOrigin(browserOrigin) === 'preview') {
     return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
   }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -555,4 +555,76 @@ describe('BrowserLocalCanvasPage', () => {
     const optionNames = screen.getAllByRole('option').map((o) => o.textContent)
     expect(optionNames).toEqual(['untitled (fresh)'])
   })
+
+  describe('daemon-only capability teasers', () => {
+    const TEASER_LABELS = ['Version history', 'Workspaces', 'Branches', 'Merge']
+
+    it('renders the four daemon-only teasers as aria-disabled with an accessible description under default (browser-local) capabilities', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await act(async () => {
+        render(<BrowserLocalCanvasPage store={store} />)
+      })
+      for (const label of TEASER_LABELS) {
+        const control = screen.getByRole('button', { name: label })
+        expect(control.getAttribute('aria-disabled')).toBe('true')
+        const describedById = control.getAttribute('aria-describedby')
+        expect(describedById).toBeTruthy()
+        const description = document.getElementById(describedById as string)
+        expect(description?.textContent).toBe(`Connect a local daemon (MCP) to enable ${label}`)
+      }
+    })
+
+    it('mutation-check: drops aria-disabled on the teasers once daemon capabilities are passed', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await act(async () => {
+        render(
+          <BrowserLocalCanvasPage
+            store={store}
+            capabilities={{
+              canvasReadWrite: true,
+              migrationExport: false,
+              migrationImport: true,
+              workspaces: true,
+              versions: true,
+              branches: true,
+              merge: true,
+            }}
+          />,
+        )
+      })
+      for (const label of TEASER_LABELS) {
+        const control = screen.getByRole('button', { name: label })
+        expect(control.getAttribute('aria-disabled')).toBeNull()
+      }
+    })
+
+    it('does not render any mode-switch control — mode stays a read-only status', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await act(async () => {
+        render(<BrowserLocalCanvasPage store={store} />)
+      })
+      expect(screen.queryByRole('switch')).toBeNull()
+      const suspiciousButtons = screen
+        .queryAllByRole('button')
+        .filter((btn) => /switch|mode|connect daemon/i.test(btn.textContent ?? ''))
+      expect(suspiciousButtons).toEqual([])
+    })
+
+    it('keeps the existing Delete button and title editing working alongside the new teasers', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await act(async () => {
+        render(<BrowserLocalCanvasPage store={store} />)
+      })
+      expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+      expect(screen.getByRole('textbox', { name: /canvas title/i })).toBeTruthy()
+    })
+  })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
+import { BROWSER_LOCAL_CAPABILITIES } from '../lib/provider.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import type { LoroStoreLike } from './use-browser-local-canvas-controller.js'
@@ -599,6 +600,28 @@ describe('BrowserLocalCanvasPage', () => {
       for (const label of TEASER_LABELS) {
         const control = screen.getByRole('button', { name: label })
         expect(control.getAttribute('aria-disabled')).toBeNull()
+      }
+    })
+
+    it('pins each teaser to its own distinct capability field', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await act(async () => {
+        render(
+          <BrowserLocalCanvasPage
+            store={store}
+            capabilities={{ ...BROWSER_LOCAL_CAPABILITIES, workspaces: true }}
+          />,
+        )
+      })
+      for (const label of TEASER_LABELS) {
+        const control = screen.getByRole('button', { name: label })
+        if (label === 'Workspaces') {
+          expect(control.getAttribute('aria-disabled')).toBeNull()
+        } else {
+          expect(control.getAttribute('aria-disabled')).toBe('true')
+        }
       }
     })
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -2,9 +2,11 @@ import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { CanvasTitle } from '../components/canvas-title/CanvasTitle.js'
+import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { derivePageState } from './browser-local-page-state.js'
 import {
@@ -19,6 +21,9 @@ interface BrowserLocalCanvasPageProps {
   // (jsdom does not implement IndexedDB); production callers rely on the
   // controller hook's own default.
   loro?: LoroStoreLike
+  // Defaults to browser-local so existing callers/tests keep working
+  // unedited; App.tsx passes the resolved ProviderState's capabilities.
+  capabilities?: WhiteboardCapabilities
 }
 
 // Map the persistence state machine to user-facing copy. `degraded` carries its
@@ -36,7 +41,11 @@ function persistenceLabel(status: BrowserLocalPersistenceState): string {
   }
 }
 
-export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPageProps) {
+export function BrowserLocalCanvasPage({
+  store,
+  loro,
+  capabilities = BROWSER_LOCAL_CAPABILITIES,
+}: BrowserLocalCanvasPageProps) {
   const {
     snapshot,
     persistence,
@@ -165,7 +174,7 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
     // h-dvh makes the page own its viewport height: without it the flex chain
     // has no sized ancestor and the editor area collapses to 0px.
     <main className="flex h-dvh w-full flex-col">
-      <header className="flex shrink-0 items-center gap-3 border-b bg-background px-4 py-2">
+      <header className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-2">
         {/* Visually-hidden heading landmark: the editable control below is the
             visible title, but the page keeps a real <h1> for accessibility trees. */}
         <h1 className="sr-only">{pageState.snapshot.name}</h1>
@@ -225,6 +234,16 @@ export function BrowserLocalCanvasPage({ store, loro }: BrowserLocalCanvasPagePr
         >
           New canvas
         </button>
+        {/* Daemon-only feature teasers: Stage 2 will move these into real
+            enabled controls once the daemon UI is ported. flex-wrap on the
+            header keeps them from forcing horizontal scroll at narrow
+            viewports. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
+          <CapabilityTeaser label="Workspaces" enabled={capabilities.workspaces} />
+          <CapabilityTeaser label="Branches" enabled={capabilities.branches} />
+          <CapabilityTeaser label="Merge" enabled={capabilities.merge} />
+        </div>
         <button
           type="button"
           onClick={() => void triggerCleanup()}

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -1,11 +1,11 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vitest/config'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { playwright } from '@vitest/browser-playwright'
-import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
+import wasm from 'vite-plugin-wasm'
+import { defineConfig } from 'vitest/config'
 import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -13,6 +13,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   resolve: {
     alias: {
+      // Matches vitest.config.ts and tsconfig's '@/*' path — needed once any
+      // browser-tested component pulls in a components/ui/* file (they all
+      // import '@/lib/utils' for the cn() helper).
+      '@': resolve(__dirname, 'src'),
       // Resolve browser-shared from source so tests run before `pnpm build`.
       '@kamiazya/whiteboard-mcp/browser-shared': resolve(
         __dirname,


### PR DESCRIPTION
First near-term slice of the **UI unification** initiative (ADR 0001 capability-gating step). Wires `WhiteboardCapabilities` into the apps/web UI and surfaces daemon-only features as **disabled teasers** with an upsell tooltip, so browser-local users discover what a local daemon unlocks — without porting the features yet (that's Stage 2).

## Change

- **Capability model**: `WhiteboardCapabilities` extended with additive `branches` / `merge` booleans (existing fields untouched). `BROWSER_LOCAL_CAPABILITIES` = false, `LOCAL_DAEMON_CAPABILITIES` = true. Kept a plain type + static per-kind const map (no Zod — it's an in-process derived constant, not a cross-process/persisted contract; noted in a comment so the Zod-discipline gate doesn't flag it).
- **Teasers**: new `CapabilityTeaser` component renders four daemon-only controls — **Version history / Workspaces / Branches / Merge** — in the page header. Under browser-local caps each is `aria-disabled` (NOT native `disabled`, so it stays keyboard-focusable) with an always-present `aria-describedby` description and a Radix tooltip reading **"Connect a local daemon (MCP) to enable <feature>"**. When caps flip to daemon, the disabled/teaser treatment drops.
- **Mode indicator stays read-only**: `BackendConfigChip` remains the fixed overlay showing "Browser only"; no runtime mode-switch control was added (per the decision that mode is config/deploy-time, auto-detected by the Wave 2 LNA probe).
- Header wraps / uses an overflow container so it never scrolls horizontally at 320–375px (asserted in a browser test).

## Verification

- apps/web jsdom 243 + web-browser 57 + typecheck all pass. Coverage: provider caps (branches/merge false for local, true for daemon), teasers aria-disabled + accessibly-described under local caps and enabled under daemon caps (mutation-checked across the flip), App passes `state.capabilities` down, a negative test asserts no mode-switch control, a narrow-viewport no-overflow browser test, and real-browser Radix tooltip coverage.
- Manual (wrangler pages dev): all four teasers render `aria-disabled=true`; the tooltip appears on **both hover and keyboard focus**.

## Visual repro

Header with disabled teasers, and the upsell tooltip:

![capability-teasers-header.png](https://github.com/user-attachments/assets/5436b501-6904-4143-b961-bcd67b2d64fb)
![capability-teaser-tooltip.png](https://github.com/user-attachments/assets/96af068f-1f78-4eed-8476-e93a71249b82)

## Scope / follow-ups

Out of scope (Stage 2): actual versions/branches/merge/workspaces features, DaemonBackend relocation + wiring, sync-hook consolidation, CanvasPage/routing port, daemon UI deletion (see `tmp/notes/ui-unification-stage2-plan.md`, 14-slice plan). A pre-existing "setState while rendering Excalidraw" React warning surfaced in browser tests (not from this slice) — tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible capability teasers on the canvas for version history, workspaces, branches, and merge.
  * Teasers now explain when a local daemon is needed and become active when those capabilities are available.

* **Bug Fixes**
  * Capability availability is now passed through the app correctly, so the canvas reflects the right feature state.
  * Improved accessibility and interaction behavior for disabled teaser controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->