### PR TITLE
ci(web): add bundle-size gate to verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
       - name: Web app artifact smoke
         run: pnpm --filter @kamiazya/whiteboard-web smoke:artifact
 
+      - name: Web app bundle-size gate
+        run: pnpm --filter @kamiazya/whiteboard-web smoke:bundle-size
+
       - name: Web app preview-origin behavioral smoke
         run: pnpm --filter @kamiazya/whiteboard-web smoke:preview-origin
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "typecheck": "tsc --noEmit",
     "smoke:artifact": "node scripts/smoke-artifact.mjs",
+    "smoke:bundle-size": "node scripts/smoke-bundle-size.mjs",
     "smoke:preview-origin": "node scripts/smoke-preview-origin.mjs"
   },
   "dependencies": {

--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Bundle-size gate for the built dist/. Run after `pnpm build`.
+//
+// Budgets (gzip): the entry chunk dominates first paint, so it gets a hard
+// ceiling; CSS has its own. Daemon-only feature chunks (ported behind
+// React.lazy) get a separate small budget so they can never leak into first
+// paint unnoticed — the pattern matches nothing until those chunks exist.
+//
+// The entry ceiling is a regression stop at today's measured size (~541 KB),
+// not an endorsement: shrinking it toward the <300 KB app budget needs
+// loro/Excalidraw first-paint splitting, tracked separately.
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const ASSETS = resolve(ROOT, 'dist', 'assets')
+
+const KB = 1024
+const BUDGETS = [
+  { label: 'entry JS (index-*.js)', pattern: /^index-.*\.js$/, limit: 560 * KB, required: true },
+  { label: 'CSS (index-*.css)', pattern: /^index-.*\.css$/, limit: 30 * KB, required: true },
+  {
+    label: 'daemon lazy chunk (daemon-*.js)',
+    pattern: /^daemon-.*\.js$/,
+    limit: 40 * KB,
+    required: false,
+  },
+]
+
+let failures = 0
+
+function gzipSize(path) {
+  return gzipSync(readFileSync(path)).length
+}
+
+const files = readdirSync(ASSETS)
+for (const { label, pattern, limit, required } of BUDGETS) {
+  const matches = files.filter((f) => pattern.test(f))
+  if (matches.length === 0) {
+    if (required) {
+      console.error(`  FAIL  ${label}: no file matching ${pattern} in dist/assets`)
+      failures++
+    } else {
+      console.log(`  skip  ${label}: no matching chunk yet`)
+    }
+    continue
+  }
+  for (const f of matches) {
+    const size = gzipSize(join(ASSETS, f))
+    const sizeKb = (size / KB).toFixed(1)
+    const limitKb = (limit / KB).toFixed(0)
+    if (size > limit) {
+      console.error(`  FAIL  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
+      failures++
+    } else {
+      console.log(`  pass  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\nbundle-size gate: ${failures} failure(s)`)
+  process.exit(1)
+}
+console.log('\nbundle-size gate: OK')

--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -9,7 +9,7 @@
 // The entry ceiling is a regression stop at today's measured size (~541 KB),
 // not an endorsement: shrinking it toward the <300 KB app budget needs
 // loro/Excalidraw first-paint splitting, tracked separately.
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gzipSync } from 'node:zlib'
@@ -33,6 +33,11 @@ let failures = 0
 
 function gzipSize(path) {
   return gzipSync(readFileSync(path)).length
+}
+
+if (!existsSync(ASSETS)) {
+  console.error(`  FAIL  dist/assets not found at ${ASSETS} — run \`pnpm build\` first`)
+  process.exit(1)
 }
 
 const files = readdirSync(ASSETS)


### PR DESCRIPTION
Implements the Q10 bundle-budget enforcement ahead of the Stage 2 daemon-UI port.

## What

- New `apps/web/scripts/smoke-bundle-size.mjs` (zero-dep, follows the existing `smoke-*.mjs` pattern): gzips built assets and asserts budgets — **entry JS ≤ 560 KB**, **CSS ≤ 30 KB**, and **`daemon-*.js` lazy chunks ≤ 40 KB** (skips until such chunks exist; once slices 5-8 ship daemon features behind `React.lazy`, this line keeps them out of first paint).
- Wired as `smoke:bundle-size` and a `verify` step right after the artifact smoke (dist already built there).

## Why these numbers

Measured today: entry 552.1 KB gzip / CSS 27.6 KB. The 560 KB ceiling is a **regression stop, not an endorsement** — the entry already exceeds the global <300 KB app budget (loro WASM glue + React + Excalidraw bootstrap), and shrinking it needs first-paint splitting tracked as a separate initiative. This gate prevents silent growth while that work is pending.

## Verification

Local run passes (entry 552.1/560, CSS 27.6/30, daemon chunk skip). Mutation-checked: lowering the entry budget to 500 KB fails the gate (exit 1); restored passes.