### PR TITLE
feat(web): make the WS-rejected (live sync off) state unmissable on DaemonCanvasPage

### DIFF
--- a/apps/web/src/hooks/useDaemonConnection.ts
+++ b/apps/web/src/hooks/useDaemonConnection.ts
@@ -27,6 +27,14 @@ function getWindow(): WindowLike | undefined {
 // token global against the seed happening on the second mount. Computing
 // once at module scope — synchronously seeding the token before returning
 // 'paired' — makes both hazards impossible by construction.
+//
+// Consequence for pairing E2E coverage: a hash-only same-document
+// navigation (e.g. setting location.hash or a client-side router push)
+// never re-runs this module's top-level code, so `cached` keeps whatever
+// it was computed from on first load and a later `#wb=` fragment is never
+// consumed. Any end-to-end test exercising the pairing flow must force a
+// full navigation (a fresh document load) for the fragment to reach
+// computeDaemonConnection() at all.
 let cached: DaemonConnectionResult | null = null
 
 function computeDaemonConnection(): DaemonConnectionResult {

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -354,9 +354,79 @@ describe('DaemonCanvasPage', () => {
       backend.handlers?.onAuthError?.()
     })
 
-    expect(screen.getByRole('alert').textContent).toMatch(/daemon rejected/i)
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/daemon rejected/i)
+    // Strengthened banner: an explicit "Live sync off" label, not just the
+    // re-pairing sentence, so the degraded state reads at a glance.
+    expect(alert.textContent).toMatch(/live sync off/i)
     // Editor chrome stays mounted — auth error is a banner, not a full-page replacement.
     expect(screen.getByTestId('excalidraw-container')).toBeTruthy()
+  })
+
+  it('shows a persistent "Sync off" indicator distinct from the alert banner while authError is true', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+    expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
+
+    await act(async () => {
+      createdBackends[0]?.handlers?.onAuthError?.()
+    })
+
+    // Deliberately not role=alert — there must be exactly one alert on the
+    // page (the banner) so existing screen.getByRole('alert') calls stay
+    // unambiguous; the chip is a secondary, persistent status indicator.
+    const chip = screen.getByLabelText(/live sync off/i)
+    expect(chip.getAttribute('role')).not.toBe('alert')
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+  })
+
+  it('renders the "Sync off" indicator even when no canvas is selected', async () => {
+    mockListWorkspaces.mockResolvedValue({
+      workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
+    })
+    mockListCanvases.mockImplementation((_fetch, _base, workspaceId) => {
+      if (workspaceId === 'w2') return Promise.resolve({ canvases: [] })
+      return Promise.resolve({
+        canvases: [
+          { slug: 'main', updatedAt: '2026-01-01' },
+          { slug: 'second', updatedAt: '2026-01-02' },
+        ],
+      })
+    })
+
+    await act(async () => {
+      render(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+    await act(async () => {
+      createdBackends[0]?.handlers?.onAuthError?.()
+    })
+    expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
+
+    // Switch into a workspace with zero canvases: the canvas backend tears
+    // down entirely (no WorkspaceTopBar mounts), but there genuinely is no
+    // live sync happening either way, so the indicator must not disappear
+    // just because the canvas-gated UI does.
+    const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+    await act(async () => {
+      workspaceSelect.value = 'w2'
+      workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
+    )
+    expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
   })
 
   it('clears the auth-error banner when switching to a new canvas (new backend identity)', async () => {
@@ -372,14 +442,16 @@ describe('DaemonCanvasPage', () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
     expect(screen.getByRole('alert').textContent).toMatch(/daemon rejected/i)
+    expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
 
     await act(async () => {
       await openCanvasSwitcher('main')
       await selectCanvasFromSwitcher('second')
     })
 
-    // The stale banner must not outlive the backend that produced it.
+    // The stale banner (and chip) must not outlive the backend that produced it.
     expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
   })
 
   it('renders a browser-local escape button in the auth banner and invokes the callback', async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -232,44 +232,44 @@ export function DaemonCanvasPage({
           </div>
         )}
         {authError && (
-          <div
-            role="alert"
-            aria-live="assertive"
-            className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-1"
-          >
-            <span aria-hidden="true" className="text-sm text-destructive">
-              ⚠
-            </span>
-            <span className="text-xs font-semibold text-destructive">Live sync off:</span>
-            <span className="text-xs text-destructive">
-              The daemon rejected this session. Try re-pairing.
-            </span>
-            {onContinueBrowserLocal && (
-              <button
-                type="button"
-                onClick={onContinueBrowserLocal}
-                className="rounded-md border px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent"
-              >
-                Continue in browser-local
-              </button>
-            )}
-          </div>
-        )}
-        {authError && (
-          // Rendered at the page level (not inside `{canvas && ...}`) so the
-          // degraded state stays visible even in the no-canvas/empty-workspace
-          // view where WorkspaceTopBar itself doesn't mount. Deliberately
-          // role="status" rather than role="alert": the page must keep
-          // exactly one alert (the banner above) so existing
-          // screen.getByRole('alert') assertions stay unambiguous, while this
-          // chip persists as a compact reminder once attention moves past it.
-          <div
-            role="status"
-            aria-label="Live sync off"
-            className="flex w-fit items-center gap-1 self-start rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] font-medium text-destructive"
-          >
-            Sync off
-          </div>
+          <>
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-1"
+            >
+              <span aria-hidden="true" className="text-sm text-destructive">
+                ⚠
+              </span>
+              <span className="text-xs font-semibold text-destructive">Live sync off:</span>
+              <span className="text-xs text-destructive">
+                The daemon rejected this session. Try re-pairing.
+              </span>
+              {onContinueBrowserLocal && (
+                <button
+                  type="button"
+                  onClick={onContinueBrowserLocal}
+                  className="rounded-md border px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent"
+                >
+                  Continue in browser-local
+                </button>
+              )}
+            </div>
+            {/* Rendered at the page level (not inside `{canvas && ...}`) so the
+                degraded state stays visible even in the no-canvas/empty-workspace
+                view where WorkspaceTopBar itself doesn't mount. Deliberately
+                role="status" rather than role="alert": the page must keep exactly
+                one alert (the banner above) so existing screen.getByRole('alert')
+                assertions stay unambiguous, while this chip persists as a compact
+                reminder once attention moves past it. */}
+            <div
+              role="status"
+              aria-label="Live sync off"
+              className="flex w-fit items-center gap-1 self-start rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] font-medium text-destructive"
+            >
+              Sync off
+            </div>
+          </>
         )}
         {canvas && (
           <WorkspaceTopBar

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -118,9 +118,12 @@ export function DaemonCanvasPage({
 
   // A rejected session belongs to one backend identity — switching to a new
   // canvas opens a fresh connection, so a stale banner must not outlive the
-  // backend that produced it.
+  // backend that produced it. Only resets on a genuine new (non-null)
+  // connection: dropping to no backend at all (e.g. switching into a
+  // workspace with zero canvases) leaves authError as-is, because live sync
+  // is still off either way and the persistent indicator should stay lit.
   useEffect(() => {
-    setAuthError(false)
+    if (backend) setAuthError(false)
   }, [backend])
 
   const { setExcalidrawAPI, onChange, clearLocalUndo } = useCanvasSync(backend, {
@@ -232,8 +235,12 @@ export function DaemonCanvasPage({
           <div
             role="alert"
             aria-live="assertive"
-            className="flex items-center gap-2 border-b bg-background px-4 py-1"
+            className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-1"
           >
+            <span aria-hidden="true" className="text-sm text-destructive">
+              ⚠
+            </span>
+            <span className="text-xs font-semibold text-destructive">Live sync off:</span>
             <span className="text-xs text-destructive">
               The daemon rejected this session. Try re-pairing.
             </span>
@@ -246,6 +253,22 @@ export function DaemonCanvasPage({
                 Continue in browser-local
               </button>
             )}
+          </div>
+        )}
+        {authError && (
+          // Rendered at the page level (not inside `{canvas && ...}`) so the
+          // degraded state stays visible even in the no-canvas/empty-workspace
+          // view where WorkspaceTopBar itself doesn't mount. Deliberately
+          // role="status" rather than role="alert": the page must keep
+          // exactly one alert (the banner above) so existing
+          // screen.getByRole('alert') assertions stay unambiguous, while this
+          // chip persists as a compact reminder once attention moves past it.
+          <div
+            role="status"
+            aria-label="Live sync off"
+            className="flex w-fit items-center gap-1 self-start rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] font-medium text-destructive"
+          >
+            Sync off
           </div>
         )}
         {canvas && (


### PR DESCRIPTION
## Summary

Dogfood follow-up: when the daemon rejects the WS session, REST-backed panels keep working and the only signal was a thin banner — easy to miss that live sync is off.

- Strengthened the auth-error banner: destructive tint + explicit 'Live sync off' label, keeps role=alert and the 'Continue in browser-local' escape.
- Added a persistent compact 'Sync off' status chip (role=status, not a second alert) rendered outside the canvas-gated block so it survives the empty-workspace state.
- Editor and REST features stay fully usable — indicator only.
- useDaemonConnection: enduring comment documenting that hash-only same-document navigations never re-run pairing consumption (module-scope memoization) — pairing E2Es must force a full navigation.

## Test plan
- [x] Red-first jsdom cases: banner+chip on authError, neither without, chip survives no-canvas state, chip clears on canvas switch, escape button intact, no duplicate role=alert
- [x] DaemonCanvasPage.test.tsx 43/43 green, typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)