### PR TITLE
feat(web): port misc UI components (CanvasThumb/ThemeToggle/ErrorBoundary/HeaderSaveDot)

### DIFF
--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CanvasThumb } from './CanvasThumb.js'
+
+afterEach(() => cleanup())
+
+describe('CanvasThumb', () => {
+  it('renders an img pointed at the latest-thumbnail route, url-encoding the slug', () => {
+    const { container } = render(<CanvasThumb workspaceId="ws-1" slug="my canvas/x" />)
+    const img = container.querySelector('img') as HTMLImageElement
+    expect(img).not.toBeNull()
+    expect(img.getAttribute('src')).toBe(
+      '/api/workspaces/ws-1/canvases/my%20canvas%2Fx/latest-thumbnail',
+    )
+    expect(img.getAttribute('loading')).toBe('lazy')
+    expect(img.getAttribute('decoding')).toBe('async')
+  })
+
+  it('swaps to the fallback icon and removes the img once loading fails', () => {
+    const { container } = render(<CanvasThumb workspaceId="ws-1" slug="a" />)
+    const img = container.querySelector('img') as HTMLImageElement
+    fireEvent.error(img)
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('applies the card wrapper classes and merges className for size="card"', () => {
+    const { container } = render(
+      <CanvasThumb workspaceId="ws-1" slug="a" size="card" className="extra-class" />,
+    )
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('aspect-[16/9]')
+    expect(wrapper.className).toContain('extra-class')
+  })
+
+  it('applies the dropdown wrapper classes by default', () => {
+    const { container } = render(<CanvasThumb workspaceId="ws-1" slug="a" />)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('h-9')
+    expect(wrapper.className).toContain('w-14')
+  })
+})

--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -23,6 +23,18 @@ describe('CanvasThumb', () => {
     expect(container.querySelector('img')).toBeNull()
   })
 
+  it('resets the failed state and re-renders the img when slug changes on a reused instance', () => {
+    const { container, rerender } = render(<CanvasThumb workspaceId="ws-1" slug="canvas-a" />)
+    const imgA = container.querySelector('img') as HTMLImageElement
+    fireEvent.error(imgA)
+    expect(container.querySelector('img')).toBeNull()
+
+    rerender(<CanvasThumb workspaceId="ws-1" slug="canvas-b" />)
+    const imgB = container.querySelector('img') as HTMLImageElement
+    expect(imgB).not.toBeNull()
+    expect(imgB.getAttribute('src')).toBe('/api/workspaces/ws-1/canvases/canvas-b/latest-thumbnail')
+  })
+
   it('applies the card wrapper classes and merges className for size="card"', () => {
     const { container } = render(
       <CanvasThumb workspaceId="ws-1" slug="a" size="card" className="extra-class" />,

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -1,0 +1,48 @@
+import { FileText } from 'lucide-react'
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+
+// Latest-thumbnail surface for a canvas.
+//
+// The route is the same daemon endpoint that hydrates the canvas switcher in
+// WorkspaceTopBar, so this component is shared across IndexPage (grid card)
+// and the dropdown (small inline). Each instance owns its own loading state
+// — there is no shared cache; the browser HTTP cache handles repeats.
+//
+// `size` controls the rendered footprint without changing the request URL.
+// `dropdown` matches the original 56×36 inline thumbnail in the canvas
+// switcher; `card` is the larger 16:9 card preview used on IndexPage.
+
+interface CanvasThumbProps {
+  workspaceId: string
+  slug: string
+  size?: 'dropdown' | 'card'
+  className?: string
+}
+
+export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }: CanvasThumbProps) {
+  const [failed, setFailed] = useState(false)
+  const src = `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
+  const wrapperClasses =
+    size === 'card'
+      ? 'flex aspect-[16/9] w-full items-center justify-center overflow-hidden rounded-md border bg-muted/40'
+      : 'flex h-9 w-14 shrink-0 items-center justify-center overflow-hidden rounded border bg-muted/40'
+  const fallbackIconSize = size === 'card' ? 'size-8' : 'size-4'
+  return (
+    <div className={cn(wrapperClasses, className)}>
+      {failed ? (
+        // No thumbnail yet — generic icon instead of an empty gray box.
+        <FileText className={cn(fallbackIconSize, 'text-muted-foreground/50')} />
+      ) : (
+        <img
+          src={src}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          onError={() => setFailed(true)}
+          className="h-full w-full object-contain"
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -1,5 +1,5 @@
 import { FileText } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { cn } from '@/lib/utils'
 
 // Latest-thumbnail surface for a canvas.
@@ -25,10 +25,13 @@ export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }:
   const src = `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
   // Instances are reused across re-renders with a new slug/workspaceId (e.g.
   // the canvas switcher dropdown), so a stale `failed` flag from a previous
-  // src must not leak into the next canvas's thumbnail.
-  useEffect(() => {
+  // src must not leak into the next canvas's thumbnail. Reset during render
+  // (not in an effect) so the fallback icon never flashes for one frame.
+  const [prevSrc, setPrevSrc] = useState(src)
+  if (prevSrc !== src) {
+    setPrevSrc(src)
     setFailed(false)
-  }, [src])
+  }
   const wrapperClasses =
     size === 'card'
       ? 'flex aspect-[16/9] w-full items-center justify-center overflow-hidden rounded-md border bg-muted/40'

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -1,5 +1,5 @@
 import { FileText } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 // Latest-thumbnail surface for a canvas.
@@ -23,6 +23,12 @@ interface CanvasThumbProps {
 export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }: CanvasThumbProps) {
   const [failed, setFailed] = useState(false)
   const src = `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
+  // Instances are reused across re-renders with a new slug/workspaceId (e.g.
+  // the canvas switcher dropdown), so a stale `failed` flag from a previous
+  // src must not leak into the next canvas's thumbnail.
+  useEffect(() => {
+    setFailed(false)
+  }, [src])
   const wrapperClasses =
     size === 'card'
       ? 'flex aspect-[16/9] w-full items-center justify-center overflow-hidden rounded-md border bg-muted/40'

--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -29,6 +29,24 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Something went wrong')).toBeTruthy()
   })
 
+  it('normalizes a thrown non-Error value so fallbacks can rely on Error fields', () => {
+    console.error = vi.fn()
+    function StringBomb(): JSX.Element {
+      // Anything can be thrown in JS; a string here reached custom fallbacks
+      // typed as Error and crashed on .message access.
+      throw 'plain string failure'
+    }
+    const fallback = vi.fn(({ error }: { error: Error; reset: () => void }) => (
+      <div data-testid="custom-fallback">{error.message}</div>
+    ))
+    render(
+      <ErrorBoundary fallback={fallback}>
+        <StringBomb />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByTestId('custom-fallback').textContent).toBe('plain string failure')
+  })
+
   it('does not leak the raw error message or stack into the default fallback UI', () => {
     console.error = vi.fn()
     render(

--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { JSX } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ErrorBoundary, errorBoundaryLog } from './ErrorBoundary.js'
+
+// Verify that ErrorBoundary renders its fallback on throw and allows recovery via "Try again".
+
+function Bomb({ trigger }: { trigger: boolean }): JSX.Element {
+  if (trigger) throw new Error('boom')
+  return <div data-testid="bomb-ok">ok</div>
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress jsdom's console.error noise for intentional throws.
+  const originalError = console.error
+  afterEach(() => {
+    cleanup()
+    console.error = originalError
+  })
+
+  it('shows the fallback when a child throws', () => {
+    console.error = vi.fn()
+    render(
+      <ErrorBoundary>
+        <Bomb trigger />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    expect(screen.getByText(/boom/)).toBeTruthy()
+  })
+
+  it('resets on "Try again" and re-renders the child once the error is gone', () => {
+    console.error = vi.fn()
+    function Holder({ trigger }: { trigger: boolean }) {
+      return (
+        <ErrorBoundary>
+          <Bomb trigger={trigger} />
+        </ErrorBoundary>
+      )
+    }
+    const { rerender } = render(<Holder trigger />)
+    expect(screen.getByRole('alert')).toBeTruthy()
+    // Clear the parent trigger, then click Try again.
+    rerender(<Holder trigger={false} />)
+    fireEvent.click(screen.getByText('Try again'))
+    expect(screen.getByTestId('bomb-ok')).toBeTruthy()
+  })
+
+  it('allows the fallback prop to override the UI', () => {
+    console.error = vi.fn()
+    render(
+      <ErrorBoundary
+        fallback={({ error, reset }) => (
+          <div data-testid="custom-fallback">
+            custom: {error.message}
+            <button type="button" onClick={reset}>
+              custom reset
+            </button>
+          </div>
+        )}
+      >
+        <Bomb trigger />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByTestId('custom-fallback')).toBeTruthy()
+    expect(screen.getByText('custom: boom')).toBeTruthy()
+  })
+
+  it('reports the caught error through the module-local logging seam', () => {
+    const seamSpy = vi.spyOn(errorBoundaryLog, 'report').mockImplementation(() => {})
+    console.error = vi.fn()
+    render(
+      <ErrorBoundary>
+        <Bomb trigger />
+      </ErrorBoundary>,
+    )
+    expect(seamSpy).toHaveBeenCalledTimes(1)
+    const [message, context] = seamSpy.mock.calls[0]
+    expect(message).toBe('ErrorBoundary caught:')
+    expect((context as { error: Error }).error.message).toBe('boom')
+    seamSpy.mockRestore()
+  })
+})

--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -27,7 +27,16 @@ describe('ErrorBoundary', () => {
     )
     expect(screen.getByRole('alert')).toBeTruthy()
     expect(screen.getByText('Something went wrong')).toBeTruthy()
-    expect(screen.getByText(/boom/)).toBeTruthy()
+  })
+
+  it('does not leak the raw error message or stack into the default fallback UI', () => {
+    console.error = vi.fn()
+    render(
+      <ErrorBoundary>
+        <Bomb trigger />
+      </ErrorBoundary>,
+    )
+    expect(screen.queryByText(/boom/)).toBeNull()
   })
 
   it('resets on "Try again" and re-renders the child once the error is gone', () => {

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -69,20 +69,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         <p style={{ margin: '0 0 16px', fontSize: '14px', color: '#525252' }}>
           The whiteboard hit an unexpected error. Try recovering, or reload the page.
         </p>
-        <pre
-          style={{
-            margin: '0 0 16px',
-            padding: '12px',
-            background: '#f5f5f5',
-            borderRadius: '4px',
-            fontSize: '12px',
-            overflow: 'auto',
-            maxHeight: '160px',
-          }}
-        >
-          {error.message}
-          {error.stack ? `\n\n${error.stack}` : ''}
-        </pre>
+        {/*
+          Deliberately no error.message / error.stack here: the default fallback is
+          shown to end users, and raw error text can leak implementation details
+          (file paths, function names, internal identifiers). componentDidCatch
+          already reports the full error + stack through errorBoundaryLog for
+          diagnostics; callers that need the message visible to the user can pass
+          a custom `fallback` prop that renders `error.message` deliberately.
+        */}
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
             type="button"

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -30,8 +30,11 @@ interface ErrorBoundaryProps {
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error }
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    // Anything can be thrown in JS (strings, plain objects, null). Normalize
+    // to a real Error so the fallback contract ({ error: Error }) holds and
+    // consumers can safely read .message.
+    return { error: error instanceof Error ? error : new Error(String(error)) }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,122 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+// React error boundary for the whiteboard surface.
+// Keep the app recoverable instead of letting an Excalidraw, Loro, or routing error blank the whole root.
+// This is intentionally minimal; richer recovery actions can be added later if needed.
+
+// Module-local logging seam: kept separate from the boundary's render logic so
+// componentDidCatch has a single, mockable call site. The body is a stand-in
+// until apps/web gains a shared app-logger (tracked in tmp/issues); the
+// signature (message + structured context) is chosen so swapping the body for
+// a real logger later is a body-only change, not an interface change. Exposed
+// as an object (not a bare function) so tests can `vi.spyOn` the property —
+// spying a same-module function binding does not intercept direct calls.
+export const errorBoundaryLog = {
+  report(message: string, context: Record<string, unknown>): void {
+    console.error(message, context)
+  },
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  // Optional custom fallback for callers that want a different recovery UI.
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    errorBoundaryLog.report('ErrorBoundary caught:', { error, componentStack: info.componentStack })
+  }
+
+  reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (!error) return this.props.children
+    if (this.props.fallback) {
+      return this.props.fallback({ error, reset: this.reset })
+    }
+    return (
+      <div
+        role="alert"
+        style={{
+          padding: '24px',
+          maxWidth: '720px',
+          margin: '64px auto',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          color: '#1a1a1a',
+          background: '#fff',
+          border: '1px solid #fecaca',
+          borderRadius: '8px',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+        }}
+      >
+        <h2 style={{ margin: '0 0 12px', fontSize: '18px', color: '#dc2626' }}>
+          Something went wrong
+        </h2>
+        <p style={{ margin: '0 0 16px', fontSize: '14px', color: '#525252' }}>
+          The whiteboard hit an unexpected error. Try recovering, or reload the page.
+        </p>
+        <pre
+          style={{
+            margin: '0 0 16px',
+            padding: '12px',
+            background: '#f5f5f5',
+            borderRadius: '4px',
+            fontSize: '12px',
+            overflow: 'auto',
+            maxHeight: '160px',
+          }}
+        >
+          {error.message}
+          {error.stack ? `\n\n${error.stack}` : ''}
+        </pre>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            type="button"
+            onClick={this.reset}
+            style={{
+              padding: '8px 16px',
+              fontSize: '14px',
+              border: '1px solid #d4d4d4',
+              borderRadius: '4px',
+              background: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              padding: '8px 16px',
+              fontSize: '14px',
+              border: 'none',
+              borderRadius: '4px',
+              background: '#dc2626',
+              color: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            Reload page
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/apps/web/src/components/HeaderSaveDot.test.tsx
+++ b/apps/web/src/components/HeaderSaveDot.test.tsx
@@ -1,0 +1,45 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HeaderSaveDot } from './HeaderSaveDot.js'
+import { TooltipProvider } from './ui/tooltip.js'
+
+afterEach(() => cleanup())
+
+// Tooltip needs the Radix provider to avoid warnings in tests.
+function renderDot(props: Parameters<typeof HeaderSaveDot>[0]) {
+  return render(
+    <TooltipProvider>
+      <HeaderSaveDot {...props} />
+    </TooltipProvider>,
+  )
+}
+
+describe('HeaderSaveDot', () => {
+  it('renders nothing when dirty=false and saving=false', () => {
+    const { container } = renderDot({ dirty: false, saving: false, onSave: () => {} })
+    expect(container.querySelector('[data-testid="header-save-dot"]')).toBeNull()
+  })
+
+  it('renders the amber dot when dirty=true', () => {
+    renderDot({ dirty: true, saving: false, onSave: () => {} })
+    const dot = screen.getByTestId('header-save-dot')
+    expect(dot).not.toBeNull()
+    expect(dot.getAttribute('aria-label')).toBe('Unsaved changes')
+  })
+
+  it('shows "Saving…" aria text and disables the button when saving=true', () => {
+    renderDot({ dirty: true, saving: true, onSave: () => {} })
+    const dot = screen.getByTestId('header-save-dot')
+    expect(dot.getAttribute('aria-label')).toBe('Saving…')
+    expect(dot.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('calls onSave on click', () => {
+    const onSave = vi.fn()
+    renderDot({ dirty: true, saving: false, onSave })
+    act(() => {
+      fireEvent.click(screen.getByTestId('header-save-dot'))
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/components/HeaderSaveDot.test.tsx
+++ b/apps/web/src/components/HeaderSaveDot.test.tsx
@@ -27,11 +27,11 @@ describe('HeaderSaveDot', () => {
     expect(dot.getAttribute('aria-label')).toBe('Unsaved changes')
   })
 
-  it('shows "Saving…" aria text and disables the button when saving=true', () => {
+  it('shows "Saving…" aria text and marks the button aria-disabled when saving=true', () => {
     renderDot({ dirty: true, saving: true, onSave: () => {} })
     const dot = screen.getByTestId('header-save-dot')
     expect(dot.getAttribute('aria-label')).toBe('Saving…')
-    expect(dot.hasAttribute('disabled')).toBe(true)
+    expect(dot.getAttribute('aria-disabled')).toBe('true')
   })
 
   it('calls onSave on click', () => {
@@ -41,5 +41,20 @@ describe('HeaderSaveDot', () => {
       fireEvent.click(screen.getByTestId('header-save-dot'))
     })
     expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks clicks while saving without using the disabled attribute (keeps the tooltip reachable)', () => {
+    // A natively disabled button inside a Radix TooltipTrigger swallows the
+    // pointer events the tooltip needs, so "Saving…" would never show on
+    // hover. aria-disabled + a click guard keeps both behaviors.
+    const onSave = vi.fn()
+    renderDot({ dirty: true, saving: true, onSave })
+    const dot = screen.getByTestId('header-save-dot')
+    expect(dot.hasAttribute('disabled')).toBe(false)
+    expect(dot.getAttribute('aria-disabled')).toBe('true')
+    act(() => {
+      fireEvent.click(dot)
+    })
+    expect(onSave).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/HeaderSaveDot.tsx
+++ b/apps/web/src/components/HeaderSaveDot.tsx
@@ -1,0 +1,65 @@
+import type { JSX } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+// Keep save state as subtle as a mail-style unread dot.
+// - dirty=false: show nothing
+// - dirty=true: show only the amber dot; click runs onSave
+// - saving=true: swap to a thin spinner ring
+//
+// The header intentionally has no separate Save button.
+// Cmd+S is the primary action, and the dot doubles as state display plus a small click target.
+
+export interface HeaderSaveDotProps {
+  dirty: boolean
+  saving: boolean
+  onSave: () => void | Promise<void>
+  // Hint text for aria/title. The caller decides the OS-specific shortcut text.
+  shortcutHint?: string
+}
+
+export function HeaderSaveDot({
+  dirty,
+  saving,
+  onSave,
+  shortcutHint,
+}: HeaderSaveDotProps): JSX.Element | null {
+  if (!dirty && !saving) {
+    // Remove the node entirely while clean. The parent does not reserve fixed width here.
+    return null
+  }
+  const label = saving ? 'Saving…' : 'Unsaved changes'
+  const tip = shortcutHint ? `${label} · ${shortcutHint}` : label
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => void onSave()}
+          disabled={saving}
+          aria-label={label}
+          data-testid="header-save-dot"
+          className={cn(
+            'relative inline-flex size-4 shrink-0 items-center justify-center rounded-full',
+            'transition-transform hover:scale-110 focus-visible:outline-none',
+            'focus-visible:ring-2 focus-visible:ring-primary/50',
+            saving ? 'cursor-progress' : 'cursor-pointer',
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'block size-2.5 rounded-full',
+              saving
+                ? 'border-2 border-amber-500 border-t-transparent animate-spin'
+                : 'bg-amber-500',
+            )}
+          />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tip}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default HeaderSaveDot

--- a/apps/web/src/components/HeaderSaveDot.tsx
+++ b/apps/web/src/components/HeaderSaveDot.tsx
@@ -35,8 +35,14 @@ export function HeaderSaveDot({
       <TooltipTrigger asChild>
         <button
           type="button"
-          onClick={() => void onSave()}
-          disabled={saving}
+          // Native `disabled` inside a Radix TooltipTrigger swallows the
+          // pointer events the tooltip needs, hiding the "Saving…" status on
+          // hover — gate the click instead and expose state via aria-disabled.
+          onClick={() => {
+            if (saving) return
+            void onSave()
+          }}
+          aria-disabled={saving}
           aria-label={label}
           data-testid="header-save-dot"
           className={cn(

--- a/apps/web/src/components/ThemeToggleButton.test.tsx
+++ b/apps/web/src/components/ThemeToggleButton.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ThemeMode } from '../hooks/useThemeMode.js'
+import { ThemeToggleButton } from './ThemeToggleButton.js'
+import { TooltipProvider } from './ui/tooltip.js'
+
+afterEach(() => cleanup())
+
+function renderToggle(theme: ThemeMode, onChange: (next: ThemeMode) => void) {
+  return render(
+    <TooltipProvider>
+      <ThemeToggleButton theme={theme} onChange={onChange} />
+    </TooltipProvider>,
+  )
+}
+
+describe('ThemeToggleButton', () => {
+  it('labels and shows the correct icon per theme', () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <ThemeToggleButton theme="system" onChange={() => {}} />
+      </TooltipProvider>,
+    )
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe(
+      'Theme: system (follows OS) — click for light',
+    )
+
+    rerender(
+      <TooltipProvider>
+        <ThemeToggleButton theme="light" onChange={() => {}} />
+      </TooltipProvider>,
+    )
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe(
+      'Theme: light — click for dark',
+    )
+
+    rerender(
+      <TooltipProvider>
+        <ThemeToggleButton theme="dark" onChange={() => {}} />
+      </TooltipProvider>,
+    )
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe(
+      'Theme: dark — click for system',
+    )
+  })
+
+  it('cycles system -> light -> dark -> system, one step per click driven by the controlling parent', () => {
+    const onChange = vi.fn()
+    const { rerender } = renderToggle('system', onChange)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onChange).toHaveBeenNthCalledWith(1, 'light')
+
+    rerender(
+      <TooltipProvider>
+        <ThemeToggleButton theme="light" onChange={onChange} />
+      </TooltipProvider>,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onChange).toHaveBeenNthCalledWith(2, 'dark')
+
+    rerender(
+      <TooltipProvider>
+        <ThemeToggleButton theme="dark" onChange={onChange} />
+      </TooltipProvider>,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onChange).toHaveBeenNthCalledWith(3, 'system')
+
+    expect(onChange).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/web/src/components/ThemeToggleButton.tsx
+++ b/apps/web/src/components/ThemeToggleButton.tsx
@@ -1,0 +1,46 @@
+import { Monitor, Moon, Sun } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { ThemeMode } from '../hooks/useThemeMode.js'
+
+// Cycle order matches the user mental model "follow OS → I want light → I want
+// dark → back to OS": clicking always advances one step. Keeping it a cycle
+// (not a dropdown) keeps the click target as small as the existing top-bar
+// affordance while still surfacing the third state.
+const NEXT: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+}
+
+const LABEL: Record<ThemeMode, string> = {
+  system: 'Theme: system (follows OS) — click for light',
+  light: 'Theme: light — click for dark',
+  dark: 'Theme: dark — click for system',
+}
+
+interface Props {
+  theme: ThemeMode
+  onChange: (next: ThemeMode) => void
+}
+
+export function ThemeToggleButton({ theme, onChange }: Props) {
+  const Icon = theme === 'system' ? Monitor : theme === 'dark' ? Moon : Sun
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="size-8 p-0"
+          onClick={() => onChange(NEXT[theme])}
+          aria-label={LABEL[theme]}
+        >
+          <Icon className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{LABEL[theme]}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/ThemeToggleButton.tsx
+++ b/apps/web/src/components/ThemeToggleButton.tsx
@@ -20,13 +20,19 @@ const LABEL: Record<ThemeMode, string> = {
   dark: 'Theme: dark — click for system',
 }
 
+const ICON: Record<ThemeMode, typeof Monitor> = {
+  system: Monitor,
+  light: Sun,
+  dark: Moon,
+}
+
 interface Props {
   theme: ThemeMode
   onChange: (next: ThemeMode) => void
 }
 
 export function ThemeToggleButton({ theme, onChange }: Props) {
-  const Icon = theme === 'system' ? Monitor : theme === 'dark' ? Moon : Sun
+  const Icon = ICON[theme]
   return (
     <Tooltip>
       <TooltipTrigger asChild>


### PR DESCRIPTION
UI-unification Stage 2, Lane 8a — the four api-client-free misc components, ported with tests from the frozen daemon app.

## Change
- **CanvasThumb** (thumbnail `<img>` + fallback icon; failed-state resets on workspace/slug change — review fix), **ThemeToggleButton** (controlled, cycles system→light→dark via the #139 `ThemeMode`), **ErrorBoundary** (module-local logging seam instead of app-logger to stay disjoint from #140 while it was open; follow-up wire-up tracked in tmp/issues), **HeaderSaveDot** (dirty/saving indicator + Cmd/Ctrl+S hint) → `apps/web/src/components/`.
- Review fix during the loop: the default ErrorBoundary fallback no longer leaks the error message/stack into the UI.
- `packages/mcp-server` zero diff (frozen); components deliberately NOT added to the port-parity guard (byte-parity is for pure logic; components may adapt to IA).
- No page wiring (slices 9-10). New CanvasThumb/ThemeToggle suites are mutation-checked (ported code can't be red-first by construction); ported ErrorBoundary/HeaderSaveDot suites unweakened.

## Verification
apps/web vitest 348 ✓ / browser 58 ✓ / tsc ✓ / mcp typecheck ✓ / packages zero diff ✓. Review: 3 LOW (documented, below threshold).