### PR TITLE
feat(web): port useBranches (callback-based) and VersionTimeline

### DIFF
--- a/apps/web/src/components/VersionTimeline.browser.test.tsx
+++ b/apps/web/src/components/VersionTimeline.browser.test.tsx
@@ -1,6 +1,6 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import '../index.css'
 import VersionTimeline from './VersionTimeline.js'
 
@@ -122,5 +122,86 @@ describe('VersionTimeline browser mode', () => {
 
     await expect.element(page.getByRole('alertdialog')).toBeInTheDocument()
     await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+  })
+
+  it('closes the dialog and notifies the caller after a real click through a successful restore', async () => {
+    const onRestored = vi.fn()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <div
+        style={{
+          width: '340px',
+          height: '480px',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />
+      </div>,
+    )
+
+    const firstVersion = await screen.findByRole('button', { name: /^Version 1\b/ })
+    firstVersion.click()
+
+    await expect.element(page.getByRole('alertdialog')).toBeInTheDocument()
+    await page.getByRole('button', { name: 'Restore' }).click()
+
+    await expect.element(page.getByRole('alertdialog')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(onRestored).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps the dialog open with an error after a real click through a failed restore', async () => {
+    const onRestored = vi.fn()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'not_found' }), { status: 404 }),
+        )
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <div
+        style={{
+          width: '340px',
+          height: '480px',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />
+      </div>,
+    )
+
+    const firstVersion = await screen.findByRole('button', { name: /^Version 1\b/ })
+    firstVersion.click()
+
+    await expect.element(page.getByRole('alertdialog')).toBeInTheDocument()
+    await page.getByRole('button', { name: 'Restore' }).click()
+
+    await expect.element(page.getByText(/restore failed/i)).toBeInTheDocument()
+    await expect.element(page.getByRole('alertdialog')).toBeInTheDocument()
+    expect(onRestored).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/VersionTimeline.browser.test.tsx
+++ b/apps/web/src/components/VersionTimeline.browser.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import '../index.css'
+import VersionTimeline from './VersionTimeline.js'
+
+type FetchArgs = [RequestInfo | URL, RequestInit?]
+
+function mkBranchesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      head: 'main',
+      branches: [
+        {
+          name: 'main',
+          tipFrontiers: '',
+          color: '#1971c2',
+          createdAt: '2026-04-23T00:00:00Z',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkVersionsResponse(count = 24): Response {
+  const versions = Array.from({ length: count }, (_, index) => ({
+    id: `v-${index}`,
+    slug: 'canvas-a',
+    createdAt: new Date(Date.now() - index * 60_000).toISOString(),
+    elementCount: 58,
+    label: `Version ${index + 1}`,
+    auto: true,
+    hasThumbnail: false,
+    branchName: 'main',
+    operator: {
+      kind: 'system' as const,
+      peerId: 'peer-system',
+      displayName: 'auto-save',
+    },
+  }))
+
+  return new Response(JSON.stringify({ versions }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+    if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+describe('VersionTimeline browser mode', () => {
+  it('keeps the history list scrollable inside the fixed-height popover', async () => {
+    const { container } = render(
+      <div
+        style={{
+          width: '340px',
+          height: '480px',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </div>,
+    )
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Version 1')
+      expect(container.textContent).toContain('Version 24')
+    })
+
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
+    expect(viewport).toBeInstanceOf(HTMLDivElement)
+
+    await waitFor(() => {
+      expect(viewport!.clientHeight).toBeGreaterThan(0)
+      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight)
+    })
+
+    const before = viewport!.scrollTop
+    viewport!.scrollTo({ top: viewport!.scrollHeight })
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    expect(viewport!.scrollTop).toBeGreaterThan(before)
+  })
+
+  it('keeps each history row keyboard-focusable and opens the restore dialog', async () => {
+    render(
+      <div
+        style={{
+          width: '340px',
+          height: '480px',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
+      >
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </div>,
+    )
+
+    const firstVersion = await screen.findByRole('button', { name: /^Version 1\b/ })
+    expect(firstVersion).toHaveAttribute('type', 'button')
+
+    firstVersion.focus()
+    expect(firstVersion).toHaveFocus()
+    firstVersion.click()
+
+    await expect.element(page.getByRole('alertdialog')).toBeInTheDocument()
+    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import VersionTimeline from './VersionTimeline.js'
+
+// Cover the current VersionTimeline contract:
+// - filter versions by the active branch (HEAD)
+// - render the mini-graph lane for each row
+// - place the "branched ->" label at the matching baseVersionId row
+//
+// Branch actions and save controls live in the header now, so VersionTimeline should not render tabs or save buttons.
+
+type FetchArgs = [RequestInfo | URL, RequestInit?]
+
+function mkBranchesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      head: 'main',
+      branches: [
+        {
+          name: 'main',
+          tipFrontiers: '',
+          color: '#1971c2',
+          createdAt: '2026-04-23T00:00:00Z',
+        },
+        {
+          name: 'feature',
+          tipFrontiers: 'AA==',
+          color: '#9333ea',
+          baseVersionId: 'v-mid',
+          createdAt: '2026-04-23T01:00:00Z',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkVersionsResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      versions: [
+        {
+          id: 'v-new',
+          slug: 'canvas-a',
+          createdAt: '2026-04-23T02:00:00Z',
+          elementCount: 5,
+          auto: true,
+          hasThumbnail: false,
+          branchName: 'main',
+          operator: {
+            kind: 'ai',
+            peerId: 'peer-ai',
+            displayName: 'Assistant',
+          },
+        },
+        {
+          id: 'v-mid',
+          slug: 'canvas-a',
+          createdAt: '2026-04-23T01:00:00Z',
+          elementCount: 3,
+          auto: true,
+          hasThumbnail: false,
+          branchName: 'main',
+          operator: {
+            kind: 'human',
+            peerId: 'peer-human',
+            displayName: 'Alice',
+          },
+        },
+        {
+          id: 'v-feat',
+          slug: 'canvas-a',
+          createdAt: '2026-04-23T01:30:00Z',
+          elementCount: 4,
+          auto: true,
+          hasThumbnail: false,
+          branchName: 'feature', // hidden from the main branch view
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+beforeEach(() => {
+  const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+    if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+describe('VersionTimeline', () => {
+  it('filters cards and mini-graph rows to the active branch', async () => {
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    // Only v-new and v-mid should render; v-feat is filtered out with the feature branch.
+    await waitFor(() => {
+      expect(screen.getAllByText(/5 els|3 els/).length).toBeGreaterThanOrEqual(2)
+    })
+    expect(screen.queryByText(/4 els/)).toBeNull()
+
+    // The mini-graph should render two SVG lanes for the two visible main-branch rows.
+    await waitFor(() => {
+      const svgs = document.querySelectorAll('svg[viewBox="0 0 24 36"]')
+      expect(svgs.length).toBe(2)
+    })
+
+    // Branch tabs are gone, so no tab role should exist.
+    expect(screen.queryAllByRole('tab').length).toBe(0)
+  })
+
+  it('renders the branchOut label on the row matching baseVersionId', async () => {
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    // "branched -> feature" should appear on the v-mid row.
+    await waitFor(() => {
+      expect(screen.getByText(/branched → feature/)).toBeTruthy()
+    })
+  })
+
+  it('renders operator affordances and keeps the lane color on the branch color', async () => {
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('🤖 Assistant')).toBeTruthy()
+      expect(screen.getByText('👤 Alice')).toBeTruthy()
+    })
+
+    const circles = document.querySelectorAll('svg[viewBox="0 0 24 36"] circle')
+    expect(circles).toHaveLength(2)
+    expect(circles[0]?.getAttribute('fill')).toBe('#1971c2')
+    expect(circles[0]?.getAttribute('stroke')).toBe('#1971c2')
+    expect(circles[1]?.getAttribute('fill')).toBe('#1971c2')
+    expect(circles[1]?.getAttribute('stroke')).toBe('#1971c2')
+  })
+
+  it('legacy row without operator renders system fallback', async () => {
+    vi.unstubAllGlobals()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              versions: [
+                {
+                  id: 'v-legacy',
+                  slug: 'canvas-a',
+                  createdAt: '2026-04-23T02:00:00Z',
+                  elementCount: 2,
+                  auto: true,
+                  hasThumbnail: false,
+                  branchName: 'main',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText('⚙ System')).toBeTruthy()
+    })
+  })
+
+  it('renders the empty state when the active branch has no versions', async () => {
+    vi.unstubAllGlobals()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              head: 'feature',
+              branches: [
+                {
+                  name: 'main',
+                  tipFrontiers: '',
+                  color: '#1971c2',
+                  createdAt: '2026-04-23T00:00:00Z',
+                },
+                {
+                  name: 'feature',
+                  tipFrontiers: '',
+                  color: '#9333ea',
+                  createdAt: '2026-04-23T01:00:00Z',
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (url.includes('/versions')) {
+        return Promise.resolve(new Response(JSON.stringify({ versions: [] }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/No versions on «feature» yet/i)).toBeTruthy()
+    })
+  })
+
+  it('scroll container can shrink inside the fixed-height history popover', async () => {
+    const { container } = render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('🤖 Assistant')).toBeTruthy()
+    })
+
+    expect(container.firstElementChild?.className).toContain('min-h-0')
+    expect(container.querySelector('[data-slot="scroll-area"]')?.className ?? '').toContain(
+      'min-h-0',
+    )
+  })
+})

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -141,6 +141,62 @@ describe('VersionTimeline', () => {
     expect(screen.queryByText(/3 els/)).toBeNull()
   })
 
+  it('closes an open restore dialog when the canvas changes', async () => {
+    // Switching canvases with the dialog open must not leave the previous
+    // canvas's version staged — confirming would POST that version id to the
+    // NEW canvas's restore endpoint.
+    const { rerender } = render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    rerender(<VersionTimeline workspaceId="sess_1" slug="canvas-b" />)
+    await waitFor(() => {
+      expect(screen.queryByText('Restore this version?')).toBeNull()
+    })
+  })
+
+  it('clamps relative timestamps to "0s ago" when the server clock is ahead', async () => {
+    vi.unstubAllGlobals()
+    const future = new Date(Date.now() + 30_000).toISOString()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              versions: [
+                {
+                  id: 'v-skew',
+                  slug: 'canvas-a',
+                  createdAt: future,
+                  elementCount: 1,
+                  auto: true,
+                  hasThumbnail: false,
+                  branchName: 'main',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/0s ago/)).toBeTruthy()
+    })
+    expect(screen.queryByText(/-\d+s ago/)).toBeNull()
+  })
+
   it('filters cards and mini-graph rows to the active branch', async () => {
     render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
 

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -2,6 +2,17 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionTimeline from './VersionTimeline.js'
 
+const mockLog = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}))
+
+vi.mock('@/lib/app-logger', () => ({
+  getAppLogger: () => mockLog,
+}))
+
 // Cover the current VersionTimeline contract:
 // - filter versions by the active branch (HEAD)
 // - render the mini-graph lane for each row
@@ -83,6 +94,10 @@ function mkVersionsResponse(): Response {
 }
 
 beforeEach(() => {
+  mockLog.error.mockClear()
+  mockLog.warn.mockClear()
+  mockLog.info.mockClear()
+  mockLog.debug.mockClear()
   const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
     const url =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
@@ -305,5 +320,267 @@ describe('VersionTimeline', () => {
     })
     expect(onRestored).not.toHaveBeenCalled()
     expect(screen.getByText('Restore this version?')).toBeTruthy()
+  })
+
+  it('keeps the dialog open with an error when the restore request throws (network failure)', async () => {
+    const onRestored = vi.fn()
+    vi.unstubAllGlobals()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) return Promise.reject(new TypeError('Failed to fetch'))
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    const restoreButton = screen.getByRole('button', { name: 'Restore' })
+    fireEvent.click(restoreButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/restore failed/i)).toBeTruthy()
+    })
+    expect(onRestored).not.toHaveBeenCalled()
+    expect(screen.getByText('Restore this version?')).toBeTruthy()
+    expect(mockLog.error).toHaveBeenCalledWith('restore request threw', expect.any(TypeError))
+  })
+
+  it('disables the Restore action while a restore is in flight so repeat activation cannot double-submit', async () => {
+    const onRestored = vi.fn()
+    const restoreCalls: string[] = []
+    vi.unstubAllGlobals()
+    let resolveRestore: (() => void) | undefined
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        restoreCalls.push(url)
+        return new Promise<Response>((resolve) => {
+          resolveRestore = () =>
+            resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+        })
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    const restoreButton = screen.getByRole('button', { name: 'Restore' })
+    fireEvent.click(restoreButton)
+    // Repeat activation while the first request is still in flight.
+    fireEvent.click(restoreButton)
+    fireEvent.click(restoreButton)
+
+    await waitFor(() => {
+      expect(restoreCalls.length).toBe(1)
+    })
+    expect((screen.getByRole('button', { name: 'Restoring…' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+
+    resolveRestore?.()
+    await waitFor(() => {
+      expect(onRestored).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('formatRelative display branches (via rendered version rows)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function mkSingleVersionResponse(createdAt: string): Response {
+    return new Response(
+      JSON.stringify({
+        versions: [
+          {
+            id: 'v-1',
+            slug: 'canvas-a',
+            createdAt,
+            elementCount: 1,
+            auto: true,
+            hasThumbnail: false,
+            branchName: 'main',
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  function stubFetchWithVersionAt(createdAt: string) {
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkSingleVersionResponse(createdAt))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  }
+
+  it('renders seconds-ago for a timestamp under a minute old', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const now = new Date('2026-04-23T02:00:00Z')
+    vi.setSystemTime(now)
+    stubFetchWithVersionAt(new Date(now.getTime() - 30_000).toISOString())
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/30s ago/)).toBeTruthy()
+    })
+  })
+
+  it('renders minutes-ago for a timestamp under an hour old', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const now = new Date('2026-04-23T02:00:00Z')
+    vi.setSystemTime(now)
+    stubFetchWithVersionAt(new Date(now.getTime() - 5 * 60_000).toISOString())
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/5m ago/)).toBeTruthy()
+    })
+  })
+
+  it('renders hours-ago for a timestamp under a day old', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const now = new Date('2026-04-23T02:00:00Z')
+    vi.setSystemTime(now)
+    stubFetchWithVersionAt(new Date(now.getTime() - 3 * 3600_000).toISOString())
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/3h ago/)).toBeTruthy()
+    })
+  })
+
+  it('renders an absolute date/time for a timestamp a day or more old', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const now = new Date('2026-04-23T02:00:00Z')
+    vi.setSystemTime(now)
+    stubFetchWithVersionAt(new Date(now.getTime() - 2 * 86_400_000).toISOString())
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      // 2026-04-21 00:00 local time rendered as M/D HH:MM.
+      expect(screen.getByText(/4\/21 \d{2}:\d{2}/)).toBeTruthy()
+    })
+  })
+
+  it('falls back to the raw ISO string for an invalid createdAt', async () => {
+    stubFetchWithVersionAt('not-a-real-date')
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/not-a-real-date/)).toBeTruthy()
+    })
+  })
+})
+
+describe('VersionTimeline error handling and canvas-switch reset', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it('does not reject or crash when the versions fetch throws a network error', async () => {
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.reject(new TypeError('network down'))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    mockLog.error.mockClear()
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    await waitFor(() => {
+      expect(mockLog.error).toHaveBeenCalledWith('versions request threw', expect.any(TypeError))
+    })
+    // Loading settles instead of spinning forever, and no unhandled rejection
+    // propagates out of the effect (a rejection here would fail the test run).
+    await waitFor(() => {
+      expect(screen.getByText(/No versions on/)).toBeTruthy()
+    })
+  })
+
+  it('logs and leaves the list empty when the versions response is not ok', async () => {
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(new Response('{}', { status: 500 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    mockLog.error.mockClear()
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    await waitFor(() => {
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'versions request failed',
+        expect.objectContaining({ status: 500 }),
+      )
+    })
+    expect(screen.getByText(/No versions on/)).toBeTruthy()
+  })
+
+  it('clears the previous canvas versions immediately when workspaceId/slug changes', async () => {
+    // canvas-new's /versions request hangs for the rest of the test, so any
+    // row rendered after the switch can only be the stale canvas-old data —
+    // unless the reset-on-change effect cleared it.
+    let versionsCallCount = 0
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) {
+        versionsCallCount += 1
+        if (versionsCallCount === 1) return Promise.resolve(mkVersionsResponse())
+        return new Promise<Response>(() => {
+          /* canvas-new's request never resolves in this test */
+        })
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<VersionTimeline workspaceId="sess_1" slug="canvas-old" />)
+
+    // Load canvas-old's versions first so there is stale data to leak.
+    await waitFor(() => {
+      expect(screen.getByText('🤖 Assistant')).toBeTruthy()
+    })
+
+    // Switching to canvas-new (same component instance, no remount key) must
+    // clear that stale data immediately, even though canvas-new's own
+    // /versions request never resolves here.
+    rerender(<VersionTimeline workspaceId="sess_1" slug="canvas-new" />)
+    await waitFor(() => {
+      expect(screen.queryByText('🤖 Assistant')).toBeNull()
+    })
   })
 })

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionTimeline from './VersionTimeline.js'
 
 // Cover the current VersionTimeline contract:
@@ -231,5 +231,79 @@ describe('VersionTimeline', () => {
     expect(container.querySelector('[data-slot="scroll-area"]')?.className ?? '').toContain(
       'min-h-0',
     )
+  })
+
+  it('calls onRestored and refreshes after a successful restore', async () => {
+    const onRestored = vi.fn()
+    const restoreCalls: string[] = []
+    vi.unstubAllGlobals()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        restoreCalls.push(url)
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    const restoreButton = screen.getByRole('button', { name: 'Restore' })
+    fireEvent.click(restoreButton)
+
+    await waitFor(() => {
+      expect(restoreCalls.some((u) => u.includes('/versions/v-new/restore'))).toBe(true)
+    })
+    await waitFor(() => {
+      expect(onRestored).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('Restore this version?')).toBeNull()
+    })
+  })
+
+  it('keeps the dialog open and does not fire onRestored when the restore request fails', async () => {
+    const onRestored = vi.fn()
+    vi.unstubAllGlobals()
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'not_found' }), { status: 404 }),
+        )
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    const restoreButton = screen.getByRole('button', { name: 'Restore' })
+    fireEvent.click(restoreButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/restore failed/i)).toBeTruthy()
+    })
+    expect(onRestored).not.toHaveBeenCalled()
+    expect(screen.getByText('Restore this version?')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import VersionTimeline from './VersionTimeline.js'
 
@@ -155,6 +155,11 @@ describe('VersionTimeline', () => {
     expect(circles[0]?.getAttribute('stroke')).toBe('#1971c2')
     expect(circles[1]?.getAttribute('fill')).toBe('#1971c2')
     expect(circles[1]?.getAttribute('stroke')).toBe('#1971c2')
+    // Every row shown here is on the active HEAD branch (versions are
+    // pre-filtered to head before reaching the mini-graph), so the dot is
+    // always solid — never the hollow "other branch" ring.
+    expect(circles[0]?.getAttribute('stroke-width')).toBe('0')
+    expect(circles[1]?.getAttribute('stroke-width')).toBe('0')
   })
 
   it('legacy row without operator renders system fallback', async () => {
@@ -400,6 +405,121 @@ describe('VersionTimeline', () => {
     await waitFor(() => {
       expect(onRestored).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('ignores Cancel and keeps the pending version locked while a restore is in flight', async () => {
+    const onRestored = vi.fn()
+    const restoreCalls: string[] = []
+    vi.unstubAllGlobals()
+    let resolveRestore: (() => void) | undefined
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        restoreCalls.push(url)
+        return new Promise<Response>((resolve) => {
+          resolveRestore = () =>
+            resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+        })
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" onRestored={onRestored} />)
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+    await waitFor(() => {
+      expect(restoreCalls.length).toBe(1)
+    })
+
+    // Cancel must not close the dialog nor unlock a second /restore submission
+    // while the first request is still in flight.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByText('Restore this version?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Restoring…' })).toBeTruthy()
+
+    resolveRestore?.()
+    await waitFor(() => {
+      expect(onRestored).toHaveBeenCalledTimes(1)
+    })
+    expect(restoreCalls).toHaveLength(1)
+    await waitFor(() => {
+      expect(screen.queryByText('Restore this version?')).toBeNull()
+    })
+  })
+})
+
+describe('VersionTimeline HEAD polling', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it('refetches branches on the same 15s poll as versions, picking up an external HEAD change', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    let head = 'main'
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              head,
+              branches: [
+                {
+                  name: 'main',
+                  tipFrontiers: '',
+                  color: '#1971c2',
+                  createdAt: '2026-04-23T00:00:00Z',
+                },
+                {
+                  name: 'feature',
+                  tipFrontiers: '',
+                  color: '#9333ea',
+                  createdAt: '2026-04-23T01:00:00Z',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+    await waitFor(() => {
+      expect(screen.getByText(/5 els/)).toBeTruthy()
+    })
+
+    // An external HEAD change (e.g. another peer switching branches) is not
+    // pushed to this component; simulate the server having moved on.
+    head = 'feature'
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000)
+    })
+
+    // mkVersionsResponse's v-feat row (branchName: 'feature', 4 elements) is
+    // the one version on the new head; the two main-branch rows must drop
+    // out of the filtered view.
+    await waitFor(() => {
+      expect(screen.getByText(/4 els/)).toBeTruthy()
+    })
+    expect(screen.queryByText(/5 els/)).toBeNull()
+    expect(screen.queryByText(/3 els/)).toBeNull()
   })
 })
 

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -114,6 +114,33 @@ afterEach(() => {
 })
 
 describe('VersionTimeline', () => {
+  it('does not render version rows while the branch HEAD is still loading', async () => {
+    // useBranches defaults head to 'main' until /branches resolves. If the
+    // real HEAD is a feature branch, rendering rows filtered by that default
+    // briefly offers the WRONG branch's versions as restore targets.
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      // Branches never resolve within this test; versions resolve immediately.
+      if (url.includes('/branches')) return new Promise<Response>(() => {})
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    // Give the versions fetch time to land.
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/versions'))).toBe(true)
+    })
+
+    // No rows filtered against the default head — show loading instead.
+    expect(screen.getByText('Loading…')).toBeTruthy()
+    expect(screen.queryByText(/5 els/)).toBeNull()
+    expect(screen.queryByText(/3 els/)).toBeNull()
+  })
+
   it('filters cards and mini-graph rows to the active branch', async () => {
     render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
 

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -35,7 +35,9 @@ interface Props {
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime()
   if (!Number.isFinite(then)) return iso
-  const diffSec = Math.floor((Date.now() - then) / 1000)
+  // Clamp: server clocks slightly ahead of the client would otherwise yield
+  // "-5s ago".
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
   if (diffSec < 60) return `${diffSec}s ago`
   if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
   if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
@@ -108,9 +110,14 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   // Clear the previously loaded canvas's versions immediately on canvas
   // change so a stale row (with thumbnail URLs pointing at the old
   // workspaceId/slug) never renders under the new canvas while the refetch
-  // is in flight.
+  // is in flight. Also drop any staged restore — confirming a dialog opened
+  // on the previous canvas would POST that version id to the NEW canvas's
+  // restore endpoint.
   useEffect(() => {
     setVersions([])
+    setPendingRestore(null)
+    setRestoreError(null)
+    setIsRestoring(false)
   }, [workspaceId, slug])
 
   // Reload whenever the canvas changes.

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -66,6 +66,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   const [loading, setLoading] = useState(false)
   const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
   const [restoreError, setRestoreError] = useState<string | null>(null)
+  const [isRestoring, setIsRestoring] = useState(false)
   // Monotonically increasing sequence stamp. Each refresh() call captures the
   // value at dispatch time; a response only commits if no newer refresh has
   // started meanwhile. Without this, a slow /versions response for an older
@@ -84,11 +85,27 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
         const parsed = listVersionsResponseSchema.safeParse(await res.json())
         if (seq !== fetchSeqRef.current) return
         if (parsed.success) setVersions(parsed.data.versions)
-        else setVersions([])
+        else {
+          log.error('versions response failed schema validation', { workspaceId, slug })
+          setVersions([])
+        }
+      } else {
+        log.error('versions request failed', { status: res.status, workspaceId, slug })
       }
+    } catch (err) {
+      if (seq !== fetchSeqRef.current) return
+      log.error('versions request threw', err)
     } finally {
       if (seq === fetchSeqRef.current) setLoading(false)
     }
+  }, [workspaceId, slug])
+
+  // Clear the previously loaded canvas's versions immediately on canvas
+  // change so a stale row (with thumbnail URLs pointing at the old
+  // workspaceId/slug) never renders under the new canvas while the refetch
+  // is in flight.
+  useEffect(() => {
+    setVersions([])
   }, [workspaceId, slug])
 
   // Reload whenever the canvas changes.
@@ -105,9 +122,12 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   }, [refresh])
 
   const confirmRestore = useCallback(async () => {
-    if (!pendingRestore) return
+    // Guard against a double-click or repeated keyboard activation firing a
+    // second /restore POST before the first response closes the dialog.
+    if (!pendingRestore || isRestoring) return
     const v = pendingRestore
     setRestoreError(null)
+    setIsRestoring(true)
     // Only clear the dialog and run success side effects (onRestored clears the
     // browser-side LoroUndoManager) once the server confirms the restore
     // actually happened. A failed request keeps the dialog open with an error
@@ -126,12 +146,14 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
       log.error('restore request threw', err)
       setRestoreError('Restore failed. Please try again.')
       return
+    } finally {
+      setIsRestoring(false)
     }
     setPendingRestore(null)
     onRestored?.()
     // Refresh immediately after restore so the pending UI closes cleanly.
     await refresh()
-  }, [pendingRestore, workspaceId, slug, onRestored, refresh])
+  }, [pendingRestore, isRestoring, workspaceId, slug, onRestored, refresh])
 
   // Keep branch state here for head filtering and the mini-graph.
   // Legacy versions without branchName are treated as main.
@@ -261,6 +283,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
           if (!open) {
             setPendingRestore(null)
             setRestoreError(null)
+            setIsRestoring(false)
           }
         }}
       >
@@ -284,12 +307,13 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
             {/* AlertDialogAction closes the dialog by default on click; prevent that so a
                 failed restore keeps the dialog open with the error instead of discarding it. */}
             <AlertDialogAction
+              disabled={isRestoring}
               onClick={(e) => {
                 e.preventDefault()
                 void confirmRestore()
               }}
             >
-              Restore
+              {isRestoring ? 'Restoring…' : 'Restore'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -120,7 +120,11 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
 
   // Keep branch state here for head filtering and the mini-graph.
   // Legacy versions without branchName are treated as main.
-  const { state: branchesState, refetch: refetchBranches } = useBranches(workspaceId, slug)
+  const {
+    state: branchesState,
+    loading: branchesLoading,
+    refetch: refetchBranches,
+  } = useBranches(workspaceId, slug)
 
   // Poll every 15 seconds for new auto-versions, and re-fetch branches on the
   // same tick. useBranches has no event subscription of its own, so this is
@@ -202,7 +206,10 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
 
       <ScrollArea className="min-h-0 flex-1 -mx-1">
         <div className="flex flex-col gap-1.5 px-1">
-          {loading && visibleVersions.length === 0 ? (
+          {branchesLoading || (loading && visibleVersions.length === 0) ? (
+            // Until /branches resolves, `head` is the hook's 'main' default —
+            // rendering rows filtered by it would offer the wrong branch's
+            // versions as restore targets during the fetch race.
             <div className="text-xs text-muted-foreground py-4 text-center">Loading…</div>
           ) : visibleVersions.length === 0 ? (
             <div className="text-xs text-muted-foreground py-4 text-center">

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -40,6 +40,11 @@ function formatRelative(iso: string): string {
   return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
+// A version's display title: its explicit label, or a fallback naming its origin.
+function versionTitle(version: Pick<VersionEntry, 'label' | 'auto'>): string {
+  return version.label || (version.auto ? 'Auto-save' : 'Manual')
+}
+
 function getOperatorAffordance(operator?: OperatorInfo): { icon: string; label: string } {
   const kind = operator?.kind ?? 'system'
   const icon = kind === 'ai' ? '🤖' : kind === 'human' ? '👤' : '⚙'
@@ -191,9 +196,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
                     )}
                     <CardContent className="px-3 flex items-center justify-between gap-2">
                       <div className="flex flex-col min-w-0">
-                        <span className="text-xs font-medium truncate">
-                          {v.label || (v.auto ? 'Auto-save' : 'Manual')}
-                        </span>
+                        <span className="text-xs font-medium truncate">{versionTitle(v)}</span>
                         <span className="text-[11px] text-muted-foreground">
                           {operator.icon} {operator.label}
                         </span>
@@ -231,11 +234,8 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
             <AlertDialogDescription>
               {pendingRestore && (
                 <>
-                  Restoring{' '}
-                  <strong>
-                    {pendingRestore.label || (pendingRestore.auto ? 'Auto-save' : 'Manual')}
-                  </strong>{' '}
-                  ({formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount}{' '}
+                  Restoring <strong>{versionTitle(pendingRestore)}</strong> (
+                  {formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount}{' '}
                   elements) will merge that state into the current canvas and broadcast the change
                   to every connected tab. Per-peer Ctrl+Z history is cleared.
                 </>

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useState } from 'react'
+import { History } from 'lucide-react'
+import { CardContent } from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  type OperatorInfo,
+  type VersionEntry,
+  listVersionsResponseSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import { useBranches } from '@/hooks/useBranches'
+import { buildMiniGraph } from '@/lib/mini-graph'
+
+interface Props {
+  workspaceId: string
+  slug: string
+  // Called after restore succeeds so the browser-side LoroUndoManager can be cleared.
+  onRestored?: () => void
+}
+
+// Render an ISO string as a short relative timestamp.
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (!Number.isFinite(then)) return iso
+  const diffSec = Math.floor((Date.now() - then) / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+  const d = new Date(then)
+  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+function getOperatorAffordance(operator?: OperatorInfo): { icon: string; label: string } {
+  const kind = operator?.kind ?? 'system'
+  const icon = kind === 'ai' ? '🤖' : kind === 'human' ? '👤' : '⚙'
+  const label = operator?.displayName?.trim()
+  if (label) return { icon, label }
+  return {
+    icon,
+    label: kind === 'ai' ? 'AI' : kind === 'human' ? 'Human' : 'System',
+  }
+}
+
+// Branch operations and save controls live in the header.
+// VersionTimeline is responsible only for the version list, mini-graph, and restore flow.
+export default function VersionTimeline({ workspaceId, slug, onRestored }: Props) {
+  const [versions, setVersions] = useState<VersionEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await apiFetch(
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
+      )
+      if (res.ok) {
+        const parsed = listVersionsResponseSchema.safeParse(await res.json())
+        if (parsed.success) setVersions(parsed.data.versions)
+        else setVersions([])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [workspaceId, slug])
+
+  // Reload whenever the canvas changes.
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Poll every 15 seconds for new auto-versions.
+  useEffect(() => {
+    const h = setInterval(() => {
+      refresh()
+    }, 15_000)
+    return () => clearInterval(h)
+  }, [refresh])
+
+  const confirmRestore = useCallback(async () => {
+    if (!pendingRestore) return
+    const v = pendingRestore
+    setPendingRestore(null)
+    await apiFetch(
+      `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
+      { method: 'POST' },
+    )
+    onRestored?.()
+    // Refresh immediately after restore so the pending UI closes cleanly.
+    await refresh()
+  }, [pendingRestore, workspaceId, slug, onRestored, refresh])
+
+  // Keep branch state here for head filtering and the mini-graph.
+  // Legacy versions without branchName are treated as main.
+  const { state: branchesState } = useBranches(workspaceId, slug)
+  const head = branchesState.head
+
+  const visibleVersions = versions.filter((v) => (v.branchName ?? 'main') === head)
+  const miniGraphRows = buildMiniGraph({
+    head,
+    branches: branchesState.branches,
+    versions: visibleVersions.map((v) => ({
+      id: v.id,
+      branchName: v.branchName ?? 'main',
+      createdAt: v.createdAt,
+    })),
+  })
+  const miniGraphById = new Map(miniGraphRows.map((r) => [r.versionId, r]))
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2 p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          <History className="size-3.5" />
+          Version history
+        </div>
+        {/* Save actions live in the header now, so this panel stays focused on history. */}
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1 -mx-1">
+        <div className="flex flex-col gap-1.5 px-1">
+          {loading && visibleVersions.length === 0 ? (
+            <div className="text-xs text-muted-foreground py-4 text-center">Loading…</div>
+          ) : visibleVersions.length === 0 ? (
+            <div className="text-xs text-muted-foreground py-4 text-center">
+              No versions on «{head}» yet.
+              <br />
+              Edit this canvas to trigger auto-save (~30s), or press ⌘/Ctrl+S.
+            </div>
+          ) : (
+            visibleVersions.map((v) => {
+              const row = miniGraphById.get(v.id)
+              const operator = getOperatorAffordance(v.operator)
+              return (
+                <div key={v.id} className="flex items-stretch gap-1.5">
+                  {/* Mini-graph lane. */}
+                  <svg className="shrink-0" width={24} height={36} viewBox="0 0 24 36" aria-hidden>
+                    {row?.connectorBefore ? (
+                      <line
+                        x1={12}
+                        y1={0}
+                        x2={12}
+                        y2={14}
+                        stroke={row.dotColor}
+                        strokeWidth={1.5}
+                        strokeOpacity={0.6}
+                      />
+                    ) : null}
+                    <circle
+                      cx={12}
+                      cy={18}
+                      r={4}
+                      fill={row?.active ? row.dotColor : '#fff'}
+                      stroke={row?.dotColor ?? '#94a3b8'}
+                      strokeWidth={row?.active ? 0 : 1.5}
+                    />
+                    <line
+                      x1={12}
+                      y1={22}
+                      x2={12}
+                      y2={36}
+                      stroke={row?.dotColor ?? '#94a3b8'}
+                      strokeWidth={1.5}
+                      strokeOpacity={0.6}
+                    />
+                  </svg>
+                  <button
+                    type="button"
+                    className="bg-card text-card-foreground flex flex-1 min-w-0 cursor-pointer flex-col gap-6 overflow-hidden rounded-xl border py-2 text-left shadow-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    onClick={() => setPendingRestore(v)}
+                  >
+                    {v.hasThumbnail && (
+                      <div className="mx-3 mb-1 border rounded overflow-hidden bg-muted/30">
+                        <img
+                          src={`/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`}
+                          alt=""
+                          className="w-full h-20 object-contain"
+                          loading="lazy"
+                        />
+                      </div>
+                    )}
+                    <CardContent className="px-3 flex items-center justify-between gap-2">
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-xs font-medium truncate">
+                          {v.label || (v.auto ? 'Auto-save' : 'Manual')}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {operator.icon} {operator.label}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {formatRelative(v.createdAt)} · {v.elementCount} els
+                          {row?.branchOut ? (
+                            <>
+                              {' · '}
+                              <span className="text-primary">branched → {row.branchOut}</span>
+                            </>
+                          ) : null}
+                        </span>
+                      </div>
+                      {!v.auto && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium shrink-0">
+                          manual
+                        </span>
+                      )}
+                    </CardContent>
+                  </button>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </ScrollArea>
+
+      <AlertDialog
+        open={!!pendingRestore}
+        onOpenChange={(open) => !open && setPendingRestore(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore this version?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRestore && (
+                <>
+                  Restoring{' '}
+                  <strong>
+                    {pendingRestore.label || (pendingRestore.auto ? 'Auto-save' : 'Manual')}
+                  </strong>{' '}
+                  ({formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount}{' '}
+                  elements) will merge that state into the current canvas and broadcast the change
+                  to every connected tab. Per-peer Ctrl+Z history is cleared.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmRestore}>Restore</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useEffect, useState } from 'react'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import {
+  listVersionsResponseSchema,
+  type OperatorInfo,
+  type VersionEntry,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
 import { History } from 'lucide-react'
-import { CardContent } from '@/components/ui/card'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -12,14 +16,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import {
-  type OperatorInfo,
-  type VersionEntry,
-  listVersionsResponseSchema,
-} from '@kamiazya/whiteboard-mcp/api-contracts'
-import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import { CardContent } from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { useBranches } from '@/hooks/useBranches'
+import { getAppLogger } from '@/lib/app-logger'
 import { buildMiniGraph } from '@/lib/mini-graph'
+
+const log = getAppLogger('VersionTimeline')
 
 interface Props {
   workspaceId: string
@@ -62,20 +65,29 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   const [versions, setVersions] = useState<VersionEntry[]>([])
   const [loading, setLoading] = useState(false)
   const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
+  const [restoreError, setRestoreError] = useState<string | null>(null)
+  // Monotonically increasing sequence stamp. Each refresh() call captures the
+  // value at dispatch time; a response only commits if no newer refresh has
+  // started meanwhile. Without this, a slow /versions response for an older
+  // workspaceId/slug pair could overwrite the list after the canvas changed.
+  const fetchSeqRef = useRef(0)
 
   const refresh = useCallback(async () => {
+    const seq = ++fetchSeqRef.current
     setLoading(true)
     try {
       const res = await apiFetch(
         `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
       )
+      if (seq !== fetchSeqRef.current) return
       if (res.ok) {
         const parsed = listVersionsResponseSchema.safeParse(await res.json())
+        if (seq !== fetchSeqRef.current) return
         if (parsed.success) setVersions(parsed.data.versions)
         else setVersions([])
       }
     } finally {
-      setLoading(false)
+      if (seq === fetchSeqRef.current) setLoading(false)
     }
   }, [workspaceId, slug])
 
@@ -95,11 +107,27 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   const confirmRestore = useCallback(async () => {
     if (!pendingRestore) return
     const v = pendingRestore
+    setRestoreError(null)
+    // Only clear the dialog and run success side effects (onRestored clears the
+    // browser-side LoroUndoManager) once the server confirms the restore
+    // actually happened. A failed request keeps the dialog open with an error
+    // so the caller never discards undo history for a restore that didn't occur.
+    try {
+      const res = await apiFetch(
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
+        { method: 'POST' },
+      )
+      if (!res.ok) {
+        log.error('restore request failed', { status: res.status, versionId: v.id })
+        setRestoreError('Restore failed. Please try again.')
+        return
+      }
+    } catch (err) {
+      log.error('restore request threw', err)
+      setRestoreError('Restore failed. Please try again.')
+      return
+    }
     setPendingRestore(null)
-    await apiFetch(
-      `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
-      { method: 'POST' },
-    )
     onRestored?.()
     // Refresh immediately after restore so the pending UI closes cleanly.
     await refresh()
@@ -182,7 +210,10 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
                   <button
                     type="button"
                     className="bg-card text-card-foreground flex flex-1 min-w-0 cursor-pointer flex-col gap-6 overflow-hidden rounded-xl border py-2 text-left shadow-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    onClick={() => setPendingRestore(v)}
+                    onClick={() => {
+                      setRestoreError(null)
+                      setPendingRestore(v)
+                    }}
                   >
                     {v.hasThumbnail && (
                       <div className="mx-3 mb-1 border rounded overflow-hidden bg-muted/30">
@@ -226,7 +257,12 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
 
       <AlertDialog
         open={!!pendingRestore}
-        onOpenChange={(open) => !open && setPendingRestore(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingRestore(null)
+            setRestoreError(null)
+          }
+        }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -240,11 +276,21 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
                   to every connected tab. Per-peer Ctrl+Z history is cleared.
                 </>
               )}
+              {restoreError && <span className="mt-2 block text-destructive">{restoreError}</span>}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmRestore}>Restore</AlertDialogAction>
+            {/* AlertDialogAction closes the dialog by default on click; prevent that so a
+                failed restore keeps the dialog open with the error instead of discarding it. */}
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void confirmRestore()
+              }}
+            >
+              Restore
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -67,6 +67,11 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
   const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
   const [restoreError, setRestoreError] = useState<string | null>(null)
   const [isRestoring, setIsRestoring] = useState(false)
+  // Mirrors pendingRestore, refreshed on every render so confirmRestore's
+  // async continuation can read the *current* pending version after an
+  // await, instead of a value closed over before the request started.
+  const pendingRestoreRef = useRef<VersionEntry | null>(pendingRestore)
+  pendingRestoreRef.current = pendingRestore
   // Monotonically increasing sequence stamp. Each refresh() call captures the
   // value at dispatch time; a response only commits if no newer refresh has
   // started meanwhile. Without this, a slow /versions response for an older
@@ -113,13 +118,22 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     refresh()
   }, [refresh])
 
-  // Poll every 15 seconds for new auto-versions.
+  // Keep branch state here for head filtering and the mini-graph.
+  // Legacy versions without branchName are treated as main.
+  const { state: branchesState, refetch: refetchBranches } = useBranches(workspaceId, slug)
+
+  // Poll every 15 seconds for new auto-versions, and re-fetch branches on the
+  // same tick. useBranches has no event subscription of its own, so this is
+  // the only path by which an externally-driven HEAD change (another peer
+  // switching branches, a merge from another tab) reaches this component's
+  // branch filter.
   useEffect(() => {
     const h = setInterval(() => {
       refresh()
+      refetchBranches()
     }, 15_000)
     return () => clearInterval(h)
-  }, [refresh])
+  }, [refresh, refetchBranches])
 
   const confirmRestore = useCallback(async () => {
     // Guard against a double-click or repeated keyboard activation firing a
@@ -149,15 +163,19 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     } finally {
       setIsRestoring(false)
     }
+    // Re-check that the dialog still refers to this same version before
+    // clearing it: the dialog is guarded against dismissal while isRestoring
+    // is true, but this identity check keeps success side effects (which
+    // clear undo history) tied to the request that actually completed rather
+    // than whatever version the dialog happens to show when the response
+    // lands.
+    if (pendingRestoreRef.current?.id !== v.id) return
     setPendingRestore(null)
     onRestored?.()
     // Refresh immediately after restore so the pending UI closes cleanly.
     await refresh()
   }, [pendingRestore, isRestoring, workspaceId, slug, onRestored, refresh])
 
-  // Keep branch state here for head filtering and the mini-graph.
-  // Legacy versions without branchName are treated as main.
-  const { state: branchesState } = useBranches(workspaceId, slug)
   const head = branchesState.head
 
   const visibleVersions = versions.filter((v) => (v.branchName ?? 'main') === head)
@@ -211,13 +229,17 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
                         strokeOpacity={0.6}
                       />
                     ) : null}
+                    {/* visibleVersions (and therefore every row here) is already
+                        filtered to the active HEAD branch, so the dot is always
+                        solid — the mini-graph's hollow "other branch" ring never
+                        applies at this call site. */}
                     <circle
                       cx={12}
                       cy={18}
                       r={4}
-                      fill={row?.active ? row.dotColor : '#fff'}
+                      fill={row?.dotColor ?? '#94a3b8'}
                       stroke={row?.dotColor ?? '#94a3b8'}
-                      strokeWidth={row?.active ? 0 : 1.5}
+                      strokeWidth={0}
                     />
                     <line
                       x1={12}
@@ -280,6 +302,12 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
       <AlertDialog
         open={!!pendingRestore}
         onOpenChange={(open) => {
+          // A restore POST is in flight for the currently pending version;
+          // dismissing here (Escape, overlay click, Cancel) would let the
+          // user reopen the same or a different row and fire a second
+          // /restore before the first resolves. Keep the dialog pinned to
+          // the in-flight request until it settles.
+          if (!open && isRestoring) return
           if (!open) {
             setPendingRestore(null)
             setRestoreError(null)
@@ -303,7 +331,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={isRestoring}>Cancel</AlertDialogCancel>
             {/* AlertDialogAction closes the dialog by default on click; prevent that so a
                 failed restore keeps the dialog open with the error instead of discarding it. */}
             <AlertDialogAction

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -1,0 +1,531 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  buildBranchUrls,
+  type BranchesState,
+  parseBranchesResponse,
+  branchesApi,
+  useBranches,
+} from './useBranches.js'
+
+describe('buildBranchUrls', () => {
+  it('encodes hierarchical slug with "/" safely', () => {
+    const urls = buildBranchUrls('sess_1', '621/header')
+    expect(urls.list).toBe('/api/workspaces/sess_1/canvases/621%2Fheader/branches')
+    expect(urls.head).toBe('/api/workspaces/sess_1/canvases/621%2Fheader/head')
+    expect(urls.deleteBranch('feature')).toBe(
+      '/api/workspaces/sess_1/canvases/621%2Fheader/branches/feature',
+    )
+    expect(urls.merge('feature')).toBe(
+      '/api/workspaces/sess_1/canvases/621%2Fheader/branches/feature/merge',
+    )
+  })
+})
+
+describe('parseBranchesResponse', () => {
+  it('defaults to empty / main when response is malformed', () => {
+    expect(parseBranchesResponse(null)).toEqual<BranchesState>({ branches: [], head: 'main' })
+    expect(parseBranchesResponse({})).toEqual<BranchesState>({ branches: [], head: 'main' })
+  })
+
+  it('passes through well-formed responses', () => {
+    expect(
+      parseBranchesResponse({
+        head: 'feature',
+        branches: [
+          { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+          {
+            name: 'feature',
+            tipFrontiers: 'AA==',
+            color: '#9333ea',
+            createdAt: '2026-04-23T01:00:00Z',
+          },
+        ],
+      }),
+    ).toEqual<BranchesState>({
+      head: 'feature',
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+        {
+          name: 'feature',
+          tipFrontiers: 'AA==',
+          color: '#9333ea',
+          createdAt: '2026-04-23T01:00:00Z',
+        },
+      ],
+    })
+  })
+
+  it('drops malformed branches entries and keeps valid ones', () => {
+    const result = parseBranchesResponse({
+      head: 'main',
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+        { name: 42 }, // malformed
+        null,
+      ],
+    })
+    expect(result.branches).toHaveLength(1)
+    expect(result.branches[0]!.name).toBe('main')
+  })
+
+  it('falls back to "main" when head is an empty string', () => {
+    expect(parseBranchesResponse({ head: '', branches: [] })).toEqual<BranchesState>({
+      branches: [],
+      head: 'main',
+    })
+  })
+})
+
+describe('branchesApi', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalThis.fetch = originalFetch
+  })
+
+  it('list() GETs branches URL and parses response', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            head: 'main',
+            branches: [
+              {
+                name: 'main',
+                tipFrontiers: '',
+                color: '#1971c2',
+                createdAt: '2026-04-23T00:00:00Z',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const state = await api.list()
+    expect(state.branches).toHaveLength(1)
+    const firstCall = fetchMock.mock.calls[0]
+    expect(firstCall?.[0]).toBe('/api/workspaces/sess_1/canvases/canvas-a/branches')
+  })
+
+  it('create() POSTs JSON body', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            branch: {
+              name: 'feature',
+              tipFrontiers: '',
+              color: '#9333ea',
+              createdAt: '2026-04-23T01:00:00Z',
+            },
+          }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } },
+        ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const branch = await api.create({ name: 'feature' })
+    expect(branch.name).toBe('feature')
+    const firstCall2 = fetchMock.mock.calls[0]
+    const init = firstCall2?.[1] as RequestInit | undefined
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBe(JSON.stringify({ name: 'feature' }))
+  })
+
+  it('create() rejects with response error payload on 4xx/5xx', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ error: 'branch_conflict', message: 'exists' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    await expect(api.create({ name: 'feature' })).rejects.toMatchObject({
+      status: 409,
+      body: { error: 'branch_conflict' },
+    })
+  })
+
+  it('setHead() PUTs { branch } and parses result', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ head: 'feature', previousHead: 'main' }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const result = await api.setHead('feature')
+    expect(result).toEqual({ head: 'feature', previousHead: 'main' })
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/workspaces/sess_1/canvases/canvas-a/head')
+    const headCall = fetchMock.mock.calls[0]
+    const headInit = headCall?.[1] as RequestInit | undefined
+    expect(headInit?.method).toBe('PUT')
+  })
+
+  it('remove() issues DELETE', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(JSON.stringify({ ok: true, unmergedCommits: 0 }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const result = await api.remove('feature')
+    expect(result.ok).toBe(true)
+    const delCall = fetchMock.mock.calls[0]
+    const delInit = delCall?.[1] as RequestInit | undefined
+    expect(delInit?.method).toBe('DELETE')
+  })
+
+  it('merge() POSTs to merge URL with { into, dryRun }', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ badges: [], preview: { elementCount: 5 } }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const result = await api.merge('feature', { into: 'main', dryRun: true })
+    expect(result.preview?.elementCount).toBe(5)
+    const mergeCall = fetchMock.mock.calls[0]
+    const url = mergeCall?.[0]
+    const init2 = mergeCall?.[1] as RequestInit | undefined
+    expect(url).toBe('/api/workspaces/sess_1/canvases/canvas-a/branches/feature/merge')
+    expect(init2?.method).toBe('POST')
+    expect(init2?.body).toBe(JSON.stringify({ into: 'main', dryRun: true }))
+  })
+
+  describe('contract_mismatch normalization: malformed 200 must not leak ZodError', () => {
+    it.each([
+      [
+        'create',
+        (api: ReturnType<typeof branchesApi>) => api.create({ name: 'x' }),
+        JSON.stringify({ branch: null }),
+      ],
+      [
+        'setHead',
+        (api: ReturnType<typeof branchesApi>) => api.setHead('main'),
+        JSON.stringify({ head: 42, previousHead: 'main' }),
+      ],
+      [
+        'remove',
+        (api: ReturnType<typeof branchesApi>) => api.remove('feature'),
+        JSON.stringify({ ok: 'yes' }),
+      ],
+      [
+        'rename',
+        (api: ReturnType<typeof branchesApi>) => api.rename('old', 'new-name'),
+        JSON.stringify({ branch: null, renamedVersionCount: 'x' }),
+      ],
+      [
+        'getStats',
+        (api: ReturnType<typeof branchesApi>) => api.getStats('feature'),
+        JSON.stringify({ unmergedCommits: 'bad' }),
+      ],
+      [
+        'merge',
+        (api: ReturnType<typeof branchesApi>) => api.merge('feature', { into: 'main' }),
+        JSON.stringify({ badges: 'not-an-array' }),
+      ],
+    ])('%s() rejects with structured error (not ZodError) when server returns malformed 200', async (_label, call, malformedBody) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(malformedBody, {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+        ),
+      )
+      const api = branchesApi('sess_1', 'canvas-a')
+      const err = await call(api).catch((e: unknown) => e)
+      // ZodError extends Error; a structured BranchApiError is a plain object
+      expect(err instanceof Error).toBe(false)
+      expect(err).toMatchObject({ body: { error: 'contract_mismatch' } })
+    })
+  })
+})
+
+describe('useBranches hook (callback model, no window event subscription)', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalThis.fetch = originalFetch
+  })
+
+  it('does not update state when the component has unmounted', async () => {
+    let resolveAfterUnmount!: () => void
+    const gate = new Promise<void>((r) => {
+      resolveAfterUnmount = r
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        await gate
+        return new Response(JSON.stringify({ head: 'should-not-appear', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { unmount } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+
+    unmount()
+
+    // Releasing the gate after unmount must not cause React state-update warnings.
+    await act(async () => {
+      resolveAfterUnmount()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    const stateUpdateErrors = consoleErrorSpy.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].includes('unmounted'),
+    )
+    expect(stateUpdateErrors).toHaveLength(0)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('does not register a window "excalidraw:head_changed" listener', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+
+    renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    const headChangedCalls = addSpy.mock.calls.filter(
+      (args) => args[0] === 'excalidraw:head_changed',
+    )
+    expect(headChangedCalls).toHaveLength(0)
+
+    addSpy.mockRestore()
+  })
+
+  it('refetch() triggers a list fetch and commits new state', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ head: 'feature', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const afterMount = fetchMock.mock.calls.length
+    expect(afterMount).toBeGreaterThan(0)
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterMount)
+    expect(result.current.state.head).toBe('feature')
+  })
+
+  it('refetch() resolving after unmount commits nothing and emits no act warning', async () => {
+    let resolveRefetch!: () => void
+    let callCount = 0
+    const gate = new Promise<void>((r) => {
+      resolveRefetch = r
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        callCount++
+        if (callCount === 1) {
+          return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        await gate
+        return new Response(JSON.stringify({ head: 'should-not-appear', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result, unmount } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    let refetchPromise!: Promise<void>
+    act(() => {
+      refetchPromise = result.current.refetch()
+    })
+
+    unmount()
+
+    await act(async () => {
+      resolveRefetch()
+      await refetchPromise
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    const stateUpdateErrors = consoleErrorSpy.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].includes('unmounted'),
+    )
+    expect(stateUpdateErrors).toHaveLength(0)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('refetch() hits the new URL after workspaceId/slug change', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId, slug }: { workspaceId: string; slug: string }) =>
+        useBranches(workspaceId, slug),
+      { initialProps: { workspaceId: 'sess_1', slug: 'canvas-a' } },
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    rerender({ workspaceId: 'sess_1', slug: 'canvas-b' })
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    const calls = fetchMock.mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall?.[0]).toBe('/api/workspaces/sess_1/canvases/canvas-b/branches')
+  })
+
+  it('discards in-flight canvas-a fetch when key changes to canvas-b before it resolves', async () => {
+    let resolveCanvasA!: () => void
+    const canvasAGate = new Promise<void>((r) => {
+      resolveCanvasA = r
+    })
+
+    let callCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        callCount++
+        if (callCount === 1) {
+          await canvasAGate
+          return new Response(JSON.stringify({ head: 'canvas-a-head', branches: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        return new Response(JSON.stringify({ head: 'canvas-b-head', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId, slug }: { workspaceId: string; slug: string }) =>
+        useBranches(workspaceId, slug),
+      { initialProps: { workspaceId: 'sess_1', slug: 'canvas-a' } },
+    )
+
+    // Switch to canvas-b while canvas-a fetch is still in-flight.
+    await act(async () => {
+      rerender({ workspaceId: 'sess_1', slug: 'canvas-b' })
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(result.current.state.head).toBe('canvas-b-head')
+
+    // Release canvas-a. Without a guard it would overwrite canvas-b state.
+    await act(async () => {
+      resolveCanvasA()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(result.current.state.head).toBe('canvas-b-head')
+  })
+
+  it('discards a stale list() that resolves after a newer refetch', async () => {
+    let resolveStale!: () => void
+    const staleGate = new Promise<void>((r) => {
+      resolveStale = r
+    })
+
+    let callCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        callCount++
+        if (callCount === 1) {
+          await staleGate
+          return new Response(
+            JSON.stringify({
+              head: 'stale-branch',
+              branches: [
+                {
+                  name: 'stale-branch',
+                  tipFrontiers: '',
+                  color: '#aaaaaa',
+                  createdAt: '2026-01-01T00:00:00Z',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        return new Response(
+          JSON.stringify({
+            head: 'main',
+            branches: [
+              {
+                name: 'main',
+                tipFrontiers: '',
+                color: '#bbbbbb',
+                createdAt: '2026-01-01T00:00:00Z',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }),
+    )
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+
+    // Initial mount triggered call #1 (held by staleGate).
+    // Trigger call #2 which resolves immediately with fresh data.
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.state.head).toBe('main')
+
+    // Release the stale call. Without the sequence guard, state would revert to 'stale-branch'.
+    await act(async () => {
+      resolveStale()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(result.current.state.head).toBe('main')
+  })
+})

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -1,10 +1,10 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  buildBranchUrls,
   type BranchesState,
-  parseBranchesResponse,
   branchesApi,
+  buildBranchUrls,
+  parseBranchesResponse,
   useBranches,
 } from './useBranches.js'
 
@@ -527,5 +527,209 @@ describe('useBranches hook (callback model, no window event subscription)', () =
     })
 
     expect(result.current.state.head).toBe('main')
+  })
+
+  it('createBranch() posts the request and refetches the list', async () => {
+    let listCallCount = 0
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (_input, reqInit) => {
+        if (reqInit?.method === 'POST') {
+          return new Response(
+            JSON.stringify({
+              branch: {
+                name: 'feature',
+                tipFrontiers: '',
+                color: '#9333ea',
+                createdAt: '2026-04-23T01:00:00Z',
+              },
+            }),
+            { status: 201, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        listCallCount++
+        return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const listCallsAfterMount = listCallCount
+
+    let created!: Awaited<ReturnType<typeof result.current.createBranch>>
+    await act(async () => {
+      created = await result.current.createBranch({ name: 'feature' })
+    })
+
+    expect(created.name).toBe('feature')
+    expect(listCallCount).toBeGreaterThan(listCallsAfterMount)
+  })
+
+  it('deleteBranch() issues DELETE and refetches the list', async () => {
+    const calls: string[] = []
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (input, reqInit) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        calls.push(`${reqInit?.method ?? 'GET'} ${url}`)
+        if (reqInit?.method === 'DELETE') {
+          return new Response(JSON.stringify({ ok: true, unmergedCommits: 0 }), { status: 200 })
+        }
+        return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const callsBefore = calls.length
+
+    await act(async () => {
+      await result.current.deleteBranch('feature')
+    })
+
+    expect(calls.some((c) => c.startsWith('DELETE'))).toBe(true)
+    expect(calls.length).toBeGreaterThan(callsBefore + 1) // DELETE + follow-up refetch
+  })
+
+  it('renameBranch() PATCHes and refetches, returning the renamed branch', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (_input, reqInit) => {
+        if (reqInit?.method === 'PATCH') {
+          return new Response(
+            JSON.stringify({
+              branch: {
+                name: 'new-name',
+                tipFrontiers: '',
+                color: '#9333ea',
+                createdAt: '2026-04-23T01:00:00Z',
+              },
+              renamedVersionCount: 2,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    let renamed!: Awaited<ReturnType<typeof result.current.renameBranch>>
+    await act(async () => {
+      renamed = await result.current.renameBranch('old', 'new-name')
+    })
+
+    expect(renamed.name).toBe('new-name')
+  })
+
+  it('setHead() PUTs and refetches, returning the new head', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (_input, reqInit) => {
+        if (reqInit?.method === 'PUT') {
+          return new Response(JSON.stringify({ head: 'feature', previousHead: 'main' }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ head: 'feature', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    let setHeadResult!: Awaited<ReturnType<typeof result.current.setHead>>
+    await act(async () => {
+      setHeadResult = await result.current.setHead('feature')
+    })
+
+    expect(setHeadResult.head).toBe('feature')
+    expect(result.current.state.head).toBe('feature')
+  })
+
+  it('merge() with dryRun does not refetch the branch list', async () => {
+    let listCallCount = 0
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (_input, reqInit) => {
+        if (reqInit?.method === 'POST') {
+          return new Response(JSON.stringify({ badges: [], preview: { elementCount: 5 } }), {
+            status: 200,
+          })
+        }
+        listCallCount++
+        return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const listCallsAfterMount = listCallCount
+
+    let mergeResult!: Awaited<ReturnType<typeof result.current.merge>>
+    await act(async () => {
+      mergeResult = await result.current.merge('feature', { into: 'main', dryRun: true })
+    })
+
+    expect(mergeResult.preview?.elementCount).toBe(5)
+    // dryRun must skip the post-merge refetch.
+    expect(listCallCount).toBe(listCallsAfterMount)
+  })
+
+  it('merge() without dryRun refetches the branch list', async () => {
+    let listCallCount = 0
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (_input, reqInit) => {
+        if (reqInit?.method === 'POST') {
+          return new Response(JSON.stringify({ badges: [] }), { status: 200 })
+        }
+        listCallCount++
+        return new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a'))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const listCallsAfterMount = listCallCount
+
+    await act(async () => {
+      await result.current.merge('feature', { into: 'main' })
+    })
+
+    // A real (non-dryRun) merge must trigger the post-merge refetch.
+    expect(listCallCount).toBeGreaterThan(listCallsAfterMount)
   })
 })

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -529,6 +529,73 @@ describe('useBranches hook (callback model, no window event subscription)', () =
     expect(result.current.state.head).toBe('main')
   })
 
+  it('resets state to the defaults when workspaceId/slug changes, instead of exposing the previous canvas', async () => {
+    let resolveB: (() => void) | undefined
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      (input) => {
+        const url = String(input)
+        if (url.includes('canvas-a')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                head: 'feature',
+                branches: [
+                  {
+                    name: 'main',
+                    tipFrontiers: '',
+                    color: '#1971c2',
+                    createdAt: '2026-01-01T00:00:00Z',
+                  },
+                  {
+                    name: 'feature',
+                    tipFrontiers: 'AA==',
+                    color: '#9333ea',
+                    createdAt: '2026-01-02T00:00:00Z',
+                  },
+                ],
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            ),
+          )
+        }
+        // canvas-b: hold the response so the reset window is observable.
+        return new Promise<Response>((resolve) => {
+          resolveB = () =>
+            resolve(
+              new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+        })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId, slug }: { workspaceId: string; slug: string }) =>
+        useBranches(workspaceId, slug),
+      { initialProps: { workspaceId: 'sess_1', slug: 'canvas-a' } },
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(result.current.state.head).toBe('feature')
+
+    rerender({ workspaceId: 'sess_1', slug: 'canvas-b' })
+    // While canvas-b's fetch is in flight, the hook must not hand canvas-a's
+    // branches/head to consumers that don't check `loading`.
+    expect(result.current.loading).toBe(true)
+    expect(result.current.state.head).toBe('main')
+    expect(result.current.state.branches).toEqual([])
+
+    await act(async () => {
+      resolveB?.()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(result.current.state.head).toBe('main')
+  })
+
   it('createBranch() posts the request and refetches the list', async () => {
     let listCallCount = 0
     const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -1,23 +1,24 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ZodError } from 'zod'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
 import {
   type BranchMeta,
   type BranchStatsResponse,
-  type CanvasBranchesState,
-  type CreateBranchRequest,
-  type DeleteBranchResponse,
-  type MergeResponse,
-  type RenameBranchResponse,
-  type SetHeadResponse,
   branchMetaSchema,
   branchStatsResponseSchema,
+  type CanvasBranchesState,
+  type CreateBranchRequest,
+  canvasBranchesStateSchema,
   createBranchResponseSchema,
+  type DeleteBranchResponse,
   deleteBranchResponseSchema,
+  type MergeResponse,
   mergeResponseSchema,
+  type RenameBranchResponse,
   renameBranchResponseSchema,
+  type SetHeadResponse,
   setHeadResponseSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
-import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ZodError } from 'zod'
 
 // Branch API helpers plus the React hook wrapper.
 // - branchesApi: pure request helpers that can be tested without React.
@@ -52,11 +53,20 @@ export function buildBranchUrls(
   }
 }
 
-// Defensive parse: filter malformed entries per-item so the BranchPicker keeps
-// rendering valid branches even if the server (or a stale cache) ships a rogue
-// row. branchMetaSchema is the single source of truth for the wire shape.
+// canvasBranchesStateSchema is the single source of truth for the envelope
+// shape. Fall back to filtering the branches array per-item only when the
+// envelope itself fails validation (e.g. a single rogue row breaks the whole
+// array parse), so the BranchPicker keeps rendering the valid branches
+// instead of dropping the entire response.
 export function parseBranchesResponse(raw: unknown): BranchesState {
   if (!raw || typeof raw !== 'object') return { branches: [], head: 'main' }
+  const envelope = canvasBranchesStateSchema.safeParse(raw)
+  if (envelope.success) {
+    return {
+      branches: envelope.data.branches,
+      head: envelope.data.head.length > 0 ? envelope.data.head : 'main',
+    }
+  }
   const data = raw as { head?: unknown; branches?: unknown }
   const branches: BranchMeta[] = []
   if (Array.isArray(data.branches)) {

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ZodError } from 'zod'
+import {
+  type BranchMeta,
+  type BranchStatsResponse,
+  type CanvasBranchesState,
+  type CreateBranchRequest,
+  type DeleteBranchResponse,
+  type MergeResponse,
+  type RenameBranchResponse,
+  type SetHeadResponse,
+  branchMetaSchema,
+  branchStatsResponseSchema,
+  createBranchResponseSchema,
+  deleteBranchResponseSchema,
+  mergeResponseSchema,
+  renameBranchResponseSchema,
+  setHeadResponseSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+
+// Branch API helpers plus the React hook wrapper.
+// - branchesApi: pure request helpers that can be tested without React.
+// - useBranches: bundles list state and mutators. Callers notify the hook of
+//   an external HEAD change (e.g. useCanvasSync's onHeadChanged) by invoking
+//   the returned `refetch`; this hook does not subscribe to any event bus.
+
+export type { BranchMeta }
+export type BranchesState = CanvasBranchesState
+export type MergeResult = MergeResponse
+
+// ── URL builder ──
+// Slugs can contain "/", so always encode them.
+export function buildBranchUrls(
+  workspaceId: string,
+  slug: string,
+): {
+  list: string
+  head: string
+  deleteBranch: (name: string) => string
+  stats: (name: string) => string
+  merge: (source: string) => string
+} {
+  const safeSlug = encodeURIComponent(slug)
+  const base = `/api/workspaces/${workspaceId}/canvases/${safeSlug}`
+  return {
+    list: `${base}/branches`,
+    head: `${base}/head`,
+    deleteBranch: (name) => `${base}/branches/${encodeURIComponent(name)}`,
+    stats: (name) => `${base}/branches/${encodeURIComponent(name)}/stats`,
+    merge: (source) => `${base}/branches/${encodeURIComponent(source)}/merge`,
+  }
+}
+
+// Defensive parse: filter malformed entries per-item so the BranchPicker keeps
+// rendering valid branches even if the server (or a stale cache) ships a rogue
+// row. branchMetaSchema is the single source of truth for the wire shape.
+export function parseBranchesResponse(raw: unknown): BranchesState {
+  if (!raw || typeof raw !== 'object') return { branches: [], head: 'main' }
+  const data = raw as { head?: unknown; branches?: unknown }
+  const branches: BranchMeta[] = []
+  if (Array.isArray(data.branches)) {
+    for (const entry of data.branches) {
+      const parsed = branchMetaSchema.safeParse(entry)
+      if (parsed.success) branches.push(parsed.data)
+    }
+  }
+  return {
+    branches,
+    head: typeof data.head === 'string' && data.head.length > 0 ? data.head : 'main',
+  }
+}
+
+// Throw structured HTTP errors so callers can branch on status and body.
+export interface BranchApiError {
+  status: number
+  body: Record<string, unknown>
+}
+
+async function requireOk(res: Response): Promise<Response> {
+  if (res.ok) return res
+  let body: Record<string, unknown> = {}
+  try {
+    body = (await res.json()) as Record<string, unknown>
+  } catch {
+    /* Leave body empty if it cannot be parsed. */
+  }
+  const err: BranchApiError = { status: res.status, body }
+  throw err
+}
+
+// A schema mismatch on a 200 response means the server shipped a shape that
+// does not match the client's contract. Normalise into a structured error so
+// callers never receive a raw ZodError whose instanceof-Error check would
+// incorrectly signal a network / auth problem.
+function safeParse<T>(schema: { parse: (v: unknown) => T }, value: unknown): T {
+  try {
+    return schema.parse(value)
+  } catch (e) {
+    if (e instanceof ZodError) {
+      const err: BranchApiError = {
+        status: 200,
+        body: { error: 'contract_mismatch', issues: e.issues },
+      }
+      throw err
+    }
+    throw e
+  }
+}
+
+// Imperative API helpers independent from React.
+export function branchesApi(workspaceId: string, slug: string) {
+  const urls = buildBranchUrls(workspaceId, slug)
+  return {
+    async list(): Promise<BranchesState> {
+      const res = await requireOk(await apiFetch(urls.list))
+      return parseBranchesResponse(await res.json())
+    },
+    async create(args: CreateBranchRequest): Promise<BranchMeta> {
+      const res = await requireOk(
+        await apiFetch(urls.list, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(args),
+        }),
+      )
+      return safeParse(createBranchResponseSchema, await res.json()).branch
+    },
+    async getStats(name: string): Promise<BranchStatsResponse> {
+      const res = await requireOk(await apiFetch(urls.stats(name)))
+      return safeParse(branchStatsResponseSchema, await res.json())
+    },
+    async remove(name: string): Promise<DeleteBranchResponse> {
+      const res = await requireOk(await apiFetch(urls.deleteBranch(name), { method: 'DELETE' }))
+      return safeParse(deleteBranchResponseSchema, await res.json())
+    },
+    async rename(oldName: string, newName: string): Promise<RenameBranchResponse> {
+      const res = await requireOk(
+        await apiFetch(urls.deleteBranch(oldName), {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: newName }),
+        }),
+      )
+      return safeParse(renameBranchResponseSchema, await res.json())
+    },
+    async setHead(branch: string): Promise<SetHeadResponse> {
+      const res = await requireOk(
+        await apiFetch(urls.head, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ branch }),
+        }),
+      )
+      return safeParse(setHeadResponseSchema, await res.json())
+    },
+    async merge(source: string, args: { into: string; dryRun?: boolean }): Promise<MergeResult> {
+      const res = await requireOk(
+        await apiFetch(urls.merge(source), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            into: args.into,
+            dryRun: args.dryRun ?? false,
+          }),
+        }),
+      )
+      return safeParse(mergeResponseSchema, await res.json())
+    },
+  }
+}
+
+// React hook.
+// Expose refetch so callers can refresh on an externally observed HEAD
+// change (e.g. useCanvasSync's onHeadChanged callback).
+export interface UseBranchesResult {
+  state: BranchesState
+  loading: boolean
+  error: BranchApiError | Error | null
+  refetch: () => Promise<void>
+  createBranch: (args: CreateBranchRequest) => Promise<BranchMeta>
+  deleteBranch: (name: string) => Promise<void>
+  getBranchStats: (name: string) => Promise<BranchStatsResponse>
+  renameBranch: (oldName: string, newName: string) => Promise<BranchMeta>
+  setHead: (branch: string) => Promise<SetHeadResponse>
+  merge: (source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>
+}
+
+export function useBranches(workspaceId: string, slug: string): UseBranchesResult {
+  const [state, setState] = useState<BranchesState>({ branches: [], head: 'main' })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<BranchApiError | Error | null>(null)
+  const apiRef = useRef(branchesApi(workspaceId, slug))
+  // Monotonically increasing counter. Each refetch call stamps its result with
+  // the counter value at dispatch time; the setter is a no-op when a newer
+  // fetch has already committed. This prevents a slower in-flight response
+  // from overwriting the result of a later refetch.
+  const fetchSeqRef = useRef(0)
+
+  // Recreate the API wrapper whenever session or slug changes.
+  useEffect(() => {
+    apiRef.current = branchesApi(workspaceId, slug)
+  }, [workspaceId, slug])
+
+  const refetch = useCallback(async () => {
+    const seq = ++fetchSeqRef.current
+    setLoading(true)
+    try {
+      const next = await apiRef.current.list()
+      if (seq !== fetchSeqRef.current) return
+      setState(next)
+      setError(null)
+    } catch (err) {
+      if (seq !== fetchSeqRef.current) return
+      setError(err as BranchApiError | Error)
+    } finally {
+      if (seq === fetchSeqRef.current) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refetch()
+  }, [refetch, workspaceId, slug])
+
+  // Bump the sequence counter on unmount so any in-flight fetch resolution is
+  // routed into the stale-fetch guard above instead of committing state after
+  // the component is gone. There is no window-event subscription here: the
+  // caller (e.g. CanvasPage via useCanvasSync's onHeadChanged option) invokes
+  // `refetch` directly when it observes an external HEAD change.
+  useEffect(() => {
+    return () => {
+      fetchSeqRef.current++
+    }
+  }, [])
+
+  const createBranch = useCallback(
+    async (args: CreateBranchRequest) => {
+      const branch = await apiRef.current.create(args)
+      await refetch()
+      return branch
+    },
+    [refetch],
+  )
+
+  const deleteBranch = useCallback(
+    async (name: string) => {
+      await apiRef.current.remove(name)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  const getBranchStats = useCallback(async (name: string) => apiRef.current.getStats(name), [])
+
+  const renameBranch = useCallback(
+    async (oldName: string, newName: string) => {
+      const { branch } = await apiRef.current.rename(oldName, newName)
+      await refetch()
+      return branch
+    },
+    [refetch],
+  )
+
+  const setHead = useCallback(
+    async (branch: string) => {
+      const result = await apiRef.current.setHead(branch)
+      await refetch()
+      return result
+    },
+    [refetch],
+  )
+
+  const merge = useCallback(
+    async (source: string, args: { into: string; dryRun?: boolean }) => {
+      const result = await apiRef.current.merge(source, args)
+      if (!(args.dryRun ?? false)) await refetch()
+      return result
+    },
+    [refetch],
+  )
+
+  return {
+    state,
+    loading,
+    error,
+    refetch,
+    createBranch,
+    deleteBranch,
+    getBranchStats,
+    renameBranch,
+    setHead,
+    merge,
+  }
+}

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -207,6 +207,18 @@ export function useBranches(workspaceId: string, slug: string): UseBranchesResul
   // from overwriting the result of a later refetch.
   const fetchSeqRef = useRef(0)
 
+  // Reset synchronously during render when the canvas changes — an effect
+  // would leave one frame where consumers that don't check `loading` see the
+  // PREVIOUS canvas's branches/head.
+  const canvasKey = `${workspaceId} ${slug}`
+  const [prevCanvasKey, setPrevCanvasKey] = useState(canvasKey)
+  if (prevCanvasKey !== canvasKey) {
+    setPrevCanvasKey(canvasKey)
+    setState({ branches: [], head: 'main' })
+    setError(null)
+    setLoading(true)
+  }
+
   // Recreate the API wrapper whenever session or slug changes.
   useEffect(() => {
     apiRef.current = branchesApi(workspaceId, slug)


### PR DESCRIPTION
UI-unification Stage 2, Lane 7 — the version-history surface, ported from the frozen daemon app with the sync-event coupling moved to the callback model per ADR-0004.

## Change

- **`useBranches`** → `apps/web/src/hooks/`: same return contract as the original (state/loading/error/refetch + create/delete/rename/setHead/merge/stats via Zod-validated `api-contracts`), with two deliberate behavior changes: (1) the `excalidraw:head_changed` **window listener is removed** — `refetch` is the notification API the unified CanvasPage will call from `useCanvasSync`'s `onHeadChanged` callback (binds lifecycle to backend identity, killing the stale-listener class); (2) an unmount cleanup bumps the existing fetch-seq guard so post-unmount resolutions are discarded (the original had no mounted guard).
- **`VersionTimeline`** → `apps/web/src/components/`: 15s polling, head filtering, restore AlertDialog, mini-graph — plus dev-loop review hardening (restore-failure keeps the dialog open and undo state; network failures don't wedge refresh; branches response validated through `canvasBranchesStateSchema`).
- **Race fix found by the review gate (HIGH, red-first)**: `useBranches` defaults `head` to `'main'` until `/branches` resolves — the timeline no longer renders (or offers restore on) versions filtered by that default; it holds on Loading… until the real HEAD arrives.
- Config aliases for the two #140 subpaths were shared with Lane 5 and already landed in #144 — this PR's configs are byte-identical to main.

`packages/mcp-server` zero diff (frozen). No page wiring (slices 9-10); apps/web copies are canonical.

## Verification

apps/web jsdom 461 ✓ / browser 65 ✓ (one first-run flake retried clean — known Vite first-run dep-optimisation jitter) / tsc ✓ / packages zero diff ✓. Ported suites unweakened; the head_changed window-event test is replaced by callback-model tests (refetch triggers exactly one list fetch; post-unmount refetch is inert; refetch after prop change hits the new canvas URL).