### PR TITLE
fix(web): percent-encode workspaceId/slug in browser-local import fetch paths

### DIFF
--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -83,10 +83,13 @@ describe('importOneCanvas', () => {
       .mockResolvedValueOnce(jsonResponse({ slug: 'my-canvas' }))
       .mockResolvedValueOnce(jsonResponse({ ok: true }))
 
+    // workspaceId deliberately needs percent-encoding: the shared api-contracts
+    // type it as an unconstrained string, so URL construction must encode it
+    // exactly like daemon-api-client.ts does for the same routes.
     const result = await importOneCanvas({
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
-      workspaceId: 'ws1',
+      workspaceId: 'ws 1#x',
       canvasName: 'My Canvas',
       loroLoad: loroOkResult(),
     })
@@ -94,12 +97,13 @@ describe('importOneCanvas', () => {
     expect(result).toEqual({ kind: 'ok', slug: 'my-canvas' })
     expect(fetchMock).toHaveBeenCalledTimes(2)
 
+    const encodedWs = encodeURIComponent('ws 1#x')
     const [createUrl, createInit] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(createUrl).toBe('http://127.0.0.1:3099/api/workspaces/ws1/canvases')
+    expect(createUrl).toBe(`http://127.0.0.1:3099/api/workspaces/${encodedWs}/canvases`)
     expect(JSON.parse(createInit.body as string)).toEqual({ slug: 'my-canvas' })
 
     const [updateUrl, updateInit] = fetchMock.mock.calls[1] as [string, RequestInit]
-    expect(updateUrl).toBe('http://127.0.0.1:3099/api/canvas/ws1/my-canvas/update')
+    expect(updateUrl).toBe(`http://127.0.0.1:3099/api/canvas/${encodedWs}/my-canvas/update`)
     expect((updateInit.headers as Record<string, string>)['Content-Type']).toBe(
       'application/octet-stream',
     )

--- a/apps/web/src/components/migration/import-browser-local.ts
+++ b/apps/web/src/components/migration/import-browser-local.ts
@@ -104,11 +104,14 @@ async function importOneCanvasUnsafe(
   for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
     const candidateSlug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`
     const body = createCanvasRequestSchema.parse({ slug: candidateSlug })
-    const res = await fetch(`${daemonBaseUrl}/api/workspaces/${workspaceId}/canvases`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+    const res = await fetch(
+      `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
 
     if (res.status === 409) continue
 
@@ -135,7 +138,7 @@ async function importOneCanvasUnsafe(
   const mergedSnapshot = mergeToSnapshot(loroLoad.snapshot, loroLoad.deltas ?? [])
 
   const updateRes = await fetch(
-    `${daemonBaseUrl}/api/canvas/${workspaceId}/${createdSlug}/update`,
+    `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(createdSlug)}/update`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },


### PR DESCRIPTION
## Summary

Final cross-slice review finding (MEDIUM): `import-browser-local.ts` interpolated `workspaceId`/`createdSlug` raw into daemon URL paths while every other caller of the same routes (`daemon-api-client.ts`, `daemon-backend.ts`) percent-encodes them. The shared api-contracts type `workspaceId` as an unconstrained string, so an encoding-required value built a malformed URL and the import silently failed.

Red-first: the URL-asserting test now uses a workspaceId with space/`#` (confirmed red), both call sites wrapped with `encodeURIComponent` (41 migration tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)