### PR TITLE
fix(mcp-server,web): keep MergeDialog confirm footer reachable below 800px viewports

### DIFF
--- a/apps/web/src/components/MergeDialog.tsx
+++ b/apps/web/src/components/MergeDialog.tsx
@@ -356,7 +356,7 @@ export function MergeDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
-      <DialogContent className="max-w-5xl">
+      <DialogContent className="grid max-h-[90dvh] max-w-5xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <GitMerge className="h-4 w-4" />
@@ -377,152 +377,160 @@ export function MergeDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {error ? (
-          <div className="flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <span className="break-all">{error}</span>
-          </div>
-        ) : null}
-
-        {/* Keep source on the left and target on the right to match the dialog title reading order. */}
-        <div className="grid grid-cols-2 gap-3">
-          <CompareCard
-            kind="source"
-            branch={source}
-            count={sourceCount}
-            delta={sourceDelta}
-            workspaceId={workspaceId}
-            slug={slug}
-            thumbVersionId={thumbs.source}
-            loading={thumbsLoading}
-          />
-          <CompareCard
-            kind="target"
-            branch={target}
-            count={targetCount}
-            workspaceId={workspaceId}
-            slug={slug}
-            thumbVersionId={thumbs.target}
-            loading={thumbsLoading}
-          />
-        </div>
-
-        {/* Arrow showing the flow into the merged preview below. */}
-        <div className="flex items-center justify-center text-muted-foreground">
-          <ArrowDown className="size-4" aria-hidden />
-        </div>
-
-        {/* Main merged preview. */}
-        <div
-          className="flex flex-col gap-2 rounded-lg border-2 bg-card p-3 ring-1 ring-emerald-500/20"
-          style={{ borderColor: '#2f9e44' }}
-          data-testid="merge-branch-card-preview"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <span
-                aria-hidden
-                className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
-              />
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
-                Merged preview
-              </span>
+        {/* Scrollable body: the confirm footer below must stay reachable even when
+            the preview panes and badge list grow taller than the viewport. */}
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto" data-slot="merge-dialog-body">
+          {error ? (
+            <div className="flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span className="break-all">{error}</span>
             </div>
-            <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
+          ) : null}
+
+          {/* Keep source on the left and target on the right to match the dialog title reading order. */}
+          <div className="grid grid-cols-2 gap-3">
+            <CompareCard
+              kind="source"
+              branch={source}
+              count={sourceCount}
+              delta={sourceDelta}
+              workspaceId={workspaceId}
+              slug={slug}
+              thumbVersionId={thumbs.source}
+              loading={thumbsLoading}
+            />
+            <CompareCard
+              kind="target"
+              branch={target}
+              count={targetCount}
+              workspaceId={workspaceId}
+              slug={slug}
+              thumbVersionId={thumbs.target}
+              loading={thumbsLoading}
+            />
           </div>
-          <div className="relative h-[340px] overflow-hidden rounded border bg-white">
-            {loading ? (
-              <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                Calculating preview…
+
+          {/* Arrow showing the flow into the merged preview below. */}
+          <div className="flex items-center justify-center text-muted-foreground">
+            <ArrowDown className="size-4" aria-hidden />
+          </div>
+
+          {/* Main merged preview. */}
+          <div
+            className="flex flex-col gap-2 rounded-lg border-2 bg-card p-3 ring-1 ring-emerald-500/20"
+            style={{ borderColor: '#2f9e44' }}
+            data-testid="merge-branch-card-preview"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
+                />
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+                  Merged preview
+                </span>
               </div>
-            ) : thumbs.source && workspaceId && slug ? (
-              // Show the latest source-branch thumbnail as a practical preview fallback.
-              <VersionThumbnail
-                workspaceId={workspaceId}
-                slug={slug}
-                versionId={thumbs.source}
-                hasThumbnail
-                className="h-full w-full object-contain"
-              />
-            ) : (
-              <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
-                <FileText className="size-6 opacity-40" />
-                <div className="text-center text-xs">
-                  <div>{previewElementCount > 0 ? 'No preview image yet' : 'No elements'}</div>
-                  <div className="mt-1 text-[10px] opacity-80">
-                    Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+              <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
+            </div>
+            <div className="relative h-[340px] overflow-hidden rounded border bg-white">
+              {loading ? (
+                <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  Calculating preview…
+                </div>
+              ) : thumbs.source && workspaceId && slug ? (
+                // Show the latest source-branch thumbnail as a practical preview fallback.
+                <VersionThumbnail
+                  workspaceId={workspaceId}
+                  slug={slug}
+                  versionId={thumbs.source}
+                  hasThumbnail
+                  className="h-full w-full object-contain"
+                />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+                  <FileText className="size-6 opacity-40" />
+                  <div className="text-center text-xs">
+                    <div>{previewElementCount > 0 ? 'No preview image yet' : 'No elements'}</div>
+                    <div className="mt-1 text-[10px] opacity-80">
+                      Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+                    </div>
                   </div>
                 </div>
+              )}
+            </div>
+          </div>
+
+          {/* Badges / conflict summary */}
+          <div className="rounded-lg border bg-muted/30 p-3">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                Checking conflicts…
+              </div>
+            ) : error && badgeViews.length === 0 ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <AlertTriangle className="size-3.5" />
+                Conflict status unavailable - see error above.
+              </div>
+            ) : badgeViews.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm">
+                <CheckCircle2 className="size-4 text-emerald-600" />
+                <span>
+                  <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
+                </span>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-center gap-3 text-sm">
+                  <AlertTriangle className="size-4 text-amber-600" />
+                  <strong>{badgeViews.length} changes to review</strong>
+                  <span className="text-xs text-muted-foreground">
+                    {(['danger', 'warning', 'info'] as const)
+                      .filter((t) => (badgeByTone[t] ?? 0) > 0)
+                      .map((t) => `${badgeByTone[t]} ${TONE_STYLE[t].summaryLabel}`)
+                      .join(' · ')}
+                  </span>
+                </div>
+                <ul className="flex flex-wrap gap-1.5">
+                  {badgeViews.map((view) => {
+                    const tone = TONE_STYLE[view.tone]
+                    const Icon = tone.icon
+                    return (
+                      <li
+                        key={view.key}
+                        title={view.title}
+                        className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]"
+                        style={{
+                          borderColor: tone.border,
+                          backgroundColor: tone.bg,
+                          color: tone.fg,
+                        }}
+                      >
+                        <Icon className="size-3" aria-hidden />
+                        {view.label}
+                      </li>
+                    )
+                  })}
+                </ul>
               </div>
             )}
           </div>
-        </div>
 
-        {/* Badges / conflict summary */}
-        <div className="rounded-lg border bg-muted/30 p-3">
-          {loading ? (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Loader2 className="size-3.5 animate-spin" />
-              Checking conflicts…
-            </div>
-          ) : error && badgeViews.length === 0 ? (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <AlertTriangle className="size-3.5" />
-              Conflict status unavailable - see error above.
-            </div>
-          ) : badgeViews.length === 0 ? (
-            <div className="flex items-center gap-2 text-sm">
-              <CheckCircle2 className="size-4 text-emerald-600" />
-              <span>
-                <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
-              </span>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <div className="flex items-center gap-3 text-sm">
-                <AlertTriangle className="size-4 text-amber-600" />
-                <strong>{badgeViews.length} changes to review</strong>
-                <span className="text-xs text-muted-foreground">
-                  {(['danger', 'warning', 'info'] as const)
-                    .filter((t) => (badgeByTone[t] ?? 0) > 0)
-                    .map((t) => `${badgeByTone[t]} ${TONE_STYLE[t].summaryLabel}`)
-                    .join(' · ')}
-                </span>
-              </div>
-              <ul className="flex flex-wrap gap-1.5">
-                {badgeViews.map((view) => {
-                  const tone = TONE_STYLE[view.tone]
-                  const Icon = tone.icon
-                  return (
-                    <li
-                      key={view.key}
-                      title={view.title}
-                      className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]"
-                      style={{ borderColor: tone.border, backgroundColor: tone.bg, color: tone.fg }}
-                    >
-                      <Icon className="size-3" aria-hidden />
-                      {view.label}
-                    </li>
-                  )
-                })}
-              </ul>
+          {/* Make the post-merge side effects explicit before the user confirms. */}
+          {source && target && source.name !== target.name && source.name !== 'main' && (
+            <div
+              className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
+              data-testid="merge-side-effect-notice"
+            >
+              <strong>After merge:</strong> switch automatically to "
+              <span className="font-semibold">{target.name}</span>" and delete "
+              <span className="font-semibold">{source.name}</span>
+              ".
             </div>
           )}
         </div>
-
-        {/* Make the post-merge side effects explicit before the user confirms. */}
-        {source && target && source.name !== target.name && source.name !== 'main' && (
-          <div
-            className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
-            data-testid="merge-side-effect-notice"
-          >
-            <strong>After merge:</strong> switch automatically to "
-            <span className="font-semibold">{target.name}</span>" and delete "
-            <span className="font-semibold">{source.name}</span>
-            ".
-          </div>
-        )}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={onClose} disabled={committing}>

--- a/apps/web/src/components/merge-ui.browser.test.tsx
+++ b/apps/web/src/components/merge-ui.browser.test.tsx
@@ -4,6 +4,7 @@ import type { BranchMeta, MergeResponse } from '@kamiazya/whiteboard-mcp/api-con
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import '../index.css'
 import { MERGE_COMMITTED_EVENT } from '@/lib/merge-committed-event'
 import { MergeDialog } from './MergeDialog.js'
 import { MergeHighlight } from './MergeHighlight.js'
@@ -76,6 +77,61 @@ describe('MergeDialog (browser — real Radix Dialog)', () => {
 
     await userEvent.keyboard('{Escape}')
     await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+})
+
+describe('MergeDialog layout (browser — confirm footer reachable below the fold)', () => {
+  afterEach(async () => {
+    // Restore the shared browser instance's default viewport so later tests
+    // in this project (default 1280x900) do not inherit this test's override.
+    await page.viewport(1280, 900)
+  })
+
+  it('keeps the Merge confirm button reachable at a ~1200x800 viewport', async () => {
+    await page.viewport(1200, 800)
+
+    // A wide badge set forces the merged-preview card, badge list, and
+    // side-effect notice to stack tall enough that the dialog exceeds an
+    // 800px-tall viewport.
+    const badges = Array.from({ length: 20 }, (_, index) => ({
+      type: 'field_merge',
+      elementId: `el-${index}`,
+      fields: ['strokeColor', 'backgroundColor'],
+    }))
+    const runMerge = vi.fn().mockResolvedValue({
+      badges,
+      preview: { elementCount: 240 },
+      target: { elementCount: 200 },
+      source: { elementCount: 220 },
+    } satisfies MergeResponse)
+
+    render(
+      <MergeDialog
+        open
+        source={feature}
+        target={main}
+        onClose={() => undefined}
+        runMerge={runMerge}
+      />,
+    )
+
+    // Real click fails with "element is outside of the viewport" if the
+    // footer falls below the fold and the body has no overflow-y.
+    await page.getByTestId('merge-confirm-button').click()
+
+    await waitFor(() => {
+      expect(runMerge).toHaveBeenLastCalledWith('feature', { into: 'main', dryRun: false })
+    })
+
+    // The dialog renders through a portal, so query the document rather
+    // than the render container.
+    const scrollBody = document.querySelector('[data-slot="merge-dialog-body"]')
+    expect(scrollBody).toBeInstanceOf(HTMLDivElement)
+    expect(scrollBody!.scrollHeight).toBeGreaterThan(scrollBody!.clientHeight)
+
+    const footer = document.querySelector('[data-slot="dialog-footer"]')
+    expect(footer).toBeInstanceOf(HTMLDivElement)
+    expect(scrollBody!.contains(footer)).toBe(false)
   })
 })
 

--- a/packages/mcp-server/src/app/components/MergeDialog.browser.test.tsx
+++ b/packages/mcp-server/src/app/components/MergeDialog.browser.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import '../index.css'
+import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
+import { MergeDialog } from './MergeDialog.js'
+
+const main: BranchMeta = {
+  name: 'main',
+  tipFrontiers: '',
+  color: '#1971c2',
+  createdAt: '2026-04-23T00:00:00Z',
+}
+const feature: BranchMeta = {
+  name: 'feature',
+  tipFrontiers: 'AAECAw==',
+  color: '#9333ea',
+  createdAt: '2026-04-23T01:00:00Z',
+}
+
+// A wide badge set forces the merged-preview card, badge list, and side-effect
+// notice to stack tall enough that the dialog exceeds an 800px-tall viewport.
+function tallMergeResult(): MergeResult {
+  const badges = Array.from({ length: 20 }, (_, index) => ({
+    type: 'field_merge',
+    elementId: `el-${index}`,
+    fields: ['strokeColor', 'backgroundColor'],
+  }))
+  return {
+    badges,
+    preview: { elementCount: 240 },
+    target: { elementCount: 200 },
+    source: { elementCount: 220 },
+  }
+}
+
+afterEach(async () => {
+  cleanup()
+  // Restore the shared browser instance's default viewport so later tests
+  // in this project (default 1280x900) do not inherit this test's override.
+  await page.viewport(1280, 900)
+})
+
+describe('MergeDialog browser mode', () => {
+  it('keeps the Merge confirm button reachable at a ~1200x800 viewport', async () => {
+    await page.viewport(1200, 800)
+
+    const runMerge = vi
+      .fn<(source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>>()
+      .mockResolvedValue(tallMergeResult())
+    render(
+      <MergeDialog
+        open
+        source={feature}
+        target={main}
+        onClose={() => undefined}
+        runMerge={runMerge}
+      />,
+    )
+
+    // Real click fails with "element is outside of the viewport" if the
+    // footer falls below the fold and the body has no overflow-y.
+    await page.getByTestId('merge-confirm-button').click()
+
+    await vi.waitFor(() => {
+      expect(runMerge).toHaveBeenLastCalledWith('feature', { into: 'main', dryRun: false })
+    })
+
+    // The dialog renders through a portal, so query the document rather
+    // than the render container.
+    const scrollBody = document.querySelector('[data-slot="merge-dialog-body"]')
+    expect(scrollBody).toBeInstanceOf(HTMLDivElement)
+    expect(scrollBody!.scrollHeight).toBeGreaterThan(scrollBody!.clientHeight)
+
+    const footer = document.querySelector('[data-slot="dialog-footer"]')
+    expect(footer).toBeInstanceOf(HTMLDivElement)
+    expect(scrollBody!.contains(footer)).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/app/components/MergeDialog.tsx
+++ b/packages/mcp-server/src/app/components/MergeDialog.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useMemo, useState, type JSX } from 'react'
 import {
   AlertTriangle,
   ArrowDown,
@@ -8,6 +7,12 @@ import {
   Info,
   Loader2,
 } from 'lucide-react'
+import { type JSX, useEffect, useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { listVersionsResponseSchema } from '../../shared/api-contracts/canvas.js'
+import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
+import { apiFetch } from '../lib/api-client.js'
+import { safeErrorCopy } from '../lib/error-copy.js'
 import { Button } from './ui/button.js'
 import {
   Dialog,
@@ -17,11 +22,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from './ui/dialog.js'
-import { cn } from '@/lib/utils'
-import { listVersionsResponseSchema } from '../../shared/api-contracts/canvas.js'
-import { apiFetch } from '../lib/api-client.js'
-import { safeErrorCopy } from '../lib/error-copy.js'
-import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
 
 // Note: this originally tried to embed a read-only <Excalidraw> preview, but Excalidraw does not
 // recommend multi-instance usage and it destabilized the main canvas scene state.
@@ -58,7 +58,8 @@ function badgeLabel(badge: Record<string, unknown>): BadgeView {
       key: `${type}:${elementId}`,
       label: `Deleted element restored: ${elementId}`,
       tone: 'warning',
-      title: 'This element was deleted on the target canvas but edited on the incoming branch, so it will be restored.',
+      title:
+        'This element was deleted on the target canvas but edited on the incoming branch, so it will be restored.',
     }
   }
   if (type === 'orphan_ref') {
@@ -67,7 +68,8 @@ function badgeLabel(badge: Record<string, unknown>): BadgeView {
       key: `${type}:${elementId}:${missing}`,
       label: `Missing reference: ${elementId} -> ${missing}`,
       tone: 'danger',
-      title: 'A referenced target such as an arrow binding was deleted, so this item will be orphaned after merge.',
+      title:
+        'A referenced target such as an arrow binding was deleted, so this item will be orphaned after merge.',
     }
   }
   if (type === 'field_merge') {
@@ -76,7 +78,8 @@ function badgeLabel(badge: Record<string, unknown>): BadgeView {
       key: `${type}:${elementId}`,
       label: `Edited on both sides: ${elementId} (${fields})`,
       tone: 'info',
-      title: 'The same element was edited on both branches, so the last-write-wins result will be kept.',
+      title:
+        'The same element was edited on both branches, so the last-write-wins result will be kept.',
     }
   }
   return {
@@ -87,7 +90,10 @@ function badgeLabel(badge: Record<string, unknown>): BadgeView {
   }
 }
 
-const TONE_STYLE: Record<BadgeView['tone'], { fg: string; bg: string; border: string; icon: typeof AlertTriangle }> = {
+const TONE_STYLE: Record<
+  BadgeView['tone'],
+  { fg: string; bg: string; border: string; icon: typeof AlertTriangle }
+> = {
   danger: { fg: '#dc2626', bg: '#fee2e2', border: '#fecaca', icon: AlertTriangle },
   warning: { fg: '#d97706', bg: '#fef3c7', border: '#fde68a', icon: AlertTriangle },
   info: { fg: '#1971c2', bg: '#dbeafe', border: '#bfdbfe', icon: Info },
@@ -102,7 +108,14 @@ interface CompareCardProps {
   loading: boolean
 }
 
-function CompareCard({ kind, branch, count, delta, thumbUrl, loading }: CompareCardProps): JSX.Element {
+function CompareCard({
+  kind,
+  branch,
+  count,
+  delta,
+  thumbUrl,
+  loading,
+}: CompareCardProps): JSX.Element {
   const accent = branch?.color ?? '#64748b'
   const title = kind === 'target' ? 'Current canvas (target)' : 'Incoming changes'
   const deltaVisible = typeof delta === 'number' && delta !== 0 ? delta : null
@@ -113,8 +126,15 @@ function CompareCard({ kind, branch, count, delta, thumbUrl, loading }: CompareC
       data-testid={`merge-branch-card-${kind}`}
     >
       <div className="flex items-center gap-2">
-        <span aria-hidden className="inline-block size-2 shrink-0 rounded-full" style={{ background: accent }} />
-        <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: accent }}>
+        <span
+          aria-hidden
+          className="inline-block size-2 shrink-0 rounded-full"
+          style={{ background: accent }}
+        />
+        <span
+          className="text-[10px] font-semibold uppercase tracking-wider"
+          style={{ color: accent }}
+        >
           {title}
         </span>
       </div>
@@ -148,7 +168,9 @@ function CompareCard({ kind, branch, count, delta, thumbUrl, loading }: CompareC
             <span
               className={cn(
                 'rounded-full px-1.5 font-medium tabular-nums',
-                deltaVisible > 0 ? 'bg-emerald-500/10 text-emerald-600' : 'bg-amber-500/10 text-amber-600',
+                deltaVisible > 0
+                  ? 'bg-emerald-500/10 text-emerald-600'
+                  : 'bg-amber-500/10 text-amber-600',
               )}
             >
               {deltaVisible > 0 ? '+' : ''}
@@ -313,7 +335,7 @@ export function MergeDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
-      <DialogContent className="max-w-5xl">
+      <DialogContent className="grid max-h-[90dvh] max-w-5xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <GitMerge className="h-4 w-4" />
@@ -329,143 +351,157 @@ export function MergeDialog({
             </span>
           </DialogTitle>
           <DialogDescription>
-            Content conflicts are resolved automatically. Use the badges below to review changes that may need attention.
+            Content conflicts are resolved automatically. Use the badges below to review changes
+            that may need attention.
           </DialogDescription>
         </DialogHeader>
 
-        {error ? (
-          <div className="flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-            <span className="break-all">{error}</span>
-          </div>
-        ) : null}
-
-        {/* Keep source on the left and target on the right to match the dialog title reading order. */}
-        <div className="grid grid-cols-2 gap-3">
-          <CompareCard
-            kind="source"
-            branch={source}
-            count={sourceCount}
-            delta={sourceDelta}
-            thumbUrl={thumbs.source}
-            loading={thumbsLoading}
-          />
-          <CompareCard
-            kind="target"
-            branch={target}
-            count={targetCount}
-            thumbUrl={thumbs.target}
-            loading={thumbsLoading}
-          />
-        </div>
-
-        {/* Arrow showing the flow into the merged preview below. */}
-        <div className="flex items-center justify-center text-muted-foreground">
-          <ArrowDown className="size-4" aria-hidden />
-        </div>
-
-        {/* Main merged preview. */}
-        <div
-          className="flex flex-col gap-2 rounded-lg border-2 bg-card p-3 ring-1 ring-emerald-500/20"
-          style={{ borderColor: '#2f9e44' }}
-          data-testid="merge-branch-card-preview"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <span aria-hidden className="inline-block size-2 shrink-0 rounded-full bg-emerald-500" />
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
-                Merged preview
-              </span>
+        {/* Scrollable body: the confirm footer below must stay reachable even when
+            the preview panes and badge list grow taller than the viewport. */}
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto" data-slot="merge-dialog-body">
+          {error ? (
+            <div className="flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span className="break-all">{error}</span>
             </div>
-            <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
+          ) : null}
+
+          {/* Keep source on the left and target on the right to match the dialog title reading order. */}
+          <div className="grid grid-cols-2 gap-3">
+            <CompareCard
+              kind="source"
+              branch={source}
+              count={sourceCount}
+              delta={sourceDelta}
+              thumbUrl={thumbs.source}
+              loading={thumbsLoading}
+            />
+            <CompareCard
+              kind="target"
+              branch={target}
+              count={targetCount}
+              thumbUrl={thumbs.target}
+              loading={thumbsLoading}
+            />
           </div>
-          <div className="relative h-[340px] overflow-hidden rounded border bg-white">
-            {loading ? (
-              <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                Calculating preview…
+
+          {/* Arrow showing the flow into the merged preview below. */}
+          <div className="flex items-center justify-center text-muted-foreground">
+            <ArrowDown className="size-4" aria-hidden />
+          </div>
+
+          {/* Main merged preview. */}
+          <div
+            className="flex flex-col gap-2 rounded-lg border-2 bg-card p-3 ring-1 ring-emerald-500/20"
+            style={{ borderColor: '#2f9e44' }}
+            data-testid="merge-branch-card-preview"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
+                />
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+                  Merged preview
+                </span>
               </div>
-            ) : thumbs.source ? (
-              // Show the latest source-branch thumbnail as a practical preview fallback.
-              <img
-                src={thumbs.source}
-                alt={`${source?.name ?? ''} merged preview`}
-                className="h-full w-full object-contain"
-              />
-            ) : (
-              <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
-                <FileText className="size-6 opacity-40" />
-                <div className="text-center text-xs">
-                  <div>
-                    {previewElementCount > 0 ? 'No preview image yet' : 'No elements'}
-                  </div>
-                  <div className="mt-1 text-[10px] opacity-80">
-                    Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+              <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
+            </div>
+            <div className="relative h-[340px] overflow-hidden rounded border bg-white">
+              {loading ? (
+                <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  Calculating preview…
+                </div>
+              ) : thumbs.source ? (
+                // Show the latest source-branch thumbnail as a practical preview fallback.
+                <img
+                  src={thumbs.source}
+                  alt={`${source?.name ?? ''} merged preview`}
+                  className="h-full w-full object-contain"
+                />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+                  <FileText className="size-6 opacity-40" />
+                  <div className="text-center text-xs">
+                    <div>{previewElementCount > 0 ? 'No preview image yet' : 'No elements'}</div>
+                    <div className="mt-1 text-[10px] opacity-80">
+                      Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+                    </div>
                   </div>
                 </div>
+              )}
+            </div>
+          </div>
+
+          {/* Badges / conflict summary */}
+          <div className="rounded-lg border bg-muted/30 p-3">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                Checking conflicts…
+              </div>
+            ) : badgeViews.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm">
+                <CheckCircle2 className="size-4 text-emerald-600" />
+                <span>
+                  <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
+                </span>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-center gap-3 text-sm">
+                  <AlertTriangle className="size-4 text-amber-600" />
+                  <strong>{badgeViews.length} changes to review</strong>
+                  <span className="text-xs text-muted-foreground">
+                    {(['danger', 'warning', 'info'] as const)
+                      .filter((t) => (badgeByTone[t] ?? 0) > 0)
+                      .map(
+                        (t) =>
+                          `${badgeByTone[t]} ${t === 'danger' ? 'critical' : t === 'warning' ? 'warning' : 'info'}`,
+                      )
+                      .join(' · ')}
+                  </span>
+                </div>
+                <ul className="flex flex-wrap gap-1.5">
+                  {badgeViews.map((view) => {
+                    const tone = TONE_STYLE[view.tone]
+                    const Icon = tone.icon
+                    return (
+                      <li
+                        key={view.key}
+                        title={view.title}
+                        className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]"
+                        style={{
+                          borderColor: tone.border,
+                          backgroundColor: tone.bg,
+                          color: tone.fg,
+                        }}
+                      >
+                        <Icon className="size-3" aria-hidden />
+                        {view.label}
+                      </li>
+                    )
+                  })}
+                </ul>
               </div>
             )}
           </div>
-        </div>
 
-        {/* Badges / conflict summary */}
-        <div className="rounded-lg border bg-muted/30 p-3">
-          {loading ? (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Loader2 className="size-3.5 animate-spin" />
-              Checking conflicts…
-            </div>
-          ) : badgeViews.length === 0 ? (
-            <div className="flex items-center gap-2 text-sm">
-              <CheckCircle2 className="size-4 text-emerald-600" />
-              <span>
-                <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
-              </span>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <div className="flex items-center gap-3 text-sm">
-                <AlertTriangle className="size-4 text-amber-600" />
-                <strong>{badgeViews.length} changes to review</strong>
-                <span className="text-xs text-muted-foreground">
-                  {(['danger', 'warning', 'info'] as const)
-                    .filter((t) => (badgeByTone[t] ?? 0) > 0)
-                    .map((t) => `${badgeByTone[t]} ${t === 'danger' ? 'critical' : t === 'warning' ? 'warning' : 'info'}`)
-                    .join(' · ')}
-                </span>
-              </div>
-              <ul className="flex flex-wrap gap-1.5">
-                {badgeViews.map((view) => {
-                  const tone = TONE_STYLE[view.tone]
-                  const Icon = tone.icon
-                  return (
-                    <li
-                      key={view.key}
-                      title={view.title}
-                      className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]"
-                      style={{ borderColor: tone.border, backgroundColor: tone.bg, color: tone.fg }}
-                    >
-                      <Icon className="size-3" aria-hidden />
-                      {view.label}
-                    </li>
-                  )
-                })}
-              </ul>
+          {/* Make the post-merge side effects explicit before the user confirms. */}
+          {source && target && source.name !== target.name && source.name !== 'main' && (
+            <div
+              className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
+              data-testid="merge-side-effect-notice"
+            >
+              <strong>After merge:</strong> switch automatically to "
+              <span className="font-semibold">{target.name}</span>" and delete "
+              <span className="font-semibold">{source.name}</span>
+              ".
             </div>
           )}
         </div>
-
-        {/* Make the post-merge side effects explicit before the user confirms. */}
-        {source && target && source.name !== target.name && source.name !== 'main' && (
-          <div
-            className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
-            data-testid="merge-side-effect-notice"
-          >
-            <strong>After merge:</strong> switch automatically to "<span className="font-semibold">{target.name}</span>" and delete "
-            <span className="font-semibold">{source.name}</span>
-            ".
-          </div>
-        )}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={onClose} disabled={committing}>

--- a/packages/mcp-server/src/app/components/MergeDialog.tsx
+++ b/packages/mcp-server/src/app/components/MergeDialog.tsx
@@ -92,11 +92,23 @@ function badgeLabel(badge: Record<string, unknown>): BadgeView {
 
 const TONE_STYLE: Record<
   BadgeView['tone'],
-  { fg: string; bg: string; border: string; icon: typeof AlertTriangle }
+  { fg: string; bg: string; border: string; icon: typeof AlertTriangle; summaryLabel: string }
 > = {
-  danger: { fg: '#dc2626', bg: '#fee2e2', border: '#fecaca', icon: AlertTriangle },
-  warning: { fg: '#d97706', bg: '#fef3c7', border: '#fde68a', icon: AlertTriangle },
-  info: { fg: '#1971c2', bg: '#dbeafe', border: '#bfdbfe', icon: Info },
+  danger: {
+    fg: '#dc2626',
+    bg: '#fee2e2',
+    border: '#fecaca',
+    icon: AlertTriangle,
+    summaryLabel: 'critical',
+  },
+  warning: {
+    fg: '#d97706',
+    bg: '#fef3c7',
+    border: '#fde68a',
+    icon: AlertTriangle,
+    summaryLabel: 'warning',
+  },
+  info: { fg: '#1971c2', bg: '#dbeafe', border: '#bfdbfe', icon: Info, summaryLabel: 'info' },
 }
 
 interface CompareCardProps {
@@ -457,10 +469,7 @@ export function MergeDialog({
                   <span className="text-xs text-muted-foreground">
                     {(['danger', 'warning', 'info'] as const)
                       .filter((t) => (badgeByTone[t] ?? 0) > 0)
-                      .map(
-                        (t) =>
-                          `${badgeByTone[t]} ${t === 'danger' ? 'critical' : t === 'warning' ? 'warning' : 'info'}`,
-                      )
+                      .map((t) => `${badgeByTone[t]} ${TONE_STYLE[t].summaryLabel}`)
                       .join(' · ')}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary

The MergeDialog's 3-pane preview grows taller than an 800px viewport; the Merge/Cancel footer fell below the fold with no scroll, making merge unreachable on laptop-height screens (Playwright real-click timed out 'outside of the viewport').

Fix in BOTH copies (packages/mcp-server original + apps/web port): DialogContent gets `max-h-[90dvh] overflow-hidden` with explicit grid rows `[auto_minmax(0,1fr)_auto]` — header fixed, body `min-h-0 overflow-y-auto`, footer always visible. Explicit row sizing is required because the shared DialogContent base class is a `grid`; max-height alone lets the implicit middle track expand.

## Test plan
- [x] Red-first mcp-browser regression (real app CSS imported): 1200x800 viewport, tall populated preview → confirm button in-viewport + body actually scrolls (scrollHeight > clientHeight); failed against pre-fix CSS
- [x] apps/web copy covered via merge-ui.browser.test.tsx extension (added the missing real-CSS import so layout assertions are meaningful)
- [x] Existing MergeDialog jsdom suites unchanged and green; typecheck green
- [x] Viewport override restored in afterEach (no leak into other tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)