### PR TITLE
feat(web): wire version history (list/restore) into the daemon-paired canvas page

### DIFF
--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -2,9 +2,10 @@
 // Bundle-size gate for the built dist/. Run after `pnpm build`.
 //
 // Budgets (gzip): the entry chunk dominates first paint, so it gets a hard
-// ceiling; CSS has its own. Daemon-only feature chunks (ported behind
-// React.lazy) get a separate small budget so they can never leak into first
-// paint unnoticed — the pattern matches nothing until those chunks exist.
+// ceiling; CSS has its own. The daemon-only feature chunk (DaemonCanvasPage,
+// loaded via React.lazy) is named `daemon-canvas-*.js` by vite.config.ts's
+// chunkFileNames so it can never leak into first paint unnoticed — this
+// budget is `required: true` because the chunk exists as of this gate.
 //
 // The entry ceiling is a regression stop at today's measured size (~541 KB),
 // not an endorsement: shrinking it toward the <300 KB app budget needs
@@ -22,10 +23,10 @@ const BUDGETS = [
   { label: 'entry JS (index-*.js)', pattern: /^index-.*\.js$/, limit: 560 * KB, required: true },
   { label: 'CSS (index-*.css)', pattern: /^index-.*\.css$/, limit: 30 * KB, required: true },
   {
-    label: 'daemon lazy chunk (daemon-*.js)',
-    pattern: /^daemon-.*\.js$/,
+    label: 'daemon lazy chunk (daemon-canvas-*.js)',
+    pattern: /^daemon-canvas-.*\.js$/,
     limit: 40 * KB,
-    required: false,
+    required: true,
   },
 ]
 

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -1,5 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DaemonApiContext } from '@/contexts/DaemonApiContext'
+import { createDaemonFetch } from '@/lib/daemon-api-client'
 import VersionTimeline from './VersionTimeline.js'
 
 const mockLog = vi.hoisted(() => ({
@@ -696,6 +698,182 @@ describe('formatRelative display branches (via rendered version rows)', () => {
     render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
     await waitFor(() => {
       expect(screen.getByText(/not-a-real-date/)).toBeTruthy()
+    })
+  })
+})
+
+describe('VersionTimeline via DaemonApiContext', () => {
+  const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  function mkThumbnailVersionsResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        versions: [
+          {
+            id: 'v-thumb',
+            slug: 'canvas-a',
+            createdAt: '2026-04-23T02:00:00Z',
+            elementCount: 5,
+            auto: true,
+            hasThumbnail: true,
+            branchName: 'main',
+            operator: { kind: 'ai', peerId: 'peer-ai', displayName: 'Assistant' },
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  it('resolves the versions request against the daemon origin with an Authorization header', async () => {
+    const underlyingFetch = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', underlyingFetch)
+    const daemonFetch = createDaemonFetch(DAEMON_BASE_URL, 'test-token')
+
+    render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </DaemonApiContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(
+        underlyingFetch.mock.calls.some(([input]) => {
+          const url = input instanceof URL ? input : new URL(String(input))
+          return url.origin === DAEMON_BASE_URL && String(url).includes('/versions')
+        }),
+      ).toBe(true)
+    })
+
+    const versionsCall = underlyingFetch.mock.calls.find(([input]) =>
+      String(input instanceof URL ? input : new URL(String(input))).includes('/versions'),
+    )
+    const init = versionsCall?.[1]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('Authorization')).toBe('Bearer test-token')
+  })
+
+  it('POSTs restore through the provided daemon fetch', async () => {
+    const restoreCalls: string[] = []
+    const underlyingFetch = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/restore')) {
+        restoreCalls.push(url)
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', underlyingFetch)
+    const daemonFetch = createDaemonFetch(DAEMON_BASE_URL, 'test-token')
+
+    render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </DaemonApiContext.Provider>,
+    )
+
+    const row = await screen.findByText('🤖 Assistant')
+    fireEvent.click(row.closest('button')!)
+    await waitFor(() => {
+      expect(screen.getByText('Restore this version?')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+
+    await waitFor(() => {
+      expect(restoreCalls.some((u) => u.startsWith(DAEMON_BASE_URL))).toBe(true)
+    })
+  })
+
+  it('does not render the thumbnail <img> when a daemon provider is active', async () => {
+    const underlyingFetch = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkThumbnailVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', underlyingFetch)
+    const daemonFetch = createDaemonFetch(DAEMON_BASE_URL, 'test-token')
+
+    render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </DaemonApiContext.Provider>,
+    )
+
+    await screen.findByText('🤖 Assistant')
+    expect(document.querySelector('img')).toBeNull()
+  })
+
+  it('renders the thumbnail <img> for the same-origin fallback (no provider)', async () => {
+    const underlyingFetch = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) return Promise.resolve(mkThumbnailVersionsResponse())
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', underlyingFetch)
+
+    render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
+
+    await screen.findByText('🤖 Assistant')
+    expect(document.querySelector('img')).not.toBeNull()
+  })
+
+  it('renders a manual-trigger version returned by the daemon list', async () => {
+    const underlyingFetch = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+      if (url.includes('/versions')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              versions: [
+                {
+                  id: 'v-manual',
+                  slug: 'canvas-a',
+                  createdAt: '2026-04-23T02:00:00Z',
+                  elementCount: 5,
+                  auto: false,
+                  hasThumbnail: false,
+                  branchName: 'main',
+                  operator: { kind: 'human', peerId: 'peer-human', displayName: 'Alice' },
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', underlyingFetch)
+    const daemonFetch = createDaemonFetch(DAEMON_BASE_URL, 'test-token')
+
+    render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <VersionTimeline workspaceId="sess_1" slug="canvas-a" />
+      </DaemonApiContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('manual')).toBeTruthy()
     })
   })
 })

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -1,4 +1,3 @@
-import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
 import {
   listVersionsResponseSchema,
   type OperatorInfo,
@@ -18,6 +17,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { CardContent } from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useDaemonApi, useHasDaemonApi } from '@/contexts/DaemonApiContext'
 import { useBranches } from '@/hooks/useBranches'
 import { getAppLogger } from '@/lib/app-logger'
 import { buildMiniGraph } from '@/lib/mini-graph'
@@ -64,6 +64,8 @@ function getOperatorAffordance(operator?: OperatorInfo): { icon: string; label: 
 // Branch operations and save controls live in the header.
 // VersionTimeline is responsible only for the version list, mini-graph, and restore flow.
 export default function VersionTimeline({ workspaceId, slug, onRestored }: Props) {
+  const fetchFn = useDaemonApi()
+  const hasDaemonApi = useHasDaemonApi()
   const [versions, setVersions] = useState<VersionEntry[]>([])
   const [loading, setLoading] = useState(false)
   const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
@@ -84,7 +86,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     const seq = ++fetchSeqRef.current
     setLoading(true)
     try {
-      const res = await apiFetch(
+      const res = await fetchFn(
         `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
       )
       if (seq !== fetchSeqRef.current) return
@@ -105,7 +107,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     } finally {
       if (seq === fetchSeqRef.current) setLoading(false)
     }
-  }, [workspaceId, slug])
+  }, [workspaceId, slug, fetchFn])
 
   // Clear the previously loaded canvas's versions immediately on canvas
   // change so a stale row (with thumbnail URLs pointing at the old
@@ -131,7 +133,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     state: branchesState,
     loading: branchesLoading,
     refetch: refetchBranches,
-  } = useBranches(workspaceId, slug)
+  } = useBranches(workspaceId, slug, fetchFn)
 
   // Poll every 15 seconds for new auto-versions, and re-fetch branches on the
   // same tick. useBranches has no event subscription of its own, so this is
@@ -158,7 +160,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     // actually happened. A failed request keeps the dialog open with an error
     // so the caller never discards undo history for a restore that didn't occur.
     try {
-      const res = await apiFetch(
+      const res = await fetchFn(
         `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
         { method: 'POST' },
       )
@@ -185,7 +187,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
     onRestored?.()
     // Refresh immediately after restore so the pending UI closes cleanly.
     await refresh()
-  }, [pendingRestore, isRestoring, workspaceId, slug, onRestored, refresh])
+  }, [pendingRestore, isRestoring, workspaceId, slug, onRestored, refresh, fetchFn])
 
   const head = branchesState.head
 
@@ -273,7 +275,10 @@ export default function VersionTimeline({ workspaceId, slug, onRestored }: Props
                       setPendingRestore(v)
                     }}
                   >
-                    {v.hasThumbnail && (
+                    {/* A plain <img src> cannot carry the daemon origin or bearer
+                        token, so thumbnails only render for the same-origin
+                        mcp-server app (no DaemonApiContext provider mounted). */}
+                    {v.hasThumbnail && !hasDaemonApi && (
                       <div className="mx-3 mb-1 border rounded overflow-hidden bg-muted/30">
                         <img
                           src={`/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/thumbnail`}

--- a/apps/web/src/contexts/DaemonApiContext.test.tsx
+++ b/apps/web/src/contexts/DaemonApiContext.test.tsx
@@ -1,11 +1,16 @@
 import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
-import { DaemonApiContext, useDaemonApi } from './DaemonApiContext.js'
+import { DaemonApiContext, useDaemonApi, useHasDaemonApi } from './DaemonApiContext.js'
 
 function Consumer() {
   const fetchFn = useDaemonApi()
   return <div data-testid="result">{fetchFn === apiFetch ? 'default' : 'injected'}</div>
+}
+
+function HasProviderConsumer() {
+  const hasProvider = useHasDaemonApi()
+  return <div data-testid="has-provider">{String(hasProvider)}</div>
 }
 
 afterEach(cleanup)
@@ -24,5 +29,22 @@ describe('DaemonApiContext', () => {
       </DaemonApiContext.Provider>,
     )
     expect(screen.getByTestId('result').textContent).toBe('injected')
+  })
+})
+
+describe('useHasDaemonApi', () => {
+  it('is false when no provider is mounted', () => {
+    render(<HasProviderConsumer />)
+    expect(screen.getByTestId('has-provider').textContent).toBe('false')
+  })
+
+  it('is true when a provider is mounted', () => {
+    const injectedFetch: typeof fetch = async () => new Response(null)
+    render(
+      <DaemonApiContext.Provider value={injectedFetch}>
+        <HasProviderConsumer />
+      </DaemonApiContext.Provider>,
+    )
+    expect(screen.getByTestId('has-provider').textContent).toBe('true')
   })
 })

--- a/apps/web/src/contexts/DaemonApiContext.tsx
+++ b/apps/web/src/contexts/DaemonApiContext.tsx
@@ -13,3 +13,13 @@ export const DaemonApiContext = createContext<typeof globalThis.fetch | null>(nu
 export function useDaemonApi(): typeof globalThis.fetch {
   return useContext(DaemonApiContext) ?? apiFetch
 }
+
+/**
+ * True when a DaemonApiContext.Provider is mounted above this component.
+ * Lets a consumer branch on same-origin vs. cross-origin daemon access — for
+ * example, VersionTimeline's thumbnail <img> cannot carry a daemon origin or
+ * bearer token, so it only renders in the same-origin (no provider) case.
+ */
+export function useHasDaemonApi(): boolean {
+  return useContext(DaemonApiContext) !== null
+}

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -1,5 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
+import { createElement } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import {
   type BranchesState,
   branchesApi,
@@ -195,6 +197,33 @@ describe('branchesApi', () => {
     expect(url).toBe('/api/workspaces/sess_1/canvases/canvas-a/branches/feature/merge')
     expect(init2?.method).toBe('POST')
     expect(init2?.body).toBe(JSON.stringify({ into: 'main', dryRun: true }))
+  })
+
+  it('constructing with an explicit fetch arg uses it for every method; omitting it defaults to apiFetch', async () => {
+    const injected = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    const api = branchesApi('sess_1', 'canvas-a', injected)
+    await api.list()
+    expect(injected).toHaveBeenCalledTimes(1)
+
+    // Omitting the third arg falls back to apiFetch, which reads global fetch.
+    const globalFetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', globalFetchMock)
+    const defaultApi = branchesApi('sess_1', 'canvas-a')
+    await defaultApi.list()
+    expect(globalFetchMock).toHaveBeenCalledTimes(1)
+    expect(injected).toHaveBeenCalledTimes(1)
   })
 
   describe('contract_mismatch normalization: malformed 200 must not leak ZodError', () => {
@@ -798,5 +827,67 @@ describe('useBranches hook (callback model, no window event subscription)', () =
 
     // A real (non-dryRun) merge must trigger the post-merge refetch.
     expect(listCallCount).toBeGreaterThan(listCallsAfterMount)
+  })
+
+  it('uses the DaemonApiContext-provided fetch when a provider is mounted', async () => {
+    const globalFetchMock = vi.fn()
+    vi.stubGlobal('fetch', globalFetchMock)
+    const providedFetch = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(
+      async () =>
+        new Response(JSON.stringify({ head: 'main', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+
+    const { result } = renderHook(() => useBranches('sess_1', 'canvas-a', providedFetch), {
+      wrapper: ({ children }) =>
+        createElement(DaemonApiContext.Provider, { value: providedFetch }, children),
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(providedFetch).toHaveBeenCalled()
+    expect(globalFetchMock).not.toHaveBeenCalled()
+    expect(result.current.state.head).toBe('main')
+  })
+
+  it('rerendering with a new fetch identity (same workspaceId/slug) routes the next refetch through it', async () => {
+    const fetchA = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ head: 'from-a', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    const fetchB = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ head: 'from-b', branches: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+
+    const { result, rerender } = renderHook(
+      ({ fetchFn }: { fetchFn: typeof fetch }) => useBranches('sess_1', 'canvas-a', fetchFn),
+      { initialProps: { fetchFn: fetchA } },
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(result.current.state.head).toBe('from-a')
+
+    rerender({ fetchFn: fetchB })
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    // A stale apiRef (recreated only on workspaceId/slug change, not fetchFn)
+    // would still call fetchA here.
+    expect(result.current.state.head).toBe('from-b')
+    expect(fetchB).toHaveBeenCalled()
   })
 })

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -209,7 +209,21 @@ export function useBranches(
   const [state, setState] = useState<BranchesState>({ branches: [], head: 'main' })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<BranchApiError | Error | null>(null)
+  // Recreated synchronously during render (compare-and-update below) rather
+  // than in an effect: refetch() reads apiRef.current, and an effect-based
+  // rebuild would depend on effect declaration order to run before the
+  // initial-fetch effect — correct today but fragile under reordering. The
+  // factory is a stateless wrapper, so rebuilding during render is safe.
   const apiRef = useRef(branchesApi(workspaceId, slug, fetchFn))
+  const apiDepsRef = useRef({ workspaceId, slug, fetchFn })
+  if (
+    apiDepsRef.current.workspaceId !== workspaceId ||
+    apiDepsRef.current.slug !== slug ||
+    apiDepsRef.current.fetchFn !== fetchFn
+  ) {
+    apiDepsRef.current = { workspaceId, slug, fetchFn }
+    apiRef.current = branchesApi(workspaceId, slug, fetchFn)
+  }
   // Monotonically increasing counter. Each refetch call stamps its result with
   // the counter value at dispatch time; the setter is a no-op when a newer
   // fetch has already committed. This prevents a slower in-flight response
@@ -227,14 +241,6 @@ export function useBranches(
     setError(null)
     setLoading(true)
   }
-
-  // Recreate the API wrapper whenever session, slug, or fetch identity
-  // changes — omitting fetchFn here would leave apiRef pinned to a stale
-  // fetch (e.g. a torn-down daemon session) after a provider swap that
-  // doesn't also change workspaceId/slug.
-  useEffect(() => {
-    apiRef.current = branchesApi(workspaceId, slug, fetchFn)
-  }, [workspaceId, slug, fetchFn])
 
   const refetch = useCallback(async () => {
     const seq = ++fetchSeqRef.current

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -118,17 +118,22 @@ function safeParse<T>(schema: { parse: (v: unknown) => T }, value: unknown): T {
   }
 }
 
-// Imperative API helpers independent from React.
-export function branchesApi(workspaceId: string, slug: string) {
+// Imperative API helpers independent from React. `fetchFn` defaults to the
+// same-origin apiFetch so every pre-existing caller (MergeDialog,
+// WorkspaceTopBar) is unaffected; a daemon-paired caller passes the
+// daemon-origin-aware fetch obtained from useDaemonApi() instead. Kept a
+// plain function (not a hook) because it is also constructed outside React
+// (branchesApi.test.ts) and inside a ref (see useBranches below).
+export function branchesApi(workspaceId: string, slug: string, fetchFn: typeof fetch = apiFetch) {
   const urls = buildBranchUrls(workspaceId, slug)
   return {
     async list(): Promise<BranchesState> {
-      const res = await requireOk(await apiFetch(urls.list))
+      const res = await requireOk(await fetchFn(urls.list))
       return parseBranchesResponse(await res.json())
     },
     async create(args: CreateBranchRequest): Promise<BranchMeta> {
       const res = await requireOk(
-        await apiFetch(urls.list, {
+        await fetchFn(urls.list, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(args),
@@ -137,16 +142,16 @@ export function branchesApi(workspaceId: string, slug: string) {
       return safeParse(createBranchResponseSchema, await res.json()).branch
     },
     async getStats(name: string): Promise<BranchStatsResponse> {
-      const res = await requireOk(await apiFetch(urls.stats(name)))
+      const res = await requireOk(await fetchFn(urls.stats(name)))
       return safeParse(branchStatsResponseSchema, await res.json())
     },
     async remove(name: string): Promise<DeleteBranchResponse> {
-      const res = await requireOk(await apiFetch(urls.deleteBranch(name), { method: 'DELETE' }))
+      const res = await requireOk(await fetchFn(urls.deleteBranch(name), { method: 'DELETE' }))
       return safeParse(deleteBranchResponseSchema, await res.json())
     },
     async rename(oldName: string, newName: string): Promise<RenameBranchResponse> {
       const res = await requireOk(
-        await apiFetch(urls.deleteBranch(oldName), {
+        await fetchFn(urls.deleteBranch(oldName), {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: newName }),
@@ -156,7 +161,7 @@ export function branchesApi(workspaceId: string, slug: string) {
     },
     async setHead(branch: string): Promise<SetHeadResponse> {
       const res = await requireOk(
-        await apiFetch(urls.head, {
+        await fetchFn(urls.head, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ branch }),
@@ -166,7 +171,7 @@ export function branchesApi(workspaceId: string, slug: string) {
     },
     async merge(source: string, args: { into: string; dryRun?: boolean }): Promise<MergeResult> {
       const res = await requireOk(
-        await apiFetch(urls.merge(source), {
+        await fetchFn(urls.merge(source), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -196,11 +201,15 @@ export interface UseBranchesResult {
   merge: (source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>
 }
 
-export function useBranches(workspaceId: string, slug: string): UseBranchesResult {
+export function useBranches(
+  workspaceId: string,
+  slug: string,
+  fetchFn: typeof fetch = apiFetch,
+): UseBranchesResult {
   const [state, setState] = useState<BranchesState>({ branches: [], head: 'main' })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<BranchApiError | Error | null>(null)
-  const apiRef = useRef(branchesApi(workspaceId, slug))
+  const apiRef = useRef(branchesApi(workspaceId, slug, fetchFn))
   // Monotonically increasing counter. Each refetch call stamps its result with
   // the counter value at dispatch time; the setter is a no-op when a newer
   // fetch has already committed. This prevents a slower in-flight response
@@ -219,10 +228,13 @@ export function useBranches(workspaceId: string, slug: string): UseBranchesResul
     setLoading(true)
   }
 
-  // Recreate the API wrapper whenever session or slug changes.
+  // Recreate the API wrapper whenever session, slug, or fetch identity
+  // changes — omitting fetchFn here would leave apiRef pinned to a stale
+  // fetch (e.g. a torn-down daemon session) after a provider swap that
+  // doesn't also change workspaceId/slug.
   useEffect(() => {
-    apiRef.current = branchesApi(workspaceId, slug)
-  }, [workspaceId, slug])
+    apiRef.current = branchesApi(workspaceId, slug, fetchFn)
+  }, [workspaceId, slug, fetchFn])
 
   const refetch = useCallback(async () => {
     const seq = ++fetchSeqRef.current
@@ -242,7 +254,7 @@ export function useBranches(workspaceId: string, slug: string): UseBranchesResul
 
   useEffect(() => {
     void refetch()
-  }, [refetch, workspaceId, slug])
+  }, [refetch, workspaceId, slug, fetchFn])
 
   // Bump the sequence counter on unmount so any in-flight fetch resolution is
   // routed into the stale-fetch guard above instead of committing state after

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -312,6 +312,199 @@ describe('DaemonCanvasPage', () => {
     expect(screen.getByRole('alert').textContent).toMatch(/slug already exists/i)
   })
 
+  describe('version history panel', () => {
+    it('opens the panel and lists versions for the current (workspaceId, slug) via the daemon fetch', async () => {
+      const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        (input) => {
+          const url = String(input)
+          if (url.includes('/branches')) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          if (url.includes('/versions')) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  versions: [
+                    {
+                      id: 'v-1',
+                      slug: 'main',
+                      createdAt: '2026-01-01T00:00:00Z',
+                      elementCount: 3,
+                      auto: true,
+                      hasThumbnail: false,
+                      branchName: 'main',
+                    },
+                  ],
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+              ),
+            )
+          }
+          return Promise.resolve(new Response('{}', { status: 200 }))
+        },
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const toggle = screen.getByRole('button', { name: 'Version history' })
+      await act(async () => {
+        toggle.click()
+      })
+
+      await waitFor(() => {
+        expect(
+          fetchMock.mock.calls.some(
+            ([reqInput]) =>
+              String(reqInput).startsWith(DAEMON_BASE_URL) &&
+              String(reqInput).includes('/workspaces/w1/canvases/main/versions'),
+          ),
+        ).toBe(true)
+      })
+      await waitFor(() => expect(screen.getByText('3 els', { exact: false })).toBeTruthy())
+
+      vi.unstubAllGlobals()
+    })
+
+    it('shows the static disabled teaser instead of the toggle when capabilities.versions is false', async () => {
+      await act(async () => {
+        render(
+          <DaemonCanvasPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            createBackend={makeCreateBackend()}
+            capabilities={{
+              canvasReadWrite: true,
+              migrationExport: false,
+              migrationImport: true,
+              workspaces: true,
+              versions: false,
+              branches: true,
+              merge: true,
+            }}
+          />,
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const versionButton = screen.getByRole('button', { name: 'Version history' })
+      // The static CapabilityTeaser renders aria-disabled; the real toggle
+      // never does, so this distinguishes the two without a false negative.
+      expect(versionButton.getAttribute('aria-disabled')).toBe('true')
+      expect(versionButton.hasAttribute('aria-pressed')).toBe(false)
+    })
+
+    it('restoring a version reflects on the canvas via the broadcast incremental update', async () => {
+      const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        (input) => {
+          const url = String(input)
+          if (url.includes('/restore')) {
+            return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+          }
+          if (url.includes('/branches')) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          if (url.includes('/versions')) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  versions: [
+                    {
+                      id: 'v-1',
+                      slug: 'main',
+                      createdAt: '2026-01-01T00:00:00Z',
+                      elementCount: 3,
+                      auto: true,
+                      hasThumbnail: false,
+                      branchName: 'main',
+                    },
+                  ],
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+              ),
+            )
+          }
+          return Promise.resolve(new Response('{}', { status: 200 }))
+        },
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const toggle = screen.getByRole('button', { name: 'Version history' })
+      await act(async () => {
+        toggle.click()
+      })
+
+      const row = await screen.findByText('⚙ System')
+      await act(async () => {
+        fireEvent.click(row.closest('button')!)
+      })
+      await waitFor(() => {
+        expect(screen.getByText('Restore this version?')).toBeTruthy()
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+      })
+      await waitFor(() => {
+        expect(
+          fetchMock.mock.calls.some(([reqInput]) =>
+            String(reqInput).includes('/versions/v-1/restore'),
+          ),
+        ).toBe(true)
+      })
+
+      // Real transport: the initial load already delivered a snapshot via
+      // onSnapshot (see FakeBackend.connect above); restore broadcasts a
+      // second, incremental update via onRemoteUpdate — not another snapshot.
+      const backend = createdBackends[0]!
+      const { LoroDoc } = require('loro-crdt') as typeof import('loro-crdt')
+      const restoredDoc = new LoroDoc()
+      const list = restoredDoc.getMovableList('elements')
+      const map = list.insertContainer(
+        0,
+        new (require('loro-crdt') as typeof import('loro-crdt')).LoroMap(),
+      )
+      map.set('id', 'restored-el')
+      map.set('type', 'rectangle')
+      map.set('x', 0)
+      map.set('y', 0)
+      map.set('width', 10)
+      map.set('height', 10)
+      map.set('isDeleted', false)
+      restoredDoc.commit()
+      const update = restoredDoc.export({ mode: 'update' })
+
+      await act(async () => {
+        backend.handlers?.onRemoteUpdate?.(update)
+      })
+
+      await waitFor(() => expect(screen.queryByText('Restore this version?')).toBeNull())
+
+      vi.unstubAllGlobals()
+    })
+  })
+
   describe('default backend wiring (no createBackend override)', () => {
     class FakeWebSocket {
       static instances: FakeWebSocket[] = []

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -376,6 +376,53 @@ describe('DaemonCanvasPage', () => {
       vi.unstubAllGlobals()
     })
 
+    it('closes via an in-panel close button, without depending on the covered toggle', async () => {
+      const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        (input) => {
+          const url = String(input)
+          if (url.includes('/branches')) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          if (url.includes('/versions')) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          return Promise.resolve(new Response('{}', { status: 200 }))
+        },
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const toggle = screen.getByRole('button', { name: 'Version history' })
+      await act(async () => {
+        toggle.click()
+      })
+
+      const closeButton = await screen.findByRole('button', { name: 'Close version history' })
+      await act(async () => {
+        closeButton.click()
+      })
+
+      expect(screen.queryByRole('button', { name: 'Close version history' })).toBeNull()
+
+      vi.unstubAllGlobals()
+    })
+
     it('shows the static disabled teaser instead of the toggle when capabilities.versions is false', async () => {
       await act(async () => {
         render(

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -160,14 +160,29 @@ export function DaemonCanvasPage({
         </div>
       </header>
       {versionPanelOpen && controller.workspaceId !== null && controller.slug !== null && (
-        <div className="w-72 shrink-0 border-l bg-background absolute right-0 top-0 bottom-0 z-10 shadow-lg overflow-hidden">
-          <DaemonApiContext.Provider value={daemonFetch}>
-            <VersionTimeline
-              workspaceId={controller.workspaceId}
-              slug={controller.slug}
-              onRestored={clearLocalUndo}
-            />
-          </DaemonApiContext.Provider>
+        <div className="w-72 shrink-0 border-l bg-background absolute right-0 top-0 bottom-0 z-10 shadow-lg overflow-hidden flex flex-col">
+          {/* The panel overlays the header (including the toggle that opened
+              it), so it needs its own close affordance rather than relying
+              on a control the panel itself may cover. */}
+          <div className="flex shrink-0 items-center justify-end border-b px-2 py-1">
+            <button
+              type="button"
+              aria-label="Close version history"
+              onClick={() => setVersionPanelOpen(false)}
+              className="rounded-md border px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent"
+            >
+              Close
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <DaemonApiContext.Provider value={daemonFetch}>
+              <VersionTimeline
+                workspaceId={controller.workspaceId}
+                slug={controller.slug}
+                onRestored={clearLocalUndo}
+              />
+            </DaemonApiContext.Provider>
+          </div>
         </div>
       )}
       {controller.canvases.length === 0 ? (

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -4,6 +4,8 @@ import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { useEffect, useMemo, useState } from 'react'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
+import VersionTimeline from '../components/VersionTimeline.js'
+import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
@@ -57,6 +59,7 @@ export function DaemonCanvasPage({
 
   const [authError, setAuthError] = useState(false)
   const [newCanvasSlug, setNewCanvasSlug] = useState('')
+  const [versionPanelOpen, setVersionPanelOpen] = useState(false)
 
   // Backend identity is keyed on (workspaceId, slug, daemonFetch) — a change
   // to any of these tears down the old connection and opens a new one via
@@ -76,7 +79,7 @@ export function DaemonCanvasPage({
     setAuthError(false)
   }, [backend])
 
-  const { setExcalidrawAPI, onChange } = useCanvasSync(backend, {
+  const { setExcalidrawAPI, onChange, clearLocalUndo } = useCanvasSync(backend, {
     onAuthError: () => setAuthError(true),
   })
 
@@ -105,7 +108,7 @@ export function DaemonCanvasPage({
   }
 
   return (
-    <main className="flex h-dvh w-full flex-col">
+    <main className="relative flex h-dvh w-full flex-col">
       <header className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-2">
         <h1 className="sr-only">Whiteboard (daemon)</h1>
         {authError && (
@@ -139,12 +142,34 @@ export function DaemonCanvasPage({
           </select>
         )}
         <div className="flex flex-wrap items-center gap-2">
-          <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
+          {capabilities.versions ? (
+            <button
+              type="button"
+              aria-pressed={versionPanelOpen}
+              onClick={() => setVersionPanelOpen((open) => !open)}
+              className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent aria-pressed:bg-accent"
+            >
+              Version history
+            </button>
+          ) : (
+            <CapabilityTeaser label="Version history" enabled={false} />
+          )}
           <CapabilityTeaser label="Workspaces" enabled={capabilities.workspaces} />
           <CapabilityTeaser label="Branches" enabled={capabilities.branches} />
           <CapabilityTeaser label="Merge" enabled={capabilities.merge} />
         </div>
       </header>
+      {versionPanelOpen && controller.workspaceId !== null && controller.slug !== null && (
+        <div className="w-72 shrink-0 border-l bg-background absolute right-0 top-0 bottom-0 z-10 shadow-lg overflow-hidden">
+          <DaemonApiContext.Provider value={daemonFetch}>
+            <VersionTimeline
+              workspaceId={controller.workspaceId}
+              slug={controller.slug}
+              onRestored={clearLocalUndo}
+            />
+          </DaemonApiContext.Provider>
+        </div>
+      )}
       {controller.canvases.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
           <p className="text-sm text-muted-foreground">This workspace has no canvases yet.</p>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -98,6 +98,19 @@ export default defineConfig({
   },
   build: {
     target: 'esnext',
+    rollupOptions: {
+      output: {
+        // The bundle-size gate (scripts/smoke-bundle-size.mjs) matches this
+        // lazy chunk by a fixed `daemon-canvas-*.js` prefix. Without an
+        // explicit name here, Rollup names it after the source file
+        // (`DaemonCanvasPage-<hash>.js`), which the gate's pattern never
+        // matches — silently skipping the budget instead of enforcing it.
+        chunkFileNames: (chunkInfo) =>
+          chunkInfo.name === 'DaemonCanvasPage'
+            ? 'assets/daemon-canvas-[hash].js'
+            : 'assets/[name]-[hash].js',
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary

S6b: the daemon-paired web page (S6a #159) gains a working version-history panel — list daemon versions (manual + auto-save) and restore, reusing the already-ported `VersionTimeline` through `DaemonApiContext`.

- **Bundle gate made real first**: the daemon lazy chunk is now emitted as `daemon-canvas-<hash>.js` (`rollupOptions.output.chunkFileNames`) and the budget entry flipped to `required: true` — previously the pattern matched nothing and silently skipped. Gate now: entry 559.8/560 KB, daemon chunk 13.7/40 KB, both `pass`.
- **`VersionTimeline` + `useBranches` route fetch through `useDaemonApi()`** — `branchesApi` gains an injected-fetch parameter (default `apiFetch`), so same-origin mcp-server app behavior is byte-identical; a staleness test proves a provider fetch-identity swap reaches the next call.
- **DaemonCanvasPage**: the static "Version history" teaser becomes a real toggle opening the panel inside `DaemonApiContext.Provider` (page's `daemonFetch`); thumbnails are gated off in daemon mode (a plain `<img src>` can't carry the daemon origin/bearer).
- Scope note: manual "Save version" UI deliberately excluded (own slice); the list is populated by daemon auto-save + MCP-side manual saves.

## Manual verification (real daemon)

Against a live daemon from the worktree (isolated data dir), paired via `#wb=`:

1. Created a scratch canvas + manual version via API; paired the page to it
2. Drew a rectangle → daemon snapshot grew and an auto-save version appeared in the panel (1 els)
3. Opened Version history → daemon-backed list rendered (auto-save + manual, operator/els labels)
4. Clicked the 0-els manual version → Restore → canvas emptied via the daemon's WS broadcast (`onRemoteUpdate` path) — no reload needed
5. Console: 0 errors

## Visual repro

Version panel open (rect drawn, auto-save + manual baseline listed):

![s6b-version-panel.png](https://github.com/user-attachments/assets/15a311c8-063d-4999-966d-aa72d78ab456)

After restoring the 0-els baseline — canvas emptied via WS broadcast:

![s6b-after-restore.png](https://github.com/user-attachments/assets/0abab267-b479-4649-ba13-eaaec4748e76)

## Test plan

- [x] Full suite green: 3928 tests, typecheck clean, `pnpm build` green
- [x] Bundle gate `pass` for entry + CSS + daemon chunk (no longer skip)
- [x] VersionTimeline via provider: daemon-origin URL asserted for GET versions; thumbnail gating
- [x] useBranches: provider vs fallback + fetch-identity staleness test
- [x] DaemonCanvasPage: toggle, restore-broadcast reflection via FakeBackend (`onSnapshot` first frame, `onRemoteUpdate` after — matches the real transport)
- [x] Manual E2E against real daemon (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-page Version History panel for supported canvases.
  * Users can view available versions, close the panel, and restore previous versions.
  * Version history access is clearly disabled when the feature is unavailable.
  * Daemon-connected requests now use the correct origin and authorization.

* **Bug Fixes**
  * Improved branch and version loading through daemon connections.
  * Prevented incompatible thumbnail rendering in daemon mode.

* **Tests**
  * Expanded coverage for version history, daemon requests, restoring versions, and branch loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->