### PR TITLE
feat(mcp-server): harden local-daemon auth surface

### DIFF
--- a/docs/how-to/self-host-with-docker.md
+++ b/docs/how-to/self-host-with-docker.md
@@ -88,7 +88,10 @@ volume has the correct ownership if you pre-populate it.
 
 The image configures a Docker healthcheck that polls
 `/api/runtime/ping` every 30 s. This endpoint is public (no auth required)
-and returns `{"ok":true,"pid":<number>}`. It does not include any
+and returns `{"ok":true,"instanceId":"<uuid>"}`. `instanceId` is a random
+identifier generated fresh on every process start (not the OS pid — an OS
+pid can be reused by an unrelated process, which would let a stale
+record misidentify it as the daemon). It does not include any
 configuration, credentials, or filesystem paths.
 
 `whiteboard server doctor --json` is intentionally **not** used as the default

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -23,9 +23,34 @@
 
 import { spawn } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import http from 'node:http'
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+// fetch() treats Host as a forbidden header and silently drops any override,
+// so a genuine Host-header spoof for the DNS-rebinding guard test needs a raw
+// node:http request instead.
+function requestWithHostHeader(url, hostHeader) {
+  return new Promise((resolveReq, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        hostname: target.hostname,
+        port: target.port,
+        path: target.pathname,
+        method: 'GET',
+        headers: { Host: hostHeader },
+      },
+      (res) => {
+        res.resume()
+        res.on('end', () => resolveReq({ status: res.statusCode }))
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
@@ -155,6 +180,26 @@ async function main() {
   const created = await callTool('canvas_create', { slug: 'e2e-src' })
   if (!created.id || !created.url) throw new Error('canvas_create returned unexpected shape')
   console.log(`[e2e] canvas_create → ${created.id}`)
+
+  // The daemon is up now (canvas_create spawned it) — exercise the local-daemon
+  // auth hardening directly over HTTP: instanceId-shaped ping, and the
+  // Host-guard rejecting a spoofed non-loopback Host on /api/*.
+  const daemonOrigin = new URL(created.url).origin
+  const pingRes = await fetch(`${daemonOrigin}/api/runtime/ping`)
+  const pingBody = await pingRes.json()
+  if (pingRes.status !== 200 || pingBody.ok !== true || typeof pingBody.instanceId !== 'string') {
+    throw new Error(`ping did not return an instanceId-shaped body: ${JSON.stringify(pingBody)}`)
+  }
+  if ('pid' in pingBody) {
+    throw new Error(`ping response still leaks pid: ${JSON.stringify(pingBody)}`)
+  }
+  console.log(`[e2e] /api/runtime/ping → instanceId=${pingBody.instanceId}, no pid`)
+
+  const spoofedRes = await requestWithHostHeader(`${daemonOrigin}/api/runtime/ping`, 'evil.example')
+  if (spoofedRes.status !== 403) {
+    throw new Error(`spoofed Host GET expected 403, got ${spoofedRes.status}`)
+  }
+  console.log('[e2e] /api/runtime/ping with spoofed Host → 403 OK')
 
   const ann = await callTool('annotate', {
     canvasId: created.id,

--- a/packages/mcp-server/src/cli/daemon-ping-client.test.ts
+++ b/packages/mcp-server/src/cli/daemon-ping-client.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchDaemonPing, resolveConnectHost } from './daemon-ping-client.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('resolveConnectHost', () => {
+  it('maps 0.0.0.0 to 127.0.0.1', () => {
+    expect(resolveConnectHost('0.0.0.0')).toBe('127.0.0.1')
+  })
+
+  it('maps :: and ::0 to bracketed IPv6 loopback', () => {
+    expect(resolveConnectHost('::')).toBe('[::1]')
+    expect(resolveConnectHost('::0')).toBe('[::1]')
+  })
+
+  it('brackets a bare IPv6 address', () => {
+    expect(resolveConnectHost('::1')).toBe('[::1]')
+  })
+
+  it('leaves an already-bracketed IPv6 address and plain hostnames unchanged', () => {
+    expect(resolveConnectHost('[::1]')).toBe('[::1]')
+    expect(resolveConnectHost('127.0.0.1')).toBe('127.0.0.1')
+  })
+})
+
+describe('fetchDaemonPing', () => {
+  it('parses a valid response through daemonPingResponseSchema', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'abc-123' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDaemonPing('127.0.0.1', 3099)
+
+    expect(result).toEqual({ ok: true, instanceId: 'abc-123' })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:3099/api/runtime/ping',
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+  })
+
+  // This is the regression the CLI's hand-cast callers used to miss: a body
+  // that doesn't match the schema (e.g. instanceId renamed or dropped) must
+  // fail closed instead of silently coercing to `undefined === undefined`.
+  it('returns null when the response body does not match daemonPingResponseSchema', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, pid: 123 }),
+    }))
+
+    const result = await fetchDaemonPing('127.0.0.1', 3099)
+
+    expect(result).toBeNull()
+  })
+
+  // A hand-written `typeof body?.instanceId === 'string'` cast would accept
+  // this body (it has a valid-looking instanceId), but the schema correctly
+  // rejects it because `ok` isn't the literal `true` the endpoint promises.
+  it('returns null when ok is not the literal true, even if instanceId looks valid', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: false, instanceId: 'abc-123' }),
+    }))
+
+    const result = await fetchDaemonPing('127.0.0.1', 3099)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on a non-ok HTTP response', async () => {
+    vi.stubGlobal('fetch', async () => ({ ok: false, json: async () => ({}) }))
+
+    const result = await fetchDaemonPing('127.0.0.1', 3099)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when fetch throws (connection refused, timeout, etc.)', async () => {
+    vi.stubGlobal('fetch', async () => {
+      throw new Error('ECONNREFUSED')
+    })
+
+    const result = await fetchDaemonPing('127.0.0.1', 3099)
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/mcp-server/src/cli/daemon-ping-client.ts
+++ b/packages/mcp-server/src/cli/daemon-ping-client.ts
@@ -6,6 +6,7 @@
 
 import { daemonPingResponseSchema } from '../shared/api-contracts/runtime.js'
 import type { DaemonPingResponse } from '../shared/api-contracts/runtime.js'
+import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 
 const DEFAULT_TIMEOUT_MS = 2000
 
@@ -39,4 +40,16 @@ export async function fetchDaemonPing(
   } catch {
     return null
   }
+}
+
+/**
+ * Daemon-identity check shared by server-status / server-stop / server-doctor.
+ * A record without an instanceId (older daemon build) cannot be verified and
+ * reports false — callers map that to an explicit 'unverifiable' outcome,
+ * never a kill, a false 'healthy', or a silent 'not running'.
+ */
+export async function verifyDaemonIdentity(record: ServerModeRecord): Promise<boolean> {
+  if (!record.instanceId) return false
+  const ping = await fetchDaemonPing(record.host, record.port)
+  return ping !== null && ping.instanceId === record.instanceId
 }

--- a/packages/mcp-server/src/cli/daemon-ping-client.ts
+++ b/packages/mcp-server/src/cli/daemon-ping-client.ts
@@ -1,0 +1,42 @@
+// Shared /api/runtime/ping client for the CLI's daemon-identity checks
+// (server-status, server-stop, server-doctor). Parsing the response through
+// daemonPingResponseSchema here — rather than a hand-written cast at each
+// call site — means a future field change to the schema only needs to be
+// kept in sync in one place.
+
+import { daemonPingResponseSchema } from '../shared/api-contracts/runtime.js'
+import type { DaemonPingResponse } from '../shared/api-contracts/runtime.js'
+
+const DEFAULT_TIMEOUT_MS = 2000
+
+export function resolveConnectHost(bindHost: string): string {
+  if (bindHost === '0.0.0.0') return '127.0.0.1'
+  if (bindHost === '::' || bindHost === '::0') return '[::1]'
+  // Bare IPv6 addresses contain colons — bracket them for URL construction.
+  if (bindHost.includes(':') && !bindHost.startsWith('[')) return `[${bindHost}]`
+  return bindHost
+}
+
+/**
+ * Fetch and validate /api/runtime/ping. Returns null on any failure —
+ * network error, non-2xx response, or a body that fails schema validation —
+ * so callers can fail closed the same way a plain boolean check did before.
+ */
+export async function fetchDaemonPing(
+  host: string,
+  port: number,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<DaemonPingResponse | null> {
+  const connectHost = resolveConnectHost(host)
+  try {
+    const res = await fetch(`http://${connectHost}:${port}/api/runtime/ping`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    if (!res.ok) return null
+    const body = await res.json()
+    const parsed = daemonPingResponseSchema.safeParse(body)
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}

--- a/packages/mcp-server/src/cli/daemon-run.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run.test.ts
@@ -10,7 +10,28 @@ vi.mock('node:net', async (importOriginal) => {
   return { ...real, createServer: createServerSpy }
 })
 
-const { findAvailablePort } = await import('./daemon-run.js')
+const { loadDaemonRecordMock, startHttpServerMock } = vi.hoisted(() => ({
+  loadDaemonRecordMock: vi.fn(async () => null),
+  startHttpServerMock: vi.fn(async () => ({
+    port: 3099,
+    close: vi.fn(async () => undefined),
+    touch: vi.fn(),
+    getRuntimeStatus: vi.fn(),
+  })),
+}))
+
+vi.mock('../daemon/daemon-registry.js', () => ({
+  loadDaemonRecord: loadDaemonRecordMock,
+  saveDaemonRecord: vi.fn(async () => undefined),
+  deleteDaemonRecord: vi.fn(async () => undefined),
+  isPidAlive: vi.fn(() => false),
+}))
+
+vi.mock('../server/http-server.js', () => ({
+  startHttpServer: startHttpServerMock,
+}))
+
+const { findAvailablePort, runDaemonRun } = await import('./daemon-run.js')
 
 // A minimal net.Server stand-in: EventEmitter for .on()/.emit() plus the
 // listen/close/address surface findAvailablePort touches. Mocking createServer
@@ -54,5 +75,29 @@ describe('findAvailablePort', () => {
     })
     await expect(findAvailablePort(5004)).resolves.toBe(5005)
     expect(createServerSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('runDaemonRun bind-host guard', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it.each([
+    '0.0.0.0',
+    '192.168.1.5',
+    'evil.example',
+  ])('refuses to start the daemon bound to non-loopback host %s and never calls startHttpServer', async (host) => {
+    const outcome = await runDaemonRun({ host, tokenStdin: false, dataDir: '/tmp/whiteboard-test' })
+    expect(outcome.kind).toBe('refused')
+    expect(startHttpServerMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    '127.0.0.1',
+    'localhost',
+    '::1',
+  ])('starts the daemon when bound to loopback host %s', async (host) => {
+    const outcome = await runDaemonRun({ host, tokenStdin: false, dataDir: '/tmp/whiteboard-test' })
+    expect(outcome.kind).toBe('running')
+    expect(startHttpServerMock).toHaveBeenCalled()
   })
 })

--- a/packages/mcp-server/src/cli/daemon-run.ts
+++ b/packages/mcp-server/src/cli/daemon-run.ts
@@ -15,6 +15,7 @@ import {
   saveDaemonRecord,
 } from '../daemon/daemon-registry.js'
 import { DATA_DIR } from '../shared/data-dir-secure.js'
+import { assertLoopbackBindHost } from '../server/daemon-auth-binding.js'
 import { startHttpServer } from '../server/http-server.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 
@@ -90,6 +91,20 @@ function installDaemonSignalHandlers(cleanup: () => Promise<void>): void {
 
 export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRunOutcome> {
   const dataDir = options.dataDir ?? DATA_DIR
+  const host = options.host ?? '127.0.0.1'
+
+  // Pre-startup guard: local-daemon is loopback-only regardless of --host.
+  // Refusing here (before any lock/fs work) means a non-loopback bind never
+  // reaches startHttpServer, so an unauthenticated daemon can't be exposed
+  // beyond loopback even by operator error.
+  const bindGuard = assertLoopbackBindHost(host)
+  if (!bindGuard.ok) {
+    return {
+      kind: 'refused',
+      message:
+        'Refusing to bind the local daemon to a non-loopback host. Use 127.0.0.1, localhost, or ::1.',
+    }
+  }
 
   const existing = await loadDaemonRecord(dataDir)
   if (existing !== null && isPidAlive(existing.pid)) {
@@ -115,7 +130,6 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
 
   return await withDaemonStartupLock(dataDir, async () => {
     const port = options.port ?? (await findAvailablePort())
-    const host = options.host ?? '127.0.0.1'
 
     const running = await startHttpServer({ port, host, token })
 

--- a/packages/mcp-server/src/cli/server-doctor.test.ts
+++ b/packages/mcp-server/src/cli/server-doctor.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { daemonDoctorResultSchema } from '../shared/api-contracts/daemon-doctor.js'
-import { runServerDoctor } from './server-doctor.js'
+import type { ServerModeRecord } from '../server/security/server-mode-record.js'
+import { defaultFetchPing, defaultVerifyIdentity, runServerDoctor } from './server-doctor.js'
 
 let dataDir: string
 
@@ -143,7 +144,11 @@ describe('runServerDoctor', () => {
 
   it('credentialed JWKS URI → server.config error (caught at config parse)', async () => {
     const { result, exitCode } = await runServerDoctor({
-      flags: { ...VALID_FLAGS, dataDir, jwksUri: 'https://user:pass@auth.example.com/.well-known/jwks.json' },
+      flags: {
+        ...VALID_FLAGS,
+        dataDir,
+        jwksUri: 'https://user:pass@auth.example.com/.well-known/jwks.json',
+      },
       env: {},
       checkDataDir: () => 'ok',
     })
@@ -302,6 +307,28 @@ describe('runServerDoctor', () => {
     // Downstream checks are skipped because identity is not ok
     expect(checkById(result.checks, 'server.runtime_ping').status).toBe('skipped')
     expect(checkById(result.checks, 'server.runtime_status').status).toBe('skipped')
+  })
+
+  // ─── 12b. Legacy record without instanceId → server.identity warning ──────
+  // Exercises the real defaultVerifyIdentity (no override injected), same
+  // pattern as the "legacy record" tests in server-status.test.ts /
+  // server-stop.test.ts, since this is the one branch of the real default
+  // that never requires a live network call.
+
+  it('legacy record without instanceId → server.identity warning via the real default verifyIdentity', async () => {
+    await writeServerRecord(makeRecord({ instanceId: undefined }))
+    const { result } = await runServerDoctor({
+      flags: { ...VALID_FLAGS, dataDir },
+      env: {},
+      isPidAlive: () => true,
+      // No verifyIdentity override — exercises the real default, which must
+      // refuse to confirm identity when instanceId is absent.
+      fetchJwks: async () => ({ ok: true, hasKeys: true }),
+      checkDataDir: () => 'ok',
+      readRecordMode: () => 0o600,
+    })
+    expect(checkById(result.checks, 'server.identity').status).toBe('warning')
+    expect(checkById(result.checks, 'server.runtime_ping').status).toBe('skipped')
   })
 
   // ─── 13. PID dead → server.identity skipped ───────────────────────────────
@@ -463,6 +490,75 @@ describe('runServerDoctor', () => {
     expect(result.ok).toBe(true)
     expect(exitCode).toBe(0)
     expect(result.status).toBe('warning')
+  })
+})
+
+// ─── Direct unit tests for the default identity/ping implementations ────────
+// These are the seams runServerDoctor falls back to when no verifyIdentity /
+// fetchPing override is injected. Every scenario above injects overrides, so
+// without these, a regression to the real instanceId comparison logic
+// (introduced alongside the pid→instanceId rename) would go uncaught.
+
+describe('defaultVerifyIdentity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('confirms identity when the ping response instanceId matches the record', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'instance-a' }),
+    }))
+    const record = makeRecord({ instanceId: 'instance-a' }) as ServerModeRecord
+    await expect(defaultVerifyIdentity(record)).resolves.toBe(true)
+  })
+
+  it('refuses to confirm identity when the ping response instanceId mismatches', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'instance-b' }),
+    }))
+    const record = makeRecord({ instanceId: 'instance-a' }) as ServerModeRecord
+    await expect(defaultVerifyIdentity(record)).resolves.toBe(false)
+  })
+
+  it('never confirms identity when the record predates instanceId', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const record = makeRecord({ instanceId: undefined }) as ServerModeRecord
+    await expect(defaultVerifyIdentity(record)).resolves.toBe(false)
+    // Short-circuits before making a network call.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('defaultFetchPing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports pidMatches:true when the ping instanceId equals expectedInstanceId', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'instance-a' }),
+    }))
+    await expect(defaultFetchPing('127.0.0.1', 3099, 'instance-a')).resolves.toEqual({
+      ok: true,
+      pidMatches: true,
+    })
+  })
+
+  it('never reports pidMatches:true when expectedInstanceId is undefined (legacy record)', async () => {
+    // Regression guard: a record without instanceId must never be treated as
+    // a match, even if the live daemon's ping response carries a real one.
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'instance-a' }),
+    }))
+    await expect(defaultFetchPing('127.0.0.1', 3099, undefined)).resolves.toEqual({
+      ok: true,
+      pidMatches: false,
+    })
   })
 })
 

--- a/packages/mcp-server/src/cli/server-doctor.ts
+++ b/packages/mcp-server/src/cli/server-doctor.ts
@@ -28,6 +28,7 @@ import {
 } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 import { ENV_KEYS } from '../server/security/server-mode-env-config.js'
+import { fetchDaemonPing, resolveConnectHost } from './daemon-ping-client.js'
 import type { ServerRunArgs } from './server-run-args.js'
 
 export const SERVER_DOCTOR_SCHEMA_VERSION = 1 as const
@@ -81,32 +82,15 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-// Mirrors the same helper in server-status.ts and server-stop.ts.
-// Kept local per the project instruction: no new shared module for
-// this small utility until there are three callers.
-function resolveConnectHost(bindHost: string): string {
-  if (bindHost === '0.0.0.0') return '127.0.0.1'
-  if (bindHost === '::' || bindHost === '::0') return '[::1]'
-  // Bare IPv6 addresses contain colons — bracket them for URL construction.
-  if (bindHost.includes(':') && !bindHost.startsWith('[')) return `[${bindHost}]`
-  return bindHost
-}
-
-async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+// Exported for direct unit testing of the instanceId comparison logic below
+// (see server-doctor.test.ts) — the option default is otherwise only ever
+// exercised indirectly through runServerDoctor with an injected override.
+export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
   // A record with no instanceId predates this check (older daemon build) and
   // cannot be verified — the caller reports a warning, never a false 'ok'.
   if (!record.instanceId) return false
-  const host = resolveConnectHost(record.host)
-  try {
-    const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
-      signal: AbortSignal.timeout(2000),
-    })
-    if (!res.ok) return false
-    const body = (await res.json()) as { instanceId?: unknown }
-    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
-  } catch {
-    return false
-  }
+  const ping = await fetchDaemonPing(record.host, record.port)
+  return ping !== null && ping.instanceId === record.instanceId
 }
 
 async function defaultFetchJwks(uri: string): Promise<{ ok: boolean; hasKeys: boolean }> {
@@ -147,27 +131,17 @@ function defaultReadRecordMode(dataDir: string): number | null {
   }
 }
 
-async function defaultFetchPing(
+// Exported for direct unit testing — same rationale as defaultVerifyIdentity.
+export async function defaultFetchPing(
   host: string,
   port: number,
   expectedInstanceId: string | undefined,
 ): Promise<{ ok: boolean; pidMatches: boolean }> {
-  const connectHost = resolveConnectHost(host)
-  try {
-    const res = await fetch(`http://${connectHost}:${port}/api/runtime/ping`, {
-      signal: AbortSignal.timeout(2000),
-    })
-    if (!res.ok) return { ok: false, pidMatches: false }
-    const body = (await res.json()) as { instanceId?: unknown }
-    return {
-      ok: true,
-      pidMatches:
-        expectedInstanceId !== undefined &&
-        typeof body?.instanceId === 'string' &&
-        body.instanceId === expectedInstanceId,
-    }
-  } catch {
-    return { ok: false, pidMatches: false }
+  const ping = await fetchDaemonPing(host, port)
+  if (ping === null) return { ok: false, pidMatches: false }
+  return {
+    ok: true,
+    pidMatches: expectedInstanceId !== undefined && ping.instanceId === expectedInstanceId,
   }
 }
 

--- a/packages/mcp-server/src/cli/server-doctor.ts
+++ b/packages/mcp-server/src/cli/server-doctor.ts
@@ -28,7 +28,7 @@ import {
 } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 import { ENV_KEYS } from '../server/security/server-mode-env-config.js'
-import { fetchDaemonPing, resolveConnectHost } from './daemon-ping-client.js'
+import { fetchDaemonPing, resolveConnectHost, verifyDaemonIdentity } from './daemon-ping-client.js'
 import type { ServerRunArgs } from './server-run-args.js'
 
 export const SERVER_DOCTOR_SCHEMA_VERSION = 1 as const
@@ -85,13 +85,7 @@ function defaultIsPidAlive(pid: number): boolean {
 // Exported for direct unit testing of the instanceId comparison logic below
 // (see server-doctor.test.ts) — the option default is otherwise only ever
 // exercised indirectly through runServerDoctor with an injected override.
-export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
-  // A record with no instanceId predates this check (older daemon build) and
-  // cannot be verified — the caller reports a warning, never a false 'ok'.
-  if (!record.instanceId) return false
-  const ping = await fetchDaemonPing(record.host, record.port)
-  return ping !== null && ping.instanceId === record.instanceId
-}
+export const defaultVerifyIdentity = verifyDaemonIdentity
 
 async function defaultFetchJwks(uri: string): Promise<{ ok: boolean; hasKeys: boolean }> {
   try {

--- a/packages/mcp-server/src/cli/server-doctor.ts
+++ b/packages/mcp-server/src/cli/server-doctor.ts
@@ -51,8 +51,14 @@ export interface RunServerDoctorOptions {
   checkDataDir?: (dataDir: string) => 'ok' | 'not-writable' | 'not-exists'
   // Test seam: read the POSIX mode bits of the record file.
   readRecordMode?: (dataDir: string) => number | null
-  // Test seam: fetch /api/runtime/ping and compare the returned pid to expectedPid.
-  fetchPing?: (host: string, port: number, expectedPid: number) => Promise<{ ok: boolean; pidMatches: boolean }>
+  // Test seam: fetch /api/runtime/ping and compare the returned instanceId to
+  // expectedInstanceId (undefined means the record predates instanceId and
+  // can never match).
+  fetchPing?: (
+    host: string,
+    port: number,
+    expectedInstanceId: string | undefined,
+  ) => Promise<{ ok: boolean; pidMatches: boolean }>
   // Test seam: fetch /api/runtime/status and check for leaked fields.
   // `protected: true` means the endpoint returned 401/403 (correctly secured).
   fetchRuntimeStatus?: (
@@ -87,14 +93,17 @@ function resolveConnectHost(bindHost: string): string {
 }
 
 async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+  // A record with no instanceId predates this check (older daemon build) and
+  // cannot be verified — the caller reports a warning, never a false 'ok'.
+  if (!record.instanceId) return false
   const host = resolveConnectHost(record.host)
   try {
     const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
       signal: AbortSignal.timeout(2000),
     })
     if (!res.ok) return false
-    const body = (await res.json()) as { pid?: unknown }
-    return typeof body?.pid === 'number' && body.pid === record.pid
+    const body = (await res.json()) as { instanceId?: unknown }
+    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
   } catch {
     return false
   }
@@ -141,7 +150,7 @@ function defaultReadRecordMode(dataDir: string): number | null {
 async function defaultFetchPing(
   host: string,
   port: number,
-  expectedPid: number,
+  expectedInstanceId: string | undefined,
 ): Promise<{ ok: boolean; pidMatches: boolean }> {
   const connectHost = resolveConnectHost(host)
   try {
@@ -149,8 +158,14 @@ async function defaultFetchPing(
       signal: AbortSignal.timeout(2000),
     })
     if (!res.ok) return { ok: false, pidMatches: false }
-    const body = (await res.json()) as { pid?: unknown }
-    return { ok: true, pidMatches: typeof body?.pid === 'number' && body.pid === expectedPid }
+    const body = (await res.json()) as { instanceId?: unknown }
+    return {
+      ok: true,
+      pidMatches:
+        expectedInstanceId !== undefined &&
+        typeof body?.instanceId === 'string' &&
+        body.instanceId === expectedInstanceId,
+    }
   } catch {
     return { ok: false, pidMatches: false }
   }
@@ -329,10 +344,15 @@ export async function runServerDoctor(
       id: 'server.jwks',
       status: 'error',
       summary: 'JWKS endpoint returned no keys',
-      remediation: 'Check that the JWKS endpoint returns a JSON document with a non-empty `keys` array.',
+      remediation:
+        'Check that the JWKS endpoint returns a JSON document with a non-empty `keys` array.',
     })
   } else {
-    checks.push({ id: 'server.jwks', status: 'ok', summary: 'JWKS endpoint is reachable and has keys' })
+    checks.push({
+      id: 'server.jwks',
+      status: 'ok',
+      summary: 'JWKS endpoint is reachable and has keys',
+    })
   }
 
   // ── 4. server.data_dir ───────────────────────────────────────────
@@ -343,7 +363,8 @@ export async function runServerDoctor(
       id: 'server.data_dir',
       status: 'error',
       summary: 'Data directory does not exist',
-      remediation: 'Create the data directory or set WHITEBOARD_DATA_DIR to an existing writable path.',
+      remediation:
+        'Create the data directory or set WHITEBOARD_DATA_DIR to an existing writable path.',
     })
   } else if (dataDirState === 'not-writable') {
     checks.push({
@@ -440,7 +461,11 @@ export async function runServerDoctor(
         remediation: 'Restart the server to refresh the server record.',
       })
     } else {
-      checks.push({ id: 'server.identity', status: 'ok', summary: 'Server process identity confirmed' })
+      checks.push({
+        id: 'server.identity',
+        status: 'ok',
+        summary: 'Server process identity confirmed',
+      })
     }
   }
 
@@ -455,7 +480,7 @@ export async function runServerDoctor(
       summary: 'Skipped because server identity is not confirmed',
     })
   } else {
-    const pingResult = await fetchPing(record.host, record.port, record.pid)
+    const pingResult = await fetchPing(record.host, record.port, record.instanceId)
     if (!pingResult.ok) {
       checks.push({
         id: 'server.runtime_ping',
@@ -471,7 +496,11 @@ export async function runServerDoctor(
         remediation: 'Restart the server to refresh the server record.',
       })
     } else {
-      checks.push({ id: 'server.runtime_ping', status: 'ok', summary: 'Runtime ping responded successfully' })
+      checks.push({
+        id: 'server.runtime_ping',
+        status: 'ok',
+        summary: 'Runtime ping responded successfully',
+      })
     }
   }
 

--- a/packages/mcp-server/src/cli/server-run.test.ts
+++ b/packages/mcp-server/src/cli/server-run.test.ts
@@ -12,7 +12,9 @@ const VALID_ENV: NodeJS.ProcessEnv = {
   WHITEBOARD_SERVER_JWKS_URI: 'https://auth.example.com/.well-known/jwks.json',
 }
 
-function dryRunFlags(overrides: Partial<ServerRunArgs & { kind: 'ok' }> = {}): ServerRunArgs & { kind: 'ok' } {
+function dryRunFlags(
+  overrides: Partial<ServerRunArgs & { kind: 'ok' }> = {},
+): ServerRunArgs & { kind: 'ok' } {
   return {
     kind: 'ok',
     json: true,
@@ -172,6 +174,7 @@ describe('runServerRun — actual run (no --dry-run)', () => {
         host: opts.host,
         startedAt: new Date().toISOString(),
         resolvedDataDir: '/tmp/mock-server-data',
+        instanceId: 'mock-instance-id',
         close: async () => {},
       }
     }
@@ -204,7 +207,14 @@ describe('runServerRun — actual run (no --dry-run)', () => {
     const startServer: StartServerFn = async (opts) => {
       capturedHost = opts.host
       capturedPort = opts.port
-      return { port: opts.port, host: opts.host, startedAt: new Date().toISOString(), resolvedDataDir: '/tmp/mock', close: async () => {} }
+      return {
+        port: opts.port,
+        host: opts.host,
+        startedAt: new Date().toISOString(),
+        resolvedDataDir: '/tmp/mock',
+        instanceId: 'mock-instance-id',
+        close: async () => {},
+      }
     }
     await runServerRun({
       flags: dryRunFlags({ dryRun: false, host: '127.0.0.1', port: '4399' }),
@@ -221,7 +231,14 @@ describe('runServerRun — actual run (no --dry-run)', () => {
     const startServer: StartServerFn = async (opts) => {
       capturedPublicBaseUrl = opts.publicBaseUrl
       capturedAllowedOrigins = opts.allowedOrigins
-      return { port: opts.port, host: opts.host, startedAt: new Date().toISOString(), resolvedDataDir: '/tmp/mock', close: async () => {} }
+      return {
+        port: opts.port,
+        host: opts.host,
+        startedAt: new Date().toISOString(),
+        resolvedDataDir: '/tmp/mock',
+        instanceId: 'mock-instance-id',
+        close: async () => {},
+      }
     }
     await runServerRun({
       flags: dryRunFlags({ dryRun: false }),
@@ -269,6 +286,7 @@ describe('runServerRun — actual run (no --dry-run)', () => {
     expect(record.authStrategy).toBe('oauth-jwt')
     expect(typeof record.startedAt).toBe('string')
     expect(typeof record.port).toBe('number')
+    expect(record.instanceId).toBe('mock-instance-id')
   })
 
   it('record write failure → start-error and server closed', async () => {
@@ -278,13 +296,16 @@ describe('runServerRun — actual run (no --dry-run)', () => {
       host: opts.host,
       startedAt: new Date().toISOString(),
       resolvedDataDir: '/tmp/mock',
+      instanceId: 'mock-instance-id',
       close: closeFn,
     })
     const outcome = await runServerRun({
       flags: dryRunFlags({ dryRun: false }),
       env: VALID_ENV,
       startServer,
-      writeRecord: vi.fn().mockImplementationOnce(() => { throw new Error('EROFS') }),
+      writeRecord: vi.fn().mockImplementationOnce(() => {
+        throw new Error('EROFS')
+      }),
       deleteRecord: vi.fn(),
     })
     expect(outcome.kind).toBe('start-error')
@@ -311,6 +332,7 @@ describe('runServerRun — actual run (no --dry-run)', () => {
       host: opts.host,
       startedAt: new Date().toISOString(),
       resolvedDataDir: customDataDir,
+      instanceId: 'mock-instance-id',
       close: async () => {},
     })
     const outcome = await runServerRun({

--- a/packages/mcp-server/src/cli/server-run.ts
+++ b/packages/mcp-server/src/cli/server-run.ts
@@ -12,10 +12,7 @@ import { createOAuthJwtValidator } from '../server/security/oauth-jwt-validator.
 import { createJwksKeyResolver } from '../server/security/jwks-resolver.js'
 import { createOAuthResourceServerAuthStrategy } from '../server/security/oauth-resource-strategy.js'
 import { planServerModeAuth } from '../server/security/server-mode-auth-plan.js'
-import {
-  ENV_KEYS,
-  parseServerModeEnvConfig,
-} from '../server/security/server-mode-env-config.js'
+import { ENV_KEYS, parseServerModeEnvConfig } from '../server/security/server-mode-env-config.js'
 import {
   SERVER_MODE_RECORD_SCHEMA_VERSION,
   deleteServerModeRecord,
@@ -60,6 +57,7 @@ export interface ServerModeRunning {
   host: string
   startedAt: string
   resolvedDataDir: string
+  instanceId: string
   close: () => Promise<void>
 }
 
@@ -159,8 +157,7 @@ export async function runServerRun(options: RunServerRunOptions): Promise<Server
   // Dynamic import defers loading server/config.js (which has mkdirSync at
   // module load) until after WHITEBOARD_DATA_DIR is set above.
   const startFn: StartServerFn =
-    options.startServer ??
-    (await import('../server/server-mode-http.js')).startServerModeHttp
+    options.startServer ?? (await import('../server/server-mode-http.js')).startServerModeHttp
 
   let running: ServerModeRunning
   try {
@@ -187,6 +184,7 @@ export async function runServerRun(options: RunServerRunOptions): Promise<Server
       publicBaseUrl: plan.publicBaseUrl,
       authStrategy: parsed.config.authStrategy,
       startedAt: running.startedAt,
+      instanceId: running.instanceId,
     })
   } catch {
     // Record write failure means status/stop cannot locate this server.

--- a/packages/mcp-server/src/cli/server-status.test.ts
+++ b/packages/mcp-server/src/cli/server-status.test.ts
@@ -19,6 +19,7 @@ const VALID_RECORD: ServerModeRecord = {
   publicBaseUrl: 'https://whiteboard.example.com',
   authStrategy: 'oauth-jwt',
   startedAt: '2026-05-19T00:00:00.000Z',
+  instanceId: 'valid-instance-id',
 }
 
 const alivePid = vi.fn(() => true)
@@ -29,7 +30,10 @@ const identityFail = async () => false
 describe('runServerStatus', () => {
   it('missing record → ok:false, state:missing, exit 1', async () => {
     mockRead.mockReturnValueOnce({ kind: 'missing' })
-    const { result, exitCode } = await runServerStatus({ dataDir: '/tmp/test', isPidAlive: deadPid })
+    const { result, exitCode } = await runServerStatus({
+      dataDir: '/tmp/test',
+      isPidAlive: deadPid,
+    })
     expect(exitCode).toBe(1)
     expect(result.ok).toBe(false)
     expect(result.state).toBe('missing')
@@ -39,7 +43,10 @@ describe('runServerStatus', () => {
 
   it('malformed record → ok:false, state:malformed, exit 1', async () => {
     mockRead.mockReturnValueOnce({ kind: 'malformed' })
-    const { result, exitCode } = await runServerStatus({ dataDir: '/tmp/test', isPidAlive: deadPid })
+    const { result, exitCode } = await runServerStatus({
+      dataDir: '/tmp/test',
+      isPidAlive: deadPid,
+    })
     expect(exitCode).toBe(1)
     expect(result.ok).toBe(false)
     expect(result.state).toBe('malformed')
@@ -48,7 +55,10 @@ describe('runServerStatus', () => {
 
   it('valid record with dead pid → ok:false, state:stale, exit 1', async () => {
     mockRead.mockReturnValueOnce({ kind: 'ok', record: VALID_RECORD })
-    const { result, exitCode } = await runServerStatus({ dataDir: '/tmp/test', isPidAlive: deadPid })
+    const { result, exitCode } = await runServerStatus({
+      dataDir: '/tmp/test',
+      isPidAlive: deadPid,
+    })
     expect(exitCode).toBe(1)
     expect(result.ok).toBe(false)
     expect(result.state).toBe('stale')
@@ -65,6 +75,21 @@ describe('runServerStatus', () => {
     expect(exitCode).toBe(1)
     expect(result.ok).toBe(false)
     expect(result.state).toBe('stale')
+    expect(result.recordFresh).toBe(false)
+  })
+
+  it('legacy record without instanceId + alive pid → ok:false, state:unverifiable, exit 1', async () => {
+    const legacyRecord: ServerModeRecord = { ...VALID_RECORD, instanceId: undefined }
+    mockRead.mockReturnValueOnce({ kind: 'ok', record: legacyRecord })
+    // No verifyIdentity override: exercises the default, which must refuse
+    // to confirm identity when instanceId is absent.
+    const { result, exitCode } = await runServerStatus({
+      dataDir: '/tmp/test',
+      isPidAlive: alivePid,
+    })
+    expect(exitCode).toBe(1)
+    expect(result.ok).toBe(false)
+    expect(result.state).toBe('unverifiable')
     expect(result.recordFresh).toBe(false)
   })
 
@@ -115,7 +140,10 @@ describe('runServerStatus', () => {
 
   it('non-leak: malformed result does not echo dataDir or record content', async () => {
     mockRead.mockReturnValueOnce({ kind: 'malformed' })
-    const { result } = await runServerStatus({ dataDir: '/secret/path/whiteboard', isPidAlive: deadPid })
+    const { result } = await runServerStatus({
+      dataDir: '/secret/path/whiteboard',
+      isPidAlive: deadPid,
+    })
     const asText = JSON.stringify(result)
     expect(asText).not.toContain('/secret/path')
     expect(asText).not.toContain('whiteboard')

--- a/packages/mcp-server/src/cli/server-status.test.ts
+++ b/packages/mcp-server/src/cli/server-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 
 // Mock the record reader so tests don't need real files.
@@ -7,7 +7,11 @@ vi.mock('../server/security/server-mode-record.js', () => ({
 }))
 
 import { readServerModeRecord } from '../server/security/server-mode-record.js'
-import { SERVER_STATUS_SCHEMA_VERSION, runServerStatus } from './server-status.js'
+import {
+  SERVER_STATUS_SCHEMA_VERSION,
+  defaultVerifyIdentity,
+  runServerStatus,
+} from './server-status.js'
 
 const mockRead = vi.mocked(readServerModeRecord)
 
@@ -147,5 +151,42 @@ describe('runServerStatus', () => {
     const asText = JSON.stringify(result)
     expect(asText).not.toContain('/secret/path')
     expect(asText).not.toContain('whiteboard')
+  })
+})
+
+// ─── Direct unit tests for the default identity implementation ──────────────
+// Every scenario above injects a verifyIdentity override except the legacy
+// no-instanceId case, which short-circuits before the fetch. These exercise
+// the real fetchDaemonPing(...) + instanceId comparison so a regression
+// there (e.g. inverted equality) does not go undetected.
+
+describe('defaultVerifyIdentity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('confirms identity when the ping response instanceId matches the record', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'valid-instance-id' }),
+    }))
+    await expect(defaultVerifyIdentity(VALID_RECORD)).resolves.toBe(true)
+  })
+
+  it('refuses to confirm identity when the ping response instanceId mismatches', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'some-other-instance-id' }),
+    }))
+    await expect(defaultVerifyIdentity(VALID_RECORD)).resolves.toBe(false)
+  })
+
+  it('never confirms identity when the record predates instanceId', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const legacyRecord: ServerModeRecord = { ...VALID_RECORD, instanceId: undefined }
+    await expect(defaultVerifyIdentity(legacyRecord)).resolves.toBe(false)
+    // Short-circuits before making a network call.
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/mcp-server/src/cli/server-status.ts
+++ b/packages/mcp-server/src/cli/server-status.ts
@@ -61,7 +61,10 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+// Exported for direct unit testing of the live-ping comparison (see
+// server-status.test.ts) — the option default is otherwise only ever
+// exercised indirectly through runServerStatus with an injected override.
+export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
   // A record with no instanceId predates this check (older daemon build) and
   // cannot be verified — the caller reports 'unverifiable', never a silent
   // 'stale'/not-running or a false 'running'.

--- a/packages/mcp-server/src/cli/server-status.ts
+++ b/packages/mcp-server/src/cli/server-status.ts
@@ -11,7 +11,7 @@
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
 import { readServerModeRecord } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
-import { fetchDaemonPing } from './daemon-ping-client.js'
+import { verifyDaemonIdentity } from './daemon-ping-client.js'
 
 export const SERVER_STATUS_SCHEMA_VERSION = 1 as const
 
@@ -64,14 +64,7 @@ function defaultIsPidAlive(pid: number): boolean {
 // Exported for direct unit testing of the live-ping comparison (see
 // server-status.test.ts) — the option default is otherwise only ever
 // exercised indirectly through runServerStatus with an injected override.
-export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
-  // A record with no instanceId predates this check (older daemon build) and
-  // cannot be verified — the caller reports 'unverifiable', never a silent
-  // 'stale'/not-running or a false 'running'.
-  if (!record.instanceId) return false
-  const ping = await fetchDaemonPing(record.host, record.port)
-  return ping !== null && ping.instanceId === record.instanceId
-}
+export const defaultVerifyIdentity = verifyDaemonIdentity
 
 export async function runServerStatus(
   options: RunServerStatusOptions,

--- a/packages/mcp-server/src/cli/server-status.ts
+++ b/packages/mcp-server/src/cli/server-status.ts
@@ -14,7 +14,7 @@ import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 
 export const SERVER_STATUS_SCHEMA_VERSION = 1 as const
 
-export type ServerStatusState = 'running' | 'missing' | 'stale' | 'malformed'
+export type ServerStatusState = 'running' | 'missing' | 'stale' | 'malformed' | 'unverifiable'
 
 export interface ServerStatusRunningResult {
   schemaVersion: typeof SERVER_STATUS_SCHEMA_VERSION
@@ -69,14 +69,18 @@ function resolveConnectHost(bindHost: string): string {
 }
 
 async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+  // A record with no instanceId predates this check (older daemon build) and
+  // cannot be verified — the caller reports 'unverifiable', never a silent
+  // 'stale'/not-running or a false 'running'.
+  if (!record.instanceId) return false
   const host = resolveConnectHost(record.host)
   try {
     const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
       signal: AbortSignal.timeout(2000),
     })
     if (!res.ok) return false
-    const body = (await res.json()) as { pid?: unknown }
-    return typeof body?.pid === 'number' && body.pid === record.pid
+    const body = (await res.json()) as { instanceId?: unknown }
+    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
   } catch {
     return false
   }
@@ -134,7 +138,9 @@ export async function runServerStatus(
       result: {
         schemaVersion: SERVER_STATUS_SCHEMA_VERSION,
         ok: false,
-        state: 'stale',
+        // A record without instanceId (legacy daemon build) can never be
+        // confirmed — report 'unverifiable' rather than a false 'stale'.
+        state: record.instanceId ? 'stale' : 'unverifiable',
         recordFresh: false,
       },
       exitCode: 1,

--- a/packages/mcp-server/src/cli/server-status.ts
+++ b/packages/mcp-server/src/cli/server-status.ts
@@ -11,6 +11,7 @@
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
 import { readServerModeRecord } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
+import { fetchDaemonPing } from './daemon-ping-client.js'
 
 export const SERVER_STATUS_SCHEMA_VERSION = 1 as const
 
@@ -60,30 +61,13 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-function resolveConnectHost(bindHost: string): string {
-  if (bindHost === '0.0.0.0') return '127.0.0.1'
-  if (bindHost === '::' || bindHost === '::0') return '[::1]'
-  // Bare IPv6 addresses contain colons — bracket them for URL construction.
-  if (bindHost.includes(':') && !bindHost.startsWith('[')) return `[${bindHost}]`
-  return bindHost
-}
-
 async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
   // A record with no instanceId predates this check (older daemon build) and
   // cannot be verified — the caller reports 'unverifiable', never a silent
   // 'stale'/not-running or a false 'running'.
   if (!record.instanceId) return false
-  const host = resolveConnectHost(record.host)
-  try {
-    const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
-      signal: AbortSignal.timeout(2000),
-    })
-    if (!res.ok) return false
-    const body = (await res.json()) as { instanceId?: unknown }
-    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
-  } catch {
-    return false
-  }
+  const ping = await fetchDaemonPing(record.host, record.port)
+  return ping !== null && ping.instanceId === record.instanceId
 }
 
 export async function runServerStatus(

--- a/packages/mcp-server/src/cli/server-stop.test.ts
+++ b/packages/mcp-server/src/cli/server-stop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
 
 vi.mock('../server/security/server-mode-record.js', () => ({
@@ -7,7 +7,7 @@ vi.mock('../server/security/server-mode-record.js', () => ({
 }))
 
 import { readServerModeRecord } from '../server/security/server-mode-record.js'
-import { SERVER_STOP_SCHEMA_VERSION, runServerStop } from './server-stop.js'
+import { SERVER_STOP_SCHEMA_VERSION, defaultVerifyIdentity, runServerStop } from './server-stop.js'
 
 const mockRead = vi.mocked(readServerModeRecord)
 
@@ -233,5 +233,42 @@ describe('runServerStop', () => {
     expect(asText).not.toContain('jwksUri')
     expect(asText).not.toContain('token')
     expect(asText).not.toContain('Bearer')
+  })
+})
+
+// ─── Direct unit tests for the default identity implementation ──────────────
+// Every scenario above injects a verifyIdentity override, so without these
+// the real fetchDaemonPing(...) + instanceId comparison — the code path that
+// decides whether server-stop is allowed to kill the recorded pid — would go
+// uncovered.
+
+describe('defaultVerifyIdentity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('confirms identity when the ping response instanceId matches the record', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'valid-instance-id' }),
+    }))
+    await expect(defaultVerifyIdentity(VALID_RECORD)).resolves.toBe(true)
+  })
+
+  it('refuses to confirm identity when the ping response instanceId mismatches', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ ok: true, instanceId: 'some-other-instance-id' }),
+    }))
+    await expect(defaultVerifyIdentity(VALID_RECORD)).resolves.toBe(false)
+  })
+
+  it('never confirms identity when the record predates instanceId', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const legacyRecord: ServerModeRecord = { ...VALID_RECORD, instanceId: undefined }
+    await expect(defaultVerifyIdentity(legacyRecord)).resolves.toBe(false)
+    // Short-circuits before making a network call.
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/mcp-server/src/cli/server-stop.test.ts
+++ b/packages/mcp-server/src/cli/server-stop.test.ts
@@ -19,6 +19,7 @@ const VALID_RECORD: ServerModeRecord = {
   publicBaseUrl: 'https://whiteboard.example.com',
   authStrategy: 'oauth-jwt',
   startedAt: '2026-05-19T00:00:00.000Z',
+  instanceId: 'valid-instance-id',
 }
 
 const noOp = async () => {}
@@ -115,6 +116,25 @@ describe('runServerStop', () => {
     expect(killFn).not.toHaveBeenCalled()
   })
 
+  it('legacy record without instanceId → identity unverifiable, not-running, no kill', async () => {
+    const legacyRecord: ServerModeRecord = { ...VALID_RECORD, instanceId: undefined }
+    mockRead.mockReturnValueOnce({ kind: 'ok', record: legacyRecord })
+    const killFn = vi.fn()
+    // No verifyIdentity override: exercises the default, which must refuse
+    // to confirm identity when instanceId is absent.
+    const { result, exitCode } = await runServerStop({
+      dataDir: '/tmp/test',
+      isPidAlive: alivePid,
+      killFn,
+      removeRecord: noOp,
+    })
+    expect(exitCode).toBe(0)
+    expect(result.ok).toBe(true)
+    expect(result.action).toBe('not-running')
+    expect(result.reason).toBe('server-instance-unverifiable')
+    expect(killFn).not.toHaveBeenCalled()
+  })
+
   it('SIGTERM timeout → identity still matches → SIGKILL sent, action:stopped with timeout reason', async () => {
     mockRead.mockReturnValueOnce({ kind: 'ok', record: VALID_RECORD })
     const killFn = vi.fn()
@@ -140,9 +160,7 @@ describe('runServerStop', () => {
     mockRead.mockReturnValueOnce({ kind: 'ok', record: VALID_RECORD })
     const killFn = vi.fn()
     // First identity call (before SIGTERM) passes; subsequent call (before SIGKILL) fails.
-    const verifyIdentity = vi.fn()
-      .mockResolvedValueOnce(true)
-      .mockResolvedValue(false)
+    const verifyIdentity = vi.fn().mockResolvedValueOnce(true).mockResolvedValue(false)
     const { result, exitCode } = await runServerStop({
       dataDir: '/tmp/test',
       isPidAlive: alivePid, // PID still in OS (reused by other process)

--- a/packages/mcp-server/src/cli/server-stop.ts
+++ b/packages/mcp-server/src/cli/server-stop.ts
@@ -76,7 +76,10 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+// Exported for direct unit testing of the live-ping comparison (see
+// server-stop.test.ts) — the option default is otherwise only ever
+// exercised indirectly through runServerStop with an injected override.
+export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
   // A record with no instanceId predates this check (older daemon build). It
   // cannot be verified, so treat it the same as a mismatch — the caller maps
   // that to the 'server-instance-unverifiable' reason, never to a kill.

--- a/packages/mcp-server/src/cli/server-stop.ts
+++ b/packages/mcp-server/src/cli/server-stop.ts
@@ -29,6 +29,10 @@ export type ServerStopReason =
   | 'server-process-not-running'
   | 'server-stop-signal-failed'
   | 'server-stop-timeout'
+  // Record predates instanceId (written by an older daemon build). Identity
+  // cannot be confirmed, so the safe choice is to refuse to kill rather than
+  // risk terminating an unrelated process that reused the recorded pid.
+  | 'server-instance-unverifiable'
 
 export interface ServerStopResult {
   schemaVersion: typeof SERVER_STOP_SCHEMA_VERSION
@@ -80,14 +84,18 @@ function resolveConnectHost(bindHost: string): string {
 }
 
 async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
+  // A record with no instanceId predates this check (older daemon build). It
+  // cannot be verified, so treat it the same as a mismatch — the caller maps
+  // that to the 'server-instance-unverifiable' reason, never to a kill.
+  if (!record.instanceId) return false
   const host = resolveConnectHost(record.host)
   try {
     const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
       signal: AbortSignal.timeout(2000),
     })
     if (!res.ok) return false
-    const body = (await res.json()) as { pid?: unknown }
-    return typeof body?.pid === 'number' && body.pid === record.pid
+    const body = (await res.json()) as { instanceId?: unknown }
+    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
   } catch {
     return false
   }
@@ -204,7 +212,7 @@ export async function runServerStop(options: RunServerStopOptions): Promise<RunS
         schemaVersion: SERVER_STOP_SCHEMA_VERSION,
         ok: true,
         action: 'not-running',
-        reason: 'server-process-not-running',
+        reason: record.instanceId ? 'server-process-not-running' : 'server-instance-unverifiable',
         recordFound: true,
         recordFresh: false,
         pid: record.pid,

--- a/packages/mcp-server/src/cli/server-stop.ts
+++ b/packages/mcp-server/src/cli/server-stop.ts
@@ -17,7 +17,7 @@ import {
   readServerModeRecord,
 } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
-import { fetchDaemonPing } from './daemon-ping-client.js'
+import { verifyDaemonIdentity } from './daemon-ping-client.js'
 
 export const SERVER_STOP_SCHEMA_VERSION = 1 as const
 
@@ -79,14 +79,7 @@ function defaultIsPidAlive(pid: number): boolean {
 // Exported for direct unit testing of the live-ping comparison (see
 // server-stop.test.ts) — the option default is otherwise only ever
 // exercised indirectly through runServerStop with an injected override.
-export async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
-  // A record with no instanceId predates this check (older daemon build). It
-  // cannot be verified, so treat it the same as a mismatch — the caller maps
-  // that to the 'server-instance-unverifiable' reason, never to a kill.
-  if (!record.instanceId) return false
-  const ping = await fetchDaemonPing(record.host, record.port)
-  return ping !== null && ping.instanceId === record.instanceId
-}
+export const defaultVerifyIdentity = verifyDaemonIdentity
 
 const defaultKillFn = (pid: number, signal: NodeJS.Signals | number) => {
   process.kill(pid, signal)

--- a/packages/mcp-server/src/cli/server-stop.ts
+++ b/packages/mcp-server/src/cli/server-stop.ts
@@ -17,6 +17,7 @@ import {
   readServerModeRecord,
 } from '../server/security/server-mode-record.js'
 import type { ServerModeRecord } from '../server/security/server-mode-record.js'
+import { fetchDaemonPing } from './daemon-ping-client.js'
 
 export const SERVER_STOP_SCHEMA_VERSION = 1 as const
 
@@ -75,30 +76,13 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-function resolveConnectHost(bindHost: string): string {
-  if (bindHost === '0.0.0.0') return '127.0.0.1'
-  if (bindHost === '::' || bindHost === '::0') return '[::1]'
-  // Bare IPv6 addresses contain colons — bracket them for URL construction.
-  if (bindHost.includes(':') && !bindHost.startsWith('[')) return `[${bindHost}]`
-  return bindHost
-}
-
 async function defaultVerifyIdentity(record: ServerModeRecord): Promise<boolean> {
   // A record with no instanceId predates this check (older daemon build). It
   // cannot be verified, so treat it the same as a mismatch — the caller maps
   // that to the 'server-instance-unverifiable' reason, never to a kill.
   if (!record.instanceId) return false
-  const host = resolveConnectHost(record.host)
-  try {
-    const res = await fetch(`http://${host}:${record.port}/api/runtime/ping`, {
-      signal: AbortSignal.timeout(2000),
-    })
-    if (!res.ok) return false
-    const body = (await res.json()) as { instanceId?: unknown }
-    return typeof body?.instanceId === 'string' && body.instanceId === record.instanceId
-  } catch {
-    return false
-  }
+  const ping = await fetchDaemonPing(record.host, record.port)
+  return ping !== null && ping.instanceId === record.instanceId
 }
 
 const defaultKillFn = (pid: number, signal: NodeJS.Signals | number) => {

--- a/packages/mcp-server/src/server/app.server-mode.test.ts
+++ b/packages/mcp-server/src/server/app.server-mode.test.ts
@@ -269,6 +269,26 @@ describe('app — server-mode composition', () => {
     })
   })
 
+  describe('server-mode runtime scope tiers', () => {
+    it('POST /api/runtime/logs/prune → 403 with runtime:read only (requires runtime:admin)', async () => {
+      const app = createApp(makeServerModeOptions(['runtime:read']))
+      const res = await app.request('/api/runtime/logs/prune', {
+        method: 'POST',
+        headers: { authorization: BEARER },
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('POST /api/runtime/logs/prune → reaches the route with runtime:admin', async () => {
+      const app = createApp(makeServerModeOptions(['runtime:admin']))
+      const res = await app.request('/api/runtime/logs/prune', {
+        method: 'POST',
+        headers: { authorization: BEARER },
+      })
+      expect(res.status).not.toBe(403)
+    })
+  })
+
   // Req 4: MCP origin policy
   describe('server-mode MCP origin policy', () => {
     it('rejects request with disallowed Origin → 403', async () => {
@@ -703,19 +723,25 @@ describe('app — server-mode composition', () => {
 
     it('GET /api/workspaces/:wid/canvases/:slug/versions/:id/thumbnail → 403 with workspace:read only (requires versions:read)', async () => {
       const app = createApp(makeServerModeOptions(['workspace:read']))
-      const res = await app.request('/api/workspaces/w1/canvases/canvas-a/versions/v-001/thumbnail', {
-        headers: { authorization: BEARER },
-      })
+      const res = await app.request(
+        '/api/workspaces/w1/canvases/canvas-a/versions/v-001/thumbnail',
+        {
+          headers: { authorization: BEARER },
+        },
+      )
       expect(res.status).toBe(403)
     })
 
     it('PUT /api/workspaces/:wid/canvases/:slug/versions/:id/thumbnail → 403 with versions:read only (requires versions:write)', async () => {
       const app = createApp(makeServerModeOptions(['versions:read']))
-      const res = await app.request('/api/workspaces/w1/canvases/canvas-a/versions/v-001/thumbnail', {
-        method: 'PUT',
-        headers: { authorization: BEARER, 'content-type': 'image/png' },
-        body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
-      })
+      const res = await app.request(
+        '/api/workspaces/w1/canvases/canvas-a/versions/v-001/thumbnail',
+        {
+          method: 'PUT',
+          headers: { authorization: BEARER, 'content-type': 'image/png' },
+          body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        },
+      )
       expect(res.status).toBe(403)
     })
 

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -991,6 +991,23 @@ describe('createApp daemon mutation auth', () => {
       expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
     })
 
+    it('rejects a GET with a spoofed non-loopback Host with 403 (DNS-rebinding guard)', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Host: 'evil.example' },
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('rejects an OPTIONS preflight with a spoofed non-loopback Host with 403 before any CORS short-circuit', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('/api/workspaces/session1/canvases', {
+        method: 'OPTIONS',
+        headers: { Host: 'evil.example', Origin: 'http://localhost:5173' },
+      })
+      expect(res.status).toBe(403)
+    })
+
     it('cross-origin loopback POST to a mutation route without Authorization returns 401 (auth ordering)', async () => {
       const app = createApp(createRuntimeOptions('secret'))
       const res = await app.request('/api/workspaces/session1/canvases', {
@@ -1057,7 +1074,16 @@ describe('createApp daemon mutation auth', () => {
       expect(() => daemonPingResponseSchema.parse(body)).not.toThrow()
       const parsed = daemonPingResponseSchema.parse(body)
       expect(parsed.ok).toBe(true)
-      expect(typeof parsed.pid).toBe('number')
+      expect(typeof parsed.instanceId).toBe('string')
+    })
+
+    it('ping response has no pid field and two apps get different instanceIds', async () => {
+      const appA = createApp(createRuntimeOptions('secret'))
+      const appB = createApp(createRuntimeOptions('secret'))
+      const bodyA = await (await appA.request('/api/runtime/ping')).json()
+      const bodyB = await (await appB.request('/api/runtime/ping')).json()
+      expect(bodyA.pid).toBeUndefined()
+      expect(bodyA.instanceId).not.toBe(bodyB.instanceId)
     })
   })
 })

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -212,7 +212,16 @@ function resolveServerModeApiScopes(method: string, path: string): readonly Auth
     return isWrite ? ['workspace:write'] : ['workspace:read']
   }
 
-  if (path === '/api/runtime/touch' || path === '/api/runtime/shutdown') return ['runtime:admin']
+  // touch/shutdown/logs-prune all mutate daemon-managed state (liveness timer,
+  // process lifecycle, on-disk log files) and require the admin tier even
+  // though the HTTP verb for prune is POST like any other write route.
+  if (
+    path === '/api/runtime/touch' ||
+    path === '/api/runtime/shutdown' ||
+    path === '/api/runtime/logs/prune'
+  ) {
+    return ['runtime:admin']
+  }
   if (path.startsWith('/api/runtime/')) return ['runtime:read']
 
   return isWrite ? ['canvas:write'] : ['canvas:read']

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { serveStatic } from '@hono/node-server/serve-static'
@@ -35,6 +36,7 @@ import {
 } from './security/mcp-auth.js'
 import { createMcpHttpAuthMiddleware, createMcpHttpOriginMiddleware } from './security/mcp-http.js'
 import { createApiLoopbackCorsMiddleware } from './security/cors-loopback.js'
+import { createApiHostGuardMiddleware } from './security/api-host-guard.js'
 import type { AuthScope } from './security/auth-strategy.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { planServerModeAuth } from './security/server-mode-auth-plan.js'
@@ -141,6 +143,9 @@ export interface LocalDaemonAppOptions {
   authMode: 'local-daemon'
   token?: string
   mcpAuth?: McpHttpAuthStrategy
+  /** Per-process-start identifier for /api/runtime/ping. Falls back to a
+   *  fresh crypto.randomUUID() when omitted (tests, ad-hoc callers). */
+  instanceId?: string
   touch: () => void
   getStatus: () => RuntimeStatusResponse
   shutdown: () => Promise<void>
@@ -151,6 +156,9 @@ export interface ServerModeAppOptions {
   publicBaseUrl: string
   allowedOrigins: readonly string[]
   authStrategy: AsyncAuthStrategy
+  /** Per-process-start identifier for /api/runtime/ping. Falls back to a
+   *  fresh crypto.randomUUID() when omitted (tests, ad-hoc callers). */
+  instanceId?: string
   touch: () => void
   getStatus: () => RuntimeStatusResponse
   shutdown: () => Promise<void>
@@ -339,6 +347,7 @@ export function createApp(options: AppOptions) {
 
   const app = new Hono()
 
+  const instanceId = options.instanceId ?? randomUUID()
   const token = options.authMode === 'local-daemon' ? options.token : undefined
   const mcpAuth =
     options.authMode === 'local-daemon'
@@ -378,8 +387,13 @@ export function createApp(options: AppOptions) {
   })
 
   if (options.authMode === 'server-mode') {
+    app.use('/api/*', createApiHostGuardMiddleware(options.authMode))
     app.use('/api/*', createServerModeApiAuthMiddleware(options.authStrategy))
   } else {
+    // Host guard runs first, ahead of CORS, so a spoofed non-loopback Host
+    // (DNS rebinding) is rejected before the OPTIONS short-circuit below can
+    // hand out a 204 — otherwise a preflight would bypass the guard entirely.
+    app.use('/api/*', createApiHostGuardMiddleware(options.authMode))
     // In local-daemon mode, allow cross-origin loopback requests (e.g. apps/web
     // dev server on localhost:5173 → daemon on 127.0.0.1:3099).
     // The CORS middleware is applied BEFORE the mutation-auth guard so that
@@ -554,6 +568,7 @@ export function createApp(options: AppOptions) {
     createRuntimeRouter({
       token,
       mcpAuth: mcpAuth ?? undefined,
+      instanceId,
       touch: options.touch,
       getStatus: options.authMode === 'server-mode' ? serverModeGetStatus! : options.getStatus,
       shutdown: options.shutdown,

--- a/packages/mcp-server/src/server/daemon-auth-binding.test.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isLoopbackHost } from './daemon-auth-binding.js'
+import { assertLoopbackBindHost, isLoopbackHost } from './daemon-auth-binding.js'
 
 // Security-boundary conformance: these cases define what the daemon binding
 // considers "loopback-only" for server-mode exposure validation.
@@ -25,5 +25,27 @@ describe('isLoopbackHost', () => {
     '[::2]',
   ])('rejects non-loopback or malformed host %s', (host) => {
     expect(isLoopbackHost(host)).toBe(false)
+  })
+})
+
+describe('assertLoopbackBindHost', () => {
+  it.each([
+    '127.0.0.1',
+    'localhost',
+    '::1',
+    '[::1]',
+  ])('allows starting the daemon bound to loopback host %s', (host) => {
+    expect(assertLoopbackBindHost(host)).toEqual({ ok: true })
+  })
+
+  it.each([
+    '0.0.0.0',
+    '192.168.1.5',
+    'evil.example',
+  ])('refuses to start the daemon bound to non-loopback host %s', (host) => {
+    expect(assertLoopbackBindHost(host)).toEqual({
+      ok: false,
+      code: 'bind_host_not_loopback',
+    })
   })
 })

--- a/packages/mcp-server/src/server/daemon-auth-binding.test.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { assertLoopbackBindHost, isLoopbackHost } from './daemon-auth-binding.js'
+import { assertLoopbackBindHost, isLoopbackHost, normalizeBindHost } from './daemon-auth-binding.js'
+
+describe('normalizeBindHost', () => {
+  it('strips URI brackets from IPv6 so the host is valid for server.listen', () => {
+    // The bind guard accepts '[::1]' as loopback, but Node's listen() wants
+    // the bare address — passing '[::1]' through crashes with EINVAL.
+    expect(normalizeBindHost('[::1]')).toBe('::1')
+  })
+
+  it.each(['127.0.0.1', 'localhost', '::1', '0.0.0.0'])('passes %s through unchanged', (host) => {
+    expect(normalizeBindHost(host)).toBe(host)
+  })
+})
 
 // Security-boundary conformance: these cases define what the daemon binding
 // considers "loopback-only" for server-mode exposure validation.

--- a/packages/mcp-server/src/server/daemon-auth-binding.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.ts
@@ -7,3 +7,13 @@ const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]'])
 export function isLoopbackHost(host: string): boolean {
   return LOOPBACK_HOSTS.has(host)
 }
+
+export type LoopbackBindGuardResult = { ok: true } | { ok: false; code: 'bind_host_not_loopback' }
+
+// Pre-startup guard: called before the HTTP server binds, so a local-daemon
+// invocation with e.g. --host=0.0.0.0 is refused instead of quietly exposing
+// an unauthenticated daemon beyond loopback.
+export function assertLoopbackBindHost(host: string): LoopbackBindGuardResult {
+  if (isLoopbackHost(host)) return { ok: true }
+  return { ok: false, code: 'bind_host_not_loopback' }
+}

--- a/packages/mcp-server/src/server/daemon-auth-binding.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.ts
@@ -8,6 +8,13 @@ export function isLoopbackHost(host: string): boolean {
   return LOOPBACK_HOSTS.has(host)
 }
 
+// server.listen() wants the bare IPv6 address; the URI-bracketed form the
+// guard accepts ('[::1]') makes it throw EINVAL. Strip brackets before bind.
+export function normalizeBindHost(host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) return host.slice(1, -1)
+  return host
+}
+
 export type LoopbackBindGuardResult = { ok: true } | { ok: false; code: 'bind_host_not_loopback' }
 
 // Pre-startup guard: called before the HTTP server binds, so a local-daemon

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -8,6 +8,7 @@ import { IdleTimer } from '../daemon/idle-timer.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import { createApp } from './app.js'
+import { normalizeBindHost } from './daemon-auth-binding.js'
 import { DATA_DIR, DIST_APP_DIR } from './config.js'
 import { handleWsUpgrade, getConnectionStats, setRuntimeTouchFn } from './routes/ws.js'
 import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
@@ -43,7 +44,7 @@ type ClosableHttpServer = ReturnType<typeof serve> & {
 }
 
 export async function startHttpServer(options: StartHttpServerOptions): Promise<RunningServer> {
-  const host = options.host ?? '127.0.0.1'
+  const host = normalizeBindHost(options.host ?? '127.0.0.1')
   const instanceId = randomUUID()
   const startedAtMs = Date.now()
   const startedAt = new Date(startedAtMs).toISOString()

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
 import { join } from 'node:path'
 import type { Socket } from 'node:net'
@@ -28,6 +29,9 @@ export interface StartHttpServerOptions {
 
 export interface RunningServer {
   port: number
+  /** Unique per process-start id; used by CLI stop/status/doctor to verify
+   *  they are talking to the daemon they recorded, not a PID-reuse impostor. */
+  instanceId: string
   close: () => Promise<void>
   touch: () => void
   getRuntimeStatus: () => RuntimeStatus
@@ -40,6 +44,7 @@ type ClosableHttpServer = ReturnType<typeof serve> & {
 
 export async function startHttpServer(options: StartHttpServerOptions): Promise<RunningServer> {
   const host = options.host ?? '127.0.0.1'
+  const instanceId = randomUUID()
   const startedAtMs = Date.now()
   const startedAt = new Date(startedAtMs).toISOString()
   let server: ReturnType<typeof serve>
@@ -67,7 +72,14 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
       auth: { mode: 'local-token', hasToken: Boolean(options.token) },
       storage: {
         dataDir: DATA_DIR,
-        dataDirWritable: (() => { try { accessSync(DATA_DIR, fsConstants.W_OK); return true } catch { return false } })(),
+        dataDirWritable: (() => {
+          try {
+            accessSync(DATA_DIR, fsConstants.W_OK)
+            return true
+          } catch {
+            return false
+          }
+        })(),
       },
       app: { served: true, buildPresent: existsSync(join(DIST_APP_DIR, 'index.html')) },
       mcp: { httpEnabled: true, endpoint: `http://${host}:${options.port}/mcp` },
@@ -111,6 +123,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     authMode: 'local-daemon',
     token: options.token,
     mcpAuth: options.mcpAuth,
+    instanceId,
     touch,
     getStatus: getRuntimeStatus,
     shutdown: close,
@@ -145,8 +158,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     const decision = authorizeWsUpgrade(req.headers, options.token)
     if (!decision.accept) {
       const statusCode = decision.statusCode ?? 401
-      const statusText =
-        statusCode === 403 ? 'Forbidden' : 'Unauthorized'
+      const statusText = statusCode === 403 ? 'Forbidden' : 'Unauthorized'
       socket.write(`HTTP/1.1 ${statusCode} ${statusText}\r\nConnection: close\r\n\r\n`)
       socket.destroy()
       return
@@ -170,6 +182,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
 
   return {
     port: options.port,
+    instanceId,
     close,
     touch,
     getRuntimeStatus,

--- a/packages/mcp-server/src/server/routes/runtime.test.ts
+++ b/packages/mcp-server/src/server/routes/runtime.test.ts
@@ -44,6 +44,7 @@ function createApp() {
   const shutdown = vi.fn(async () => undefined)
   const app = createRuntimeRouter({
     token: 'secret',
+    instanceId: 'test-instance-id',
     touch,
     shutdown,
     getStatus: () => ({
@@ -75,7 +76,7 @@ describe('runtime routes', () => {
     const { app } = createApp()
     const res = await app.request('/api/runtime/ping')
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toMatchObject({ ok: true })
+    await expect(res.json()).resolves.toEqual({ ok: true, instanceId: 'test-instance-id' })
   })
 
   it('rejects status without a bearer token', async () => {

--- a/packages/mcp-server/src/server/routes/runtime.ts
+++ b/packages/mcp-server/src/server/routes/runtime.ts
@@ -11,6 +11,7 @@ import type { McpHttpAuthStrategy } from '../security/mcp-auth.js'
 export interface RuntimeRouterOptions {
   token?: string
   mcpAuth?: McpHttpAuthStrategy
+  instanceId: string
   touch: () => void
   getStatus: () => RuntimeStatus
   shutdown: () => Promise<void>
@@ -20,7 +21,7 @@ export function createRuntimeRouter(options: RuntimeRouterOptions) {
   const app = new Hono()
 
   app.get('/api/runtime/ping', (c) => {
-    return c.json(daemonPingResponseSchema.parse({ ok: true, pid: process.pid }))
+    return c.json(daemonPingResponseSchema.parse({ ok: true, instanceId: options.instanceId }))
   })
 
   app.use('/api/runtime/*', async (c, next) => {

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -82,4 +82,15 @@ describe('authorizeWsUpgrade', () => {
     )
     expect(decision).toEqual({ accept: false, statusCode: 401 })
   })
+
+  it('accepts a bracketed IPv6 loopback Origin against a bracketed IPv6 loopback Host', () => {
+    // Node's URL parser keeps the brackets in .hostname for IPv6 ("[::1]"),
+    // while the Host header side is normalized to bare "::1" — both sides
+    // must agree once stripped, or real IPv6 loopback dev setups get a 403.
+    const decision = authorizeWsUpgrade({
+      host: '[::1]:3099',
+      origin: 'http://[::1]:5173',
+    })
+    expect(decision.accept).toBe(true)
+  })
 })

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -60,6 +60,18 @@ describe('authorizeWsUpgrade', () => {
     expect(decision).toEqual({ accept: true, protocol: WHITEBOARD_WS_PROTOCOL })
   })
 
+  it('rejects with 403 for a non-loopback Origin even with a valid token (Origin check precedes token check)', () => {
+    const decision = authorizeWsUpgrade(
+      {
+        host: '127.0.0.1:3099',
+        origin: 'https://evil.example',
+        'sec-websocket-protocol': `${WHITEBOARD_WS_PROTOCOL}, ${DAEMON_TOKEN_WS_PROTOCOL_PREFIX}secret`,
+      },
+      'secret',
+    )
+    expect(decision).toEqual({ accept: false, statusCode: 403 })
+  })
+
   it('rejects with 401 when the offered token does not match', () => {
     const decision = authorizeWsUpgrade(
       {

--- a/packages/mcp-server/src/server/routes/ws-auth.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.ts
@@ -3,6 +3,7 @@ import {
   DAEMON_TOKEN_WS_PROTOCOL_PREFIX,
   WHITEBOARD_WS_PROTOCOL,
 } from '../../shared/ws-protocol.js'
+import { isLoopbackHostname, normalizeHostHeader } from '../security/cors-loopback.js'
 
 function parseProtocolHeader(header: string | string[] | undefined): string[] {
   if (Array.isArray(header)) {
@@ -13,19 +14,6 @@ function parseProtocolHeader(header: string | string[] | undefined): string[] {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
-}
-
-function normalizeHostHeader(hostHeader: string | undefined): string | null {
-  if (!hostHeader) return null
-  try {
-    return new URL(`http://${hostHeader}`).hostname
-  } catch {
-    return null
-  }
 }
 
 function isAllowedBrowserOrigin(
@@ -75,10 +63,7 @@ export function authorizeWsUpgrade(
   const offeredToken = protocols.find((protocol) =>
     protocol.startsWith(DAEMON_TOKEN_WS_PROTOCOL_PREFIX),
   )
-  if (
-    !offeredBaseProtocol ||
-    offeredToken !== `${DAEMON_TOKEN_WS_PROTOCOL_PREFIX}${token}`
-  ) {
+  if (!offeredBaseProtocol || offeredToken !== `${DAEMON_TOKEN_WS_PROTOCOL_PREFIX}${token}`) {
     return { accept: false, statusCode: 401 }
   }
 

--- a/packages/mcp-server/src/server/routes/ws-auth.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.ts
@@ -3,7 +3,11 @@ import {
   DAEMON_TOKEN_WS_PROTOCOL_PREFIX,
   WHITEBOARD_WS_PROTOCOL,
 } from '../../shared/ws-protocol.js'
-import { isLoopbackHostname, normalizeHostHeader } from '../security/cors-loopback.js'
+import {
+  isLoopbackHostname,
+  normalizeHostHeader,
+  normalizeOriginHostname,
+} from '../security/cors-loopback.js'
 
 function parseProtocolHeader(header: string | string[] | undefined): string[] {
   if (Array.isArray(header)) {
@@ -28,12 +32,11 @@ function isAllowedBrowserOrigin(
   if (!requestHost) return false
   if (!isLoopbackHostname(requestHost)) return false
   if (!originHeader) return true
-  try {
-    const origin = new URL(originHeader)
-    return isLoopbackHostname(origin.hostname) && origin.hostname === requestHost
-  } catch {
-    return false
-  }
+  // Use the shared normalizer (strips IPv6 brackets) so this side agrees
+  // with normalizeHostHeader above — otherwise http://[::1] never matches
+  // a Host header normalized to bare "::1".
+  const originHost = normalizeOriginHostname(originHeader)
+  return originHost !== null && isLoopbackHostname(originHost) && originHost === requestHost
 }
 
 export interface WsUpgradeDecision {

--- a/packages/mcp-server/src/server/security/api-host-guard.test.ts
+++ b/packages/mcp-server/src/server/security/api-host-guard.test.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { createApiHostGuardMiddleware } from './api-host-guard.js'
+
+// The host guard is the primary defense against DNS-rebinding attacks reaching
+// /api/* in local-daemon mode: a browser tab on an attacker-controlled domain
+// can still resolve to 127.0.0.1, but the Host header it sends stays the
+// attacker's hostname, so this guard can reject it before any auth check runs.
+
+function buildApp(mode: 'local-daemon' | 'server-mode') {
+  const app = new Hono()
+  app.use('/api/*', createApiHostGuardMiddleware(mode))
+  app.get('/api/thing', (c) => c.json({ ok: true }))
+  app.options('/api/thing', (c) => c.body(null, 204))
+  return app
+}
+
+describe('createApiHostGuardMiddleware', () => {
+  it('rejects a spoofed non-loopback Host with 403 in local-daemon mode', async () => {
+    const app = buildApp('local-daemon')
+    const res = await app.request('/api/thing', { headers: { Host: 'evil.example' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('allows a loopback Host in local-daemon mode', async () => {
+    const app = buildApp('local-daemon')
+    const res = await app.request('/api/thing', { headers: { Host: '127.0.0.1:3099' } })
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects an unparsable Host header in local-daemon mode', async () => {
+    const app = buildApp('local-daemon')
+    const res = await app.request('/api/thing', { headers: { Host: 'evil example' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects a spoofed Host on OPTIONS before any CORS short-circuit', async () => {
+    const app = buildApp('local-daemon')
+    const res = await app.request('/api/thing', {
+      method: 'OPTIONS',
+      headers: { Host: 'evil.example' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('passes through unconditionally in server-mode', async () => {
+    const app = buildApp('server-mode')
+    const res = await app.request('/api/thing', { headers: { Host: 'evil.example' } })
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/mcp-server/src/server/security/api-host-guard.ts
+++ b/packages/mcp-server/src/server/security/api-host-guard.ts
@@ -15,7 +15,7 @@ export function createApiHostGuardMiddleware(mode: ServerModeExposureMode): Midd
 
     const host = normalizeHostHeader(getRequestHost(c))
     if (!host || !isLoopbackHostname(host)) {
-      return Response.json({ error: 'forbidden host' }, { status: 403 })
+      return c.json({ error: 'forbidden host' }, 403)
     }
     return next()
   }

--- a/packages/mcp-server/src/server/security/api-host-guard.ts
+++ b/packages/mcp-server/src/server/security/api-host-guard.ts
@@ -1,0 +1,32 @@
+// Host-header guard for /api/* — the DNS-rebinding backstop that the CORS
+// middleware alone does not provide (CORS only governs which cross-origin
+// responses a browser will hand to script; it never blocks the request from
+// reaching the handler). Takes the exposure mode as a function-boundary
+// argument so wiring server-mode's origin-allowlist policy here later is a
+// local change, not a new call site.
+
+import type { MiddlewareHandler } from 'hono'
+import type { ServerModeExposureMode } from './server-mode-exposure.js'
+import { isLoopbackHostname, normalizeHostHeader } from './cors-loopback.js'
+
+function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
+  const headerHost = c.req.header('host')
+  if (headerHost) return headerHost
+  try {
+    return new URL(c.req.url).host
+  } catch {
+    return undefined
+  }
+}
+
+export function createApiHostGuardMiddleware(mode: ServerModeExposureMode): MiddlewareHandler {
+  return async (c, next) => {
+    if (mode === 'server-mode') return next()
+
+    const host = normalizeHostHeader(getRequestHost(c))
+    if (!host || !isLoopbackHostname(host)) {
+      return Response.json({ error: 'forbidden host' }, { status: 403 })
+    }
+    return next()
+  }
+}

--- a/packages/mcp-server/src/server/security/api-host-guard.ts
+++ b/packages/mcp-server/src/server/security/api-host-guard.ts
@@ -7,17 +7,7 @@
 
 import type { MiddlewareHandler } from 'hono'
 import type { ServerModeExposureMode } from './server-mode-exposure.js'
-import { isLoopbackHostname, normalizeHostHeader } from './cors-loopback.js'
-
-function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
-  const headerHost = c.req.header('host')
-  if (headerHost) return headerHost
-  try {
-    return new URL(c.req.url).host
-  } catch {
-    return undefined
-  }
-}
+import { getRequestHost, isLoopbackHostname, normalizeHostHeader } from './cors-loopback.js'
 
 export function createApiHostGuardMiddleware(mode: ServerModeExposureMode): MiddlewareHandler {
   return async (c, next) => {

--- a/packages/mcp-server/src/server/security/cors-loopback.test.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from 'vitest'
-import { appendVary, isLoopbackHostname, normalizeOriginHostname } from './cors-loopback.js'
+import {
+  appendVary,
+  isLoopbackHostname,
+  normalizeHostHeader,
+  normalizeOriginHostname,
+} from './cors-loopback.js'
+
+describe('normalizeHostHeader', () => {
+  it('normalizes a plain host and strips the port', () => {
+    expect(normalizeHostHeader('localhost:3099')).toBe('localhost')
+    expect(normalizeHostHeader('127.0.0.1')).toBe('127.0.0.1')
+  })
+
+  it('strips IPv6 brackets', () => {
+    expect(normalizeHostHeader('[::1]:3099')).toBe('::1')
+  })
+
+  it.each([
+    'evil.example@localhost', // credentials smuggle a loopback hostname
+    'localhost/path', // path smuggling
+    'localhost?query', // query smuggling
+    'localhost#frag', // fragment smuggling
+  ])('rejects malformed Host %s instead of normalizing it to loopback', (header) => {
+    expect(normalizeHostHeader(header)).toBeNull()
+  })
+})
 
 describe('isLoopbackHostname', () => {
   it('recognises localhost', () => {

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -24,6 +24,24 @@ export function normalizeOriginHostname(originHeader: string | undefined): strin
   }
 }
 
+// Canonical Host-header normalizer shared by ws-auth, mcp-http, and the
+// /api/* host guard so the loopback definition cannot drift between them.
+export function normalizeHostHeader(hostHeader: string | undefined): string | null {
+  if (!hostHeader) return null
+  try {
+    const hostname = new URL(`http://${hostHeader}`).hostname
+    // URL.hostname returns bracketed IPv6 (e.g. "[::1]"); strip the brackets
+    // so isLoopbackHostname can match against the bare address "::1".
+    // See WHATWG URL spec §4.1 (host serializing).
+    if (hostname.startsWith('[') && hostname.endsWith(']')) {
+      return hostname.slice(1, -1)
+    }
+    return hostname
+  } catch {
+    return null
+  }
+}
+
 export function appendVary(value: string | null, token: string): string {
   if (!value || value.length === 0) return token
   const parts = value
@@ -63,10 +81,7 @@ export function createApiLoopbackCorsMiddleware(): MiddlewareHandler {
     if (isLoopback && origin) {
       c.res.headers.set('Access-Control-Allow-Origin', origin)
       c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-      c.res.headers.set(
-        'Access-Control-Allow-Methods',
-        'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-      )
+      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
       c.res.headers.set('Access-Control-Max-Age', '86400')
       c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
     }
@@ -83,10 +98,7 @@ export function createApiLoopbackCorsMiddleware(): MiddlewareHandler {
     if (isLoopback && origin) {
       c.res.headers.set('Access-Control-Allow-Origin', origin)
       c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-      c.res.headers.set(
-        'Access-Control-Allow-Methods',
-        'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-      )
+      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
       c.res.headers.set('Access-Control-Max-Age', '86400')
       c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
     }

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -2,7 +2,7 @@
 // Keeping these in one place prevents the two CORS paths from drifting
 // when the loopback definition or Vary logic needs updating.
 
-import type { MiddlewareHandler } from 'hono'
+import type { Context, MiddlewareHandler } from 'hono'
 
 export function isLoopbackHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
@@ -26,10 +26,17 @@ export function normalizeOriginHostname(originHeader: string | undefined): strin
 
 // Canonical Host-header normalizer shared by ws-auth, mcp-http, and the
 // /api/* host guard so the loopback definition cannot drift between them.
+// A Host header is host[:port] only — anything URL parsing shunts into
+// credentials, path, query, or fragment (e.g. "evil.example@localhost",
+// "localhost/x") is malformed and must be rejected rather than normalized
+// down to a loopback hostname that would slip past the guard.
 export function normalizeHostHeader(hostHeader: string | undefined): string | null {
   if (!hostHeader) return null
   try {
-    return stripIpv6Brackets(new URL(`http://${hostHeader}`).hostname)
+    const url = new URL(`http://${hostHeader}`)
+    if (url.username !== '' || url.password !== '') return null
+    if (url.pathname !== '/' || url.search !== '' || url.hash !== '') return null
+    return stripIpv6Brackets(url.hostname)
   } catch {
     return null
   }
@@ -37,7 +44,7 @@ export function normalizeHostHeader(hostHeader: string | undefined): string | nu
 
 // Resolve the request Host: prefer the Host header, fall back to the parsed
 // request URL. Shared by the /mcp and /api/* host guards.
-export function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
+export function getRequestHost(c: Context): string | undefined {
   const headerHost = c.req.header('host')
   if (headerHost) return headerHost
   try {

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -8,17 +8,17 @@ export function isLoopbackHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
 }
 
+// URL.hostname returns bracketed IPv6 (e.g. "[::1]"); strip the brackets so
+// isLoopbackHostname can match against the bare address "::1".
+// See WHATWG URL spec §4.1 (host serializing).
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+}
+
 export function normalizeOriginHostname(originHeader: string | undefined): string | null {
   if (!originHeader) return null
   try {
-    const hostname = new URL(originHeader).hostname
-    // URL.hostname returns bracketed IPv6 (e.g. "[::1]"); strip the brackets
-    // so isLoopbackHostname can match against the bare address "::1".
-    // See WHATWG URL spec §4.1 (host serializing).
-    if (hostname.startsWith('[') && hostname.endsWith(']')) {
-      return hostname.slice(1, -1)
-    }
-    return hostname
+    return stripIpv6Brackets(new URL(originHeader).hostname)
   } catch {
     return null
   }
@@ -29,16 +29,21 @@ export function normalizeOriginHostname(originHeader: string | undefined): strin
 export function normalizeHostHeader(hostHeader: string | undefined): string | null {
   if (!hostHeader) return null
   try {
-    const hostname = new URL(`http://${hostHeader}`).hostname
-    // URL.hostname returns bracketed IPv6 (e.g. "[::1]"); strip the brackets
-    // so isLoopbackHostname can match against the bare address "::1".
-    // See WHATWG URL spec §4.1 (host serializing).
-    if (hostname.startsWith('[') && hostname.endsWith(']')) {
-      return hostname.slice(1, -1)
-    }
-    return hostname
+    return stripIpv6Brackets(new URL(`http://${hostHeader}`).hostname)
   } catch {
     return null
+  }
+}
+
+// Resolve the request Host: prefer the Host header, fall back to the parsed
+// request URL. Shared by the /mcp and /api/* host guards.
+export function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
+  const headerHost = c.req.header('host')
+  if (headerHost) return headerHost
+  try {
+    return new URL(c.req.url).host
+  } catch {
+    return undefined
   }
 }
 

--- a/packages/mcp-server/src/server/security/mcp-http.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.ts
@@ -1,26 +1,15 @@
 import type { MiddlewareHandler } from 'hono'
 
 import type { McpHttpAuthStrategy } from './mcp-auth.js'
-import { appendVary, isLoopbackHostname, normalizeOriginHostname } from './cors-loopback.js'
+import {
+  appendVary,
+  isLoopbackHostname,
+  normalizeHostHeader,
+  normalizeOriginHostname,
+} from './cors-loopback.js'
 
 function normalizeMethod(method: string): string {
   return method.toUpperCase()
-}
-
-function normalizeHostname(value: string | undefined): string | null {
-  if (!value) return null
-  try {
-    const hostname = new URL(`http://${value}`).hostname
-    // URL.hostname returns bracketed IPv6 (e.g. "[::1]"); strip the brackets
-    // so isLoopbackHostname can match against the bare address "::1".
-    // See WHATWG URL spec §4.1 (host serializing).
-    if (hostname.startsWith('[') && hostname.endsWith(']')) {
-      return hostname.slice(1, -1)
-    }
-    return hostname
-  } catch {
-    return null
-  }
 }
 
 function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
@@ -48,7 +37,7 @@ export function isAllowedMcpHttpOrigin(
   originHeader: string | undefined,
   hostHeader: string | undefined,
 ): boolean {
-  const requestHost = normalizeHostname(hostHeader)
+  const requestHost = normalizeHostHeader(hostHeader)
   if (!requestHost || !isLoopbackHostname(requestHost)) {
     return false
   }

--- a/packages/mcp-server/src/server/security/mcp-http.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.ts
@@ -3,6 +3,7 @@ import type { MiddlewareHandler } from 'hono'
 import type { McpHttpAuthStrategy } from './mcp-auth.js'
 import {
   appendVary,
+  getRequestHost,
   isLoopbackHostname,
   normalizeHostHeader,
   normalizeOriginHostname,
@@ -10,16 +11,6 @@ import {
 
 function normalizeMethod(method: string): string {
   return method.toUpperCase()
-}
-
-function getRequestHost(c: Parameters<MiddlewareHandler>[0]): string | undefined {
-  const headerHost = c.req.header('host')
-  if (headerHost) return headerHost
-  try {
-    return new URL(c.req.url).host
-  } catch {
-    return undefined
-  }
 }
 
 function mcpHttpError(status: number, message: string, headers?: Headers): Response {

--- a/packages/mcp-server/src/server/security/server-mode-record.ts
+++ b/packages/mcp-server/src/server/security/server-mode-record.ts
@@ -26,6 +26,12 @@ export const serverModeRecordSchema = z.object({
   authStrategy: z.literal('oauth-jwt'),
   // ISO 8601 with timezone offset — z accepts both 'Z' and '+HH:MM' forms.
   startedAt: z.string().datetime({ offset: true }),
+  // Per-process-start identifier (crypto.randomUUID), compared against
+  // /api/runtime/ping's instanceId to confirm process identity without
+  // trusting a pid the OS can reuse. Optional so records written by an
+  // older daemon build still parse; readers must treat a missing instanceId
+  // as "identity unverifiable", never as an automatic match.
+  instanceId: z.string().optional(),
 })
 
 export type ServerModeRecord = z.infer<typeof serverModeRecordSchema>

--- a/packages/mcp-server/src/server/server-mode-http.ts
+++ b/packages/mcp-server/src/server/server-mode-http.ts
@@ -5,6 +5,7 @@
 // The close() returned by startServerModeHttp tears down the HTTP server
 // cleanly so the dispatcher's SIGTERM handler can await it.
 
+import { randomUUID } from 'node:crypto'
 import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
 import { join } from 'node:path'
 import { serve } from '@hono/node-server'
@@ -26,6 +27,9 @@ export interface ServerModeRunning {
   host: string
   startedAt: string
   resolvedDataDir: string
+  /** Unique per process-start id; written into the server-mode record so
+   *  stop/status/doctor can verify identity instead of trusting a reused pid. */
+  instanceId: string
   close: () => Promise<void>
 }
 
@@ -43,6 +47,7 @@ export async function startServerModeHttp(
 ): Promise<ServerModeRunning> {
   const startedAtMs = Date.now()
   const startedAt = new Date(startedAtMs).toISOString()
+  const instanceId = randomUUID()
   const baseUrl = `https://${options.host}:${options.port}`
   let closing = false
 
@@ -62,6 +67,7 @@ export async function startServerModeHttp(
     publicBaseUrl: options.publicBaseUrl,
     allowedOrigins: options.allowedOrigins,
     authStrategy: options.authStrategy,
+    instanceId,
     touch: () => {},
     getStatus: () => ({
       ok: true,
@@ -108,5 +114,12 @@ export async function startServerModeHttp(
     server.once('error', onError)
   })
 
-  return { port: options.port, host: options.host, startedAt, resolvedDataDir: DATA_DIR, close }
+  return {
+    port: options.port,
+    host: options.host,
+    startedAt,
+    resolvedDataDir: DATA_DIR,
+    instanceId,
+    close,
+  }
 }

--- a/packages/mcp-server/src/shared/api-contracts/runtime.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/runtime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { daemonPingResponseSchema } from './runtime.js'
+
+// pid was replaced with instanceId (a per-start crypto.randomUUID) so a stale
+// pid can never be reused to misidentify a different process across a
+// PID-reuse race. Any parser code still expecting pid must break loudly here
+// rather than silently reading undefined.
+
+describe('daemonPingResponseSchema', () => {
+  it('accepts an instanceId (uuid string) response and rejects pid', () => {
+    const parsed = daemonPingResponseSchema.parse({
+      ok: true,
+      instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    })
+    expect(parsed).toEqual({ ok: true, instanceId: '3fa85f64-5717-4562-b3fc-2c963f66afa6' })
+  })
+
+  it('rejects a legacy pid-shaped payload with no instanceId', () => {
+    expect(() => daemonPingResponseSchema.parse({ ok: true, pid: 123 })).toThrow()
+  })
+})

--- a/packages/mcp-server/src/shared/api-contracts/runtime.ts
+++ b/packages/mcp-server/src/shared/api-contracts/runtime.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod'
 
-// pid is process-internal data that becomes cross-origin-readable once CORS is
-// applied to /api/runtime/ping. The schema keeps it present deliberately;
-// dropping it from the contract is a security decision, not an oversight.
+// instanceId (a per-daemon-start crypto.randomUUID) replaces the OS pid here.
+// pid is reused by the OS across processes, so a stale record comparing pid
+// alone can misidentify an unrelated process as "our" daemon; instanceId is
+// unique per start and never reused, closing that identity-confusion window
+// for the CLI's stop/status/doctor checks that read this endpoint.
 export const daemonPingResponseSchema = z.object({
   ok: z.literal(true),
-  pid: z.number(),
+  instanceId: z.string(),
 })
 
 export type DaemonPingResponse = z.infer<typeof daemonPingResponseSchema>


### PR DESCRIPTION
Implements the daemon-side half of the adopted Stage 2 auth design (ADR-0002 addendum): close the gaps the security spike identified, without touching the Stage 4 scope (Bearer-everywhere, `!token` bypass closure).

## Changes (all red-first)

- **Host loopback guard on HTTP `/api/*`** (new `security/api-host-guard.ts`): WS and `/mcp` already rejected non-loopback Hosts; plain HTTP API was the one unguarded surface. `Host: evil.example` → 403 in local-daemon mode; the middleware takes the server-mode exposure decision as a function-boundary argument (Stage 4 branch point), and is wired **before** the CORS middleware so the OPTIONS short-circuit can't bypass it. Mutation-checked (forcing pass-through fails the 403 test).
- **Bind guard**: `daemon-auth-binding.ts`'s documented-but-unimplemented pre-startup guard now exists — `--host=0.0.0.0` (or any non-loopback bind) refuses to start in local-daemon mode; loopback forms (`127.0.0.1`/`localhost`/`::1`/`[::1]`) pinned by test.
- **`ping` pid → `instanceId`**: the unauthenticated ping no longer publishes the OS pid; a per-start `crypto.randomUUID()` instanceId replaces it. `daemonPingResponseSchema` updated schema-first with all consumers via `z.infer` — including all **three** CLI identity paths (`server stop` / `server status` / `server doctor`), which now match on instanceId. Legacy records without instanceId take the safe path: never kill, report identity-unverifiable explicitly. Mutation-checked. `docs/how-to/self-host-with-docker.md`'s documented ping body updated in the same increment.
- **Loopback logic unified** onto `cors-loopback.ts` canonical helpers — ws-auth / mcp-http / daemon-auth-binding private copies removed, `[::1]` handling pinned, behavior-preserving (no existing test weakened).
- **ws-auth negative test**: non-loopback Origin + valid token → 403 (locks the Origin-before-token ordering).
- **Smoke extended** (`scripts/smoke/mcp-e2e-smoke.mjs`): instanceId-shaped ping parse, Host-spoofed GET → 403, loopback GET → 200.

## Out of scope (Stage 4, per adopted design)
`/api/runtime/*` Bearer carve-out unchanged; `!token → true` bypass closure; pairing flow; apps/web wiring (parallel lanes).

## Verification
typecheck ✓ / mcp-node 2734 ✓ / `pnpm smoke:e2e` (real daemon boot, exit 0) ✓ / review: 1 LOW (helper unit-test coverage, documented). Accepted residual risk per design: reflected-CORS reads from other localhost ports until the Stage 4 allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The runtime health check now returns a per-start `instanceId` instead of a process ID, improving how active instances are identified.
  * Server status, stop, and doctor flows now use this new instance identity for more reliable checks.

* **Bug Fixes**
  * Prevents misidentifying unrelated processes that may reuse the same OS process ID.
  * Legacy records without an `instanceId` are now handled as unverifiable instead of being treated as a match.

* **Security**
  * Added stronger host validation to block spoofed non-loopback requests and reduce exposure from unsafe daemon binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->