### PR TITLE
fix(web): allow browser-local mode on Cloudflare Pages preview origins

### DIFF
--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -159,11 +159,28 @@ describe('resolveHostedProviderStateFromRaw', () => {
     }
   })
 
-  // browserOrigin guard: preview browser origin is rejected even with no runtime config,
-  // so a Cloudflare Pages preview deploy cannot silently enter browser-local mode.
-  it('preview browserOrigin returns invalid-config even with empty runtime config', () => {
+  // browserOrigin policy: preview deploys (latest.<project>.pages.dev, per-PR
+  // branch aliases, hash previews) run in browser-local mode — offline and
+  // origin-agnostic — but must never connect to a daemon from a preview origin.
+  it('preview browserOrigin with empty runtime config returns browser-local', () => {
     const state = resolveHostedProviderStateFromRaw(
       {},
+      'https://abc123.kamiazya-whiteboard.pages.dev',
+    )
+    expect(state.kind).toBe('browser-local')
+  })
+
+  it('latest-alias browserOrigin with empty runtime config returns browser-local', () => {
+    const state = resolveHostedProviderStateFromRaw(
+      {},
+      'https://latest.kamiazya-whiteboard.pages.dev',
+    )
+    expect(state.kind).toBe('browser-local')
+  })
+
+  it('preview browserOrigin with a daemonBaseUrl config returns invalid-config (daemon refused on previews)', () => {
+    const state = resolveHostedProviderStateFromRaw(
+      { daemonBaseUrl: 'http://127.0.0.1:3099' },
       'https://abc123.kamiazya-whiteboard.pages.dev',
     )
     expect(state.kind).toBe('invalid-config')
@@ -179,9 +196,9 @@ describe('resolveHostedProviderStateFromRaw', () => {
     expect(state.kind).toBe('browser-local')
   })
 
-  it('invalid-config from preview browserOrigin does not expose the origin value', () => {
+  it('daemon refusal on a preview browserOrigin does not expose the origin value', () => {
     const state = resolveHostedProviderStateFromRaw(
-      {},
+      { daemonBaseUrl: 'http://127.0.0.1:3099' },
       'https://secret-hash.kamiazya-whiteboard.pages.dev',
     )
     expect(state.kind).toBe('invalid-config')

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -73,15 +73,25 @@ export function resolveProviderStateFromRaw(raw: unknown): ProviderState {
   }
 }
 
-// Hosted-production variant: rejects non-production publicOrigin values and
-// Cloudflare Pages preview browser origins so that preview deploys cannot
-// silently enter browser-local mode. localhost is allowed for local dev.
+// Hosted-production variant: rejects non-production publicOrigin values;
+// localhost is allowed for local dev. Cloudflare Pages preview browser origins
+// (latest.<project>.pages.dev, per-PR branch aliases, hash previews) run in
+// browser-local mode — it is offline and origin-agnostic — but a daemon
+// connection is refused there so a preview deploy can never reach a daemon.
 export function resolveHostedProviderStateFromRaw(
   raw: unknown,
   browserOrigin?: string,
 ): ProviderState {
   if (browserOrigin !== undefined && classifyPagesOrigin(browserOrigin) === 'preview') {
-    return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
+    try {
+      const state = resolveProviderState(resolveHostedRuntimeConfig(raw))
+      if (state.kind === 'local-daemon') {
+        return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
+      }
+      return state
+    } catch {
+      return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
+    }
   }
   try {
     return resolveProviderState(resolveHostedRuntimeConfig(raw))


### PR DESCRIPTION
## Bug

`https://latest.kamiazya-whiteboard.pages.dev/` (and every per-PR preview) rendered **"Runtime configuration is invalid."** instead of the app.

`resolveHostedProviderStateFromRaw` hard-rejected any browser origin classified as a Pages **preview** (`*.kamiazya-whiteboard.pages.dev` other than the exact production origin). That guard predates the preview environments — now that `latest` + per-PR previews are a supported surface, it blocked exactly what they exist for.

## Fix

- Preview browser origins now resolve to **browser-local** mode (offline, origin-agnostic — safe on any origin).
- The original security intent is **kept**: a `daemonBaseUrl` config on a preview origin is still refused (`invalid-config`), so a preview deploy can never reach a daemon. The error message still leaks no origin/URL fragments.
- `publicOrigin` (config-declared) validation is unchanged — declaring a preview `publicOrigin` in config remains a config error.

## Verification

- Red-first: new tests (preview / `latest.` alias origin → `browser-local`; preview + daemon config → `invalid-config`, no origin leak) failed against the old impl, pass now. provider 27 / jsdom 246 / browser 58 / typecheck green.
- **Live proof**: this PR's own Cloudflare preview (comment below) should render the whiteboard editor instead of the error — and after merge, `latest.kamiazya-whiteboard.pages.dev` will too.