### PR TITLE
fix(test): pre-bundle testing-library deps to stop vitest browser dynamic-import flake

### DIFF
--- a/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
+++ b/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
@@ -14,7 +14,14 @@ describe('apps/web vitest.browser.config optimizeDeps', () => {
     const include = browserConfig.optimizeDeps?.include ?? []
 
     expect(include).toEqual(
-      expect.arrayContaining(['@testing-library/react', 'react', 'react-dom', 'react-dom/client']),
+      expect.arrayContaining([
+        '@testing-library/react',
+        'react',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react-dom',
+        'react-dom/client',
+      ]),
     )
   })
 })

--- a/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
+++ b/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
@@ -21,6 +21,7 @@ describe('apps/web vitest.browser.config optimizeDeps', () => {
         'react/jsx-dev-runtime',
         'react-dom',
         'react-dom/client',
+        'react-router-dom',
       ]),
     )
   })

--- a/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
+++ b/apps/web/src/test-config/vitest-browser-optimize-deps.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import browserConfig from '../../vitest.browser.config.js'
+
+// Vitest browser mode fetches test dependencies through the Vite dev server
+// instead of bundling them ahead of time. Under CI load the lazy
+// dependency-optimization pass can race with the first HTTP fetch of a
+// dynamically imported module, producing a "Failed to fetch dynamically
+// imported module" error that has nothing to do with the test's assertions.
+// Pre-bundling the packages every browser test transitively imports removes
+// that race at the source instead of retrying around it.
+describe('apps/web vitest.browser.config optimizeDeps', () => {
+  it('pre-bundles the testing-library and react runtime deps every browser test imports', () => {
+    const include = browserConfig.optimizeDeps?.include ?? []
+
+    expect(include).toEqual(
+      expect.arrayContaining(['@testing-library/react', 'react', 'react-dom', 'react-dom/client']),
+    )
+  })
+})

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -49,6 +49,8 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       'react',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
       'react-dom',
       'react-dom/client',
       'react-router-dom',

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -39,6 +39,22 @@ export default defineConfig({
   // tailwindcss: layout browser tests import src/index.css to assert real
   // computed geometry (e.g. the Excalidraw container filling the viewport).
   plugins: [tailwindcss(), react(), wasm(), topLevelAwait()],
+  // Vitest browser mode serves test dependencies from the Vite dev server on
+  // demand instead of bundling them ahead of time. Under CI load, the lazy
+  // dependency-optimization scan can race with the browser's first fetch of
+  // one of these modules, producing a spurious "Failed to fetch dynamically
+  // imported module" import error unrelated to the test itself. Listing the
+  // packages every browser test transitively imports forces them into the
+  // pre-bundle before any test file runs, removing the race at the source.
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'react-dom/client',
+      'react-router-dom',
+      '@testing-library/react',
+    ],
+  },
   test: {
     name: 'web-browser',
     include: ['src/**/*.browser.test.tsx'],

--- a/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
+++ b/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
@@ -20,6 +20,7 @@ describe('mcp-server vitest.browser.config optimizeDeps', () => {
         'react/jsx-dev-runtime',
         'react-dom',
         'react-dom/client',
+        'react-router-dom',
         '@testing-library/react',
       ]),
     )

--- a/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
+++ b/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import browserConfig from '../../vitest.browser.config.js'
+
+// Vitest browser mode fetches test dependencies through the Vite dev server
+// instead of bundling them ahead of time. Under CI load the lazy
+// dependency-optimization pass can race with the first HTTP fetch of a
+// dynamically imported module, producing a "Failed to fetch dynamically
+// imported module" error unrelated to the test's assertions. Pre-bundling
+// the packages every browser test transitively imports removes that race
+// at the source instead of retrying around it.
+describe('mcp-server vitest.browser.config optimizeDeps', () => {
+  it('pre-bundles the testing-library and react runtime deps every browser test imports', () => {
+    const include = browserConfig.optimizeDeps?.include ?? []
+
+    expect(include).toEqual(
+      expect.arrayContaining(['react', 'react-dom', 'react-dom/client', '@testing-library/react']),
+    )
+  })
+})

--- a/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
+++ b/packages/mcp-server/scripts/dev/vitest-browser-optimize-deps.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest'
 import browserConfig from '../../vitest.browser.config.js'
 
@@ -13,7 +14,14 @@ describe('mcp-server vitest.browser.config optimizeDeps', () => {
     const include = browserConfig.optimizeDeps?.include ?? []
 
     expect(include).toEqual(
-      expect.arrayContaining(['react', 'react-dom', 'react-dom/client', '@testing-library/react']),
+      expect.arrayContaining([
+        'react',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react-dom',
+        'react-dom/client',
+        '@testing-library/react',
+      ]),
     )
   })
 })

--- a/packages/mcp-server/vitest.shared.ts
+++ b/packages/mcp-server/vitest.shared.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     include: [
       'react',
       'react/jsx-runtime',
+      'react/jsx-dev-runtime',
       'react-dom',
       // Vitest browser mode fetches test dependencies through the Vite dev
       // server on demand instead of bundling them ahead of time. Under CI

--- a/packages/mcp-server/vitest.shared.ts
+++ b/packages/mcp-server/vitest.shared.ts
@@ -28,7 +28,16 @@ export default defineConfig({
       'react',
       'react/jsx-runtime',
       'react-dom',
+      // Vitest browser mode fetches test dependencies through the Vite dev
+      // server on demand instead of bundling them ahead of time. Under CI
+      // load the lazy dependency-optimization scan can race with the
+      // browser's first fetch of one of these modules, producing a spurious
+      // "Failed to fetch dynamically imported module" import error unrelated
+      // to the test itself. Listing every browser test's transitive deps
+      // here forces them into the pre-bundle before any test file runs.
+      'react-dom/client',
       'react-router-dom',
+      '@testing-library/react',
       '@radix-ui/react-alert-dialog',
       '@radix-ui/react-dialog',
       '@radix-ui/react-dropdown-menu',


### PR DESCRIPTION
## Summary

Vitest browser-mode runs intermittently failed with `Failed to fetch dynamically imported module ... @testing-library_react.js` — Vite's on-demand dep optimization raced the test import. This pre-bundles the affected deps via `optimizeDeps.include` in both browser test configs (apps/web `vitest.browser.config.ts` and packages/mcp-server `vitest.shared.ts`), so the optimized chunks exist before any test imports them.

This was one of the three flakes that blocked npm publish (0.0.12); the publish-gate side is already resolved by #157, this fixes the flake at its source for regular CI runs.

## Test plan

- [x] Config-guard tests assert the `optimizeDeps.include` entries stay present in both configs
- [x] Repeated local browser-mode runs without the dynamic-import failure
- [ ] verify CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-based test reliability by preloading required React and testing-library dependencies.
  * Reduced intermittent failures caused by dynamically loaded modules not being ready during test startup.

* **Tests**
  * Added coverage to verify required browser test dependencies are included in the optimization configuration.
  * Applied the same reliability checks across web and MCP server browser test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->