### PR TITLE
feat(mcp-server): add daemon exact-match hosted-origin allowlist (LNA prerequisite)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,6 +13,15 @@ Runtime environment variables and sandbox quirks.
 | `WHITEBOARD_MCP_RESOURCE` | Canonical MCP resource URL exposed in metadata. If unset, `/mcp` is derived from the incoming request URL. | unset |
 | `WHITEBOARD_MCP_SCOPES_SUPPORTED` | Comma-separated list of scopes exposed in metadata. | unset |
 | `MCP_HTTP_DEBUG` | When set to `1`, the HTTP MCP server logs `[mcp-http:init]` / `[mcp-http]` events to help diagnose request flow. | unset |
+| `WHITEBOARD_ALLOWED_WEB_ORIGINS` | Comma-separated list of extra hosted origins admitted alongside the fixed loopback set (`localhost`, `127.0.0.1`, `::1`) on `/api/*` CORS, `/mcp`, and WS upgrade — **local-daemon mode only**. Each entry must be an exact `https://` origin (no path/query/fragment/credentials); wildcards are rejected. Matching is case-insensitive on the host and normalizes the default `:443` port, but any other port is significant. An invalid entry aborts daemon startup with a logged error naming the offending entry's index (the raw value is never echoed). | unset (loopback-only, unchanged) |
+
+Setting `WHITEBOARD_ALLOWED_WEB_ORIGINS` only widens which browser *origins*
+the daemon will talk to over CORS/WS — it does not change authentication.
+Mutating `/api/*` routes still require the daemon Bearer token, and `/mcp`
+still requires its own auth regardless of origin. Only add an origin you
+control; the hosted pairing flow this enables also depends on the browser's
+own Local Network Access permission prompt (Chrome), which is a separate,
+per-user consent step.
 
 ## Codex sandbox constraints
 

--- a/packages/mcp-server/src/cli/daemon-run.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { captureLogsForTests } from '../server/log.js'
 
 const { createServerSpy } = vi.hoisted(() => ({ createServerSpy: vi.fn() }))
 
@@ -99,5 +100,61 @@ describe('runDaemonRun bind-host guard', () => {
     const outcome = await runDaemonRun({ host, tokenStdin: false, dataDir: '/tmp/whiteboard-test' })
     expect(outcome.kind).toBe('running')
     expect(startHttpServerMock).toHaveBeenCalled()
+  })
+})
+
+describe('runDaemonRun WHITEBOARD_ALLOWED_WEB_ORIGINS wiring', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('fails fast with a structured outcome and logs an error record on an invalid env value', async () => {
+    const capture = captureLogsForTests('debug')
+    try {
+      const outcome = await runDaemonRun({
+        host: '127.0.0.1',
+        tokenStdin: false,
+        dataDir: '/tmp/whiteboard-test',
+        env: { WHITEBOARD_ALLOWED_WEB_ORIGINS: 'not a url' },
+      })
+      expect(outcome).toEqual({
+        kind: 'input-error',
+        message: expect.stringContaining('WHITEBOARD_ALLOWED_WEB_ORIGINS'),
+        code: 'invalid_allowed_web_origins',
+      })
+      expect(startHttpServerMock).not.toHaveBeenCalled()
+      const record = capture.records.find(
+        (r) => r.scope === 'web-origin-allowlist' && r.level === 'error',
+      )
+      expect(record).toBeDefined()
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('threads a valid allowlist through to startHttpServer', async () => {
+    const outcome = await runDaemonRun({
+      host: '127.0.0.1',
+      tokenStdin: false,
+      dataDir: '/tmp/whiteboard-test',
+      env: { WHITEBOARD_ALLOWED_WEB_ORIGINS: 'https://kamiazya-whiteboard.pages.dev' },
+    })
+    expect(outcome.kind).toBe('running')
+    expect(startHttpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedWebOrigins: ['https://kamiazya-whiteboard.pages.dev'],
+      }),
+    )
+  })
+
+  it('defaults to an empty allowlist when the env var is unset', async () => {
+    const outcome = await runDaemonRun({
+      host: '127.0.0.1',
+      tokenStdin: false,
+      dataDir: '/tmp/whiteboard-test',
+      env: {},
+    })
+    expect(outcome.kind).toBe('running')
+    expect(startHttpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedWebOrigins: [] }),
+    )
   })
 })

--- a/packages/mcp-server/src/cli/daemon-run.ts
+++ b/packages/mcp-server/src/cli/daemon-run.ts
@@ -17,6 +17,7 @@ import {
 import { DATA_DIR } from '../shared/data-dir-secure.js'
 import { assertLoopbackBindHost } from '../server/daemon-auth-binding.js'
 import { startHttpServer } from '../server/http-server.js'
+import { loadAllowedWebOriginsFromEnv } from '../server/security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 
 const DAEMON_RUN_SCHEMA_VERSION = 1 as const
@@ -32,7 +33,7 @@ export interface DaemonRunReadyResult {
 }
 
 export type DaemonRunOutcome =
-  | { kind: 'input-error'; message: string }
+  | { kind: 'input-error'; message: string; code?: 'invalid_allowed_web_origins' }
   | { kind: 'refused'; message: string }
   | { kind: 'running'; result: DaemonRunReadyResult }
 
@@ -41,6 +42,8 @@ export interface DaemonRunOptions {
   port?: number
   dataDir?: string
   tokenStdin: boolean
+  /** Defaults to process.env; overridable for tests. */
+  env?: Readonly<Record<string, string | undefined>>
 }
 
 // Exported for unit testing of the EADDRINUSE-only retry contract.
@@ -106,6 +109,19 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
     }
   }
 
+  // Fail fast before any lock/fs work: an invalid WHITEBOARD_ALLOWED_WEB_ORIGINS
+  // must never start a daemon with a silently-empty or partially-parsed
+  // allowlist. loadAllowedWebOriginsFromEnv logs the structured failure via
+  // getLogger without echoing the raw offending value.
+  const allowedWebOrigins = loadAllowedWebOriginsFromEnv(options.env ?? process.env)
+  if (allowedWebOrigins === null) {
+    return {
+      kind: 'input-error',
+      message: 'Invalid WHITEBOARD_ALLOWED_WEB_ORIGINS entry. See the daemon log for details.',
+      code: 'invalid_allowed_web_origins',
+    }
+  }
+
   const existing = await loadDaemonRecord(dataDir)
   if (existing !== null && isPidAlive(existing.pid)) {
     return {
@@ -131,7 +147,7 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
   return await withDaemonStartupLock(dataDir, async () => {
     const port = options.port ?? (await findAvailablePort())
 
-    const running = await startHttpServer({ port, host, token })
+    const running = await startHttpServer({ port, host, token, allowedWebOrigins })
 
     const startedAt = new Date().toISOString()
 

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1041,6 +1041,122 @@ describe('createApp daemon mutation auth', () => {
       expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173')
       expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
     })
+
+    it('OPTIONS preflight for a loopback Origin also carries Access-Control-Allow-Local-Network', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('/api/runtime/ping', {
+        method: 'OPTIONS',
+        headers: { Origin: 'http://localhost:5173' },
+      })
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
+    })
+  })
+
+  describe('/api/* hosted-origin allowlist (WHITEBOARD_ALLOWED_WEB_ORIGINS)', () => {
+    const allowedWebOrigins = ['https://kamiazya-whiteboard.pages.dev']
+
+    it('reflects ACAO for an allowlisted hosted origin on GET', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+        'https://kamiazya-whiteboard.pages.dev',
+      )
+      expect(res.headers.get('Vary')).toContain('Origin')
+    })
+
+    it('OPTIONS preflight for an allowlisted hosted origin returns PNA + ALN headers', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/runtime/ping', {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+        'https://kamiazya-whiteboard.pages.dev',
+      )
+      expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
+      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
+    })
+
+    it('does NOT reflect ACAO for an evil-prefix lookalike origin', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Origin: 'https://evil-kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('does NOT reflect ACAO for a suffix-match lookalike origin', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev.evil.com' },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('does NOT reflect ACAO for an http:// scheme variant of the allowlisted origin', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Origin: 'http://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('does NOT reflect ACAO for the hosted origin when no allowlist is configured (default preserved)', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('/api/runtime/ping', {
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('mutation route from an allowlisted hosted origin without Bearer still 401s', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('/api/workspaces/session1/canvases', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://kamiazya-whiteboard.pages.dev',
+        },
+        body: JSON.stringify({ slug: 'demo' }),
+      })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('/mcp hosted-origin allowlist (WHITEBOARD_ALLOWED_WEB_ORIGINS)', () => {
+    const allowedWebOrigins = ['https://kamiazya-whiteboard.pages.dev']
+
+    it('OPTIONS /mcp with an allowlisted hosted Origin returns PNA + ALN headers', async () => {
+      const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
+      const res = await app.request('http://127.0.0.1/mcp', {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+        'https://kamiazya-whiteboard.pages.dev',
+      )
+      expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
+      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
+    })
+
+    it('OPTIONS /mcp with a non-allowlisted hosted Origin is still forbidden (default preserved)', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('http://127.0.0.1/mcp', {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://kamiazya-whiteboard.pages.dev' },
+      })
+      expect(res.status).toBe(403)
+    })
   })
 
   describe('runtime config injection', () => {

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -158,6 +158,11 @@ export interface LocalDaemonAppOptions {
   touch: () => void
   getStatus: () => RuntimeStatusResponse
   shutdown: () => Promise<void>
+  /** Exact-match hosted origins admitted alongside the fixed loopback set
+   *  (WHITEBOARD_ALLOWED_WEB_ORIGINS). Empty by default — current loopback-only
+   *  behavior is unchanged unless an operator opts in. Local-daemon only;
+   *  server-mode governs its origins solely via allowedOrigins below. */
+  allowedWebOrigins?: readonly string[]
 }
 
 export interface ServerModeAppOptions {
@@ -417,7 +422,7 @@ export function createApp(options: AppOptions) {
     // The CORS middleware is applied BEFORE the mutation-auth guard so that
     // OPTIONS preflights short-circuit to 204 without needing a bearer token,
     // while non-OPTIONS methods fall through to the auth chain unchanged.
-    app.use('/api/*', createApiLoopbackCorsMiddleware())
+    app.use('/api/*', createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
     app.use('/api/*', createDaemonMutationAuthMiddleware(token))
   }
 
@@ -450,7 +455,7 @@ export function createApp(options: AppOptions) {
     }
     app.use('/mcp', createServerModeAsyncAuthMiddleware(options.authStrategy, ['mcp:call']))
   } else {
-    app.use('/mcp', createMcpHttpOriginMiddleware())
+    app.use('/mcp', createMcpHttpOriginMiddleware(options.allowedWebOrigins ?? []))
     app.use('/mcp', createMcpHttpAuthMiddleware(mcpAuth!))
   }
   app.use(

--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { request } from 'node:http'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findAvailablePort } from '../cli/daemon-run.js'
+import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
 import { authorizeWsUpgrade } from './routes/ws-auth.js'
+import { startHttpServer, type RunningServer } from './http-server.js'
 
 describe('authorizeWsUpgrade', () => {
   it('rejects websocket upgrade without the daemon subprotocol token when token auth is enabled', () => {
@@ -68,5 +72,66 @@ describe('authorizeWsUpgrade', () => {
         'secret',
       ),
     ).toEqual({ accept: false, statusCode: 403 })
+  })
+})
+
+// Attempts a raw WS handshake and resolves with the response status code:
+// either the HTTP upgrade response (101 on accept) or the plain HTTP
+// rejection response the 'upgrade' handler writes by hand for a refusal.
+function attemptWsUpgrade(port: number, origin: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = request({
+      host: '127.0.0.1',
+      port,
+      path: '/ws/ws_test/canvas',
+      method: 'GET',
+      headers: {
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        'Sec-WebSocket-Version': '13',
+        'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Protocol': WHITEBOARD_WS_PROTOCOL,
+        Origin: origin,
+      },
+    })
+    req.on('upgrade', (res, socket) => {
+      socket.destroy()
+      resolve(res.statusCode ?? 0)
+    })
+    req.on('response', (res) => {
+      res.resume()
+      resolve(res.statusCode ?? 0)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('startHttpServer WS upgrade with allowedWebOrigins', () => {
+  let running: RunningServer | undefined
+
+  afterEach(async () => {
+    await running?.close()
+    running = undefined
+  })
+
+  it('threads allowedWebOrigins through to the real WS upgrade handler', async () => {
+    const port = await findAvailablePort(4100)
+    const hostedOrigin = 'https://kamiazya-whiteboard.pages.dev'
+    running = await startHttpServer({
+      port,
+      host: '127.0.0.1',
+      allowedWebOrigins: [hostedOrigin],
+    })
+
+    // Listed hosted origin is admitted -- proves the option reached the
+    // real Node HTTP upgrade handler, not just the pure authorizeWsUpgrade
+    // unit under test above.
+    await expect(attemptWsUpgrade(port, hostedOrigin)).resolves.toBe(101)
+
+    // An origin absent from the allowlist is still refused, confirming the
+    // allowlist is actually consulted rather than the upgrade path always
+    // accepting.
+    await expect(attemptWsUpgrade(port, 'https://not-allowed.example')).resolves.toBe(403)
   })
 })

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -26,6 +26,9 @@ export interface StartHttpServerOptions {
   mcpAuth?: McpHttpAuthStrategy
   idleTimeoutMs?: number
   onClose?: () => Promise<void> | void
+  /** Exact-match hosted origins admitted alongside loopback, on /api CORS,
+   *  /mcp, and WS upgrade (WHITEBOARD_ALLOWED_WEB_ORIGINS). Empty by default. */
+  allowedWebOrigins?: readonly string[]
 }
 
 export interface RunningServer {
@@ -128,6 +131,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     touch,
     getStatus: getRuntimeStatus,
     shutdown: close,
+    allowedWebOrigins: options.allowedWebOrigins,
   })
 
   setRuntimeTouchFn(touch)
@@ -156,7 +160,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
       socket.destroy()
       return
     }
-    const decision = authorizeWsUpgrade(req.headers, options.token)
+    const decision = authorizeWsUpgrade(req.headers, options.token, options.allowedWebOrigins)
     if (!decision.accept) {
       const statusCode = decision.statusCode ?? 401
       const statusText = statusCode === 403 ? 'Forbidden' : 'Unauthorized'

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -57,6 +57,25 @@ describe('server/index main() WHITEBOARD_ALLOWED_WEB_ORIGINS startup gate', () =
     }
   })
 
+  it('refuses to start when an allowlist is set but no auth token is provided', async () => {
+    process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS = 'https://kamiazya-whiteboard.pages.dev'
+    delete process.env.WHITEBOARD_TOKEN
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const capture = captureLogsForTests('debug')
+    try {
+      await expect(main()).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(startHttpServerMock).not.toHaveBeenCalled()
+      const record = capture.records.find((r) => r.scope === 'server-index' && r.level === 'error')
+      expect(record).toBeDefined()
+    } finally {
+      capture.restore()
+      exitSpy.mockRestore()
+    }
+  })
+
   it('threads a valid allowlist through to startHttpServer and never exits', async () => {
     process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS = 'https://kamiazya-whiteboard.pages.dev'
     process.env.WHITEBOARD_TOKEN = 'test-token'

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { captureLogsForTests } from './log.js'
+
+const { startHttpServerMock } = vi.hoisted(() => ({
+  startHttpServerMock: vi.fn(async () => ({
+    port: 3099,
+    getRuntimeStatus: () => ({ startedAt: '2026-01-01T00:00:00.000Z' }),
+  })),
+}))
+
+vi.mock('./http-server.js', () => ({ startHttpServer: startHttpServerMock }))
+vi.mock('../daemon/daemon-registry.js', () => ({
+  saveDaemonRecord: vi.fn(async () => undefined),
+  deleteDaemonRecord: vi.fn(async () => undefined),
+}))
+vi.mock('./security/mcp-auth.js', () => ({
+  createLocalTokenMcpHttpAuthStrategy: vi.fn(() => ({})),
+  resolveMcpProtectedResourceMetadataFromEnv: vi.fn(() => undefined),
+}))
+vi.mock('./observability/tracing.js', () => ({ initTracing: vi.fn(async () => undefined) }))
+vi.mock('./store/db/prepare.js', () => ({ prepareDataDir: vi.fn(async () => undefined) }))
+vi.mock('./export/headless-renderer.js', () => ({
+  prewarmHeadlessExporter: vi.fn(async () => undefined),
+}))
+
+// isDirectEntryPoint gates the auto-invoked `main()` at module load; it is
+// false under vitest (argv1 is the test runner, not this file), so importing
+// this module never triggers the top-level `main().catch(...)` path — tests
+// call the exported `main` directly instead.
+const { main } = await import('./index.js')
+
+describe('server/index main() WHITEBOARD_ALLOWED_WEB_ORIGINS startup gate', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    delete process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS
+  })
+
+  it('aborts before startHttpServer and logs a structured record on an invalid env value', async () => {
+    process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS = 'not a url'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const capture = captureLogsForTests('debug')
+    try {
+      await expect(main()).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(startHttpServerMock).not.toHaveBeenCalled()
+      const record = capture.records.find(
+        (r) => r.scope === 'web-origin-allowlist' && r.level === 'error',
+      )
+      expect(record).toBeDefined()
+      expect(JSON.stringify(record)).not.toContain('not a url')
+    } finally {
+      capture.restore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('threads a valid allowlist through to startHttpServer and never exits', async () => {
+    process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS = 'https://kamiazya-whiteboard.pages.dev'
+    process.env.WHITEBOARD_TOKEN = 'test-token'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await main()
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(startHttpServerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedWebOrigins: ['https://kamiazya-whiteboard.pages.dev'],
+        }),
+      )
+    } finally {
+      exitSpy.mockRestore()
+      stdoutSpy.mockRestore()
+      delete process.env.WHITEBOARD_TOKEN
+    }
+  })
+})

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -9,6 +9,7 @@ import {
 import { isDirectEntryPoint } from './entrypoint.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
+import { getLogger } from './log.js'
 
 function readArg(name: string, fallback?: string): string | undefined {
   const prefix = `--${name}=`
@@ -60,6 +61,23 @@ export async function main() {
   if (allowedWebOrigins === null) {
     process.exit(1)
   }
+
+  // A hosted origin in the allowlist widens which browser origins may reach
+  // /api CORS, /mcp, and WS upgrade. Without a Bearer token, missing-token
+  // auth strategies treat every request as authenticated (local-dev
+  // convenience), so pairing that fallback with a hosted origin would let an
+  // allowlisted hosted page mutate the daemon with no auth barrier at all.
+  // Refuse to start rather than silently downgrade the allowlist's promise
+  // that it "does not change authentication".
+  if (allowedWebOrigins.length > 0 && !token) {
+    const log = getLogger('server-index')
+    log.error(
+      { allowedOriginCount: allowedWebOrigins.length },
+      'WHITEBOARD_ALLOWED_WEB_ORIGINS is set but no auth token was provided (--token or WHITEBOARD_TOKEN); refusing to start',
+    )
+    process.exit(1)
+  }
+
   const daemonMode = hasFlag('daemon')
   const version = process.env.npm_package_version ?? PACKAGE_VERSION
   const mcpAuth = createLocalTokenMcpHttpAuthStrategy({

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -7,6 +7,7 @@ import {
   resolveMcpProtectedResourceMetadataFromEnv,
 } from './security/mcp-auth.js'
 import { isDirectEntryPoint } from './entrypoint.js'
+import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 
 function readArg(name: string, fallback?: string): string | undefined {
@@ -42,7 +43,7 @@ export function resolveToken(
 export { createApp } from './app.js'
 export { startHttpServer } from './http-server.js'
 
-async function main() {
+export async function main() {
   const port = parseInt(readArg('port', '3099') ?? '3099', 10)
   const host = readArg('host', '127.0.0.1') ?? '127.0.0.1'
   const token = resolveToken(process.argv, process.env)
@@ -50,6 +51,15 @@ async function main() {
     readArg('idle-timeout-ms', `${15 * 60_000}`) ?? `${15 * 60_000}`,
     10,
   )
+
+  // Fail fast, before any tracing/store/server wiring: an invalid
+  // WHITEBOARD_ALLOWED_WEB_ORIGINS must abort startup rather than silently
+  // fall back to an empty (loopback-only) allowlist. The failure record is
+  // logged by loadAllowedWebOriginsFromEnv itself (no raw value echoed).
+  const allowedWebOrigins = loadAllowedWebOriginsFromEnv(process.env)
+  if (allowedWebOrigins === null) {
+    process.exit(1)
+  }
   const daemonMode = hasFlag('daemon')
   const version = process.env.npm_package_version ?? PACKAGE_VERSION
   const mcpAuth = createLocalTokenMcpHttpAuthStrategy({
@@ -83,6 +93,7 @@ async function main() {
     token,
     mcpAuth,
     idleTimeoutMs,
+    allowedWebOrigins,
     onClose: daemonMode
       ? async () => {
           await deleteDaemonRecord(DATA_DIR)

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -93,4 +93,82 @@ describe('authorizeWsUpgrade', () => {
     })
     expect(decision.accept).toBe(true)
   })
+
+  describe('loopback Origin/Host mismatch regression (allowlist must not loosen it)', () => {
+    // A localhost Origin against a 127.0.0.1 Host is still a loopback-origin/
+    // loopback-host MISMATCH under the originHost === requestHost rule. The
+    // allowedOrigins allowlist widens admission for exact non-loopback
+    // matches only — it must not accidentally loosen this rule for loopback
+    // origins.
+    it('rejects with an empty allowlist', () => {
+      const decision = authorizeWsUpgrade(
+        { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
+        undefined,
+        [],
+      )
+      expect(decision).toEqual({ accept: false, statusCode: 403 })
+    })
+
+    it('rejects when the allowlist has unrelated entries', () => {
+      const decision = authorizeWsUpgrade(
+        { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
+        undefined,
+        ['https://kamiazya-whiteboard.pages.dev'],
+      )
+      expect(decision).toEqual({ accept: false, statusCode: 403 })
+    })
+
+    it('only accepts once that exact origin is itself allowlisted', () => {
+      const decision = authorizeWsUpgrade(
+        { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
+        undefined,
+        ['http://localhost:5173'],
+      )
+      expect(decision.accept).toBe(true)
+    })
+  })
+
+  describe('hosted-origin allowlist admission', () => {
+    const allowedOrigins = ['https://kamiazya-whiteboard.pages.dev']
+
+    it('admits an exact allowlisted hosted origin against a loopback Host', () => {
+      const decision = authorizeWsUpgrade(
+        { host: '127.0.0.1:3099', origin: 'https://kamiazya-whiteboard.pages.dev' },
+        undefined,
+        allowedOrigins,
+      )
+      expect(decision.accept).toBe(true)
+    })
+
+    it('still rejects a non-loopback Host even for an allowlisted origin (DNS-rebinding guard)', () => {
+      const decision = authorizeWsUpgrade(
+        { host: 'evil.example.com:3099', origin: 'https://kamiazya-whiteboard.pages.dev' },
+        undefined,
+        allowedOrigins,
+      )
+      expect(decision).toEqual({ accept: false, statusCode: 403 })
+    })
+
+    it('rejects a lookalike origin not present in the allowlist', () => {
+      const decision = authorizeWsUpgrade(
+        { host: '127.0.0.1:3099', origin: 'https://evil-kamiazya-whiteboard.pages.dev' },
+        undefined,
+        allowedOrigins,
+      )
+      expect(decision).toEqual({ accept: false, statusCode: 403 })
+    })
+
+    it('401s an allowlisted origin without the required token', () => {
+      const decision = authorizeWsUpgrade(
+        {
+          host: '127.0.0.1:3099',
+          origin: 'https://kamiazya-whiteboard.pages.dev',
+          'sec-websocket-protocol': WHITEBOARD_WS_PROTOCOL,
+        },
+        'secret',
+        allowedOrigins,
+      )
+      expect(decision).toEqual({ accept: false, statusCode: 401 })
+    })
+  })
 })

--- a/packages/mcp-server/src/server/routes/ws-auth.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.ts
@@ -8,6 +8,7 @@ import {
   normalizeHostHeader,
   normalizeOriginHostname,
 } from '../security/cors-loopback.js'
+import { isAllowedWebOrigin } from '../security/web-origin-allowlist.js'
 
 function parseProtocolHeader(header: string | string[] | undefined): string[] {
   if (Array.isArray(header)) {
@@ -23,11 +24,13 @@ function parseProtocolHeader(header: string | string[] | undefined): string[] {
 function isAllowedBrowserOrigin(
   originHeader: string | undefined,
   hostHeader: string | undefined,
+  allowedOrigins: readonly string[] = [],
 ): boolean {
   // Requests without Origin (curl, ws CLI, MCP daemon clients, etc.) are treated as
   // non-browser callers and are allowed, but DNS rebinding protection still requires
   // the Host header to be loopback (localhost / 127.0.0.1 / ::1). Otherwise an attacker
-  // domain could still reach 127.0.0.1 through rebinding.
+  // domain could still reach 127.0.0.1 through rebinding. This Host check is unchanged
+  // by the allowedOrigins allowlist below — only the Origin branch widens.
   const requestHost = normalizeHostHeader(hostHeader)
   if (!requestHost) return false
   if (!isLoopbackHostname(requestHost)) return false
@@ -36,7 +39,13 @@ function isAllowedBrowserOrigin(
   // with normalizeHostHeader above — otherwise http://[::1] never matches
   // a Host header normalized to bare "::1".
   const originHost = normalizeOriginHostname(originHeader)
-  return originHost !== null && isLoopbackHostname(originHost) && originHost === requestHost
+  if (originHost !== null && isLoopbackHostname(originHost) && originHost === requestHost) {
+    return true
+  }
+  // A hosted pairing origin (e.g. https://kamiazya-whiteboard.pages.dev) is
+  // never loopback, so it cannot satisfy originHost === requestHost above —
+  // it is admitted only via an exact allowlist match instead.
+  return isAllowedWebOrigin(originHeader, allowedOrigins)
 }
 
 export interface WsUpgradeDecision {
@@ -48,8 +57,9 @@ export interface WsUpgradeDecision {
 export function authorizeWsUpgrade(
   headers: IncomingHttpHeaders,
   token?: string,
+  allowedOrigins: readonly string[] = [],
 ): WsUpgradeDecision {
-  if (!isAllowedBrowserOrigin(headers.origin, headers.host)) {
+  if (!isAllowedBrowserOrigin(headers.origin, headers.host, allowedOrigins)) {
     return { accept: false, statusCode: 403 }
   }
 

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -55,6 +55,14 @@ export function getRequestHost(c: Context): string | undefined {
   }
 }
 
+function setApiCorsHeaders(c: Context, origin: string): void {
+  c.res.headers.set('Access-Control-Allow-Origin', origin)
+  c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+  c.res.headers.set('Access-Control-Max-Age', '86400')
+  c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+}
+
 export function appendVary(value: string | null, token: string): string {
   if (!value || value.length === 0) return token
   const parts = value
@@ -97,11 +105,7 @@ export function createApiLoopbackCorsMiddleware(
     const isAdmitted = isLoopback || isAllowedWebOrigin(origin, allowedOrigins)
 
     if (isAdmitted && origin) {
-      c.res.headers.set('Access-Control-Allow-Origin', origin)
-      c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
-      c.res.headers.set('Access-Control-Max-Age', '86400')
-      c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+      setApiCorsHeaders(c, origin)
     }
 
     if (c.req.method.toUpperCase() === 'OPTIONS') {
@@ -119,11 +123,7 @@ export function createApiLoopbackCorsMiddleware(
     await next()
 
     if (isAdmitted && origin) {
-      c.res.headers.set('Access-Control-Allow-Origin', origin)
-      c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
-      c.res.headers.set('Access-Control-Max-Age', '86400')
-      c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+      setApiCorsHeaders(c, origin)
     }
   }
 }

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -3,6 +3,7 @@
 // when the loopback definition or Vary logic needs updating.
 
 import type { Context, MiddlewareHandler } from 'hono'
+import { isAllowedWebOrigin } from './web-origin-allowlist.js'
 
 export function isLoopbackHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
@@ -70,27 +71,32 @@ export function appendVary(value: string | null, token: string): string {
  * Middleware for /api/* routes in local-daemon mode.
  *
  * OPTIONS requests always return 204 immediately regardless of origin — no
- * CORS headers are emitted for non-loopback origins, and the downstream auth
+ * CORS headers are emitted for non-admitted origins, and the downstream auth
  * chain is never reached for OPTIONS.
  *
- * For loopback Origins (localhost, 127.0.0.1, ::1) on non-OPTIONS requests:
+ * For admitted Origins (loopback — localhost, 127.0.0.1, ::1 — OR an exact
+ * match in `allowedOrigins`, e.g. a hosted pairing origin) on non-OPTIONS
+ * requests:
  *   - Reflects Access-Control-Allow-Origin and Vary: Origin.
  *   - Falls through to the downstream auth chain so mutation routes are never
- *     bypassed.
+ *     bypassed (Bearer is still required for mutations regardless of origin).
  *
- * For non-loopback Origins or no Origin header on non-OPTIONS requests: no
+ * For non-admitted Origins or no Origin header on non-OPTIONS requests: no
  * CORS headers emitted and the request is forwarded (same-origin and
  * daemon-served-page callers must not be broken by a 403).
  *
  * Never applied in server-mode (the caller guards this).
  */
-export function createApiLoopbackCorsMiddleware(): MiddlewareHandler {
+export function createApiLoopbackCorsMiddleware(
+  allowedOrigins: readonly string[] = [],
+): MiddlewareHandler {
   return async (c, next) => {
     const origin = c.req.header('origin')
     const originHost = normalizeOriginHostname(origin)
     const isLoopback = originHost !== null && isLoopbackHostname(originHost)
+    const isAdmitted = isLoopback || isAllowedWebOrigin(origin, allowedOrigins)
 
-    if (isLoopback && origin) {
+    if (isAdmitted && origin) {
       c.res.headers.set('Access-Control-Allow-Origin', origin)
       c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
       c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
@@ -99,15 +105,20 @@ export function createApiLoopbackCorsMiddleware(): MiddlewareHandler {
     }
 
     if (c.req.method.toUpperCase() === 'OPTIONS') {
-      if (isLoopback && origin) {
+      if (isAdmitted && origin) {
+        // Access-Control-Allow-Local-Network is Chrome's in-flight successor
+        // to Access-Control-Allow-Private-Network; both are emitted so the
+        // preflight satisfies whichever LNA generation the browser enforces.
+        // https://wicg.github.io/local-network-access/
         c.res.headers.set('Access-Control-Allow-Private-Network', 'true')
+        c.res.headers.set('Access-Control-Allow-Local-Network', 'true')
       }
       return new Response(null, { status: 204, headers: c.res.headers })
     }
 
     await next()
 
-    if (isLoopback && origin) {
+    if (isAdmitted && origin) {
       c.res.headers.set('Access-Control-Allow-Origin', origin)
       c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
       c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')

--- a/packages/mcp-server/src/server/security/mcp-http.test.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  isAllowedMcpHttpOrigin,
-  requiresMcpHttpAuth,
-} from './mcp-http.js'
+import { isAllowedMcpHttpOrigin, requiresMcpHttpAuth } from './mcp-http.js'
 
 describe('MCP HTTP security', () => {
   describe('isAllowedMcpHttpOrigin', () => {
@@ -34,6 +31,46 @@ describe('MCP HTTP security', () => {
       // isLoopbackHostname can match the bare "::1" address.
       expect(isAllowedMcpHttpOrigin(undefined, '[::1]:3099')).toBe(true)
       expect(isAllowedMcpHttpOrigin('http://[::1]:6274', '[::1]:3099')).toBe(true)
+    })
+
+    describe('with an allowedOrigins allowlist', () => {
+      const allowlist = ['https://kamiazya-whiteboard.pages.dev']
+
+      it('admits an exact allowlisted hosted origin for a loopback host', () => {
+        expect(
+          isAllowedMcpHttpOrigin(
+            'https://kamiazya-whiteboard.pages.dev',
+            '127.0.0.1:3099',
+            allowlist,
+          ),
+        ).toBe(true)
+      })
+
+      it('still requires a loopback Host even for an allowlisted origin', () => {
+        expect(
+          isAllowedMcpHttpOrigin(
+            'https://kamiazya-whiteboard.pages.dev',
+            'evil.example',
+            allowlist,
+          ),
+        ).toBe(false)
+      })
+
+      it('rejects a lookalike origin not in the allowlist', () => {
+        expect(
+          isAllowedMcpHttpOrigin(
+            'https://evil-kamiazya-whiteboard.pages.dev',
+            '127.0.0.1:3099',
+            allowlist,
+          ),
+        ).toBe(false)
+      })
+
+      it('defaults to empty allowlist and preserves prior 403 behavior', () => {
+        expect(
+          isAllowedMcpHttpOrigin('https://kamiazya-whiteboard.pages.dev', '127.0.0.1:3099'),
+        ).toBe(false)
+      })
     })
   })
 

--- a/packages/mcp-server/src/server/security/mcp-http.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.ts
@@ -8,6 +8,7 @@ import {
   normalizeHostHeader,
   normalizeOriginHostname,
 } from './cors-loopback.js'
+import { isAllowedWebOrigin } from './web-origin-allowlist.js'
 
 function normalizeMethod(method: string): string {
   return method.toUpperCase()
@@ -27,25 +28,31 @@ function mcpHttpError(status: number, message: string, headers?: Headers): Respo
 export function isAllowedMcpHttpOrigin(
   originHeader: string | undefined,
   hostHeader: string | undefined,
+  allowedOrigins: readonly string[] = [],
 ): boolean {
+  // DNS-rebinding guard: unchanged regardless of the Origin allowlist below —
+  // the request Host must always be loopback.
   const requestHost = normalizeHostHeader(hostHeader)
   if (!requestHost || !isLoopbackHostname(requestHost)) {
     return false
   }
   if (!originHeader) return true
   const originHost = normalizeOriginHostname(originHeader)
-  return originHost !== null && isLoopbackHostname(originHost)
+  if (originHost !== null && isLoopbackHostname(originHost)) return true
+  return isAllowedWebOrigin(originHeader, allowedOrigins)
 }
 
 export function requiresMcpHttpAuth(method: string): boolean {
   return normalizeMethod(method) !== 'OPTIONS'
 }
 
-export function createMcpHttpOriginMiddleware(): MiddlewareHandler {
+export function createMcpHttpOriginMiddleware(
+  allowedOrigins: readonly string[] = [],
+): MiddlewareHandler {
   return async (c, next) => {
     const origin = c.req.header('origin')
     const host = getRequestHost(c)
-    if (!isAllowedMcpHttpOrigin(origin, host)) {
+    if (!isAllowedMcpHttpOrigin(origin, host, allowedOrigins)) {
       return mcpHttpError(403, 'forbidden origin')
     }
 
@@ -63,9 +70,13 @@ export function createMcpHttpOriginMiddleware(): MiddlewareHandler {
 
     if (normalizeMethod(c.req.method) === 'OPTIONS') {
       if (origin) {
-        // Local Network Access preflight header — required by Chrome for
-        // private-network → loopback requests regardless of PNA spec state.
+        // Local Network Access preflight headers — required by Chrome for
+        // private-network → loopback requests. Both the legacy PNA header and
+        // its in-flight successor (ALN) are emitted so the preflight
+        // satisfies whichever LNA generation the browser enforces.
+        // https://wicg.github.io/local-network-access/
         c.res.headers.set('Access-Control-Allow-Private-Network', 'true')
+        c.res.headers.set('Access-Control-Allow-Local-Network', 'true')
       }
       return new Response(null, { status: 204, headers: c.res.headers })
     }

--- a/packages/mcp-server/src/server/security/mcp-http.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareHandler } from 'hono'
+import type { Context, MiddlewareHandler } from 'hono'
 
 import type { McpHttpAuthStrategy } from './mcp-auth.js'
 import {
@@ -46,6 +46,18 @@ export function requiresMcpHttpAuth(method: string): boolean {
   return normalizeMethod(method) !== 'OPTIONS'
 }
 
+function setMcpCorsHeaders(c: Context, origin: string): void {
+  c.res.headers.set('Access-Control-Allow-Origin', origin)
+  c.res.headers.set(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version',
+  )
+  c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
+  c.res.headers.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
+  c.res.headers.set('Access-Control-Max-Age', '86400')
+  c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+}
+
 export function createMcpHttpOriginMiddleware(
   allowedOrigins: readonly string[] = [],
 ): MiddlewareHandler {
@@ -57,15 +69,7 @@ export function createMcpHttpOriginMiddleware(
     }
 
     if (origin) {
-      c.res.headers.set('Access-Control-Allow-Origin', origin)
-      c.res.headers.set(
-        'Access-Control-Allow-Headers',
-        'Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version',
-      )
-      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
-      c.res.headers.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
-      c.res.headers.set('Access-Control-Max-Age', '86400')
-      c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+      setMcpCorsHeaders(c, origin)
     }
 
     if (normalizeMethod(c.req.method) === 'OPTIONS') {
@@ -84,15 +88,7 @@ export function createMcpHttpOriginMiddleware(
     await next()
 
     if (origin) {
-      c.res.headers.set('Access-Control-Allow-Origin', origin)
-      c.res.headers.set(
-        'Access-Control-Allow-Headers',
-        'Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version',
-      )
-      c.res.headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
-      c.res.headers.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
-      c.res.headers.set('Access-Control-Max-Age', '86400')
-      c.res.headers.set('Vary', appendVary(c.res.headers.get('Vary'), 'Origin'))
+      setMcpCorsHeaders(c, origin)
     }
   }
 }

--- a/packages/mcp-server/src/server/security/origin-validation.test.ts
+++ b/packages/mcp-server/src/server/security/origin-validation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { validateOriginEntry } from './origin-validation.js'
+
+describe('validateOriginEntry', () => {
+  it('accepts an exact https origin', () => {
+    const result = validateOriginEntry('https://kamiazya-whiteboard.pages.dev')
+    expect(result).toEqual({ ok: true, origin: 'https://kamiazya-whiteboard.pages.dev' })
+  })
+
+  it('normalizes a trailing slash to the bare origin', () => {
+    const result = validateOriginEntry('https://kamiazya-whiteboard.pages.dev/')
+    expect(result).toEqual({ ok: true, origin: 'https://kamiazya-whiteboard.pages.dev' })
+  })
+
+  it('normalizes host case and collapses the default port', () => {
+    const result = validateOriginEntry('https://Example.com:443')
+    expect(result).toEqual({ ok: true, origin: 'https://example.com' })
+  })
+
+  it('keeps a non-default port significant', () => {
+    const result = validateOriginEntry('https://example.com:8443')
+    expect(result).toEqual({ ok: true, origin: 'https://example.com:8443' })
+  })
+
+  it('rejects the wildcard entry', () => {
+    expect(validateOriginEntry('*')).toEqual({ ok: false, reason: 'wildcard' })
+  })
+
+  it('rejects http:// scheme', () => {
+    expect(validateOriginEntry('http://kamiazya-whiteboard.pages.dev')).toEqual({
+      ok: false,
+      reason: 'not_https',
+    })
+  })
+
+  it('rejects a path suffix', () => {
+    expect(validateOriginEntry('https://example.com/app')).toEqual({
+      ok: false,
+      reason: 'not_origin',
+    })
+  })
+
+  it('rejects a query string', () => {
+    expect(validateOriginEntry('https://example.com/?x=1')).toEqual({
+      ok: false,
+      reason: 'not_origin',
+    })
+  })
+
+  it('rejects a fragment', () => {
+    expect(validateOriginEntry('https://example.com/#frag')).toEqual({
+      ok: false,
+      reason: 'not_origin',
+    })
+  })
+
+  it('rejects embedded credentials', () => {
+    expect(validateOriginEntry('https://user:pass@example.com')).toEqual({
+      ok: false,
+      reason: 'not_origin',
+    })
+  })
+
+  it('rejects an unparseable value', () => {
+    expect(validateOriginEntry('not a url')).toEqual({ ok: false, reason: 'unparseable' })
+  })
+})

--- a/packages/mcp-server/src/server/security/origin-validation.ts
+++ b/packages/mcp-server/src/server/security/origin-validation.ts
@@ -1,0 +1,45 @@
+// Neutral per-origin validation rules shared by every allowlist that must
+// accept exact HTTPS origins: server-mode's WHITEBOARD_SERVER_ALLOWED_ORIGINS
+// and the local-daemon's WHITEBOARD_ALLOWED_WEB_ORIGINS. Kept caller-agnostic
+// (no server_mode.* / web_origins.* failure codes here) so each caller can map
+// the neutral reason onto its own stable failure-code namespace without this
+// module knowing about either.
+
+export type OriginValidationFailureReason = 'unparseable' | 'wildcard' | 'not_https' | 'not_origin'
+
+export type OriginValidationResult =
+  | { ok: true; origin: string }
+  | { ok: false; reason: OriginValidationFailureReason }
+
+// Validates a single configured origin entry and, on success, returns the
+// URL-normalised origin (lowercased host, explicit default port dropped) so
+// per-request exact-match comparisons always compare canonical forms.
+export function validateOriginEntry(value: string): OriginValidationResult {
+  if (value === '*') return { ok: false, reason: 'wildcard' }
+
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return { ok: false, reason: 'unparseable' }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'not_https' }
+  }
+
+  // Origin-only contract: credentials, non-root path, query string, and
+  // fragment are all rejected. The raw value is never echoed by callers of
+  // this validator so sensitive query/credential data cannot leak into logs.
+  if (
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    parsed.pathname !== '/' ||
+    parsed.search !== '' ||
+    parsed.hash !== ''
+  ) {
+    return { ok: false, reason: 'not_origin' }
+  }
+
+  return { ok: true, origin: parsed.origin }
+}

--- a/packages/mcp-server/src/server/security/server-mode-exposure.ts
+++ b/packages/mcp-server/src/server/security/server-mode-exposure.ts
@@ -26,6 +26,7 @@
 // them without a flag day.
 
 import { isLoopbackHost } from '../daemon-auth-binding.js'
+import { validateOriginEntry } from './origin-validation.js'
 
 function bracketIpv6(host: string): string {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
@@ -128,36 +129,25 @@ export function resolveServerModeExposure(
     return { ok: false, code: 'server_mode.external_url_must_be_origin' }
   }
 
+  // Same origin-only rules as externalUrl (https required, no
+  // credentials/path/query/fragment) via the shared neutral validator; the
+  // neutral reason is mapped back onto this module's own failure-code
+  // namespace so existing callers see byte-identical codes. The raw origin
+  // string is never echoed in the failure decision.
   const allowedOrigins = input.allowedOrigins ?? []
   const normalizedOrigins: string[] = []
   for (const origin of allowedOrigins) {
-    if (origin === '*') {
-      return { ok: false, code: 'server_mode.wildcard_origin_forbidden' }
+    const result = validateOriginEntry(origin)
+    if (!result.ok) {
+      return {
+        ok: false,
+        code:
+          result.reason === 'wildcard'
+            ? 'server_mode.wildcard_origin_forbidden'
+            : 'server_mode.external_url_must_be_origin',
+      }
     }
-    let parsedOrigin: URL
-    try {
-      parsedOrigin = new URL(origin)
-    } catch {
-      return { ok: false, code: 'server_mode.external_url_must_be_origin' }
-    }
-    // Same origin-only rules as externalUrl: https required, no
-    // credentials/path/query/fragment. The raw origin string is never
-    // echoed in the failure decision.
-    if (
-      parsedOrigin.protocol !== 'https:' ||
-      parsedOrigin.username !== '' ||
-      parsedOrigin.password !== '' ||
-      parsedOrigin.pathname !== '/' ||
-      parsedOrigin.search !== '' ||
-      parsedOrigin.hash !== ''
-    ) {
-      return { ok: false, code: 'server_mode.external_url_must_be_origin' }
-    }
-    // Store the URL-normalised origin (lowercased host, explicit-default port
-    // dropped) so the per-request exact-match compares canonical forms. An
-    // operator writing `https://Example.com:443` otherwise false-denies the
-    // browser's canonical `https://example.com`.
-    normalizedOrigins.push(parsedOrigin.origin)
+    normalizedOrigins.push(result.origin)
   }
 
   return {

--- a/packages/mcp-server/src/server/security/web-origin-allowlist.test.ts
+++ b/packages/mcp-server/src/server/security/web-origin-allowlist.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../log.js'
+import {
+  isAllowedWebOrigin,
+  loadAllowedWebOriginsFromEnv,
+  parseAllowedWebOriginsEnv,
+} from './web-origin-allowlist.js'
+
+describe('parseAllowedWebOriginsEnv', () => {
+  it('returns an empty allowlist when unset', () => {
+    expect(parseAllowedWebOriginsEnv(undefined)).toEqual({ ok: true, origins: [] })
+  })
+
+  it('returns an empty allowlist for an empty string', () => {
+    expect(parseAllowedWebOriginsEnv('')).toEqual({ ok: true, origins: [] })
+  })
+
+  it('parses a single origin', () => {
+    expect(parseAllowedWebOriginsEnv('https://kamiazya-whiteboard.pages.dev')).toEqual({
+      ok: true,
+      origins: ['https://kamiazya-whiteboard.pages.dev'],
+    })
+  })
+
+  it('parses comma-separated origins, trimming whitespace', () => {
+    expect(parseAllowedWebOriginsEnv(' https://a.example , https://b.example  ')).toEqual({
+      ok: true,
+      origins: ['https://a.example', 'https://b.example'],
+    })
+  })
+
+  it('normalizes a trailing slash', () => {
+    expect(parseAllowedWebOriginsEnv('https://a.example/')).toEqual({
+      ok: true,
+      origins: ['https://a.example'],
+    })
+  })
+
+  it('fails with the entry index for a path suffix', () => {
+    expect(parseAllowedWebOriginsEnv('https://a.example, https://b.example/app')).toEqual({
+      ok: false,
+      code: 'web_origins.entry_must_be_origin',
+      entryIndex: 1,
+    })
+  })
+
+  it('fails for a wildcard entry', () => {
+    expect(parseAllowedWebOriginsEnv('*')).toEqual({
+      ok: false,
+      code: 'web_origins.wildcard_forbidden',
+      entryIndex: 0,
+    })
+  })
+
+  it('fails for an http:// entry', () => {
+    expect(parseAllowedWebOriginsEnv('http://a.example')).toEqual({
+      ok: false,
+      code: 'web_origins.entry_must_be_https',
+      entryIndex: 0,
+    })
+  })
+
+  it('fails for an unparseable entry', () => {
+    expect(parseAllowedWebOriginsEnv('not a url')).toEqual({
+      ok: false,
+      code: 'web_origins.entry_unparseable',
+      entryIndex: 0,
+    })
+  })
+})
+
+describe('isAllowedWebOrigin', () => {
+  const allowlist = ['https://kamiazya-whiteboard.pages.dev', 'https://second.example']
+
+  it('admits an exact match', () => {
+    expect(isAllowedWebOrigin('https://kamiazya-whiteboard.pages.dev', allowlist)).toBe(true)
+  })
+
+  it('admits a match against a later allowlist entry', () => {
+    expect(isAllowedWebOrigin('https://second.example', allowlist)).toBe(true)
+  })
+
+  it('rejects an evil-prefix lookalike host', () => {
+    expect(isAllowedWebOrigin('https://evil-kamiazya-whiteboard.pages.dev', allowlist)).toBe(false)
+  })
+
+  it('rejects a suffix-match lookalike host', () => {
+    expect(isAllowedWebOrigin('https://kamiazya-whiteboard.pages.dev.evil.com', allowlist)).toBe(
+      false,
+    )
+  })
+
+  it('rejects a scheme mismatch', () => {
+    expect(isAllowedWebOrigin('http://kamiazya-whiteboard.pages.dev', allowlist)).toBe(false)
+  })
+
+  it('rejects a port mismatch', () => {
+    expect(isAllowedWebOrigin('https://kamiazya-whiteboard.pages.dev:8443', allowlist)).toBe(false)
+  })
+
+  it('rejects when the allowlist is empty', () => {
+    expect(isAllowedWebOrigin('https://kamiazya-whiteboard.pages.dev', [])).toBe(false)
+  })
+
+  it('normalizes case and default port on the request origin', () => {
+    expect(isAllowedWebOrigin('https://Kamiazya-Whiteboard.pages.dev:443', allowlist)).toBe(true)
+  })
+
+  it('is false for an undefined origin header', () => {
+    expect(isAllowedWebOrigin(undefined, allowlist)).toBe(false)
+  })
+})
+
+describe('loadAllowedWebOriginsFromEnv', () => {
+  it('returns an empty allowlist when unset', () => {
+    expect(loadAllowedWebOriginsFromEnv({})).toEqual([])
+  })
+
+  it('returns the parsed allowlist on success', () => {
+    expect(
+      loadAllowedWebOriginsFromEnv({
+        WHITEBOARD_ALLOWED_WEB_ORIGINS: 'https://kamiazya-whiteboard.pages.dev',
+      }),
+    ).toEqual(['https://kamiazya-whiteboard.pages.dev'])
+  })
+
+  it('returns null and logs an error record without echoing the raw value on failure', () => {
+    const capture = captureLogsForTests('debug')
+    try {
+      const result = loadAllowedWebOriginsFromEnv({
+        WHITEBOARD_ALLOWED_WEB_ORIGINS: 'not a url',
+      })
+      expect(result).toBeNull()
+      const record = capture.records.find(
+        (r) => r.scope === 'web-origin-allowlist' && r.level === 'error',
+      )
+      expect(record).toBeDefined()
+      expect(record?.data?.code).toBe('web_origins.entry_unparseable')
+      expect(record?.data?.entryIndex).toBe(0)
+      expect(JSON.stringify(record)).not.toContain('not a url')
+    } finally {
+      capture.restore()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/security/web-origin-allowlist.ts
+++ b/packages/mcp-server/src/server/security/web-origin-allowlist.ts
@@ -1,0 +1,87 @@
+// Single source of truth for the local-daemon's hosted-origin admission
+// contract: parses WHITEBOARD_ALLOWED_WEB_ORIGINS and exposes the one
+// predicate every surface (/api CORS, /mcp origin gate, WS upgrade) must use
+// so origin matching cannot drift between them. Exact-match only — wildcard
+// and suffix matching are never introduced here (ADR-0002 addendum).
+//
+// This env var governs local-daemon mode only. Server-mode reads
+// WHITEBOARD_SERVER_ALLOWED_ORIGINS via server-mode-exposure.ts and never
+// consults this module.
+
+import { getLogger } from '../log.js'
+import { validateOriginEntry, type OriginValidationFailureReason } from './origin-validation.js'
+
+export type WebOriginsFailureCode =
+  | 'web_origins.entry_must_be_https'
+  | 'web_origins.entry_must_be_origin'
+  | 'web_origins.wildcard_forbidden'
+  | 'web_origins.entry_unparseable'
+
+const REASON_TO_CODE: Record<OriginValidationFailureReason, WebOriginsFailureCode> = {
+  unparseable: 'web_origins.entry_unparseable',
+  wildcard: 'web_origins.wildcard_forbidden',
+  not_https: 'web_origins.entry_must_be_https',
+  not_origin: 'web_origins.entry_must_be_origin',
+}
+
+export type ParseAllowedWebOriginsResult =
+  | { ok: true; origins: readonly string[] }
+  | { ok: false; code: WebOriginsFailureCode; entryIndex: number }
+
+// Parses the raw WHITEBOARD_ALLOWED_WEB_ORIGINS env value: comma-separated
+// exact HTTPS origins. Unset/empty is a valid, empty allowlist (byte-identical
+// current loopback-only behavior). A malformed entry fails fast with its
+// index rather than being silently dropped.
+export function parseAllowedWebOriginsEnv(value: string | undefined): ParseAllowedWebOriginsResult {
+  if (!value || value.trim() === '') return { ok: true, origins: [] }
+
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+
+  const origins: string[] = []
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+    const result = validateOriginEntry(entries[entryIndex])
+    if (!result.ok) {
+      return { ok: false, code: REASON_TO_CODE[result.reason], entryIndex }
+    }
+    origins.push(result.origin)
+  }
+  return { ok: true, origins }
+}
+
+// Per-request exact-match predicate shared by /api CORS, /mcp origin gate,
+// and WS upgrade. Normalises the request Origin header through URL.origin so
+// host case and default-port variants compare canonically against the
+// already-normalised allowlist produced by parseAllowedWebOriginsEnv.
+export function isAllowedWebOrigin(
+  originHeader: string | undefined,
+  allowlist: readonly string[],
+): boolean {
+  if (!originHeader || allowlist.length === 0) return false
+  try {
+    return allowlist.includes(new URL(originHeader).origin)
+  } catch {
+    return false
+  }
+}
+
+// Startup-time wiring helper shared by both entrypoints (cli/daemon-run.ts,
+// server/index.ts): parses the env once and logs a structured failure record
+// (never echoing the raw offending value) instead of each entrypoint
+// re-implementing the parse-and-log seam.
+export function loadAllowedWebOriginsFromEnv(
+  env: Readonly<Record<string, string | undefined>>,
+): readonly string[] | null {
+  const result = parseAllowedWebOriginsEnv(env.WHITEBOARD_ALLOWED_WEB_ORIGINS)
+  if (!result.ok) {
+    const log = getLogger('web-origin-allowlist')
+    log.error(
+      { code: result.code, entryIndex: result.entryIndex },
+      'invalid WHITEBOARD_ALLOWED_WEB_ORIGINS entry',
+    )
+    return null
+  }
+  return result.origins
+}

--- a/packages/mcp-server/src/server/security/web-origin-allowlist.ts
+++ b/packages/mcp-server/src/server/security/web-origin-allowlist.ts
@@ -35,14 +35,15 @@ export type ParseAllowedWebOriginsResult =
 export function parseAllowedWebOriginsEnv(value: string | undefined): ParseAllowedWebOriginsResult {
   if (!value || value.trim() === '') return { ok: true, origins: [] }
 
-  const entries = value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-
+  // Iterate the raw split so a reported entryIndex points at the true position
+  // in the operator's comma-separated value; empty/whitespace entries are
+  // skipped in-loop rather than filtered out first (which would shift indices).
+  const entries = value.split(',')
   const origins: string[] = []
   for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
-    const result = validateOriginEntry(entries[entryIndex])
+    const entry = entries[entryIndex].trim()
+    if (entry.length === 0) continue
+    const result = validateOriginEntry(entry)
     if (!result.ok) {
       return { ok: false, code: REASON_TO_CODE[result.reason], entryIndex }
     }


### PR DESCRIPTION
## Summary

Implements the ADR-0002 LNA-addendum prerequisite for hosted `apps/web` → local-daemon pairing: widens the daemon's origin control from "reflect any loopback hostname" to "loopback OR an exact-match allowlist", opt-in via `WHITEBOARD_ALLOWED_WEB_ORIGINS` (comma-separated). Default behavior (env unset) is unchanged.

**Single shared decision across all 3 surfaces** (no duplicated matching):
- `/api/*` CORS reflection (`cors-loopback.ts`)
- `/mcp` origin gate (`mcp-http.ts`)
- WS upgrade (`ws-auth.ts`)

**Exact-origin only** (`new URL(v).origin` normalization): `https://evil-…pages.dev`, `…pages.dev.evil.com`, suffix matches, and `http://` scheme variants are all rejected; wildcard entries are a config error. The per-origin validator is extracted into a neutral helper (`origin-validation.ts`) that both the new env parser and `server-mode-exposure.ts` consume — server-mode failure codes stay byte-identical.

**Security invariants preserved (tested):**
- Host-loopback DNS-rebinding guard on `/mcp` + WS is NOT loosened — only the Origin branch widens. A loopback origin whose host differs from the request Host still 403s unless explicitly allowlisted (dedicated WS regression test).
- Auth unchanged: allowlisted origin + mutation without Bearer still 401s on both HTTP surfaces and WS.
- **Fail-fast**: starting the local daemon with a hosted-origin allowlist but no auth token is refused (`d53f0f5`); invalid `WHITEBOARD_ALLOWED_WEB_ORIGINS` aborts startup with a structured error + logger record (no secret echo).
- OPTIONS preflight now returns both `Access-Control-Allow-Private-Network: true` and the LNA-successor `Access-Control-Allow-Local-Network: true`.

Docs: `WHITEBOARD_ALLOWED_WEB_ORIGINS` documented in `docs/reference/configuration.md` (same increment).

## Test plan

- [x] `pnpm test --project mcp-node` — 2832 passed / 2 skipped (incl. new allowlist tests across CORS/mcp/WS + a real WS-upgrade handshake test + server-mode non-leak + fail-fast startup)
- [x] typecheck clean
- [x] Existing loopback/PNA/Host-guard/auth tests pass unmodified (behavior-preserving)
- [ ] Manual daemon spin deferred (local entry-invocation hiccup on my side; the WS-upgrade handshake + app CORS tests cover the real reflection path). CI is authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional browser web origins through `WHITEBOARD_ALLOWED_WEB_ORIGINS`.
  * Enabled exact HTTPS origins for CORS, MCP, and WebSocket connections alongside loopback origins.
  * Added strict validation for origin entries, with startup errors identifying invalid entry positions.
  * Clarified that configured origins do not bypass required API, MCP, or WebSocket authentication.

* **Documentation**
  * Added configuration guidance, accepted formats, normalization rules, and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->