### PR TITLE
ci: split PR preview into untrusted build + trusted deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,27 +1,23 @@
-# Cloudflare Pages preview deployments (separate from the tag-gated production
-# deploy in release.yml). Two aliases on the same `kamiazya-whiteboard` project:
-#   - push to main         -> https://latest.kamiazya-whiteboard.pages.dev  (tracks main)
-#   - same-repo pull request -> https://<branch>.kamiazya-whiteboard.pages.dev (per-PR)
-# `--branch` is never the project's production branch, so these are always
-# previews and never touch the production URL.
+# Cloudflare Pages "latest" preview alias, tracking main (separate from the
+# tag-gated production deploy in release.yml). Deploys to
+# https://latest.kamiazya-whiteboard.pages.dev — `--branch=latest` is never the
+# production branch, so it never touches the production URL.
 #
-# Security: uses `pull_request` (NOT pull_request_target), so fork PRs receive no
-# secrets — the deploy step self-skips when the token is absent. The PR-preview
-# job additionally runs only for same-repo PRs, and fork PR workflow runs require
-# maintainer approval (repo Actions setting: all external contributors). Secrets
-# live in the non-protected `preview-web` environment.
+# This workflow only runs on TRUSTED refs (push to main / manual dispatch), so
+# building + deploying with secrets in one job is safe. Untrusted PR previews are
+# split across preview-pr-build.yml (build, no secrets) and preview-pr-deploy.yml
+# (deploy a trusted artifact) so PR code never runs with deploy secrets.
 name: Deploy Preview
 
 on:
   push:
     branches: [main]
-  pull_request:
   # Manual trigger to (re)deploy the latest alias — e.g. to verify preview-web
   # secrets or re-publish main on demand.
   workflow_dispatch:
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number || github.ref }}
+  group: preview-latest
   cancel-in-progress: true
 
 permissions:
@@ -29,9 +25,6 @@ permissions:
 
 jobs:
   deploy-latest:
-    # "latest" alias tracking main (also runnable on demand via workflow_dispatch).
-    # Skipped until the preview-web secrets exist.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: preview-web
     env:
@@ -49,6 +42,7 @@ jobs:
       - name: Build apps/web
         run: pnpm --filter @kamiazya/whiteboard-web build
       - name: Deploy latest preview
+        # Self-skips until the preview-web secrets exist.
         if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
@@ -59,71 +53,3 @@ jobs:
           # ships as an apps/web devDependency so the action finds it preinstalled.
           packageManager: pnpm
           command: pages deploy dist --project-name=kamiazya-whiteboard --branch=latest
-
-  deploy-pr-preview:
-    # Per-PR preview for SAME-REPO PRs only. Fork PRs are skipped entirely (they
-    # get no secrets from pull_request, and this guard avoids even attempting).
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    environment: preview-web
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build apps/web
-        run: pnpm --filter @kamiazya/whiteboard-web build
-      - name: Compute safe preview branch label
-        id: label
-        env:
-          # Read the untrusted branch name via env (never inline into a command)
-          # and sanitize to [a-z0-9-] so it can't inject args/shell into the
-          # deploy command below.
-          HEAD_REF: ${{ github.head_ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          label=$(printf '%s' "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-28)
-          [ -z "$label" ] && label="pr-$PR_NUMBER"
-          echo "branch=$label" >> "$GITHUB_OUTPUT"
-      - name: Deploy PR preview
-        id: deploy
-        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/web
-          packageManager: pnpm
-          command: pages deploy dist --project-name=kamiazya-whiteboard --branch=${{ steps.label.outputs.branch }}
-      - name: Comment preview URL on the PR
-        if: steps.deploy.outputs.deployment-url != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          MARKER='<!-- cf-pages-preview -->'
-          URL="${ALIAS_URL:-$DEPLOY_URL}"
-          BODY=$(printf '%s\n🔎 **Cloudflare Pages preview**: %s\nLatest deploy: %s\n\nBrowser-local mode works on preview URLs; daemon mode is origin-locked to production.' "$MARKER" "$URL" "$DEPLOY_URL")
-          CID=$(gh api "repos/$REPO/issues/$PR/comments" --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id // empty")
-          if [ -n "$CID" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" >/dev/null
-          else
-            gh api --method POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
-          fi

--- a/.github/workflows/preview-pr-build.yml
+++ b/.github/workflows/preview-pr-build.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This job runs untrusted PR code; don't leave the git credential in
+          # .git/config where pnpm install/build scripts could read it.
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/preview-pr-build.yml
+++ b/.github/workflows/preview-pr-build.yml
@@ -1,0 +1,58 @@
+# PR preview — BUILD half (untrusted). Runs the PR's code to build apps/web but
+# has NO secrets, so a malicious PR cannot exfiltrate deploy credentials. The
+# built static site + PR metadata are uploaded as artifacts; preview-pr-deploy.yml
+# (workflow_run, trusted) publishes them with the Cloudflare secrets.
+name: Preview PR Build
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # Same-repo PRs only (fork PRs cannot be opened here — collaborators-only — but
+    # this keeps runner minutes off any edge case and mirrors the deploy guard).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build apps/web
+        run: pnpm --filter @kamiazya/whiteboard-web build
+      - name: Save PR metadata
+        env:
+          # Untrusted; read via env and only written to a file here. The deploy
+          # workflow re-sanitizes these before using them.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p pr-meta
+          {
+            printf 'pr=%s\n' "$PR_NUMBER"
+            printf 'branch=%s\n' "$HEAD_REF"
+          } > pr-meta/pr.txt
+      - name: Upload built site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-pr-dist
+          path: apps/web/dist
+          retention-days: 3
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-pr-meta
+          path: pr-meta
+          retention-days: 3

--- a/.github/workflows/preview-pr-deploy.yml
+++ b/.github/workflows/preview-pr-deploy.yml
@@ -64,7 +64,9 @@ jobs:
           set -euo pipefail
           # wrangler reads CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID from env.
           # BRANCH is pre-sanitized to [a-z0-9-]; --project pins the target project.
-          out=$(npx --yes wrangler@^4.105.0 pages deploy artifacts/preview-pr-dist \
+          # Exact-pinned: this step holds deploy secrets, so the tool version must
+          # not float at run time — bump deliberately.
+          out=$(npx --yes wrangler@4.105.0 pages deploy artifacts/preview-pr-dist \
             --project-name=kamiazya-whiteboard --branch="$BRANCH" 2>&1) || { printf '%s\n' "$out"; exit 1; }
           printf '%s\n' "$out"
           url=$(printf '%s' "$out" | grep -oE 'https://[a-z0-9.-]+\.pages\.dev' | tail -1)

--- a/.github/workflows/preview-pr-deploy.yml
+++ b/.github/workflows/preview-pr-deploy.yml
@@ -1,0 +1,88 @@
+# PR preview — DEPLOY half (trusted). Triggered by a completed "Preview PR Build"
+# run. Because workflow_run always uses the workflow definition from the default
+# branch and this job never checks out or runs PR code, the Cloudflare secrets are
+# only ever exposed to trusted repo-owned steps. It downloads the artifact the
+# build produced and publishes those pre-built static files — the untrusted PR
+# code that produced them never touched a secret.
+name: Preview PR Deploy
+
+on:
+  workflow_run:
+    workflows: ["Preview PR Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: preview-pr-deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment: preview-web
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+      - name: Download build artifacts from the triggering run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+      - name: Read and sanitize PR metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          meta="artifacts/preview-pr-meta/pr.txt"
+          test -f "$meta"
+          # Untrusted artifact data: PR number to digits only, branch to [a-z0-9-].
+          pr=$(sed -n 's/^pr=//p' "$meta" | head -1 | tr -cd '0-9' | cut -c1-9)
+          raw=$(sed -n 's/^branch=//p' "$meta" | head -1)
+          label=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-28)
+          test -n "$pr"
+          [ -z "$label" ] && label="pr-$pr"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "branch=$label" >> "$GITHUB_OUTPUT"
+      - name: Deploy the built artifact (no PR code executes here)
+        id: deploy
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
+        env:
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # wrangler reads CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID from env.
+          # BRANCH is pre-sanitized to [a-z0-9-]; --project pins the target project.
+          out=$(npx --yes wrangler@^4.105.0 pages deploy artifacts/preview-pr-dist \
+            --project-name=kamiazya-whiteboard --branch="$BRANCH" 2>&1) || { printf '%s\n' "$out"; exit 1; }
+          printf '%s\n' "$out"
+          url=$(printf '%s' "$out" | grep -oE 'https://[a-z0-9.-]+\.pages\.dev' | tail -1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Comment preview URL on the PR
+        if: steps.deploy.outputs.url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.deploy.outputs.url }}
+          PR: ${{ steps.meta.outputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- cf-pages-preview -->'
+          BODY=$(printf '%s\n🔎 **Cloudflare Pages preview**: %s\n\nBuilt from this PR without exposing deploy secrets to PR code. Browser-local mode works on preview URLs; daemon mode is origin-locked to production.' "$MARKER" "$URL")
+          CID=$(gh api "repos/$REPO/issues/$PR/comments" --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id // empty")
+          if [ -n "$CID" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" >/dev/null
+          else
+            gh api --method POST "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null
+          fi

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -565,15 +565,20 @@ describe('apps/web Cloudflare Pages config (wrangler.toml)', () => {
 })
 
 // ── Cloudflare deploy secrets drift guard ─────────────────────────────────────
-// Cloudflare Pages deploy secrets are allowed only in the two intentional deploy
-// paths: release.yml (tag-gated production deploy, production-web env) and
-// deploy-preview.yml (latest + per-PR previews, non-protected preview-web env).
-// Every other workflow file and apps/web config file must not embed these
-// secrets — add to the allowlist below only if a new deploy path is introduced
-// intentionally and reviewed.
+// Cloudflare Pages deploy secrets are allowed only in the intentional deploy
+// paths: release.yml (tag-gated production deploy, production-web env),
+// deploy-preview.yml (main -> "latest" alias), and preview-pr-deploy.yml (the
+// trusted workflow_run half that publishes a PR's pre-built artifact). Note
+// preview-pr-build.yml is deliberately NOT here — it runs untrusted PR code and
+// must never see these secrets. Every other workflow / apps/web config file must
+// not embed them — extend the allowlist only for a new, reviewed deploy path.
 
 const CF_SECRETS = ['CLOUDFLARE_API_TOKEN', 'CF_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID'] as const
-const CF_SECRET_WORKFLOW_ALLOWLIST = new Set(['release.yml', 'deploy-preview.yml'])
+const CF_SECRET_WORKFLOW_ALLOWLIST = new Set([
+  'release.yml',
+  'deploy-preview.yml',
+  'preview-pr-deploy.yml',
+])
 
 describe('apps/web Cloudflare deploy secrets guard', () => {
   const configFiles = [


### PR DESCRIPTION
Hardens the preview-deploy trust model per the ci-cd-trust finding. Splits the per-PR preview into a **build half without secrets** and a **deploy half that never runs PR code**.

## Before (risk)
`deploy-preview.yml`'s `deploy-pr-preview` job ran the PR's `pnpm install` + `pnpm build` **with the Cloudflare deploy token in the environment** — a malicious PR (or dependency) could exfiltrate the token ("pwn request").

## After
- **`preview-pr-build.yml`** (`pull_request`, **NO secrets**): builds apps/web from the PR, uploads the built site + PR metadata as artifacts. PR code runs, but there is nothing to steal.
- **`preview-pr-deploy.yml`** (`workflow_run`, **trusted**): triggered on a successful build. Because `workflow_run` always uses the workflow definition from the default branch and this job **never checks out or runs PR code**, the Cloudflare secrets are only exposed to trusted, repo-owned steps. It downloads the build artifact and publishes the pre-built static files with `wrangler pages deploy`, then comments the preview URL. PR metadata (number/branch) is re-sanitized (`[0-9]` / `[a-z0-9-]`) before use.
- **`deploy-preview.yml`** keeps only the trusted `latest` path (push to main / manual dispatch).

## Guard
The `web-app-boundary` secrets guard allowlists `preview-pr-deploy.yml` (holds secrets) and deliberately **excludes `preview-pr-build.yml`** so a future edit can't slip secrets into the untrusted build half — the test fails if it does. `mcp-node` 42 tests pass.

## Notes
- Still `pull_request` (never `pull_request_target`); same-repo guard on both halves; repo is collaborators-only, so this is defense-in-depth.
- This PR's own preview deploy activates only after merge (the `workflow_run` deploy half must exist on main first). The build half runs on this PR and uploads its artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new preview build flow for pull requests, producing deployable site artifacts.
  * Added automated preview deployment for successful pull request builds, including a PR comment with the preview link.

* **Chores**
  * Limited preview deployment workflows to trusted runs and simplified preview deployment concurrency.
  * Updated deployment safeguards to recognize the new trusted preview deployment path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->