### PR TITLE
test(mcp): dedupe window-teardown simulation into withWindowTornDown helper

### DIFF
--- a/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
@@ -19,6 +19,23 @@ function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200 })
 }
 
+// Simulate Vitest tearing the jsdom environment down (as it does once a test
+// file finishes) while a component-scheduled timer is still pending, then
+// restore `window`. React 19 silently no-ops a setState on an unmounted root
+// under a *live* jsdom window; the crash only reproduces once `window` itself
+// is gone by the time the timer fires — dispatchSetState then touches the
+// now-undefined `window` and throws "ReferenceError: window is not defined".
+// If waitForPendingTimer throws, it propagates and fails the test.
+async function withWindowTornDown(waitForPendingTimer: () => Promise<unknown>): Promise<void> {
+  const savedWindow = (globalThis as { window?: unknown }).window
+  delete (globalThis as { window?: unknown }).window
+  try {
+    await waitForPendingTimer()
+  } finally {
+    ;(globalThis as { window?: unknown }).window = savedWindow
+  }
+}
+
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-05-01T00:00:00Z'))
@@ -187,32 +204,16 @@ describe('StorageReportCard', () => {
     // fetch response and MIN_REFRESH_MS floor — this is the timing window
     // that let a post-unmount setLoading(false) fire during jsdom teardown.
     unmount()
-    // Simulate the jsdom environment being torn down (as Vitest does once a
-    // test file's tests finish) while refresh()'s pending setTimeout is
-    // still scheduled. React 19 silently no-ops a setState call on an
-    // already-unmounted root under a *live* jsdom window — the crash seen
-    // in CI only reproduces once `window` itself is gone by the time the
-    // timer fires, which is what actually happened: dispatchSetState
-    // touched the (now-undefined) `window` and threw
-    // "ReferenceError: window is not defined".
-    const savedWindow = (globalThis as { window?: unknown }).window
-    delete (globalThis as { window?: unknown }).window
-    let thrown: unknown = null
-    try {
-      await vi.advanceTimersByTimeAsync(500)
-    } catch (err) {
-      thrown = err
-    } finally {
-      ;(globalThis as { window?: unknown }).window = savedWindow
-    }
-    expect(thrown).toBeNull()
+    // Tear down `window` while refresh()'s pending setTimeout is still
+    // scheduled — the CI crash reproduces only once `window` is gone.
+    await withWindowTornDown(() => vi.advanceTimersByTimeAsync(500))
   })
 
   it(
     'does not call setState after unmount while the optimizeAll status-clear timer is still pending',
     async () => {
       const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      fetchMock.mockImplementation((input: RequestInfo | URL) => {
         const url =
           typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
         if (url === '/api/runtime/storage') {
@@ -249,20 +250,11 @@ describe('StorageReportCard', () => {
       // scheduleStatusClear's own mountedRef branch instead of refresh()'s.
       unmount()
 
-      // Simulate the jsdom environment being torn down before the timer
-      // fires — the same "window is not defined" hazard the refresh() test
-      // guards against, reached through a different handler this time.
-      const savedWindow = (globalThis as { window?: unknown }).window
-      delete (globalThis as { window?: unknown }).window
-      let thrown: unknown = null
-      try {
-        await new Promise((resolve) => setTimeout(resolve, STATUS_CLEAR_MS + 200))
-      } catch (err) {
-        thrown = err
-      } finally {
-        ;(globalThis as { window?: unknown }).window = savedWindow
-      }
-      expect(thrown).toBeNull()
+      // Tear down `window` before the timer fires — the same hazard the
+      // refresh() test guards against, reached through scheduleStatusClear.
+      await withWindowTornDown(
+        () => new Promise((resolve) => setTimeout(resolve, STATUS_CLEAR_MS + 200)),
+      )
     },
     STATUS_CLEAR_MS + 5000,
   )


### PR DESCRIPTION
## Summary

Follow-up to #111 (StorageReportCard post-unmount setState guard). The refresh() and optimizeAll unmount regression tests each inlined the same ~10-line save-window / delete-window / run-pending-timer / restore block; this extracts a single `withWindowTornDown` helper so the React-19 teardown rationale lives in one place. A timer callback that throws now propagates and fails the test directly (equivalent to the old capture-and-assert).

Test-only, behavior-preserving. Produced by a dev-loop whose production fix turned out to be already merged as #111 — this refactor was the only surviving delta.

## Test plan

- [x] `vitest run --project mcp-jsdom StorageReportCard` — 6/6 pass (3x repeat, no flake)
- [x] mcp-jsdom full project 283 passed; typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for delayed UI updates and teardown scenarios.
  * Consolidated repeated test setup for simulating cleanup timing issues.
  * Refined timer-based checks to better validate behavior when the app is unmounted mid-update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->