### PR TITLE
feat(mcp-server): move daemonToken out of runtime config into a one-shot TokenStore

### DIFF
--- a/apps/web/src/runtime-config.test.ts
+++ b/apps/web/src/runtime-config.test.ts
@@ -58,6 +58,22 @@ describe('runtimeConfigSchema', () => {
     expect(() => resolveRuntimeConfig({ Authorization: 'Bearer tok' })).toThrow()
   })
 
+  // Mutation-check target: the daemon auth token travels via its own global
+  // (window.__WHITEBOARD_DAEMON_TOKEN__), never inside this config object.
+  // Reverting that split — putting daemonToken back into the injected config —
+  // must make this assertion fail.
+  it('rejects a payload containing daemonToken (.strict() rejection of the token channel)', () => {
+    expect(runtimeConfigSchema.safeParse({ daemonToken: 'secret' }).success).toBe(false)
+    expect(() =>
+      resolveRuntimeConfig({ daemonBaseUrl: 'http://127.0.0.1:3099', daemonToken: 'secret' }),
+    ).toThrow()
+  })
+
+  it('parses the split shape: a token-free config with daemonBaseUrl only', () => {
+    const config = resolveRuntimeConfig({ daemonBaseUrl: 'http://127.0.0.1:3099' })
+    expect(config).toEqual({ daemonBaseUrl: 'http://127.0.0.1:3099' })
+  })
+
   it('explicit default port 443 is rejected (URL.origin normalizes it away)', () => {
     expect(() => resolveRuntimeConfig({ publicOrigin: 'https://app.example.com:443' })).toThrow()
   })

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -211,12 +211,21 @@ async function main() {
   if (canvasHtml.includes('daemonToken')) {
     throw new Error('served HTML still carries daemonToken inside __WHITEBOARD_RUNTIME_CONFIG__')
   }
-  // ensureDaemon always generates a token (nanoid), so local-daemon mode
-  // always configures one — the dedicated token global must be present.
-  if (!canvasHtml.includes('window.__WHITEBOARD_DAEMON_TOKEN__')) {
-    throw new Error('served HTML is missing window.__WHITEBOARD_DAEMON_TOKEN__')
+  if (canvasHtml.includes('__WHITEBOARD_RUNTIME_CONFIG__')) {
+    // The injection path ran (dist/app exists). ensureDaemon always generates
+    // a token (nanoid), so the dedicated token global must accompany the
+    // config script.
+    if (!canvasHtml.includes('window.__WHITEBOARD_DAEMON_TOKEN__')) {
+      throw new Error('served HTML is missing window.__WHITEBOARD_DAEMON_TOKEN__')
+    }
+    console.log('[e2e] served HTML: no daemonToken in config, dedicated token global present')
+  } else {
+    // No injected config at all — dist/app is absent (CI runs this smoke
+    // before pnpm build), so there is no injection path to verify here.
+    console.log(
+      '[e2e] served HTML has no runtime-config injection (dist/app absent) — token-global check skipped',
+    )
   }
-  console.log('[e2e] served HTML: no daemonToken in config, dedicated token global present')
 
   const ann = await callTool('annotate', {
     canvasId: created.id,

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -201,6 +201,23 @@ async function main() {
   }
   console.log('[e2e] /api/runtime/ping with spoofed Host → 403 OK')
 
+  // Token channel split (ADR-0002 addendum): the served HTML must never carry
+  // the daemon token inside __WHITEBOARD_RUNTIME_CONFIG__. This is a
+  // serialization-surface reduction, not a security boundary — a script that
+  // ran earlier in the page could still have observed the token global before
+  // TokenStore consumed it.
+  const canvasHtmlRes = await fetch(created.url)
+  const canvasHtml = await canvasHtmlRes.text()
+  if (canvasHtml.includes('daemonToken')) {
+    throw new Error('served HTML still carries daemonToken inside __WHITEBOARD_RUNTIME_CONFIG__')
+  }
+  // ensureDaemon always generates a token (nanoid), so local-daemon mode
+  // always configures one — the dedicated token global must be present.
+  if (!canvasHtml.includes('window.__WHITEBOARD_DAEMON_TOKEN__')) {
+    throw new Error('served HTML is missing window.__WHITEBOARD_DAEMON_TOKEN__')
+  }
+  console.log('[e2e] served HTML: no daemonToken in config, dedicated token global present')
+
   const ann = await callTool('annotate', {
     canvasId: created.id,
     type: 'rectangle',

--- a/packages/mcp-server/scripts/vite-dev-token-plugin.test.ts
+++ b/packages/mcp-server/scripts/vite-dev-token-plugin.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Nearest-layer test for the Vite dev-server plugin that injects
-// window.__WHITEBOARD_RUNTIME_CONFIG__ into the HTML served by `pnpm dev`.
+// window.__WHITEBOARD_DAEMON_TOKEN__ into the HTML served by `pnpm dev`.
 // We import the plugin factory directly and exercise its transformIndexHtml
 // hook so no running Vite server is needed.
 
@@ -17,15 +17,15 @@ describe('runtimeConfigDevPlugin', () => {
     }
   })
 
-  it('injects a <script> that sets window.__WHITEBOARD_RUNTIME_CONFIG__ with the default token', async () => {
+  it('injects a <script> that sets window.__WHITEBOARD_DAEMON_TOKEN__ with the default token, and no daemonToken key inside a config object', async () => {
     delete process.env.WHITEBOARD_TOKEN
     const { runtimeConfigDevPlugin } = await import('./vite-dev-token-plugin.js')
     const plugin = runtimeConfigDevPlugin()
     const result = (plugin as { transformIndexHtml: (html: string) => string }).transformIndexHtml(
       '<html><head></head><body></body></html>',
     )
-    expect(result).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
-    expect(result).toContain('"daemonToken"')
+    expect(result).toContain('window.__WHITEBOARD_DAEMON_TOKEN__')
+    expect(result).not.toContain('daemonToken')
     expect(result).toContain('"whiteboard-dev"')
     expect(result).toContain('<script>')
   })

--- a/packages/mcp-server/scripts/vite-dev-token-plugin.ts
+++ b/packages/mcp-server/scripts/vite-dev-token-plugin.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite'
 
-// Dev-only Vite plugin that injects window.__WHITEBOARD_RUNTIME_CONFIG__
-// into every HTML response so apiFetch (api-client.ts) sends
+// Dev-only Vite plugin that injects window.__WHITEBOARD_DAEMON_TOKEN__
+// into every HTML response so TokenStore (via apiFetch) sends
 // Authorization: Bearer <token> on every /api/* request.
 //
 // apply: 'serve' ensures Vite never includes this script in production builds.
@@ -21,8 +21,11 @@ export function runtimeConfigDevPlugin(): Plugin {
       // Escape `<` so a token containing `</script>` cannot break out of the
       // script tag and inject arbitrary markup. The production server path
       // applies the same guard before inlining runtime config.
-      const config = JSON.stringify({ daemonToken: token }).replace(/</g, '\\u003c')
-      const script = `<script>window.__WHITEBOARD_RUNTIME_CONFIG__ = ${config};</script>`
+      //
+      // The token ships on its own global (window.__WHITEBOARD_DAEMON_TOKEN__),
+      // not inside __WHITEBOARD_RUNTIME_CONFIG__ — see shared/token-store.ts.
+      const tokenJson = JSON.stringify(token).replace(/</g, '\\u003c')
+      const script = `<script>window.__WHITEBOARD_DAEMON_TOKEN__ = ${tokenJson};</script>`
       if (!html.includes('</head>')) {
         throw new Error(
           'vite-dev-token-plugin: missing </head> in index.html — runtime config script cannot be injected',

--- a/packages/mcp-server/src/app/lib/api-client.test.ts
+++ b/packages/mcp-server/src/app/lib/api-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetTokenStoreForTests } from '../../shared/token-store.js'
 
 const { apiFetch } = await import('./api-client.js')
 
@@ -9,6 +10,7 @@ describe('apiFetch', () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch
     originalWindow = globalThis.window
+    resetTokenStoreForTests()
   })
 
   afterEach(() => {
@@ -18,13 +20,14 @@ describe('apiFetch', () => {
       configurable: true,
       writable: true,
     })
+    resetTokenStoreForTests()
   })
 
   it('attaches the daemon bearer token to local API requests', async () => {
     Object.defineProperty(globalThis, 'window', {
       value: {
         location: { origin: 'http://localhost:3099' },
-        __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'secret' },
+        __WHITEBOARD_DAEMON_TOKEN__: 'secret',
       },
       configurable: true,
       writable: true,
@@ -42,7 +45,7 @@ describe('apiFetch', () => {
     Object.defineProperty(globalThis, 'window', {
       value: {
         location: { origin: 'http://localhost:3099' },
-        __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'secret' },
+        __WHITEBOARD_DAEMON_TOKEN__: 'secret',
       },
       configurable: true,
       writable: true,

--- a/packages/mcp-server/src/app/lib/daemon-backend.auth-failure.test.ts
+++ b/packages/mcp-server/src/app/lib/daemon-backend.auth-failure.test.ts
@@ -5,8 +5,9 @@
  * Transient codes (1001, 1006, etc.) must still trigger the normal backoff reconnect.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { DaemonBackend } from './daemon-backend.js'
+import { resetTokenStoreForTests } from '../../shared/token-store.js'
 import type { CanvasBackendHandlers } from './canvas-backend.js'
+import { DaemonBackend } from './daemon-backend.js'
 
 interface FakeCloseEvent extends Event {
   code: number
@@ -73,10 +74,12 @@ describe('DaemonBackend – auth failure (close code 1008)', () => {
     vi.useFakeTimers()
     FakeWebSocket.instances = []
     originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
-    // DaemonBackend reads window.__WHITEBOARD_RUNTIME_CONFIG__; stub it.
+    // DaemonBackend reads the token via TokenStore, seeded from
+    // window.__WHITEBOARD_DAEMON_TOKEN__; stub the global.
     originalWindow = (globalThis as Record<string, unknown>).window
+    resetTokenStoreForTests()
     ;(globalThis as Record<string, unknown>).window = {
-      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: null },
+      __WHITEBOARD_DAEMON_TOKEN__: undefined,
     }
     ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
   })
@@ -85,6 +88,7 @@ describe('DaemonBackend – auth failure (close code 1008)', () => {
     vi.useRealTimers()
     ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
     ;(globalThis as Record<string, unknown>).window = originalWindow
+    resetTokenStoreForTests()
   })
 
   it('does NOT reconnect on close code 1008', async () => {

--- a/packages/mcp-server/src/app/lib/daemon-backend.reconnect.test.ts
+++ b/packages/mcp-server/src/app/lib/daemon-backend.reconnect.test.ts
@@ -11,10 +11,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // api-client/upload-files imports resolve to src/shared/*, not the
 // src/app/lib re-export shims.
 const apiFetchMock = vi.fn()
-const readRuntimeConfigMock = vi.fn(() => ({ daemonToken: null }))
 vi.mock('../../shared/api-client.js', () => ({
   apiFetch: apiFetchMock,
-  readRuntimeConfig: readRuntimeConfigMock,
+}))
+
+const readDaemonTokenOnceMock = vi.fn(() => null)
+vi.mock('../../shared/token-store.js', () => ({
+  readDaemonTokenOnce: readDaemonTokenOnceMock,
 }))
 
 const uploadFilesMock = vi.fn()

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -134,13 +134,23 @@ describe('createApp daemon mutation auth', () => {
     expect(authedDebugRes.status).toBe(200)
   })
 
-  it('injects runtime config with daemon token into served HTML', async () => {
+  it('injects the daemon token into its own dedicated global, not the runtime-config object', async () => {
     const app = createApp(createRuntimeOptions('secret'))
     const res = await app.request('/canvas/session1/demo')
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
-    expect(html).toContain('"daemonToken":"secret"')
+    expect(html).not.toContain('daemonToken')
+    expect(html).toContain('window.__WHITEBOARD_DAEMON_TOKEN__ = "secret"')
+  })
+
+  it('omits the token script entirely when no daemon token is configured', async () => {
+    const app = createApp(createRuntimeOptions(undefined))
+    const res = await app.request('/canvas/session1/demo')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
+    expect(html).not.toContain('__WHITEBOARD_DAEMON_TOKEN__')
   })
 
   it('adds baseline security headers to HTML responses', async () => {
@@ -1034,24 +1044,31 @@ describe('createApp daemon mutation auth', () => {
   })
 
   describe('runtime config injection', () => {
-    it('injects daemonBaseUrl composed from 127.0.0.1 and port into served HTML', async () => {
+    it('injects daemonBaseUrl composed from 127.0.0.1 and port into served HTML, with no daemonToken key', async () => {
       const app = createApp(createRuntimeOptions('secret'))
       const res = await app.request('/canvas/session1/demo')
       expect(res.status).toBe(200)
       const html = await res.text()
       expect(html).toContain('"daemonBaseUrl":"http://127.0.0.1:3099"')
-      // existing daemonToken assertion must still pass
-      expect(html).toContain('"daemonToken":"secret"')
+      // Token separation (ADR-0002 addendum): the config object never carries
+      // the token; it travels via window.__WHITEBOARD_DAEMON_TOKEN__ instead.
+      expect(html).not.toContain('daemonToken')
+      expect(html).toContain('window.__WHITEBOARD_DAEMON_TOKEN__ = "secret"')
     })
 
-    it('emitted runtime-config is accepted by the active dist/app reader (non-strict)', async () => {
-      // The dist/app reader (packages/mcp-server/src/app/lib/api-client.ts) uses a
-      // hand-written non-strict interface RuntimeConfig { daemonToken: string | null }
-      // Extra keys (daemonBaseUrl) must be silently ignored - this test locks that behavior.
-      const emittedConfig = { daemonToken: 'secret', daemonBaseUrl: 'http://127.0.0.1:3099' }
-      // Non-strict: accessing known properties works, extra ones are ignored
-      const config = emittedConfig as { daemonToken: string | null }
-      expect(config.daemonToken).toBe('secret')
+    it('emitted runtime-config is accepted by the shared api-client reader (strict, token-free)', async () => {
+      const { runtimeConfigSchema } = await import('../shared/api-client.js')
+      const emittedConfig = { daemonBaseUrl: 'http://127.0.0.1:3099' }
+      expect(() => runtimeConfigSchema.parse(emittedConfig)).not.toThrow()
+    })
+
+    it('shared api-client strict runtimeConfigSchema REJECTS a payload that includes daemonToken', async () => {
+      // .strict() forbids unknown keys. daemonToken is NOT in the schema, so
+      // .parse({ daemonToken, daemonBaseUrl }) must throw. This locks the
+      // token-channel split as a deliberate guarded step.
+      const { runtimeConfigSchema } = await import('../shared/api-client.js')
+      const badPayload = { daemonToken: 'secret', daemonBaseUrl: 'http://127.0.0.1:3099' }
+      expect(() => runtimeConfigSchema.parse(badPayload)).toThrow()
     })
 
     it('apps/web strict runtimeConfigSchema REJECTS a payload that includes daemonToken', async () => {

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -6,6 +6,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { Hono, type MiddlewareHandler } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { decodeFrontiers, encodeFrontiers, LoroDoc } from 'loro-crdt'
+import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import { detectMergeBadges } from '../shared/merge-engine.js'
 import { reconcileElementsOnDoc } from '../shared/reconcile-elements.js'
 import { DIST_APP_DIR } from './config.js'
@@ -29,18 +30,17 @@ import {
   setResolveExportFn,
   setResolveViewportFn,
 } from './routes/ws.js'
+import { createApiHostGuardMiddleware } from './security/api-host-guard.js'
+import type { AuthScope } from './security/auth-strategy.js'
+import { createApiLoopbackCorsMiddleware } from './security/cors-loopback.js'
 import {
   buildMcpProtectedResourceMetadata,
   createLocalTokenMcpHttpAuthStrategy,
   type McpHttpAuthStrategy,
 } from './security/mcp-auth.js'
 import { createMcpHttpAuthMiddleware, createMcpHttpOriginMiddleware } from './security/mcp-http.js'
-import { createApiLoopbackCorsMiddleware } from './security/cors-loopback.js'
-import { createApiHostGuardMiddleware } from './security/api-host-guard.js'
-import type { AuthScope } from './security/auth-strategy.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { planServerModeAuth } from './security/server-mode-auth-plan.js'
-import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import {
   BranchNotFoundError,
   deleteBranch,
@@ -874,16 +874,24 @@ export function createApp(options: AppOptions) {
       // cannot terminate the tag. The current token is generated with nanoid and is not
       // dangerous, but this keeps runtime config safe if user-controlled values are added later.
       // Details: https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+      //
+      // The daemon token is deliberately NOT part of __WHITEBOARD_RUNTIME_CONFIG__
+      // (see shared/token-store.ts) — it ships in its own global so it never
+      // rides along inside an object that logging / error-reporting could
+      // serialize wholesale.
       const runtimeConfigJson = JSON.stringify({
-        daemonToken: token ?? null,
         // Composed from 127.0.0.1 + port (not getStatus().baseUrl) so the
         // value is always a loopback origin, even when the daemon binds 0.0.0.0.
         daemonBaseUrl: `http://127.0.0.1:${options.getStatus().port}`,
       }).replace(/</g, '\\u003c')
       const runtimeConfigScript = `<script>window.__WHITEBOARD_RUNTIME_CONFIG__ = ${runtimeConfigJson}</script>`
+      const tokenScript = token
+        ? `<script>window.__WHITEBOARD_DAEMON_TOKEN__ = ${JSON.stringify(token).replace(/</g, '\\u003c')}</script>`
+        : ''
+      const injected = `${runtimeConfigScript}${tokenScript}`
       const withRuntimeConfig = html.includes('</head>')
-        ? html.replace('</head>', `${runtimeConfigScript}</head>`)
-        : `${runtimeConfigScript}${html}`
+        ? html.replace('</head>', `${injected}</head>`)
+        : `${injected}${html}`
       return c.html(withRuntimeConfig)
     } catch {
       return c.text('Not found. Run `pnpm build` first.', 404)

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -90,6 +90,15 @@ function setBaselineSecurityHeaders(headers: Headers): void {
   headers.set('Cross-Origin-Resource-Policy', 'same-origin')
 }
 
+// Serialize a value for inlining into a `<script>` body, escaping `<` so a
+// value such as `</script>` cannot terminate the tag and inject markup. Tokens
+// today are nanoid-generated (safe), but this keeps the path safe if
+// user-controlled values are ever inlined here.
+// https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+function toInlineScriptJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c')
+}
+
 function extractInitializeDebugPayload(parsedBody: unknown) {
   if (!isJsonObject(parsedBody) || parsedBody.method !== 'initialize') {
     return null
@@ -870,23 +879,18 @@ export function createApp(options: AppOptions) {
   app.get('*', async (c) => {
     try {
       const html = await readFile(join(DIST_APP_DIR, 'index.html'), 'utf-8')
-      // When inlining JSON into `<script>`, escape `<` so strings such as `</script>`
-      // cannot terminate the tag. The current token is generated with nanoid and is not
-      // dangerous, but this keeps runtime config safe if user-controlled values are added later.
-      // Details: https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
-      //
       // The daemon token is deliberately NOT part of __WHITEBOARD_RUNTIME_CONFIG__
       // (see shared/token-store.ts) — it ships in its own global so it never
       // rides along inside an object that logging / error-reporting could
       // serialize wholesale.
-      const runtimeConfigJson = JSON.stringify({
+      const runtimeConfigJson = toInlineScriptJson({
         // Composed from 127.0.0.1 + port (not getStatus().baseUrl) so the
         // value is always a loopback origin, even when the daemon binds 0.0.0.0.
         daemonBaseUrl: `http://127.0.0.1:${options.getStatus().port}`,
-      }).replace(/</g, '\\u003c')
+      })
       const runtimeConfigScript = `<script>window.__WHITEBOARD_RUNTIME_CONFIG__ = ${runtimeConfigJson}</script>`
       const tokenScript = token
-        ? `<script>window.__WHITEBOARD_DAEMON_TOKEN__ = ${JSON.stringify(token).replace(/</g, '\\u003c')}</script>`
+        ? `<script>window.__WHITEBOARD_DAEMON_TOKEN__ = ${toInlineScriptJson(token)}</script>`
         : ''
       const injected = `${runtimeConfigScript}${tokenScript}`
       const withRuntimeConfig = html.includes('</head>')

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -96,6 +96,7 @@ const ALLOWED_SHARED_EXACT = new Set([
   'loro-raw-element.js', // Zod schema for Loro-stored element shape — zod-only, no Node APIs
   'migration-bundle.js', // MigrationBundle Zod contract — zod-only, no Node APIs
   'resolve-parented-elements.js', // pure data transformation
+  'token-store.js', // in-memory daemon-token holder, no Node APIs
   'upload-files.js', // file upload transport, no Node APIs
   'ws-messages.js', // WebSocket protocol types/constants
   'ws-protocol.js', // WebSocket protocol helpers

--- a/packages/mcp-server/src/shared/api-client.test.ts
+++ b/packages/mcp-server/src/shared/api-client.test.ts
@@ -1,48 +1,87 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { readRuntimeConfig, runtimeConfigSchema } from './api-client.js'
+import { resetTokenStoreForTests } from './token-store.js'
 
 describe('runtimeConfigSchema', () => {
-  it('accepts a valid daemonToken string', () => {
-    expect(runtimeConfigSchema.parse({ daemonToken: 'abc' })).toEqual({ daemonToken: 'abc' })
+  it('accepts a valid daemonBaseUrl', () => {
+    expect(runtimeConfigSchema.parse({ daemonBaseUrl: 'http://127.0.0.1:3099' })).toEqual({
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
   })
 
-  it('accepts a null daemonToken', () => {
-    expect(runtimeConfigSchema.parse({ daemonToken: null })).toEqual({ daemonToken: null })
+  it('accepts an empty object', () => {
+    expect(runtimeConfigSchema.parse({})).toEqual({})
   })
 
-  it('rejects a non-string, non-null daemonToken', () => {
-    expect(() => runtimeConfigSchema.parse({ daemonToken: 42 })).toThrow()
+  it('rejects a non-string daemonBaseUrl', () => {
+    expect(() => runtimeConfigSchema.parse({ daemonBaseUrl: 42 })).toThrow()
+  })
+
+  // Mutation-check target: reverting the token-channel split to put daemonToken
+  // back inside this object must make this assertion fail — .strict() is what
+  // makes that regression visible instead of silently dropping the extra key.
+  it('rejects a payload that still carries daemonToken (.strict() rejection, not silent drop)', () => {
+    expect(runtimeConfigSchema.safeParse({ daemonToken: 'secret' }).success).toBe(false)
   })
 })
 
 describe('readRuntimeConfig', () => {
-  it('falls back to a null daemonToken when window is not defined', () => {
-    expect(readRuntimeConfig()).toEqual({ daemonToken: null })
+  it('falls back to the token-free default when window is not defined', () => {
+    expect(readRuntimeConfig()).toEqual({})
   })
 
-  it('falls back to a null daemonToken when the injected global fails schema validation', () => {
+  it('falls back to the token-free default when the injected global fails schema validation', () => {
     const fakeWindow = {
       location: { origin: 'http://localhost' },
-      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 42 },
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'secret' },
     }
     ;(globalThis as { window?: unknown }).window = fakeWindow
     try {
-      expect(readRuntimeConfig()).toEqual({ daemonToken: null })
+      expect(readRuntimeConfig()).toEqual({})
     } finally {
       delete (globalThis as { window?: unknown }).window
     }
   })
 
-  it('returns the injected daemonToken when it passes schema validation', () => {
+  it('returns the injected daemonBaseUrl when it passes schema validation', () => {
     const fakeWindow = {
       location: { origin: 'http://localhost' },
-      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'seeded-token' },
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonBaseUrl: 'http://127.0.0.1:3099' },
     }
     ;(globalThis as { window?: unknown }).window = fakeWindow
     try {
-      expect(readRuntimeConfig()).toEqual({ daemonToken: 'seeded-token' })
+      expect(readRuntimeConfig()).toEqual({ daemonBaseUrl: 'http://127.0.0.1:3099' })
     } finally {
       delete (globalThis as { window?: unknown }).window
+    }
+  })
+})
+
+describe('apiFetch auth header (TokenStore-sourced)', () => {
+  afterEach(() => {
+    resetTokenStoreForTests()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('attaches Authorization from the TokenStore token, ignoring any daemonToken on the runtime-config global', async () => {
+    const { apiFetch } = await import('./api-client.js')
+    let capturedHeaders: Headers | undefined
+    const fakeWindow = {
+      location: { origin: 'http://localhost' },
+      __WHITEBOARD_RUNTIME_CONFIG__: { daemonToken: 'ignored-config-token' },
+      __WHITEBOARD_DAEMON_TOKEN__: 'store-token',
+    }
+    ;(globalThis as { window?: unknown }).window = fakeWindow
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers)
+      return Promise.resolve(new Response('ok'))
+    }) as typeof fetch
+    try {
+      await apiFetch('http://localhost/api/workspaces')
+      expect(capturedHeaders?.get('Authorization')).toBe('Bearer store-token')
+    } finally {
+      globalThis.fetch = originalFetch
     }
   })
 })

--- a/packages/mcp-server/src/shared/api-client.ts
+++ b/packages/mcp-server/src/shared/api-client.ts
@@ -1,18 +1,28 @@
 import { z } from 'zod'
 import { injectTraceContextIntoHeaders } from './browser-tracing.js'
+import { readDaemonTokenOnce } from './token-store.js'
 
 // The server injects this shape into `window.__WHITEBOARD_RUNTIME_CONFIG__`
 // via a same-origin inline <script> (see server/app.ts). It crosses a
 // process boundary (server -> browser), so it is validated on read rather
 // than trusted as a cast — a malformed or tampered global falls back to the
 // unauthenticated default instead of propagating a bad value into apiFetch.
-export const runtimeConfigSchema = z.object({
-  daemonToken: z.string().nullable(),
-})
+//
+// Permanently token-free (ADR-0002 addendum): the daemon auth token travels
+// through its own global (see token-store.ts) so it never lands in a config
+// object that logging / error-reporting could serialize wholesale. `.strict()`
+// means a payload that still carries `daemonToken` fails validation rather
+// than silently dropping the extra key, so a stale server build cannot slip
+// a token back into this object undetected.
+export const runtimeConfigSchema = z
+  .object({
+    daemonBaseUrl: z.string().optional(),
+  })
+  .strict()
 
 export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>
 
-const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = { daemonToken: null }
+const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {}
 
 // This module compiles under both tsconfig.server.json (lib ES2022 + types
 // node — no DOM lib, no ambient `window`) and apps/web's DOM-enabled
@@ -66,7 +76,7 @@ export async function apiFetch(
   // stitch the inbound request span onto whatever client-side span (if
   // any) is active. No-op when browser tracing has not been enabled.
   injectTraceContextIntoHeaders(headers)
-  const { daemonToken } = readRuntimeConfig()
+  const daemonToken = readDaemonTokenOnce()
   if (daemonToken) {
     headers.set('Authorization', `Bearer ${daemonToken}`)
   }

--- a/packages/mcp-server/src/shared/daemon-backend.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ts
@@ -21,12 +21,13 @@
  * UndoManager history.
  */
 
-import { apiFetch, readRuntimeConfig } from './api-client.js'
+import { apiFetch } from './api-client.js'
 import type {
   BinaryFileDataLike,
   CanvasBackend,
   CanvasBackendHandlers,
 } from './canvas-backend-contract.js'
+import { readDaemonTokenOnce } from './token-store.js'
 import { uploadFiles } from './upload-files.js'
 import {
   clientReadyMessageSchema,
@@ -116,7 +117,7 @@ export class DaemonBackend implements CanvasBackend {
   private openSocket(handlers: CanvasBackendHandlers): void {
     if (this.cancelled) return
 
-    const { daemonToken } = readRuntimeConfig()
+    const daemonToken = readDaemonTokenOnce()
 
     const ws = new WebSocket(
       buildWhiteboardWsUrl(this.locationHref, this.workspaceId, this.slug),

--- a/packages/mcp-server/src/shared/token-redaction.test.ts
+++ b/packages/mcp-server/src/shared/token-redaction.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+//
+// Regression guard: the daemon auth token must never surface in a log
+// record while flowing through TokenStore -> apiFetch -> DaemonBackend.
+// None of these modules call getLogger today, so this test is a tripwire —
+// it fails the moment a future log call captures the token value anywhere
+// in a record's message or structured fields.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../server/log.js'
+import { readDaemonTokenOnce, resetTokenStoreForTests } from './token-store.js'
+
+const SENTINEL_TOKEN = 'sentinel-do-not-log-9f3c2a'
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  binaryType = 'blob'
+  onopen: (() => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: (() => void) | null = null
+  readonly url: string
+  readonly protocols: string | string[] | undefined
+
+  constructor(url: string | URL, protocols?: string | string[]) {
+    this.url = String(url)
+    this.protocols = protocols
+    FakeWebSocket.instances.push(this)
+  }
+
+  close(): void {
+    /* no-op */
+  }
+}
+
+function recordsContainSentinel(
+  records: ReturnType<typeof captureLogsForTests>['records'],
+): boolean {
+  return records.some((record) => {
+    const haystack = `${record.msg} ${JSON.stringify(record.data ?? {})}`
+    return haystack.includes(SENTINEL_TOKEN)
+  })
+}
+
+describe('token redaction: sentinel never reaches a log record', () => {
+  let originalWindow: unknown
+  let originalWebSocket: unknown
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    resetTokenStoreForTests()
+    originalWindow = (globalThis as Record<string, unknown>).window
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
+    originalFetch = globalThis.fetch
+    ;(globalThis as Record<string, unknown>).window = {
+      location: { origin: 'http://localhost' },
+      __WHITEBOARD_DAEMON_TOKEN__: SENTINEL_TOKEN,
+    }
+    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
+    globalThis.fetch = (async () => new Response('ok')) as typeof fetch
+  })
+
+  afterEach(() => {
+    ;(globalThis as Record<string, unknown>).window = originalWindow
+    ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
+    globalThis.fetch = originalFetch
+    resetTokenStoreForTests()
+  })
+
+  it('token-store read does not log the sentinel', () => {
+    const capture = captureLogsForTests()
+    try {
+      readDaemonTokenOnce()
+      expect(recordsContainSentinel(capture.records)).toBe(false)
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('apiFetch auth-header attachment does not log the sentinel', async () => {
+    const capture = captureLogsForTests()
+    try {
+      const { apiFetch } = await import('./api-client.js')
+      await apiFetch('http://localhost/api/workspaces')
+      expect(recordsContainSentinel(capture.records)).toBe(false)
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('DaemonBackend.openSocket (incl. simulated auth failure) does not log the sentinel', async () => {
+    const capture = captureLogsForTests()
+    try {
+      const { DaemonBackend } = await import('./daemon-backend.js')
+      const backend = new DaemonBackend('ws-id', 'slug', 'http://localhost/')
+      backend.connect({
+        onSnapshot: () => {},
+        onRemoteUpdate: () => {},
+        onVersionCreated: () => {},
+        onRestoreStarted: () => {},
+        onRestoreComplete: () => {},
+        onHeadChanged: () => {},
+        onViewportRequest: () => {},
+        onExportRequest: () => {},
+        onConnected: () => {},
+        onAuthError: () => {},
+      })
+      // Simulate the server rejecting the connection due to auth failure.
+      FakeWebSocket.instances[0]?.onclose?.({ code: 1008 })
+      backend.disconnect()
+      expect(recordsContainSentinel(capture.records)).toBe(false)
+    } finally {
+      capture.restore()
+    }
+  })
+})

--- a/packages/mcp-server/src/shared/token-store.test.ts
+++ b/packages/mcp-server/src/shared/token-store.test.ts
@@ -24,6 +24,19 @@ describe('token-store', () => {
     ).toBeUndefined()
   })
 
+  it('still returns the token when the global is non-configurable (delete throws in strict mode)', () => {
+    const win: Record<string, unknown> = {}
+    Object.defineProperty(win, '__WHITEBOARD_DAEMON_TOKEN__', {
+      value: 'pinned-token',
+      configurable: false,
+      writable: false,
+    })
+    setWindow(win)
+    expect(readDaemonTokenOnce()).toBe('pinned-token')
+    // The scrub failed (property is non-configurable) but reads still work.
+    expect(readDaemonTokenOnce()).toBe('pinned-token')
+  })
+
   it('returns null when the global is absent', () => {
     setWindow({})
     expect(readDaemonTokenOnce()).toBeNull()

--- a/packages/mcp-server/src/shared/token-store.test.ts
+++ b/packages/mcp-server/src/shared/token-store.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { readDaemonTokenOnce, resetTokenStoreForTests } from './token-store.js'
+
+function setWindow(value: unknown): void {
+  ;(globalThis as { window?: unknown }).window = value
+}
+
+function deleteWindow(): void {
+  delete (globalThis as { window?: unknown }).window
+}
+
+describe('token-store', () => {
+  afterEach(() => {
+    resetTokenStoreForTests()
+    deleteWindow()
+  })
+
+  it('returns the token when window.__WHITEBOARD_DAEMON_TOKEN__ is set and deletes the global', () => {
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 'seeded-token' })
+    expect(readDaemonTokenOnce()).toBe('seeded-token')
+    expect(
+      (globalThis as { window?: { __WHITEBOARD_DAEMON_TOKEN__?: unknown } }).window
+        ?.__WHITEBOARD_DAEMON_TOKEN__,
+    ).toBeUndefined()
+  })
+
+  it('returns null when the global is absent', () => {
+    setWindow({})
+    expect(readDaemonTokenOnce()).toBeNull()
+  })
+
+  it('one-shot semantics: stays null even if the global appears after the first (null) read', () => {
+    setWindow({})
+    expect(readDaemonTokenOnce()).toBeNull()
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 'too-late' })
+    expect(readDaemonTokenOnce()).toBeNull()
+  })
+
+  it('second call returns the stored value with the global already deleted', () => {
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 'seeded-token' })
+    expect(readDaemonTokenOnce()).toBe('seeded-token')
+    expect(readDaemonTokenOnce()).toBe('seeded-token')
+  })
+
+  it('non-string global value falls back to null without throwing', () => {
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 42 })
+    expect(() => readDaemonTokenOnce()).not.toThrow()
+    expect(readDaemonTokenOnce()).toBeNull()
+  })
+
+  it('no window (Node/server context) returns null without throwing', () => {
+    deleteWindow()
+    expect(() => readDaemonTokenOnce()).not.toThrow()
+    expect(readDaemonTokenOnce()).toBeNull()
+  })
+
+  it('resetTokenStoreForTests restores first-read semantics between tests', () => {
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 'first' })
+    expect(readDaemonTokenOnce()).toBe('first')
+    resetTokenStoreForTests()
+    setWindow({ __WHITEBOARD_DAEMON_TOKEN__: 'second' })
+    expect(readDaemonTokenOnce()).toBe('second')
+  })
+})

--- a/packages/mcp-server/src/shared/token-store.ts
+++ b/packages/mcp-server/src/shared/token-store.ts
@@ -34,7 +34,14 @@ export function readDaemonTokenOnce(): string | null {
     return null
   }
   const raw = win.__WHITEBOARD_DAEMON_TOKEN__
-  delete win.__WHITEBOARD_DAEMON_TOKEN__
+  try {
+    delete win.__WHITEBOARD_DAEMON_TOKEN__
+  } catch {
+    // In strict mode, delete on a non-configurable property throws a
+    // TypeError (e.g. the global was declared rather than assigned).
+    // Failing to scrub is acceptable — the value is already cached, and the
+    // delete is surface reduction, not a security boundary.
+  }
   const result = tokenValueSchema.safeParse(raw)
   cachedToken = result.success ? result.data : null
   return cachedToken

--- a/packages/mcp-server/src/shared/token-store.ts
+++ b/packages/mcp-server/src/shared/token-store.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+// The daemon auth token crosses the server -> browser boundary once, via its
+// own global (window.__WHITEBOARD_DAEMON_TOKEN__), separate from
+// __WHITEBOARD_RUNTIME_CONFIG__. Keeping it off the runtime-config object
+// shrinks the surface that gets serialized wholesale by logging / error
+// reporting — this is a serialization-surface reduction, not a security
+// boundary: any script that runs before this module reads the global still
+// sees it in plaintext.
+//
+// Module-singleton in-memory store, never persisted. First read consumes the
+// global (deletes it so later code paths cannot find a second copy lying
+// around) and caches the result for the rest of the session.
+const tokenValueSchema = z.string()
+
+type WindowLike = {
+  __WHITEBOARD_DAEMON_TOKEN__?: unknown
+}
+
+function getWindow(): WindowLike | undefined {
+  return (globalThis as { window?: WindowLike }).window
+}
+
+let cachedToken: string | null = null
+let hasRead = false
+
+export function readDaemonTokenOnce(): string | null {
+  if (hasRead) {
+    return cachedToken
+  }
+  hasRead = true
+  const win = getWindow()
+  if (win === undefined) {
+    return null
+  }
+  const raw = win.__WHITEBOARD_DAEMON_TOKEN__
+  delete win.__WHITEBOARD_DAEMON_TOKEN__
+  const result = tokenValueSchema.safeParse(raw)
+  cachedToken = result.success ? result.data : null
+  return cachedToken
+}
+
+// Test-only: restores first-read semantics so each test seeds and reads its
+// own token value independently of module-singleton state from earlier tests.
+export function resetTokenStoreForTests(): void {
+  cachedToken = null
+  hasRead = false
+}

--- a/packages/mcp-server/vite.config.ts
+++ b/packages/mcp-server/vite.config.ts
@@ -38,8 +38,8 @@ export default defineConfig({
         getExcalidrawFontCopyTarget(__dirname),
       ],
     }),
-    // Dev-only: injects window.__WHITEBOARD_RUNTIME_CONFIG__ so apiFetch
-    // sends Authorization: Bearer <token> on every /api/* request.
+    // Dev-only: injects window.__WHITEBOARD_DAEMON_TOKEN__ so TokenStore
+    // (via apiFetch) sends Authorization: Bearer <token> on every /api/* request.
     // apply: 'serve' inside the plugin ensures this never reaches production.
     runtimeConfigDevPlugin(),
   ],


### PR DESCRIPTION
Implements the ADR-0002 addendum's token-delivery decision (adopted Stage 2 auth design): the daemon token no longer travels inside `__WHITEBOARD_RUNTIME_CONFIG__`.

## Change (red-first, three sides changed together)

- **Injection**: daemon self-serve HTML (`server/app.ts`) and the vite dev plugin inject the token as a dedicated `window.__WHITEBOARD_DAEMON_TOKEN__` script (omitted when no token is configured); the runtime config script is token-free.
- **Consumption**: new `src/shared/token-store.ts` — module-singleton, `readDaemonTokenOnce()` reads the global once, validates with `z.string()`, caches in memory, **deletes the global**. `apiFetch` and `DaemonBackend.openSocket` both take the token from the store. Node-safe / browser-safe (boundary-allowlisted, plus a new transitive-safety scan so allowlisted shared modules can't smuggle Node builtins through indirect imports).
- **Schema hardening**: the shared `runtimeConfigSchema` becomes the strict single source of truth (`{ daemonBaseUrl? }.strict()`) — a payload still carrying `daemonToken` fails parse and falls back to defaults (regression-locked + mutation-checked); this also closed a pre-existing drift where the served config's `daemonBaseUrl` wasn't in the schema. apps/web's schema already rejected the key; now locked by test.
- **Redaction test**: a fake logger sink asserts a sentinel token never appears in any log record across store read, Bearer attachment, and WS auth-failure paths.
- **Smoke**: `smoke:e2e` now fetches the served HTML and asserts config-token absence + dedicated-global presence, alongside the existing authenticated /api + WS steps (exit 0 with a real daemon).

**Framing (per ADR-0002 addendum): this is serialization-surface reduction, not a security boundary** — it keeps the token out of the runtime-config object that logging/error-reporting paths may serialize; it does nothing against a script that runs before the delete.

Frozen-side note: `src/app` production code is untouched; three of its test files changed only their token-seeding mechanism (config-key → dedicated global + `resetTokenStoreForTests`), with auth-failure coverage unweakened.

## Verification
mcp-node 2771 ✓ / mcp-jsdom 286 ✓ / `pnpm smoke:e2e` (real daemon) exit 0 ✓ / apps/web 497 ✓ / both typechecks ✓. Review: 1 LOW (malformed daemonBaseUrl acceptance — noted).