### PR TITLE
docs: sync README and user docs with the shipped product for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ Add to `~/.gemini/settings.json`:
 
 In your agent session, ask it to call `canvas_create({ slug: "smoke" })`. The first call opens a Chromium tab pointed at the canvas and creates `~/.whiteboard/{workspaceId}/`.
 
+## Pair with your local daemon
+
+Already have the browser canvas open (see [Get started](docs/tutorials/getting-started.md))
+and a local daemon running? Ask your AI agent to call the `create_pairing_link`
+MCP tool. It mints a `#wb=` link that carries a short-lived bootstrap token —
+open it in your browser to connect that tab to the daemon's workspaces,
+version history, branches, and merge, with live sync over WebSocket.
+
+- Loopback web origins (`http://127.0.0.1:...`) need no extra configuration.
+- HTTPS hosted origins must be added to `WHITEBOARD_ALLOWED_WEB_ORIGINS`
+  (exact-match, no wildcards) before they can pair. This setting governs
+  local-daemon pairing only; [server mode](docs/how-to/self-host-with-docker.md)
+  reads the separate `WHITEBOARD_SERVER_ALLOWED_ORIGINS` variable instead.
+- Treat the pairing link like a credential: anyone who has it can pair with
+  your daemon until the token is rotated.
+
+See [Connect to a local daemon](docs/how-to/connect-to-local-daemon.md) for
+the full flow, including copy-first import of browser-local canvases.
+
 ## Bundled skills
 
 Three opinionated `SKILL.md` packs ship inside the npm package. The recommended **plugin install above wires them up automatically** — no manual linking. If you instead used `claude mcp add`, the Codex CLI snippet, or `npx`, link them yourself per [docs/contributing/development.md#bundled-skills-install](docs/contributing/development.md#bundled-skills-install).
@@ -183,7 +202,8 @@ The agent returns the `export_png` result as an MCP `ImageContent`, so the next 
 | Components, data flow, MCP tool surface, design boundaries | [docs/explanation/architecture.md](docs/explanation/architecture.md) |
 | Custom template fragment JSON format used by `template_insert` | [docs/reference/templates.md](docs/reference/templates.md) |
 | MCP debugging workflow (Inspector, `MCP_HTTP_DEBUG`, transport checks) | [docs/contributing/mcp-debugging.md](docs/contributing/mcp-debugging.md) |
-| Token-gated local HTTP, daemon trust model | [docs/explanation/security-model.md](docs/explanation/security-model.md) |
+| Trust model for all three runtimes (browser-local, local daemon, server mode) | [docs/explanation/security-model.md](docs/explanation/security-model.md) |
+| Pairing a browser tab to a local daemon, copy-first import | [docs/how-to/connect-to-local-daemon.md](docs/how-to/connect-to-local-daemon.md) |
 | WebSocket message shapes between daemon and browser | [docs/contributing/architecture/wire-protocol.md](docs/contributing/architecture/wire-protocol.md) |
 | Test layers, commit conventions, release process | [CONTRIBUTING.md](CONTRIBUTING.md) |
 

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -7,11 +7,10 @@ following step by step.
 Explanation pages:
 
 - **[architecture](architecture.md)** — components, data flow, MCP tool surface, and design boundaries.
-- **[security-model](security-model.md)** — trust boundaries, HTTP protections, and file-system safety.
+- **[security-model](security-model.md)** — the three runtimes (browser-local, local daemon, server mode), their separate trust boundaries, HTTP protections, and file-system safety.
 
 Planned:
 
-- **Runtime modes** — browser-local vs. local daemon vs. server mode, on one page.
 - **The local daemon** — how the loopback daemon is discovered and why.
 
 ← Back to [documentation home](../)

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -1,8 +1,17 @@
 # Security Model
 
-This server is currently designed for local use first.
+Whiteboard runs in one of three runtimes, each with its own trust model:
+**browser-local** (canvas data never leaves the browser's IndexedDB),
+**local daemon** (loopback-only server for MCP/agent work, covered below),
+and **server mode** (a shared server behind your own Identity Provider and
+TLS, covered in its own section and in
+[Self-host with Docker](../how-to/self-host-with-docker.md)). Do not read
+one runtime's trust model as describing another — local-daemon tokens and
+server-mode JWTs are separate credential systems and must never be mixed.
 
-## Trust boundary
+This page describes the **local daemon** in detail first, then server mode.
+
+## Local daemon: trust boundary
 
 - The daemon binds to `127.0.0.1` (not `localhost`) by default, restricting access to the loopback interface.
 - HTTP routes under `/api/*` apply auth in two layers. First, a global middleware protects all mutation methods (`POST`, `PUT`, `PATCH`, `DELETE`) under `/api/*` except `/api/runtime/*`, which has its own per-router middleware. Second, `/api/runtime/*` routes — including read-only endpoints such as `GET /api/runtime/status` and `GET /api/runtime/storage` — require a Bearer token for every request except `/api/runtime/ping`, which is an unauthenticated liveness probe. Canvas and workspace `GET` routes outside `/api/runtime/` are unauthenticated in local-daemon mode and serve canvas metadata to the local browser without requiring credentials.
@@ -13,6 +22,7 @@ This server is currently designed for local use first.
 
 - **Bearer token**: local HTTP clients must send `Authorization: Bearer <token>` when token auth is enabled. The token is written to `daemon.json` in the data directory (`~/.whiteboard` by default) so the stdio MCP server can locate the running daemon. The file is created with mode `0o600` (owner-read/write only) and is re-chmod'd after write on non-Windows platforms to counteract a permissive umask. Treat `daemon.json` as a credential file and ensure the data directory itself is not world-readable.
 - **Origin checks**: `/mcp` only allows loopback browser origins (`127.0.0.1`, `::1`, or `localhost`) for local HTTP use. All three resolve to the same loopback interface; allowing `localhost` is consistent with browser behavior across platforms.
+- **Hosted web-app pairing**: a browser app served from a non-loopback (hosted `https:`) origin can still pair with the local daemon, but only once that origin is listed in `WHITEBOARD_ALLOWED_WEB_ORIGINS` — a comma-separated, exact-match, HTTPS-only allowlist (no wildcards). Loopback origins need no allowlist entry. This env var governs the local daemon only; it is unrelated to server mode's origin allowlist below.
 - **Security headers**: the app serves `frame-ancestors 'none'`, `X-Frame-Options: DENY`, `nosniff`, `no-referrer`, and same-origin cross-origin headers.
 - **Debug route gate**: `/api/debug` is hidden unless `WHITEBOARD_DEBUG=1` is set, and still requires Bearer auth when a token exists.
 
@@ -31,8 +41,38 @@ Some operations require a connected browser client.
 
 These actions are routed through the daemon to the browser and fail fast when no browser client is connected.
 
+## Server mode: trust boundary
+
+Server mode (`whiteboard server run`, packaged as `Dockerfile.server` — see
+[Self-host with Docker](../how-to/self-host-with-docker.md)) is a separate,
+shipped deployment path for running whiteboard as a shared server beyond
+loopback. It uses its own credential system — **never mix local-daemon
+Bearer tokens with server-mode JWTs; they are not interchangeable.**
+
+- Every request is authenticated with a JWT issued by an external Identity
+  Provider (OAuth/JWT resource-server validation); the server itself does
+  not issue or manage user credentials.
+- Cross-origin access is restricted by `WHITEBOARD_SERVER_ALLOWED_ORIGINS`,
+  an explicit `https://` allowlist — wildcards are rejected. This is a
+  distinct setting from the local daemon's `WHITEBOARD_ALLOWED_WEB_ORIGINS`
+  above; the two are read by different code paths and never consult each
+  other.
+- The container binds plain HTTP on loopback only; **TLS termination is the
+  operator's responsibility**, done by a reverse proxy in front of the
+  container (nginx, Caddy, Traefik, …). Server mode is not safe to expose
+  directly to the internet without that proxy in place.
+- Server mode is only as secure as its operator's configuration: a
+  correctly configured Identity Provider, a correctly scoped origin
+  allowlist, and TLS termination are all prerequisites the operator must
+  provide — server mode does not ship "safe out of the box" without them.
+
 ## Current limitations
 
-- The project is local-first, not a fully productized remote MCP deployment.
-- OAuth 2.1 metadata plumbing exists for future remote readiness, but the default trust model is still local loopback plus Bearer token.
-- Storage quotas, telemetry policy, and remote threat-model docs are still separate follow-up items.
+- Server mode is shipped and used today for team/remote deployments (see
+  above); it is not itself production-hardened beyond what is documented on
+  this page — treat it as "usable with a competent operator," not
+  "zero-configuration safe."
+- Storage quotas, telemetry policy, and remote threat-model docs are still
+  separate follow-up items: this page describes trust boundaries and
+  protections as implemented, not a vetted threat model for adversarial
+  remote environments.

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -53,13 +53,16 @@ Bearer tokens with server-mode JWTs; they are not interchangeable.**
   Provider (OAuth/JWT resource-server validation); the server itself does
   not issue or manage user credentials.
 - Cross-origin access is restricted by `WHITEBOARD_SERVER_ALLOWED_ORIGINS`,
-  an explicit `https://` allowlist — wildcards are rejected. This is a
-  distinct setting from the local daemon's `WHITEBOARD_ALLOWED_WEB_ORIGINS`
-  above; the two are read by different code paths and never consult each
-  other.
-- The container binds plain HTTP on loopback only; **TLS termination is the
-  operator's responsibility**, done by a reverse proxy in front of the
-  container (nginx, Caddy, Traefik, …). Server mode is not safe to expose
+  an explicit `https://` allowlist (defaulting to
+  `WHITEBOARD_SERVER_EXTERNAL_URL` when unset) — wildcards are rejected.
+  This is a distinct setting from the local daemon's
+  `WHITEBOARD_ALLOWED_WEB_ORIGINS` above; the two are read by different
+  code paths and never consult each other.
+- The container binds plain HTTP to **all interfaces (`0.0.0.0`) by
+  default** (`WHITEBOARD_SERVER_HOST` overrides this); **TLS termination is
+  the operator's responsibility**, done by a reverse proxy in front of the
+  container (nginx, Caddy, Traefik, …). Mapping the port straight to a
+  public interface exposes plain HTTP — server mode is not safe to expose
   directly to the internet without that proxy in place.
 - Server mode is only as secure as its operator's configuration: a
   correctly configured Identity Provider, a correctly scoped origin

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -14,9 +14,11 @@ pnpm install
 pnpm dev          # open http://localhost:5173
 ```
 
-This is a minimal browser-local canvas: click **Add rectangle** to add an element
-and watch the counter go up, then reload the tab — the elements are still there.
-That's your canvas persisting in your own browser, with no server and no account.
+The page mounts a full Excalidraw canvas. Pick the rectangle tool from the
+toolbar (or press `r`) and draw a shape, then reload the tab — the shape is
+still there. That's your canvas persisting to IndexedDB in your own browser,
+with no server and no account. Draw, close the tab, and come back later: the
+same canvas is right where you left it.
 
 **Where to go next:** want your AI agent (Claude Code, Codex, Gemini) to draw with
 you, or durable canvases as files on disk? That's the **Local daemon** — see


### PR DESCRIPTION
## Summary

Release-facing user docs refresh — honesty pass against the shipped code (each commit body cites the source files it was verified against):

- **README**: adds a 'Pair with your local daemon' section (ask your AI agent to call `create_pairing_link` → open the `#wb=` link; loopback origins need no allowlist; HTTPS hosted origins need `WHITEBOARD_ALLOWED_WEB_ORIGINS`, exact-match, local-daemon mode only) and refreshes the three-modes story + doc table. No hosted URL invented — provisional-origin wording kept consistent with `pages-origin-policy.ts`.
- **tutorials/getting-started**: replaces the fictional 'Add rectangle / counter' walkthrough (that UI never shipped) with the real Excalidraw flow + reload-persistence check.
- **explanation/security-model**: server mode is shipped, not 'future' — three runtimes with separate trust models (browser-local / local-daemon token / server JWT), operator-responsibility note (TLS, IdP, origins), cross-link to the Docker how-to; remote threat-model follow-up caveat preserved.
- how-to/connect-to-local-daemon cross-checked against the shipped flow — no drift found, unchanged.

## Test plan
- [x] Drift greps clean ('Add rectangle' gone; no 'future remote readiness' relabeling)
- [x] All relative links in touched files resolve
- [x] Docs-only; no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)