### PR TITLE
test(mcp-server): add CanvasPage main render path jsdom coverage

### DIFF
--- a/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
+++ b/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Excalidraw is heavy and not relevant to CanvasPage's own render logic;
+// stub it to a lightweight marker so tests can assert the editor mounted
+// without pulling in the real canvas engine.
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: () => <div data-testid="excalidraw-stub" />,
+  exportToBlob: vi.fn(),
+  CaptureUpdateAction: { NEVER: 'never' },
+  restoreElements: vi.fn(),
+}))
+vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
+
+// Mutable state read by the mocked hook on every render so tests can drive
+// restoreInProgress / restoreLabel transitions across a rerender.
+const hookState: { restoreInProgress: boolean; restoreLabel: string | null } = {
+  restoreInProgress: false,
+  restoreLabel: null,
+}
+vi.mock('../hooks/useWhiteboardSync.js', () => ({
+  useWhiteboardSync: () => ({
+    onApiReady: vi.fn(),
+    onSceneChange: vi.fn(),
+    clearLocalUndo: vi.fn(),
+    restoreInProgress: hookState.restoreInProgress,
+    restoreLabel: hookState.restoreLabel,
+  }),
+}))
+
+vi.mock('../components/WorkspaceTopBar.js', () => ({
+  default: () => <div data-testid="workspace-top-bar" />,
+}))
+vi.mock('../components/MergeToast.js', () => ({
+  MergeToast: () => null,
+}))
+vi.mock('../components/MergeHighlight.js', () => ({
+  MergeHighlight: () => null,
+}))
+vi.mock('../components/HeaderBranchBanner.js', () => ({
+  HeaderBranchBanner: () => <div data-testid="header-branch-banner" />,
+}))
+
+// The canvases-list and libraries fetches are best-effort background loads;
+// keep them pending forever by default so tests only exercise CanvasPage's
+// own render branches, not the fetch resolution paths already covered by
+// CanvasPage.abort.test.tsx.
+const mockApiFetch = vi.fn()
+vi.mock('../lib/api-client.js', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+const { default: CanvasPage } = await import('./CanvasPage.js')
+
+function renderCanvasPage() {
+  return render(
+    <MemoryRouter initialEntries={['/canvas/sess_1/canvas-a']}>
+      <Routes>
+        <Route path="/canvas/:workspaceId/*" element={(<CanvasPage />) as ReactNode} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  hookState.restoreInProgress = false
+  hookState.restoreLabel = null
+  mockApiFetch.mockClear()
+  mockApiFetch.mockImplementation(() => new Promise(() => {}))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CanvasPage main render path', () => {
+  it('mounts the editor and top bar on initial render', async () => {
+    renderCanvasPage()
+    await act(async () => {})
+
+    expect(screen.getByTestId('excalidraw-stub')).toBeTruthy()
+    expect(screen.getByTestId('workspace-top-bar')).toBeTruthy()
+    expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
+  })
+
+  it('does not show the restore overlay while no restore is in progress', async () => {
+    renderCanvasPage()
+    await act(async () => {})
+
+    expect(screen.queryByText(/restoring version/i)).toBeNull()
+  })
+
+  it('shows the restore-in-progress overlay when a version restore starts', async () => {
+    hookState.restoreInProgress = true
+    hookState.restoreLabel = 'v3 · 2 hours ago'
+
+    renderCanvasPage()
+    await act(async () => {})
+
+    expect(screen.getByText(/restoring version/i)).toBeTruthy()
+    expect(screen.getByText('v3 · 2 hours ago')).toBeTruthy()
+    // The editor stays mounted underneath the overlay rather than unmounting.
+    expect(screen.getByTestId('excalidraw-stub')).toBeTruthy()
+  })
+
+  it('transitions from the restore overlay back to the normal view when restore completes', async () => {
+    hookState.restoreInProgress = true
+    hookState.restoreLabel = 'v3 · 2 hours ago'
+    const { rerender } = renderCanvasPage()
+    await act(async () => {})
+    expect(screen.getByText(/restoring version/i)).toBeTruthy()
+
+    hookState.restoreInProgress = false
+    hookState.restoreLabel = null
+    rerender(
+      <MemoryRouter initialEntries={['/canvas/sess_1/canvas-a']}>
+        <Routes>
+          <Route path="/canvas/:workspaceId/*" element={(<CanvasPage />) as ReactNode} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await act(async () => {})
+
+    expect(screen.queryByText(/restoring version/i)).toBeNull()
+  })
+
+  it('hides the chrome (top bar, branch banner) and shows the exit-fullscreen control when fullscreen is toggled on', async () => {
+    renderCanvasPage()
+    await act(async () => {})
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'f', bubbles: true })
+      window.dispatchEvent(event)
+    })
+
+    expect(screen.queryByTestId('workspace-top-bar')).toBeNull()
+    expect(screen.queryByTestId('header-branch-banner')).toBeNull()
+    expect(screen.getByTitle(/exit fullscreen/i)).toBeTruthy()
+    // The editor itself keeps rendering while only the surrounding chrome hides.
+    expect(screen.getByTestId('excalidraw-stub')).toBeTruthy()
+  })
+})

--- a/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
+++ b/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
@@ -55,14 +55,18 @@ vi.mock('../lib/api-client.js', () => ({
 
 const { default: CanvasPage } = await import('./CanvasPage.js')
 
-function renderCanvasPage() {
-  return render(
+function canvasPageTree() {
+  return (
     <MemoryRouter initialEntries={['/canvas/sess_1/canvas-a']}>
       <Routes>
         <Route path="/canvas/:workspaceId/*" element={(<CanvasPage />) as ReactNode} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   )
+}
+
+function renderCanvasPage() {
+  return render(canvasPageTree())
 }
 
 beforeEach(() => {
@@ -116,13 +120,7 @@ describe('CanvasPage main render path', () => {
 
     hookState.restoreInProgress = false
     hookState.restoreLabel = null
-    rerender(
-      <MemoryRouter initialEntries={['/canvas/sess_1/canvas-a']}>
-        <Routes>
-          <Route path="/canvas/:workspaceId/*" element={(<CanvasPage />) as ReactNode} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    rerender(canvasPageTree())
     await act(async () => {})
 
     expect(screen.queryByText(/restoring version/i)).toBeNull()

--- a/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
+++ b/packages/mcp-server/src/app/pages/CanvasPage.test.tsx
@@ -1,14 +1,28 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { type ReactNode, useEffect } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Excalidraw is heavy and not relevant to CanvasPage's own render logic;
 // stub it to a lightweight marker so tests can assert the editor mounted
-// without pulling in the real canvas engine.
+// without pulling in the real canvas engine. The stub DOES invoke the
+// excalidrawAPI callback on mount: CanvasPage polls apiRef for up to 5s,
+// and a never-set ref would leak that background timer loop into every
+// test in this file.
 vi.mock('@excalidraw/excalidraw', () => ({
-  Excalidraw: () => <div data-testid="excalidraw-stub" />,
+  Excalidraw: ({ excalidrawAPI }: { excalidrawAPI?: (api: unknown) => void }) => {
+    useEffect(() => {
+      excalidrawAPI?.({
+        updateScene: vi.fn(),
+        addFiles: vi.fn(),
+        getSceneElements: () => [],
+        getAppState: () => ({}),
+        getFiles: () => ({}),
+      })
+    }, [excalidrawAPI])
+    return <div data-testid="excalidraw-stub" />
+  },
   exportToBlob: vi.fn(),
   CaptureUpdateAction: { NEVER: 'never' },
   restoreElements: vi.fn(),


### PR DESCRIPTION
## Summary

Closes the CanvasPage jsdom test gap: the page previously had only abort/upload-error jsdom tests. Adds coverage for the main render path — initial editor+chrome mount, the restore-in-progress overlay lifecycle, and the fullscreen chrome-hiding branch.

Note: the backlog note assumed a distinct loading/load-error UI for the canvases/libraries fetches, but the component treats those as best-effort background loads with no error surface — the tests target the real state machine instead of inventing one.

Test-only change; no production files touched.

## Test plan
- [x] Targeted: 5/5 green (mcp-jsdom)
- [x] Full mcp-jsdom project: 298/298 green
- [x] typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)