### PR TITLE
docs(adr): resolve ADR-0002 token story and add ADR-0004 unified CanvasPage

### DIFF
--- a/docs/contributing/adr/0002-browser-to-daemon-transport.md
+++ b/docs/contributing/adr/0002-browser-to-daemon-transport.md
@@ -47,4 +47,66 @@ Availability detection in `apps/web`:
 
 **Portless (`whiteboard.localhost`)** — Would avoid mixed-content for the hosted case. Rejected: `whiteboard.localhost` is not in `isLoopbackHostname`, so the daemon returns 403; deferred pending security review.
 
-**Token delivery via `runtimeConfigSchema` extension** — Inject `daemonToken` alongside `daemonBaseUrl`. Deferred: `runtimeConfigSchema.strict()` would reject an unknown `daemonToken` field, throwing `invalid-config`. The schema must be extended first via `z.infer<>` (no parallel interface). This open question is resolved at Stage 4 planning.
+**Token delivery via `runtimeConfigSchema` extension** — Inject `daemonToken` alongside `daemonBaseUrl`. Rejected — see the addendum below; the schema stays permanently token-free.
+
+## Addendum (accepted): token delivery and local auth model resolved
+
+This ADR originally deferred the token-delivery question to Stage 4 planning.
+That question is now resolved.
+
+### Decision
+
+- `runtimeConfigSchema` remains **permanently token-free**: no `daemonToken`
+  field is added. A static Pages build has no per-user injection point at
+  build time, so baking a token into a build artifact is not possible; and
+  keeping the token out of the runtime-config surface avoids exposing it to
+  the logging/error-reporting code paths that already read that config.
+- Daemon self-serving and local dev deliver the token through a dedicated,
+  separate global — `window.__WHITEBOARD_DAEMON_TOKEN__` — distinct from
+  `__WHITEBOARD_RUNTIME_CONFIG__`. The `apps/web` client reads it once at
+  startup into an in-memory `TokenStore` (module singleton, never persisted),
+  then deletes the global. This is a **serialization-surface reduction, not a
+  security boundary** — it does nothing against a script that runs before the
+  delete, and is documented as such.
+- A static-Pages deployment (Stage 4) uses a pairing flow: a short-lived
+  `bootstrapToken` (delivered as a code, or a one-time URL fragment) is
+  exchanged for a `sessionToken` that is itself short-lived and memory-only.
+- Wire transport is restricted to two channels: the WS subprotocol
+  `daemon-token.<token>` and the HTTP `Authorization: Bearer` header. URL
+  query parameters, `runtimeConfig`, and build artifacts are all prohibited
+  as token carriers.
+- Local-daemon read-path carve-out: canvas/asset `GET` endpoints stay
+  tokenless, relying on the existing trust model (loopback bind + Host
+  loopback check + hard-to-guess IDs). All of `/api/runtime/*` except `ping`
+  requires Bearer, including on `GET`. Server-mode requires Bearer on every
+  method, with no bypass.
+- The `ping` response no longer includes the daemon's OS `pid`; a random
+  `instanceId` minted at daemon startup replaces it. `whiteboard server
+  stop`'s ownership check switches from pid-matching to instanceId-matching,
+  preserving protection against killing an unrelated process that reused the
+  port.
+
+### Consequences
+
+- Closes the open question above; no further `runtimeConfigSchema` changes
+  are anticipated for the token story.
+- As of this addendum the design is accepted but not yet shipped: the
+  `/api/*` Host-loopback middleware, the daemon bind-host guard, the
+  token-global plumbing on both daemon and `apps/web`, and the ping
+  `pid`→`instanceId` swap are tracked as follow-up slices.
+- Residual accepted risk: a malicious page on another localhost port can
+  still read canvas `GET` responses via reflected CORS; a Stage 4 origin
+  allowlist is the planned mitigation.
+
+### Alternatives considered (addendum)
+
+- **Extend `runtimeConfigSchema` with `daemonToken`** — rejected: no per-user
+  injection point in a static build, and it would widen the serialization
+  surface visible to logging/error-reporting.
+- **Tokenize canvas/asset `GET`** — rejected: breaks `<img src>` thumbnail
+  usage for negligible defense-in-depth, since a loopback attacker can
+  already read the token from local config files.
+- **Keep `pid` in `ping` for `server stop` matching** — rejected: publishes
+  an OS-level process identifier from an intentionally unauthenticated
+  endpoint; a startup-time `instanceId` gives an equivalent ownership check
+  without exposing `pid`.

--- a/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
+++ b/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
@@ -1,0 +1,105 @@
+# ADR-0004: Unified capability-gated CanvasPage
+
+**Status:** Accepted
+
+## Context
+
+`apps/web` must support two operating modes long-term: browser-local (no
+daemon, IndexedDB-backed Loro doc) and daemon-connected (WebSocket + REST
+sync, ADR-0002). The `CanvasBackend` seam already exists as the behavioral
+interface swapped at the page level.
+
+Additional constraints from architecture and UX review:
+
+- Branches, the version-history timeline, and the branch banner / merge toast
+  are daemon-only concepts; browser-local has no equivalent state.
+- The daemon side has no single controller today — the index page's ad-hoc
+  `apiFetch` calls and `useBranches` are the existing daemon-side
+  data-fetching shape, separate from the browser-local controller.
+- Mode is decided once at page load (config + probe result), not switched at
+  runtime within a session.
+- `apps/web` has no router today; the daemon-served `src/app` already has one.
+
+## Decision
+
+Adopt a single `CanvasPage` component that receives an injected
+`CanvasBackend` and renders capability-gated JSX, rather than maintaining
+separate pages per mode or building a fully generic `CanvasController`
+abstraction.
+
+1. **One page, capability-gated chrome.** `CanvasPage` owns the
+   header/editor/state-machine shell for both modes. Slots that apply only to
+   one mode (branch chip, History, Merge) render through a shared
+   teaser/live-widget pair driven by capability flags rather than by
+   branching the page identity. This keeps the eventual removal of the
+   daemon-served UI (ADR-0001 Stage 5) to a local diff of conditionals.
+2. **Controller layer stays capability-selected, not force-unified (YAGNI).**
+   `useBrowserLocalCanvasController` encodes IndexedDB-specific invariants
+   (serialized `flushSave`, orphan rollback on `createCanvas`, pointer
+   ordering in `startFresh`) that do not map onto a generic repository
+   interface without leaking or breaking them. The daemon side has no single
+   controller to unify against yet. `CanvasPage` selects the controller hook
+   based on `ProviderState.kind`; the shared shape between controllers is
+   limited to the fields the header actually branches on.
+3. **Daemon connectivity is a sub-state of `editing`.** The page state
+   machine is `load-degraded | cleanup-completed (browser-local only) |
+   loading | { kind: 'editing', snapshot, persistence, overlay:
+   EditingOverlay }`, where `EditingOverlay = none | { restoring, label? } |
+   auth-error`. The existing `derivePageState` cascade-order invariant is
+   preserved unchanged. Branch banner and merge toast render as
+   capability-gated JSX inside `editing` — chrome, not a distinct page state.
+4. **Introduce React Router in `apps/web`.** `/` renders the canvas list
+   (browser-local populates from IndexedDB; daemon mode uses the existing
+   grid/search/pin pattern). `/canvas/:id/*slug` is the shared editor URL for
+   both modes (`:id` is the IndexedDB id with an empty slug in browser-local,
+   or `workspaceId` + slug in daemon mode), giving both modes an equivalent
+   bookmarkable, deep-linkable URL.
+5. **Mode is a read-only status decided at page load.** There is no
+   in-session runtime toggle between browser-local and daemon mode.
+
+## Consequences
+
+- ADR-0001 Stage 5 (removing the daemon-served UI) reduces to deleting
+  capability-gated branches inside the unified `CanvasPage`, not a parallel
+  page tree.
+- Daemon-only affordances render as a teaser when unavailable instead of
+  being absent, giving browser-local users visibility into daemon-only
+  functionality without implying it currently works.
+- Dependencies that must land alongside or before this work: porting
+  `useThemeMode` into `apps/web` (currently absent there), capability-gating
+  the library-import effect (currently an unguarded effect in the daemon
+  page that would silently no-op under browser-local), and exporting
+  `apiFetch` and the API-contract schemas from stable subpaths so
+  daemon-side fetch logic can be reused rather than copy-pasted.
+- The `window` event bus (`excalidraw:head_changed`, `merge_committed`) that
+  `useBranches` uses to coordinate with the sync hook: sync-originated
+  events move to hook callbacks (bound to backend identity, eliminating
+  stale-listener classes), while UI-originated `merge_committed` stays on the
+  window bus with its payload promoted to a Zod-validated contract.
+- As of this decision, `apps/web` has no router, and the shared
+  `CanvasPage` / capability-gated controller selection are unimplemented
+  follow-up slices — this ADR records the accepted design, not a completed
+  migration.
+- Several UX details remain open for product decision (narrow-viewport
+  overflow-collapse breakpoint, mode-indicator dismissibility, a
+  browser-local "Optimize" equivalent, Delete placement, offline-toast
+  threshold, and how Workspaces surfaces in browser-local). These do not
+  block the architecture but should be resolved before the corresponding UI
+  slice ships.
+
+## Alternatives considered
+
+**Keep separate pages per mode.** Rejected: perpetuates duplicate management
+of fullscreen/theme/shortcut logic across two page implementations and
+repeats a failure mode already seen once — a feature ported to the daemon
+path while the browser-local path is forgotten.
+
+**Fully generic `CanvasController` abstraction unifying browser-local and
+daemon data access.** Rejected as speculative generality: browser-local's
+IndexedDB invariants have no daemon-side equivalent to unify against, and the
+daemon side itself has no single controller to unify with yet — that
+consolidation is a separate, currently out-of-scope effort.
+
+**Runtime mode switching within a single session.** Rejected: no product
+requirement calls for switching without a reload, and treating mode as
+load-time-fixed simplifies event-listener lifecycle handling.

--- a/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
+++ b/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
@@ -50,10 +50,11 @@ abstraction.
    capability-gated JSX inside `editing` — chrome, not a distinct page state.
 4. **Introduce React Router in `apps/web`.** `/` renders the canvas list
    (browser-local populates from IndexedDB; daemon mode uses the existing
-   grid/search/pin pattern). `/canvas/:id/*slug` is the shared editor URL for
-   both modes (`:id` is the IndexedDB id with an empty slug in browser-local,
-   or `workspaceId` + slug in daemon mode), giving both modes an equivalent
-   bookmarkable, deep-linkable URL.
+   grid/search/pin pattern). `/canvas/:id/*` is the shared editor URL for
+   both modes — the trailing splat carries the slug, read via `params['*']`
+   per React Router v6 conventions (`:id` is the IndexedDB id with an empty
+   splat in browser-local, or `workspaceId` + slug in daemon mode) — giving
+   both modes an equivalent bookmarkable, deep-linkable URL.
 5. **Mode is a read-only status decided at page load.** There is no
    in-session runtime toggle between browser-local and daemon mode.
 

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -36,3 +36,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0001](0001-apps-web-canonical-frontend.md) | apps/web as the canonical frontend | Accepted |
 | [ADR-0002](0002-browser-to-daemon-transport.md) | Browser-to-daemon transport for Stage 4 | Accepted |
 | [ADR-0003](0003-track-claude-dev-flow-tooling.md) | Track .claude AI dev-flow tooling in git with repo-relative workflow scriptPaths | Accepted |
+| [ADR-0004](0004-unified-capability-gated-canvas-page.md) | Unified capability-gated CanvasPage | Accepted |


### PR DESCRIPTION
Records two accepted Stage 2 design decisions as durable ADRs (docs only, no code changes).

- **ADR-0002 addendum** — closes the deferred token-delivery question: `runtimeConfigSchema` stays permanently token-free; token arrives via a dedicated `window.__WHITEBOARD_DAEMON_TOKEN__` global read once into an in-memory TokenStore (explicitly documented as serialization-surface reduction, not a security boundary); static Pages pairs via bootstrapToken → sessionToken (Stage 4); wire transport = WS subprotocol + HTTP Bearer only; local-daemon canvas GETs stay tokenless under the loopback trust model while `/api/runtime/*` keeps Bearer; ping's `pid` is replaced by a startup `instanceId` (preserving `server stop`'s mis-kill protection). The stale 'deferred to Stage 4 planning' bullet now points at the addendum.
- **ADR-0004** (0003 was taken) — the unified capability-gated CanvasPage: single page + `CanvasBackend` injection, capability-selected controllers, daemon overlays as `editing` sub-state, React Router with a shared `/canvas/:id` URL scheme, mode as read-only load-time status. Consequences honestly mark what is accepted-but-unshipped.

Both follow the existing MADR-lite template; index updated.