### PR TITLE
feat(web): probe-based capability tiers with an honest tier-2 notice

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -32,7 +32,10 @@ describe('DaemonDetectedBanner', () => {
     )
 
     await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
-    expect(probeFn.mock.calls[0]?.[1]).toMatchObject({ forceRecheck: undefined })
+    expect(probeFn.mock.calls[0]?.[1]).toMatchObject({
+      forceRecheck: undefined,
+      pageOriginScheme: 'http',
+    })
   })
 
   it('does not auto-probe on https: and renders a manual affordance instead', async () => {
@@ -63,7 +66,10 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
     await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
-    expect(probeFn.mock.calls[0]?.[1]).toMatchObject({ forceRecheck: true })
+    expect(probeFn.mock.calls[0]?.[1]).toMatchObject({
+      forceRecheck: true,
+      pageOriginScheme: 'https',
+    })
   })
 
   it('renders the manual affordance on http: too when the result is not-detected', async () => {

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -126,6 +126,47 @@ describe('DaemonDetectedBanner', () => {
     expect(saved.storage.dismissedDaemonCtaAt).toEqual(expect.any(String))
   })
 
+  it('shows the honest unsupported notice instead of the CTA when the probe proves the browser blocked it', async () => {
+    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'blocked' })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(
+      'Your browser cannot connect to a local daemon; canvases stay in this browser.',
+    )
+    expect(screen.queryByRole('button', { name: /check for local daemon/i })).toBeNull()
+  })
+
+  it('keeps the CTA affordance when the probe fails inconclusively (not proven blocked)', async () => {
+    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'network' })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
+    expect(
+      screen.queryByText(
+        'Your browser cannot connect to a local daemon; canvases stay in this browser.',
+      ),
+    ).toBeNull()
+  })
+
   it('aborts the in-flight probe on unmount and never sets state after unmount', async () => {
     let capturedSignal: AbortSignal | undefined
     const probeFn = vi.fn().mockImplementation(

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { deriveCapabilityTier } from '../../lib/capability-tier.js'
 import {
   DEFAULT_DAEMON_BASE_URL,
   type DaemonProbeResult,
@@ -7,6 +8,12 @@ import {
 } from '../../lib/daemon-probe.js'
 import type { UserSettingsStore } from '../../lib/user-settings-store.js'
 import { shouldShowDaemonCta } from './daemon-cta-visibility.js'
+
+// Shown only once a probe PROVES the browser blocked the request (tier
+// 'tier2-blocked') — never on a merely inconclusive failure. Honesty
+// discipline: an unproven guess is worse than no notice at all.
+export const UNSUPPORTED_BROWSER_NOTICE =
+  'Your browser cannot connect to a local daemon; canvases stay in this browser.'
 
 // Docs are not served from apps/web (no /docs route), so the banner links to
 // the source-of-truth GitHub blob rather than fabricating a local route.
@@ -48,11 +55,22 @@ export function DaemonDetectedBanner({
     [settingsStore],
   )
 
+  // 'http:'/'https:' -> 'http'/'https'; any other scheme (e.g. jsdom's
+  // default 'about:' outside these injected-prop tests) falls back to
+  // 'https' — the conservative choice since it never claims a loopback
+  // path is open without evidence.
+  const pageOriginScheme = locationProtocol === 'http:' ? 'http' : 'https'
+
   function runProbe(forceRecheck?: boolean) {
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
-    probeFn(baseUrl, { fetch, forceRecheck, signal: controller.signal }).then((next) => {
+    probeFn(baseUrl, {
+      fetch,
+      forceRecheck,
+      signal: controller.signal,
+      pageOriginScheme,
+    }).then((next) => {
       if (controller.signal.aborted) return
       setResult(next)
     })
@@ -79,7 +97,9 @@ export function DaemonDetectedBanner({
     setDismissedAt(now)
   }
 
-  const showManualAffordance = result === null || !result.detected
+  const tier = deriveCapabilityTier({ pageOriginScheme, probe: result })
+  const showUnsupportedNotice = tier === 'tier2-blocked'
+  const showManualAffordance = (result === null || !result.detected) && !showUnsupportedNotice
 
   // Every mutation path that affects visibility flows through `result` or
   // `dismissedAt` state, so the memo stays correct while skipping the
@@ -99,6 +119,9 @@ export function DaemonDetectedBanner({
 
   return (
     <>
+      {showUnsupportedNotice && (
+        <span className="text-xs text-muted-foreground">{UNSUPPORTED_BROWSER_NOTICE}</span>
+      )}
       {showManualAffordance && (
         <button
           type="button"

--- a/apps/web/src/lib/capability-tier.test.ts
+++ b/apps/web/src/lib/capability-tier.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { deriveCapabilityTier } from './capability-tier.js'
+import type { DaemonProbeResult } from './daemon-probe.js'
+
+describe('deriveCapabilityTier', () => {
+  it('treats an http/loopback page origin as tier1-path-open when no probe has run', () => {
+    expect(deriveCapabilityTier({ pageOriginScheme: 'http', probe: null })).toBe('tier1-path-open')
+  })
+
+  it('confirms tier1 on http origin once the probe detects a daemon', () => {
+    const probe: DaemonProbeResult = { detected: true, instanceId: 'inst-1' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'http', probe })).toBe('tier1-confirmed')
+  })
+
+  it('keeps tier1-path-open on http origin for a refused probe (scheme dominates)', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'refused' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'http', probe })).toBe('tier1-path-open')
+  })
+
+  it('keeps tier1-path-open on http origin for a network-failed probe (scheme dominates)', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'network' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'http', probe })).toBe('tier1-path-open')
+  })
+
+  it('confirms tier1 on https origin when the probe detects a daemon', () => {
+    const probe: DaemonProbeResult = { detected: true, instanceId: 'inst-1' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('tier1-confirmed')
+  })
+
+  it('confirms tier1 on https origin for an http-error reason (an HTTP response proves the path is open)', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'http-error' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('tier1-confirmed')
+  })
+
+  it('confirms tier1 on https origin for a malformed reason (an HTTP response proves the path is open)', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'malformed' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('tier1-confirmed')
+  })
+
+  it('reports tier1-path-open on https origin for a refused probe', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'refused' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('tier1-path-open')
+  })
+
+  it('reports tier2-blocked on https origin for a proven-blocked probe', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'blocked' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('tier2-blocked')
+  })
+
+  it('reports unknown on https origin for a timeout (not proven blocked)', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'timeout' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('unknown')
+  })
+
+  it('reports unknown on https origin for an unclassified network failure', () => {
+    const probe: DaemonProbeResult = { detected: false, reason: 'network' }
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe })).toBe('unknown')
+  })
+
+  it('reports unknown on https origin when no probe has run yet', () => {
+    expect(deriveCapabilityTier({ pageOriginScheme: 'https', probe: null })).toBe('unknown')
+  })
+})

--- a/apps/web/src/lib/capability-tier.ts
+++ b/apps/web/src/lib/capability-tier.ts
@@ -65,10 +65,14 @@ export function deriveCapabilityTier({
         return 'unknown'
       case 'http-error':
       case 'malformed':
-        // Unreachable: handled by isProvenReachableFailure above. Listed
-        // here so adding a new ProbeFailureReason breaks this switch at
-        // compile time instead of silently falling through.
+        // Unreachable: handled by isProvenReachableFailure above.
         return 'tier1-confirmed'
+      default:
+        // Compile-time exhaustiveness: adding a new ProbeFailureReason fails
+        // typecheck here instead of silently falling through to 'unknown'
+        // (the post-switch fallback exists for the probe===null path and
+        // would otherwise mask a missing case).
+        return probe.reason satisfies never
     }
   }
 

--- a/apps/web/src/lib/capability-tier.ts
+++ b/apps/web/src/lib/capability-tier.ts
@@ -1,0 +1,76 @@
+import type { DaemonProbeResult, ProbeFailureReason } from './daemon-probe.js'
+
+/**
+ * Capability tier for daemon pairing, derived purely from feature probes —
+ * never from User-Agent sniffing. Two independent signals decide the tier:
+ *
+ * 1. Page origin scheme. An http (loopback) page origin can always reach a
+ *    same-scheme loopback daemon; no browser mixed-content/LNA gate applies.
+ *    An https (hosted) page origin needs Local Network Access (Chromium) or
+ *    a permissive mixed-content policy (Firefox) — WebKit blocks it outright
+ *    (see .claude/investigation-lna-hosted-daemon-transport.md).
+ * 2. The latest probeDaemon() result, which distinguishes a confirmed daemon
+ *    (detected:true, or an HTTP response reason like 'http-error'/'malformed'
+ *    that still proves the transport path is open) from a merely-open path
+ *    ('refused' — connection refused, nothing running yet) from a
+ *    browser-proven block ('blocked') from an inconclusive failure
+ *    ('timeout'/'network', or no probe run yet).
+ *
+ * States:
+ * - 'tier1-confirmed': a daemon responded (or answered with a shape proving
+ *   the path is open), regardless of origin scheme.
+ * - 'tier1-path-open': no daemon confirmed yet, but nothing has proven the
+ *   browser can't reach one — either the page origin is http/loopback
+ *   (scheme dominates: the path is inherently open there) or the probe was
+ *   refused on an https origin (proves the request left the browser).
+ * - 'tier2-blocked': an https origin whose probe failure was proven to be a
+ *   browser-side block, not a network condition. Only this state renders the
+ *   "not supported in this browser" notice — honesty requires a proven
+ *   blockage, not a guess from an inconclusive failure.
+ * - 'unknown': no probe has run yet, or its failure could not be attributed
+ *   to either an open path or a proven block (timeout, unclassified network
+ *   error). The CTA/recheck affordance stays available in this state.
+ */
+export type CapabilityTier = 'tier1-confirmed' | 'tier1-path-open' | 'tier2-blocked' | 'unknown'
+
+export interface CapabilityTierInput {
+  pageOriginScheme: 'http' | 'https'
+  probe: DaemonProbeResult | null
+}
+
+// An HTTP response — even a non-2xx or unexpected-shape one — proves the
+// transport path reached a live server, which is the strongest tier1 signal
+// short of an actual detected:true.
+function isProvenReachableFailure(reason: ProbeFailureReason): boolean {
+  return reason === 'http-error' || reason === 'malformed'
+}
+
+export function deriveCapabilityTier({
+  pageOriginScheme,
+  probe,
+}: CapabilityTierInput): CapabilityTier {
+  if (probe?.detected === true) return 'tier1-confirmed'
+  if (probe && !probe.detected && isProvenReachableFailure(probe.reason)) return 'tier1-confirmed'
+
+  if (pageOriginScheme === 'http') return 'tier1-path-open'
+
+  if (probe && !probe.detected) {
+    switch (probe.reason) {
+      case 'refused':
+        return 'tier1-path-open'
+      case 'blocked':
+        return 'tier2-blocked'
+      case 'timeout':
+      case 'network':
+        return 'unknown'
+      case 'http-error':
+      case 'malformed':
+        // Unreachable: handled by isProvenReachableFailure above. Listed
+        // here so adding a new ProbeFailureReason breaks this switch at
+        // compile time instead of silently falling through.
+        return 'tier1-confirmed'
+    }
+  }
+
+  return 'unknown'
+}

--- a/apps/web/src/lib/daemon-probe.schema-drift.test.ts
+++ b/apps/web/src/lib/daemon-probe.schema-drift.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { daemonPingResponseSchema as serverDaemonPingResponseSchema } from '../../../../packages/mcp-server/src/shared/api-contracts/runtime.js'
-import { probeDaemon } from './daemon-probe.js'
+import { probeDaemon, probeFailureReasonSchema } from './daemon-probe.js'
 
 // Test-only deep import of the server's source of truth for the ping
 // response shape. apps/web keeps its own local Zod mirror (daemon-probe.ts)
@@ -29,5 +29,17 @@ describe('daemon-probe schema drift pin', () => {
     expect(serverDaemonPingResponseSchema.safeParse(clientObservedSuccessPayload).success).toBe(
       true,
     )
+  })
+
+  it('widens the probe failure reason enum additively — a legacy pre-tier memo value still parses', () => {
+    // Pins the reason set gained by the capability-tier slice ('blocked',
+    // 'refused') as additive: a sessionStorage memo written by a pre-tier
+    // build (reason: 'network') must still round-trip after the upgrade.
+    expect(probeFailureReasonSchema.safeParse('network').success).toBe(true)
+    expect(probeFailureReasonSchema.safeParse('timeout').success).toBe(true)
+    expect(probeFailureReasonSchema.safeParse('http-error').success).toBe(true)
+    expect(probeFailureReasonSchema.safeParse('malformed').success).toBe(true)
+    expect(probeFailureReasonSchema.safeParse('blocked').success).toBe(true)
+    expect(probeFailureReasonSchema.safeParse('refused').success).toBe(true)
   })
 })

--- a/apps/web/src/lib/daemon-probe.test.ts
+++ b/apps/web/src/lib/daemon-probe.test.ts
@@ -75,6 +75,50 @@ describe('probeDaemon', () => {
     expect(result).toEqual({ detected: false, reason: 'network' })
   })
 
+  it('returns not-detected with reason refused when a fetch rejects on an http/loopback page origin', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const result = await probeDaemon(DEFAULT_DAEMON_BASE_URL, {
+      fetch: fetchMock,
+      pageOriginScheme: 'http',
+    })
+
+    expect(result).toEqual({ detected: false, reason: 'refused' })
+  })
+
+  it('classifies a WebKit mixed-content rejection as blocked on an https page origin', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Load failed'))
+
+    const result = await probeDaemon(DEFAULT_DAEMON_BASE_URL, {
+      fetch: fetchMock,
+      pageOriginScheme: 'https',
+    })
+
+    expect(result).toEqual({ detected: false, reason: 'blocked' })
+  })
+
+  it('never classifies a Load failed rejection as blocked on an http/loopback page origin', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Load failed'))
+
+    const result = await probeDaemon(DEFAULT_DAEMON_BASE_URL, {
+      fetch: fetchMock,
+      pageOriginScheme: 'http',
+    })
+
+    expect(result).toEqual({ detected: false, reason: 'refused' })
+  })
+
+  it('keeps an https-origin CORS-shaped rejection as network, not blocked (F4: CORS failure is not a proven browser block)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const result = await probeDaemon(DEFAULT_DAEMON_BASE_URL, {
+      fetch: fetchMock,
+      pageOriginScheme: 'https',
+    })
+
+    expect(result).toEqual({ detected: false, reason: 'network' })
+  })
+
   it('never throws and never logs to the console', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error')
     const consoleWarnSpy = vi.spyOn(console, 'warn')

--- a/apps/web/src/lib/daemon-probe.test.ts
+++ b/apps/web/src/lib/daemon-probe.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { DEFAULT_DAEMON_BASE_URL, probeDaemon } from './daemon-probe.js'
+import { DEFAULT_DAEMON_BASE_URL, daemonProbeResultSchema, probeDaemon } from './daemon-probe.js'
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -191,5 +191,21 @@ describe('probeDaemon', () => {
     ])
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('exports the persisted-memo schema as the single source of truth for DaemonProbeResult', () => {
+    // Locks DaemonProbeResult to z.infer<typeof daemonProbeResultSchema> —
+    // a hand-written type alongside this schema is exactly the drift shape
+    // that shipped the create_frame assignedMembers bug.
+    expect(
+      daemonProbeResultSchema.safeParse({ detected: true, instanceId: 'inst-1' }).success,
+    ).toBe(true)
+    expect(daemonProbeResultSchema.safeParse({ detected: false, reason: 'timeout' }).success).toBe(
+      true,
+    )
+    expect(daemonProbeResultSchema.safeParse({ detected: true }).success).toBe(false)
+    expect(
+      daemonProbeResultSchema.safeParse({ detected: false, reason: 'not-a-reason' }).success,
+    ).toBe(false)
   })
 })

--- a/apps/web/src/lib/daemon-probe.test.ts
+++ b/apps/web/src/lib/daemon-probe.test.ts
@@ -67,6 +67,20 @@ describe('probeDaemon', () => {
     expect(result).toEqual({ detected: false, reason: 'malformed' })
   })
 
+  it('returns not-detected with reason malformed on a 200 response with a non-JSON body', async () => {
+    // e.g. a captive portal or misconfigured proxy answering with HTML. The
+    // HTTP response itself proves the transport path is reachable, so this
+    // must classify as 'malformed' (tier1 evidence), never as a fetch-level
+    // 'refused'/'network' failure.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('<html>not json</html>', { status: 200 }))
+
+    const result = await probeDaemon(DEFAULT_DAEMON_BASE_URL, { fetch: fetchMock })
+
+    expect(result).toEqual({ detected: false, reason: 'malformed' })
+  })
+
   it('returns not-detected with reason network when fetch rejects with a network error', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
 

--- a/apps/web/src/lib/daemon-probe.ts
+++ b/apps/web/src/lib/daemon-probe.ts
@@ -134,7 +134,17 @@ async function runProbe(baseUrl: string, options: ProbeDaemonOptions): Promise<D
       return { detected: false, reason: 'http-error' }
     }
 
-    const body: unknown = await response.json()
+    // json() throwing (200 with an HTML/garbage body — captive portal,
+    // misconfigured proxy) must classify as 'malformed': the HTTP response
+    // itself proves the transport path is reachable, so letting it fall to
+    // the outer catch would misclassify it as a fetch-level failure and
+    // wrongly downgrade the capability tier.
+    let body: unknown
+    try {
+      body = await response.json()
+    } catch {
+      return { detected: false, reason: 'malformed' }
+    }
     const parsed = daemonPingResponseSchema.safeParse(body)
     if (!parsed.success) {
       return { detected: false, reason: 'malformed' }

--- a/apps/web/src/lib/daemon-probe.ts
+++ b/apps/web/src/lib/daemon-probe.ts
@@ -32,9 +32,15 @@ export const probeFailureReasonSchema = z.enum([
 ])
 export type ProbeFailureReason = z.infer<typeof probeFailureReasonSchema>
 
-export type DaemonProbeResult =
-  | { detected: true; instanceId: string }
-  | { detected: false; reason: ProbeFailureReason }
+// Single source of truth for the probe result shape, shared by the
+// in-memory return value and the persisted sessionStorage memo (readMemo /
+// writeMemo below) — deriving the type via z.infer keeps a future field
+// addition from silently drifting between the two.
+export const daemonProbeResultSchema = z.union([
+  z.object({ detected: z.literal(true), instanceId: z.string() }),
+  z.object({ detected: z.literal(false), reason: probeFailureReasonSchema }),
+])
+export type DaemonProbeResult = z.infer<typeof daemonProbeResultSchema>
 
 export interface ProbeDaemonOptions {
   fetch: typeof globalThis.fetch
@@ -93,15 +99,7 @@ function readMemo(baseUrl: string): DaemonProbeResult | null {
 
   try {
     const parsed: unknown = JSON.parse(raw)
-    const result = z
-      .union([
-        z.object({ detected: z.literal(true), instanceId: z.string() }),
-        z.object({
-          detected: z.literal(false),
-          reason: probeFailureReasonSchema,
-        }),
-      ])
-      .safeParse(parsed)
+    const result = daemonProbeResultSchema.safeParse(parsed)
     return result.success ? result.data : null
   } catch {
     return null

--- a/apps/web/src/lib/daemon-probe.ts
+++ b/apps/web/src/lib/daemon-probe.ts
@@ -19,15 +19,63 @@ const daemonPingResponseSchema = z.object({
   instanceId: z.string(),
 })
 
+// Single source of truth for the probe's failure classification, shared by
+// the in-memory result type and the persisted sessionStorage memo (see
+// readMemo below) so the two can never drift apart.
+export const probeFailureReasonSchema = z.enum([
+  'timeout',
+  'http-error',
+  'malformed',
+  'network',
+  'blocked',
+  'refused',
+])
+export type ProbeFailureReason = z.infer<typeof probeFailureReasonSchema>
+
 export type DaemonProbeResult =
   | { detected: true; instanceId: string }
-  | { detected: false; reason: 'timeout' | 'http-error' | 'malformed' | 'network' }
+  | { detected: false; reason: ProbeFailureReason }
 
 export interface ProbeDaemonOptions {
   fetch: typeof globalThis.fetch
   timeoutMs?: number
   forceRecheck?: boolean
   signal?: AbortSignal
+  // Scheme of the page origin the probe runs from. Drives the
+  // refused-vs-blocked-vs-network classification below (see runProbe).
+  // Optional and backward compatible: omitting it preserves the pre-tier
+  // behavior of classifying every non-timeout fetch rejection as 'network'.
+  pageOriginScheme?: 'http' | 'https'
+}
+
+// WebKit's mixed-content block surfaces as a fetch rejection with this exact
+// message (measured against Safari/WebKit hitting an https page fetching a
+// loopback http origin — see .claude/investigation-lna-hosted-daemon-transport.md
+// F3). Chromium/Firefox hitting the daemon's CORS gate from an unlisted
+// origin (F4) reject with the unrelated "Failed to fetch" message, which
+// this deliberately does NOT match: that failure is a same-engine CORS
+// rejection, not proof the browser refused to attempt the request, so it
+// stays classified as 'network' (-> tier 'unknown') rather than 'blocked'.
+const WEBKIT_MIXED_CONTENT_BLOCK_MESSAGE = 'Load failed'
+
+function classifyFetchRejection(
+  error: unknown,
+  pageOriginScheme: 'http' | 'https' | undefined,
+): ProbeFailureReason {
+  if (pageOriginScheme === 'http') {
+    // A same-scheme loopback fetch can never be blocked by the browser, so
+    // any rejection here proves the network path is open (nothing answered,
+    // or the connection was refused) — never a browser-side block.
+    return 'refused'
+  }
+  if (
+    pageOriginScheme === 'https' &&
+    error instanceof TypeError &&
+    error.message === WEBKIT_MIXED_CONTENT_BLOCK_MESSAGE
+  ) {
+    return 'blocked'
+  }
+  return 'network'
 }
 
 function memoKey(baseUrl: string): string {
@@ -50,7 +98,7 @@ function readMemo(baseUrl: string): DaemonProbeResult | null {
         z.object({ detected: z.literal(true), instanceId: z.string() }),
         z.object({
           detected: z.literal(false),
-          reason: z.enum(['timeout', 'http-error', 'malformed', 'network']),
+          reason: probeFailureReasonSchema,
         }),
       ])
       .safeParse(parsed)
@@ -99,7 +147,7 @@ async function runProbe(baseUrl: string, options: ProbeDaemonOptions): Promise<D
     if (error instanceof DOMException && error.name === 'AbortError') {
       return { detected: false, reason: 'timeout' }
     }
-    return { detected: false, reason: 'network' }
+    return { detected: false, reason: classifyFetchRejection(error, options.pageOriginScheme) }
   } finally {
     clearTimeout(timeoutId)
     options.signal?.removeEventListener('abort', onExternalAbort)

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -23,6 +23,28 @@ If a daemon is detected, a banner offers to connect. Dismissing it hides the
 banner for 14 days or until a different daemon instance is detected,
 whichever comes first.
 
+## Browser support for daemon pairing
+
+Whether your browser can reach a loopback daemon from a hosted `https:` page
+depends on capability, not a fixed version list:
+
+- **Any browser on an `http:` loopback page origin** (the common local
+  development setup) can always reach the daemon — there is no cross-scheme
+  restriction to work around.
+- **Chromium-based browsers on a hosted `https:` origin** can reach the
+  daemon once you grant the Local Network Access permission prompt.
+- **Firefox on a hosted `https:` origin** can reach the daemon without an
+  extra permission prompt, because Firefox does not yet gate loopback
+  fetches behind Local Network Access.
+- **Safari/WebKit on a hosted `https:` origin cannot reach the daemon.**
+  WebKit blocks the request as mixed content with no override. On this
+  browser, canvases stay in this browser (IndexedDB) — the app shows an
+  explicit notice instead of a silently missing "connect" option.
+
+This is determined by probing the daemon, not by inspecting your browser's
+identity string: the app only shows the "not supported" notice once a probe
+has actually proven the browser blocked the request.
+
 ## How pairing works
 
 Detecting a daemon is not the same as pairing with it. Actually connecting


### PR DESCRIPTION
## Summary

S11 (capability tiers, probe-based — UA sniffing forbidden):

- **`capability-tier.ts`**: pure state machine deriving the tier from (page origin scheme × latest daemon-probe outcome) — `tier1-confirmed` (probe reached a daemon or got any HTTP response), `tier1-path-open` (http/loopback origin, or https+connection-refused: transport path proven open, just no daemon), `tier2-blocked` (https origin + browser-blocked fetch signature), `unknown` (no probe / timeout / unclassifiable). Full machine documented in the module docstring.
- **Probe reason refinement**: `daemon-probe.ts` failure reasons gain `blocked` / `refused`, encoded conservatively — `blocked` only for signatures re-verified per engine; unclassifiable failures stay `network` → tier `unknown` → **no notice** (honesty: we never claim "unsupported" without probe-proven blockage). The reason enum is unified into one exported Zod schema with the TS union via `z.infer` (was declared twice); legacy sessionStorage memos still parse (drift test extended).
- **Tier-2 notice**: on `tier2-blocked`, the browser-local chrome replaces the "Check for local daemon" CTA with "Your browser cannot connect to a local daemon; canvases stay in this browser." All S12 CTA/dismissal behavior untouched otherwise (suites un-weakened).
- **ConnectionIndicator descoped** to the S6e wiring PR (would have been an unmounted component here); follow-up noted in tmp/issues.
- Docs: `connect-to-local-daemon.md` gains an honest per-engine support statement (capability-worded, not version-worded).

## Verification

- 4037 tests green (incl. new tier state-machine matrix + notice gating + memo-compat drift tests), typecheck clean, build green, bundle-size + pwa-precache gates OK.
- The WebKit-blocked signature is intentionally conservative; a false-negative shows the normal CTA affordance instead of the notice (safe failure mode). Real-WebKit spot check tracked with the cross-engine LNA harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local daemon detection across HTTP and HTTPS connections.
  * Added clearer handling for blocked browser connections, including an unsupported-browser notice.
  * Preserved the connection option when detection results are inconclusive.

* **Documentation**
  * Added guidance on browser support for local daemon pairing, including Safari/WebKit limitations.

* **Tests**
  * Expanded coverage for connection outcomes, browser restrictions, malformed responses, and detection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->