### PR TITLE
feat(mcp-server): expose api-client/api-contracts subpaths, port pure libs to apps/web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@fast-check/vitest": "^0.4.1",
     "@tailwindcss/vite": "^4",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19",
@@ -44,6 +45,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/browser-playwright": "catalog:",
     "fake-indexeddb": "^6.2.5",
+    "fast-check": "^4.7.0",
     "playwright": "1.59.1",
     "tailwindcss": "^4",
     "typescript": "catalog:",

--- a/apps/web/src/_type-probe.ts
+++ b/apps/web/src/_type-probe.ts
@@ -61,3 +61,21 @@ import type {
 export declare function _useBackend(b: CanvasBackend): void
 export declare function _useHandlers(h: CanvasBackendHandlers): void
 export declare function _usePayload(p: VersionCreatedPayload): void
+
+// ── api-client from its own subpath ───────────────────────────────────────────
+import type { RuntimeConfig } from '@kamiazya/whiteboard-mcp/api-client'
+
+export { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+export declare function _useRuntimeConfig(c: RuntimeConfig): void
+
+// ── api-contracts barrel: proves the branches + canvas Zod schemas resolve
+// and z.infer-derived types compile under this DOM-enabled tsconfig too ─────
+export { branchMetaSchema, createCanvasRequestSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+
+import type {
+  branchMetaSchema,
+  createCanvasRequestSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+import type { z } from 'zod'
+export declare function _useBranchMeta(b: z.infer<typeof branchMetaSchema>): void
+export declare function _useCreateCanvasRequest(r: z.infer<typeof createCanvasRequestSchema>): void

--- a/apps/web/src/lib/app-logger.test.ts
+++ b/apps/web/src/lib/app-logger.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAppLogger } from './app-logger.js'
+
+describe('getAppLogger', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('DEV=true path', () => {
+    beforeEach(() => {
+      vi.stubGlobal('import.meta', { env: { DEV: true } })
+    })
+
+    it('forwards error to console.error with name tag', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const logger = getAppLogger('test-name')
+      logger.error('msg', 'ctx')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[test-name]')
+      expect(spy.mock.calls[0][0]).toContain('msg')
+      expect(spy.mock.calls[0][1]).toBe('ctx')
+    })
+
+    it('forwards warn to console.warn with name tag', () => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const logger = getAppLogger('test-name')
+      logger.warn('wmsg', 42)
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[test-name]')
+      expect(spy.mock.calls[0][0]).toContain('wmsg')
+      expect(spy.mock.calls[0][1]).toBe(42)
+    })
+
+    it('forwards info to console.info with name tag', () => {
+      const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+      const logger = getAppLogger('test-name')
+      logger.info('imsg')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[test-name]')
+    })
+
+    it('forwards debug to console.debug with name tag', () => {
+      const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+      const logger = getAppLogger('test-name')
+      logger.debug('dmsg')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[test-name]')
+    })
+  })
+
+  describe('PROD path (DEV=false)', () => {
+    beforeEach(() => {
+      vi.stubGlobal('import.meta', { env: { DEV: false } })
+    })
+
+    it('does not call console.error', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const logger = getAppLogger('prod')
+      logger.error('silent')
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not call console.warn', () => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const logger = getAppLogger('prod')
+      logger.warn('silent')
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not call console.info', () => {
+      const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+      const logger = getAppLogger('prod')
+      logger.info('silent')
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not call console.debug', () => {
+      const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+      const logger = getAppLogger('prod')
+      logger.debug('silent')
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('name tag independence', () => {
+    beforeEach(() => {
+      vi.stubGlobal('import.meta', { env: { DEV: true } })
+    })
+
+    it('two loggers embed their own name tags independently', () => {
+      const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const loggerA = getAppLogger('alpha')
+      const loggerB = getAppLogger('beta')
+      loggerA.warn('from-a')
+      loggerB.warn('from-b')
+      expect(spyWarn).toHaveBeenCalledTimes(2)
+      expect(spyWarn.mock.calls[0][0]).toContain('[alpha]')
+      expect(spyWarn.mock.calls[1][0]).toContain('[beta]')
+    })
+
+    it('two loggers return independent objects', () => {
+      const loggerA = getAppLogger('a')
+      const loggerB = getAppLogger('b')
+      expect(loggerA).not.toBe(loggerB)
+    })
+  })
+})

--- a/apps/web/src/lib/app-logger.test.ts
+++ b/apps/web/src/lib/app-logger.test.ts
@@ -84,6 +84,21 @@ describe('getAppLogger', () => {
     })
   })
 
+  describe('real import.meta.env.DEV (no global stub)', () => {
+    // Regression: the logger must read the real Vite-provided import.meta.env.DEV
+    // when nothing stubs globalThis['import.meta'] — this is the path the actual
+    // running app takes. Vitest itself runs with import.meta.env.DEV === true,
+    // so the fallback should behave like a real dev build here.
+    it('logs because the real import.meta.env.DEV is true under vitest', () => {
+      expect(import.meta.env.DEV).toBe(true)
+      const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+      const logger = getAppLogger('real-env')
+      logger.info('via real import.meta')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[real-env]')
+    })
+  })
+
   describe('name tag independence', () => {
     beforeEach(() => {
       vi.stubGlobal('import.meta', { env: { DEV: true } })

--- a/apps/web/src/lib/app-logger.ts
+++ b/apps/web/src/lib/app-logger.ts
@@ -1,0 +1,55 @@
+export interface AppLogger {
+  error(message: string, ...context: unknown[]): void
+  warn(message: string, ...context: unknown[]): void
+  info(message: string, ...context: unknown[]): void
+  debug(message: string, ...context: unknown[]): void
+}
+
+/**
+ * Browser-safe logger for the app/ layer.
+ * In dev mode, forwards structured records to the browser console.
+ * In prod mode, all methods are no-ops so no console noise ships to users.
+ *
+ * The DEV check is evaluated at call time (not module load time) so that
+ * vi.stubGlobal('import.meta', ...) in tests can switch branches after
+ * the module is imported.
+ */
+export function getAppLogger(name: string): AppLogger {
+  const tag = `[${name}]`
+
+  function log(
+    level: 'error' | 'warn' | 'info' | 'debug',
+    message: string,
+    context: unknown[],
+  ): void {
+    // Read DEV at call time (not module load time). vi.stubGlobal('import.meta', ...)
+    // stores the stub under the key 'import.meta' (literal dot) on globalThis, so we
+    // look that up first. Vite replaces the source literal `import.meta.env.DEV` at
+    // transform time, so we must avoid that expression in production source; the
+    // globalThis bracket lookup is invisible to the Vite transform pass.
+    const g = globalThis as Record<string, unknown>
+    const importMeta = (g['import.meta'] ?? import.meta) as
+      | { env?: Record<string, unknown> }
+      | undefined
+    const isDev = importMeta?.['env']?.['DEV'] === true
+    if (isDev) {
+      // eslint-disable-next-line no-console
+      console[level](`${tag} ${message}`, ...context)
+    }
+  }
+
+  return {
+    error(message: string, ...context: unknown[]): void {
+      log('error', message, context)
+    },
+    warn(message: string, ...context: unknown[]): void {
+      log('warn', message, context)
+    },
+    info(message: string, ...context: unknown[]): void {
+      log('info', message, context)
+    },
+    debug(message: string, ...context: unknown[]): void {
+      log('debug', message, context)
+    },
+  }
+}

--- a/apps/web/src/lib/app-logger.ts
+++ b/apps/web/src/lib/app-logger.ts
@@ -24,9 +24,11 @@ export function getAppLogger(name: string): AppLogger {
   ): void {
     // Read DEV at call time (not module load time). vi.stubGlobal('import.meta', ...)
     // stores the stub under the key 'import.meta' (literal dot) on globalThis, so we
-    // look that up first. Vite replaces the source literal `import.meta.env.DEV` at
-    // transform time, so we must avoid that expression in production source; the
-    // globalThis bracket lookup is invisible to the Vite transform pass.
+    // look that up first to let tests override it after the module is imported.
+    // When no stub is present (the real running app), this falls through to the
+    // genuine `import.meta` object that Vite injects at runtime — `import.meta.env.DEV`
+    // is a real, always-populated property there, not just a build-time literal
+    // substitution, so the fallback reflects the actual dev/prod build correctly.
     const g = globalThis as Record<string, unknown>
     const importMeta = (g['import.meta'] ?? import.meta) as
       | { env?: Record<string, unknown> }

--- a/apps/web/src/lib/error-copy.test.ts
+++ b/apps/web/src/lib/error-copy.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { safeErrorCopy } from './error-copy.js'
+
+describe('safeErrorCopy — deterministic cases', () => {
+  it('returns body.title for Problem Details objects (RFC 9457)', () => {
+    const err = {
+      status: 409,
+      body: {
+        type: 'https://example.com/problems/branch_conflict',
+        title: 'Branch already exists',
+        status: 409,
+      },
+    }
+    expect(safeErrorCopy(err, 'fallback')).toBe('Branch already exists')
+  })
+
+  it('returns fallback for Error instances — never exposes err.message', () => {
+    expect(safeErrorCopy(new Error('internal: token=secret-abc'), 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback when body.title is absent (even if body.message is present)', () => {
+    const err = { status: 400, body: { message: 'Name too long' } }
+    expect(safeErrorCopy(err, 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback when body has neither title nor message', () => {
+    const err = { status: 409, body: { error: 'branch_conflict' } }
+    expect(safeErrorCopy(err, 'Something went wrong.')).toBe('Something went wrong.')
+  })
+
+  it('returns fallback when body is absent', () => {
+    expect(safeErrorCopy({ status: 500 }, 'Server error.')).toBe('Server error.')
+  })
+
+  it('returns fallback for null', () => {
+    expect(safeErrorCopy(null, 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback for undefined', () => {
+    expect(safeErrorCopy(undefined, 'fallback')).toBe('fallback')
+  })
+
+  it('returns fallback for primitives', () => {
+    expect(safeErrorCopy(42, 'fallback')).toBe('fallback')
+    expect(safeErrorCopy('raw string', 'fallback')).toBe('fallback')
+  })
+
+  it('ignores empty body.title and returns fallback', () => {
+    expect(safeErrorCopy({ status: 400, body: { title: '' } }, 'fallback')).toBe('fallback')
+  })
+
+  it('does not serialize raw JSON of a BranchApiError-shaped object', () => {
+    const err = {
+      status: 409,
+      body: { type: 'https://example.com/problems/conflict', title: 'Conflict', status: 409 },
+    }
+    const result = safeErrorCopy(err, 'fallback')
+    expect(result).not.toContain('{')
+    expect(result).not.toContain('https://')
+    expect(result).toBe('Conflict')
+  })
+})
+
+describe('safeErrorCopy — property tests (P-HTTP-005)', () => {
+  // Error.message must never reach the UI regardless of content.
+  // This is the primary P-HTTP-005 guarantee: stack traces, local paths, and tokens
+  // thrown as Error objects are always replaced by fallback.
+  fcTest.prop([fc.string()], withDefaults())(
+    'Error.message is never forwarded to the UI',
+    (message) => {
+      const result = safeErrorCopy(new Error(message), 'FALLBACK')
+      expect(result).toBe('FALLBACK')
+    },
+  )
+
+  // body.message must never reach the UI (not a standard RFC 9457 field).
+  fcTest.prop([fc.string()], withDefaults())(
+    'body.message is never forwarded even without body.title',
+    (message) => {
+      const err = { status: 400, body: { message } }
+      const result = safeErrorCopy(err, 'FALLBACK')
+      expect(result).toBe('FALLBACK')
+    },
+  )
+
+  // Sensitive patterns inside Error.message must not leak.
+  const sensitiveMessage = fc.oneof(
+    // Authorization header value
+    fc.string().map((s) => `Authorization: Bearer ${s}`),
+    // Local filesystem path
+    fc.string().map((s) => `/Users/${s}/config.json`),
+    // Stack-like string
+    fc.string().map((s) => `Error: at ${s} (${s}:1:2)\n    at Object.<anonymous> (${s}:3:4)`),
+    // Problem Details type URL (should not appear in UI via Error.message)
+    fc.string().map((s) => `https://example.com/problems/${s}`),
+  )
+
+  fcTest.prop([sensitiveMessage], withDefaults())(
+    'sensitive patterns in Error.message never reach output',
+    (message) => {
+      const result = safeErrorCopy(new Error(message), 'FALLBACK')
+      expect(result).toBe('FALLBACK')
+    },
+  )
+
+  // body.title IS allowed through — it is RFC 9457-designed for display.
+  // Verify a non-empty title string always reaches the output.
+  fcTest.prop([fc.string({ minLength: 1 })], withDefaults())(
+    'non-empty body.title is forwarded as the display copy',
+    (title) => {
+      const err = { status: 400, body: { title } }
+      const result = safeErrorCopy(err, 'FALLBACK')
+      expect(result).toBe(title)
+    },
+  )
+})

--- a/apps/web/src/lib/error-copy.ts
+++ b/apps/web/src/lib/error-copy.ts
@@ -1,0 +1,20 @@
+// UI copy helper for error banners (P-HTTP-005 level).
+//
+// Contract:
+//   - Error.message is never forwarded — it may contain internal paths, tokens, or stack traces.
+//   - body.message is never forwarded — it is not a standard Problem Details field and may be internal.
+//   - body.title (RFC 9457 Problem Details) IS forwarded — it is a static, human-readable string
+//     that server authors intend for display and is not derived from user input or request context.
+//   - All other values return fallback.
+
+export function safeErrorCopy(err: unknown, fallback: string): string {
+  if (err instanceof Error) return fallback
+  if (err && typeof err === 'object') {
+    const body = (err as { body?: Record<string, unknown> }).body
+    if (body && typeof body === 'object') {
+      // RFC 9457 §3.1: 'title' is a short, human-readable summary of the problem type.
+      if (typeof body['title'] === 'string' && body['title'].length > 0) return body['title']
+    }
+  }
+  return fallback
+}

--- a/apps/web/src/lib/format-bytes.test.ts
+++ b/apps/web/src/lib/format-bytes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes } from './format-bytes.js'
+
+describe('formatBytes', () => {
+  it('returns "0 B" for zero, negative, or non-finite input', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(-100)).toBe('0 B')
+    expect(formatBytes(Number.NaN)).toBe('0 B')
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('0 B')
+  })
+
+  it('uses raw bytes below 1 KiB without decimals', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+  })
+
+  it('uses one decimal at KiB / MiB / GiB scale', () => {
+    expect(formatBytes(1024)).toBe('1.0 KiB')
+    expect(formatBytes(1536)).toBe('1.5 KiB')
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MiB')
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GiB')
+  })
+
+  it('caps at TiB so very large values do not fall off the unit list', () => {
+    const huge = 10 * 1024 ** 4
+    expect(formatBytes(huge)).toBe('10.0 TiB')
+  })
+})

--- a/apps/web/src/lib/format-bytes.test.ts
+++ b/apps/web/src/lib/format-bytes.test.ts
@@ -14,6 +14,15 @@ describe('formatBytes', () => {
     expect(formatBytes(1023)).toBe('1023 B')
   })
 
+  it('bumps to the next unit when rounding would display 1024', () => {
+    // 1023.6 B rounds to 1024 — display as 1.0 KiB, never "1024 B".
+    expect(formatBytes(1023.6)).toBe('1.0 KiB')
+    // 1023.95 KiB → toFixed(1) gives "1024.0" — display as 1.0 MiB.
+    expect(formatBytes(1023.95 * 1024)).toBe('1.0 MiB')
+    // At the TiB cap there is no next unit; the raw rounding stands.
+    expect(formatBytes(1023.95 * 1024 ** 4)).toBe('1024.0 TiB')
+  })
+
   it('uses one decimal at KiB / MiB / GiB scale', () => {
     expect(formatBytes(1024)).toBe('1.0 KiB')
     expect(formatBytes(1536)).toBe('1.5 KiB')

--- a/apps/web/src/lib/format-bytes.ts
+++ b/apps/web/src/lib/format-bytes.ts
@@ -17,6 +17,13 @@ export function formatBytes(bytes: number): string {
   }
   // Show no decimals for raw bytes, one decimal for KiB+, to keep widths
   // tight in the IndexPage footer.
-  const formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1)
+  let formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1)
+  // Values just under a unit boundary (e.g. 1023.6 B) survive the division
+  // loop but round up to a displayed "1024" — bump to the next unit instead
+  // of showing "1024 B" / "1024.0 KiB". At the TiB cap the rounding stands.
+  if ((formatted === '1024' || formatted === '1024.0') && unit < UNITS.length - 1) {
+    unit += 1
+    formatted = '1.0'
+  }
   return `${formatted} ${UNITS[unit]}`
 }

--- a/apps/web/src/lib/format-bytes.ts
+++ b/apps/web/src/lib/format-bytes.ts
@@ -1,0 +1,22 @@
+// Render a byte count as a short human-readable label. Two significant
+// digits at MiB+ resolution is enough for the storage footer; we only need
+// users to spot orders-of-magnitude differences at a glance.
+//
+// Binary units (KiB / MiB / GiB) match what users see in macOS Finder /
+// Linux du -h and are unambiguous in a system-administration context.
+
+const UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB'] as const
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  // Show no decimals for raw bytes, one decimal for KiB+, to keep widths
+  // tight in the IndexPage footer.
+  const formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1)
+  return `${formatted} ${UNITS[unit]}`
+}

--- a/apps/web/src/lib/mini-graph.test.ts
+++ b/apps/web/src/lib/mini-graph.test.ts
@@ -63,6 +63,26 @@ describe('buildMiniGraph', () => {
     expect(v2Row?.branchOut).toBe('feature')
   })
 
+  it('joins multiple branch names with a comma when they share a baseVersionId', () => {
+    const input: MiniGraphInput = {
+      head: 'feature-b',
+      branches: [
+        branch('main', '#1971c2'),
+        branch('feature-a', '#9333ea', 'main', 'v2'),
+        branch('feature-b', '#e8590c', 'main', 'v2'),
+      ],
+      versions: [
+        version('b1', 'feature-b', '2026-04-23T05:00:00Z'),
+        version('a1', 'feature-a', '2026-04-23T04:00:00Z'),
+        version('v2', 'main', '2026-04-23T02:00:00Z'),
+        version('v1', 'main', '2026-04-23T01:00:00Z'),
+      ],
+    }
+    const rows = buildMiniGraph(input)
+    const v2Row = rows.find((r) => r.versionId === 'v2')
+    expect(v2Row?.branchOut).toBe('feature-a, feature-b')
+  })
+
   it('falls back to neutral gray for unknown branch names', () => {
     const input: MiniGraphInput = {
       head: 'main',

--- a/apps/web/src/lib/mini-graph.test.ts
+++ b/apps/web/src/lib/mini-graph.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { buildMiniGraph, type MiniGraphInput } from './mini-graph.js'
+
+const branch = (name: string, color: string, baseBranch?: string, baseVersionId?: string) => ({
+  name,
+  color,
+  baseBranch,
+  baseVersionId,
+})
+
+const version = (id: string, branchName: string, createdAt: string) => ({
+  id,
+  branchName,
+  createdAt,
+})
+
+describe('buildMiniGraph', () => {
+  it('renders a straight line for a single branch', () => {
+    const input: MiniGraphInput = {
+      head: 'main',
+      branches: [branch('main', '#1971c2')],
+      versions: [
+        version('v3', 'main', '2026-04-23T03:00:00Z'),
+        version('v2', 'main', '2026-04-23T02:00:00Z'),
+        version('v1', 'main', '2026-04-23T01:00:00Z'),
+      ],
+    }
+    const rows = buildMiniGraph(input)
+    expect(rows).toHaveLength(3)
+    expect(rows.map((r) => r.dotColor)).toEqual(['#1971c2', '#1971c2', '#1971c2'])
+    expect(rows[0].connectorBefore).toBe(false)
+    expect(rows[1].connectorBefore).toBe(true)
+    expect(rows[2].connectorBefore).toBe(true)
+  })
+
+  it('marks versions outside the active HEAD branch as inactive rings', () => {
+    const input: MiniGraphInput = {
+      head: 'feature',
+      branches: [branch('main', '#1971c2'), branch('feature', '#9333ea', 'main', 'v2')],
+      versions: [
+        version('f1', 'feature', '2026-04-23T04:00:00Z'),
+        version('v2', 'main', '2026-04-23T02:00:00Z'),
+      ],
+    }
+    const rows = buildMiniGraph(input)
+    expect(rows[0].dotColor).toBe('#9333ea')
+    expect(rows[0].active).toBe(true)
+    expect(rows[1].active).toBe(false)
+  })
+
+  it('adds a branchOut label to the row referenced by baseVersionId', () => {
+    const input: MiniGraphInput = {
+      head: 'feature',
+      branches: [branch('main', '#1971c2'), branch('feature', '#9333ea', 'main', 'v2')],
+      versions: [
+        version('f1', 'feature', '2026-04-23T04:00:00Z'),
+        version('v2', 'main', '2026-04-23T02:00:00Z'),
+        version('v1', 'main', '2026-04-23T01:00:00Z'),
+      ],
+    }
+    const rows = buildMiniGraph(input)
+    const v2Row = rows.find((r) => r.versionId === 'v2')
+    expect(v2Row?.branchOut).toBe('feature')
+  })
+
+  it('falls back to neutral gray for unknown branch names', () => {
+    const input: MiniGraphInput = {
+      head: 'main',
+      branches: [branch('main', '#1971c2')],
+      versions: [version('x', 'deleted-branch', '2026-04-23T01:00:00Z')],
+    }
+    const rows = buildMiniGraph(input)
+    expect(rows[0].dotColor).toMatch(/^#[a-f0-9]{3,6}$/i)
+    // The fallback color is a neutral outside the branch palette.
+    expect(rows[0].dotColor).not.toBe('#1971c2')
+  })
+
+  it('preserves the input order of versions', () => {
+    const input: MiniGraphInput = {
+      head: 'main',
+      branches: [branch('main', '#1971c2')],
+      versions: [
+        version('newer', 'main', '2026-04-23T05:00:00Z'),
+        version('older', 'main', '2026-04-23T01:00:00Z'),
+      ],
+    }
+    const rows = buildMiniGraph(input)
+    expect(rows.map((r) => r.versionId)).toEqual(['newer', 'older'])
+  })
+})

--- a/apps/web/src/lib/mini-graph.ts
+++ b/apps/web/src/lib/mini-graph.ts
@@ -1,0 +1,71 @@
+// Build the dot-and-connector data for the 32px lane at the left edge of VersionTimeline.
+// Per Spec §9 in the design canvas, each version row gets a centered dot and rows are joined
+// by a vertical connector.
+// `branchOut` marks the version where another branch split off.
+//
+// UX rules:
+// - rows on the active HEAD branch use a solid dot
+// - rows on other branches use a ring dot
+// - row colors reuse BranchMeta.color
+// - unknown branches fall back to neutral gray
+
+export interface MiniGraphBranch {
+  name: string
+  color: string
+  baseBranch?: string
+  baseVersionId?: string
+}
+
+export interface MiniGraphVersion {
+  id: string
+  branchName: string
+  createdAt: string
+}
+
+export interface MiniGraphInput {
+  head: string
+  branches: MiniGraphBranch[]
+  versions: MiniGraphVersion[]
+}
+
+export interface MiniGraphRow {
+  versionId: string
+  dotColor: string
+  active: boolean
+  connectorBefore: boolean
+  branchOut?: string
+}
+
+const FALLBACK_COLOR = '#94a3b8' // slate-400
+
+export function buildMiniGraph(input: MiniGraphInput): MiniGraphRow[] {
+  const branchByName = new Map<string, MiniGraphBranch>()
+  for (const b of input.branches) branchByName.set(b.name, b)
+
+  // Attach branchOut labels to the version referenced by baseVersionId.
+  // If multiple branches split from the same version, join their names with commas.
+  const branchOutByVersionId = new Map<string, string[]>()
+  for (const b of input.branches) {
+    if (!b.baseVersionId) continue
+    const existing = branchOutByVersionId.get(b.baseVersionId) ?? []
+    existing.push(b.name)
+    branchOutByVersionId.set(b.baseVersionId, existing)
+  }
+
+  const rows: MiniGraphRow[] = []
+  for (let i = 0; i < input.versions.length; i++) {
+    const v = input.versions[i]!
+    const branch = branchByName.get(v.branchName)
+    const active = v.branchName === input.head
+    const labels = branchOutByVersionId.get(v.id)
+    const row: MiniGraphRow = {
+      versionId: v.id,
+      dotColor: branch?.color ?? FALLBACK_COLOR,
+      active,
+      connectorBefore: i > 0,
+      ...(labels && labels.length > 0 ? { branchOut: labels.join(', ') } : {}),
+    }
+    rows.push(row)
+  }
+  return rows
+}

--- a/apps/web/src/test-utils/fast-check.ts
+++ b/apps/web/src/test-utils/fast-check.ts
@@ -1,0 +1,8 @@
+import { test as fcTest } from '@fast-check/vitest'
+import * as fc from 'fast-check'
+
+export { fc, fcTest }
+
+export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
+  return { numRuns: 200, ...override }
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -46,6 +46,14 @@
       "types": "./src/shared/migration-bundle.ts",
       "import": "./dist/shared/migration-bundle.js"
     },
+    "./api-client": {
+      "types": "./src/shared/api-client.ts",
+      "import": "./dist/shared/api-client.js"
+    },
+    "./api-contracts": {
+      "types": "./src/shared/api-contracts/index.ts",
+      "import": "./dist/shared/api-contracts/index.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -88,6 +96,14 @@
       "./migration-bundle": {
         "types": "./dist/shared/migration-bundle.d.ts",
         "import": "./dist/shared/migration-bundle.js"
+      },
+      "./api-client": {
+        "types": "./dist/shared/api-client.d.ts",
+        "import": "./dist/shared/api-client.js"
+      },
+      "./api-contracts": {
+        "types": "./dist/shared/api-contracts/index.d.ts",
+        "import": "./dist/shared/api-contracts/index.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/mcp-server/src/app/lib/format-bytes.test.ts
+++ b/packages/mcp-server/src/app/lib/format-bytes.test.ts
@@ -14,6 +14,15 @@ describe('formatBytes', () => {
     expect(formatBytes(1023)).toBe('1023 B')
   })
 
+  it('bumps to the next unit when rounding would display 1024', () => {
+    // 1023.6 B rounds to 1024 — display as 1.0 KiB, never "1024 B".
+    expect(formatBytes(1023.6)).toBe('1.0 KiB')
+    // 1023.95 KiB → toFixed(1) gives "1024.0" — display as 1.0 MiB.
+    expect(formatBytes(1023.95 * 1024)).toBe('1.0 MiB')
+    // At the TiB cap there is no next unit; the raw rounding stands.
+    expect(formatBytes(1023.95 * 1024 ** 4)).toBe('1024.0 TiB')
+  })
+
   it('uses one decimal at KiB / MiB / GiB scale', () => {
     expect(formatBytes(1024)).toBe('1.0 KiB')
     expect(formatBytes(1536)).toBe('1.5 KiB')

--- a/packages/mcp-server/src/app/lib/format-bytes.ts
+++ b/packages/mcp-server/src/app/lib/format-bytes.ts
@@ -17,6 +17,13 @@ export function formatBytes(bytes: number): string {
   }
   // Show no decimals for raw bytes, one decimal for KiB+, to keep widths
   // tight in the IndexPage footer.
-  const formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1)
+  let formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1)
+  // Values just under a unit boundary (e.g. 1023.6 B) survive the division
+  // loop but round up to a displayed "1024" — bump to the next unit instead
+  // of showing "1024 B" / "1024.0 KiB". At the TiB cap the rounding stands.
+  if ((formatted === '1024' || formatted === '1024.0') && unit < UNITS.length - 1) {
+    unit += 1
+    formatted = '1.0'
+  }
   return `${formatted} ${UNITS[unit]}`
 }

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -95,6 +95,14 @@ describe('publish contract', () => {
         types: './src/shared/migration-bundle.ts',
         import: './dist/shared/migration-bundle.js',
       },
+      './api-client': {
+        types: './src/shared/api-client.ts',
+        import: './dist/shared/api-client.js',
+      },
+      './api-contracts': {
+        types: './src/shared/api-contracts/index.ts',
+        import: './dist/shared/api-contracts/index.js',
+      },
       './package.json': './package.json',
     })
     // publishConfig.exports is the shape pnpm substitutes on npm publish,
@@ -119,6 +127,14 @@ describe('publish contract', () => {
       './migration-bundle': {
         types: './dist/shared/migration-bundle.d.ts',
         import: './dist/shared/migration-bundle.js',
+      },
+      './api-client': {
+        types: './dist/shared/api-client.d.ts',
+        import: './dist/shared/api-client.js',
+      },
+      './api-contracts': {
+        types: './dist/shared/api-contracts/index.d.ts',
+        import: './dist/shared/api-contracts/index.js',
       },
       './package.json': './package.json',
     })

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -1,0 +1,31 @@
+// Guard against scope creep on the `./api-contracts` public npm subpath.
+//
+// The barrel at src/shared/api-contracts/index.ts is deliberately narrow
+// (branches + canvas only). web-app-boundary.test.ts scans every file under
+// src/shared/api-contracts/ for browser-safety, but it does not — and
+// structurally cannot — assert what the barrel itself re-exports. Without
+// this test, someone could add `export * from './runtime.js'` (or
+// canvas-runtime / daemon-doctor / export / libraries / palette) to the
+// barrel and widen the public semver surface without any test noticing.
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// __dirname -> packages/mcp-server/src/server/release
+const BARREL_PATH = resolve(__dirname, '../../shared/api-contracts/index.ts')
+
+function reExportSpecifiers(source: string): string[] {
+  const re = /export\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]/g
+  return [...source.matchAll(re)].map((match) => match[1]!)
+}
+
+describe('api-contracts barrel scope', () => {
+  it('re-exports exactly branches and canvas — no other api-contracts modules', () => {
+    const source = readFileSync(BARREL_PATH, 'utf-8')
+    const specifiers = reExportSpecifiers(source)
+    expect(specifiers).toEqual(['./branches.js', './canvas.js'])
+  })
+})

--- a/packages/mcp-server/src/shared/api-client.test.ts
+++ b/packages/mcp-server/src/shared/api-client.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { readRuntimeConfig, runtimeConfigSchema } from './api-client.js'
+
+describe('runtimeConfigSchema', () => {
+  it('accepts a valid daemonToken string', () => {
+    expect(runtimeConfigSchema.parse({ daemonToken: 'abc' })).toEqual({ daemonToken: 'abc' })
+  })
+
+  it('accepts a null daemonToken', () => {
+    expect(runtimeConfigSchema.parse({ daemonToken: null })).toEqual({ daemonToken: null })
+  })
+
+  it('rejects a non-string, non-null daemonToken', () => {
+    expect(() => runtimeConfigSchema.parse({ daemonToken: 42 })).toThrow()
+  })
+})
+
+describe('readRuntimeConfig', () => {
+  it('falls back to a null daemonToken when window is not defined', () => {
+    expect(readRuntimeConfig()).toEqual({ daemonToken: null })
+  })
+
+  it('falls back to a null daemonToken when the injected global fails schema validation', () => {
+    const fakeWindow = {
+      location: { origin: 'http://localhost' },
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 42 },
+    }
+    ;(globalThis as { window?: unknown }).window = fakeWindow
+    try {
+      expect(readRuntimeConfig()).toEqual({ daemonToken: null })
+    } finally {
+      delete (globalThis as { window?: unknown }).window
+    }
+  })
+
+  it('returns the injected daemonToken when it passes schema validation', () => {
+    const fakeWindow = {
+      location: { origin: 'http://localhost' },
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'seeded-token' },
+    }
+    ;(globalThis as { window?: unknown }).window = fakeWindow
+    try {
+      expect(readRuntimeConfig()).toEqual({ daemonToken: 'seeded-token' })
+    } finally {
+      delete (globalThis as { window?: unknown }).window
+    }
+  })
+})

--- a/packages/mcp-server/src/shared/api-client.ts
+++ b/packages/mcp-server/src/shared/api-client.ts
@@ -1,8 +1,18 @@
+import { z } from 'zod'
 import { injectTraceContextIntoHeaders } from './browser-tracing.js'
 
-export interface RuntimeConfig {
-  daemonToken: string | null
-}
+// The server injects this shape into `window.__WHITEBOARD_RUNTIME_CONFIG__`
+// via a same-origin inline <script> (see server/app.ts). It crosses a
+// process boundary (server -> browser), so it is validated on read rather
+// than trusted as a cast — a malformed or tampered global falls back to the
+// unauthenticated default instead of propagating a bad value into apiFetch.
+export const runtimeConfigSchema = z.object({
+  daemonToken: z.string().nullable(),
+})
+
+export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>
+
+const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = { daemonToken: null }
 
 // This module compiles under both tsconfig.server.json (lib ES2022 + types
 // node — no DOM lib, no ambient `window`) and apps/web's DOM-enabled
@@ -12,7 +22,7 @@ export interface RuntimeConfig {
 // DOM globals across all server/cli/daemon code).
 type WindowLike = {
   location: { origin: string }
-  __WHITEBOARD_RUNTIME_CONFIG__?: RuntimeConfig
+  __WHITEBOARD_RUNTIME_CONFIG__?: unknown
 }
 
 function getWindow(): WindowLike | undefined {
@@ -20,7 +30,12 @@ function getWindow(): WindowLike | undefined {
 }
 
 export function readRuntimeConfig(): RuntimeConfig {
-  return getWindow()?.__WHITEBOARD_RUNTIME_CONFIG__ ?? { daemonToken: null }
+  const injected = getWindow()?.__WHITEBOARD_RUNTIME_CONFIG__
+  if (injected === undefined) {
+    return DEFAULT_RUNTIME_CONFIG
+  }
+  const result = runtimeConfigSchema.safeParse(injected)
+  return result.success ? result.data : DEFAULT_RUNTIME_CONFIG
 }
 
 function isLocalApiRequest(input: Request | string | URL): boolean {

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -1,0 +1,9 @@
+// Public barrel for the `./api-contracts` package subpath.
+//
+// Deliberately narrow: only branches.ts and canvas.ts are re-exported here.
+// canvas-runtime.ts, daemon-doctor.ts, export.ts, libraries.ts, palette.ts,
+// and runtime.ts stay off the published npm surface — widening this barrel
+// widens semver liability for a public package, so any addition here must be
+// an intentional decision, not incidental scope creep.
+export * from './branches.js'
+export * from './canvas.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: ^4
         version: 4.2.4(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -159,6 +162,9 @@ importers:
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.8.0
       playwright:
         specifier: 1.59.1
         version: 1.59.1
@@ -9250,9 +9256,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:


### PR DESCRIPTION
UI-unification Stage 2, slice 0 — the shared foundation every component-port lane (5-8) depends on.

## Part A: new subpath exports

- **`@kamiazya/whiteboard-mcp/api-client`** — exposes `apiFetch` (already relocated to `src/shared` in slice 2), cloned from the `./daemon-backend` export pattern (dev types → source, publish types → dist d.ts; both `exports` and `publishConfig.exports`).
- **`@kamiazya/whiteboard-mcp/api-contracts`** — a **deliberately narrow barrel** re-exporting only `branches.ts` and `canvas.ts` Zod schemas (the two contracts lanes 5-8 consume). A new **barrel-scope guard test** asserts the barrel's specifiers equal exactly those two files, so scope creep into runtime/libraries/palette/etc. fails CI — the boundary test alone can't catch that (it scans per-file browser safety, not barrel contents).
- `publish-contract.test.ts` updated red-first and mutation-checked (reverting the package.json addition fails it). No boundary-allowlist change needed (`api-client.js` exact + `api-contracts/` prefix already allowed). Type probes added in `apps/web/src/_type-probe.ts`.

## Part B: pure lib port (red-first)

`error-copy` / `mini-graph` / `format-bytes` / `app-logger` (+ their 4 test suites, incl. fast-check property tests via a local `test-utils/fast-check.ts` helper — no pinned seed) copied to `apps/web/src/lib/`. apps/web copies are canonical; the `src/app` originals are frozen until Stage 5 deletes them. No consumer wiring beyond the type probe — lanes 5-8 own consumption. `fast-check`/`@fast-check/vitest` added to apps/web devDeps at the same versions mcp-server uses.

## Verification

mcp typecheck ✓ / mcp-node 2684 ✓ (publish-contract + barrel-scope + boundary) / apps/web vitest 345 ✓ / tsc ✓. Review: 0 confirmed findings.