### PR TITLE
ci: add Cloudflare Pages preview deploys (latest + per-PR)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,125 @@
+# Cloudflare Pages preview deployments (separate from the tag-gated production
+# deploy in release.yml). Two aliases on the same `kamiazya-whiteboard` project:
+#   - push to main         -> https://latest.kamiazya-whiteboard.pages.dev  (tracks main)
+#   - same-repo pull request -> https://<branch>.kamiazya-whiteboard.pages.dev (per-PR)
+# `--branch` is never the project's production branch, so these are always
+# previews and never touch the production URL.
+#
+# Security: uses `pull_request` (NOT pull_request_target), so fork PRs receive no
+# secrets — the deploy step self-skips when the token is absent. The PR-preview
+# job additionally runs only for same-repo PRs, and fork PR workflow runs require
+# maintainer approval (repo Actions setting: all external contributors). Secrets
+# live in the non-protected `preview-web` environment.
+name: Deploy Preview
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-latest:
+    # "latest" alias tracking main. Skipped until the preview-web secrets exist.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: preview-web
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build apps/web
+        run: pnpm --filter @kamiazya/whiteboard-web build
+      - name: Deploy latest preview
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          # pnpm required: the npm fallback cannot parse the catalog: protocol; wrangler
+          # ships as an apps/web devDependency so the action finds it preinstalled.
+          packageManager: pnpm
+          command: pages deploy dist --project-name=kamiazya-whiteboard --branch=latest
+
+  deploy-pr-preview:
+    # Per-PR preview for SAME-REPO PRs only. Fork PRs are skipped entirely (they
+    # get no secrets from pull_request, and this guard avoids even attempting).
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment: preview-web
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build apps/web
+        run: pnpm --filter @kamiazya/whiteboard-web build
+      - name: Compute safe preview branch label
+        id: label
+        env:
+          # Read the untrusted branch name via env (never inline into a command)
+          # and sanitize to [a-z0-9-] so it can't inject args/shell into the
+          # deploy command below.
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          label=$(printf '%s' "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-28)
+          [ -z "$label" ] && label="pr-$PR_NUMBER"
+          echo "branch=$label" >> "$GITHUB_OUTPUT"
+      - name: Deploy PR preview
+        id: deploy
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          packageManager: pnpm
+          command: pages deploy dist --project-name=kamiazya-whiteboard --branch=${{ steps.label.outputs.branch }}
+      - name: Comment preview URL on the PR
+        if: steps.deploy.outputs.deployment-url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- cf-pages-preview -->'
+          URL="${ALIAS_URL:-$DEPLOY_URL}"
+          BODY=$(printf '%s\n🔎 **Cloudflare Pages preview**: %s\nLatest deploy: %s\n\nBrowser-local mode works on preview URLs; daemon mode is origin-locked to production.' "$MARKER" "$URL" "$DEPLOY_URL")
+          CID=$(gh api "repos/$REPO/issues/$PR/comments" --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id // empty")
+          if [ -n "$CID" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" >/dev/null
+          else
+            gh api --method POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
+          fi

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -565,13 +565,15 @@ describe('apps/web Cloudflare Pages config (wrangler.toml)', () => {
 })
 
 // ── Cloudflare deploy secrets drift guard ─────────────────────────────────────
-// Production Cloudflare Pages deploy secrets are allowed only in release.yml
-// (the deploy-web job). All other workflow files and apps/web config files must
-// not embed these secrets — add to the allowlist below if a second deploy path
-// is introduced intentionally.
+// Cloudflare Pages deploy secrets are allowed only in the two intentional deploy
+// paths: release.yml (tag-gated production deploy, production-web env) and
+// deploy-preview.yml (latest + per-PR previews, non-protected preview-web env).
+// Every other workflow file and apps/web config file must not embed these
+// secrets — add to the allowlist below only if a new deploy path is introduced
+// intentionally and reviewed.
 
 const CF_SECRETS = ['CLOUDFLARE_API_TOKEN', 'CF_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID'] as const
-const CF_SECRET_WORKFLOW_ALLOWLIST = new Set(['release.yml'])
+const CF_SECRET_WORKFLOW_ALLOWLIST = new Set(['release.yml', 'deploy-preview.yml'])
 
 describe('apps/web Cloudflare deploy secrets guard', () => {
   const configFiles = [


### PR DESCRIPTION
Adds preview environments on the existing `kamiazya-whiteboard` Cloudflare Pages project, separate from the tag-gated production deploy.

## What it does
- **`push` to main** → deploys to **`https://latest.kamiazya-whiteboard.pages.dev`** (always tracks main).
- **same-repo PR** → deploys to **`https://<branch>.kamiazya-whiteboard.pages.dev`** and posts/updates a sticky PR comment with the URL.
- `--branch` is never the project's production branch, so these are always **previews** — production (`kamiazya-whiteboard.pages.dev`, released on tag) is never touched.

## Security (per the requirement that fork PRs can't deploy without permission)
- Uses **`pull_request`** (not `pull_request_target`), so **fork PRs receive no secrets** — the deploy step self-skips when the token is absent.
- The PR-preview job runs **only for same-repo PRs** (`head.repo.full_name == repository`); fork PRs skip entirely.
- Repo Actions setting tightened: **fork PR workflows now require maintainer approval for all external contributors** (was first-time-only).
- The untrusted branch name is read via `env:` and **sanitized to `[a-z0-9-]`** before use — no command/arg injection.
- Secrets live in the **non-protected `preview-web`** environment (created).

## Required before previews go live (maintainer action)
Add these to the **`preview-web`** environment (same values already in `production-web`):
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

Until then the deploy steps self-skip (no failures). Merging this PR's own preview job will also skip until the secrets exist.

Note: browser-local mode (all of Wave 1) works fine on preview URLs; daemon mode is origin-locked to the production domain (not wired to production yet, so no impact).