### PR TITLE
ci: align GitHub Environments with deployed URLs and release previews on PR close

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -26,7 +26,10 @@ permissions:
 jobs:
   deploy-latest:
     runs-on: ubuntu-latest
-    environment: preview-web
+    environment:
+      name: preview-web
+      # Surfaces the real alias in the Environments UI ("View deployment").
+      url: https://latest.kamiazya-whiteboard.pages.dev
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,59 @@
+# Releases a PR's preview-web deployment records when the PR closes (merged or
+# not), so the Environments UI doesn't accumulate stale "Active" previews.
+# Matches records by their environment_url (the branch-alias URL that
+# preview-pr-deploy.yml attaches), marks them inactive, then deletes them.
+#
+# Deliberately has NO environment binding and NO Cloudflare secrets: it only
+# touches GitHub deployment records via the workflow token, so the cleanup run
+# itself never mints a new deployment record. The Cloudflare-side preview
+# deployments are inert static files that the next push to the same branch
+# alias overwrites; they are left to Cloudflare's own retention.
+name: Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  deployments: write
+
+concurrency:
+  group: preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  release-deployment:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deactivate and delete this PR's preview deployment records
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Untrusted branch name: read via env and sanitized to [a-z0-9-] with
+          # the same rules the deploy path uses, so the alias hostnames match.
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          label=$(printf '%s' "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-28)
+          [ -z "$label" ] && label="pr-$PR_NUMBER"
+          alias_prefix="https://$label.kamiazya-whiteboard.pages.dev"
+          echo "releasing preview deployments with environment_url under: $alias_prefix"
+
+          ids=$(gh api "repos/$REPO/deployments?environment=preview-web&per_page=100" --jq '.[].id')
+          released=0
+          for id in $ids; do
+            url=$(gh api "repos/$REPO/deployments/$id/statuses?per_page=1" --jq '.[0].environment_url // empty')
+            case "$url" in
+              "$alias_prefix"|"$alias_prefix"/*)
+                # Deployments must be inactive before they can be deleted.
+                gh api --method POST "repos/$REPO/deployments/$id/statuses" \
+                  -f state=inactive >/dev/null
+                gh api --method DELETE "repos/$REPO/deployments/$id" >/dev/null
+                released=$((released+1))
+                echo "released deployment $id ($url)"
+                ;;
+            esac
+          done
+          echo "released $released deployment record(s)"

--- a/.github/workflows/preview-pr-deploy.yml
+++ b/.github/workflows/preview-pr-deploy.yml
@@ -27,7 +27,13 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: preview-web
+    environment:
+      name: preview-web
+      # Attaches this PR's branch-alias preview URL to the deployment record so
+      # the Environments UI reflects reality; preview-cleanup.yml releases the
+      # record when the PR closes. (environment.url is resolved at job end, so
+      # it may reference the deploy step's output.)
+      url: ${{ steps.deploy.outputs.url }}
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,10 @@ jobs:
     # Secrets are scoped to the production-web environment (tag-protected in repo settings).
     # Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID in the production-web environment.
     if: needs.release-please.outputs.releases_created == 'true'
-    environment: production-web
+    environment:
+      name: production-web
+      # Surfaces the live production URL in the Environments UI.
+      url: https://kamiazya-whiteboard.pages.dev
     permissions:
       contents: read
     env:

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -643,8 +643,10 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     )
     expect(
       deployWebSection,
-      'deploy-web job must declare the production-web environment (secrets scoped to tag-protected env); the string form and the name/url mapping form are both valid',
-    ).toMatch(/environment:\s*(?:production-web\b|\n\s+name:\s*production-web\b)/)
+      'deploy-web job must declare the production-web environment (secrets scoped to tag-protected env); the string form and the name/url mapping form are both valid, with optional quotes and any key order',
+    ).toMatch(
+      /environment:\s*(?:['"]?production-web['"]?\s*(?:\r?\n|$)|\r?\n(?:\s+[\w-]+:[^\n]*\r?\n)*?\s+name:\s*['"]?production-web['"]?)/,
+    )
   })
 
   it('deploy-web avoids the wrangler-action npm-install fallback (catalog: is pnpm-only)', () => {

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -643,8 +643,8 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
     )
     expect(
       deployWebSection,
-      'deploy-web job must declare environment: production-web (secrets scoped to tag-protected env)',
-    ).toContain('environment: production-web')
+      'deploy-web job must declare the production-web environment (secrets scoped to tag-protected env); the string form and the name/url mapping form are both valid',
+    ).toMatch(/environment:\s*(?:production-web\b|\n\s+name:\s*production-web\b)/)
   })
 
   it('deploy-web avoids the wrangler-action npm-install fallback (catalog: is pnpm-only)', () => {


### PR DESCRIPTION
Follow-up to the preview environments: makes the **Environments UI match reality** and **releases preview deployment records when a PR closes**.

## Changes

**1. Real URLs on deployment records** (Environments sidebar "View deployment" now works):
- `production-web` (release.yml deploy-web) → `https://kamiazya-whiteboard.pages.dev`
- `preview-web` latest job → `https://latest.kamiazya-whiteboard.pages.dev`
- `preview-web` per-PR deploy → that PR's branch-alias URL (`environment.url` resolves at job end, so it uses the deploy step's output)

**2. `preview-cleanup.yml`** — on PR close (merged or not): finds this PR's preview-web deployment records by their `environment_url` (branch-alias hostname, recomputed with the same sanitize rules as the deploy path), marks them **inactive**, then **deletes** them. So closed PRs no longer leave stale "Active" previews in the Environments view.
- Deliberately **no environment binding and no secrets**: the cleanup run itself never mints a new deployment record, and it only touches GitHub records via the workflow token (`deployments: write`).
- Cloudflare-side preview files are inert statics (overwritten per push to the same alias) and are left to Cloudflare's retention.

**3. Guard update**: `web-app-boundary` now accepts the `environment: {name, url}` mapping form for deploy-web (mutation-checked — dropping the environment declaration still fails the test). 42 mcp-node tests pass.

## Notes
- Records created *before* this change have no `environment_url`, so cleanup can't match them; they can be deleted once by hand (or just age out as new deploys supersede them).
- Untrusted branch names are read via `env:` and sanitized to `[a-z0-9-]`; no `pull_request_target`.