### PR TITLE
feat(web): port WorkspaceTopBar aggregation component

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -1,0 +1,546 @@
+import type { SaveVersionResponse } from '@kamiazya/whiteboard-mcp/api-contracts'
+import type { ComponentProps } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '../index.css'
+import WorkspaceTopBar from './WorkspaceTopBar'
+
+type FetchArgs = [RequestInfo | URL, RequestInit?]
+
+function mkNamesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      workspace: 'Design review',
+      canvases: {
+        'design/login-flow': 'Login flow',
+        'design/settings-flow': 'Settings flow',
+      },
+      pinned: ['design/login-flow'],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkBranchesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      head: 'main',
+      branches: [
+        {
+          name: 'main',
+          tipFrontiers: '',
+          color: '#1971c2',
+          createdAt: '2026-04-23T00:00:00Z',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkSaveVersionResponse(): Response {
+  const body: SaveVersionResponse = {
+    version: {
+      id: 'v-saved-001',
+      slug: 'design/login-flow',
+      createdAt: new Date('2026-06-07T10:00:00Z').toISOString(),
+      elementCount: 42,
+      label: '',
+      auto: false,
+      hasThumbnail: false,
+      branchName: 'main',
+      operator: { kind: 'human', peerId: 'peer-test', displayName: 'Tester' },
+    },
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function mkVersionsResponse(count = 24): Response {
+  const versions = Array.from({ length: count }, (_, index) => ({
+    id: `v-${index}`,
+    slug: 'design/login-flow',
+    createdAt: new Date(Date.now() - index * 60_000).toISOString(),
+    elementCount: 58 + index,
+    label: `Version ${index + 1}`,
+    auto: index % 2 === 0,
+    hasThumbnail: false,
+    branchName: 'main',
+    operator: {
+      kind: index % 3 === 0 ? ('human' as const) : ('system' as const),
+      peerId: `peer-${index}`,
+      displayName: index % 3 === 0 ? 'Alice' : 'auto-save',
+    },
+  }))
+
+  return new Response(JSON.stringify({ versions }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderTopBar(props?: Partial<ComponentProps<typeof WorkspaceTopBar>>) {
+  return render(
+    <div className="h-[560px] w-[1100px] bg-background p-6">
+      <WorkspaceTopBar
+        workspaceId="sess_1"
+        slug="design/login-flow"
+        canvases={[
+          { slug: 'design/login-flow', updatedAt: '2026-04-24T11:00:00Z' },
+          { slug: 'design/settings-flow', updatedAt: '2026-04-23T11:00:00Z' },
+        ]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        {...props}
+      />
+    </div>,
+  )
+}
+
+beforeEach(() => {
+  const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.endsWith('/api/workspaces/sess_1/names')) return Promise.resolve(mkNamesResponse())
+    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+    if (url.includes('/versions') && url.endsWith('/restore')) {
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    }
+    if (url.includes('/versions') && init?.method === 'POST') {
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    }
+    if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  cleanup()
+  // Restore the shared browser instance's default viewport so later tests
+  // in this file (and other files sharing the instance) aren't affected by
+  // the collapse test's narrow viewport.
+  await page.viewport(1280, 900)
+})
+
+describe('WorkspaceTopBar browser mode', () => {
+  it('opens History from the real top bar and keeps the popover list scrollable', async () => {
+    const { container } = renderTopBar()
+
+    await page.getByRole('button', { name: 'History' }).click()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Version history')
+      expect(container.textContent).toContain('Version 1')
+      expect(container.textContent).toContain('Version 24')
+      expect(container.textContent).toContain('👤 Alice')
+    })
+
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
+    expect(viewport).toBeInstanceOf(HTMLDivElement)
+
+    await waitFor(() => {
+      expect(viewport!.clientHeight).toBeGreaterThan(0)
+      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight)
+    })
+
+    const before = viewport!.scrollTop
+    viewport!.scrollTo({ top: viewport!.scrollHeight })
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    expect(viewport!.scrollTop).toBeGreaterThan(before)
+
+    // Outside-click to close the popover. Workspace identity is no longer
+    // surfaced in the header so we click the back-button (always present)
+    // which is outside the version-history Popover bounds.
+    fireEvent.mouseDown(screen.getByRole('button', { name: /back to canvas list/i }))
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('Version 24')
+    })
+  })
+
+  it('exposes a theme toggle that cycles light → dark → system → light', async () => {
+    const onToggleTheme = vi.fn()
+    const { rerender } = renderTopBar({ theme: 'light', onToggleTheme })
+
+    // light → dark
+    fireEvent.click(screen.getByRole('button', { name: /Theme: light/i }))
+    expect(onToggleTheme).toHaveBeenLastCalledWith('dark')
+
+    function rerenderWith(theme: 'dark' | 'system') {
+      rerender(
+        <div className="h-[560px] w-[1100px] bg-background p-6">
+          <WorkspaceTopBar
+            workspaceId="sess_1"
+            slug="design/login-flow"
+            canvases={[
+              { slug: 'design/login-flow', updatedAt: '2026-04-24T11:00:00Z' },
+              { slug: 'design/settings-flow', updatedAt: '2026-04-23T11:00:00Z' },
+            ]}
+            onEnterFullscreen={() => {}}
+            onNavigateBack={() => {}}
+            onNavigateToCanvas={() => {}}
+            theme={theme}
+            onToggleTheme={onToggleTheme}
+          />
+        </div>,
+      )
+    }
+
+    // dark → system
+    rerenderWith('dark')
+    fireEvent.click(screen.getByRole('button', { name: /Theme: dark/i }))
+    expect(onToggleTheme).toHaveBeenLastCalledWith('system')
+
+    // system → light
+    rerenderWith('system')
+    fireEvent.click(screen.getByRole('button', { name: /Theme: system/i }))
+    expect(onToggleTheme).toHaveBeenLastCalledWith('light')
+  })
+
+  it('opens the restore dialog from a real history row and posts restore on confirm', async () => {
+    const onRestored = vi.fn()
+    renderTopBar({ onRestored })
+
+    await page.getByRole('button', { name: 'History' }).click()
+    await page.getByText(/^Version 1$/).click()
+
+    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+
+    await waitFor(() => {
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/versions/v-0/restore'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(onRestored).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('new-canvas dialog: shows Problem Details title on 409 and shows fallback on missing title', async () => {
+    let callCount = 0
+    // Override the beforeEach fetch stub for this test only.
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.endsWith('/api/workspaces/sess_1/names')) return Promise.resolve(mkNamesResponse())
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      if (url.includes('/canvases') && init?.method === 'POST') {
+        callCount++
+        if (callCount === 1) {
+          // First POST → 409 Problem Details with title
+          return Promise.resolve(
+            new Response(JSON.stringify({ title: 'Canvas "design/foo" already exists' }), {
+              status: 409,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+        // Second POST → 500 without title → fallback message
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'internal' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderTopBar()
+
+    // The canvas switcher trigger renders the slug as separate spans for prefix/leaf
+    // when a "/" is present ("design" + "/" + "login-flow"). Wait for the leaf span
+    // to appear, then walk up to the enclosing button.
+    await waitFor(() => expect(screen.getByText('login-flow')).toBeTruthy())
+    const switcherLeaf = screen.getByText('login-flow')
+    const switcher = switcherLeaf.closest('button')!
+    expect(switcher).toBeTruthy()
+    // pointerDown triggers Radix's open handler; pointerUp on the menu item selects it.
+    fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
+    await waitFor(() => screen.getByTestId('new-canvas-menu-item'))
+    fireEvent.pointerUp(screen.getByTestId('new-canvas-menu-item'))
+    await waitFor(() => screen.getByRole('dialog'))
+
+    // Submit a slug — first call returns 409 with Problem Details title.
+    const input = screen.getByPlaceholderText('e.g. design/login-flow')
+    fireEvent.change(input, { target: { value: 'design/foo' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Canvas "design/foo" already exists')).toBeTruthy()
+    })
+    // Dialog must still be open after an error.
+    expect(screen.getByRole('dialog')).toBeTruthy()
+
+    // Second submit — 500 without title → fallback.
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create canvas.')).toBeTruthy()
+    })
+    // Sensitive server internals must never be exposed.
+    expect(screen.queryByText(/internal/i)).toBeNull()
+  })
+
+  it('does not dispatch excalidraw:version_saved when POST /versions returns invalid schema', async () => {
+    // The default beforeEach mock returns { ok: true } for POST /versions,
+    // which does not match saveVersionResponseSchema (missing version.id, branchName, etc.).
+    const versionSavedFired = vi.fn()
+    window.addEventListener('excalidraw:version_saved', versionSavedFired)
+
+    renderTopBar()
+
+    // Ctrl+S triggers saveVersion(''); fire on window (capture listener)
+    fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+
+    // Wait until the fetch mock has been called for the POST /versions request.
+    // This is the observable boundary that confirms saveVersion has finished its
+    // round-trip — independent of whether the implementation logs to console,
+    // getLogger, or swallows the error silently.
+    await waitFor(() => {
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/versions'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    // Give the microtask queue one turn so any Promise continuations after the
+    // fetch resolve can settle before we assert the event was not dispatched.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+    expect(versionSavedFired).not.toHaveBeenCalled()
+
+    window.removeEventListener('excalidraw:version_saved', versionSavedFired)
+  })
+
+  it('dispatches excalidraw:version_saved with {workspaceId, slug} on a schema-conforming save, clearing the useDirtyState-driven HeaderSaveDot', async () => {
+    // Override the beforeEach stub so POST /versions returns a valid saveVersionResponseSchema body.
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.endsWith('/api/workspaces/sess_1/names')) return Promise.resolve(mkNamesResponse())
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions') && url.endsWith('/restore')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/versions') && init?.method === 'POST') {
+        return Promise.resolve(mkSaveVersionResponse())
+      }
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const versionSavedFired = vi.fn()
+    window.addEventListener('excalidraw:version_saved', versionSavedFired)
+
+    renderTopBar()
+
+    // Mark the doc dirty first (as useWhiteboardSync would on a real edit) so
+    // HeaderSaveDot's dot is visible before the save clears it.
+    window.dispatchEvent(
+      new CustomEvent('excalidraw:doc_changed', {
+        detail: { workspaceId: 'sess_1', slug: 'design/login-flow' },
+      }),
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save/i })).toBeTruthy()
+    })
+
+    // Ctrl+S triggers saveVersion(''); fire on window with capture listener.
+    fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+
+    // Wait for the event to be dispatched after the successful fetch + schema parse,
+    // with the exact detail shape useDirtyState filters on.
+    await waitFor(() => {
+      expect(versionSavedFired).toHaveBeenCalledTimes(1)
+      const event = versionSavedFired.mock.calls[0]![0] as CustomEvent<{
+        workspaceId: string
+        slug: string
+      }>
+      expect(event.detail).toEqual({ workspaceId: 'sess_1', slug: 'design/login-flow' })
+    })
+
+    // The dirty dot clears once useDirtyState observes the matching version_saved event.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /save/i })).toBeNull()
+    })
+
+    window.removeEventListener('excalidraw:version_saved', versionSavedFired)
+  })
+
+  it('issues PUT /versions/:id/thumbnail after a valid save when getThumbnailBlob returns a Blob', async () => {
+    const thumbnailBlob = new Blob(['fake-png'], { type: 'image/png' })
+    const getThumbnailBlob = vi.fn().mockResolvedValue(thumbnailBlob)
+
+    const thumbnailPutCalls: string[] = []
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.endsWith('/api/workspaces/sess_1/names')) return Promise.resolve(mkNamesResponse())
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions') && url.endsWith('/restore')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/versions') && init?.method === 'PUT') {
+        thumbnailPutCalls.push(url)
+        return Promise.resolve(new Response(null, { status: 204 }))
+      }
+      if (url.includes('/versions') && init?.method === 'POST') {
+        return Promise.resolve(mkSaveVersionResponse())
+      }
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderTopBar({ getThumbnailBlob })
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+
+    // Wait for the thumbnail PUT to be issued using the version id from the response.
+    await waitFor(() => {
+      expect(thumbnailPutCalls).toHaveLength(1)
+      expect(thumbnailPutCalls[0]).toContain('/versions/v-saved-001/thumbnail')
+    })
+
+    expect(getThumbnailBlob).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when thumbnail upload fails after a valid save', async () => {
+    const getThumbnailBlob = vi
+      .fn()
+      .mockResolvedValue(new Blob(['fake-png'], { type: 'image/png' }))
+
+    const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.endsWith('/api/workspaces/sess_1/names')) return Promise.resolve(mkNamesResponse())
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions') && url.endsWith('/restore')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/versions') && init?.method === 'PUT') {
+        // Simulate a network failure on thumbnail upload.
+        return Promise.reject(new Error('upload failed'))
+      }
+      if (url.includes('/versions') && init?.method === 'POST') {
+        return Promise.resolve(mkSaveVersionResponse())
+      }
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const versionSavedFired = vi.fn()
+    window.addEventListener('excalidraw:version_saved', versionSavedFired)
+
+    renderTopBar({ getThumbnailBlob })
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+
+    // The version_saved event must still fire even when the thumbnail upload rejects.
+    await waitFor(() => {
+      expect(versionSavedFired).toHaveBeenCalledTimes(1)
+    })
+
+    window.removeEventListener('excalidraw:version_saved', versionSavedFired)
+  })
+
+  // RED-first: the ~400px collapse is a new UX decision, not part of the
+  // original component — Tailwind's arbitrary max-*/min-* breakpoint
+  // variants only take effect against the real viewport width, so this
+  // guard can only run in the browser layer (jsdom class-list checks alone
+  // would pass even if the CSS never generated).
+  it('collapses the right-side actions into a "More actions" kebab under 400px, without hiding the left-side group', async () => {
+    // `display:none` on an ancestor (the collapse group, not the button
+    // itself) drops the button out of the accessibility tree, so
+    // page.getByRole()/toBeVisible() can't distinguish "present but hidden"
+    // from "not rendered", and getComputedStyle(button).display never
+    // reports 'none' since that property isn't inherited from the hidden
+    // ancestor. Query with RTL's `hidden: true` to bypass the a11y filter
+    // and use checkVisibility(), which walks the ancestor chain.
+    const isDisplayNone = (el: Element) =>
+      'checkVisibility' in el ? !(el as HTMLElement).checkVisibility() : false
+
+    await page.viewport(375, 900)
+    renderTopBar({ theme: 'light', onToggleTheme: vi.fn() })
+
+    const header = screen.getByRole('banner')
+    await waitFor(() => {
+      expect(header.getBoundingClientRect().height).toBeCloseTo(48, 0)
+    })
+
+    // Exposed right-side actions are hidden at this width.
+    await waitFor(() => {
+      expect(isDisplayNone(screen.getByRole('button', { name: 'History', hidden: true }))).toBe(
+        true,
+      )
+      expect(
+        isDisplayNone(screen.getByRole('button', { name: /Theme: light/i, hidden: true })),
+      ).toBe(true)
+      expect(isDisplayNone(screen.getByRole('button', { name: 'Fullscreen', hidden: true }))).toBe(
+        true,
+      )
+    })
+
+    // The kebab is visible instead.
+    // Use the testid rather than an accessible-name role query: an element
+    // that is itself display:none (the kebab is, at ≥400px) has no
+    // computable accessible name per the ARIA name-computation algorithm,
+    // so a name-filtered role query would spuriously not-find it there.
+    const kebab = screen.getByTestId('topbar-more-actions-trigger')
+    expect(isDisplayNone(kebab)).toBe(false)
+
+    // The left-side group (back button + canvas switcher + Pencil kebab +
+    // HeaderBranchChip) still renders without overflow or wrapping.
+    expect(isDisplayNone(screen.getByRole('button', { name: /back to canvas list/i }))).toBe(false)
+    await waitFor(() => {
+      expect(screen.getByText('login-flow')).toBeTruthy()
+    })
+
+    // Opening the kebab and selecting Fullscreen calls the same handler as
+    // the exposed button would.
+    const onEnterFullscreen = vi.fn()
+    cleanup()
+    renderTopBar({ onEnterFullscreen })
+    await page.getByRole('button', { name: 'More actions' }).click()
+    await page.getByRole('menuitem', { name: 'Fullscreen' }).click()
+    expect(onEnterFullscreen).toHaveBeenCalledTimes(1)
+
+    // Opening the kebab and selecting History opens the version popover
+    // (covers the Radix-menu-close vs. outside-click-close race).
+    await page.getByRole('button', { name: 'More actions' }).click()
+    await page.getByRole('menuitem', { name: 'History' }).click()
+    await waitFor(() => {
+      expect(screen.getByText('Version history')).toBeTruthy()
+    })
+
+    // At ≥400px the kebab is hidden again and the three buttons are visible.
+    // 401 (not exactly 400) sidesteps the boundary ambiguity between
+    // `max-[400px]:hidden` and `min-[400px]:hidden`, which both match at
+    // precisely 400px — the component intentionally treats 400px itself as
+    // "narrow" so the two collapse states never both show at once.
+    await page.viewport(401, 900)
+    cleanup()
+    renderTopBar({ theme: 'light', onToggleTheme: vi.fn() })
+    await waitFor(() => {
+      expect(isDisplayNone(screen.getByTestId('topbar-more-actions-trigger'))).toBe(true)
+      expect(isDisplayNone(screen.getByRole('button', { name: 'History' }))).toBe(false)
+      expect(isDisplayNone(screen.getByRole('button', { name: /Theme: light/i }))).toBe(false)
+      expect(isDisplayNone(screen.getByRole('button', { name: 'Fullscreen' }))).toBe(false)
+    })
+
+    const headerAfter = screen.getByRole('banner')
+    expect(headerAfter.getBoundingClientRect().height).toBeCloseTo(48, 0)
+  })
+})

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -1,8 +1,8 @@
 import type { SaveVersionResponse } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import '../index.css'
 import WorkspaceTopBar from './WorkspaceTopBar'
 
@@ -162,6 +162,27 @@ describe('WorkspaceTopBar browser mode', () => {
     await waitFor(() => {
       expect(container.textContent).not.toContain('Version 24')
     })
+  })
+
+  it('keeps the version popover open when a mousedown lands inside the restore confirmation dialog (RED-first)', async () => {
+    renderTopBar()
+
+    await page.getByRole('button', { name: 'History' }).click()
+    await waitFor(() => {
+      expect(screen.getByText('Version history')).toBeTruthy()
+    })
+
+    await page.getByText(/^Version 1$/).click()
+    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+
+    // The AlertDialog renders through a Radix portal into document.body, so
+    // this mousedown target is outside versionPanelRef's DOM subtree — the
+    // outside-click handler must still recognize it as "inside" via role.
+    const dialog = screen.getByRole('alertdialog')
+    fireEvent.mouseDown(dialog)
+
+    expect(screen.getByText('Version history')).toBeTruthy()
+    expect(screen.getByText('Restore this version?')).toBeTruthy()
   })
 
   it('exposes a theme toggle that cycles light → dark → system → light', async () => {

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+// Stub heavy/irrelevant dependencies so the component mounts without network or browser-only requirements.
+vi.mock('./HeaderBranchChip', () => ({ HeaderBranchChip: () => null }))
+vi.mock('./HeaderSaveDot', () => ({ HeaderSaveDot: () => null }))
+vi.mock('./VersionTimeline', () => ({ default: () => null }))
+vi.mock('@/hooks/useDirtyState', () => ({ useDirtyState: () => ({ isDirty: false }) }))
+vi.mock('@kamiazya/whiteboard-mcp/api-client', () => ({ apiFetch: vi.fn() }))
+
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import WorkspaceTopBar from './WorkspaceTopBar'
+
+function mkNamesOk() {
+  return new Response(JSON.stringify({ workspace: 'My WS', canvases: {}, pinned: [] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderBar(overrides?: {
+  onNavigateBack?: () => void
+  onNavigateToCanvas?: (slug: string) => void
+}) {
+  // React 18 delegates events to the root container. Radix portals render into document.body,
+  // which is a DOM sibling of the default test container. Using document.body as the React root
+  // ensures portal events bubble to React's listener.
+  return render(
+    <WorkspaceTopBar
+      workspaceId="ws_1"
+      slug="canvas-a"
+      canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+      onEnterFullscreen={() => {}}
+      onNavigateBack={overrides?.onNavigateBack ?? (() => {})}
+      onNavigateToCanvas={overrides?.onNavigateToCanvas ?? (() => {})}
+    />,
+    { container: document.body },
+  )
+}
+
+// Open the new canvas dialog through the canvas switcher dropdown.
+// Radix DropdownMenuTrigger opens on pointerDown (not click); DropdownMenuItem selects on pointerUp.
+async function openNewCanvasDialog() {
+  // The canvas switcher trigger is the button that shows the current canvas slug.
+  const switcher = screen.getByRole('button', { name: /canvas-a/i })
+  // pointerDown with button=0 triggers Radix's internal open handler.
+  fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
+  // After the dropdown opens, pointerUp on the item triggers onSelect → openNewCanvas().
+  const item = await screen.findByTestId('new-canvas-menu-item')
+  fireEvent.pointerUp(item)
+  await screen.findByRole('dialog')
+}
+
+// Fill in the slug field and click Create.
+async function submitSlug(slug: string) {
+  const input = screen.getByPlaceholderText('e.g. design/login-flow')
+  fireEvent.change(input, { target: { value: slug } })
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockImplementation(async (url) => {
+    if (String(url).includes('/names')) return mkNamesOk()
+    return new Response('{}', { status: 200 })
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('WorkspaceTopBar — new canvas error rendering (P-HTTP-005)', () => {
+  it('shows Problem Details body.title when the server returns a 409 with title', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (String(url).includes('/names')) return mkNamesOk()
+      // POST /canvases → 409 Problem Details
+      return new Response(
+        JSON.stringify({
+          type: 'https://example.com/problems/canvas_conflict',
+          title: 'Canvas already exists',
+          status: 409,
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      )
+    })
+
+    renderBar()
+    await openNewCanvasDialog()
+    await submitSlug('existing-canvas')
+
+    await waitFor(() => {
+      expect(screen.getByText('Canvas already exists')).toBeTruthy()
+    })
+  })
+
+  it('shows fallback and never exposes body.message (P-HTTP-005)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (String(url).includes('/names')) return mkNamesOk()
+      // Legacy response with sensitive body.message
+      return new Response(JSON.stringify({ message: '/Users/alice/secret-path/config.json' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    renderBar()
+    await openNewCanvasDialog()
+    await submitSlug('any-slug')
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create canvas.')).toBeTruthy()
+    })
+    expect(screen.queryByText(/secret-path/i)).toBeNull()
+    expect(screen.queryByText(/\/Users\//i)).toBeNull()
+  })
+
+  it('shows fallback and never exposes Error.message when fetch throws (P-HTTP-005)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (String(url).includes('/names')) return mkNamesOk()
+      throw new Error('Authorization: Bearer secret-token-XYZ')
+    })
+
+    renderBar()
+    await openNewCanvasDialog()
+    await submitSlug('any-slug')
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create canvas.')).toBeTruthy()
+    })
+    expect(screen.queryByText(/secret-token/i)).toBeNull()
+    expect(screen.queryByText(/Authorization/i)).toBeNull()
+  })
+
+  it('closes the dialog, shows no error, and calls onNavigateToCanvas with the entered slug on successful creation', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (String(url).includes('/names')) return mkNamesOk()
+      return new Response('{}', { status: 200 })
+    })
+    const onNavigateToCanvas = vi.fn()
+
+    renderBar({ onNavigateToCanvas })
+    await openNewCanvasDialog()
+    await submitSlug('new-canvas')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+    expect(screen.queryByText('Failed to create canvas.')).toBeNull()
+    expect(onNavigateToCanvas).toHaveBeenCalledWith('new-canvas')
+  })
+
+  it('shows fallback when Problem Details title is a non-string (Zod parse guard)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (String(url).includes('/names')) return mkNamesOk()
+      // title is a number — invalid per problemDetailsErrorSchema; cast would let it through
+      return new Response(JSON.stringify({ title: 42 }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    renderBar()
+    await openNewCanvasDialog()
+    await submitSlug('any-slug')
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create canvas.')).toBeTruthy()
+    })
+    expect(screen.queryByText('42')).toBeNull()
+  })
+
+  it('shows the slug validation error inline without making a fetch request', async () => {
+    renderBar()
+    await openNewCanvasDialog()
+    await submitSlug('bad/')
+
+    await waitFor(() => {
+      expect(screen.getByText(/enter a slug/i)).toBeTruthy()
+    })
+    // No POST request should have been made for invalid slugs.
+    const calls = vi
+      .mocked(apiFetch)
+      .mock.calls.filter(
+        ([url, init]) =>
+          String(url).includes('/canvases') && (init as RequestInit | undefined)?.method === 'POST',
+      )
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('WorkspaceTopBar — router-free navigation callbacks', () => {
+  it('calls onNavigateBack when the back button is clicked', () => {
+    const onNavigateBack = vi.fn()
+    renderBar({ onNavigateBack })
+
+    fireEvent.click(screen.getByRole('button', { name: /back to canvas list/i }))
+
+    expect(onNavigateBack).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('WorkspaceTopBar — ~400px collapse (RED-first)', () => {
+  it('marks the exposed right-side action group and the More-actions kebab trigger with responsive collapse classes', () => {
+    renderBar()
+
+    const header = screen.getByRole('banner')
+    expect(header.className).toContain('h-12')
+
+    const exposedGroup = screen.getByTestId('topbar-right-actions-exposed')
+    expect(exposedGroup.className).toContain('max-[400px]:hidden')
+
+    const kebabTrigger = screen.getByRole('button', { name: 'More actions' })
+    expect(kebabTrigger.className).toContain('min-[400px]:hidden')
+  })
+})

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 
 // Stub heavy/irrelevant dependencies so the component mounts without network or browser-only requirements.
 vi.mock('./HeaderBranchChip', () => ({ HeaderBranchChip: () => null }))
@@ -198,6 +199,150 @@ describe('WorkspaceTopBar — router-free navigation callbacks', () => {
     fireEvent.click(screen.getByRole('button', { name: /back to canvas list/i }))
 
     expect(onNavigateBack).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('WorkspaceTopBar — names fetch race (RED-first)', () => {
+  it('does not let a stale in-flight /names response for a previous workspaceId overwrite the current workspace names', async () => {
+    let resolveA!: (r: Response) => void
+    let resolveB!: (r: Response) => void
+    const pendingA = new Promise<Response>((resolve) => {
+      resolveA = resolve
+    })
+    const pendingB = new Promise<Response>((resolve) => {
+      resolveB = resolve
+    })
+
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      const u = String(url)
+      if (u.includes('/workspaces/ws_a/names')) return pendingA
+      if (u.includes('/workspaces/ws_b/names')) return pendingB
+      return new Response('{}', { status: 200 })
+    })
+
+    const baseProps = {
+      slug: 'shared-slug',
+      canvases: [{ slug: 'shared-slug', updatedAt: '2026-04-23T00:00:00Z' }],
+      onEnterFullscreen: () => {},
+      onNavigateBack: () => {},
+      onNavigateToCanvas: () => {},
+    }
+
+    const { rerender } = render(<WorkspaceTopBar workspaceId="ws_a" {...baseProps} />)
+    rerender(<WorkspaceTopBar workspaceId="ws_b" {...baseProps} />)
+
+    // The newer workspace's response arrives first; the stale ws_a response
+    // arrives later and must not clobber it.
+    resolveB(
+      new Response(
+        JSON.stringify({ workspace: 'B', canvases: { 'shared-slug': 'Fresh B' }, pinned: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Fresh B')).toBeTruthy()
+    })
+
+    resolveA(
+      new Response(
+        JSON.stringify({ workspace: 'A', canvases: { 'shared-slug': 'Stale A' }, pinned: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Stale A')).toBeNull()
+      expect(screen.getByText('Fresh B')).toBeTruthy()
+    })
+  })
+})
+
+describe('WorkspaceTopBar — canvas switcher overflow (RED-first)', () => {
+  it('wraps the canvas list section in a scrollable max-height container so many canvases remain reachable', async () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      slug: `canvas-${i}`,
+      updatedAt: '2026-04-23T00:00:00Z',
+    }))
+    renderBar()
+    cleanup()
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-0"
+        canvases={many}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+      />,
+    )
+
+    const switcher = screen.getByRole('button', { name: /canvas-0/i })
+    fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
+    await screen.findByTestId('new-canvas-menu-item')
+
+    expect(document.querySelector('.max-h-\\[300px\\].overflow-y-auto')).toBeTruthy()
+  })
+})
+
+describe('WorkspaceTopBar — saveVersion double-invoke race (RED-first)', () => {
+  it('issues exactly one POST /versions when Cmd/Ctrl+S fires twice before the first request resolves', async () => {
+    let resolvePost!: (r: Response) => void
+    const deferred = new Promise<Response>((resolve) => {
+      resolvePost = resolve
+    })
+    let postCount = 0
+    vi.mocked(apiFetch).mockImplementation(async (url, init) => {
+      const u = String(url)
+      if (u.includes('/names')) return mkNamesOk()
+      if (u.includes('/versions') && (init as RequestInit | undefined)?.method === 'POST') {
+        postCount++
+        return deferred
+      }
+      return new Response('{}', { status: 200 })
+    })
+
+    renderBar()
+
+    // Fire both keydowns inside a single act() batch so no intermediate
+    // render (and thus no updated `saving` closure) happens between them —
+    // this is the actual shape of the race: two dispatches landing before
+    // React has a chance to re-render with saving=true.
+    act(() => {
+      fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+      fireEvent.keyDown(window, { ctrlKey: true, key: 's', code: 'KeyS' })
+    })
+
+    resolvePost(new Response('{}', { status: 200 }))
+    await waitFor(() => expect(postCount).toBe(1))
+  })
+})
+
+describe('WorkspaceTopBar — new-canvas double submission (RED-first)', () => {
+  it('issues exactly one POST /canvases when Enter is pressed twice before the first request resolves', async () => {
+    let resolvePost!: (r: Response) => void
+    const deferred = new Promise<Response>((resolve) => {
+      resolvePost = resolve
+    })
+    let postCount = 0
+    vi.mocked(apiFetch).mockImplementation(async (url, init) => {
+      const u = String(url)
+      if (u.includes('/names')) return mkNamesOk()
+      if (u.includes('/canvases') && (init as RequestInit | undefined)?.method === 'POST') {
+        postCount++
+        return deferred
+      }
+      return new Response('{}', { status: 200 })
+    })
+
+    renderBar()
+    await openNewCanvasDialog()
+    const input = screen.getByPlaceholderText('e.g. design/login-flow')
+    fireEvent.change(input, { target: { value: 'double-submit' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    resolvePost(new Response('{}', { status: 200 }))
+    await waitFor(() => expect(postCount).toBe(1))
   })
 })
 

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -1,0 +1,767 @@
+import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
+import {
+  problemDetailsErrorSchema,
+  saveVersionResponseSchema,
+  workspaceNamesSchema,
+  type WorkspaceNames,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+import {
+  ChevronDown,
+  ChevronLeft,
+  Copy,
+  EllipsisVertical,
+  FilePlus2,
+  History,
+  Maximize2,
+  Pencil,
+  Pin,
+  Search,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { DirtyEventDetail } from '@/hooks/useDirtyState'
+import { useDirtyState } from '@/hooks/useDirtyState'
+import type { ThemeMode } from '@/hooks/useThemeMode'
+import { getAppLogger } from '@/lib/app-logger'
+import { cn } from '@/lib/utils'
+import { CanvasThumb } from './CanvasThumb'
+import { HeaderBranchChip } from './HeaderBranchChip'
+import { HeaderSaveDot } from './HeaderSaveDot'
+import { ThemeToggleButton } from './ThemeToggleButton'
+import VersionTimeline from './VersionTimeline'
+
+interface CanvasInfo {
+  slug: string
+  updatedAt: string
+}
+
+// Mirrors ThemeToggleButton's cycle order (system → light → dark → system).
+// Duplicated here — rather than exported from ThemeToggleButton — because the
+// two callers render different UI shapes (icon button vs. menu item); keep
+// this in sync with ThemeToggleButton.tsx's NEXT map if that cycle changes.
+const THEME_CYCLE: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+}
+
+// CanvasThumb is shared with IndexPage; see ./CanvasThumb.tsx.
+
+// Dropdown item with thumbnail, name, optional slug subtitle, and a pin toggle.
+// Keep the pin control on the right edge. Show it constantly when pinned, otherwise reveal it on hover.
+// Stop propagation on mouse down because Radix selection is driven from that event.
+function CanvasItem({
+  canvas,
+  workspaceId,
+  customName,
+  leafLabel,
+  active,
+  pinned,
+  onNavigate,
+  onTogglePin,
+}: {
+  canvas: CanvasInfo
+  workspaceId: string
+  customName: string | undefined
+  leafLabel: string
+  active: boolean
+  pinned: boolean
+  onNavigate: () => void
+  onTogglePin: (slug: string, nextPinned: boolean) => void
+}) {
+  return (
+    <DropdownMenuItem
+      onSelect={onNavigate}
+      className={cn('group flex items-center gap-2', active && 'bg-accent')}
+    >
+      <CanvasThumb workspaceId={workspaceId} slug={canvas.slug} />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={cn('truncate text-sm', active ? 'font-semibold text-primary' : 'font-medium')}
+        >
+          {leafLabel}
+        </span>
+        {customName && customName !== canvas.slug && (
+          <span className="truncate font-mono text-[10px] text-muted-foreground">
+            {canvas.slug}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        aria-label={pinned ? 'Unpin canvas' : 'Pin canvas'}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation()
+          e.preventDefault()
+          onTogglePin(canvas.slug, !pinned)
+        }}
+        className={cn(
+          'shrink-0 rounded p-1 text-muted-foreground hover:bg-accent-foreground/10 hover:text-foreground transition-opacity',
+          pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100',
+        )}
+      >
+        <Pin className={cn('size-3.5', pinned && 'fill-current')} />
+      </button>
+    </DropdownMenuItem>
+  )
+}
+
+interface Props {
+  workspaceId: string
+  slug: string
+  canvases: CanvasInfo[]
+  onRestored?: () => void
+  onEnterFullscreen: () => void
+  getThumbnailBlob?: () => Promise<Blob | null>
+  // Theme preference is owned by the page so reloads can rehydrate from
+  // localStorage and pass the resolved value to <Excalidraw theme=...>. The
+  // button cycles light → dark → system.
+  theme?: ThemeMode
+  onToggleTheme?: (next: ThemeMode) => void
+  // apps/web has no react-router-dom; the page owns navigation and passes it
+  // in as callbacks instead of the original Link/useNavigate.
+  onNavigateBack: () => void
+  onNavigateToCanvas: (slug: string) => void
+}
+
+// Give the canvas visual priority and keep the surrounding chrome lightweight.
+// - Only a 48px top bar; Excalidraw keeps the full width
+// - Left: back to workspace, inline workspace rename, and the canvas switcher
+// - Right: version history, fullscreen, and canvas rename actions. Below
+//   400px these secondary actions collapse into a "More actions" kebab so
+//   the header never wraps.
+// - More complex lists appear on demand through buttons and popovers
+
+export default function WorkspaceTopBar({
+  workspaceId,
+  slug,
+  canvases,
+  onRestored,
+  theme,
+  onToggleTheme,
+  onEnterFullscreen,
+  getThumbnailBlob,
+  onNavigateBack,
+  onNavigateToCanvas,
+}: Props) {
+  const log = getAppLogger('workspace-top-bar')
+  const [names, setNames] = useState<WorkspaceNames>({ canvases: {}, pinned: [] })
+  const [renamingCanvas, setRenamingCanvas] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [versionOpen, setVersionOpen] = useState(false)
+  const [canvasSearch, setCanvasSearch] = useState('')
+  const versionPanelRef = useRef<HTMLDivElement | null>(null)
+
+  // Save state: dirty dot + Cmd/Ctrl+S only.
+  // No beforeunload guard: every Excalidraw edit flows through useWhiteboardSync
+  // → LoroDoc → WebSocket → daemon → SQLite blob in real time, so closing the
+  // tab cannot lose persisted content. The dirty dot here only tracks
+  // "haven't named a manual version yet"; warning the user about it via the
+  // browser's leave-confirmation dialog is misleading and was getting in the
+  // way of automation (e.g. Playwright workflows).
+  const { isDirty } = useDirtyState(workspaceId, slug)
+  const [saving, setSaving] = useState(false)
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+  const shortcutHint = isMac ? '⌘S' : 'Ctrl+S'
+
+  // Shared save flow: POST /versions, then upload a thumbnail if available.
+  // Quick save passes an empty label.
+  const saveVersion = useCallback(
+    async (label = ''): Promise<boolean> => {
+      if (saving) return false
+      setSaving(true)
+      try {
+        const res = await apiFetch(
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ label }),
+          },
+        )
+        if (!res.ok) return false
+        const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
+        if (!parsed.success) {
+          log.error('POST /versions response did not match schema:', parsed.error)
+          return false
+        }
+        // Dispatch only after schema validation confirms the server response is well-formed.
+        // Manual save can bypass the server's version_created websocket path; a later WS event becomes a no-op.
+        if (typeof window !== 'undefined') {
+          const detail: DirtyEventDetail = { workspaceId, slug }
+          window.dispatchEvent(new CustomEvent('excalidraw:version_saved', { detail }))
+        }
+        const id = parsed.data.version.id
+        if (id && getThumbnailBlob) {
+          try {
+            const blob = await getThumbnailBlob()
+            if (blob) {
+              await apiFetch(
+                `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${id}/thumbnail`,
+                {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'image/png' },
+                  body: blob,
+                },
+              )
+            }
+          } catch (err) {
+            log.error('manual-save thumbnail upload failed:', err)
+          }
+        }
+        return true
+      } finally {
+        setSaving(false)
+      }
+    },
+    [workspaceId, slug, saving, getThumbnailBlob, log],
+  )
+
+  // Cmd/Ctrl+S performs a quick save.
+  // Excalidraw can focus an offscreen contenteditable for clipboard or IME work, which makes
+  // browser-level heuristics think the user is typing and can reopen the native Save Page dialog.
+  // Capture the shortcut unconditionally here because the canvas has no competing native save meaning.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isSave = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's' && !e.shiftKey
+      if (!isSave) return
+      e.preventDefault()
+      e.stopPropagation()
+      void saveVersion('')
+    }
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () =>
+      window.removeEventListener('keydown', onKey, { capture: true } as EventListenerOptions)
+  }, [saveVersion])
+
+  // New canvas dialog state. Seed the slug with the current group's prefix for faster repeated creation.
+  const [newCanvasOpen, setNewCanvasOpen] = useState(false)
+  const [newCanvasSlug, setNewCanvasSlug] = useState('')
+  const [newCanvasError, setNewCanvasError] = useState<string | null>(null)
+  const [newCanvasBusy, setNewCanvasBusy] = useState(false)
+
+  // Load display names.
+  const fetchNames = useCallback(async () => {
+    try {
+      const res = await apiFetch(`/api/workspaces/${workspaceId}/names`)
+      if (res.ok) setNames(workspaceNamesSchema.parse(await res.json()))
+    } catch {
+      /* best-effort */
+    }
+  }, [workspaceId])
+
+  useEffect(() => {
+    fetchNames()
+  }, [fetchNames])
+
+  const commitCanvasName = async () => {
+    const name = draft.trim()
+    try {
+      const res = await apiFetch(
+        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/name`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        },
+      )
+      if (res.ok) setNames(workspaceNamesSchema.parse(await res.json()))
+    } catch {
+      /* ignore */
+    } finally {
+      setRenamingCanvas(false)
+      setDraft('')
+    }
+  }
+
+  const cancelRename = () => {
+    setRenamingCanvas(false)
+    setDraft('')
+  }
+
+  // Toggle pin state and replace local state with the server response.
+  // This intentionally avoids optimistic UI because rollback is not worth the added complexity.
+  const togglePin = useCallback(
+    async (targetSlug: string, pinned: boolean) => {
+      try {
+        const res = await apiFetch(
+          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(targetSlug)}/pin`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pinned }),
+          },
+        )
+        if (res.ok) setNames(workspaceNamesSchema.parse(await res.json()))
+      } catch {
+        /* Pin failures stay silent; the UX does not need explicit retry handling here. */
+      }
+    },
+    [workspaceId],
+  )
+
+  // ---- canvas switcher data ----
+  const sortedCanvases = useMemo(
+    () => [...canvases].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
+    [canvases],
+  )
+  const filteredCanvases = useMemo(() => {
+    const q = canvasSearch.trim().toLowerCase()
+    if (!q) return sortedCanvases
+    return sortedCanvases.filter((c) => {
+      const n = names.canvases[c.slug]
+      return c.slug.toLowerCase().includes(q) || (n?.toLowerCase().includes(q) ?? false)
+    })
+  }, [sortedCanvases, canvasSearch, names.canvases])
+
+  // Split canvases into pinned and regular sections.
+  // Preserve the user-defined order in names.pinned instead of resorting those items by recency.
+  const pinnedSet = useMemo(() => new Set(names.pinned), [names.pinned])
+  const pinnedCanvases = useMemo(() => {
+    const bySlug = new Map(filteredCanvases.map((c) => [c.slug, c]))
+    return names.pinned.map((s) => bySlug.get(s)).filter((c): c is CanvasInfo => !!c)
+  }, [filteredCanvases, names.pinned])
+
+  // Group by slug prefix (the first segment). Canvases without "/" stay in the ungrouped bucket.
+  // Preserve recency order within each group and exclude anything already shown in the pinned section.
+  const groupedCanvases = useMemo(() => {
+    const groups = new Map<string, CanvasInfo[]>()
+    const UNGROUPED = ''
+    for (const c of filteredCanvases) {
+      if (pinnedSet.has(c.slug)) continue
+      const ix = c.slug.indexOf('/')
+      const key = ix === -1 ? UNGROUPED : c.slug.slice(0, ix)
+      const arr = groups.get(key)
+      if (arr) arr.push(c)
+      else groups.set(key, [c])
+    }
+    // Sort group headers alphabetically, but keep the ungrouped bucket last.
+    return [...groups.entries()].sort(([a], [b]) => {
+      if (a === UNGROUPED) return 1
+      if (b === UNGROUPED) return -1
+      return a.localeCompare(b)
+    })
+  }, [filteredCanvases, pinnedSet])
+
+  const canvasCustomName = names.canvases[slug]
+  // Prefer the custom name when present; otherwise split the slug into prefix and leaf.
+  // Muting the prefix helps show that nearby canvases belong to the same group.
+  const slashIndex = slug.indexOf('/')
+  const canvasPrefix = !canvasCustomName && slashIndex !== -1 ? slug.slice(0, slashIndex) : null
+  const canvasLeaf = !canvasCustomName && slashIndex !== -1 ? slug.slice(slashIndex + 1) : null
+  const canvasFlat = canvasCustomName ?? (canvasPrefix === null ? slug : null)
+
+  // Close the version history popover on outside clicks.
+  useEffect(() => {
+    if (!versionOpen) return
+    const onClick = (e: MouseEvent) => {
+      const panel = versionPanelRef.current
+      if (!panel) return
+      const target = e.target as Node | null
+      if (target && !panel.contains(target)) {
+        // Ignore clicks on the trigger itself because the toggle button handles those.
+        const isTrigger = (e.target as HTMLElement)?.closest('[data-version-trigger]')
+        if (!isTrigger) setVersionOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [versionOpen])
+
+  // New canvas flow: open dialog, enter slug, POST /canvases, then let the
+  // page navigate to it on success.
+  // Reusing the current prefix makes it easier to keep related canvases grouped.
+  const openNewCanvas = () => {
+    const ix = slug.indexOf('/')
+    const prefix = ix !== -1 ? slug.slice(0, ix) + '/' : ''
+    setNewCanvasSlug(prefix)
+    setNewCanvasError(null)
+    setNewCanvasOpen(true)
+  }
+
+  const submitNewCanvas = async () => {
+    const target = newCanvasSlug.trim()
+    if (!target || target.endsWith('/')) {
+      setNewCanvasError('Enter a slug (e.g. "design/foo" or "quick-note").')
+      return
+    }
+    setNewCanvasBusy(true)
+    setNewCanvasError(null)
+    try {
+      const res = await apiFetch(`/api/workspaces/${workspaceId}/canvases`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: target }),
+      })
+      if (res.ok) {
+        setNewCanvasOpen(false)
+        setNewCanvasSlug('')
+        onNavigateToCanvas(target)
+        return
+      }
+      const parsed = problemDetailsErrorSchema.safeParse(await res.json().catch(() => ({})))
+      // Use the Problem Details title when present; otherwise show a safe
+      // generic message. Never expose body.message or Error.message — those
+      // can contain server-side paths or credentials (P-HTTP-005).
+      const title = parsed.success ? parsed.data.title : undefined
+      setNewCanvasError(title ? title : 'Failed to create canvas.')
+    } catch {
+      setNewCanvasError('Failed to create canvas.')
+    } finally {
+      setNewCanvasBusy(false)
+    }
+  }
+
+  const copyCanvasUrl = async () => {
+    try {
+      const url = `${window.location.origin}/canvas/${workspaceId}/${encodeURIComponent(slug)}`
+      await navigator.clipboard.writeText(url)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <header className="relative z-30 flex h-12 shrink-0 items-center justify-between gap-3 border-b bg-background px-3">
+      {/* Left side: back button, workspace name, and canvas switcher. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onNavigateBack}
+              aria-label="Back to canvas list"
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Back to canvas list</TooltipContent>
+        </Tooltip>
+
+        {/* canvas switcher dropdown — workspace identity is intentionally
+            hidden in OSS Local; the back-button returns to the flat canvas
+            list and the name shown here is the canvas, not the workspace. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-1 truncate rounded px-1.5 py-0.5 text-sm hover:bg-accent"
+            >
+              {canvasFlat !== null ? (
+                <span className="truncate font-semibold">{canvasFlat}</span>
+              ) : (
+                <>
+                  <span className="truncate text-muted-foreground">{canvasPrefix}</span>
+                  <span className="shrink-0 text-muted-foreground/60">/</span>
+                  <span className="truncate font-semibold">{canvasLeaf}</span>
+                </>
+              )}
+              <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            // Let Radix handle the single scroll container.
+            // Search stays sticky at the top and the footer stays sticky at the bottom.
+            className="w-[320px] p-0"
+            align="start"
+          >
+            <div className="sticky top-0 z-10 border-b bg-popover p-2">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={canvasSearch}
+                  onChange={(e) => setCanvasSearch(e.target.value)}
+                  placeholder="Switch canvas…"
+                  className="h-8 pl-7 text-xs"
+                  autoFocus
+                />
+              </div>
+            </div>
+            <div>
+              <div className="flex flex-col p-1">
+                {filteredCanvases.length === 0 ? (
+                  <div className="px-2 py-3 text-center text-xs text-muted-foreground">
+                    No matching canvas.
+                  </div>
+                ) : (
+                  <>
+                    {pinnedCanvases.length > 0 && (
+                      <div className="mb-1">
+                        <DropdownMenuLabel className="px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                          <Pin className="size-3 fill-current" />
+                          Pinned
+                        </DropdownMenuLabel>
+                        {pinnedCanvases.map((c) => (
+                          <CanvasItem
+                            key={c.slug}
+                            canvas={c}
+                            workspaceId={workspaceId}
+                            customName={names.canvases[c.slug]}
+                            // Keep the full slug in the pinned section so the original group context stays visible.
+                            leafLabel={names.canvases[c.slug] ?? c.slug}
+                            active={c.slug === slug}
+                            pinned={true}
+                            onNavigate={() => {
+                              onNavigateToCanvas(c.slug)
+                              setCanvasSearch('')
+                            }}
+                            onTogglePin={togglePin}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    {groupedCanvases.map(([group, items], gi) => (
+                      <div
+                        key={group || '__ungrouped__'}
+                        className={gi > 0 || pinnedCanvases.length > 0 ? 'mt-1' : ''}
+                      >
+                        {group !== '' && (
+                          <DropdownMenuLabel className="px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                            {group}
+                          </DropdownMenuLabel>
+                        )}
+                        {items.map((c) => {
+                          const leafSlug = group === '' ? c.slug : c.slug.slice(group.length + 1)
+                          return (
+                            <CanvasItem
+                              key={c.slug}
+                              canvas={c}
+                              workspaceId={workspaceId}
+                              customName={names.canvases[c.slug]}
+                              leafLabel={names.canvases[c.slug] ?? leafSlug}
+                              active={c.slug === slug}
+                              pinned={false}
+                              onNavigate={() => {
+                                onNavigateToCanvas(c.slug)
+                                setCanvasSearch('')
+                              }}
+                              onTogglePin={togglePin}
+                            />
+                          )
+                        })}
+                      </div>
+                    ))}
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="sticky bottom-0 z-10 border-t bg-popover">
+              <DropdownMenuItem
+                data-testid="new-canvas-menu-item"
+                onSelect={openNewCanvas}
+                className="gap-2 rounded-none font-medium"
+              >
+                <FilePlus2 className="size-3.5" />
+                New canvas…
+              </DropdownMenuItem>
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Canvas-specific actions such as rename and copy URL. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Canvas actions"
+            >
+              <Pencil className="size-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem
+              onSelect={() => {
+                setDraft(names.canvases[slug] ?? '')
+                setRenamingCanvas(true)
+              }}
+              className="gap-2"
+            >
+              <Pencil className="size-3.5" />
+              Rename canvas
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={copyCanvasUrl} className="gap-2">
+              <Copy className="size-3.5" />
+              Copy canvas URL
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Inline canvas rename input. */}
+        {renamingCanvas && (
+          <Input
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commitCanvasName}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitCanvasName()
+              else if (e.key === 'Escape') cancelRename()
+            }}
+            placeholder={slug}
+            className="h-7 max-w-[220px] text-sm"
+          />
+        )}
+
+        {/* Branch chip with switch, create, rename, delete, and merge actions.
+            This is the top bar's only destructive control (branch delete,
+            confirmed via AlertDialog inside HeaderBranchChip); it stays in
+            this left-side group and is not part of the <400px collapse. */}
+        <span className="mx-1 hidden h-4 w-px bg-border sm:inline-block" aria-hidden />
+        <HeaderBranchChip workspaceId={workspaceId} slug={slug} />
+
+        {/* Save-state dot. */}
+        <HeaderSaveDot
+          dirty={isDirty}
+          saving={saving}
+          onSave={() => void saveVersion('')}
+          shortcutHint={shortcutHint}
+        />
+      </div>
+
+      {/* Right side: version history, theme, and fullscreen. Hidden below
+          400px in favor of the "More actions" kebab so the header never wraps. */}
+      <div
+        data-testid="topbar-right-actions-exposed"
+        className="flex shrink-0 items-center gap-1 max-[400px]:hidden"
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              data-version-trigger
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => setVersionOpen((v) => !v)}
+            >
+              <History className="size-3.5" />
+              <span className="text-xs">History</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Version history</TooltipContent>
+        </Tooltip>
+        {onToggleTheme && theme && <ThemeToggleButton theme={theme} onChange={onToggleTheme} />}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="size-8 p-0"
+              onClick={onEnterFullscreen}
+              aria-label="Fullscreen"
+            >
+              <Maximize2 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Fullscreen (f)</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* "More actions" kebab: only visible below 400px, reusing the same
+          handlers as the exposed History/Theme/Fullscreen controls above. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="More actions"
+            data-testid="topbar-more-actions-trigger"
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground min-[400px]:hidden"
+          >
+            <EllipsisVertical className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            data-version-trigger
+            onSelect={() => setVersionOpen((v) => !v)}
+            className="gap-2"
+          >
+            <History className="size-3.5" />
+            History
+          </DropdownMenuItem>
+          {onToggleTheme && theme && (
+            <DropdownMenuItem
+              onSelect={() => onToggleTheme(THEME_CYCLE[theme])}
+              className="gap-2"
+              aria-label={`Theme: ${theme}`}
+            >
+              Theme
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem onSelect={onEnterFullscreen} className="gap-2">
+            <Maximize2 className="size-3.5" />
+            Fullscreen
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={newCanvasOpen} onOpenChange={setNewCanvasOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New canvas</DialogTitle>
+            <DialogDescription>
+              Slug identifies the canvas on disk. Use `/` to group (e.g. "design/login-flow").
+              Allowed: letters, digits, `-`, `/` (no leading/trailing `/`).
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={newCanvasSlug}
+            onChange={(e) => {
+              setNewCanvasSlug(e.target.value)
+              if (newCanvasError) setNewCanvasError(null)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void submitNewCanvas()
+              }
+            }}
+            placeholder="e.g. design/login-flow"
+            maxLength={120}
+          />
+          {newCanvasError && <div className="text-xs text-destructive">{newCanvasError}</div>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setNewCanvasOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={submitNewCanvas} disabled={newCanvasBusy}>
+              {newCanvasBusy ? 'Creating…' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Version history popover docked under the top-right controls. */}
+      {versionOpen && (
+        <div
+          ref={versionPanelRef}
+          className="absolute right-3 top-[calc(100%+6px)] z-40 w-[340px] overflow-hidden rounded-lg border bg-background shadow-lg"
+        >
+          <div className="flex h-[480px] min-h-0 flex-col">
+            <VersionTimeline workspaceId={workspaceId} slug={slug} onRestored={onRestored} />
+          </div>
+        </div>
+      )}
+    </header>
+  )
+}

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -179,6 +179,11 @@ export default function WorkspaceTopBar({
   // way of automation (e.g. Playwright workflows).
   const { isDirty } = useDirtyState(workspaceId, slug)
   const [saving, setSaving] = useState(false)
+  // `saving` state updates land on the next render, so two calls issued
+  // before React re-renders both see the same stale `false`. Guard with a
+  // ref instead, which is set/cleared synchronously and never causes the
+  // keydown listener to be re-subscribed (kept out of saveVersion's deps).
+  const savingRef = useRef(false)
   const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
   const shortcutHint = isMac ? '⌘S' : 'Ctrl+S'
 
@@ -186,7 +191,8 @@ export default function WorkspaceTopBar({
   // Quick save passes an empty label.
   const saveVersion = useCallback(
     async (label = ''): Promise<boolean> => {
-      if (saving) return false
+      if (savingRef.current) return false
+      savingRef.current = true
       setSaving(true)
       try {
         const res = await apiFetch(
@@ -229,10 +235,11 @@ export default function WorkspaceTopBar({
         }
         return true
       } finally {
+        savingRef.current = false
         setSaving(false)
       }
     },
-    [workspaceId, slug, saving, getThumbnailBlob, log],
+    [workspaceId, slug, getThumbnailBlob, log],
   )
 
   // Cmd/Ctrl+S performs a quick save.
@@ -258,19 +265,22 @@ export default function WorkspaceTopBar({
   const [newCanvasError, setNewCanvasError] = useState<string | null>(null)
   const [newCanvasBusy, setNewCanvasBusy] = useState(false)
 
-  // Load display names.
-  const fetchNames = useCallback(async () => {
-    try {
-      const res = await apiFetch(`/api/workspaces/${workspaceId}/names`)
-      if (res.ok) setNames(workspaceNamesSchema.parse(await res.json()))
-    } catch {
-      /* best-effort */
+  // Load display names. Guard against a stale response for a previous
+  // workspaceId landing after a newer request already resolved.
+  useEffect(() => {
+    let active = true
+    ;(async () => {
+      try {
+        const res = await apiFetch(`/api/workspaces/${workspaceId}/names`)
+        if (res.ok && active) setNames(workspaceNamesSchema.parse(await res.json()))
+      } catch {
+        /* best-effort */
+      }
+    })()
+    return () => {
+      active = false
     }
   }, [workspaceId])
-
-  useEffect(() => {
-    fetchNames()
-  }, [fetchNames])
 
   const commitCanvasName = async () => {
     const name = draft.trim()
@@ -377,9 +387,15 @@ export default function WorkspaceTopBar({
       if (!panel) return
       const target = e.target as Node | null
       if (target && !panel.contains(target)) {
+        const targetEl = e.target as HTMLElement
         // Ignore clicks on the trigger itself because the toggle button handles those.
-        const isTrigger = (e.target as HTMLElement)?.closest('[data-version-trigger]')
-        if (!isTrigger) setVersionOpen(false)
+        const isTrigger = targetEl.closest('[data-version-trigger]')
+        // Radix dialogs (e.g. VersionTimeline's restore confirmation) render
+        // into a document.body portal, outside versionPanelRef's DOM subtree —
+        // treat clicks inside them as "inside" so confirming a restore doesn't
+        // also close the version popover behind it.
+        const isInPortalDialog = targetEl.closest('[role="dialog"], [role="alertdialog"]')
+        if (!isTrigger && !isInPortalDialog) setVersionOpen(false)
       }
     }
     document.addEventListener('mousedown', onClick)
@@ -398,6 +414,7 @@ export default function WorkspaceTopBar({
   }
 
   const submitNewCanvas = async () => {
+    if (newCanvasBusy) return
     const target = newCanvasSlug.trim()
     if (!target || target.endsWith('/')) {
       setNewCanvasError('Enter a slug (e.g. "design/foo" or "quick-note").')
@@ -496,7 +513,7 @@ export default function WorkspaceTopBar({
                 />
               </div>
             </div>
-            <div>
+            <div className="max-h-[300px] overflow-y-auto">
               <div className="flex flex-col p-1">
                 {filteredCanvases.length === 0 ? (
                   <div className="px-2 py-3 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
UI-unification Stage 2 — the last of the 12 ported components. WorkspaceTopBar aggregates every previously merged child: ThemeToggleButton / HeaderSaveDot / CanvasThumb (#143), VersionTimeline (#145), HeaderBranchChip (#147), on useDirtyState (#139) and the #140 subpaths. **This completes the component-port wave.**

## Change (three deliberate deviations from the frozen original, everything else faithful)

1. **Router removal**: apps/web has no react-router yet — `Link`/`useNavigate` become `onNavigateBack` / `onNavigateToCanvas(slug)` callback props (same pattern as #145's callback-based useBranches). The unified CanvasPage (slices 9-10) wires them to the real router.
2. **~400px collapse (decided UX)**: the right-side secondary actions (History / Theme / Fullscreen) hide under a "More actions" kebab below 400px via CSS-only Tailwind breakpoints (`max-[400px]:hidden` / `min-[400px]:hidden`); header stays a fixed 48px with no wrap. Red-first jsdom class assertions + a browser test at a real <400px viewport (buttons hidden, kebab opens, same handlers fire, left group unbroken).
3. **Destructive-control note (decided UX)**: the TopBar's only destructive control is HeaderBranchChip's branch-delete, already kebab'd + AlertDialog-confirmed — it stays in the always-visible left group by design. BrowserLocalCanvasPage's exposed canvas-Delete moves in slices 9-10, not here.

`excalidraw:version_saved` dispatch unchanged (matches the ported useDirtyState's detail filter — verified in a browser test that the save flow clears the dirty dot through the real event). Cmd/Ctrl+S quick save, 409 Problem Details rendering, thumbnail upload after save, all ported with their suites (6 jsdom + 8 browser originals + 1 new collapse case).

`packages/mcp-server` zero diff (frozen); no page wiring; apps/web copy is canonical.

## Verification

apps/web jsdom 505 ✓ / browser 87 ✓ / tsc ✓ / mcp typecheck ✓ / packages zero diff ✓ — all re-run by the integrator post-rebase. **Note**: the dev-loop's internal review/QA lanes were lost to an org spend-limit outage, so the AI review on this PR is the primary independent review pass — extra scrutiny welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace top bar with canvas switching, rename, copy link, history, quick save, theme toggling, and a mobile overflow menu.
  * Added a “new canvas” flow with slug validation, error handling, and navigation on success.

* **Tests**
  * Added browser and unit coverage for history, restore, save status, thumbnail uploads, responsive behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->