### PR TITLE
feat(mcp-server): create_pairing_link tool — mint #wb= daemon-pairing URLs

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -101,7 +101,7 @@ describe('DaemonDetectedBanner', () => {
     )
 
     await screen.findByText(
-      'A local whiteboard daemon is running. Connect to unlock versions, branches, and merge.',
+      'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, branches, and merge.',
     )
     const link = screen.getByRole('link', { name: /connect/i })
     expect(link.getAttribute('href')).toBe(HOW_TO_CONNECT_URL)
@@ -123,7 +123,7 @@ describe('DaemonDetectedBanner', () => {
 
     expect(
       screen.queryByText(
-        'A local whiteboard daemon is running. Connect to unlock versions, branches, and merge.',
+        'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, branches, and merge.',
       ),
     ).toBeNull()
 

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -137,7 +137,8 @@ export function DaemonDetectedBanner({
           className="flex shrink-0 items-center justify-between gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
         >
           <span>
-            A local whiteboard daemon is running. Connect to unlock versions, branches, and merge.
+            A local whiteboard daemon is running. Ask your AI agent for a pairing link
+            (create_pairing_link) to unlock versions, branches, and merge.
           </span>
           <a
             href={HOW_TO_CONNECT_URL}

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -48,13 +48,31 @@ has actually proven the browser blocked the request.
 ## How pairing works
 
 Detecting a daemon is not the same as pairing with it. Actually connecting
-the web app's canvas editor to a specific workspace requires a pairing link
-issued from the **daemon or MCP side** — for example, an MCP tool call or the
-daemon CLI generates a URL carrying a `#wb=` fragment with a short-lived
-bootstrap token (see [ADR-0002](../contributing/adr/0002-browser-to-daemon-transport.md)
-for the transport design). The web app has no way to mint that token itself;
-it can only detect that *a* daemon is reachable and prompt you toward the
-pairing flow that produced the link.
+the web app's canvas editor to a specific workspace requires a pairing link,
+which the web app cannot mint itself — it can only detect that *a* daemon is
+reachable and prompt you toward the pairing flow below.
+
+1. Ask your AI agent (Claude, Codex, or any MCP client connected to the
+   whiteboard daemon) to call the `create_pairing_link` MCP tool. Optionally
+   pass `workspaceId` / `slug` to target a specific canvas, or `webOrigin` to
+   point at a non-default web app deployment.
+2. The tool returns a URL carrying a `#wb=` fragment with a short-lived
+   bootstrap token (see [ADR-0002](../contributing/adr/0002-browser-to-daemon-transport.md)
+   for the transport design). Open that URL in your browser.
+3. On a hosted `https:` origin, the browser's Local Network Access permission
+   prompt appears — grant it to let the page reach your loopback daemon.
+4. The web app consumes the fragment and connects to the paired workspace.
+
+**Treat the pairing link like a credential.** It embeds the daemon's
+bootstrap token, so anyone who has the link can pair with your daemon until
+the token is rotated. Share it only with the intended recipient, and prefer
+loopback (`http://127.0.0.1:...`) origins for purely local use.
+
+For hosted (non-loopback) `webOrigin` values, the daemon must also be
+configured to accept that origin via `WHITEBOARD_ALLOWED_WEB_ORIGINS` —
+`create_pairing_link` cannot confirm that allowlist coverage on its own, so
+verify it yourself before sharing a hosted pairing link. Loopback origins
+need no allowlist entry.
 
 ## Copy-first import
 

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -587,6 +587,49 @@ async function main() {
     `[e2e] library_list_items → itemCount=${libListed.itemCount} name=${libListed.items[0].name}`,
   )
 
+  // create_pairing_link: the MCP SDK validates structuredContent against the
+  // tool's outputSchema at runtime, so this exercises drift the type system
+  // can't see. Decode the emitted fragment and structurally check it against
+  // the daemon-connection-payload contract (baseUrl matches the live daemon,
+  // authMode/bootstrapToken coherent).
+  const workspaceId = created.id.split('/')[0]
+  const pairing = await callTool('create_pairing_link', {
+    workspaceId,
+    slug: sourceSlug,
+  })
+  if (!pairing.url || !pairing.webOrigin || !pairing.authMode) {
+    throw new Error(`create_pairing_link returned unexpected shape: ${JSON.stringify(pairing)}`)
+  }
+  const expectedPrefix = `${pairing.webOrigin}/#wb=`
+  if (!pairing.url.startsWith(expectedPrefix)) {
+    throw new Error(
+      `create_pairing_link url does not start with "${expectedPrefix}": ${pairing.url}`,
+    )
+  }
+  const fragmentB64 = pairing.url.slice(expectedPrefix.length)
+  const decodedPayload = JSON.parse(Buffer.from(fragmentB64, 'base64url').toString('utf-8'))
+  if (decodedPayload.baseUrl !== daemonOrigin) {
+    throw new Error(
+      `create_pairing_link payload baseUrl ${decodedPayload.baseUrl} ≠ live daemon origin ${daemonOrigin}`,
+    )
+  }
+  if (decodedPayload.workspaceId !== workspaceId || decodedPayload.slug !== sourceSlug) {
+    throw new Error(
+      `create_pairing_link payload workspaceId/slug mismatch: ${JSON.stringify(decodedPayload)}`,
+    )
+  }
+  if (
+    decodedPayload.authMode === 'bootstrap' &&
+    (typeof decodedPayload.bootstrapToken !== 'string' || decodedPayload.bootstrapToken.length < 8)
+  ) {
+    throw new Error(
+      `create_pairing_link bootstrap payload missing a valid token: ${JSON.stringify(decodedPayload)}`,
+    )
+  }
+  console.log(
+    `[e2e] create_pairing_link → ${pairing.authMode} url for baseUrl=${decodedPayload.baseUrl}`,
+  )
+
   console.log('\n[e2e] ALL OK')
 }
 

--- a/packages/mcp-server/src/server/mcp/daemon-client.ts
+++ b/packages/mcp-server/src/server/mcp/daemon-client.ts
@@ -3,6 +3,7 @@ import { injectContextIntoHeaders } from '../observability/tracing.js'
 export interface DaemonClient {
   port: number
   baseUrl: string
+  token: string
   request: (path: string, init?: RequestInit) => Promise<Response>
   touch: () => Promise<void>
 }
@@ -40,6 +41,7 @@ export function createDaemonClient(input: {
   return {
     port: input.port,
     baseUrl: input.baseUrl,
+    token: input.token,
     request(path, init) {
       return fetch(buildUrl(input.baseUrl, path), withBearerToken(init, input.token))
     },

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -39,6 +39,7 @@ export const ALL_REGISTERED_TOOLS = [
   'canvas_open',
   'create_embed',
   'create_frame',
+  'create_pairing_link',
   'delete_element',
   'delete_elements',
   'delete_group',
@@ -80,6 +81,7 @@ export const COVERED_TOOLS = [
   'canvas_list',
   'annotate',
   'create_frame',
+  'create_pairing_link',
   'canvas_inspect',
   'version_save',
   'version_restore',
@@ -92,9 +94,7 @@ export const COVERED_TOOLS = [
   'library_uninstall',
 ] as const
 
-export const ERROR_PATH_ONLY_TOOLS = [
-  'viewport_set',
-] as const
+export const ERROR_PATH_ONLY_TOOLS = ['viewport_set'] as const
 
 export const UNIT_ONLY_TOOLS = [
   'align_elements',
@@ -139,7 +139,9 @@ export type DeferredTool = {
 export const DEFERRED_TOOLS: DeferredTool[] = [
   {
     name: 'library_install',
-    reason: 'Success path calls fetchExternalLibraryPayload() → global fetch. Additionally, validateExternalUrl() rejects localhost and private-range IPs, so a plain node:http.createServer stub is blocked before the fetch even fires.',
-    unblock: 'Use nock or MSW to intercept fetch at the DNS/request level (bypasses validateExternalUrl), OR make the external-URL lookup injectable so the smoke can whitelist a loopback address.',
+    reason:
+      'Success path calls fetchExternalLibraryPayload() → global fetch. Additionally, validateExternalUrl() rejects localhost and private-range IPs, so a plain node:http.createServer stub is blocked before the fetch even fires.',
+    unblock:
+      'Use nock or MSW to intercept fetch at the DNS/request level (bypasses validateExternalUrl), OR make the external-URL lookup injectable so the smoke can whitelist a loopback address.',
   },
 ]

--- a/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
@@ -11,6 +11,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { TOOL_PROFILES } from './tool-profiles.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -56,5 +57,9 @@ describe('MCP tool annotations coverage', () => {
     for (const entry of entries) {
       expect(entry).toMatch(/title:/)
     }
+  })
+
+  it('never annotates create_pairing_link as read-only, since its response discloses the live daemon bearer token', () => {
+    expect(TOOL_PROFILES.create_pairing_link.profile.readOnlyHint).not.toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -34,7 +34,6 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   user_library_metadata_get: { profile: READ_ONLY, title: 'Get user library metadata' },
   library_list_items: { profile: READ_ONLY, title: 'List library items' },
   library_list_installed: { profile: READ_ONLY, title: 'List installed libraries' },
-  create_pairing_link: { profile: READ_ONLY, title: 'Create daemon pairing link' },
 
   // Read-only (external fetch)
   library_catalog_list: { profile: READ_ONLY_EXTERNAL, title: 'Search official library catalog' },
@@ -75,6 +74,12 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   },
 
   // Mutating non-idempotent (side effects / new IDs / state changes)
+  //
+  // create_pairing_link never mutates canvas state, but its response embeds the
+  // live daemon bearer token (see pairing-link.ts). readOnlyHint drives client
+  // auto-run/approval policy, so annotating this as read-only would let a client
+  // silently disclose a full-access credential without a human approval step.
+  create_pairing_link: { profile: MUTATING, title: 'Create daemon pairing link' },
   canvas_create: { profile: MUTATING, title: 'Create canvas' },
   annotate: { profile: MUTATING, title: 'Add annotation element' },
   annotate_batch: { profile: MUTATING, title: 'Add multiple annotation elements' },

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -34,6 +34,7 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   user_library_metadata_get: { profile: READ_ONLY, title: 'Get user library metadata' },
   library_list_items: { profile: READ_ONLY, title: 'List library items' },
   library_list_installed: { profile: READ_ONLY, title: 'List installed libraries' },
+  create_pairing_link: { profile: READ_ONLY, title: 'Create daemon pairing link' },
 
   // Read-only (external fetch)
   library_catalog_list: { profile: READ_ONLY_EXTERNAL, title: 'Search official library catalog' },

--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -1658,9 +1658,15 @@ export function registerAllTools(
     },
     async (args) => {
       const result = await withDaemon((client) => pairingLink.execute(args, client))
+      // content[0] stays JSON (the structuredJsonResult convention every other
+      // tool follows, and what callers/smoke parse as the primary payload); the
+      // credential note travels as a second text block instead of overwriting it.
       return {
         structuredContent: result,
-        content: [{ type: 'text' as const, text: buildPairingLinkText(result, result.webOrigin) }],
+        content: [
+          { type: 'text' as const, text: JSON.stringify(result) },
+          { type: 'text' as const, text: buildPairingLinkText(result, result.webOrigin) },
+        ],
       }
     },
   )

--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -90,6 +90,12 @@ import {
   paletteSetTool,
 } from './tools/palette.js'
 import {
+  buildPairingLinkText,
+  createPairingLinkInputShape,
+  createPairingLinkOutputSchema,
+  pairingLinkTool,
+} from './tools/pairing-link.js'
+import {
   insertTemplateTool,
   listTemplatesTool,
   templateInsertOutputSchema,
@@ -151,6 +157,7 @@ export function registerAllTools(
   const versionSave = versionSaveTool()
   const versionRestore = versionRestoreTool()
   const versionList = versionListTool()
+  const pairingLink = pairingLinkTool()
 
   registerToolWithAnnotations(
     server,
@@ -1638,6 +1645,23 @@ export function registerAllTools(
         embedCreate.execute({ canvasId, url, x, y, width, height }, client),
       )
       return structuredJsonResult(result)
+    },
+  )
+
+  registerToolWithAnnotations(
+    server,
+    pairingLink.name,
+    {
+      description: pairingLink.description,
+      inputSchema: createPairingLinkInputShape,
+      outputSchema: createPairingLinkOutputSchema,
+    },
+    async (args) => {
+      const result = await withDaemon((client) => pairingLink.execute(args, client))
+      return {
+        structuredContent: result,
+        content: [{ type: 'text' as const, text: buildPairingLinkText(result, result.webOrigin) }],
+      }
     },
   )
 }

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
@@ -121,6 +121,20 @@ describe('create_pairing_link tool', () => {
     }
   })
 
+  it('rejects an invalid WHITEBOARD_WEB_ORIGIN env value instead of minting an unvalidated link', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+
+    const previousEnv = process.env.WHITEBOARD_WEB_ORIGIN
+    try {
+      process.env.WHITEBOARD_WEB_ORIGIN = 'https://example.com/some/path'
+      await expect(tool.execute({}, client)).rejects.toThrow(/WHITEBOARD_WEB_ORIGIN/)
+    } finally {
+      if (previousEnv === undefined) delete process.env.WHITEBOARD_WEB_ORIGIN
+      else process.env.WHITEBOARD_WEB_ORIGIN = previousEnv
+    }
+  })
+
   it('rejects a non-bare-origin webOrigin at the input schema layer', () => {
     expect(() =>
       createPairingLinkInputSchema.parse({ webOrigin: 'https://example.com/some/path' }),

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
@@ -121,6 +121,21 @@ describe('create_pairing_link tool', () => {
     }
   })
 
+  it('treats an empty WHITEBOARD_WEB_ORIGIN as unset and falls back to the default origin', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+
+    const previousEnv = process.env.WHITEBOARD_WEB_ORIGIN
+    try {
+      process.env.WHITEBOARD_WEB_ORIGIN = ''
+      const result = await tool.execute({}, client)
+      expect(result.webOrigin).toBe('https://kamiazya-whiteboard.pages.dev')
+    } finally {
+      if (previousEnv === undefined) delete process.env.WHITEBOARD_WEB_ORIGIN
+      else process.env.WHITEBOARD_WEB_ORIGIN = previousEnv
+    }
+  })
+
   it('rejects an invalid WHITEBOARD_WEB_ORIGIN env value instead of minting an unvalidated link', async () => {
     const tool = pairingLinkTool()
     const client = stubClient()
@@ -168,6 +183,29 @@ describe('create_pairing_link tool', () => {
     const loopbackText = buildPairingLinkText(loopbackResult, loopbackResult.webOrigin)
     expect(loopbackText).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
     expect(loopbackText).not.toContain('cannot confirm it is present')
+  })
+
+  it('treats the whole 127.0.0.0/8 range (and bracketed IPv6) as loopback — no allowlist warning', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+
+    for (const origin of ['http://127.0.0.5:5173', 'http://[::1]:5173']) {
+      const result = await tool.execute({ webOrigin: origin }, client)
+      const text = buildPairingLinkText(result, result.webOrigin)
+      expect(text, origin).not.toContain('cannot confirm it is present')
+    }
+  })
+
+  it('normalizes a trailing-slash daemon baseUrl instead of failing the payload parse', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient({ baseUrl: 'http://127.0.0.1:3099/' })
+
+    const result = await tool.execute({}, client)
+    const fragment = result.url.split('#wb=')[1]
+    const payload = JSON.parse(Buffer.from(fragment, 'base64url').toString('utf-8')) as {
+      baseUrl: string
+    }
+    expect(payload.baseUrl).toBe('http://127.0.0.1:3099')
   })
 })
 

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.test.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  buildPairingLinkText,
+  createPairingLinkInputSchema,
+  createPairingLinkInputShape,
+  createPairingLinkOutputSchema,
+  pairingLinkTool,
+  PAIRING_LINK_CREDENTIAL_NOTE,
+} from './pairing-link.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Mirrors apps/web/src/lib/daemon-connection-payload.ts's daemonConnectionPayloadSchema,
+// duplicated here to decode the fragment the tool emits without importing across the
+// package boundary. Kept in sync with the production schema by the round-trip test below.
+const mirroredWebPayloadSchema = z
+  .object({
+    baseUrl: z.string().url(),
+    workspaceId: z.string().min(1).optional(),
+    slug: z.string().min(1).optional(),
+    bootstrapToken: z.string().min(8).optional(),
+    authMode: z.enum(['bootstrap', 'none']),
+    fullscreen: z.boolean().optional(),
+  })
+  .strict()
+
+function decodeFragment(url: string): unknown {
+  const marker = '/#wb='
+  const idx = url.indexOf(marker)
+  if (idx === -1) throw new Error(`url missing #wb= fragment: ${url}`)
+  const fragment = url.slice(idx + marker.length)
+  const json = Buffer.from(fragment, 'base64url').toString('utf-8')
+  return JSON.parse(json)
+}
+
+function stubClient(overrides: Partial<{ baseUrl: string; token: string }> = {}) {
+  return {
+    baseUrl: overrides.baseUrl ?? 'http://127.0.0.1:54231',
+    token: overrides.token ?? 'a'.repeat(21),
+  }
+}
+
+describe('pairing-link input/registration shape coherence', () => {
+  it('derives createPairingLinkInputSchema from the exact registered raw shape', () => {
+    expect(createPairingLinkInputSchema.shape).toStrictEqual(createPairingLinkInputShape)
+  })
+})
+
+describe('create_pairing_link tool', () => {
+  it('emits a url whose fragment decodes to a valid bootstrap payload', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient({ baseUrl: 'http://127.0.0.1:54231', token: 'x'.repeat(24) })
+    const result = await tool.execute(
+      { workspaceId: 'ws1', slug: 'canvas-a', fullscreen: true },
+      client,
+    )
+
+    expect(result.authMode).toBe('bootstrap')
+    expect(result.url.startsWith(`${result.webOrigin}/#wb=`)).toBe(true)
+    // Exactly one '#' in the URL.
+    expect(result.url.split('#').length - 1).toBe(1)
+
+    const decoded = mirroredWebPayloadSchema.parse(decodeFragment(result.url))
+    expect(decoded).toEqual({
+      baseUrl: 'http://127.0.0.1:54231',
+      workspaceId: 'ws1',
+      slug: 'canvas-a',
+      fullscreen: true,
+      authMode: 'bootstrap',
+      bootstrapToken: 'x'.repeat(24),
+    })
+  })
+
+  it('uses authMode "none" and omits bootstrapToken when the daemon has no token', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient({ token: '' })
+    const result = await tool.execute({}, client)
+
+    expect(result.authMode).toBe('none')
+    const decoded = decodeFragment(result.url) as Record<string, unknown>
+    expect('bootstrapToken' in decoded).toBe(false)
+  })
+
+  it('rejects a short daemon token loudly instead of emitting a dead link', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient({ token: 'short' })
+    await expect(tool.execute({}, client)).rejects.toThrow(/token/i)
+  })
+
+  it('rejects slug without workspaceId before any daemon interaction', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+    await expect(tool.execute({ slug: 'canvas-a' }, client)).rejects.toThrow(/workspaceId/i)
+  })
+
+  it('resolves webOrigin: explicit input > env > default production origin', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+
+    const defaultResult = await tool.execute({}, client)
+    expect(defaultResult.webOrigin).toBe('https://kamiazya-whiteboard.pages.dev')
+
+    const previousEnv = process.env.WHITEBOARD_WEB_ORIGIN
+    try {
+      process.env.WHITEBOARD_WEB_ORIGIN = 'https://custom.example.com'
+      const envResult = await tool.execute({}, client)
+      expect(envResult.webOrigin).toBe('https://custom.example.com')
+
+      const explicitResult = await tool.execute(
+        { webOrigin: 'https://explicit.example.com' },
+        client,
+      )
+      expect(explicitResult.webOrigin).toBe('https://explicit.example.com')
+    } finally {
+      if (previousEnv === undefined) delete process.env.WHITEBOARD_WEB_ORIGIN
+      else process.env.WHITEBOARD_WEB_ORIGIN = previousEnv
+    }
+  })
+
+  it('rejects a non-bare-origin webOrigin at the input schema layer', () => {
+    expect(() =>
+      createPairingLinkInputSchema.parse({ webOrigin: 'https://example.com/some/path' }),
+    ).toThrow()
+    expect(() => createPairingLinkInputSchema.parse({ webOrigin: 'ftp://example.com' })).toThrow()
+  })
+
+  it('omits expiresHint entirely — no real expiry source exists today', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+    const result = await tool.execute({}, client)
+    expect('expiresHint' in result).toBe(false)
+  })
+
+  it('registered tool description carries the credential security note', () => {
+    const tool = pairingLinkTool()
+    expect(tool.description).toContain('bootstrap token')
+    expect(tool.description).toContain('WHITEBOARD_ALLOWED_WEB_ORIGINS')
+  })
+
+  it('text output warns about the allowlist for non-loopback webOrigin, not for loopback', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+
+    const hostedResult = await tool.execute({ webOrigin: 'https://example.pages.dev' }, client)
+    const hostedText = buildPairingLinkText(hostedResult, hostedResult.webOrigin)
+    expect(hostedText).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+    expect(hostedText).toContain('WHITEBOARD_ALLOWED_WEB_ORIGINS')
+
+    const loopbackResult = await tool.execute({ webOrigin: 'http://localhost:5173' }, client)
+    const loopbackText = buildPairingLinkText(loopbackResult, loopbackResult.webOrigin)
+    expect(loopbackText).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+    expect(loopbackText).not.toContain('cannot confirm it is present')
+  })
+})
+
+describe('output schema', () => {
+  it('accepts the shape returned by the tool', async () => {
+    const tool = pairingLinkTool()
+    const client = stubClient()
+    const result = await tool.execute({}, client)
+    expect(() => createPairingLinkOutputSchema.parse(result)).not.toThrow()
+  })
+})
+
+describe('PROVISIONAL_PRODUCTION_ORIGIN drift pin', () => {
+  it('matches the literal declared in apps/web/src/lib/pages-origin-policy.ts', async () => {
+    const p = resolve(__dirname, '../../../../../../apps/web/src/lib/pages-origin-policy.ts')
+    if (!existsSync(p)) throw new Error(`expected web source file not found: ${p}`)
+    const src = readFileSync(p, 'utf-8')
+    const match = src.match(/PROVISIONAL_PRODUCTION_ORIGIN = '([^']+)'/)
+    if (!match)
+      throw new Error('could not find PROVISIONAL_PRODUCTION_ORIGIN literal in web source')
+
+    const tool = pairingLinkTool()
+    const client = stubClient()
+    const result = await tool.execute({}, client)
+    expect(result.webOrigin).toBe(match[1])
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod'
+import type { DaemonClient } from '../daemon-client.js'
+
+// Defense-in-depth floor mirroring apps/web/src/lib/daemon-connection-payload.ts's
+// MIN_BOOTSTRAP_TOKEN_LENGTH — the daemon itself is the real security boundary
+// (ADR-0002), this only stops us minting a link the web parser would reject outright.
+const MIN_BOOTSTRAP_TOKEN_LENGTH = 8
+
+// Duplicated from apps/web/src/lib/pages-origin-policy.ts's PROVISIONAL_PRODUCTION_ORIGIN.
+// mcp-server cannot import across the apps/web package boundary, so this literal is
+// pinned by a drift test in pairing-link.test.ts that reads the web source directly.
+const PROVISIONAL_PRODUCTION_ORIGIN = 'https://kamiazya-whiteboard.pages.dev'
+
+// Bare http(s) origin: scheme + host + optional port, nothing else. Mirrors
+// bareOriginSchema in apps/web/src/runtime-config.ts, narrowed to http(s) only —
+// daemon pairing (ADR-0002) never uses another scheme.
+const bareHttpOriginSchema = z
+  .string()
+  .url()
+  .refine(
+    (v) => {
+      try {
+        const url = new URL(v)
+        return (
+          url.origin === v &&
+          !url.hostname.includes('*') &&
+          (url.protocol === 'http:' || url.protocol === 'https:')
+        )
+      } catch {
+        return false
+      }
+    },
+    {
+      message:
+        'webOrigin must be a bare http(s) origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
+    },
+  )
+
+// Single source of truth for create_pairing_link's input: a raw shape so it can be
+// passed directly to registerToolWithAnnotations (which requires z.ZodRawShape and
+// cannot accept a refined z.object()). The cross-field "slug requires workspaceId"
+// rule cannot live here for that reason — it is enforced in execute() below instead.
+export const createPairingLinkInputShape = {
+  workspaceId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Target workspace ID. Required when slug is set.'),
+  slug: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Target canvas slug within workspaceId. Requires workspaceId to also be set.'),
+  webOrigin: bareHttpOriginSchema
+    .optional()
+    .describe(
+      'Web app origin to embed in the link (e.g. "https://app.example.com"). Defaults to the WHITEBOARD_WEB_ORIGIN env var, or the production whiteboard web app origin.',
+    ),
+  fullscreen: z
+    .boolean()
+    .optional()
+    .describe('Open the paired canvas in fullscreen mode once connected.'),
+} satisfies z.ZodRawShape
+
+export const createPairingLinkInputSchema = z.object(createPairingLinkInputShape)
+
+export const createPairingLinkOutputSchema = z.object({
+  url: z.string().url().describe('The `${webOrigin}/#wb=<payload>` pairing URL.'),
+  webOrigin: z.string().describe('The web app origin embedded in url.'),
+  authMode: z.enum(['bootstrap', 'none']).describe('Auth mode encoded in the pairing payload.'),
+  // Omitted entirely (never emitted as `undefined`) whenever no real expiry source
+  // exists — which is always today, since bootstrap tokens surface no TTL to the
+  // MCP layer. Flip this to always-emitted only once a real expiry source lands.
+  expiresHint: z.string().optional().describe('Human-readable expiry hint, when known.'),
+})
+
+// Mirrors apps/web/src/lib/daemon-connection-payload.ts's daemonConnectionPayloadSchema.
+// Duplicated (not imported) because mcp-server cannot depend on apps/web; the fixture
+// round-trip assertions in pairing-link.test.ts guard against silent drift.
+const mirroredDaemonConnectionPayloadSchema = z
+  .object({
+    baseUrl: bareHttpOriginSchema,
+    workspaceId: z.string().min(1).optional(),
+    slug: z.string().min(1).optional(),
+    bootstrapToken: z.string().min(MIN_BOOTSTRAP_TOKEN_LENGTH).optional(),
+    authMode: z.enum(['bootstrap', 'none']),
+    fullscreen: z.boolean().optional(),
+  })
+  .strict()
+  .refine((payload) => payload.authMode !== 'bootstrap' || payload.bootstrapToken !== undefined, {
+    message: 'bootstrapToken is required when authMode is "bootstrap"',
+    path: ['bootstrapToken'],
+  })
+  .refine((payload) => payload.slug === undefined || payload.workspaceId !== undefined, {
+    message: 'workspaceId is required when slug is set',
+    path: ['workspaceId'],
+  })
+
+// Node's 'base64url' Buffer encoding is unpadded and uses the same alphabet as the
+// web side's hand-rolled encodeBase64Url, so the two implementations produce
+// byte-identical fragments for the same JSON text.
+function encodeBase64UrlJson(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url')
+}
+
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const { hostname } = new URL(origin)
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '[::1]'
+    )
+  } catch {
+    return false
+  }
+}
+
+export const PAIRING_LINK_CREDENTIAL_NOTE =
+  'SECURITY: this URL embeds the daemon bootstrap token — treat it like a credential and share it only with the intended recipient. Hosted (non-loopback) webOrigin values must be added to WHITEBOARD_ALLOWED_WEB_ORIGINS on the daemon; loopback origins need no allowlist entry.'
+
+// The MCP process cannot read the daemon's WHITEBOARD_ALLOWED_WEB_ORIGINS
+// configuration, so this warning is deliberate best-effort: it reminds the
+// caller to check rather than confirming coverage.
+const HOSTED_ORIGIN_ALLOWLIST_WARNING =
+  'This webOrigin is non-loopback; the MCP process cannot confirm it is present in WHITEBOARD_ALLOWED_WEB_ORIGINS on the daemon — verify that allowlist entry yourself before sharing the link.'
+
+export function buildPairingLinkText(
+  result: z.infer<typeof createPairingLinkOutputSchema>,
+  webOrigin: string,
+): string {
+  const lines = [result.url, '', PAIRING_LINK_CREDENTIAL_NOTE]
+  if (!isLoopbackOrigin(webOrigin)) lines.push(HOSTED_ORIGIN_ALLOWLIST_WARNING)
+  return lines.join('\n')
+}
+
+export function pairingLinkTool() {
+  return {
+    name: 'create_pairing_link',
+    description:
+      'Mint a `#wb=` daemon-pairing URL that lets the whiteboard web app connect to this local daemon, optionally targeting a specific workspace/canvas. ' +
+      PAIRING_LINK_CREDENTIAL_NOTE,
+    execute: async (
+      args: z.infer<typeof createPairingLinkInputSchema>,
+      client: Pick<DaemonClient, 'baseUrl' | 'token'>,
+    ): Promise<z.infer<typeof createPairingLinkOutputSchema>> => {
+      // Cross-field guard: raw-shape registration cannot express this as a schema
+      // refinement (registerToolWithAnnotations requires z.ZodRawShape), so it is
+      // enforced here, before any daemon interaction.
+      if (args.slug !== undefined && args.workspaceId === undefined) {
+        throw new Error('create_pairing_link: workspaceId is required when slug is set')
+      }
+
+      const webOrigin =
+        args.webOrigin ?? process.env.WHITEBOARD_WEB_ORIGIN ?? PROVISIONAL_PRODUCTION_ORIGIN
+
+      const hasToken = client.token.length > 0
+      if (hasToken && client.token.length < MIN_BOOTSTRAP_TOKEN_LENGTH) {
+        // Fail loudly rather than emit a URL the web-side schema would reject as
+        // invalid once opened — a dead link is worse than an explicit tool error.
+        throw new Error(
+          `create_pairing_link: daemon bootstrap token is only ${client.token.length} chars (minimum ${MIN_BOOTSTRAP_TOKEN_LENGTH}); refusing to mint a pairing link the web app would reject`,
+        )
+      }
+
+      const payload = mirroredDaemonConnectionPayloadSchema.parse({
+        baseUrl: client.baseUrl,
+        workspaceId: args.workspaceId,
+        slug: args.slug,
+        fullscreen: args.fullscreen,
+        authMode: hasToken ? 'bootstrap' : 'none',
+        bootstrapToken: hasToken ? client.token : undefined,
+      })
+
+      const fragment = encodeBase64UrlJson(payload)
+      const url = `${webOrigin}/#wb=${fragment}`
+
+      return { url, webOrigin, authMode: payload.authMode }
+    },
+  }
+}

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
@@ -110,7 +110,9 @@ function encodeBase64UrlJson(payload: unknown): string {
 // parser rejects outright.
 function resolveEnvWebOrigin(): string | undefined {
   const raw = process.env.WHITEBOARD_WEB_ORIGIN
-  if (raw === undefined) return undefined
+  // Empty string means "unset" (a cleared env var in shell scripts), not a
+  // misconfiguration — fall back to the default rather than failing loudly.
+  if (!raw) return undefined
 
   const parsed = bareHttpOriginSchema.safeParse(raw)
   if (!parsed.success) {
@@ -126,7 +128,10 @@ function isLoopbackOrigin(origin: string): boolean {
     const { hostname } = new URL(origin)
     return (
       hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
+      // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
+      // Node's WHATWG URL keeps the brackets ('[::1]'); the bare form is
+      // retained for runtimes that strip them.
       hostname === '::1' ||
       hostname === '[::1]'
     )
@@ -182,7 +187,10 @@ export function pairingLinkTool() {
       }
 
       const payload = mirroredDaemonConnectionPayloadSchema.parse({
-        baseUrl: client.baseUrl,
+        // Normalize to a bare origin: a trailing slash (or any non-normalized
+        // form) in the client's baseUrl would fail the strict mirror schema
+        // and turn a valid daemon into a tool error.
+        baseUrl: new URL(client.baseUrl).origin,
         workspaceId: args.workspaceId,
         slug: args.slug,
         fullscreen: args.fullscreen,

--- a/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
+++ b/packages/mcp-server/src/server/mcp/tools/pairing-link.ts
@@ -103,6 +103,24 @@ function encodeBase64UrlJson(payload: unknown): string {
   return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url')
 }
 
+// The explicit webOrigin input is constrained by bareHttpOriginSchema at the
+// schema layer; the env var fallback bypasses that layer entirely unless it is
+// re-validated here, so a misconfigured WHITEBOARD_WEB_ORIGIN would otherwise
+// silently mint a link with a path/query/wrong-scheme origin the web app
+// parser rejects outright.
+function resolveEnvWebOrigin(): string | undefined {
+  const raw = process.env.WHITEBOARD_WEB_ORIGIN
+  if (raw === undefined) return undefined
+
+  const parsed = bareHttpOriginSchema.safeParse(raw)
+  if (!parsed.success) {
+    throw new Error(
+      `create_pairing_link: WHITEBOARD_WEB_ORIGIN is not a bare http(s) origin: ${raw}`,
+    )
+  }
+  return parsed.data
+}
+
 function isLoopbackOrigin(origin: string): boolean {
   try {
     const { hostname } = new URL(origin)
@@ -152,8 +170,7 @@ export function pairingLinkTool() {
         throw new Error('create_pairing_link: workspaceId is required when slug is set')
       }
 
-      const webOrigin =
-        args.webOrigin ?? process.env.WHITEBOARD_WEB_ORIGIN ?? PROVISIONAL_PRODUCTION_ORIGIN
+      const webOrigin = args.webOrigin ?? resolveEnvWebOrigin() ?? PROVISIONAL_PRODUCTION_ORIGIN
 
       const hasToken = client.token.length > 0
       if (hasToken && client.token.length < MIN_BOOTSTRAP_TOKEN_LENGTH) {


### PR DESCRIPTION
## Summary

Closes the HIGH final-review dogfood finding: the web app's pairing RECEIVER (`#wb=` fragment) was complete, but nothing in the product could MINT a pairing link — a real user hit a dead-end (banner says a daemon is running → docs say links come from the MCP side → no tool existed).

- **New MCP tool `create_pairing_link`**: builds a `daemonConnectionPayloadSchema`-valid payload from the LIVE daemon (dynamic port from ensureDaemon, real token → `authMode: bootstrap`; no token → `authMode: none`), base64url-encodes it exactly per the web parser's format, and returns `${webOrigin}/#wb=<payload>`. webOrigin: input > `WHITEBOARD_WEB_ORIGIN` env (validated) > production origin (drift-pinned against `pages-origin-policy.ts`).
- **Safety rails**: slug-requires-workspaceId guard; short-token loud failure (never a dead link); security note in the description + output (the link embeds the daemon token — credential); best-effort warning for non-loopback webOrigins about `WHITEBOARD_ALLOWED_WEB_ORIGINS`; NOT annotated read-only (it discloses a credential).
- **Contract discipline**: input declared once as a raw shape (registration) + derived z.object (tests); output via `z.infer`; fixture-level round-trip drift-pin against the web-side fragment format.
- **`smoke:e2e` extended** to call the tool and structurally validate the URL + fragment (runtime outputSchema validation).
- **Banner copy fix** (dogfood MEDIUM): "Connect to unlock…" implied a nonexistent button — now says to ask your AI agent for a pairing link via `create_pairing_link`.
- **Docs**: `connect-to-local-daemon.md` now documents the concrete flow (run tool → open URL → LNA prompt → paired) + allowlist env + credential nature.

## Verification

- 4085 tests green, typecheck clean, build green
- `pnpm smoke:e2e` green including the new `create_pairing_link` step (real daemon, dynamic port 3100 in the run)
- 13 unit tests: token/none branches, origin resolution chain, URL shape, drift-pin, guard/error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP tool that generates pairing links for connecting the web app to a local daemon.
  * Updated the detected-daemon banner to instruct users to request a pairing link from their AI agent.
  * Added pairing guidance, security warnings, and hosted-origin configuration details to the local-daemon documentation.

* **Bug Fixes**
  * Improved pairing-link validation and connection-flow handling.

* **Tests**
  * Added coverage for pairing-link generation, validation, security messaging, and end-to-end behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->