### PR TITLE
feat(web): port pure-logic hooks (theme/dirty-state/fullscreen) to apps/web

### DIFF
--- a/apps/web/src/hooks/useDirtyState.test.ts
+++ b/apps/web/src/hooks/useDirtyState.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useDirtyState } from './useDirtyState.js'
+
+// Thin CustomEvent helpers; jsdom can dispatch these directly.
+function dispatchDocChanged(workspaceId: string, slug: string): void {
+  window.dispatchEvent(new CustomEvent('excalidraw:doc_changed', { detail: { workspaceId, slug } }))
+}
+function dispatchVersionSaved(workspaceId: string, slug: string): void {
+  window.dispatchEvent(
+    new CustomEvent('excalidraw:version_saved', { detail: { workspaceId, slug } }),
+  )
+}
+
+afterEach(() => {
+  // renderHook should unmount listeners for us; no extra cleanup is needed here.
+})
+
+describe('useDirtyState', () => {
+  it('starts clean (dirty=false)', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('marks dirty on doc_changed and clean on version_saved', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+    act(() => dispatchVersionSaved('s1', 'c1'))
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('ignores events from another canvas', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'other'))
+    act(() => dispatchDocChanged('other', 'c1'))
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('markSaved() also marks the state clean explicitly', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+    act(() => result.current.markSaved())
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('resets counters when the canvas changes', () => {
+    const { result, rerender } = renderHook(
+      ({ sid, slug }: { sid: string; slug: string }) => useDirtyState(sid, slug),
+      { initialProps: { sid: 's1', slug: 'c1' } },
+    )
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+    rerender({ sid: 's1', slug: 'c2' })
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('becomes dirty again when another change arrives after save', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    act(() => dispatchVersionSaved('s1', 'c1'))
+    expect(result.current.isDirty).toBe(false)
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+  })
+
+  it('markSaved() after multiple unsaved changes does not permanently block future dirty state', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    // Three changes, one save-at-count-3 via markSaved.
+    act(() => dispatchDocChanged('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    act(() => result.current.markSaved())
+    expect(result.current.isDirty).toBe(false)
+    // One more change → must become dirty again.
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+  })
+
+  it('does not update state after unmount (no stale event listener)', () => {
+    const { result, unmount } = renderHook(() => useDirtyState('s1', 'c1'))
+    unmount()
+    // Dispatching after unmount should not throw or update React state.
+    act(() => dispatchDocChanged('s1', 'c1'))
+    // If the listener were still attached, isDirty would flip; we cannot read
+    // it after unmount, but the main signal here is that no React warning is thrown.
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('ignores events where detail is missing', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => {
+      window.dispatchEvent(new CustomEvent('excalidraw:doc_changed', { detail: null }))
+    })
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('version_saved ignores events for a different canvas', () => {
+    const { result } = renderHook(() => useDirtyState('s1', 'c1'))
+    act(() => dispatchDocChanged('s1', 'c1'))
+    expect(result.current.isDirty).toBe(true)
+    act(() => dispatchVersionSaved('s1', 'other-canvas'))
+    expect(result.current.isDirty).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/useDirtyState.ts
+++ b/apps/web/src/hooks/useDirtyState.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Track unsaved state with the same minimal affordance as a mail-style unread dot.
+// - default (dirty=false): show nothing
+// - dirty: show an amber dot in the header
+//
+// Implementation notes:
+//  useWhiteboardSync dispatches excalidraw:doc_changed whenever doc.subscribe observes a local or remote edit.
+//  When version_created arrives, it dispatches excalidraw:version_saved.
+//  This hook filters those events by workspaceId/slug and tracks dirty vs clean counts.
+//  Passing the doc reference around would couple tests to Loro internals, so this stays event-based.
+
+export interface UseDirtyStateResult {
+  isDirty: boolean
+  // Call this when the UI needs to mark the document clean explicitly, such as right after Cmd+S succeeds.
+  // Most callers can rely on excalidraw:version_saved instead.
+  markSaved: () => void
+}
+
+export interface DirtyEventDetail {
+  workspaceId: string
+  slug: string
+}
+
+export function useDirtyState(workspaceId: string, slug: string): UseDirtyStateResult {
+  const [isDirty, setIsDirty] = useState(false)
+  const changeCountRef = useRef(0)
+  const savedAtRef = useRef(0)
+
+  // Reset counters when switching canvases; a new document starts clean.
+  useEffect(() => {
+    changeCountRef.current = 0
+    savedAtRef.current = 0
+    setIsDirty(false)
+  }, [workspaceId, slug])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onChanged = (event: Event) => {
+      const detail = (event as CustomEvent<DirtyEventDetail>).detail
+      if (!detail || detail.workspaceId !== workspaceId || detail.slug !== slug) return
+      changeCountRef.current += 1
+      if (changeCountRef.current > savedAtRef.current) setIsDirty(true)
+    }
+    const onSaved = (event: Event) => {
+      const detail = (event as CustomEvent<DirtyEventDetail>).detail
+      if (!detail || detail.workspaceId !== workspaceId || detail.slug !== slug) return
+      savedAtRef.current = changeCountRef.current
+      setIsDirty(false)
+    }
+    window.addEventListener('excalidraw:doc_changed', onChanged)
+    window.addEventListener('excalidraw:version_saved', onSaved)
+    return () => {
+      window.removeEventListener('excalidraw:doc_changed', onChanged)
+      window.removeEventListener('excalidraw:version_saved', onSaved)
+    }
+  }, [workspaceId, slug])
+
+  const markSaved = useCallback(() => {
+    savedAtRef.current = changeCountRef.current
+    setIsDirty(false)
+  }, [])
+
+  return { isDirty, markSaved }
+}

--- a/apps/web/src/hooks/useThemeMode.test.tsx
+++ b/apps/web/src/hooks/useThemeMode.test.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import {
+  THEME_STORAGE_KEY,
+  applyThemeClass,
+  readPersistedTheme,
+  resolveTheme,
+  useThemeMode,
+} from './useThemeMode.js'
+
+// Minimal matchMedia stub: tracks listeners so tests can simulate the OS
+// flipping prefers-color-scheme without a real browser.
+function installMatchMediaMock(initial: 'light' | 'dark') {
+  let prefersDark = initial === 'dark'
+  const listeners = new Set<(e: { matches: boolean }) => void>()
+  const mql = {
+    get matches() {
+      return prefersDark
+    },
+    addEventListener: (_: string, fn: (e: { matches: boolean }) => void) => {
+      listeners.add(fn)
+    },
+    removeEventListener: (_: string, fn: (e: { matches: boolean }) => void) => {
+      listeners.delete(fn)
+    },
+  }
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((_query: string) => mql),
+  )
+  ;(window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia =
+    globalThis.matchMedia as typeof window.matchMedia
+  return {
+    setSystem(next: 'light' | 'dark') {
+      prefersDark = next === 'dark'
+      for (const fn of listeners) fn({ matches: prefersDark })
+    },
+  }
+}
+
+beforeEach(() => {
+  installMatchMediaMock('light')
+})
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.classList.remove('dark')
+  window.localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+describe('readPersistedTheme', () => {
+  it('returns the stored value for "dark", "light", or "system" — defaults to "system" when nothing is stored', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    expect(readPersistedTheme()).toBe('dark')
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    expect(readPersistedTheme()).toBe('light')
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    expect(readPersistedTheme()).toBe('system')
+    window.localStorage.removeItem(THEME_STORAGE_KEY)
+    expect(readPersistedTheme()).toBe('system')
+  })
+
+  it('falls back to "system" when an unrecognised value is stored', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'auto')
+    expect(readPersistedTheme()).toBe('system')
+    window.localStorage.setItem(THEME_STORAGE_KEY, '')
+    expect(readPersistedTheme()).toBe('system')
+  })
+})
+
+describe('resolveTheme', () => {
+  it('returns the explicit value for light/dark and follows matchMedia for system', () => {
+    expect(resolveTheme('light')).toBe('light')
+    expect(resolveTheme('dark')).toBe('dark')
+    expect(resolveTheme('system')).toBe('light')
+    installMatchMediaMock('dark')
+    expect(resolveTheme('system')).toBe('dark')
+  })
+})
+
+describe('applyThemeClass', () => {
+  it('adds "dark" to <html> for dark and removes it for light', () => {
+    applyThemeClass('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    applyThemeClass('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})
+
+describe('useThemeMode', () => {
+  function Probe({ onState }: { onState: (api: ReturnType<typeof useThemeMode>) => void }) {
+    const api = useThemeMode()
+    onState(api)
+    return null
+  }
+
+  it('explicit light/dark toggles the dark class and persists the preference', () => {
+    let api: ReturnType<typeof useThemeMode> | null = null
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
+
+    // Default is system → light because matchMedia mock returns light.
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(api!.theme).toBe('system')
+    expect(api!.resolvedTheme).toBe('light')
+
+    act(() => api!.setTheme('dark'))
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(api!.resolvedTheme).toBe('dark')
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+
+    act(() => api!.setTheme('light'))
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(api!.resolvedTheme).toBe('light')
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+  })
+
+  it('hydrates initial theme from localStorage', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    let api: ReturnType<typeof useThemeMode> | null = null
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
+    expect(api!.theme).toBe('dark')
+    expect(api!.resolvedTheme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('system preference follows matchMedia and reacts to OS-level changes', () => {
+    const mq = installMatchMediaMock('dark')
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    let api: ReturnType<typeof useThemeMode> | null = null
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
+
+    expect(api!.theme).toBe('system')
+    expect(api!.resolvedTheme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    // Simulate the OS flipping to light without touching the persisted preference.
+    act(() => mq.setSystem('light'))
+    expect(api!.resolvedTheme).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    // Preference itself is unchanged — the user picked "system", not "light".
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+  })
+
+  it('switching from explicit dark to system re-enables OS tracking', () => {
+    const mq = installMatchMediaMock('dark')
+    let api: ReturnType<typeof useThemeMode> | null = null
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
+
+    // Pin to explicit dark first.
+    act(() => api!.setTheme('dark'))
+    expect(api!.resolvedTheme).toBe('dark')
+
+    // Switch back to system — OS is dark so resolvedTheme stays dark.
+    act(() => api!.setTheme('system'))
+    expect(api!.theme).toBe('system')
+    expect(api!.resolvedTheme).toBe('dark')
+
+    // OS flips to light — system mode must follow.
+    act(() => mq.setSystem('light'))
+    expect(api!.resolvedTheme).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('switching away from system removes the OS-change listener', () => {
+    const mq = installMatchMediaMock('dark')
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    let api: ReturnType<typeof useThemeMode> | null = null
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
+
+    expect(api!.resolvedTheme).toBe('dark')
+
+    // Pin to light — the matchMedia listener should be removed.
+    act(() => api!.setTheme('light'))
+    expect(api!.resolvedTheme).toBe('light')
+
+    // OS flips to dark, but we are no longer in system mode — no change expected.
+    act(() => mq.setSystem('dark'))
+    expect(api!.resolvedTheme).toBe('light')
+  })
+})

--- a/apps/web/src/hooks/useThemeMode.test.tsx
+++ b/apps/web/src/hooks/useThemeMode.test.tsx
@@ -67,6 +67,15 @@ describe('readPersistedTheme', () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, '')
     expect(readPersistedTheme()).toBe('system')
   })
+
+  it('falls back to "system" instead of throwing when storage access is blocked', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    expect(() => readPersistedTheme()).not.toThrow()
+    expect(readPersistedTheme()).toBe('system')
+    getItemSpy.mockRestore()
+  })
 })
 
 describe('resolveTheme', () => {
@@ -207,5 +216,32 @@ describe('useThemeMode', () => {
     // OS flips to dark, but we are no longer in system mode — no change expected.
     act(() => mq.setSystem('dark'))
     expect(api!.resolvedTheme).toBe('light')
+  })
+
+  it('does not crash when localStorage access throws (privacy mode / sandboxed iframe)', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+
+    let api: ReturnType<typeof useThemeMode> | null = null
+    expect(() =>
+      render(
+        <Probe
+          onState={(s) => {
+            api = s
+          }}
+        />,
+      ),
+    ).not.toThrow()
+    expect(api!.theme).toBe('system')
+
+    expect(() => act(() => api!.setTheme('dark'))).not.toThrow()
+    expect(api!.resolvedTheme).toBe('dark')
+
+    getItemSpy.mockRestore()
+    setItemSpy.mockRestore()
   })
 })

--- a/apps/web/src/hooks/useThemeMode.ts
+++ b/apps/web/src/hooks/useThemeMode.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react'
+
+// Stored preference. `'system'` defers to `prefers-color-scheme`, which lets
+// users keep the OS setting authoritative without sacrificing manual override.
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+// What actually paints. Excalidraw and `<html class="dark">` only understand
+// concrete values, so we resolve `'system'` against `matchMedia` before use.
+export type ResolvedTheme = 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'whiteboard:theme'
+
+const SYSTEM_QUERY = '(prefers-color-scheme: dark)'
+
+// Read the persisted preference without triggering a render. Safe to call from
+// module init (main.tsx) so we set <html class="dark"> before React mounts and
+// avoid a flash on cold load.
+export function readPersistedTheme(): ThemeMode {
+  if (typeof window === 'undefined') return 'system'
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+  if (stored === 'dark' || stored === 'light' || stored === 'system') return stored
+  return 'system'
+}
+
+export function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'light'
+  return window.matchMedia(SYSTEM_QUERY).matches ? 'dark' : 'light'
+}
+
+export function resolveTheme(mode: ThemeMode): ResolvedTheme {
+  return mode === 'system' ? getSystemTheme() : mode
+}
+
+// Tailwind v4 + shadcn rely on `.dark` on an ancestor — we put it on <html>
+// so every child route (Index, Canvas, dialogs portalled to body) inherits
+// the dark variables.
+export function applyThemeClass(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined') return
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+}
+
+export function useThemeMode(): {
+  theme: ThemeMode
+  resolvedTheme: ResolvedTheme
+  setTheme: (next: ThemeMode) => void
+} {
+  const [theme, setThemeState] = useState<ThemeMode>(() => readPersistedTheme())
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => resolveTheme(theme))
+
+  // Re-resolve whenever the preference changes. For `'system'` also subscribe
+  // to OS-level flips so the UI follows along without a reload.
+  useEffect(() => {
+    if (theme !== 'system') {
+      setResolvedTheme(theme)
+      return
+    }
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      setResolvedTheme('light')
+      return
+    }
+    const mql = window.matchMedia(SYSTEM_QUERY)
+    const update = (e: { matches: boolean }) => setResolvedTheme(e.matches ? 'dark' : 'light')
+    update(mql)
+    mql.addEventListener('change', update)
+    return () => mql.removeEventListener('change', update)
+  }, [theme])
+
+  useEffect(() => {
+    applyThemeClass(resolvedTheme)
+  }, [resolvedTheme])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+    }
+  }, [theme])
+
+  const setTheme = useCallback((next: ThemeMode) => setThemeState(next), [])
+
+  return { theme, resolvedTheme, setTheme }
+}

--- a/apps/web/src/hooks/useThemeMode.ts
+++ b/apps/web/src/hooks/useThemeMode.ts
@@ -12,12 +12,33 @@ export const THEME_STORAGE_KEY = 'whiteboard:theme'
 
 const SYSTEM_QUERY = '(prefers-color-scheme: dark)'
 
+// localStorage access itself can throw (SecurityError when the browser blocks
+// storage via privacy settings or embedded/sandboxed contexts). Theme
+// persistence is a nice-to-have, not a correctness requirement, so a throwing
+// storage degrades to an in-memory-only "system" default rather than crashing
+// render.
+function safeGetItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // Contract: never throws; an unwritable storage just loses persistence.
+  }
+}
+
 // Read the persisted preference without triggering a render. Safe to call from
 // module init (main.tsx) so we set <html class="dark"> before React mounts and
 // avoid a flash on cold load.
 export function readPersistedTheme(): ThemeMode {
   if (typeof window === 'undefined') return 'system'
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+  const stored = safeGetItem(THEME_STORAGE_KEY)
   if (stored === 'dark' || stored === 'light' || stored === 'system') return stored
   return 'system'
 }
@@ -71,7 +92,7 @@ export function useThemeMode(): {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+      safeSetItem(THEME_STORAGE_KEY, theme)
     }
   }, [theme])
 

--- a/apps/web/src/lib/canvas-fullscreen-hash.test.ts
+++ b/apps/web/src/lib/canvas-fullscreen-hash.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { syncFullscreenHash } from './canvas-fullscreen-hash.js'
+
+// The CanvasPage effect that mirrors `isFullscreen` into the URL hash used
+// to clobber any other hash on mount, breaking the add-library import
+// flow that opens the canvas with `#addLibrary=…`. The contract this
+// helper enforces:
+//   1. Going INTO fullscreen rewrites the hash to `#fullscreen` even if a
+//      non-fullscreen hash existed (the user explicitly switched modes).
+//   2. Going OUT of fullscreen clears the hash *only* when the current
+//      hash is `#fullscreen` — never touching a third-party hash like
+//      `#addLibrary=…` that the library-import effect needs to read.
+
+describe('syncFullscreenHash', () => {
+  // Convenience helper to drive the function deterministically without
+  // needing an actual jsdom Location/History pair.
+  function run(
+    isFullscreen: boolean,
+    initial: { pathname: string; search: string; hash: string },
+  ): { hash: string; replaceCalls: number } {
+    let hash = initial.hash
+    let replaceCalls = 0
+    syncFullscreenHash(isFullscreen, {
+      location: {
+        get pathname() {
+          return initial.pathname
+        },
+        get search() {
+          return initial.search
+        },
+        get hash() {
+          return hash
+        },
+      },
+      history: {
+        replaceState(_state, _title, url) {
+          replaceCalls++
+          // Mirror the URL parser the helper hands the History API so the
+          // assertions below see the post-replace hash exactly as the
+          // browser would.
+          const parsed = new URL(url, 'http://example.test')
+          hash = parsed.hash
+        },
+        get state() {
+          return null
+        },
+      },
+    })
+    return { hash, replaceCalls }
+  }
+
+  it('preserves a non-fullscreen hash on initial mount in non-fullscreen mode', () => {
+    const out = run(false, {
+      pathname: '/canvas/ws_a/design',
+      search: '',
+      hash: '#addLibrary=https%3A%2F%2Flibs.example%2Fpack',
+    })
+    expect(out.hash).toBe('#addLibrary=https%3A%2F%2Flibs.example%2Fpack')
+    expect(out.replaceCalls).toBe(0)
+  })
+
+  it('writes #fullscreen when toggled on, even if a different hash existed', () => {
+    const out = run(true, {
+      pathname: '/canvas/ws_a/design',
+      search: '?x=1',
+      hash: '#addLibrary=foo',
+    })
+    expect(out.hash).toBe('#fullscreen')
+    expect(out.replaceCalls).toBe(1)
+  })
+
+  it('clears the hash only when leaving fullscreen mode', () => {
+    const out = run(false, {
+      pathname: '/canvas/ws_a/design',
+      search: '',
+      hash: '#fullscreen',
+    })
+    expect(out.hash).toBe('')
+    expect(out.replaceCalls).toBe(1)
+  })
+
+  it('is a no-op when fullscreen state already matches the hash', () => {
+    const a = run(true, { pathname: '/c', search: '', hash: '#fullscreen' })
+    expect(a.replaceCalls).toBe(0)
+    const b = run(false, { pathname: '/c', search: '', hash: '' })
+    expect(b.replaceCalls).toBe(0)
+  })
+
+  it('does not strip an unrelated hash when toggling off (defensive)', () => {
+    // Hypothetical race: fullscreen flipped off via an external hashchange
+    // that already updated the URL. The effect must not aggressively
+    // re-write the hash to empty just because isFullscreen is false.
+    const out = run(false, {
+      pathname: '/canvas/ws_a/design',
+      search: '',
+      hash: '#someOther=1',
+    })
+    expect(out.hash).toBe('#someOther=1')
+    expect(out.replaceCalls).toBe(0)
+  })
+})

--- a/apps/web/src/lib/canvas-fullscreen-hash.ts
+++ b/apps/web/src/lib/canvas-fullscreen-hash.ts
@@ -1,0 +1,48 @@
+// Mirrors the locally-toggled `isFullscreen` state into the URL hash
+// without disturbing other hashes.
+//
+// Background: the canvas page can be opened with payload-bearing hashes
+// like `#addLibrary=…` (Excalidraw library import return flow). The
+// previous implementation wrote `''` whenever isFullscreen was false,
+// which clobbered those hashes on initial mount before the consuming
+// effect could read them.
+//
+// Contract:
+//   • When isFullscreen flips on  → write `#fullscreen` (overwrites any
+//     pre-existing hash because the user explicitly switched modes).
+//   • When isFullscreen flips off → clear the hash *only* if the current
+//     hash is `#fullscreen`. Any other hash is left alone so its owner
+//     can still consume it.
+//   • Idempotent: skip the History call when the hash already matches.
+//
+// Extracted as a pure helper so the regression has a unit test that does
+// not need a live React tree.
+
+const FULLSCREEN_HASH = '#fullscreen'
+
+export interface FullscreenHashTarget {
+  location: {
+    readonly pathname: string
+    readonly search: string
+    readonly hash: string
+  }
+  history: {
+    replaceState(state: unknown, unused: string, url: string): void
+    readonly state: unknown
+  }
+}
+
+export function syncFullscreenHash(isFullscreen: boolean, target: FullscreenHashTarget): void {
+  const currentHash = target.location.hash
+  if (isFullscreen) {
+    if (currentHash === FULLSCREEN_HASH) return
+    const url = `${target.location.pathname}${target.location.search}${FULLSCREEN_HASH}`
+    target.history.replaceState(target.history.state, '', url)
+    return
+  }
+  // Non-fullscreen: only clean up our own marker. Leaving foreign hashes
+  // untouched is the whole point of this helper.
+  if (currentHash !== FULLSCREEN_HASH) return
+  const url = `${target.location.pathname}${target.location.search}`
+  target.history.replaceState(target.history.state, '', url)
+}

--- a/apps/web/src/lib/canvas-page-fullscreen.test.ts
+++ b/apps/web/src/lib/canvas-page-fullscreen.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { detectInitialFullscreen, isFullscreenHash } from './canvas-page-fullscreen.js'
+
+describe('isFullscreenHash', () => {
+  it('matches the canonical fragment', () => {
+    expect(isFullscreenHash('#fullscreen')).toBe(true)
+  })
+
+  it('rejects empty / unrelated / case-shifted fragments', () => {
+    expect(isFullscreenHash('')).toBe(false)
+    expect(isFullscreenHash('#other')).toBe(false)
+    expect(isFullscreenHash('#FULLSCREEN')).toBe(false)
+  })
+})
+
+describe('detectInitialFullscreen', () => {
+  it('honours the #fullscreen hash even when the query is absent', () => {
+    expect(detectInitialFullscreen({ hash: '#fullscreen', search: new URLSearchParams() })).toBe(
+      true,
+    )
+  })
+
+  it('falls back to ?fullscreen=1 for legacy callers', () => {
+    expect(detectInitialFullscreen({ hash: '', search: new URLSearchParams('fullscreen=1') })).toBe(
+      true,
+    )
+  })
+
+  it('returns false when neither signal is present', () => {
+    expect(detectInitialFullscreen({ hash: '', search: new URLSearchParams() })).toBe(false)
+  })
+
+  it('treats fullscreen=0 (or any non-1 value) as not fullscreen', () => {
+    expect(detectInitialFullscreen({ hash: '', search: new URLSearchParams('fullscreen=0') })).toBe(
+      false,
+    )
+    expect(
+      detectInitialFullscreen({ hash: '', search: new URLSearchParams('fullscreen=true') }),
+    ).toBe(false)
+  })
+
+  it('accepts a raw search string and parses it identically', () => {
+    expect(detectInitialFullscreen({ hash: '', search: '?fullscreen=1' })).toBe(true)
+    expect(detectInitialFullscreen({ hash: '', search: 'fullscreen=1' })).toBe(true)
+  })
+})

--- a/apps/web/src/lib/canvas-page-fullscreen.ts
+++ b/apps/web/src/lib/canvas-page-fullscreen.ts
@@ -1,0 +1,26 @@
+// Fullscreen detection helpers for CanvasPage.
+//
+// Two URL forms are accepted:
+//   • `#fullscreen` (current) — fragment-only, so re-opening the same canvas
+//     fires `hashchange` instead of a real navigation. The page never reloads,
+//     in-page state (dialogs, tooltips, history popovers) is preserved, and
+//     any beforeunload listener registered by the page or libraries cannot
+//     interject.
+//   • `?fullscreen=1` (legacy) — read on mount only, kept for back-compat
+//     with existing transcripts and bookmarks. The hash form is what
+//     `canvas_open` emits going forward.
+
+const FULLSCREEN_HASH = '#fullscreen'
+
+export function isFullscreenHash(hash: string): boolean {
+  return hash === FULLSCREEN_HASH
+}
+
+export function detectInitialFullscreen(args: {
+  search: URLSearchParams | string
+  hash: string
+}): boolean {
+  if (isFullscreenHash(args.hash)) return true
+  const params = typeof args.search === 'string' ? new URLSearchParams(args.search) : args.search
+  return params.get('fullscreen') === '1'
+}

--- a/apps/web/src/port-parity.test.ts
+++ b/apps/web/src/port-parity.test.ts
@@ -13,7 +13,12 @@ import { describe, expect, it } from 'vitest'
 //   1. Relative import specifier extension style (e.g. `./foo.js` vs `./foo`)
 //   2. The `// @vitest-environment jsdom` pragma line (apps/web defaults to
 //      jsdom, so the pragma is redundant there and was dropped)
-//   3. Trailing whitespace / trailing-newline differences
+//   3. Whitespace differences, including line-wrapping, and the trailing
+//      commas the formatter adds/removes as a direct consequence of
+//      wrapping — apps/web and packages/mcp-server run separate formatter
+//      configs (Biome pre-commit hooks reformat on each commit
+//      independently), so wrap width drifts between the two trees without
+//      any logic change
 //
 // Any other divergence is a real drift and must fail.
 
@@ -70,18 +75,31 @@ const pairs: PortPair[] = [
 ]
 
 function normalize(source: string): string {
-  return source
+  let normalized = source
     .split('\n')
     .filter((line) => line.trim() !== '// @vitest-environment jsdom')
-    .map((line) =>
-      line.replace(
-        /from ('|")(\.\.?\/[^'"]+)\.js\1/g,
-        (_match, quote, spec) => `from ${quote}${spec}${quote}`,
-      ),
-    )
-    .map((line) => line.replace(/[ \t]+$/, ''))
     .join('\n')
+    .replace(
+      /from ('|")(\.\.?\/[^'"]+)\.js\1/g,
+      (_match, quote, spec) => `from ${quote}${spec}${quote}`,
+    )
+    .replace(/\s+/g, ' ')
     .trim()
+
+  // Wrapping a call/array/object across multiple lines is a pure formatter
+  // choice: it can add/remove a trailing comma before the closing bracket,
+  // and it always inserts a newline (collapsed to a space above) right
+  // after an opening bracket / before a closing one. Neither is a logic
+  // change, so strip whitespace touching brackets and drop dangling
+  // trailing commas. Repeat until stable — removing one can expose another
+  // (e.g. `a, ], )`).
+  let previous: string
+  do {
+    previous = normalized
+    normalized = normalized.replace(/,\s*([)\]}])/g, '$1').replace(/\s*([()[\]{}])\s*/g, '$1')
+  } while (normalized !== previous)
+
+  return normalized
 }
 
 function unifiedDiff(label: string, expected: string, actual: string): string {

--- a/apps/web/src/port-parity.test.ts
+++ b/apps/web/src/port-parity.test.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Stage 2 slice 4 (ADR 0001) ported four API-free pure-logic modules from the
+// daemon app (packages/mcp-server/src/app, frozen, deleted in Stage 5) into
+// apps/web (canonical going forward). During the dual-copy window a fix
+// landing on only one side would drift silently — this test pins the two
+// copies together so CI catches that instead of a future bug report.
+//
+// Allowed adaptations (the only differences tolerated by normalization):
+//   1. Relative import specifier extension style (e.g. `./foo.js` vs `./foo`)
+//   2. The `// @vitest-environment jsdom` pragma line (apps/web defaults to
+//      jsdom, so the pragma is redundant there and was dropped)
+//   3. Trailing whitespace / trailing-newline differences
+//
+// Any other divergence is a real drift and must fail.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../../..')
+
+interface PortPair {
+  label: string
+  original: string
+  ported: string
+}
+
+const pairs: PortPair[] = [
+  {
+    label: 'useThemeMode.ts',
+    original: 'packages/mcp-server/src/app/hooks/useThemeMode.ts',
+    ported: 'apps/web/src/hooks/useThemeMode.ts',
+  },
+  {
+    label: 'useThemeMode.test.tsx',
+    original: 'packages/mcp-server/src/app/hooks/useThemeMode.test.tsx',
+    ported: 'apps/web/src/hooks/useThemeMode.test.tsx',
+  },
+  {
+    label: 'useDirtyState.ts',
+    original: 'packages/mcp-server/src/app/hooks/useDirtyState.ts',
+    ported: 'apps/web/src/hooks/useDirtyState.ts',
+  },
+  {
+    label: 'useDirtyState.test.ts',
+    original: 'packages/mcp-server/src/app/hooks/useDirtyState.test.ts',
+    ported: 'apps/web/src/hooks/useDirtyState.test.ts',
+  },
+  {
+    label: 'canvas-page-fullscreen.ts',
+    original: 'packages/mcp-server/src/app/pages/canvas-page-fullscreen.ts',
+    ported: 'apps/web/src/lib/canvas-page-fullscreen.ts',
+  },
+  {
+    label: 'canvas-page-fullscreen.test.ts',
+    original: 'packages/mcp-server/src/app/pages/canvas-page-fullscreen.test.ts',
+    ported: 'apps/web/src/lib/canvas-page-fullscreen.test.ts',
+  },
+  {
+    label: 'canvas-fullscreen-hash.ts',
+    original: 'packages/mcp-server/src/app/pages/canvas-fullscreen-hash.ts',
+    ported: 'apps/web/src/lib/canvas-fullscreen-hash.ts',
+  },
+  {
+    label: 'canvas-fullscreen-hash.test.ts',
+    original: 'packages/mcp-server/src/app/pages/canvas-fullscreen-hash.test.ts',
+    ported: 'apps/web/src/lib/canvas-fullscreen-hash.test.ts',
+  },
+]
+
+function normalize(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => line.trim() !== '// @vitest-environment jsdom')
+    .map((line) =>
+      line.replace(
+        /from ('|")(\.\.?\/[^'"]+)\.js\1/g,
+        (_match, quote, spec) => `from ${quote}${spec}${quote}`,
+      ),
+    )
+    .map((line) => line.replace(/[ \t]+$/, ''))
+    .join('\n')
+    .trim()
+}
+
+function unifiedDiff(label: string, expected: string, actual: string): string {
+  const expectedLines = expected.split('\n')
+  const actualLines = actual.split('\n')
+  const max = Math.max(expectedLines.length, actualLines.length)
+  const diffLines: string[] = []
+  for (let i = 0; i < max; i++) {
+    if (expectedLines[i] !== actualLines[i]) {
+      diffLines.push(`  line ${i + 1}:`)
+      diffLines.push(`    - ${expectedLines[i] ?? '<missing>'}`)
+      diffLines.push(`    + ${actualLines[i] ?? '<missing>'}`)
+    }
+  }
+  return `${label} diverged beyond allowed adaptations:\n${diffLines.join('\n')}`
+}
+
+describe('port-parity (Stage 2 slice 4 dual-copy guard)', () => {
+  for (const pair of pairs) {
+    it(`${pair.label}: apps/web copy matches the frozen packages/mcp-server original`, () => {
+      const originalPath = resolve(repoRoot, pair.original)
+      const portedPath = resolve(repoRoot, pair.ported)
+      expect(existsSync(originalPath), `missing original: ${pair.original}`).toBe(true)
+      expect(existsSync(portedPath), `missing ported copy: ${pair.ported}`).toBe(true)
+
+      const originalSource = readFileSync(originalPath, 'utf8')
+      const portedSource = readFileSync(portedPath, 'utf8')
+      expect(originalSource.length, `original is empty: ${pair.original}`).toBeGreaterThan(0)
+      expect(portedSource.length, `ported copy is empty: ${pair.ported}`).toBeGreaterThan(0)
+
+      const normalizedOriginal = normalize(originalSource)
+      const normalizedPorted = normalize(portedSource)
+      expect(normalizedPorted, unifiedDiff(pair.label, normalizedOriginal, normalizedPorted)).toBe(
+        normalizedOriginal,
+      )
+    })
+  }
+})

--- a/packages/mcp-server/src/app/hooks/useThemeMode.test.tsx
+++ b/packages/mcp-server/src/app/hooks/useThemeMode.test.tsx
@@ -67,6 +67,15 @@ describe('readPersistedTheme', () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, '')
     expect(readPersistedTheme()).toBe('system')
   })
+
+  it('falls back to "system" instead of throwing when storage access is blocked', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    expect(() => readPersistedTheme()).not.toThrow()
+    expect(readPersistedTheme()).toBe('system')
+    getItemSpy.mockRestore()
+  })
 })
 
 describe('resolveTheme', () => {
@@ -97,7 +106,13 @@ describe('useThemeMode', () => {
 
   it('explicit light/dark toggles the dark class and persists the preference', () => {
     let api: ReturnType<typeof useThemeMode> | null = null
-    render(<Probe onState={(s) => { api = s }} />)
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
 
     // Default is system → light because matchMedia mock returns light.
     expect(document.documentElement.classList.contains('dark')).toBe(false)
@@ -118,7 +133,13 @@ describe('useThemeMode', () => {
   it('hydrates initial theme from localStorage', () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
     let api: ReturnType<typeof useThemeMode> | null = null
-    render(<Probe onState={(s) => { api = s }} />)
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
     expect(api!.theme).toBe('dark')
     expect(api!.resolvedTheme).toBe('dark')
     expect(document.documentElement.classList.contains('dark')).toBe(true)
@@ -128,7 +149,13 @@ describe('useThemeMode', () => {
     const mq = installMatchMediaMock('dark')
     window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
     let api: ReturnType<typeof useThemeMode> | null = null
-    render(<Probe onState={(s) => { api = s }} />)
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
 
     expect(api!.theme).toBe('system')
     expect(api!.resolvedTheme).toBe('dark')
@@ -145,7 +172,13 @@ describe('useThemeMode', () => {
   it('switching from explicit dark to system re-enables OS tracking', () => {
     const mq = installMatchMediaMock('dark')
     let api: ReturnType<typeof useThemeMode> | null = null
-    render(<Probe onState={(s) => { api = s }} />)
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
 
     // Pin to explicit dark first.
     act(() => api!.setTheme('dark'))
@@ -166,7 +199,13 @@ describe('useThemeMode', () => {
     const mq = installMatchMediaMock('dark')
     window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
     let api: ReturnType<typeof useThemeMode> | null = null
-    render(<Probe onState={(s) => { api = s }} />)
+    render(
+      <Probe
+        onState={(s) => {
+          api = s
+        }}
+      />,
+    )
 
     expect(api!.resolvedTheme).toBe('dark')
 
@@ -177,5 +216,32 @@ describe('useThemeMode', () => {
     // OS flips to dark, but we are no longer in system mode — no change expected.
     act(() => mq.setSystem('dark'))
     expect(api!.resolvedTheme).toBe('light')
+  })
+
+  it('does not crash when localStorage access throws (privacy mode / sandboxed iframe)', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError')
+    })
+
+    let api: ReturnType<typeof useThemeMode> | null = null
+    expect(() =>
+      render(
+        <Probe
+          onState={(s) => {
+            api = s
+          }}
+        />,
+      ),
+    ).not.toThrow()
+    expect(api!.theme).toBe('system')
+
+    expect(() => act(() => api!.setTheme('dark'))).not.toThrow()
+    expect(api!.resolvedTheme).toBe('dark')
+
+    getItemSpy.mockRestore()
+    setItemSpy.mockRestore()
   })
 })

--- a/packages/mcp-server/src/app/hooks/useThemeMode.ts
+++ b/packages/mcp-server/src/app/hooks/useThemeMode.ts
@@ -12,12 +12,33 @@ export const THEME_STORAGE_KEY = 'whiteboard:theme'
 
 const SYSTEM_QUERY = '(prefers-color-scheme: dark)'
 
+// localStorage access itself can throw (SecurityError when the browser blocks
+// storage via privacy settings or embedded/sandboxed contexts). Theme
+// persistence is a nice-to-have, not a correctness requirement, so a throwing
+// storage degrades to an in-memory-only "system" default rather than crashing
+// render.
+function safeGetItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // Contract: never throws; an unwritable storage just loses persistence.
+  }
+}
+
 // Read the persisted preference without triggering a render. Safe to call from
 // module init (main.tsx) so we set <html class="dark"> before React mounts and
 // avoid a flash on cold load.
 export function readPersistedTheme(): ThemeMode {
   if (typeof window === 'undefined') return 'system'
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+  const stored = safeGetItem(THEME_STORAGE_KEY)
   if (stored === 'dark' || stored === 'light' || stored === 'system') return stored
   return 'system'
 }
@@ -71,7 +92,7 @@ export function useThemeMode(): {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+      safeSetItem(THEME_STORAGE_KEY, theme)
     }
   }, [theme])
 

--- a/packages/mcp-server/src/server/release/port-parity.test.ts
+++ b/packages/mcp-server/src/server/release/port-parity.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from 'vitest'
 // Any other divergence is a real drift and must fail.
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const repoRoot = resolve(__dirname, '../../..')
+const repoRoot = resolve(__dirname, '../../../../..')
 
 interface PortPair {
   label: string


### PR DESCRIPTION
UI-unification Stage 2, slice 4 (ADR 0001/0004). Ports the four API-free pure-logic modules the unified CanvasPage needs, with tests, red-first per module:

- `useThemeMode` (+9 tests) — self-contained theme hook (localStorage `whiteboard:theme`, `prefers-color-scheme` subscription, `.dark` on `<html>`); flagged by architecture review as a hidden dependency of slices 9-10
- `useDirtyState` (+10) — window CustomEvent-based dirty tracking; event coupling kept as-is (the apps/web dispatcher is a slice 9-10 decision per ADR-0004's event-bus policy)
- `canvas-page-fullscreen` (+7) and `canvas-fullscreen-hash` (+5) — fullscreen detection + hash mirroring, relocated to `apps/web/src/lib/`

**Canonical/frozen policy**: the apps/web copies are canonical; the `src/app` originals stay in place until Stage 5 deletes them. A new **`port-parity.test.ts` drift guard** asserts the copies stay identical (modulo import-extension/pragma adaptations) so a fix landing on only one side fails CI during the dual-copy window (mutation-checked).

**One deliberate freeze deviation**: a real bug fix — `localStorage` access can throw (SecurityError in privacy-restricted/embedded contexts) — was applied **symmetrically to both copies** (with tests on both sides), because the parity guard by design requires fixes to land on both. Behavior only degrades to in-memory "system" default instead of crashing render. `useWhiteboardSync` and all other frozen files are untouched.

No consumers wired yet (BrowserLocalCanvasPage untouched — wiring is slices 9-10).

## Verification
apps/web jsdom 318 ✓ (ported 31+ cases + parity guard collected) / browser 58 ✓ / tsc ✓ / mcp typecheck ✓ / mcp-jsdom 285 ✓ (daemon-side safe-storage tests included). Review: 3 LOW (documented, below fix threshold).