### PR TITLE
fix(web): apply theme tokens to page root so dark mode text is readable

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -70,3 +70,16 @@
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
 }
+
+/*
+ * Without this, page chrome text (canvas title, header, teaser buttons)
+ * falls back to the UA-default black regardless of --foreground, since
+ * nothing else applies the design tokens to the actual page root. In dark
+ * mode that reads as unreadable black-on-black.
+ */
+@layer base {
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+  }
+}

--- a/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
+++ b/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
@@ -4,28 +4,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '../index.css'
 import WorkspaceTopBar from '../components/WorkspaceTopBar'
 
-function mkNamesResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      workspace: 'Design review',
-      canvases: { 'design/login-flow': 'Login flow' },
-      pinned: [],
-    }),
-    { status: 200, headers: { 'Content-Type': 'application/json' } },
-  )
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
 }
 
-function mkBranchesResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      head: 'main',
-      branches: [
-        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
-      ],
-    }),
-    { status: 200, headers: { 'Content-Type': 'application/json' } },
-  )
-}
+// Lightness thresholds for the 0..1 estimate below: text must read as light
+// (near-white) and dark backgrounds as near-black.
+const LIGHT = 0.7
+const DARK = 0.3
 
 // Normalizes a computed-style color string — Chromium reports `rgb(r, g, b)`
 // for sRGB values but `oklch(L C H)` for colors declared in the oklch
@@ -47,11 +36,25 @@ function lightness(color: string): number {
 beforeEach(() => {
   const fetchMock = vi.fn((input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString()
-    if (url.endsWith('/names')) return Promise.resolve(mkNamesResponse())
-    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
-    if (url.includes('/versions'))
-      return Promise.resolve(new Response(JSON.stringify({ versions: [] }), { status: 200 }))
-    return Promise.resolve(new Response('{}', { status: 200 }))
+    if (url.endsWith('/names'))
+      return Promise.resolve(
+        jsonResponse({
+          workspace: 'Design review',
+          canvases: { 'design/login-flow': 'Login flow' },
+          pinned: [],
+        }),
+      )
+    if (url.includes('/branches'))
+      return Promise.resolve(
+        jsonResponse({
+          head: 'main',
+          branches: [
+            { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+          ],
+        }),
+      )
+    if (url.includes('/versions')) return Promise.resolve(jsonResponse({ versions: [] }))
+    return Promise.resolve(jsonResponse({}))
   })
   vi.stubGlobal('fetch', fetchMock)
 })
@@ -75,17 +78,17 @@ describe('dark-mode chrome (root token application)', () => {
 
     // Root cause of the bug: without a `body { color: var(--foreground) }`
     // base-layer rule, UA default black wins regardless of the dark tokens.
-    expect(lightness(bodyColor)).toBeGreaterThan(0.7)
-    expect(lightness(bodyBackground)).toBeLessThan(0.3)
-    expect(lightness(elColor)).toBeGreaterThan(0.7)
+    expect(lightness(bodyColor)).toBeGreaterThan(LIGHT)
+    expect(lightness(bodyBackground)).toBeLessThan(DARK)
+    expect(lightness(elColor)).toBeGreaterThan(LIGHT)
   })
 
   it('body-inherited text stays near-black on a light background in light mode', () => {
     const { container } = render(<div data-testid="chrome-fixture-light">Canvas title</div>)
     const el = container.querySelector('[data-testid="chrome-fixture-light"]') as HTMLElement
 
-    expect(lightness(getComputedStyle(document.body).color)).toBeLessThan(0.3)
-    expect(lightness(getComputedStyle(el).color)).toBeLessThan(0.3)
+    expect(lightness(getComputedStyle(document.body).color)).toBeLessThan(DARK)
+    expect(lightness(getComputedStyle(el).color)).toBeLessThan(DARK)
   })
 
   it('WorkspaceTopBar (daemon-side chrome) inherits light text under .dark without any edit to that component', () => {
@@ -103,6 +106,6 @@ describe('dark-mode chrome (root token application)', () => {
     )
 
     const leaf = getByText('login-flow')
-    expect(lightness(getComputedStyle(leaf).color)).toBeGreaterThan(0.7)
+    expect(lightness(getComputedStyle(leaf).color)).toBeGreaterThan(LIGHT)
   })
 })

--- a/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
+++ b/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+// Real app styles — the bug is that these tokens never reach the page root.
+import '../index.css'
+import WorkspaceTopBar from '../components/WorkspaceTopBar'
+
+function mkNamesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      workspace: 'Design review',
+      canvases: { 'design/login-flow': 'Login flow' },
+      pinned: [],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkBranchesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      head: 'main',
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+// Normalizes a computed-style color string — Chromium reports `rgb(r, g, b)`
+// for sRGB values but `oklch(L C H)` for colors declared in the oklch
+// color space (our tokens) — into a 0..1 lightness estimate so tests can
+// assert "light" vs "near-black" without depending on an exact color or
+// color-space representation.
+function lightness(color: string): number {
+  if (color.startsWith('oklch')) {
+    const match = color.match(/oklch\(\s*([\d.]+)/)
+    if (!match) throw new Error(`unparsable oklch color: ${color}`)
+    return Number(match[1])
+  }
+  const match = color.match(/\d+(\.\d+)?/g)
+  if (!match) throw new Error(`unparsable color: ${color}`)
+  const [r, g, b] = match.map(Number)
+  return (r! + g! + b!) / (3 * 255)
+}
+
+beforeEach(() => {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith('/names')) return Promise.resolve(mkNamesResponse())
+    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+    if (url.includes('/versions'))
+      return Promise.resolve(new Response(JSON.stringify({ versions: [] }), { status: 200 }))
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+  document.documentElement.classList.remove('dark')
+})
+
+describe('dark-mode chrome (root token application)', () => {
+  it('body-inherited text is light on a dark background when .dark is on <html>', () => {
+    document.documentElement.classList.add('dark')
+
+    const { container } = render(<div data-testid="chrome-fixture">Canvas title</div>)
+    const el = container.querySelector('[data-testid="chrome-fixture"]') as HTMLElement
+
+    const bodyColor = getComputedStyle(document.body).color
+    const bodyBackground = getComputedStyle(document.body).backgroundColor
+    const elColor = getComputedStyle(el).color
+
+    // Root cause of the bug: without a `body { color: var(--foreground) }`
+    // base-layer rule, UA default black wins regardless of the dark tokens.
+    expect(lightness(bodyColor)).toBeGreaterThan(0.7)
+    expect(lightness(bodyBackground)).toBeLessThan(0.3)
+    expect(lightness(elColor)).toBeGreaterThan(0.7)
+  })
+
+  it('body-inherited text stays near-black on a light background in light mode', () => {
+    const { container } = render(<div data-testid="chrome-fixture-light">Canvas title</div>)
+    const el = container.querySelector('[data-testid="chrome-fixture-light"]') as HTMLElement
+
+    expect(lightness(getComputedStyle(document.body).color)).toBeLessThan(0.3)
+    expect(lightness(getComputedStyle(el).color)).toBeLessThan(0.3)
+  })
+
+  it('WorkspaceTopBar (daemon-side chrome) inherits light text under .dark without any edit to that component', () => {
+    document.documentElement.classList.add('dark')
+
+    const { getByText } = render(
+      <WorkspaceTopBar
+        workspaceId="sess_1"
+        slug="design/login-flow"
+        canvases={[{ slug: 'design/login-flow', updatedAt: '2026-04-24T11:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+      />,
+    )
+
+    const leaf = getByText('login-flow')
+    expect(lightness(getComputedStyle(leaf).color)).toBeGreaterThan(0.7)
+  })
+})

--- a/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
+++ b/apps/web/src/pages/dark-mode-chrome.browser.test.tsx
@@ -22,12 +22,14 @@ const DARK = 0.3
 // assert "light" vs "near-black" without depending on an exact color or
 // color-space representation.
 function lightness(color: string): number {
-  if (color.startsWith('oklch')) {
-    const match = color.match(/oklch\(\s*([\d.]+)/)
+  const normalized = color.trim().toLowerCase()
+  if (normalized === 'transparent') return 0
+  if (normalized.startsWith('oklch')) {
+    const match = normalized.match(/oklch\(\s*([\d.]+)/)
     if (!match) throw new Error(`unparsable oklch color: ${color}`)
     return Number(match[1])
   }
-  const match = color.match(/\d+(\.\d+)?/g)
+  const match = normalized.match(/\d+(\.\d+)?/g)
   if (!match) throw new Error(`unparsable color: ${color}`)
   const [r, g, b] = match.map(Number)
   return (r! + g! + b!) / (3 * 255)
@@ -91,10 +93,10 @@ describe('dark-mode chrome (root token application)', () => {
     expect(lightness(getComputedStyle(el).color)).toBeLessThan(DARK)
   })
 
-  it('WorkspaceTopBar (daemon-side chrome) inherits light text under .dark without any edit to that component', () => {
+  it('WorkspaceTopBar (daemon-side chrome) inherits light text under .dark without any edit to that component', async () => {
     document.documentElement.classList.add('dark')
 
-    const { getByText } = render(
+    const { findByText } = render(
       <WorkspaceTopBar
         workspaceId="sess_1"
         slug="design/login-flow"
@@ -105,7 +107,9 @@ describe('dark-mode chrome (root token application)', () => {
       />,
     )
 
-    const leaf = getByText('login-flow')
+    // Await the post-/names-fetch rename ('login-flow' → 'Login flow') so the
+    // async state update settles inside the test instead of warning after it.
+    const leaf = await findByText('Login flow')
     expect(lightness(getComputedStyle(leaf).color)).toBeGreaterThan(LIGHT)
   })
 })


### PR DESCRIPTION
## Summary

Design-audit CRITICAL: in dark mode, apps/web page chrome (canvas title, header, capability-teaser buttons) computed to `color: rgb(0,0,0)` on a near-black background — unreadable.

Root cause: `index.css` defines the light/dark token values and `useThemeMode` toggles the `dark` class correctly, but the shadcn-standard base layer that applies the tokens to the page root was missing — untokened text inherited UA-default black.

Fix: `@layer base { body { background-color: var(--background); color: var(--foreground); } }` (+ regression coverage).

## Test plan
- [x] Red-first web-browser computed-style test (real index.css + html.dark): body + mounted WorkspaceTopBar text resolve to a light color, not rgb(0,0,0); light mode asserted too (guards inversion)
- [x] Mutation check: reverting the base-layer rule sends both assertions red
- [x] Existing useThemeMode / WorkspaceTopBar suites green; typecheck green
- Visual verification screenshot to follow in a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)