### PR TITLE
chore: add cleanup-worktrees script for parallel-lane disk reclamation

### DIFF
--- a/.claude/scripts/cleanup-worktrees.mjs
+++ b/.claude/scripts/cleanup-worktrees.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Reclaim disk from parallel-lane debris: remove .claude/worktrees/* whose
+// branch is already merged into origin/main (or whose tip is reachable from
+// it) and carries no uncommitted changes, delete the local branch, prune
+// worktree metadata, and optionally prune the pnpm store.
+//
+//   node .claude/scripts/cleanup-worktrees.mjs [--dry-run] [--store-prune]
+//
+// Safety: a worktree with uncommitted changes or an unmerged branch is always
+// left alone and reported — nothing here ever discards work.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../..')
+const worktreesDir = join(repoRoot, '.claude', 'worktrees')
+const dryRun = process.argv.includes('--dry-run')
+const storePrune = process.argv.includes('--store-prune')
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8', ...opts }).trim()
+}
+
+if (!existsSync(worktreesDir)) {
+  console.log('no .claude/worktrees directory — nothing to clean')
+  process.exit(0)
+}
+
+git(['fetch', 'origin', '--quiet'])
+
+const entries = readdirSync(worktreesDir, { withFileTypes: true }).filter((e) => e.isDirectory())
+let removed = 0
+let kept = 0
+
+for (const entry of entries) {
+  const wt = join(worktreesDir, entry.name)
+  let branch = ''
+  let dirty = ''
+  let tip = ''
+  try {
+    branch = git(['-C', wt, 'branch', '--show-current'])
+    dirty = git(['-C', wt, 'status', '--porcelain'])
+    tip = git(['-C', wt, 'rev-parse', 'HEAD'])
+  } catch {
+    console.log(`skip ${entry.name}: not a valid worktree (run \`git worktree prune\` if stale)`)
+    kept++
+    continue
+  }
+
+  if (dirty) {
+    console.log(`keep ${entry.name}: uncommitted changes present`)
+    kept++
+    continue
+  }
+
+  // A branch whose tip still equals origin/main has produced no commits yet —
+  // that is a freshly-created lane (possibly with an agent about to work in
+  // it), not a folded one. The ancestor check below would misread it as
+  // merged, so keep it unless --include-fresh is passed.
+  const mainTip = git(['rev-parse', 'origin/main'])
+  if (tip === mainTip && !process.argv.includes('--include-fresh')) {
+    console.log(`keep ${entry.name}: no commits yet (fresh lane; use --include-fresh to remove)`)
+    kept++
+    continue
+  }
+
+  let merged = false
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', tip, 'origin/main'], { cwd: repoRoot })
+    merged = true
+  } catch {
+    // Squash-merged branches are not ancestors of main; fall back to
+    // "remote branch deleted" as the merged signal (gh merge --delete-branch
+    // and our PR flow both delete the remote ref on merge).
+    try {
+      git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`])
+    } catch {
+      merged = branch !== '' // remote gone → treat as folded
+    }
+  }
+
+  if (!merged) {
+    console.log(`keep ${entry.name}: branch '${branch}' not merged and remote still exists`)
+    kept++
+    continue
+  }
+
+  if (dryRun) {
+    console.log(`would remove ${entry.name} (branch '${branch}')`)
+    removed++
+    continue
+  }
+
+  git(['worktree', 'remove', '--force', wt])
+  if (branch) {
+    try {
+      git(['branch', '-D', branch])
+    } catch {
+      /* branch already gone */
+    }
+  }
+  console.log(`removed ${entry.name} (branch '${branch}')`)
+  removed++
+}
+
+git(['worktree', 'prune'])
+
+if (storePrune && !dryRun) {
+  console.log('pruning pnpm store…')
+  execFileSync('pnpm', ['store', 'prune'], { cwd: repoRoot, stdio: 'inherit' })
+}
+
+console.log(`done: ${removed} ${dryRun ? 'removable' : 'removed'}, ${kept} kept`)

--- a/.claude/scripts/cleanup-worktrees.mjs
+++ b/.claude/scripts/cleanup-worktrees.mjs
@@ -4,20 +4,22 @@
 // it) and carries no uncommitted changes, delete the local branch, prune
 // worktree metadata, and optionally prune the pnpm store.
 //
-//   node .claude/scripts/cleanup-worktrees.mjs [--dry-run] [--store-prune]
+//   node .claude/scripts/cleanup-worktrees.mjs [--dry-run] [--store-prune] [--include-fresh]
 //
 // Safety: a worktree with uncommitted changes or an unmerged branch is always
 // left alone and reported — nothing here ever discards work.
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const repoRoot = resolve(fileURLToPath(import.meta.url), '../../..')
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../..')
 const worktreesDir = join(repoRoot, '.claude', 'worktrees')
 const dryRun = process.argv.includes('--dry-run')
 const storePrune = process.argv.includes('--store-prune')
+const includeFresh = process.argv.includes('--include-fresh')
 
 function git(args, opts = {}) {
   return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8', ...opts }).trim()
@@ -28,7 +30,19 @@ if (!existsSync(worktreesDir)) {
   process.exit(0)
 }
 
-git(['fetch', 'origin', '--quiet'])
+try {
+  git(['fetch', 'origin', '--quiet'])
+} catch {
+  console.warn('warning: fetch from origin failed (offline?) — proceeding with local ref cache')
+}
+
+let mainTip
+try {
+  mainTip = git(['rev-parse', 'origin/main'])
+} catch {
+  console.error('error: origin/main ref not found — cannot determine merged status')
+  process.exit(1)
+}
 
 const entries = readdirSync(worktreesDir, { withFileTypes: true }).filter((e) => e.isDirectory())
 let removed = 0
@@ -59,8 +73,7 @@ for (const entry of entries) {
   // that is a freshly-created lane (possibly with an agent about to work in
   // it), not a folded one. The ancestor check below would misread it as
   // merged, so keep it unless --include-fresh is passed.
-  const mainTip = git(['rev-parse', 'origin/main'])
-  if (tip === mainTip && !process.argv.includes('--include-fresh')) {
+  if (tip === mainTip && !includeFresh) {
     console.log(`keep ${entry.name}: no commits yet (fresh lane; use --include-fresh to remove)`)
     kept++
     continue
@@ -73,11 +86,14 @@ for (const entry of entries) {
   } catch {
     // Squash-merged branches are not ancestors of main; fall back to
     // "remote branch deleted" as the merged signal (gh merge --delete-branch
-    // and our PR flow both delete the remote ref on merge).
-    try {
-      git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`])
-    } catch {
-      merged = branch !== '' // remote gone → treat as folded
+    // and our PR flow both delete the remote ref on merge). A detached HEAD
+    // (empty branch) has no remote ref to consult — leave it kept.
+    if (branch) {
+      try {
+        git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`])
+      } catch {
+        merged = true // remote gone → treat as folded
+      }
     }
   }
 
@@ -109,7 +125,9 @@ git(['worktree', 'prune'])
 
 if (storePrune && !dryRun) {
   console.log('pruning pnpm store…')
-  execFileSync('pnpm', ['store', 'prune'], { cwd: repoRoot, stdio: 'inherit' })
+  // pnpm is a .cmd shim on Windows; execFileSync needs the exact filename.
+  const pnpmCmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  execFileSync(pnpmCmd, ['store', 'prune'], { cwd: repoRoot, stdio: 'inherit' })
 }
 
 console.log(`done: ${removed} ${dryRun ? 'removable' : 'removed'}, ${kept} kept`)


### PR DESCRIPTION
## Summary

Adds `.claude/scripts/cleanup-worktrees.mjs`: removes `.claude/worktrees/*` whose branch is merged (ancestor of origin/main, or remote ref deleted after a squash merge) and has no uncommitted changes; keeps fresh no-commit lanes unless `--include-fresh`. `--dry-run` previews, `--store-prune` chains `pnpm store prune`.

Companion to `new-worktree.mjs` — the standing countermeasure for the disk-full incidents caused by worktree/node_modules accumulation during parallel dev-loops.

## Test plan
- [x] `--dry-run` against live worktrees: correctly keeps 2 active fresh lanes (no commits yet), flags nothing else
- [x] Earlier equivalent manual cleanup of 3 merged worktrees this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to identify and remove stale Git worktrees.
  * Supports preview mode, optional removal of fresh worktrees, and pnpm store cleanup.
  * Preserves worktrees with uncommitted changes and reports removed and retained worktrees.
  * Handles unavailable remote repositories gracefully and cleans up worktree metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->