### PR TITLE
fix(mcp-server): admit cross-name loopback origins on the WS upgrade

### DIFF
--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -50,7 +50,10 @@ describe('authorizeWsUpgrade', () => {
     ).toEqual({ accept: true, protocol: undefined })
   })
 
-  it('rejects browser origins that are not same-host localhost addresses', () => {
+  it('admits cross-name loopback origins but rejects non-loopback ones', () => {
+    // Loopback-to-loopback name mismatch (localhost page, 127.0.0.1 daemon)
+    // is admitted — same policy as the HTTP CORS middleware; the token is
+    // still required and offered here.
     expect(
       authorizeWsUpgrade(
         {
@@ -60,7 +63,7 @@ describe('authorizeWsUpgrade', () => {
         },
         'secret',
       ),
-    ).toEqual({ accept: false, statusCode: 403 })
+    ).toEqual({ accept: true, protocol: 'excalidraw-v1' })
 
     expect(
       authorizeWsUpgrade(

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -94,35 +94,42 @@ describe('authorizeWsUpgrade', () => {
     expect(decision.accept).toBe(true)
   })
 
-  describe('loopback Origin/Host mismatch regression (allowlist must not loosen it)', () => {
-    // A localhost Origin against a 127.0.0.1 Host is still a loopback-origin/
-    // loopback-host MISMATCH under the originHost === requestHost rule. The
-    // allowedOrigins allowlist widens admission for exact non-loopback
-    // matches only — it must not accidentally loosen this rule for loopback
-    // origins.
-    it('rejects with an empty allowlist', () => {
+  describe('cross-name loopback Origin admission (parity with the HTTP CORS policy)', () => {
+    // Loopback names (localhost / 127.0.0.1 / ::1) all resolve to the same
+    // interface, and any local page can trivially target the daemon under
+    // its own loopback name — so requiring originHost === requestHost never
+    // blocked a local attacker, it only broke legitimate cross-name pairs
+    // (a localhost:5173 page pairing with a 127.0.0.1 daemon). The policy is
+    // therefore loopback-OR-allowlist, identical to the HTTP CORS middleware;
+    // the real guards remain the loopback Host check (DNS rebinding) and the
+    // token requirement below.
+    it('admits a localhost Origin against a 127.0.0.1 Host without an allowlist entry', () => {
       const decision = authorizeWsUpgrade(
         { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
         undefined,
         [],
       )
-      expect(decision).toEqual({ accept: false, statusCode: 403 })
+      expect(decision.accept).toBe(true)
     })
 
-    it('rejects when the allowlist has unrelated entries', () => {
+    it('still requires the token for a cross-name loopback Origin when token auth is on', () => {
       const decision = authorizeWsUpgrade(
         { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
-        undefined,
-        ['https://kamiazya-whiteboard.pages.dev'],
+        'secret-token',
+        [],
       )
-      expect(decision).toEqual({ accept: false, statusCode: 403 })
+      expect(decision).toEqual({ accept: false, statusCode: 401 })
     })
 
-    it('only accepts once that exact origin is itself allowlisted', () => {
+    it('admits a cross-name loopback Origin offering the correct token', () => {
       const decision = authorizeWsUpgrade(
-        { host: '127.0.0.1:3099', origin: 'http://localhost:5173' },
-        undefined,
-        ['http://localhost:5173'],
+        {
+          host: '127.0.0.1:3099',
+          origin: 'http://localhost:5173',
+          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.secret-token',
+        },
+        'secret-token',
+        [],
       )
       expect(decision.accept).toBe(true)
     })

--- a/packages/mcp-server/src/server/routes/ws-auth.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.ts
@@ -35,16 +35,20 @@ function isAllowedBrowserOrigin(
   if (!requestHost) return false
   if (!isLoopbackHostname(requestHost)) return false
   if (!originHeader) return true
-  // Use the shared normalizer (strips IPv6 brackets) so this side agrees
-  // with normalizeHostHeader above — otherwise http://[::1] never matches
-  // a Host header normalized to bare "::1".
+  // Any loopback Origin is admitted, mirroring the HTTP CORS policy
+  // (createApiLoopbackCorsMiddleware). Loopback names (localhost /
+  // 127.0.0.1 / ::1) all resolve to the same interface and a local page can
+  // always target the daemon under its own loopback name, so requiring
+  // originHost === requestHost never blocked a local attacker — it only
+  // broke legitimate cross-name pairs (a localhost:5173 page against a
+  // 127.0.0.1 daemon). The real guards are the loopback Host check above
+  // (DNS rebinding) and the token check in authorizeWsUpgrade.
   const originHost = normalizeOriginHostname(originHeader)
-  if (originHost !== null && isLoopbackHostname(originHost) && originHost === requestHost) {
+  if (originHost !== null && isLoopbackHostname(originHost)) {
     return true
   }
   // A hosted pairing origin (e.g. https://kamiazya-whiteboard.pages.dev) is
-  // never loopback, so it cannot satisfy originHost === requestHost above —
-  // it is admitted only via an exact allowlist match instead.
+  // never loopback — it is admitted only via an exact allowlist match.
   return isAllowedWebOrigin(originHeader, allowedOrigins)
 }
 


### PR DESCRIPTION
## Summary

Dogfooding the `create_pairing_link` → `#wb=` pairing flow surfaced a live-sync failure: a page at `http://localhost:5173` paired with the daemon at `127.0.0.1:3099` gets **WS 403** (3 retries, then the auth-error banner), while every REST call works.

Root cause: the WS upgrade required `originHost === requestHost` for loopback origins, but the HTTP CORS middleware admits **any** loopback origin. The equality rule was deliberate (it had its own regression tests) but provides no real protection — loopback names all resolve to the same interface and a local attacker page can simply target the daemon under its own loopback name (ports are stripped by normalization), so the rule only broke legitimate cross-name pairs.

**Policy change (explicit):** WS origin admission is now *loopback OR exact allowlist*, identical to `createApiLoopbackCorsMiddleware`. This also makes the shipped `create_pairing_link` docs ("loopback origins need no allowlist entry") true for the WS channel. Unchanged guards, still tested: loopback Host check (DNS rebinding), token auth (401 without / with wrong token), non-loopback origins still need the exact allowlist (403).

## Test plan
- [x] Red-first: 3 new unit tests failed against the old policy, pass now
- [x] Full mcp-node suite: 190 files / 2904 tests green (including the http-server.test.ts twin of the old policy, updated)
- [x] Manual handshake verification against a live daemon built from this branch:
  - cross-name loopback + valid token → **101**
  - cross-name loopback, no token → **401**
  - non-loopback origin + valid token → **403**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
