### PR TITLE
feat(web): port branch UI (HeaderBranchChip / HeaderBranchBanner)

### DIFF
--- a/apps/web/src/components/HeaderBranchBanner.test.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.test.tsx
@@ -88,6 +88,15 @@ describe('HeaderBranchBanner', () => {
     expect(screen.queryByTestId('header-branch-banner')).toBeNull()
   })
 
+  it('hides the banner when getBranchStats rejects (failures stay silent)', async () => {
+    state.current.getBranchStats = vi.fn().mockRejectedValue(new Error('network error'))
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await waitFor(() => {
+      expect(state.current.getBranchStats).toHaveBeenCalled()
+    })
+    expect(screen.queryByTestId('header-branch-banner')).toBeNull()
+  })
+
   it('does NOT register an excalidraw:head_changed listener (callback model, not window bus)', () => {
     const addSpy = vi.spyOn(window, 'addEventListener')
     render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)

--- a/apps/web/src/components/HeaderBranchBanner.test.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.test.tsx
@@ -1,0 +1,153 @@
+import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { UseBranchesResult } from '@/hooks/useBranches'
+import { dispatchMergeCommitted, type MergeCommittedDetail } from '@/lib/merge-committed-event'
+
+// MergeDialog touches Excalidraw-adjacent thumbnail fetches; nothing to stub here since
+// this component only mounts MergeDialog behind a closed `open={false}` state by default.
+
+const branches: BranchMeta[] = [
+  { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+  { name: 'feature-a', tipFrontiers: '', color: '#9333ea', createdAt: '2026-04-23T01:00:00Z' },
+]
+
+const state: { current: UseBranchesResult } = {
+  current: {
+    state: { head: 'feature-a', branches },
+    loading: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    createBranch: vi.fn(),
+    deleteBranch: vi.fn(),
+    getBranchStats: vi.fn().mockResolvedValue({ unmergedCommits: 3, isHead: true }),
+    renameBranch: vi.fn(),
+    setHead: vi.fn(),
+    merge: vi.fn(),
+  },
+}
+
+vi.mock('@/hooks/useBranches', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useBranches')>('@/hooks/useBranches')
+  return {
+    ...actual,
+    useBranches: () => state.current,
+  }
+})
+
+import { HeaderBranchBanner } from './HeaderBranchBanner.js'
+
+function baseDetail(overrides: Partial<MergeCommittedDetail> = {}): MergeCommittedDetail {
+  return {
+    workspaceId: 's1',
+    slug: 'c1',
+    sourceName: 'feature-a',
+    targetName: 'main',
+    newCount: 0,
+    changedCount: 0,
+    conflictCount: 0,
+    newElementIds: [],
+    conflictElementIds: [],
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  state.current.state.head = 'feature-a'
+  state.current.getBranchStats = vi.fn().mockResolvedValue({ unmergedCommits: 3, isHead: true })
+})
+
+describe('HeaderBranchBanner', () => {
+  it('does not render the banner when HEAD is main', async () => {
+    state.current.state.head = 'main'
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    // Wait for the initial fetch path.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('header-branch-banner')).toBeNull()
+  })
+
+  it('renders the banner when HEAD is not main and unmergedCommits > 0', async () => {
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
+    })
+    expect(screen.getByText(/changes not yet merged into/)).toBeTruthy()
+    expect(screen.getByText(/3/)).toBeTruthy()
+    expect(screen.getByTestId('header-branch-banner-merge')).toBeTruthy()
+  })
+
+  it('hides the banner when unmergedCommits is 0', async () => {
+    state.current.getBranchStats = vi.fn().mockResolvedValue({ unmergedCommits: 0, isHead: true })
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('header-branch-banner')).toBeNull()
+  })
+
+  it('does NOT register an excalidraw:head_changed listener (callback model, not window bus)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    const registeredEvents = addSpy.mock.calls.map((call) => call[0])
+    expect(registeredEvents).not.toContain('excalidraw:head_changed')
+    addSpy.mockRestore()
+  })
+
+  it('re-fetches stats on a matching merge_committed event', async () => {
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
+    })
+    const callsBefore = (state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length
+
+    await act(async () => {
+      dispatchMergeCommitted(baseDetail())
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(
+        (state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeGreaterThan(callsBefore)
+    })
+  })
+
+  it('ignores a merge_committed event for a different workspace/slug', async () => {
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
+    })
+    const callsBefore = (state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length
+
+    await act(async () => {
+      dispatchMergeCommitted(baseDetail({ workspaceId: 'other-workspace' }))
+      await Promise.resolve()
+    })
+
+    expect((state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsBefore,
+    )
+  })
+
+  it('ignores a Zod-invalid merge_committed event detail', async () => {
+    render(<HeaderBranchBanner workspaceId="s1" slug="c1" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
+    })
+    const callsBefore = (state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('excalidraw:merge_committed', { detail: { not: 'valid' } }),
+      )
+      await Promise.resolve()
+    })
+
+    expect((state.current.getBranchStats as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsBefore,
+    )
+  })
+})

--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -1,0 +1,117 @@
+import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { AlertTriangle, GitMerge } from 'lucide-react'
+import { type JSX, useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import type { MergeResult } from '@/hooks/useBranches'
+import { useBranches } from '@/hooks/useBranches'
+import { MERGE_COMMITTED_EVENT, parseMergeCommittedEvent } from '@/lib/merge-committed-event'
+import { MergeDialog } from './MergeDialog'
+
+// Show a banner under the header when the current branch is ahead of main.
+// - Condition: HEAD !== 'main' and getBranchStats(HEAD).unmergedCommits > 0
+// - Clicking the CTA opens MergeDialog directly with source=HEAD and target=main
+// - Refresh whenever HEAD or branches change; failures stay silent and simply hide the banner
+//
+// Unlike the packages/mcp-server original, this component does not subscribe to an
+// "excalidraw:head_changed" window event: apps/web's useBranches has no such
+// broadcast, so external HEAD changes reach this component passively through
+// its own hook state (a future caller wires useCanvasSync.onHeadChanged ->
+// branches.refetch()). merge_committed stays a window event, but is parsed
+// through the shared Zod contract instead of a hand-written detail cast.
+
+export interface HeaderBranchBannerProps {
+  workspaceId: string
+  slug: string
+}
+
+export function HeaderBranchBanner({
+  workspaceId,
+  slug,
+}: HeaderBranchBannerProps): JSX.Element | null {
+  const { state, getBranchStats, merge: runMerge } = useBranches(workspaceId, slug)
+  const head = state.head
+  const targetBranch: BranchMeta | undefined = state.branches.find((b) => b.name === 'main')
+  const sourceBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
+  const [unmergedCommits, setUnmergedCommits] = useState<number>(0)
+  const [mergeOpen, setMergeOpen] = useState(false)
+
+  // Shared loader for unmerged stats. Skip work and force 0 while HEAD is main.
+  // Refetch on direct head changes and merge_committed events.
+  useEffect(() => {
+    let cancelled = false
+    const refresh = async () => {
+      if (head === 'main') {
+        if (!cancelled) setUnmergedCommits(0)
+        return
+      }
+      try {
+        const s = await getBranchStats(head)
+        if (!cancelled) setUnmergedCommits(s.unmergedCommits)
+      } catch {
+        if (!cancelled) setUnmergedCommits(0)
+      }
+    }
+    refresh()
+    if (typeof window === 'undefined') {
+      return () => {
+        cancelled = true
+      }
+    }
+    const onMergeCommitted = (event: Event) => {
+      const detail = parseMergeCommittedEvent(event)
+      if (!detail) return
+      if (detail.workspaceId !== workspaceId || detail.slug !== slug) return
+      void refresh()
+    }
+    window.addEventListener(MERGE_COMMITTED_EVENT, onMergeCommitted)
+    return () => {
+      cancelled = true
+      window.removeEventListener(MERGE_COMMITTED_EVENT, onMergeCommitted)
+    }
+  }, [head, getBranchStats, workspaceId, slug])
+
+  const visible = useMemo(
+    () => head !== 'main' && unmergedCommits > 0 && !!targetBranch && !!sourceBranch,
+    [head, unmergedCommits, targetBranch, sourceBranch],
+  )
+
+  if (!visible) return null
+
+  return (
+    <>
+      <div
+        role="status"
+        data-testid="header-branch-banner"
+        className="flex items-center gap-3 border-b border-amber-400/40 bg-amber-50 px-3 py-1.5 text-xs text-amber-900"
+      >
+        <AlertTriangle className="size-3.5 shrink-0 text-amber-600" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">
+          Branch «<strong>{head}</strong>» has <strong>{unmergedCommits}</strong> changes not yet
+          merged into main
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 border-amber-400/60 bg-amber-100/70 text-xs text-amber-900 hover:bg-amber-200"
+          data-testid="header-branch-banner-merge"
+          onClick={() => setMergeOpen(true)}
+        >
+          <GitMerge className="size-3.5" />
+          Merge into main
+        </Button>
+      </div>
+      <MergeDialog
+        open={mergeOpen}
+        source={sourceBranch ?? null}
+        target={targetBranch ?? null}
+        onClose={() => setMergeOpen(false)}
+        runMerge={(src, args) => runMerge(src, args) as Promise<MergeResult>}
+        workspaceId={workspaceId}
+        slug={slug}
+      />
+    </>
+  )
+}
+
+export default HeaderBranchBanner

--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -1,6 +1,5 @@
-import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { AlertTriangle, GitMerge } from 'lucide-react'
-import { type JSX, useEffect, useMemo, useState } from 'react'
+import { type JSX, useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import type { MergeResult } from '@/hooks/useBranches'
 import { useBranches } from '@/hooks/useBranches'
@@ -30,9 +29,9 @@ export function HeaderBranchBanner({
 }: HeaderBranchBannerProps): JSX.Element | null {
   const { state, getBranchStats, merge: runMerge } = useBranches(workspaceId, slug)
   const head = state.head
-  const targetBranch: BranchMeta | undefined = state.branches.find((b) => b.name === 'main')
-  const sourceBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
-  const [unmergedCommits, setUnmergedCommits] = useState<number>(0)
+  const targetBranch = state.branches.find((b) => b.name === 'main')
+  const sourceBranch = state.branches.find((b) => b.name === head)
+  const [unmergedCommits, setUnmergedCommits] = useState(0)
   const [mergeOpen, setMergeOpen] = useState(false)
 
   // Shared loader for unmerged stats. Skip work and force 0 while HEAD is main.
@@ -70,10 +69,7 @@ export function HeaderBranchBanner({
     }
   }, [head, getBranchStats, workspaceId, slug])
 
-  const visible = useMemo(
-    () => head !== 'main' && unmergedCommits > 0 && !!targetBranch && !!sourceBranch,
-    [head, unmergedCommits, targetBranch, sourceBranch],
-  )
+  const visible = head !== 'main' && unmergedCommits > 0 && !!targetBranch && !!sourceBranch
 
   if (!visible) return null
 

--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -126,10 +126,11 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     const input = await screen.findByPlaceholderText('New branch name')
     await userEvent.type(input, 'my-new-branch{Enter}')
 
-    // The dropdown stays open on error so the user can retry, which puts the
-    // error banner under Radix's aria-hidden'd background wrapper — query
-    // with `hidden: true` to reach it.
-    const alert = await screen.findByRole('alert', { hidden: true })
+    // The dropdown stays open on error so the user can retry; the error must
+    // render inside the still-open dropdown content, not behind Radix's
+    // aria-hidden'd background wrapper — a plain (non-hidden) query proves
+    // it is actually visible/announced.
+    const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain('Failed to create branch')
   })
 
@@ -160,7 +161,9 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await userEvent.clear(input)
     await userEvent.type(input, 'renamed-branch{Enter}')
 
-    const alert = await screen.findByRole('alert', { hidden: true })
+    // The rename dialog stays open on error; the error must render inside the
+    // still-open dialog content, so a plain (non-hidden) query must find it.
+    const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain('Failed to rename branch')
   })
 
@@ -218,6 +221,41 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await userEvent.type(input, 'renamed-branch{Enter}')
 
     expect(stateHolder.current.renameBranch).toHaveBeenCalledWith('feature-x', 'renamed-branch')
+  })
+
+  it('does not open MergeDialog when HEAD is stale (not yet present in the branches list)', async () => {
+    // Simulates HEAD changing before the branches list has been refetched to
+    // include it: `state.branches.find(b => b.name === head)` is undefined,
+    // so a merge pick must not open MergeDialog with a null target.
+    stateHolder.current.state = { head: 'ghost-branch', branches }
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const mergeItem = await screen.findByText('feature-x')
+    await userEvent.click(mergeItem)
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(stateHolder.current.merge).not.toHaveBeenCalled()
+  })
+
+  it('omits the unmerged-commits count when getBranchStats rejects during delete confirmation', async () => {
+    stateHolder.current.state = { head: 'feature-x', branches }
+    stateHolder.current.getBranchStats = vi.fn().mockRejectedValue(new Error('network error'))
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const deleteItem = await screen.findByText(/Delete/)
+    await userEvent.click(deleteItem)
+
+    await screen.findByText(/Delete «feature-x»\?/)
+    expect(screen.queryByText(/unmerged commits remain/)).toBeNull()
+
+    const confirmButton = await screen.findByRole('button', { name: 'Delete' })
+    await userEvent.click(confirmButton)
+
+    expect(stateHolder.current.deleteBranch).toHaveBeenCalledWith('feature-x')
   })
 
   it('keeps the merge target stable when HEAD changes while the merge dialog is open', async () => {

--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -1,6 +1,6 @@
 import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import type { UseBranchesResult } from '@/hooks/useBranches'
 
@@ -39,8 +39,18 @@ vi.mock('@/hooks/useBranches', async () => {
 
 import { HeaderBranchChip } from './HeaderBranchChip.js'
 
+beforeEach(() => {
+  // MergeDialog's thumbnail-fallback effect calls apiFetch(.../versions); return
+  // an empty (but schema-valid) list so it resolves without a preview image.
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ versions: [] }), { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
 afterEach(() => {
   cleanup()
+  vi.unstubAllGlobals()
   stateHolder.current = makeState()
 })
 
@@ -121,5 +131,117 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     // with `hidden: true` to reach it.
     const alert = await screen.findByRole('alert', { hidden: true })
     expect(alert.textContent).toContain('Failed to create branch')
+  })
+
+  it('surfaces setHead rejection as a role=alert with the safe error copy', async () => {
+    stateHolder.current.setHead = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const chip = screen.getByTestId('header-branch-chip')
+    await userEvent.click(chip)
+
+    const option = await screen.findByText('feature-x')
+    await userEvent.click(option)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Failed to switch branch')
+  })
+
+  it('surfaces renameBranch rejection as a role=alert with the safe error copy', async () => {
+    stateHolder.current.state = { head: 'feature-x', branches }
+    stateHolder.current.renameBranch = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const renameItem = await screen.findByText(/Rename/)
+    await userEvent.click(renameItem)
+
+    const input = await screen.findByPlaceholderText('feature-x')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'renamed-branch{Enter}')
+
+    const alert = await screen.findByRole('alert', { hidden: true })
+    expect(alert.textContent).toContain('Failed to rename branch')
+  })
+
+  it('surfaces deleteBranch rejection as a role=alert with the safe error copy', async () => {
+    stateHolder.current.state = { head: 'feature-x', branches }
+    stateHolder.current.deleteBranch = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const deleteItem = await screen.findByText(/Delete/)
+    await userEvent.click(deleteItem)
+
+    const confirmButton = await screen.findByRole('button', { name: 'Delete' })
+    await userEvent.click(confirmButton)
+
+    const alert = await screen.findByRole('alert', { hidden: true })
+    expect(alert.textContent).toContain('Failed to delete branch')
+  })
+
+  it('kebab -> merge opens MergeDialog with the chosen source and current HEAD as target', async () => {
+    stateHolder.current.state = { head: 'main', branches }
+    stateHolder.current.merge = vi.fn().mockResolvedValue({})
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const mergeItem = await screen.findByText('feature-x')
+    await userEvent.click(mergeItem)
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.textContent).toContain('feature-x')
+    expect(dialog.textContent).toContain('main')
+    expect(stateHolder.current.merge).toHaveBeenCalledWith('feature-x', {
+      into: 'main',
+      dryRun: true,
+    })
+  })
+
+  it('keeps the rename target stable when HEAD changes while the rename dialog is open', async () => {
+    stateHolder.current.state = { head: 'feature-x', branches }
+    const { rerender } = render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const renameItem = await screen.findByText(/Rename/)
+    await userEvent.click(renameItem)
+
+    // Simulate an external onHeadChanged update landing while the dialog is open.
+    stateHolder.current.state = { head: 'main', branches }
+    rerender(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+
+    const input = await screen.findByPlaceholderText('feature-x')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'renamed-branch{Enter}')
+
+    expect(stateHolder.current.renameBranch).toHaveBeenCalledWith('feature-x', 'renamed-branch')
+  })
+
+  it('keeps the merge target stable when HEAD changes while the merge dialog is open', async () => {
+    stateHolder.current.state = { head: 'main', branches }
+    stateHolder.current.merge = vi.fn().mockResolvedValue({})
+    const { rerender } = render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const mergeItem = await screen.findByText('feature-x')
+    await userEvent.click(mergeItem)
+    await screen.findByRole('dialog')
+
+    // Simulate an external onHeadChanged update landing while the dialog is open.
+    stateHolder.current.state = { head: 'feature-x', branches: [branches[1], branches[0]] }
+    rerender(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+
+    // Assert on the *last* call: a stale-target regression would fire a second
+    // preview request for `into: 'feature-x'` once the dialog re-derives its
+    // target from the (now-changed) HEAD, even though the first call above is
+    // still correct.
+    expect(stateHolder.current.merge).toHaveBeenLastCalledWith('feature-x', {
+      into: 'main',
+      dryRun: true,
+    })
   })
 })

--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -1,0 +1,125 @@
+import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import type { UseBranchesResult } from '@/hooks/useBranches'
+
+// Real pointer/keyboard interaction with the Radix dropdown/dialog/alert-dialog
+// stack, which the jsdom-based HeaderBranchChip.test.tsx deliberately skips.
+
+const branches: BranchMeta[] = [
+  { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+  { name: 'feature-x', tipFrontiers: '', color: '#9333ea', createdAt: '2026-04-23T01:00:00Z' },
+]
+
+function makeState(): UseBranchesResult {
+  return {
+    state: { head: 'main', branches },
+    loading: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    createBranch: vi.fn().mockResolvedValue(branches[0]),
+    deleteBranch: vi.fn().mockResolvedValue(undefined),
+    getBranchStats: vi.fn().mockResolvedValue({ unmergedCommits: 2, isHead: false }),
+    renameBranch: vi.fn().mockResolvedValue(branches[0]),
+    setHead: vi.fn().mockResolvedValue({ head: 'feature-x' }),
+    merge: vi.fn(),
+  }
+}
+
+const stateHolder: { current: UseBranchesResult } = { current: makeState() }
+
+vi.mock('@/hooks/useBranches', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useBranches')>('@/hooks/useBranches')
+  return {
+    ...actual,
+    useBranches: () => stateHolder.current,
+  }
+})
+
+import { HeaderBranchChip } from './HeaderBranchChip.js'
+
+afterEach(() => {
+  cleanup()
+  stateHolder.current = makeState()
+})
+
+describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)', () => {
+  it('selecting another branch from the dropdown calls setHead', async () => {
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const chip = screen.getByTestId('header-branch-chip')
+    await userEvent.click(chip)
+
+    const option = await screen.findByText('feature-x')
+    await userEvent.click(option)
+
+    expect(stateHolder.current.setHead).toHaveBeenCalledWith('feature-x')
+  })
+
+  it('kebab -> rename -> Enter calls renameBranch with the old and new names', async () => {
+    // Rename is disabled while head === 'main', so switch HEAD first.
+    stateHolder.current.state = { head: 'feature-x', branches }
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const renameItem = await screen.findByText(/Rename/)
+    await userEvent.click(renameItem)
+
+    const input = await screen.findByPlaceholderText('feature-x')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'renamed-branch{Enter}')
+
+    expect(stateHolder.current.renameBranch).toHaveBeenCalledWith('feature-x', 'renamed-branch')
+  })
+
+  it('kebab -> delete -> confirm shows the unmerged-commits warning and calls deleteBranch', async () => {
+    stateHolder.current.state = { head: 'feature-x', branches }
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const kebab = screen.getByTestId('header-branch-kebab')
+    await userEvent.click(kebab)
+
+    const deleteItem = await screen.findByText(/Delete/)
+    await userEvent.click(deleteItem)
+
+    await screen.findByText(/unmerged commits remain/)
+
+    const confirmButton = await screen.findByRole('button', { name: 'Delete' })
+    await userEvent.click(confirmButton)
+
+    expect(stateHolder.current.deleteBranch).toHaveBeenCalledWith('feature-x')
+  })
+
+  it('inline "New branch…" form submits createBranch with the typed name', async () => {
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const chip = screen.getByTestId('header-branch-chip')
+    await userEvent.click(chip)
+
+    const newBranchItem = await screen.findByText(/New branch/)
+    await userEvent.click(newBranchItem)
+
+    const input = await screen.findByPlaceholderText('New branch name')
+    await userEvent.type(input, 'my-new-branch{Enter}')
+
+    expect(stateHolder.current.createBranch).toHaveBeenCalledWith({ name: 'my-new-branch' })
+  })
+
+  it('surfaces createBranch rejection as a role=alert with the safe error copy', async () => {
+    stateHolder.current.createBranch = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    const chip = screen.getByTestId('header-branch-chip')
+    await userEvent.click(chip)
+
+    const newBranchItem = await screen.findByText(/New branch/)
+    await userEvent.click(newBranchItem)
+
+    const input = await screen.findByPlaceholderText('New branch name')
+    await userEvent.type(input, 'my-new-branch{Enter}')
+
+    // The dropdown stays open on error so the user can retry, which puts the
+    // error banner under Radix's aria-hidden'd background wrapper — query
+    // with `hidden: true` to reach it.
+    const alert = await screen.findByRole('alert', { hidden: true })
+    expect(alert.textContent).toContain('Failed to create branch')
+  })
+})

--- a/apps/web/src/components/HeaderBranchChip.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.test.tsx
@@ -1,0 +1,98 @@
+import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { UseBranchesResult } from '@/hooks/useBranches'
+
+// Keep this test shallow.
+// Radix dropdown content depends on portals and pointer interactions that are unstable in jsdom.
+// Deeper switch/rename/delete/merge flows belong in browser or E2E coverage.
+
+const branches: BranchMeta[] = [
+  { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+  {
+    name: 'feature-x',
+    tipFrontiers: '',
+    color: '#9333ea',
+    createdAt: '2026-04-23T01:00:00Z',
+  },
+]
+
+const state: { current: UseBranchesResult } = {
+  current: {
+    state: { head: 'main', branches },
+    loading: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    createBranch: vi.fn(),
+    deleteBranch: vi.fn(),
+    getBranchStats: vi.fn().mockResolvedValue({ unmergedCommits: 0, isHead: false }),
+    renameBranch: vi.fn(),
+    setHead: vi.fn(),
+    merge: vi.fn(),
+  },
+}
+
+vi.mock('@/hooks/useBranches', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useBranches')>('@/hooks/useBranches')
+  return {
+    ...actual,
+    useBranches: () => state.current,
+  }
+})
+
+import { HeaderBranchChip } from './HeaderBranchChip.js'
+
+function renderChip() {
+  return render(
+    <TooltipProvider>
+      <HeaderBranchChip workspaceId="s1" slug="c1" />
+    </TooltipProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  state.current.state.head = 'main'
+})
+
+describe('HeaderBranchChip', () => {
+  it('renders the HEAD name in the chip trigger', () => {
+    renderChip()
+    const chip = screen.getByTestId('header-branch-chip')
+    expect(chip.textContent).toContain('main')
+  })
+
+  it('updates chip text when HEAD changes', () => {
+    state.current.state.head = 'feature-x'
+    renderChip()
+    const chip = screen.getByTestId('header-branch-chip')
+    expect(chip.textContent).toContain('feature-x')
+  })
+
+  it('applies the active branch color to the chip style', () => {
+    state.current.state.head = 'feature-x'
+    renderChip()
+    const chip = screen.getByTestId('header-branch-chip')
+    // jsdom converts hex colors to rgb().
+    expect(chip.getAttribute('style') ?? '').toContain('rgb(147, 51, 234)')
+  })
+
+  it('renders the kebab trigger', () => {
+    renderChip()
+    expect(screen.getByTestId('header-branch-kebab')).not.toBeNull()
+  })
+
+  it('uses an English aria-label on the chip trigger', () => {
+    renderChip()
+    const chip = screen.getByTestId('header-branch-chip')
+    expect(chip.getAttribute('aria-label')).toContain('Switch branch')
+    expect(chip.getAttribute('aria-label')).toContain('current: main')
+  })
+
+  it('uses an English aria-label on the kebab trigger', () => {
+    renderChip()
+    const kebab = screen.getByTestId('header-branch-kebab')
+    expect(kebab.getAttribute('aria-label')).toBe('Branch actions')
+  })
+})

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -60,6 +60,11 @@ export interface HeaderBranchChipProps {
   disabled?: boolean
 }
 
+interface PendingMerge {
+  source: BranchMeta
+  target: BranchMeta | null
+}
+
 export function HeaderBranchChip({
   workspaceId,
   slug,
@@ -98,21 +103,27 @@ export function HeaderBranchChip({
     }
   }
 
-  // Rename state.
+  // Rename state. Snapshot the branch being renamed at open time so a HEAD
+  // change while the dialog is open (e.g. from an external onHeadChanged
+  // update) cannot redirect the rename onto a different branch.
   const [renameOpen, setRenameOpen] = useState(false)
+  const [renameTarget, setRenameTarget] = useState<BranchMeta | null>(null)
   const [renameDraft, setRenameDraft] = useState('')
   const openRename = () => {
-    setRenameDraft(head)
+    if (!activeBranch) return
+    setRenameTarget(activeBranch)
+    setRenameDraft(activeBranch.name)
     setRenameOpen(true)
   }
   const submitRename = async () => {
+    if (!renameTarget) return
     const next = renameDraft.trim()
-    if (!next || next === head) {
+    if (!next || next === renameTarget.name) {
       setRenameOpen(false)
       return
     }
     try {
-      await renameBranch(head, next)
+      await renameBranch(renameTarget.name, next)
       setRenameOpen(false)
       setErrorMessage(null)
     } catch (err) {
@@ -144,8 +155,10 @@ export function HeaderBranchChip({
   }, [pendingDelete, getBranchStats])
 
   // Merge state. Reuse MergeDialog with source=chosen and target=HEAD.
-  const [mergeSource, setMergeSource] = useState<BranchMeta | null>(null)
-  const mergeTarget = activeBranch ?? null
+  // Snapshot both source and target together when the user picks a branch to
+  // merge, so a HEAD change while the dialog is open cannot merge into a
+  // different target than the one shown when the action was chosen.
+  const [pendingMerge, setPendingMerge] = useState<PendingMerge | null>(null)
 
   const chipColor = activeBranch?.color ?? '#64748b'
 
@@ -293,7 +306,7 @@ export function HeaderBranchChip({
             otherBranches.map((b) => (
               <DropdownMenuItem
                 key={`merge-${b.name}`}
-                onSelect={() => setMergeSource(b)}
+                onSelect={() => setPendingMerge({ source: b, target: activeBranch ?? null })}
                 className="gap-2"
               >
                 <span
@@ -355,7 +368,7 @@ export function HeaderBranchChip({
       <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Rename «{head}»</DialogTitle>
+            <DialogTitle>Rename «{renameTarget?.name ?? head}»</DialogTitle>
             <DialogDescription>
               Enter a new name. Every saved version on this branch will be relinked to it.
             </DialogDescription>
@@ -370,7 +383,7 @@ export function HeaderBranchChip({
                 void submitRename()
               }
             }}
-            placeholder={head}
+            placeholder={renameTarget?.name ?? head}
             maxLength={80}
           />
           <DialogFooter>
@@ -433,10 +446,10 @@ export function HeaderBranchChip({
 
       {/* Reuse the shared merge dialog. */}
       <MergeDialog
-        open={mergeSource !== null}
-        source={mergeSource}
-        target={mergeTarget}
-        onClose={() => setMergeSource(null)}
+        open={pendingMerge !== null}
+        source={pendingMerge?.source ?? null}
+        target={pendingMerge?.target ?? null}
+        onClose={() => setPendingMerge(null)}
         runMerge={(source, args) => runMerge(source, args) as Promise<MergeResult>}
         workspaceId={workspaceId}
         slug={slug}

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -389,7 +389,11 @@ export function HeaderBranchChip({
             className="gap-2 text-destructive focus:text-destructive"
             onSelect={(e) => {
               e.preventDefault()
-              if (activeBranch) setPendingDelete(activeBranch)
+              if (activeBranch) {
+                // Same stale-error hygiene as the rename flow.
+                setErrorMessage(null)
+                setPendingDelete(activeBranch)
+              }
             }}
           >
             <Trash2 className="size-3.5" />

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -111,6 +111,9 @@ export function HeaderBranchChip({
   const [renameDraft, setRenameDraft] = useState('')
   const openRename = () => {
     if (!activeBranch) return
+    // Errors from a previous operation (e.g. a failed create) must not
+    // greet the user inside a fresh rename dialog.
+    setErrorMessage(null)
     setRenameTarget(activeBranch)
     setRenameDraft(activeBranch.name)
     setRenameOpen(true)
@@ -189,7 +192,18 @@ export function HeaderBranchChip({
   return (
     <div className="flex items-center gap-1">
       {/* Main chip: branch switching and creation live in this dropdown. */}
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (open) {
+            // A stale error from the previous interaction shouldn't greet
+            // the user when they re-open the menu.
+            setErrorMessage(null)
+          } else {
+            setCreateOpen(false)
+            setNewName('')
+          }
+        }}
+      >
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
@@ -270,8 +284,15 @@ export function HeaderBranchChip({
                   autoFocus
                   aria-label="New branch name"
                   className="h-7 text-xs"
+                  maxLength={80}
                 />
-                <Button type="submit" size="sm" variant="outline" className="h-7 px-2 text-xs">
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-2 text-xs"
+                  disabled={!newName.trim()}
+                >
                   Add
                 </Button>
                 <Button
@@ -383,7 +404,14 @@ export function HeaderBranchChip({
       {!createOpen && !renameOpen ? errorBanner : null}
 
       {/* Rename dialog */}
-      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+      <Dialog
+        open={renameOpen}
+        onOpenChange={(open) => {
+          setRenameOpen(open)
+          // A rename error must not leak into the header row after close.
+          if (!open) setErrorMessage(null)
+        }}
+      >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Rename «{renameTarget?.name ?? head}»</DialogTitle>
@@ -409,7 +437,12 @@ export function HeaderBranchChip({
             <Button variant="outline" onClick={() => setRenameOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={submitRename}>Rename</Button>
+            <Button
+              onClick={submitRename}
+              disabled={!renameDraft.trim() || renameDraft.trim() === renameTarget?.name}
+            >
+              Rename
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -1,0 +1,448 @@
+import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
+import {
+  ChevronDown,
+  GitBranch,
+  GitMerge,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+} from 'lucide-react'
+import { type JSX, useEffect, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { MergeResult } from '@/hooks/useBranches'
+import { useBranches } from '@/hooks/useBranches'
+import { safeErrorCopy } from '@/lib/error-copy'
+import { cn } from '@/lib/utils'
+import { MergeDialog } from './MergeDialog'
+
+// Consolidate branch operations into a single `●branch▾` chip in the header.
+//
+// Behavior:
+//   - Left trigger: switch branches from a dropdown
+//   - Right kebab: rename, delete, or merge from another branch
+//   - New branch: inline form inside the dropdown
+//
+// Unlike the old tab layout, there is always exactly one visible chip for HEAD.
+// Other branches are managed through the dropdown and kebab menu.
+
+export interface HeaderBranchChipProps {
+  workspaceId: string
+  slug: string
+  disabled?: boolean
+}
+
+export function HeaderBranchChip({
+  workspaceId,
+  slug,
+  disabled,
+}: HeaderBranchChipProps): JSX.Element {
+  const {
+    state,
+    createBranch,
+    deleteBranch,
+    getBranchStats,
+    renameBranch,
+    setHead,
+    merge: runMerge,
+  } = useBranches(workspaceId, slug)
+
+  const head = state.head
+  const activeBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
+  const otherBranches = state.branches.filter((b) => b.name !== head)
+
+  // Surface create/rename/delete failures through one shared inline error banner.
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  // Create branch state for the inline dropdown form.
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+  const submitCreate = async () => {
+    const name = newName.trim()
+    if (!name) return
+    try {
+      await createBranch({ name })
+      setNewName('')
+      setCreateOpen(false)
+      setErrorMessage(null)
+    } catch (err) {
+      setErrorMessage(safeErrorCopy(err, 'Failed to create branch'))
+    }
+  }
+
+  // Rename state.
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renameDraft, setRenameDraft] = useState('')
+  const openRename = () => {
+    setRenameDraft(head)
+    setRenameOpen(true)
+  }
+  const submitRename = async () => {
+    const next = renameDraft.trim()
+    if (!next || next === head) {
+      setRenameOpen(false)
+      return
+    }
+    try {
+      await renameBranch(head, next)
+      setRenameOpen(false)
+      setErrorMessage(null)
+    } catch (err) {
+      setErrorMessage(safeErrorCopy(err, 'Failed to rename branch'))
+    }
+  }
+
+  // Delete state plus unmerged commit stats.
+  const [pendingDelete, setPendingDelete] = useState<BranchMeta | null>(null)
+  const [pendingStats, setPendingStats] = useState<{ unmergedCommits: number } | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  useEffect(() => {
+    if (!pendingDelete) {
+      setPendingStats(null)
+      return
+    }
+    let cancelled = false
+    setPendingStats(null)
+    getBranchStats(pendingDelete.name)
+      .then((s) => {
+        if (!cancelled) setPendingStats({ unmergedCommits: s.unmergedCommits })
+      })
+      .catch(() => {
+        /* If stats fail, just omit the count. */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [pendingDelete, getBranchStats])
+
+  // Merge state. Reuse MergeDialog with source=chosen and target=HEAD.
+  const [mergeSource, setMergeSource] = useState<BranchMeta | null>(null)
+  const mergeTarget = activeBranch ?? null
+
+  const chipColor = activeBranch?.color ?? '#64748b'
+
+  return (
+    <div className="flex items-center gap-1">
+      {/* Main chip: branch switching and creation live in this dropdown. */}
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={disabled}
+                aria-label={`Switch branch (current: ${head})`}
+                data-testid="header-branch-chip"
+                className={cn(
+                  'flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium',
+                  'max-w-[220px] transition-colors hover:bg-accent disabled:opacity-60',
+                )}
+                style={{ borderColor: chipColor, color: chipColor }}
+              >
+                <span
+                  aria-hidden
+                  className="inline-block size-2 shrink-0 rounded-full"
+                  style={{ background: chipColor }}
+                />
+                <span className="truncate" title={head}>
+                  {head}
+                </span>
+                <ChevronDown className="size-3 shrink-0 opacity-70" aria-hidden />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Branch</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" className="w-[240px]">
+          <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
+            <GitBranch className="size-3" />
+            Switch branch
+          </DropdownMenuLabel>
+          {/* Show HEAD first and mark it as the current branch. */}
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="gap-2" disabled>
+            <span
+              aria-hidden
+              className="inline-block size-2 rounded-full"
+              style={{ background: chipColor }}
+            />
+            <span className="truncate">{head}</span>
+            <span className="ml-auto text-[10px] text-muted-foreground">Current</span>
+          </DropdownMenuItem>
+          {otherBranches.map((b) => (
+            <DropdownMenuItem
+              key={b.name}
+              onSelect={() => {
+                setHead(b.name).catch((err: unknown) => {
+                  setErrorMessage(safeErrorCopy(err, 'Failed to switch branch'))
+                })
+              }}
+              className="gap-2"
+            >
+              <span
+                aria-hidden
+                className="inline-block size-2 rounded-full"
+                style={{ background: b.color }}
+              />
+              <span className="truncate" title={b.name}>
+                {b.name}
+              </span>
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          {createOpen ? (
+            <form
+              className="flex items-center gap-1 p-1"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void submitCreate()
+              }}
+            >
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="New branch name"
+                autoFocus
+                aria-label="New branch name"
+                className="h-7 text-xs"
+              />
+              <Button type="submit" size="sm" variant="outline" className="h-7 px-2 text-xs">
+                Add
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2 text-xs"
+                onClick={() => {
+                  setCreateOpen(false)
+                  setNewName('')
+                }}
+              >
+                Cancel
+              </Button>
+            </form>
+          ) : (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault()
+                setCreateOpen(true)
+              }}
+              className="gap-2"
+            >
+              <Plus className="size-3.5" />
+              New branch…
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Kebab menu: rename, merge, and delete. */}
+      {/* Note: DropdownMenuTrigger asChild must wrap a plain <button>. If a shadcn <Button>
+          sits in between, the Radix ref never reaches the real DOM node and the popover
+          can stay stuck at its initial off-screen position. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Branch actions"
+            data-testid="header-branch-kebab"
+            disabled={disabled}
+            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          >
+            <MoreHorizontal className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-[240px]">
+          <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
+            <GitMerge className="size-3" />
+            Merge into «{head}»
+          </DropdownMenuLabel>
+          {otherBranches.length === 0 ? (
+            <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+              No other branches
+            </DropdownMenuItem>
+          ) : (
+            otherBranches.map((b) => (
+              <DropdownMenuItem
+                key={`merge-${b.name}`}
+                onSelect={() => setMergeSource(b)}
+                className="gap-2"
+              >
+                <span
+                  aria-hidden
+                  className="inline-block size-2 rounded-full"
+                  style={{ background: b.color }}
+                />
+                <span className="truncate">{b.name}</span>
+              </DropdownMenuItem>
+            ))
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={head === 'main'}
+            onSelect={(e) => {
+              e.preventDefault()
+              openRename()
+            }}
+            className="gap-2"
+          >
+            <Pencil className="size-3.5" />
+            Rename «{head}»…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={head === 'main'}
+            className="gap-2 text-destructive focus:text-destructive"
+            onSelect={(e) => {
+              e.preventDefault()
+              if (activeBranch) setPendingDelete(activeBranch)
+            }}
+          >
+            <Trash2 className="size-3.5" />
+            Delete «{head}»…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {errorMessage ? (
+        <div
+          role="alert"
+          className="flex max-w-[200px] items-center gap-1 text-[11px] text-destructive"
+        >
+          <span aria-hidden>⚠</span>
+          <span className="truncate" title={errorMessage}>
+            {errorMessage}
+          </span>
+          <button
+            type="button"
+            className="ml-auto text-muted-foreground hover:text-foreground"
+            onClick={() => setErrorMessage(null)}
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        </div>
+      ) : null}
+
+      {/* Rename dialog */}
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename «{head}»</DialogTitle>
+            <DialogDescription>
+              Enter a new name. Every saved version on this branch will be relinked to it.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={renameDraft}
+            onChange={(e) => setRenameDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void submitRename()
+              }
+            }}
+            placeholder={head}
+            maxLength={80}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={submitRename}>Rename</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete alert */}
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(next) => {
+          if (!next) setPendingDelete(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete «{pendingDelete?.name ?? ''}»?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes the branch. Saved versions stay in version history, but the branch will
+              no longer be reachable from branch navigation.
+              {pendingStats && pendingStats.unmergedCommits > 0 ? (
+                <>
+                  <br />
+                  <strong className="text-destructive">
+                    ⚠ {pendingStats.unmergedCommits} unmerged commits remain
+                  </strong>
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleting || !pendingDelete}
+              onClick={async (e) => {
+                if (!pendingDelete) return
+                e.preventDefault()
+                setDeleting(true)
+                try {
+                  await deleteBranch(pendingDelete.name)
+                  setErrorMessage(null)
+                  setPendingDelete(null)
+                } catch (err) {
+                  setErrorMessage(safeErrorCopy(err, 'Failed to delete branch'))
+                  setPendingDelete(null)
+                } finally {
+                  setDeleting(false)
+                }
+              }}
+            >
+              {deleting ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Reuse the shared merge dialog. */}
+      <MergeDialog
+        open={mergeSource !== null}
+        source={mergeSource}
+        target={mergeTarget}
+        onClose={() => setMergeSource(null)}
+        runMerge={(source, args) => runMerge(source, args) as Promise<MergeResult>}
+        workspaceId={workspaceId}
+        slug={slug}
+      />
+    </div>
+  )
+}
+
+export default HeaderBranchChip

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -76,7 +76,7 @@ export function HeaderBranchChip({
   } = useBranches(workspaceId, slug)
 
   const head = state.head
-  const activeBranch: BranchMeta | undefined = state.branches.find((b) => b.name === head)
+  const activeBranch = state.branches.find((b) => b.name === head)
   const otherBranches = state.branches.filter((b) => b.name !== head)
 
   // Surface create/rename/delete failures through one shared inline error banner.

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -162,6 +162,30 @@ export function HeaderBranchChip({
 
   const chipColor = activeBranch?.color ?? '#64748b'
 
+  // Radix marks background content inert/aria-hidden while a dropdown or
+  // dialog is open, so an error raised inside one of those flows must render
+  // *inside* the still-open surface to stay visible and announced — a copy
+  // rendered only in the header row would be hidden until the user closes it.
+  const errorBanner = errorMessage ? (
+    <div
+      role="alert"
+      className="flex max-w-[200px] items-center gap-1 text-[11px] text-destructive"
+    >
+      <span aria-hidden>⚠</span>
+      <span className="truncate" title={errorMessage}>
+        {errorMessage}
+      </span>
+      <button
+        type="button"
+        className="ml-auto text-muted-foreground hover:text-foreground"
+        onClick={() => setErrorMessage(null)}
+        aria-label="Dismiss error"
+      >
+        ×
+      </button>
+    </div>
+  ) : null
+
   return (
     <div className="flex items-center gap-1">
       {/* Main chip: branch switching and creation live in this dropdown. */}
@@ -231,37 +255,40 @@ export function HeaderBranchChip({
           ))}
           <DropdownMenuSeparator />
           {createOpen ? (
-            <form
-              className="flex items-center gap-1 p-1"
-              onSubmit={(event) => {
-                event.preventDefault()
-                void submitCreate()
-              }}
-            >
-              <Input
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="New branch name"
-                autoFocus
-                aria-label="New branch name"
-                className="h-7 text-xs"
-              />
-              <Button type="submit" size="sm" variant="outline" className="h-7 px-2 text-xs">
-                Add
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                className="h-7 px-2 text-xs"
-                onClick={() => {
-                  setCreateOpen(false)
-                  setNewName('')
+            <>
+              <form
+                className="flex items-center gap-1 p-1"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void submitCreate()
                 }}
               >
-                Cancel
-              </Button>
-            </form>
+                <Input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="New branch name"
+                  autoFocus
+                  aria-label="New branch name"
+                  className="h-7 text-xs"
+                />
+                <Button type="submit" size="sm" variant="outline" className="h-7 px-2 text-xs">
+                  Add
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => {
+                    setCreateOpen(false)
+                    setNewName('')
+                  }}
+                >
+                  Cancel
+                </Button>
+              </form>
+              {errorBanner ? <div className="px-1 pb-1">{errorBanner}</div> : null}
+            </>
           ) : (
             <DropdownMenuItem
               onSelect={(event) => {
@@ -306,7 +333,13 @@ export function HeaderBranchChip({
             otherBranches.map((b) => (
               <DropdownMenuItem
                 key={`merge-${b.name}`}
-                onSelect={() => setPendingMerge({ source: b, target: activeBranch ?? null })}
+                onSelect={() => {
+                  // activeBranch can be momentarily undefined if HEAD changed
+                  // but the branches list has not been refetched yet. Never
+                  // open MergeDialog with a null target in that window.
+                  if (!activeBranch) return
+                  setPendingMerge({ source: b, target: activeBranch })
+                }}
                 className="gap-2"
               >
                 <span
@@ -344,25 +377,10 @@ export function HeaderBranchChip({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {errorMessage ? (
-        <div
-          role="alert"
-          className="flex max-w-[200px] items-center gap-1 text-[11px] text-destructive"
-        >
-          <span aria-hidden>⚠</span>
-          <span className="truncate" title={errorMessage}>
-            {errorMessage}
-          </span>
-          <button
-            type="button"
-            className="ml-auto text-muted-foreground hover:text-foreground"
-            onClick={() => setErrorMessage(null)}
-            aria-label="Dismiss error"
-          >
-            ×
-          </button>
-        </div>
-      ) : null}
+      {/* Rendered inline inside the create form / rename dialog while those
+          surfaces are open (see errorBanner above); only fall back to this
+          header-row copy once neither is open. */}
+      {!createOpen && !renameOpen ? errorBanner : null}
 
       {/* Rename dialog */}
       <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
@@ -386,6 +404,7 @@ export function HeaderBranchChip({
             placeholder={renameTarget?.name ?? head}
             maxLength={80}
           />
+          {renameOpen && errorBanner ? errorBanner : null}
           <DialogFooter>
             <Button variant="outline" onClick={() => setRenameOpen(false)}>
               Cancel


### PR DESCRIPTION
UI-unification Stage 2, Lane 6 — the branch surface, ported from the frozen daemon app on top of the #144/#145 stack. This completes the component-port wave except WorkspaceTopBar.

## Change

- **HeaderBranchChip** → `apps/web/src/components/`: HEAD dropdown (switch/create), kebab (rename Dialog / delete AlertDialog with unmerged-commits warning), opens MergeDialog (#144). Consumes the callback-model `useBranches` (#145); the Radix `DropdownMenuTrigger asChild` plain-button gotcha comment preserved.
- **HeaderBranchBanner** → same, with the event-model adaptation per ADR-0004: **no `excalidraw:head_changed` window listener** (external HEAD changes arrive when the future CanvasPage drives `useCanvasSync.onHeadChanged → branches.refetch()`; a spy test locks that no listener is registered), and the `merge_committed` subscription goes through the **Zod contract** (`parseMergeCommittedEvent`, #144) instead of a hand-written detail cast — invalid or mismatched details are ignored (red-first tests).
- Browser-layer suite (`HeaderBranchChip.browser.test.tsx`) covers the real Radix flows jsdom can't: dropdown→setHead, kebab→rename, delete confirm, inline create, create-failure alert.

`packages/mcp-server` zero diff (frozen); apps/web copies are canonical. No page wiring (slices 9-10) — noted dependency: an apps/web-rendered Banner/Chip reacts to external HEAD changes only after the slice 9-10 wiring.

## Verification

apps/web jsdom 495 ✓ / browser 78 ✓ / tsc ✓ / mcp typecheck ✓ / packages zero diff ✓. Review: 3 LOW (documented). The run's review lane was resumed after a usage-limit outage — full local verification re-run by the integrator post-rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified branch chip in the header for switching branches, creating new branches, renaming, deleting, and merging.
  * Added a branch status banner that appears when the current branch has unmerged commits and offers a merge action.
* **Bug Fixes**
  * Improved branch action dialogs to keep showing the correct branch details even if the active branch changes while a dialog is open.
  * Added clearer error handling and warnings for branch operations, including unmerged-commit notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->