### PR TITLE
feat(web): port StorageReportCard with Zod-validated storage responses

### DIFF
--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { STATUS_CLEAR_MS, StorageReportCard } from './StorageReportCard.js'
+
+const PAYLOAD = {
+  totalBytes: 4096,
+  fileCount: 6,
+  byCategory: {
+    blobs: { bytes: 1024, files: 2 },
+    versions: { bytes: 2048, files: 1 },
+    files: { bytes: 0, files: 0 },
+    libraries: { bytes: 0, files: 0 },
+    db: { bytes: 1024, files: 1 },
+    other: { bytes: 0, files: 2 },
+  },
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-01T00:00:00Z'))
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(JSON.stringify(PAYLOAD), { status: 200 }))),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('StorageReportCard', () => {
+  it('renders each storage category as its own row so future actions can hang off objects', async () => {
+    const { container } = render(<StorageReportCard />)
+    // Eight rows render synchronously from the static descriptor list:
+    // blobs, versions, files, exports, logs, db, other, libraries.
+    // Values fill in once fetch + the min-refresh timer settle.
+    expect(container.querySelectorAll('[data-storage-row]').length).toBe(8)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    const versionsRow = container.querySelector('[data-storage-row="versions"]')
+    expect(versionsRow).not.toBeNull()
+    expect(versionsRow!.textContent).toContain('Versions')
+    expect(versionsRow!.textContent).toMatch(/2\.0\s*KiB|2048/)
+    // Reserved per-row action slot is the OOUI hook for future Optimize.
+    expect(container.querySelector('[data-storage-actions="versions"]')).not.toBeNull()
+    // User libraries row is pinned to the bottom so management UI lives
+    // away from the hot maintenance buckets.
+    const allRows = Array.from(container.querySelectorAll('[data-storage-row]'))
+    expect(allRows[allRows.length - 1]?.getAttribute('data-storage-row')).toBe('libraries')
+  })
+
+  it('exposes Optimize all on the Canvas snapshots row and aggregates across workspaces', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws_a' }, { workspaceId: 'ws_b' }] }),
+        )
+      }
+      if (init?.method === 'POST' && url.endsWith('/canvases/optimize-all')) {
+        return Promise.resolve(
+          jsonResponse({
+            results: [],
+            totalBeforeBytes: url.includes('ws_a') ? 4000 : 1500,
+            totalAfterBytes: url.includes('ws_a') ? 1000 : 1000,
+          }),
+        )
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    // Use real timers for this test — the optimize handler chains many
+    // awaits (workspaces fetch → per-workspace POSTs → implicit refresh)
+    // and threading them through fake timers without wedging Promise
+    // microtasks is not worth the test complexity.
+    vi.useRealTimers()
+
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+    })
+
+    // The Optimize action lives on the Canvas snapshots row — the object
+    // it acts on. Locate it via the reserved actions slot.
+    const blobsActions = container.querySelector('[data-storage-actions="blobs"]')
+    expect(blobsActions).not.toBeNull()
+    const button = blobsActions!.querySelector('button')
+    expect(button).not.toBeNull()
+    fireEvent.click(button!)
+
+    // Both workspaces must be hit, in either order.
+    await waitFor(() => {
+      const optimizeUrls = fetchMock.mock.calls
+        .map(([u, i]) => ({
+          u: typeof u === 'string' ? u : u instanceof URL ? u.toString() : (u as Request).url,
+          method: (i as RequestInit | undefined)?.method,
+        }))
+        .filter((c) => c.method === 'POST' && c.u.endsWith('/canvases/optimize-all'))
+        .map((c) => c.u)
+        .sort()
+      expect(optimizeUrls).toEqual([
+        '/api/workspaces/ws_a/canvases/optimize-all',
+        '/api/workspaces/ws_b/canvases/optimize-all',
+      ])
+    })
+
+    // Status string lands on the row after the action settles.
+    await waitFor(() => {
+      expect(blobsActions!.textContent ?? '').toMatch(/saved|optimal|optimi/i)
+    })
+  })
+
+  it('exposes Cleanup on the Uploaded files row and aggregates dangling-file purges across workspaces', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws_a' }, { workspaceId: 'ws_b' }] }),
+        )
+      }
+      if (init?.method === 'POST' && url.endsWith('/files/purge-dangling')) {
+        return Promise.resolve(
+          jsonResponse({
+            purgedCount: url.includes('ws_a') ? 3 : 1,
+            purgedBytes: url.includes('ws_a') ? 6000 : 2000,
+          }),
+        )
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="files"]')).not.toBeNull()
+    })
+
+    const filesActions = container.querySelector('[data-storage-actions="files"]')
+    expect(filesActions).not.toBeNull()
+    const button = filesActions!.querySelector('button')
+    expect(button).not.toBeNull()
+    fireEvent.click(button!)
+
+    await waitFor(() => {
+      const purgeUrls = fetchMock.mock.calls
+        .map(([u, i]) => ({
+          u: typeof u === 'string' ? u : u instanceof URL ? u.toString() : (u as Request).url,
+          method: (i as RequestInit | undefined)?.method,
+        }))
+        .filter((c) => c.method === 'POST' && c.u.endsWith('/files/purge-dangling'))
+        .map((c) => c.u)
+        .sort()
+      expect(purgeUrls).toEqual([
+        '/api/workspaces/ws_a/files/purge-dangling',
+        '/api/workspaces/ws_b/files/purge-dangling',
+      ])
+    })
+
+    await waitFor(() => {
+      // 3+1 files removed, 6000+2000 bytes — the row's transient status
+      // should reflect a non-zero summary (we do not pin the exact byte
+      // formatting since formatBytes may pick KiB / MiB depending on size).
+      expect(filesActions!.textContent ?? '').toMatch(/Removed\s+4/i)
+    })
+  })
+
+  it('does not call setState after unmount while the min-refresh delay is still pending', async () => {
+    const { unmount } = render(<StorageReportCard />)
+    // Unmount while the initial mount-time refresh() is still awaiting its
+    // fetch response and MIN_REFRESH_MS floor — this is the timing window
+    // that let a post-unmount setLoading(false) fire during jsdom teardown.
+    unmount()
+    // Simulate the jsdom environment being torn down (as Vitest does once a
+    // test file's tests finish) while refresh()'s pending setTimeout is
+    // still scheduled. React 19 silently no-ops a setState call on an
+    // already-unmounted root under a *live* jsdom window — the crash seen
+    // in CI only reproduces once `window` itself is gone by the time the
+    // timer fires, which is what actually happened: dispatchSetState
+    // touched the (now-undefined) `window` and threw
+    // "ReferenceError: window is not defined".
+    const savedWindow = (globalThis as { window?: unknown }).window
+    delete (globalThis as { window?: unknown }).window
+    let thrown: unknown = null
+    try {
+      await vi.advanceTimersByTimeAsync(500)
+    } catch (err) {
+      thrown = err
+    } finally {
+      ;(globalThis as { window?: unknown }).window = savedWindow
+    }
+    expect(thrown).toBeNull()
+  })
+
+  it(
+    'does not call setState after unmount while the optimizeAll status-clear timer is still pending',
+    async () => {
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockImplementation((input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        if (url === '/api/runtime/storage') {
+          return Promise.resolve(jsonResponse(PAYLOAD))
+        }
+        if (url === '/api/workspaces') {
+          return Promise.resolve(jsonResponse({ workspaces: [] }))
+        }
+        return Promise.reject(new Error(`unexpected fetch: ${url}`))
+      })
+
+      // Real timers — optimizeAll's own fetch chain must actually settle
+      // before its finally-block schedules the STATUS_CLEAR_MS timer that
+      // this test unmounts underneath.
+      vi.useRealTimers()
+
+      const { container, unmount } = render(<StorageReportCard />)
+      await waitFor(() => {
+        expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+      })
+
+      const blobsActions = container.querySelector('[data-storage-actions="blobs"]')!
+      const button = blobsActions.querySelector('button')!
+      fireEvent.click(button)
+
+      // Wait for optimizeAll to settle — its finally block has now called
+      // scheduleStatusClear(), arming a pending STATUS_CLEAR_MS setTimeout.
+      await waitFor(() => {
+        expect(blobsActions.textContent ?? '').toMatch(/optimal|saved/i)
+      })
+
+      // Unmount while that setTimeout is still pending. This mirrors the
+      // refresh()-focused unmount test above but exercises
+      // scheduleStatusClear's own mountedRef branch instead of refresh()'s.
+      unmount()
+
+      // Simulate the jsdom environment being torn down before the timer
+      // fires — the same "window is not defined" hazard the refresh() test
+      // guards against, reached through a different handler this time.
+      const savedWindow = (globalThis as { window?: unknown }).window
+      delete (globalThis as { window?: unknown }).window
+      let thrown: unknown = null
+      try {
+        await new Promise((resolve) => setTimeout(resolve, STATUS_CLEAR_MS + 200))
+      } catch (err) {
+        thrown = err
+      } finally {
+        ;(globalThis as { window?: unknown }).window = savedWindow
+      }
+      expect(thrown).toBeNull()
+    },
+    STATUS_CLEAR_MS + 5000,
+  )
+
+  it('humanises the "Updated …" line and ticks across humanise boundaries without per-second flicker', async () => {
+    const { container } = render(<StorageReportCard />)
+    // Settle the initial fetch + min-refresh delay. The fresh fetch lands
+    // <30s ago so the displayed string collapses to "just now".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(container.textContent ?? '').toMatch(/Updated just now/i)
+    // Cross the minute boundary — the tick interval is 30s so the
+    // humanise should advance to "1 minute ago" once the clock passes 60s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(70_000)
+    })
+    expect(container.textContent ?? '').toMatch(/Updated\s+1\s+minute\s+ago/i)
+  })
+})

--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -311,6 +311,74 @@ describe('StorageReportCard', () => {
     expect(orphanRow.textContent).toMatch(/file missing/i)
   })
 
+  it('shows the fetch error instead of "No user libraries installed." when the list request fails', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/user-libraries') {
+        return Promise.resolve(new Response('{}', { status: 500 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
+
+    await waitFor(() => {
+      expect(document.body.textContent).toMatch(/HTTP 500/)
+    })
+    // An empty list caused by a failed fetch must not masquerade as
+    // "no libraries installed".
+    expect(document.body.textContent).not.toMatch(/No user libraries installed/)
+  })
+
+  it('surfaces a network failure from remove as libsError instead of an unhandled rejection', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/user-libraries' && !init?.method) {
+        return Promise.resolve(
+          jsonResponse({
+            libraries: [
+              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
+            ],
+          }),
+        )
+      }
+      if (url.startsWith('/api/user-libraries/') && init?.method === 'DELETE') {
+        return Promise.reject(new Error('network down'))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
+    await waitFor(() => {
+      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+    })
+
+    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
+    await waitFor(() => {
+      expect(document.body.textContent).toMatch(/network down/)
+    })
+  })
+
   it('removes a user library optimistically and re-pulls the list on success', async () => {
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
     let libraries = [

--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { STATUS_CLEAR_MS, StorageReportCard } from './StorageReportCard.js'
 
 const PAYLOAD = {
@@ -266,6 +266,315 @@ describe('StorageReportCard', () => {
     },
     STATUS_CLEAR_MS + 5000,
   )
+
+  it('opens the libraries dialog, fetches rows, and renders the "file missing" branch', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/user-libraries') {
+        return Promise.resolve(
+          jsonResponse({
+            libraries: [
+              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
+              { name: 'orphan', path: '/data/orphan.excalidrawlib', itemCount: 1, bytes: null },
+            ],
+          }),
+        )
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    })
+
+    const manageButton = container.querySelector(
+      '[aria-label="Manage installed user libraries"]',
+    ) as HTMLButtonElement
+    expect(manageButton).not.toBeNull()
+    fireEvent.click(manageButton)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+    })
+    const shapesRow = document.querySelector('[data-user-library-row="shapes"]')!
+    expect(shapesRow.textContent).toMatch(/3\s*items?/i)
+    expect(shapesRow.textContent).toMatch(/KiB|2048/)
+
+    const orphanRow = document.querySelector('[data-user-library-row="orphan"]')!
+    expect(orphanRow.textContent).toMatch(/file missing/i)
+  })
+
+  it('removes a user library optimistically and re-pulls the list on success', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    let libraries = [
+      { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
+    ]
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/user-libraries') {
+        return Promise.resolve(jsonResponse({ libraries }))
+      }
+      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
+        libraries = []
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    })
+    fireEvent.click(
+      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
+    )
+    await waitFor(() => {
+      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+    })
+
+    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-user-library-row="shapes"]')).toBeNull()
+    })
+  })
+
+  it('surfaces a remove failure without dropping the row', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/user-libraries') {
+        return Promise.resolve(
+          jsonResponse({
+            libraries: [
+              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
+            ],
+          }),
+        )
+      }
+      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
+        return Promise.resolve(new Response(null, { status: 500 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    })
+    fireEvent.click(
+      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
+    )
+    await waitFor(() => {
+      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+    })
+
+    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
+
+    await waitFor(() => {
+      expect(document.body.textContent ?? '').toMatch(/Remove failed: HTTP 500/i)
+    })
+    // The row must still be there — a failed remove should not disappear.
+    expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+  })
+
+  it('exposes Cleanup on the Versions row and aggregates sandwiched-auto-version prunes across workspaces', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws_a' }, { workspaceId: 'ws_b' }] }),
+        )
+      }
+      if (init?.method === 'POST' && url.endsWith('/versions/prune-sandwiched')) {
+        return Promise.resolve(jsonResponse({ totalDeleted: url.includes('ws_a') ? 2 : 1 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="versions"]')).not.toBeNull()
+    })
+
+    const versionsActions = container.querySelector('[data-storage-actions="versions"]')!
+    fireEvent.click(versionsActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(versionsActions.textContent ?? '').toMatch(/Removed\s+3\s+auto-version/i)
+    })
+  })
+
+  it('exposes Cleanup on the Logs row and prunes old daemon logs', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (init?.method === 'POST' && url === '/api/runtime/logs/prune') {
+        return Promise.resolve(jsonResponse({ purgedCount: 5, purgedBytes: 10_240 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="logs"]')).not.toBeNull()
+    })
+
+    const logsActions = container.querySelector('[data-storage-actions="logs"]')!
+    fireEvent.click(logsActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(logsActions.textContent ?? '').toMatch(/Removed\s+5/i)
+    })
+  })
+
+  it('reports "Nothing to prune" when the Logs row Cleanup finds nothing to remove', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (init?.method === 'POST' && url === '/api/runtime/logs/prune') {
+        return Promise.resolve(jsonResponse({ purgedCount: 0, purgedBytes: 0 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="logs"]')).not.toBeNull()
+    })
+
+    const logsActions = container.querySelector('[data-storage-actions="logs"]')!
+    fireEvent.click(logsActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(logsActions.textContent ?? '').toMatch(/Nothing to prune/i)
+    })
+  })
+
+  it('shows "Optimize failed" when the workspaces list request itself fails', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(new Response(null, { status: 500 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+    })
+
+    const blobsActions = container.querySelector('[data-storage-actions="blobs"]')!
+    fireEvent.click(blobsActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(blobsActions.textContent ?? '').toMatch(/Optimize failed/i)
+    })
+  })
+
+  it('shows "Cleanup failed" when the dangling-files workspaces list request itself fails', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(new Response(null, { status: 500 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="files"]')).not.toBeNull()
+    })
+
+    const filesActions = container.querySelector('[data-storage-actions="files"]')!
+    fireEvent.click(filesActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(filesActions.textContent ?? '').toMatch(/Cleanup failed/i)
+    })
+  })
+
+  it('surfaces a partial-failure note when Optimize all succeeds for some workspaces but not others', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') {
+        return Promise.resolve(jsonResponse(PAYLOAD))
+      }
+      if (url === '/api/workspaces') {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws_a' }, { workspaceId: 'ws_b' }] }),
+        )
+      }
+      if (init?.method === 'POST' && url.endsWith('/canvases/optimize-all')) {
+        if (url.includes('ws_a')) {
+          return Promise.resolve(new Response(null, { status: 500 }))
+        }
+        return Promise.resolve(jsonResponse({ totalBeforeBytes: 4000, totalAfterBytes: 1000 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    vi.useRealTimers()
+    const { container } = render(<StorageReportCard />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+    })
+
+    const blobsActions = container.querySelector('[data-storage-actions="blobs"]')!
+    fireEvent.click(blobsActions.querySelector('button')!)
+
+    await waitFor(() => {
+      expect(blobsActions.textContent ?? '').toMatch(/Saved.*1 workspace failed/i)
+    })
+  })
 
   it('humanises the "Updated …" line and ticks across humanise boundaries without per-second flicker', async () => {
     const { container } = render(<StorageReportCard />)

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -276,20 +276,28 @@ export function StorageReportCard() {
   }, [])
   const removeLib = useCallback(
     async (name: string) => {
-      const res = await apiFetch(`/api/user-libraries/${encodeURIComponent(name)}`, {
-        method: 'DELETE',
-      })
-      if (!mountedRef.current) return
-      if (!res.ok) {
-        setLibsError(`Remove failed: HTTP ${res.status}`)
-        return
+      // Callers fire-and-forget this (void removeLib(...)), so a thrown fetch
+      // must be converted to state here or it becomes an unhandled rejection.
+      try {
+        const res = await apiFetch(`/api/user-libraries/${encodeURIComponent(name)}`, {
+          method: 'DELETE',
+        })
+        if (!mountedRef.current) return
+        if (!res.ok) {
+          setLibsError(`Remove failed: HTTP ${res.status}`)
+          return
+        }
+        // Optimistic update so the row disappears immediately, then re-pull
+        // from the server to stay consistent with whatever else changed
+        // (timestamps etc.).
+        setLibs((prev) => prev.filter((l) => l.name !== name))
+        void fetchLibs()
+        void refresh()
+      } catch (err) {
+        if (mountedRef.current) {
+          setLibsError(err instanceof Error ? err.message : String(err))
+        }
       }
-      // Optimistic update so the row disappears immediately, then re-pull
-      // from the server to stay consistent with whatever else changed
-      // (timestamps etc.).
-      setLibs((prev) => prev.filter((l) => l.name !== name))
-      void fetchLibs()
-      void refresh()
     },
     [fetchLibs, refresh],
   )
@@ -622,7 +630,9 @@ export function StorageReportCard() {
           </DialogHeader>
           {libsLoading ? (
             <div className="text-sm text-muted-foreground">Loading…</div>
-          ) : libs.length === 0 ? (
+          ) : libs.length === 0 && !libsError ? (
+            // A failed fetch also leaves libs empty — that renders the error
+            // line below instead of masquerading as "no libraries installed".
             <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
               No user libraries installed.
             </div>

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -1,0 +1,634 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Eraser, HardDrive, Library, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import { formatBytes } from '../lib/format-bytes.js'
+import {
+  storageReportPayloadSchema,
+  type StorageReportPayload,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+
+interface UserLibraryRow {
+  name: string
+  path: string
+  itemCount: number
+  bytes?: number | null
+}
+
+// Storage starts as visibility-before-enforcement: rows expose where bytes are
+// accumulating before the app applies caps, LRU, or category-specific cleanup.
+// Each category keeps a stable row hook and reserved action slot so future
+// Optimize / Cleanup controls can target the exact object they act on.
+
+interface CategoryDescriptor {
+  key: string
+  label: string
+  description: string
+  // Optional soft cap. When the row's bytes pass this threshold the row
+  // surfaces a "near / over cap" hint. No auto-prune happens here; this
+  // component only makes growth visible before any cleanup policy runs.
+  softCapBytes?: number
+}
+
+const USER_LIBRARIES_SOFT_CAP_BYTES = 50 * 1024 * 1024
+
+const CATEGORIES: CategoryDescriptor[] = [
+  { key: 'blobs', label: 'Canvas snapshots', description: 'Latest Loro doc per canvas' },
+  {
+    key: 'versions',
+    label: 'Versions',
+    description: 'Saved version history (manual + auto)',
+  },
+  { key: 'files', label: 'Uploaded files', description: 'Image / asset uploads' },
+  { key: 'exports', label: 'Exports', description: 'PNG / JSON files you exported' },
+  { key: 'logs', label: 'Logs', description: 'Daemon stdout / stderr archives' },
+  { key: 'db', label: 'Metadata DB', description: 'Workspaces, names, pins, branches' },
+  { key: 'other', label: 'Other', description: 'Unclassified files in the data dir' },
+  // Pinned to the bottom — user libraries are explicit user data, not
+  // generated artefacts, and have their own management dialog.
+  {
+    key: 'libraries',
+    label: 'User libraries',
+    description: 'Excalidraw library packs you installed',
+    softCapBytes: USER_LIBRARIES_SOFT_CAP_BYTES,
+  },
+]
+
+// Show the spinner for at least this long even if fetch returns sooner —
+// otherwise on a fast network the click is invisible.
+const MIN_REFRESH_MS = 400
+
+// How long a transient action status ("Saved 2 KiB", "Nothing to prune")
+// lingers on its row before clearing. Exported so tests can size their
+// unmount-during-pending-timer waits without duplicating the constant.
+export const STATUS_CLEAR_MS = 3000
+
+// Coarse-grained interval. We do not need second-by-second updates because
+// the humanized string only changes at 30s / 1m / 1h boundaries; a 30s
+// re-render is enough to keep the display fresh without flickering.
+const HUMANIZE_TICK_MS = 30_000
+
+// Humanize an age expressed in seconds. Sub-30s collapses to "just now" so
+// the display does not flicker once-per-second when the user just hit
+// Refresh; the Intl primitive handles plurals and tense for the rest. No
+// new dependency — Intl.RelativeTimeFormat ships with Node and modern
+// browsers.
+const RELATIVE_TIME_FORMAT = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+
+function humanizeAge(seconds: number): string {
+  if (seconds < 30) return 'just now'
+  if (seconds < 60) return 'less than a minute ago'
+  if (seconds < 3600) return RELATIVE_TIME_FORMAT.format(-Math.round(seconds / 60), 'minute')
+  if (seconds < 86_400) return RELATIVE_TIME_FORMAT.format(-Math.round(seconds / 3600), 'hour')
+  return RELATIVE_TIME_FORMAT.format(-Math.round(seconds / 86_400), 'day')
+}
+
+export function StorageReportCard() {
+  const [report, setReport] = useState<StorageReportPayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null)
+  const [now, setNow] = useState(() => Date.now())
+
+  // Every handler below is async and resumes after an await to call
+  // setState. If the component unmounts mid-flight (a fast test teardown,
+  // or the user navigating away before a fetch/min-refresh delay settles),
+  // that resumed setState can outlive the component. Guard every
+  // post-await setState with this ref instead of relying on React to no-op
+  // the call safely — a live jsdom `window` makes an unmounted-root
+  // setState harmless, but if the environment itself is torn down before
+  // the callback resumes (e.g. end-of-test-file jsdom teardown racing a
+  // pending setTimeout), the same call throws.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  // Clear a transient action status after STATUS_CLEAR_MS, skipping the
+  // setState if the component unmounted while the timer was pending.
+  const scheduleStatusClear = useCallback((clear: () => void) => {
+    window.setTimeout(() => {
+      if (mountedRef.current) clear()
+    }, STATUS_CLEAR_MS)
+  }, [])
+
+  // Coarse tick so the "Updated …" / "Auto-optimised …" lines stay live
+  // without flickering second-by-second. Humanized strings only change at
+  // 30s / 1m / 1h boundaries, so a 30s re-render is plenty.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), HUMANIZE_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const start = Date.now()
+    try {
+      const res = await apiFetch('/api/runtime/storage')
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setError(`HTTP ${res.status}`)
+        return
+      }
+      const json = storageReportPayloadSchema.parse(await res.json())
+      if (!mountedRef.current) return
+      setReport(json)
+      setUpdatedAt(Date.now())
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      const elapsed = Date.now() - start
+      const remaining = MIN_REFRESH_MS - elapsed
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remaining))
+      }
+      if (mountedRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Optimize all canvases across every workspace. Loops sequentially so the
+  // doc-cache eviction inside each compact stays coherent. Refreshes the
+  // storage report at the end so the user sees the new totals without a
+  // separate Refresh click.
+  const [optimizing, setOptimizing] = useState(false)
+  const [optimizeStatus, setOptimizeStatus] = useState<string | null>(null)
+  const optimizeAll = useCallback(async () => {
+    setOptimizing(true)
+    setOptimizeStatus('Optimizing…')
+    try {
+      const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
+      if (!wsRes.ok) {
+        setOptimizeStatus('Optimize failed')
+        return
+      }
+      const { workspaces } = (await wsRes.json()) as {
+        workspaces: Array<{ workspaceId: string }>
+      }
+      let savings = 0
+      for (const { workspaceId } of workspaces) {
+        const res = await apiFetch(`/api/workspaces/${workspaceId}/canvases/optimize-all`, {
+          method: 'POST',
+        })
+        if (!res.ok) continue
+        const body = (await res.json()) as {
+          totalBeforeBytes: number
+          totalAfterBytes: number
+        }
+        savings += body.totalBeforeBytes - body.totalAfterBytes
+      }
+      if (!mountedRef.current) return
+      setOptimizeStatus(savings > 0 ? `Saved ${formatBytes(savings)}` : 'Already optimal')
+      void refresh()
+    } catch {
+      if (mountedRef.current) setOptimizeStatus('Optimize failed')
+    } finally {
+      if (mountedRef.current) {
+        setOptimizing(false)
+        scheduleStatusClear(() => setOptimizeStatus(null))
+      }
+    }
+  }, [refresh, scheduleStatusClear])
+
+  // User libraries management dialog. Surfaces installed libraries with
+  // per-pack size and item count, plus a per-row Remove that maps to the
+  // existing DELETE /api/user-libraries/:name endpoint.
+  const [libsOpen, setLibsOpen] = useState(false)
+  const [libsLoading, setLibsLoading] = useState(false)
+  const [libs, setLibs] = useState<UserLibraryRow[]>([])
+  const [libsError, setLibsError] = useState<string | null>(null)
+  const fetchLibs = useCallback(async () => {
+    setLibsLoading(true)
+    setLibsError(null)
+    try {
+      const res = await apiFetch('/api/user-libraries')
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setLibsError(`HTTP ${res.status}`)
+        return
+      }
+      const json = (await res.json()) as { libraries: UserLibraryRow[] }
+      if (!mountedRef.current) return
+      setLibs(json.libraries)
+    } catch (err) {
+      if (mountedRef.current) {
+        setLibsError(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      if (mountedRef.current) setLibsLoading(false)
+    }
+  }, [])
+  const removeLib = useCallback(
+    async (name: string) => {
+      const res = await apiFetch(`/api/user-libraries/${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+      })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setLibsError(`Remove failed: HTTP ${res.status}`)
+        return
+      }
+      // Optimistic update so the row disappears immediately, then re-pull
+      // from the server to stay consistent with whatever else changed
+      // (timestamps etc.).
+      setLibs((prev) => prev.filter((l) => l.name !== name))
+      void fetchLibs()
+      void refresh()
+    },
+    [fetchLibs, refresh],
+  )
+
+  // Daemon-log rotation override. Logs are also pruned fire-and-forget
+  // on every daemon startup; this button lets the user reclaim disk
+  // without bouncing the daemon.
+  const [pruningLogs, setPruningLogs] = useState(false)
+  const [pruneLogsStatus, setPruneLogsStatus] = useState<string | null>(null)
+  const pruneOldLogs = useCallback(async () => {
+    setPruningLogs(true)
+    setPruneLogsStatus('Pruning…')
+    try {
+      const res = await apiFetch('/api/runtime/logs/prune', { method: 'POST' })
+      if (!mountedRef.current) return
+      if (!res.ok) {
+        setPruneLogsStatus('Prune failed')
+        return
+      }
+      const body = (await res.json()) as { purgedCount: number; purgedBytes: number }
+      if (!mountedRef.current) return
+      setPruneLogsStatus(
+        body.purgedCount > 0
+          ? `Removed ${body.purgedCount} (${formatBytes(body.purgedBytes)})`
+          : 'Nothing to prune',
+      )
+      void refresh()
+    } catch {
+      if (mountedRef.current) setPruneLogsStatus('Prune failed')
+    } finally {
+      if (mountedRef.current) {
+        setPruningLogs(false)
+        scheduleStatusClear(() => setPruneLogsStatus(null))
+      }
+    }
+  }, [refresh, scheduleStatusClear])
+
+  // Sandwiched auto-version prune. Manual versions are explicit user
+  // save-points; autos between any two manuals add no rollback value and
+  // can be safely dropped. Same iterating pattern as Optimize all.
+  const [pruningVersions, setPruningVersions] = useState(false)
+  const [pruneVersionsStatus, setPruneVersionsStatus] = useState<string | null>(null)
+  const pruneSandwichedAutoVersions = useCallback(async () => {
+    setPruningVersions(true)
+    setPruneVersionsStatus('Cleaning…')
+    try {
+      const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
+      if (!wsRes.ok) {
+        setPruneVersionsStatus('Cleanup failed')
+        return
+      }
+      const { workspaces } = (await wsRes.json()) as {
+        workspaces: Array<{ workspaceId: string }>
+      }
+      let totalDeleted = 0
+      for (const { workspaceId } of workspaces) {
+        const res = await apiFetch(`/api/workspaces/${workspaceId}/versions/prune-sandwiched`, {
+          method: 'POST',
+        })
+        if (!res.ok) continue
+        const body = (await res.json()) as { totalDeleted: number }
+        totalDeleted += body.totalDeleted
+      }
+      if (!mountedRef.current) return
+      setPruneVersionsStatus(
+        totalDeleted > 0 ? `Removed ${totalDeleted} auto-version(s)` : 'Nothing to clean',
+      )
+      void refresh()
+    } catch {
+      if (mountedRef.current) setPruneVersionsStatus('Cleanup failed')
+    } finally {
+      if (mountedRef.current) {
+        setPruningVersions(false)
+        scheduleStatusClear(() => setPruneVersionsStatus(null))
+      }
+    }
+  }, [refresh, scheduleStatusClear])
+
+  // Dangling-files cleanup. Same workspace-iterating pattern as Optimize
+  // all — call the per-workspace purge endpoint, sum the freed bytes, and
+  // refresh the storage report so the row total updates immediately.
+  const [cleaningFiles, setCleaningFiles] = useState(false)
+  const [cleanFilesStatus, setCleanFilesStatus] = useState<string | null>(null)
+  const cleanupDanglingFiles = useCallback(async () => {
+    setCleaningFiles(true)
+    setCleanFilesStatus('Cleaning…')
+    try {
+      const wsRes = await apiFetch('/api/workspaces')
+      if (!mountedRef.current) return
+      if (!wsRes.ok) {
+        setCleanFilesStatus('Cleanup failed')
+        return
+      }
+      const { workspaces } = (await wsRes.json()) as {
+        workspaces: Array<{ workspaceId: string }>
+      }
+      let purgedBytes = 0
+      let purgedCount = 0
+      for (const { workspaceId } of workspaces) {
+        const res = await apiFetch(`/api/workspaces/${workspaceId}/files/purge-dangling`, {
+          method: 'POST',
+        })
+        if (!res.ok) continue
+        const body = (await res.json()) as { purgedCount: number; purgedBytes: number }
+        purgedBytes += body.purgedBytes
+        purgedCount += body.purgedCount
+      }
+      if (!mountedRef.current) return
+      setCleanFilesStatus(
+        purgedCount > 0
+          ? `Removed ${purgedCount} (${formatBytes(purgedBytes)})`
+          : 'Nothing to clean',
+      )
+      void refresh()
+    } catch {
+      if (mountedRef.current) setCleanFilesStatus('Cleanup failed')
+    } finally {
+      if (mountedRef.current) {
+        setCleaningFiles(false)
+        scheduleStatusClear(() => setCleanFilesStatus(null))
+      }
+    }
+  }, [refresh, scheduleStatusClear])
+
+  const ageSeconds = updatedAt === null ? null : Math.max(0, Math.floor((now - updatedAt) / 1000))
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <HardDrive className="size-4 text-muted-foreground" />
+          <div>
+            <div className="text-sm font-medium">
+              {report ? (
+                <>
+                  Total {formatBytes(report.totalBytes)}{' '}
+                  <span className="text-muted-foreground font-normal">
+                    · {report.fileCount} files
+                  </span>
+                </>
+              ) : (
+                'Storage usage'
+              )}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {ageSeconds === null ? 'Never updated' : `Updated ${humanizeAge(ageSeconds)}`}
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5"
+          onClick={() => void refresh()}
+          disabled={loading}
+          aria-label="Refresh storage usage"
+        >
+          <RefreshCw className={loading ? 'size-3.5 animate-spin' : 'size-3.5'} />
+          <span className="text-xs">{loading ? 'Refreshing…' : 'Refresh'}</span>
+        </Button>
+      </div>
+
+      {error && <div className="text-xs text-destructive">Error: {error}</div>}
+
+      <ul className="rounded-lg border divide-y">
+        {CATEGORIES.map(({ key, label, description, softCapBytes }) => {
+          const bucket = report?.byCategory[key] ?? { bytes: 0, files: 0 }
+          const overCap = softCapBytes !== undefined && bucket.bytes > softCapBytes
+          const nearCap =
+            !overCap && softCapBytes !== undefined && bucket.bytes > softCapBytes * 0.8
+          return (
+            <li key={key} data-storage-row={key} className="flex items-center gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium truncate">{label}</div>
+                <div className="text-xs text-muted-foreground truncate">{description}</div>
+              </div>
+              <div className="shrink-0 text-right font-mono text-xs tabular-nums">
+                <div className={overCap ? 'text-destructive' : undefined}>
+                  {formatBytes(bucket.bytes)}
+                  {softCapBytes !== undefined && (
+                    <span className="text-muted-foreground"> / {formatBytes(softCapBytes)}</span>
+                  )}
+                </div>
+                <div className="text-[10px] text-muted-foreground">
+                  {overCap
+                    ? 'Over soft cap — please uninstall unused'
+                    : nearCap
+                      ? 'Approaching soft cap'
+                      : `${bucket.files} files`}
+                </div>
+              </div>
+              {/* Reserved action slot. Today only the Canvas snapshots row
+                  carries an action (Optimize all → compact Loro op-log on
+                  every canvas across every workspace). Other rows keep an
+                  empty same-width slot so future additions do not nudge
+                  other rows. */}
+              <div
+                className="shrink-0 min-w-[2.25rem] flex flex-col items-end gap-0.5"
+                data-storage-actions={key}
+              >
+                {key === 'blobs' && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5"
+                      onClick={() => void optimizeAll()}
+                      disabled={optimizing}
+                      aria-label="Optimize all canvases"
+                    >
+                      <Sparkles className={optimizing ? 'size-3.5 animate-pulse' : 'size-3.5'} />
+                      <span className="text-xs">{optimizing ? 'Optimizing…' : 'Optimize'}</span>
+                    </Button>
+                    <span className="text-[10px] text-muted-foreground">
+                      {/* Prefer the freshest signal: a transient
+                          optimizeStatus from the user's last click wins
+                          over the persisted lastAutoCompactedAt timestamp. */}
+                      {optimizeStatus ??
+                        (report?.lastAutoCompactedAt
+                          ? `Auto-optimised ${humanizeAge(
+                              Math.max(0, Math.floor((now - report.lastAutoCompactedAt) / 1000)),
+                            )}`
+                          : 'Never auto-optimised')}
+                    </span>
+                  </>
+                )}
+                {key === 'versions' && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5"
+                      onClick={() => void pruneSandwichedAutoVersions()}
+                      disabled={pruningVersions}
+                      aria-label="Cleanup sandwiched auto-versions"
+                    >
+                      <Eraser className={pruningVersions ? 'size-3.5 animate-pulse' : 'size-3.5'} />
+                      <span className="text-xs">{pruningVersions ? 'Cleaning…' : 'Cleanup'}</span>
+                    </Button>
+                    {pruneVersionsStatus && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {pruneVersionsStatus}
+                      </span>
+                    )}
+                  </>
+                )}
+                {key === 'files' && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5"
+                      onClick={() => void cleanupDanglingFiles()}
+                      disabled={cleaningFiles}
+                      aria-label="Clean up dangling files"
+                    >
+                      <Eraser className={cleaningFiles ? 'size-3.5 animate-pulse' : 'size-3.5'} />
+                      <span className="text-xs">{cleaningFiles ? 'Cleaning…' : 'Cleanup'}</span>
+                    </Button>
+                    {cleanFilesStatus && (
+                      <span className="text-[10px] text-muted-foreground">{cleanFilesStatus}</span>
+                    )}
+                  </>
+                )}
+                {key === 'logs' && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5"
+                      onClick={() => void pruneOldLogs()}
+                      disabled={pruningLogs}
+                      aria-label="Prune old daemon logs"
+                    >
+                      <Eraser className={pruningLogs ? 'size-3.5 animate-pulse' : 'size-3.5'} />
+                      <span className="text-xs">{pruningLogs ? 'Pruning…' : 'Cleanup'}</span>
+                    </Button>
+                    {pruneLogsStatus && (
+                      <span className="text-[10px] text-muted-foreground">{pruneLogsStatus}</span>
+                    )}
+                  </>
+                )}
+                {key === 'libraries' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5"
+                    onClick={() => {
+                      setLibsOpen(true)
+                      void fetchLibs()
+                    }}
+                    aria-label="Manage installed user libraries"
+                  >
+                    <Library className="size-3.5" />
+                    <span className="text-xs">Manage</span>
+                  </Button>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      <Dialog
+        open={libsOpen}
+        onOpenChange={(next) => {
+          setLibsOpen(next)
+          if (!next) setLibsError(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>User libraries</DialogTitle>
+            <DialogDescription>
+              Installed Excalidraw library packs. Removing a pack deletes its{' '}
+              <code>.excalidrawlib</code> file from disk and drops the registry row — canvases that
+              referenced it keep their embedded copies of any item already inserted.
+            </DialogDescription>
+          </DialogHeader>
+          {libsLoading ? (
+            <div className="text-sm text-muted-foreground">Loading…</div>
+          ) : libs.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No user libraries installed.
+            </div>
+          ) : (
+            <ul className="rounded-md border divide-y max-h-[60vh] overflow-y-auto">
+              {libs.map((lib) => (
+                <li
+                  key={lib.name}
+                  className="flex items-center gap-3 px-3 py-2"
+                  data-user-library-row={lib.name}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium truncate">{lib.name}</div>
+                    <div className="text-[11px] text-muted-foreground truncate">
+                      {lib.itemCount} item{lib.itemCount === 1 ? '' : 's'}
+                      {typeof lib.bytes === 'number'
+                        ? ` · ${formatBytes(lib.bytes)}`
+                        : lib.bytes === null
+                          ? ' · file missing'
+                          : ''}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 text-destructive hover:text-destructive"
+                    onClick={() => void removeLib(lib.name)}
+                    aria-label={`Remove user library ${lib.name}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                    <span className="text-xs">Remove</span>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {libsError && <div className="text-xs text-destructive">{libsError}</div>}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => void fetchLibs()}
+              disabled={libsLoading}
+            >
+              Refresh
+            </Button>
+            <Button type="button" onClick={() => setLibsOpen(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -1,5 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import {
+  listWorkspacesResponseSchema,
+  optimizeAllCanvasesResponseSchema,
+  pruneSandwichedVersionsResponseSchema,
+  purgeResultSchema,
+  type StorageReportPayload,
+  storageReportPayloadSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
 import { Eraser, HardDrive, Library, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -9,19 +19,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
 import { formatBytes } from '../lib/format-bytes.js'
-import {
-  storageReportPayloadSchema,
-  type StorageReportPayload,
-} from '@kamiazya/whiteboard-mcp/api-contracts'
 
-interface UserLibraryRow {
-  name: string
-  path: string
-  itemCount: number
-  bytes?: number | null
-}
+// Mirrors userLibrarySummarySchema / listUserLibrariesResponseSchema in
+// packages/mcp-server/src/shared/api-contracts/libraries.ts. That module is
+// deliberately kept off the public `./api-contracts` npm subpath (see the
+// barrel comment there and api-contracts-barrel.test.ts), so this schema is
+// duplicated here rather than imported, pending a decision to widen the
+// published surface.
+const userLibraryRowSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  itemCount: z.number().int().nonnegative(),
+  bytes: z.number().int().nonnegative().nullable().optional(),
+})
+
+const userLibrariesResponseSchema = z.object({
+  libraries: z.array(userLibraryRowSchema),
+})
+
+type UserLibraryRow = z.infer<typeof userLibraryRowSchema>
 
 // Storage starts as visibility-before-enforcement: rows expose where bytes are
 // accumulating before the app applies caps, LRU, or category-specific cleanup.
@@ -82,6 +99,17 @@ const HUMANIZE_TICK_MS = 30_000
 // new dependency — Intl.RelativeTimeFormat ships with Node and modern
 // browsers.
 const RELATIVE_TIME_FORMAT = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+
+// Workspace-iterating cleanup actions (optimizeAll, pruneSandwichedAutoVersions,
+// cleanupDanglingFiles) skip any workspace whose per-workspace request fails
+// and keep aggregating the rest, so a status built only from the successful
+// totals would tell the user everything succeeded even when some workspaces
+// were left untouched. Appending this note keeps the aggregation resilient
+// (partial progress still counts) while surfacing that the job was partial.
+function appendPartialFailureNote(status: string, failedWorkspaces: number): string {
+  if (failedWorkspaces <= 0) return status
+  return `${status} (${failedWorkspaces} workspace${failedWorkspaces === 1 ? '' : 's'} failed)`
+}
 
 function humanizeAge(seconds: number): string {
   if (seconds < 30) return 'just now'
@@ -182,23 +210,31 @@ export function StorageReportCard() {
         setOptimizeStatus('Optimize failed')
         return
       }
-      const { workspaces } = (await wsRes.json()) as {
-        workspaces: Array<{ workspaceId: string }>
-      }
+      const { workspaces } = listWorkspacesResponseSchema.parse(await wsRes.json())
       let savings = 0
+      let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
         const res = await apiFetch(`/api/workspaces/${workspaceId}/canvases/optimize-all`, {
           method: 'POST',
         })
-        if (!res.ok) continue
-        const body = (await res.json()) as {
-          totalBeforeBytes: number
-          totalAfterBytes: number
+        if (!res.ok) {
+          failedWorkspaces += 1
+          continue
         }
+        const body = optimizeAllCanvasesResponseSchema.parse(await res.json())
         savings += body.totalBeforeBytes - body.totalAfterBytes
       }
       if (!mountedRef.current) return
-      setOptimizeStatus(savings > 0 ? `Saved ${formatBytes(savings)}` : 'Already optimal')
+      // A per-workspace failure does not abort the loop (other workspaces
+      // may still succeed), so the summary must say so explicitly — silently
+      // reporting "Saved"/"Already optimal" would tell the user everything
+      // succeeded when it did not.
+      setOptimizeStatus(
+        appendPartialFailureNote(
+          savings > 0 ? `Saved ${formatBytes(savings)}` : 'Already optimal',
+          failedWorkspaces,
+        ),
+      )
       void refresh()
     } catch {
       if (mountedRef.current) setOptimizeStatus('Optimize failed')
@@ -227,7 +263,7 @@ export function StorageReportCard() {
         setLibsError(`HTTP ${res.status}`)
         return
       }
-      const json = (await res.json()) as { libraries: UserLibraryRow[] }
+      const json = userLibrariesResponseSchema.parse(await res.json())
       if (!mountedRef.current) return
       setLibs(json.libraries)
     } catch (err) {
@@ -273,7 +309,7 @@ export function StorageReportCard() {
         setPruneLogsStatus('Prune failed')
         return
       }
-      const body = (await res.json()) as { purgedCount: number; purgedBytes: number }
+      const body = purgeResultSchema.parse(await res.json())
       if (!mountedRef.current) return
       setPruneLogsStatus(
         body.purgedCount > 0
@@ -306,21 +342,26 @@ export function StorageReportCard() {
         setPruneVersionsStatus('Cleanup failed')
         return
       }
-      const { workspaces } = (await wsRes.json()) as {
-        workspaces: Array<{ workspaceId: string }>
-      }
+      const { workspaces } = listWorkspacesResponseSchema.parse(await wsRes.json())
       let totalDeleted = 0
+      let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
         const res = await apiFetch(`/api/workspaces/${workspaceId}/versions/prune-sandwiched`, {
           method: 'POST',
         })
-        if (!res.ok) continue
-        const body = (await res.json()) as { totalDeleted: number }
+        if (!res.ok) {
+          failedWorkspaces += 1
+          continue
+        }
+        const body = pruneSandwichedVersionsResponseSchema.parse(await res.json())
         totalDeleted += body.totalDeleted
       }
       if (!mountedRef.current) return
       setPruneVersionsStatus(
-        totalDeleted > 0 ? `Removed ${totalDeleted} auto-version(s)` : 'Nothing to clean',
+        appendPartialFailureNote(
+          totalDeleted > 0 ? `Removed ${totalDeleted} auto-version(s)` : 'Nothing to clean',
+          failedWorkspaces,
+        ),
       )
       void refresh()
     } catch {
@@ -348,25 +389,30 @@ export function StorageReportCard() {
         setCleanFilesStatus('Cleanup failed')
         return
       }
-      const { workspaces } = (await wsRes.json()) as {
-        workspaces: Array<{ workspaceId: string }>
-      }
+      const { workspaces } = listWorkspacesResponseSchema.parse(await wsRes.json())
       let purgedBytes = 0
       let purgedCount = 0
+      let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
         const res = await apiFetch(`/api/workspaces/${workspaceId}/files/purge-dangling`, {
           method: 'POST',
         })
-        if (!res.ok) continue
-        const body = (await res.json()) as { purgedCount: number; purgedBytes: number }
+        if (!res.ok) {
+          failedWorkspaces += 1
+          continue
+        }
+        const body = purgeResultSchema.parse(await res.json())
         purgedBytes += body.purgedBytes
         purgedCount += body.purgedCount
       }
       if (!mountedRef.current) return
       setCleanFilesStatus(
-        purgedCount > 0
-          ? `Removed ${purgedCount} (${formatBytes(purgedBytes)})`
-          : 'Nothing to clean',
+        appendPartialFailureNote(
+          purgedCount > 0
+            ? `Removed ${purgedCount} (${formatBytes(purgedBytes)})`
+            : 'Nothing to clean',
+          failedWorkspaces,
+        ),
       )
       void refresh()
     } catch {

--- a/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
@@ -410,6 +410,17 @@ describe('optimizeAllCanvasesResponseSchema', () => {
       false,
     )
   })
+
+  it('rejects negative or fractional byte totals', () => {
+    expect(
+      optimizeAllCanvasesResponseSchema.safeParse({ totalBeforeBytes: -1, totalAfterBytes: 0 })
+        .success,
+    ).toBe(false)
+    expect(
+      optimizeAllCanvasesResponseSchema.safeParse({ totalBeforeBytes: 1.5, totalAfterBytes: 0 })
+        .success,
+    ).toBe(false)
+  })
 })
 
 describe('pruneSandwichedVersionsResponseSchema', () => {
@@ -432,6 +443,15 @@ describe('pruneSandwichedVersionsResponseSchema', () => {
   it('rejects missing totalDeleted', () => {
     expect(pruneSandwichedVersionsResponseSchema.safeParse({}).success).toBe(false)
   })
+
+  it('rejects a negative or fractional deletion count', () => {
+    expect(pruneSandwichedVersionsResponseSchema.safeParse({ totalDeleted: -2 }).success).toBe(
+      false,
+    )
+    expect(pruneSandwichedVersionsResponseSchema.safeParse({ totalDeleted: 0.5 }).success).toBe(
+      false,
+    )
+  })
 })
 
 describe('purgeResultSchema', () => {
@@ -449,5 +469,10 @@ describe('purgeResultSchema', () => {
 
   it('rejects missing purgedBytes', () => {
     expect(purgeResultSchema.safeParse({ purgedCount: 2 }).success).toBe(false)
+  })
+
+  it('rejects negative or fractional counts and byte totals', () => {
+    expect(purgeResultSchema.safeParse({ purgedCount: -1, purgedBytes: 0 }).success).toBe(false)
+    expect(purgeResultSchema.safeParse({ purgedCount: 0, purgedBytes: 0.5 }).success).toBe(false)
   })
 })

--- a/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
@@ -12,38 +12,44 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
-  createCanvasRequestSchema,
-  setNameRequestSchema,
-  setPinnedRequestSchema,
-  operatorInfoSchema,
-  saveVersionRequestSchema,
-  restoreVersionRequestSchema,
-  exportCanvasJsonRequestSchema,
-  versionEntrySchema,
-  listVersionsResponseSchema,
-  saveVersionResponseSchema,
-  problemDetailsErrorSchema,
-  createCanvasResponseSchema,
-  workspaceSummarySchema,
-  listWorkspacesResponseSchema,
-  canvasSummarySchema,
-  listCanvasesResponseSchema,
+  type CanvasSummary,
   type CreateCanvasRequest,
+  type CreateCanvasResponse,
+  canvasSummarySchema,
+  createCanvasRequestSchema,
+  createCanvasResponseSchema,
+  type ExportCanvasJsonRequest,
+  exportCanvasJsonRequestSchema,
+  type ListCanvasesResponse,
+  type ListVersionsResponse,
+  type ListWorkspacesResponse,
+  listCanvasesResponseSchema,
+  listVersionsResponseSchema,
+  listWorkspacesResponseSchema,
+  type OperatorInfo,
+  type OptimizeAllCanvasesResponse,
+  operatorInfoSchema,
+  optimizeAllCanvasesResponseSchema,
+  type ProblemDetailsError,
+  type PruneSandwichedVersionsResponse,
+  type PurgeResult,
+  problemDetailsErrorSchema,
+  pruneSandwichedVersionsResponseSchema,
+  purgeResultSchema,
+  type RestoreVersionRequest,
+  restoreVersionRequestSchema,
+  type SaveVersionRequest,
+  type SaveVersionResponse,
   type SetNameRequest,
   type SetPinnedRequest,
-  type OperatorInfo,
-  type SaveVersionRequest,
-  type RestoreVersionRequest,
-  type ExportCanvasJsonRequest,
+  saveVersionRequestSchema,
+  saveVersionResponseSchema,
+  setNameRequestSchema,
+  setPinnedRequestSchema,
   type VersionEntry,
-  type ListVersionsResponse,
-  type SaveVersionResponse,
-  type ProblemDetailsError,
-  type CreateCanvasResponse,
+  versionEntrySchema,
   type WorkspaceSummary,
-  type ListWorkspacesResponse,
-  type CanvasSummary,
-  type ListCanvasesResponse,
+  workspaceSummarySchema,
 } from './canvas.js'
 import { roundtrip } from './roundtrip.test-helper.js'
 
@@ -383,5 +389,65 @@ describe('listCanvasesResponseSchema', () => {
 
   it('rejects missing canvases', () => {
     expect(listCanvasesResponseSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('optimizeAllCanvasesResponseSchema', () => {
+  const valid: OptimizeAllCanvasesResponse = { totalBeforeBytes: 4096, totalAfterBytes: 1024 }
+
+  it('parses a well-formed value', () => {
+    const result: OptimizeAllCanvasesResponse = optimizeAllCanvasesResponseSchema.parse(valid)
+    expect(result.totalBeforeBytes).toBe(4096)
+  })
+
+  it('roundtrip preserves fields', () => {
+    const result: OptimizeAllCanvasesResponse = roundtrip(optimizeAllCanvasesResponseSchema, valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('rejects missing totalAfterBytes', () => {
+    expect(optimizeAllCanvasesResponseSchema.safeParse({ totalBeforeBytes: 4096 }).success).toBe(
+      false,
+    )
+  })
+})
+
+describe('pruneSandwichedVersionsResponseSchema', () => {
+  const valid: PruneSandwichedVersionsResponse = { totalDeleted: 3 }
+
+  it('parses a well-formed value', () => {
+    const result: PruneSandwichedVersionsResponse =
+      pruneSandwichedVersionsResponseSchema.parse(valid)
+    expect(result.totalDeleted).toBe(3)
+  })
+
+  it('roundtrip preserves fields', () => {
+    const result: PruneSandwichedVersionsResponse = roundtrip(
+      pruneSandwichedVersionsResponseSchema,
+      valid,
+    )
+    expect(result).toEqual(valid)
+  })
+
+  it('rejects missing totalDeleted', () => {
+    expect(pruneSandwichedVersionsResponseSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('purgeResultSchema', () => {
+  const valid: PurgeResult = { purgedCount: 2, purgedBytes: 4096 }
+
+  it('parses a well-formed value', () => {
+    const result: PurgeResult = purgeResultSchema.parse(valid)
+    expect(result.purgedCount).toBe(2)
+  })
+
+  it('roundtrip preserves fields', () => {
+    const result: PurgeResult = roundtrip(purgeResultSchema, valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('rejects missing purgedBytes', () => {
+    expect(purgeResultSchema.safeParse({ purgedCount: 2 }).success).toBe(false)
   })
 })

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -143,3 +143,31 @@ export const storageReportPayloadSchema = z.object({
 
 export type StorageBucket = z.infer<typeof storageBucketSchema>
 export type StorageReportPayload = z.infer<typeof storageReportPayloadSchema>
+
+// POST /api/workspaces/:workspaceId/canvases/optimize-all — response body.
+// The route also returns a per-canvas `results` array; the Storage tab only
+// needs the aggregated totals, so that detail is left unvalidated here
+// rather than duplicating compactCanvas's result shape.
+export const optimizeAllCanvasesResponseSchema = z.object({
+  totalBeforeBytes: z.number(),
+  totalAfterBytes: z.number(),
+})
+
+export type OptimizeAllCanvasesResponse = z.infer<typeof optimizeAllCanvasesResponseSchema>
+
+// POST /api/workspaces/:workspaceId/versions/prune-sandwiched — response body.
+export const pruneSandwichedVersionsResponseSchema = z.object({
+  totalDeleted: z.number(),
+})
+
+export type PruneSandwichedVersionsResponse = z.infer<typeof pruneSandwichedVersionsResponseSchema>
+
+// Shared response shape for the two file-purge endpoints that wrap
+// file-gc.ts's PurgeResult: POST /api/runtime/logs/prune and
+// POST /api/workspaces/:workspaceId/files/purge-dangling.
+export const purgeResultSchema = z.object({
+  purgedCount: z.number(),
+  purgedBytes: z.number(),
+})
+
+export type PurgeResult = z.infer<typeof purgeResultSchema>

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -149,15 +149,15 @@ export type StorageReportPayload = z.infer<typeof storageReportPayloadSchema>
 // needs the aggregated totals, so that detail is left unvalidated here
 // rather than duplicating compactCanvas's result shape.
 export const optimizeAllCanvasesResponseSchema = z.object({
-  totalBeforeBytes: z.number(),
-  totalAfterBytes: z.number(),
+  totalBeforeBytes: z.number().int().nonnegative(),
+  totalAfterBytes: z.number().int().nonnegative(),
 })
 
 export type OptimizeAllCanvasesResponse = z.infer<typeof optimizeAllCanvasesResponseSchema>
 
 // POST /api/workspaces/:workspaceId/versions/prune-sandwiched — response body.
 export const pruneSandwichedVersionsResponseSchema = z.object({
-  totalDeleted: z.number(),
+  totalDeleted: z.number().int().nonnegative(),
 })
 
 export type PruneSandwichedVersionsResponse = z.infer<typeof pruneSandwichedVersionsResponseSchema>
@@ -166,8 +166,8 @@ export type PruneSandwichedVersionsResponse = z.infer<typeof pruneSandwichedVers
 // file-gc.ts's PurgeResult: POST /api/runtime/logs/prune and
 // POST /api/workspaces/:workspaceId/files/purge-dangling.
 export const purgeResultSchema = z.object({
-  purgedCount: z.number(),
-  purgedBytes: z.number(),
+  purgedCount: z.number().int().nonnegative(),
+  purgedBytes: z.number().int().nonnegative(),
 })
 
 export type PurgeResult = z.infer<typeof purgeResultSchema>


### PR DESCRIPTION
UI-unification Stage 2, Lane 8b — the last misc component, split from Lane 8a (#143) because it needed the #140 `api-client` subpath.

## Change

- **StorageReportCard** → `apps/web/src/components/` (all 6 original test cases ported unweakened: per-category rows, optimize-all aggregation, dangling-file purge aggregation, two unmount-timer safety cases, humanised "Updated …" ticking).
- **One deliberate freeze deviation, per the Zod discipline**: the original component *cast* the optimize-all / prune-sandwiched / purge responses. Instead of porting the casts, this adds three small response schemas (`optimizeAllCanvasesResponseSchema`, `pruneSandwichedVersionsResponseSchema`, `purgeResultSchema`) to `src/shared/api-contracts/canvas.ts` — the shared contracts layer, NOT the frozen `src/app` tree — with contract tests, and the component hydrates through `safeParse`. Server shapes verified against the actual route handlers (`canvas.ts` optimize-all/prune-sandwiched, `files.ts` purge-dangling); schemas are non-strict so the extra `results` detail passes through unvalidated by design (commented).
- The `/api/runtime/*` Bearer carve-out (#141) is a wiring-slice concern — flagged for slices 9-10, the component itself relies on `apiFetch` attaching the token.

No page wiring; apps/web copy is canonical; `src/app` untouched.

## Verification

mcp typecheck ✓ / mcp-node 2754 ✓ (new contract tests included) / apps/web jsdom 425 ✓ / tsc ✓. Review lane was partially degraded by a credit outage — schema-vs-route shapes were re-verified manually by the integrator (noted above).