### PR TITLE
feat(web): add delete confirmation dialog to browser-local canvas page

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import { IndexedDBStore } from '../lib/browser-local-store.js'
 // Real app styles so layout assertions measure the shipped geometry.
@@ -49,6 +49,10 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
       timeout: 5000,
     })
     screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    within(dialog)
+      .getByRole('button', { name: /^delete$/i })
+      .click()
     await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
       timeout: 5000,
     })
@@ -60,6 +64,10 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
       timeout: 5000,
     })
     screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    within(dialog)
+      .getByRole('button', { name: /^delete$/i })
+      .click()
     await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
       timeout: 5000,
     })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -21,6 +21,13 @@ async function renderLoaded(store = new IndexedDBStore()) {
   return store
 }
 
+// Click the header "Delete canvas" trigger and wait for the confirmation
+// dialog to appear.
+async function openDeleteDialog(): Promise<HTMLElement> {
+  screen.getByRole('button', { name: /delete canvas/i }).click()
+  return screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+}
+
 describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB)', () => {
   beforeEach(async () => {
     await clearDb()
@@ -32,8 +39,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
 
   it('opening the delete dialog does not delete the canvas yet', async () => {
     const store = await renderLoaded()
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    await openDeleteDialog()
 
     // Not yet deleted: the cleanup-completed screen has not been shown, and the
     // canvas row is still present in the store.
@@ -47,8 +53,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     const beforeIds = (await store.listCanvases()).map((c) => c.id)
     expect(beforeIds.length).toBeGreaterThan(0)
 
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
     within(dialog)
       .getByRole('button', { name: /^delete$/i })
       .click()
@@ -64,8 +69,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
 
   it('cancelling via the Cancel button keeps the canvas intact', async () => {
     await renderLoaded()
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
     within(dialog)
       .getByRole('button', { name: /cancel/i })
       .click()
@@ -78,8 +82,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
 
   it('cancelling via Escape keeps the canvas intact', async () => {
     await renderLoaded()
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
     fireEvent.keyDown(dialog, { key: 'Escape' })
 
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
@@ -89,8 +92,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
 
   it('dialog exposes an accessible name and description tied to the destructive action', async () => {
     await renderLoaded()
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
 
     expect(dialog).toHaveAccessibleName('Delete this canvas?')
     expect(dialog).toHaveAccessibleDescription(/permanently removes the canvas.*cannot be undone/i)
@@ -122,8 +124,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Pending edit' } })
 
-    screen.getByRole('button', { name: /delete canvas/i }).click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
     within(dialog)
       .getByRole('button', { name: /^delete$/i })
       .click()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+// Real app styles so a11y/focus assertions run against the shipped geometry.
+import '../index.css'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+async function renderLoaded(store = new IndexedDBStore()) {
+  render(<BrowserLocalCanvasPage store={store} />)
+  await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+    timeout: 5000,
+  })
+  return store
+}
+
+describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opening the delete dialog does not delete the canvas yet', async () => {
+    const store = await renderLoaded()
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+
+    // Not yet deleted: the cleanup-completed screen has not been shown, and the
+    // canvas row is still present in the store.
+    expect(screen.queryByTestId('cleanup-completed')).toBeNull()
+    const list = await store.listCanvases()
+    expect(list.length).toBeGreaterThan(0)
+  })
+
+  it('confirming deletion shows the cleanup-completed view and removes the canvas row', async () => {
+    const store = await renderLoaded()
+    const beforeIds = (await store.listCanvases()).map((c) => c.id)
+    expect(beforeIds.length).toBeGreaterThan(0)
+
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    within(dialog)
+      .getByRole('button', { name: /^delete$/i })
+      .click()
+
+    await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const afterIds = (await store.listCanvases()).map((c) => c.id)
+    for (const id of beforeIds) {
+      expect(afterIds).not.toContain(id)
+    }
+  })
+
+  it('cancelling via the Cancel button keeps the canvas intact', async () => {
+    await renderLoaded()
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    within(dialog)
+      .getByRole('button', { name: /cancel/i })
+      .click()
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
+    expect(screen.queryByTestId('cleanup-completed')).toBeNull()
+    expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument()
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('cancelling via Escape keeps the canvas intact', async () => {
+    await renderLoaded()
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
+    expect(screen.queryByTestId('cleanup-completed')).toBeNull()
+    expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument()
+  })
+
+  it('dialog exposes an accessible name and description tied to the destructive action', async () => {
+    await renderLoaded()
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+
+    expect(dialog).toHaveAccessibleName('Delete this canvas?')
+    expect(dialog).toHaveAccessibleDescription(/permanently removes the canvas.*cannot be undone/i)
+  })
+
+  it('focus moves into the dialog on open and returns to the trigger on close', async () => {
+    await renderLoaded()
+    const trigger = screen.getByRole('button', { name: /delete canvas/i })
+    trigger.click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true), {
+      timeout: 5000,
+    })
+
+    within(dialog)
+      .getByRole('button', { name: /cancel/i })
+      .click()
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
+    await waitFor(() => expect(document.activeElement).toBe(trigger), { timeout: 5000 })
+  })
+
+  it('confirming delete while a save is pending flushes and deletes exactly once', async () => {
+    const store = await renderLoaded()
+    const beforeIds = (await store.listCanvases()).map((c) => c.id)
+
+    // Put the header persistence state into "pending" by renaming, then
+    // immediately open+confirm the delete dialog before the debounce fires.
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Pending edit' } })
+
+    screen.getByRole('button', { name: /delete canvas/i }).click()
+    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    within(dialog)
+      .getByRole('button', { name: /^delete$/i })
+      .click()
+
+    await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const afterIds = (await store.listCanvases()).map((c) => c.id)
+    for (const id of beforeIds) {
+      expect(afterIds).not.toContain(id)
+    }
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
@@ -13,6 +13,20 @@ async function clearDb(): Promise<void> {
   })
 }
 
+async function renderLoaded(): Promise<void> {
+  render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+  await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+    timeout: 5000,
+  })
+}
+
+async function waitForTitle(expected: string): Promise<void> {
+  await waitFor(
+    () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(expected),
+    { timeout: 5000 },
+  )
+}
+
 describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
   beforeEach(async () => {
     await clearDb()
@@ -23,51 +37,33 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
   })
 
   it('reload: edited title survives an unmount + fresh-store remount', async () => {
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Reloaded title' } })
     titleInput.blur()
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Reloaded title'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('Reloaded title')
     await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
 
     cleanup()
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Reloaded title'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('Reloaded title')
   })
 
   it('layout: excalidraw container still fills the viewport after editing the title', async () => {
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Layout check' } })
     titleInput.blur()
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Layout check'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('Layout check')
     const container = screen.getByTestId('excalidraw-container')
     expect(container.clientHeight).toBeGreaterThan(300)
     expect(container.clientWidth).toBeGreaterThan(600)
   })
 
   it("keyboard isolation: Enter/Escape/Backspace/Delete typed in the title do not reach Excalidraw's document-level shortcut handlers", async () => {
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const documentKeyDown = vi.fn()
     document.addEventListener('keydown', documentKeyDown)
     try {
@@ -86,32 +82,20 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
   })
 
   it('Escape during edit reverts without persisting to IndexedDB', async () => {
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Should not persist' } })
     fireEvent.keyDown(titleInput, { key: 'Escape' })
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('untitled')
 
     cleanup()
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('untitled')
   })
 
   it("whitespace-only commit persists 'untitled' and restores it on remount", async () => {
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
     // Commit a real name first so the remount assertion below can distinguish
     // "restored the whitespace-commit's normalized value" from "never persisted
@@ -119,27 +103,18 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Named canvas' } })
     titleInput.blur()
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Named canvas'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('Named canvas')
     await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
 
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: '   ' } })
     titleInput.blur()
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('untitled')
     await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
 
     cleanup()
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('untitled')
   })
 
   it('network-negative: editing the title triggers no fetch to /api/ or daemon endpoints', async () => {
@@ -155,18 +130,12 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
       calls.push(url)
       return original(...args)
     })
-    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
-    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
-      timeout: 5000,
-    })
+    await renderLoaded()
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
     titleInput.focus()
     fireEvent.change(titleInput, { target: { value: 'Network check' } })
     titleInput.blur()
-    await waitFor(
-      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Network check'),
-      { timeout: 5000 },
-    )
+    await waitForTitle('Network check')
     const daemonCalls = calls.filter(
       (url) => url.includes('/api/') || url.includes('localhost:3') || url.includes('127.0.0.1'),
     )

--- a/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
@@ -85,6 +85,63 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
     }
   })
 
+  it('Escape during edit reverts without persisting to IndexedDB', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Should not persist' } })
+    fireEvent.keyDown(titleInput, { key: 'Escape' })
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
+      { timeout: 5000 },
+    )
+
+    cleanup()
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
+      { timeout: 5000 },
+    )
+  })
+
+  it("whitespace-only commit persists 'untitled' and restores it on remount", async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    // Commit a real name first so the remount assertion below can distinguish
+    // "restored the whitespace-commit's normalized value" from "never persisted
+    // anything, so it's just showing the initial default".
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Named canvas' } })
+    titleInput.blur()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Named canvas'),
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: '   ' } })
+    titleInput.blur()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+
+    cleanup()
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled'),
+      { timeout: 5000 },
+    )
+  })
+
   it('network-negative: editing the title triggers no fetch to /api/ or daemon endpoints', async () => {
     const calls: string[] = []
     const original = window.fetch.bind(window)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -162,7 +162,7 @@ describe('BrowserLocalCanvasPage', () => {
     expect(screen.getByText('Could not start a new canvas. Please try again.')).toBeTruthy()
   })
 
-  it('renders cleanup-completed view after delete button click', async () => {
+  it('renders cleanup-completed view after delete button click and confirm', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
@@ -173,9 +173,36 @@ describe('BrowserLocalCanvasPage', () => {
     const cleanupBtn = screen.getByRole('button', { name: /delete/i })
     await act(async () => {
       cleanupBtn.click()
+    })
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+    const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
+    await act(async () => {
+      confirmBtn.click()
       await vi.runAllTimersAsync()
     })
     expect(screen.getByTestId('cleanup-completed')).toBeTruthy()
+  })
+
+  it('does not delete the canvas when the confirmation dialog is cancelled', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    const cleanupBtn = screen.getByRole('button', { name: /delete canvas/i })
+    await act(async () => {
+      cleanupBtn.click()
+    })
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    await act(async () => {
+      cancelBtn.click()
+      await vi.runAllTimersAsync()
+    })
+    expect(screen.queryByTestId('cleanup-completed')).toBeNull()
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+    expect(screen.getByRole('main')).toBeTruthy()
   })
 
   it('renders a human-readable save status instead of the raw state enum', async () => {
@@ -223,6 +250,10 @@ describe('BrowserLocalCanvasPage', () => {
     const deleteBtn = screen.getByRole('button', { name: /delete/i })
     await act(async () => {
       deleteBtn.click()
+    })
+    const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
+    await act(async () => {
+      confirmBtn.click()
       await vi.runAllTimersAsync()
     })
     // cleanup-completed must not be a dead end: Start fresh mints a new canvas.
@@ -247,6 +278,10 @@ describe('BrowserLocalCanvasPage', () => {
     const deleteBtn = screen.getByRole('button', { name: /delete/i })
     await act(async () => {
       deleteBtn.click()
+    })
+    const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
+    await act(async () => {
+      confirmBtn.click()
       await vi.runAllTimersAsync()
     })
     expect(fetchSpy).not.toHaveBeenCalled()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,6 +1,17 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '../components/ui/alert-dialog.js'
 import { CanvasTitle } from '../components/canvas-title/CanvasTitle.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
@@ -244,14 +255,30 @@ export function BrowserLocalCanvasPage({
           <CapabilityTeaser label="Branches" enabled={capabilities.branches} />
           <CapabilityTeaser label="Merge" enabled={capabilities.merge} />
         </div>
-        <button
-          type="button"
-          onClick={() => void triggerCleanup()}
-          aria-label="Delete canvas"
-          className="ml-auto rounded-md border px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
-        >
-          Delete
-        </button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button
+              type="button"
+              aria-label="Delete canvas"
+              className="ml-auto rounded-md border px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+            >
+              Delete
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This permanently removes the canvas and its drawing data from this browser. This
+                action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => void triggerCleanup()}>Delete</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </header>
       <div data-testid="excalidraw-container" className="min-h-0 flex-1">
         <Excalidraw excalidrawAPI={setExcalidrawAPI} onChange={onChange} />

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -275,7 +275,12 @@ export function BrowserLocalCanvasPage({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={() => void triggerCleanup()}>Delete</AlertDialogAction>
+              <AlertDialogAction
+                onClick={() => void triggerCleanup()}
+                className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>


### PR DESCRIPTION
## Summary

First Step completion (part). Adds a confirmation dialog to the browser-local canvas page's Delete action, plus fills two rename regression gaps against real IndexedDB.

Title editing already landed on main (CanvasTitle inline edit with Enter/blur commit, Esc revert, empty→'untitled', immediate IndexedDB persistence via renameCanvas). The design step confirmed this, so this lane's delta is scoped to:

- **Delete confirmation**: the Delete button now opens the existing Radix `AlertDialog` (role=alertdialog, focus trap, Esc-to-close) with a destructive-action title/description; `triggerCleanup` runs only on confirm. Cancel/Esc leaves the canvas intact.
- **Updated (not weakened)** the existing one-click-delete tests to the open-dialog→confirm flow, preserving each original end-state assertion.
- **Gap-fill** rename browser coverage: page-level Escape-revert (no IndexedDB write) and whitespace→'untitled' restore-on-remount, which were only covered at the component/controller layer before.

View-layer only — no controller, store, or contract changes.

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 510 passed (jsdom project)
- [x] `pnpm --filter @kamiazya/whiteboard-web test:browser` — 97 passed (real IndexedDB, delete-confirm + rename)
- [x] typecheck clean
- [ ] Manual: delete-confirm/cancel + title-edit reload-restore via wrangler pages dev (deferred — pending disk/env; tests cover the flows at web-browser layer)