### PR TITLE
feat(web): add daemonConnectionPayloadSchema for the #wb= pairing fragment

### DIFF
--- a/apps/web/src/lib/daemon-connection-payload.test.ts
+++ b/apps/web/src/lib/daemon-connection-payload.test.ts
@@ -61,6 +61,24 @@ describe('daemonConnectionPayloadSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('accepts workspaceId without slug (workspace-level target)', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      workspaceId: 'ws-1',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects slug without workspaceId (a canvas is addressed by the pair)', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      slug: 'my-canvas',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(false)
+  })
+
   it('rejects extra unknown keys (strict)', () => {
     const result = daemonConnectionPayloadSchema.safeParse({
       baseUrl: 'http://127.0.0.1:3099',

--- a/apps/web/src/lib/daemon-connection-payload.test.ts
+++ b/apps/web/src/lib/daemon-connection-payload.test.ts
@@ -147,6 +147,15 @@ describe('parseDaemonConnectionFragment', () => {
     expect(result.status).toBe('invalid')
   })
 
+  it('reports not-present for a percent-encoded "wb" key, matching removal behavior', () => {
+    // URLSearchParams would decode '%77%62' to 'wb' and match it, but
+    // consumeDaemonConnectionFragment's raw-string removal would not strip it —
+    // parsing must use the same raw-key comparison so an unrecognized encoding
+    // is never silently accepted and left lingering in the hash.
+    const encoded = encodeRawBase64Url(JSON.stringify(payload))
+    expect(parseDaemonConnectionFragment(`#%77%62=${encoded}`)).toEqual({ status: 'not-present' })
+  })
+
   it('does not throw on arbitrary garbage input', () => {
     expect(() => parseDaemonConnectionFragment('#wb=%%%')).not.toThrow()
     expect(() => parseDaemonConnectionFragment('garbage')).not.toThrow()

--- a/apps/web/src/lib/daemon-connection-payload.test.ts
+++ b/apps/web/src/lib/daemon-connection-payload.test.ts
@@ -69,6 +69,22 @@ describe('daemonConnectionPayloadSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  it('rejects authMode "bootstrap" with no bootstrapToken', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'bootstrap',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts authMode "none" with no bootstrapToken', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(true)
+  })
 })
 
 describe('parseDaemonConnectionFragment', () => {
@@ -167,6 +183,20 @@ describe('consumeDaemonConnectionFragment', () => {
     consumeDaemonConnectionFragment()
     expect(window.location.hash).toBe('')
     expect(window.location.pathname).toBe('/some/path')
+  })
+
+  it('preserves an unrelated fragment segment sharing the hash with wb', () => {
+    window.history.replaceState(
+      null,
+      '',
+      `/some/path?query=1#fullscreen&wb=${encodeRawBase64Url('{}')}`,
+    )
+
+    consumeDaemonConnectionFragment()
+
+    expect(window.location.hash).toBe('#fullscreen')
+    expect(window.location.pathname).toBe('/some/path')
+    expect(window.location.search).toBe('?query=1')
   })
 })
 

--- a/apps/web/src/lib/daemon-connection-payload.test.ts
+++ b/apps/web/src/lib/daemon-connection-payload.test.ts
@@ -1,0 +1,179 @@
+import { fc, test as fcTest } from '@fast-check/vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  consumeDaemonConnectionFragment,
+  daemonConnectionPayloadSchema,
+  encodeDaemonConnectionFragment,
+  parseDaemonConnectionFragment,
+} from './daemon-connection-payload.js'
+
+describe('daemonConnectionPayloadSchema', () => {
+  it('accepts a minimal valid payload', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a full payload with all optional fields', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'https://daemon.example.com',
+      workspaceId: 'ws-1',
+      slug: 'canvas-slug',
+      bootstrapToken: 'a-long-enough-token',
+      authMode: 'bootstrap',
+      fullscreen: true,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects baseUrl with a path component', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099/foo',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-http(s) baseUrl scheme', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'ftp://127.0.0.1:3099',
+      authMode: 'none',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown authMode values', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'oauth',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects too-short bootstrapToken', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'bootstrap',
+      bootstrapToken: 'x',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra unknown keys (strict)', () => {
+    const result = daemonConnectionPayloadSchema.safeParse({
+      baseUrl: 'http://127.0.0.1:3099',
+      authMode: 'none',
+      extra: 'nope',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('parseDaemonConnectionFragment', () => {
+  const payload = {
+    baseUrl: 'http://127.0.0.1:3099',
+    workspaceId: 'ws-1',
+    slug: 'my-canvas',
+    bootstrapToken: 'a-long-enough-token',
+    authMode: 'bootstrap' as const,
+    fullscreen: true,
+  }
+
+  it('round-trips a valid payload through encode/parse', () => {
+    const hash = encodeDaemonConnectionFragment(payload)
+    const result = parseDaemonConnectionFragment(hash)
+    expect(result).toEqual({ status: 'ok', payload })
+  })
+
+  it('round-trips when the encoded fragment already has the leading #', () => {
+    const hash = encodeDaemonConnectionFragment(payload)
+    expect(hash.startsWith('#wb=')).toBe(true)
+    const result = parseDaemonConnectionFragment(hash)
+    expect(result.status).toBe('ok')
+  })
+
+  it('reports not-present for an empty hash', () => {
+    expect(parseDaemonConnectionFragment('')).toEqual({ status: 'not-present' })
+  })
+
+  it('reports not-present for a bare "#"', () => {
+    expect(parseDaemonConnectionFragment('#')).toEqual({ status: 'not-present' })
+  })
+
+  it('reports not-present when the hash has unrelated content', () => {
+    expect(parseDaemonConnectionFragment('#other=1')).toEqual({ status: 'not-present' })
+  })
+
+  it('reports malformed for invalid base64url content', () => {
+    const result = parseDaemonConnectionFragment('#wb=not-valid-base64url!!!')
+    expect(result.status).toBe('malformed')
+  })
+
+  it('reports malformed for base64url content that is not valid JSON', () => {
+    const notJson = encodeRawBase64Url('this is not json')
+    const result = parseDaemonConnectionFragment(`#wb=${notJson}`)
+    expect(result.status).toBe('malformed')
+  })
+
+  it('reports invalid for JSON that fails schema validation', () => {
+    const badPayload = encodeRawBase64Url(JSON.stringify({ authMode: 'none' }))
+    const result = parseDaemonConnectionFragment(`#wb=${badPayload}`)
+    expect(result.status).toBe('invalid')
+  })
+
+  it('reports invalid when the payload has unknown extra keys', () => {
+    const badPayload = encodeRawBase64Url(
+      JSON.stringify({ baseUrl: 'http://127.0.0.1:3099', authMode: 'none', extra: 'x' }),
+    )
+    const result = parseDaemonConnectionFragment(`#wb=${badPayload}`)
+    expect(result.status).toBe('invalid')
+  })
+
+  it('does not throw on arbitrary garbage input', () => {
+    expect(() => parseDaemonConnectionFragment('#wb=%%%')).not.toThrow()
+    expect(() => parseDaemonConnectionFragment('garbage')).not.toThrow()
+  })
+
+  fcTest.prop([fc.jsonValue()])('never throws for any base64url-wrapped JSON value', (json) => {
+    const encoded = encodeRawBase64Url(JSON.stringify(json))
+    expect(() => parseDaemonConnectionFragment(`#wb=${encoded}`)).not.toThrow()
+  })
+
+  fcTest.prop([fc.string()])('never throws for arbitrary hash strings', (raw) => {
+    expect(() => parseDaemonConnectionFragment(raw)).not.toThrow()
+  })
+})
+
+describe('consumeDaemonConnectionFragment', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/some/path?query=1')
+  })
+
+  it('removes the #wb= fragment from the URL without a page reload', () => {
+    window.history.replaceState(null, '', `/some/path?query=1#wb=${encodeRawBase64Url('{}')}`)
+    expect(window.location.hash).not.toBe('')
+
+    consumeDaemonConnectionFragment()
+
+    expect(window.location.hash).toBe('')
+    expect(window.location.pathname).toBe('/some/path')
+    expect(window.location.search).toBe('?query=1')
+  })
+
+  it('is a no-op when there is no fragment', () => {
+    window.history.replaceState(null, '', '/some/path?query=1')
+    consumeDaemonConnectionFragment()
+    expect(window.location.hash).toBe('')
+    expect(window.location.pathname).toBe('/some/path')
+  })
+})
+
+// Test-only helper that skips schema validation, for exercising malformed-payload paths.
+function encodeRawBase64Url(json: string): string {
+  const bytes = new TextEncoder().encode(json)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -28,6 +28,12 @@ export const daemonConnectionPayloadSchema = z
     fullscreen: z.boolean().optional(),
   })
   .strict()
+  // ADR-0002's bootstrap pairing exchange has no meaning without a token to
+  // exchange, so the schema — not just the docs — enforces the pairing.
+  .refine((payload) => payload.authMode !== 'bootstrap' || payload.bootstrapToken !== undefined, {
+    message: 'bootstrapToken is required when authMode is "bootstrap"',
+    path: ['bootstrapToken'],
+  })
 
 export type DaemonConnectionPayload = z.infer<typeof daemonConnectionPayloadSchema>
 
@@ -110,11 +116,23 @@ export function encodeDaemonConnectionFragment(payload: DaemonConnectionPayload)
   return `#${FRAGMENT_KEY}=${encodeBase64Url(json)}`
 }
 
-// Strips the `#wb=...` fragment from the current URL via history.replaceState so a
+// Removes only the `wb=...` segment from a location.hash-shaped string, leaving any
+// other '&'-joined segments (e.g. `fullscreen`) untouched and in their original form.
+function removeFragmentKey(hash: string): string {
+  const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash
+  return withoutHash
+    .split('&')
+    .filter((segment) => segment.split('=')[0] !== FRAGMENT_KEY)
+    .join('&')
+}
+
+// Strips the `wb=...` segment from the current URL's hash via history.replaceState so a
 // consumed bootstrapToken never lingers in browser history or a shared/screen-recorded URL.
+// Other hash segments sharing the fragment (e.g. `#fullscreen&wb=...`) are preserved —
+// mirrors the hash-ownership pattern in canvas-fullscreen-hash.ts.
 export function consumeDaemonConnectionFragment(): void {
   if (window.location.hash.length === 0) return
   const url = new URL(window.location.href)
-  url.hash = ''
+  url.hash = removeFragmentKey(url.hash)
   window.history.replaceState(window.history.state, '', url.toString())
 }

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -64,10 +64,23 @@ function encodeBase64Url(value: string): string {
 
 // Extracts the raw `wb` fragment value from a location.hash-shaped string, tolerant of
 // a missing leading '#' and of other unrelated fragment params sharing the hash.
+//
+// Segment keys are compared as raw strings (no percent-decoding) rather than via
+// URLSearchParams, which would decode a key like `%77%62` to `wb` and accept it.
+// removeFragmentKey() below does the same raw comparison to strip a consumed token
+// from the URL, so a percent-encoded key must be rejected here too — otherwise a
+// payload could be parsed but never cleaned up, leaving a bootstrapToken lingering
+// in window.location.hash.
 function extractFragmentValue(hash: string): string | null {
   const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash
   if (withoutHash.length === 0) return null
-  return new URLSearchParams(withoutHash).get(FRAGMENT_KEY)
+  for (const segment of withoutHash.split('&')) {
+    const separatorIndex = segment.indexOf('=')
+    const key = separatorIndex === -1 ? segment : segment.slice(0, separatorIndex)
+    if (key !== FRAGMENT_KEY) continue
+    return separatorIndex === -1 ? '' : segment.slice(separatorIndex + 1)
+  }
+  return null
 }
 
 // Parses the `#wb=<base64url-json>` daemon-pairing fragment. Never throws — every

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -61,13 +61,7 @@ function encodeBase64Url(value: string): string {
 function extractFragmentValue(hash: string): string | null {
   const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash
   if (withoutHash.length === 0) return null
-  let params: URLSearchParams
-  try {
-    params = new URLSearchParams(withoutHash)
-  } catch {
-    return null
-  }
-  return params.get(FRAGMENT_KEY)
+  return new URLSearchParams(withoutHash).get(FRAGMENT_KEY)
 }
 
 // Parses the `#wb=<base64url-json>` daemon-pairing fragment. Never throws — every

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -34,6 +34,13 @@ export const daemonConnectionPayloadSchema = z
     message: 'bootstrapToken is required when authMode is "bootstrap"',
     path: ['bootstrapToken'],
   })
+  // A canvas is addressed by the (workspaceId, slug) pair, so a slug is
+  // meaningless without a workspaceId. workspaceId alone is a valid
+  // workspace-level target, so the constraint is one-directional.
+  .refine((payload) => payload.slug === undefined || payload.workspaceId !== undefined, {
+    message: 'workspaceId is required when slug is set',
+    path: ['workspaceId'],
+  })
 
 export type DaemonConnectionPayload = z.infer<typeof daemonConnectionPayloadSchema>
 

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -151,6 +151,9 @@ function removeFragmentKey(hash: string): string {
 // Other hash segments sharing the fragment (e.g. `#fullscreen&wb=...`) are preserved —
 // mirrors the hash-ownership pattern in canvas-fullscreen-hash.ts.
 export function consumeDaemonConnectionFragment(): void {
+  // Guard against non-DOM contexts (SSR, a Node-side import that never set up
+  // jsdom) so the module is safe to reference anywhere, not just in the browser.
+  if (typeof window === 'undefined') return
   if (window.location.hash.length === 0) return
   const url = new URL(window.location.href)
   url.hash = removeFragmentKey(url.hash)

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod'
+import { bareOriginSchema } from '../runtime-config.js'
+
+// URL hash key carrying the daemon-pairing payload: `#wb=<base64url-json>`.
+const FRAGMENT_KEY = 'wb'
+
+// Minimum bootstrapToken length is a defense-in-depth floor, not the real security
+// boundary — the daemon itself decides whether a bootstrapToken is valid and
+// exchanges it for a short-lived sessionToken (see ADR-0002).
+const MIN_BOOTSTRAP_TOKEN_LENGTH = 8
+
+// bareOriginSchema alone permits any URL scheme (ws:, file:, etc.); daemon pairing is
+// restricted to http(s) since that is the only transport ADR-0002 defines.
+const daemonBaseUrlSchema = bareOriginSchema.refine(
+  (v) => v.startsWith('http://') || v.startsWith('https://'),
+  { message: 'baseUrl must use http or https' },
+)
+
+// authMode is a literal union rather than a bare string so new modes require an
+// explicit schema change instead of silently round-tripping unknown values.
+export const daemonConnectionPayloadSchema = z
+  .object({
+    baseUrl: daemonBaseUrlSchema,
+    workspaceId: z.string().min(1).optional(),
+    slug: z.string().min(1).optional(),
+    bootstrapToken: z.string().min(MIN_BOOTSTRAP_TOKEN_LENGTH).optional(),
+    authMode: z.enum(['bootstrap', 'none']),
+    fullscreen: z.boolean().optional(),
+  })
+  .strict()
+
+export type DaemonConnectionPayload = z.infer<typeof daemonConnectionPayloadSchema>
+
+export type ParseDaemonConnectionFragmentResult =
+  | { status: 'ok'; payload: DaemonConnectionPayload }
+  | { status: 'not-present' }
+  | { status: 'malformed'; stage: 'base64' | 'json'; message: string }
+  | { status: 'invalid'; issues: z.ZodIssue[] }
+
+// Decodes a base64url string to its original UTF-8 text.
+// Throws on invalid base64url input (surfaced by the caller as a 'malformed' result).
+function decodeBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const paddingLength = (4 - (base64.length % 4)) % 4
+  const padded = base64 + '='.repeat(paddingLength)
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}
+
+// Encodes UTF-8 text to a base64url string (no padding), matching the `#wb=` fragment format.
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// Extracts the raw `wb` fragment value from a location.hash-shaped string, tolerant of
+// a missing leading '#' and of other unrelated fragment params sharing the hash.
+function extractFragmentValue(hash: string): string | null {
+  const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash
+  if (withoutHash.length === 0) return null
+  let params: URLSearchParams
+  try {
+    params = new URLSearchParams(withoutHash)
+  } catch {
+    return null
+  }
+  return params.get(FRAGMENT_KEY)
+}
+
+// Parses the `#wb=<base64url-json>` daemon-pairing fragment. Never throws — every
+// failure mode (absent, malformed encoding, malformed JSON, schema violation) is
+// reported as a distinct discriminated-union variant so callers can branch safely.
+export function parseDaemonConnectionFragment(hash: string): ParseDaemonConnectionFragmentResult {
+  const raw = extractFragmentValue(hash)
+  if (raw === null || raw.length === 0) {
+    return { status: 'not-present' }
+  }
+
+  let decoded: string
+  try {
+    decoded = decodeBase64Url(raw)
+  } catch (err) {
+    return {
+      status: 'malformed',
+      stage: 'base64',
+      message: err instanceof Error ? err.message : 'invalid base64url encoding',
+    }
+  }
+
+  let json: unknown
+  try {
+    json = JSON.parse(decoded)
+  } catch (err) {
+    return {
+      status: 'malformed',
+      stage: 'json',
+      message: err instanceof Error ? err.message : 'invalid JSON',
+    }
+  }
+
+  const result = daemonConnectionPayloadSchema.safeParse(json)
+  if (!result.success) {
+    return { status: 'invalid', issues: result.error.issues }
+  }
+
+  return { status: 'ok', payload: result.data }
+}
+
+// Encodes a payload into the `#wb=<base64url-json>` fragment string, including the
+// leading '#'. Primarily a test/dev helper for round-tripping parseDaemonConnectionFragment.
+export function encodeDaemonConnectionFragment(payload: DaemonConnectionPayload): string {
+  const json = JSON.stringify(daemonConnectionPayloadSchema.parse(payload))
+  return `#${FRAGMENT_KEY}=${encodeBase64Url(json)}`
+}
+
+// Strips the `#wb=...` fragment from the current URL via history.replaceState so a
+// consumed bootstrapToken never lingers in browser history or a shared/screen-recorded URL.
+export function consumeDaemonConnectionFragment(): void {
+  if (window.location.hash.length === 0) return
+  const url = new URL(window.location.href)
+  url.hash = ''
+  window.history.replaceState(window.history.state, '', url.toString())
+}

--- a/apps/web/src/runtime-config.ts
+++ b/apps/web/src/runtime-config.ts
@@ -3,17 +3,25 @@ import { isProductionPagesOrigin } from './lib/pages-origin-policy.js'
 
 // Validates that a URL string is a bare origin: scheme + host + optional port, no path/query/hash/credentials.
 // Downstream CORS, OAuth, and Cloudflare config all require a strict origin, not an arbitrary URL.
-const bareOriginSchema = z.string().url().refine(
-  (v) => {
-    try {
-      const url = new URL(v)
-      return url.origin === v && !url.hostname.includes('*')
-    } catch {
-      return false
-    }
-  },
-  { message: 'must be a bare origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)' },
-)
+// Exported so other cross-boundary contracts (e.g. daemon-connection-payload.ts) reuse the same
+// origin-validation rules instead of redefining them.
+export const bareOriginSchema = z
+  .string()
+  .url()
+  .refine(
+    (v) => {
+      try {
+        const url = new URL(v)
+        return url.origin === v && !url.hostname.includes('*')
+      } catch {
+        return false
+      }
+    },
+    {
+      message:
+        'must be a bare origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
+    },
+  )
 
 export const runtimeConfigSchema = z
   .object({


### PR DESCRIPTION
## Summary

Library layer for daemon pairing (S5). Adds the Zod schema + safe parser for the `#wb=<base64url-json>` URL-hash fragment that a daemon uses to hand pairing info to the hosted apps/web page. Per ADR-0002, the fragment (not the query string) carries the pairing payload because it is never sent to the Pages server, so a bootstrap token can ride in it. No UI wiring or backend connection here — purely the parse/validate/consume primitives.

- `apps/web/src/lib/daemon-connection-payload.ts`: `daemonConnectionPayloadSchema` (strict) + `parseDaemonConnectionFragment(hash)` returning a discriminated union (ok / not-present / malformed / invalid) — never throws. `baseUrl` reuses the runtime-config bare-origin validation; `bootstrapToken` enforced when authMode requires it; foreign hash keys preserved.
- `consumeDaemonConnectionFragment()` strips the fragment from the URL via `history.replaceState` so a bootstrap token is not left in history / screen-share. Not yet wired into any page.

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 534 passed (round-trip, not-present, malformed base64url/JSON, strict-reject excess keys, non-http scheme, path-bearing baseUrl, fragment consumption)
- [x] typecheck clean
- [x] `web-app-boundary.test.ts` — 44 passed (no node-builtin / cross-boundary import)