### PR TITLE
ci: add workflow_dispatch to deploy-preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,6 +16,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual trigger to (re)deploy the latest alias — e.g. to verify preview-web
+  # secrets or re-publish main on demand.
+  workflow_dispatch:
 
 concurrency:
   group: preview-${{ github.event.pull_request.number || github.ref }}
@@ -26,8 +29,9 @@ permissions:
 
 jobs:
   deploy-latest:
-    # "latest" alias tracking main. Skipped until the preview-web secrets exist.
-    if: github.event_name == 'push'
+    # "latest" alias tracking main (also runnable on demand via workflow_dispatch).
+    # Skipped until the preview-web secrets exist.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: preview-web
     env:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to deploy-preview.yml so the `latest` alias can be (re)deployed on demand — useful for verifying the preview-web secrets or re-publishing main without waiting for a push.

This PR's own `deploy-pr-preview` job also serves as a live check that the newly-added preview-web secrets work: if it deploys and posts a preview URL below, the secrets are correct.