### PR TITLE
test(web): lock no-setState-in-render warnings for BrowserLocalCanvasPage and CanvasThumb

### DIFF
--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -5,6 +5,13 @@ import { CanvasThumb } from './CanvasThumb.js'
 
 afterEach(() => cleanup())
 
+// React's warning text for a same-component setState-during-render violation
+// (as opposed to the sanctioned "adjust state during render for the current
+// component" pattern, which never triggers this). Wording has drifted across
+// React 18/19 point releases, so the match stays tolerant of both phrasings.
+const REACT_SETSTATE_IN_RENDER_RE =
+  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
+
 describe('CanvasThumb', () => {
   it('renders an img pointed at the latest-thumbnail route, url-encoding the slug', () => {
     const { container } = render(<CanvasThumb workspaceId="ws-1" slug="my canvas/x" />)
@@ -50,6 +57,20 @@ describe('CanvasThumb', () => {
     const wrapper = container.firstElementChild as HTMLElement
     expect(wrapper.className).toContain('h-9')
     expect(wrapper.className).toContain('w-14')
+  })
+
+  it('does not trigger a React setState-in-render warning when the guarded prevSrc reset runs on a src change', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { rerender } = render(<CanvasThumb workspaceId="ws-1" slug="canvas-a" />)
+    // Changing slug changes `src`, which drives the guarded prevSrc reset
+    // (CanvasThumb.tsx L37-41) during this render — the React-sanctioned
+    // "adjust state during render" form, not the cross-component violation.
+    rerender(<CanvasThumb workspaceId="ws-1" slug="canvas-b" />)
+    const matchingCalls = errorSpy.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === 'string' && REACT_SETSTATE_IN_RENDER_RE.test(arg)),
+    )
+    expect(matchingCalls).toEqual([])
+    errorSpy.mockRestore()
   })
 
   it('renders the fallback placeholder instead of an <img> when a DaemonApiContext provider is mounted (cross-origin)', () => {

--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -55,13 +55,16 @@ describe('CanvasThumb', () => {
 
   it('does not trigger a React setState-in-render warning when the guarded prevSrc reset runs on a src change', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const { rerender } = render(<CanvasThumb workspaceId="ws-1" slug="canvas-a" />)
-    // Changing slug changes `src`, which drives the guarded prevSrc reset
-    // (CanvasThumb.tsx L37-41) during this render — the React-sanctioned
-    // "adjust state during render" form, not the cross-component violation.
-    rerender(<CanvasThumb workspaceId="ws-1" slug="canvas-b" />)
-    assertNoSetStateInRenderWarning(errorSpy)
-    errorSpy.mockRestore()
+    try {
+      const { rerender } = render(<CanvasThumb workspaceId="ws-1" slug="canvas-a" />)
+      // Changing slug changes `src`, which drives the guarded prevSrc reset
+      // (CanvasThumb.tsx L37-41) during this render — the React-sanctioned
+      // "adjust state during render" form, not the cross-component violation.
+      rerender(<CanvasThumb workspaceId="ws-1" slug="canvas-b" />)
+      assertNoSetStateInRenderWarning(errorSpy)
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 
   it('renders the fallback placeholder instead of an <img> when a DaemonApiContext provider is mounted (cross-origin)', () => {

--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -1,16 +1,10 @@
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DaemonApiContext } from '@/contexts/DaemonApiContext'
+import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
 import { CanvasThumb } from './CanvasThumb.js'
 
 afterEach(() => cleanup())
-
-// React's warning text for a same-component setState-during-render violation
-// (as opposed to the sanctioned "adjust state during render for the current
-// component" pattern, which never triggers this). Wording has drifted across
-// React 18/19 point releases, so the match stays tolerant of both phrasings.
-const REACT_SETSTATE_IN_RENDER_RE =
-  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
 
 describe('CanvasThumb', () => {
   it('renders an img pointed at the latest-thumbnail route, url-encoding the slug', () => {
@@ -66,10 +60,7 @@ describe('CanvasThumb', () => {
     // (CanvasThumb.tsx L37-41) during this render — the React-sanctioned
     // "adjust state during render" form, not the cross-component violation.
     rerender(<CanvasThumb workspaceId="ws-1" slug="canvas-b" />)
-    const matchingCalls = errorSpy.mock.calls.filter((args) =>
-      args.some((arg) => typeof arg === 'string' && REACT_SETSTATE_IN_RENDER_RE.test(arg)),
-    )
-    expect(matchingCalls).toEqual([])
+    assertNoSetStateInRenderWarning(errorSpy)
     errorSpy.mockRestore()
   })
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -606,35 +606,37 @@ describe('BrowserLocalCanvasPage', () => {
 
   it('never triggers a React setState-in-render warning across mount, canvas switch, and create-canvas', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
-    await act(async () => {
-      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
-    })
-    await act(async () => {
-      await vi.runAllTimersAsync()
-    })
-    assertNoSetStateInRenderWarning(errorSpy)
+    try {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
+      await act(async () => {
+        render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+      })
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+      assertNoSetStateInRenderWarning(errorSpy)
 
-    // Canvas switch re-renders CanvasTitle with a new key/props.
-    const switcher = screen.getByRole('combobox', { name: /canvases/i })
-    await act(async () => {
-      fireEvent.change(switcher, { target: { value: 'c2' } })
-      await vi.runAllTimersAsync()
-    })
-    assertNoSetStateInRenderWarning(errorSpy)
+      // Canvas switch re-renders CanvasTitle with a new key/props.
+      const switcher = screen.getByRole('combobox', { name: /canvases/i })
+      await act(async () => {
+        fireEvent.change(switcher, { target: { value: 'c2' } })
+        await vi.runAllTimersAsync()
+      })
+      assertNoSetStateInRenderWarning(errorSpy)
 
-    // Create-canvas flow drives another switch + re-render.
-    const newBtn = screen.getByRole('button', { name: /new canvas/i })
-    await act(async () => {
-      newBtn.click()
-      await vi.runAllTimersAsync()
-    })
-    assertNoSetStateInRenderWarning(errorSpy)
-
-    errorSpy.mockRestore()
+      // Create-canvas flow drives another switch + re-render.
+      const newBtn = screen.getByRole('button', { name: /new canvas/i })
+      await act(async () => {
+        newBtn.click()
+        await vi.runAllTimersAsync()
+      })
+      assertNoSetStateInRenderWarning(errorSpy)
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 
   describe('daemon-only capability teasers', () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -78,6 +78,21 @@ const snap: CanvasSnapshot = {
   updatedAt: '2026-05-24T00:00:00.000Z',
 }
 
+// React's warning text for an unguarded/cross-component setState-during-render
+// violation. Distinct from the sanctioned "adjust state during render for the
+// current component" pattern (see CanvasThumb's guarded prevSrc reset), which
+// never triggers this. Wording has drifted across React 18/19 point releases,
+// so the match stays tolerant of both phrasings.
+const REACT_SETSTATE_IN_RENDER_RE =
+  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
+
+function assertNoSetStateInRenderWarning(errorSpy: ReturnType<typeof vi.spyOn>): void {
+  const matchingCalls = (errorSpy.mock.calls as unknown[][]).filter((args) =>
+    args.some((arg) => typeof arg === 'string' && REACT_SETSTATE_IN_RENDER_RE.test(arg)),
+  )
+  expect(matchingCalls).toEqual([])
+}
+
 describe('BrowserLocalCanvasPage', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => {
@@ -601,6 +616,39 @@ describe('BrowserLocalCanvasPage', () => {
     // The stale (generation 2) resolution must not clobber the fresh one.
     const optionNames = screen.getAllByRole('option').map((o) => o.textContent)
     expect(optionNames).toEqual(['untitled (fresh)'])
+  })
+
+  it('never triggers a React setState-in-render warning across mount, canvas switch, and create-canvas', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await store.save({ id: 'c2', name: 'Other canvas', updatedAt: '2026-05-25T00:00:00.000Z' })
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+    assertNoSetStateInRenderWarning(errorSpy)
+
+    // Canvas switch re-renders CanvasTitle with a new key/props.
+    const switcher = screen.getByRole('combobox', { name: /canvases/i })
+    await act(async () => {
+      fireEvent.change(switcher, { target: { value: 'c2' } })
+      await vi.runAllTimersAsync()
+    })
+    assertNoSetStateInRenderWarning(errorSpy)
+
+    // Create-canvas flow drives another switch + re-render.
+    const newBtn = screen.getByRole('button', { name: /new canvas/i })
+    await act(async () => {
+      newBtn.click()
+      await vi.runAllTimersAsync()
+    })
+    assertNoSetStateInRenderWarning(errorSpy)
+
+    errorSpy.mockRestore()
   })
 
   describe('daemon-only capability teasers', () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -4,6 +4,7 @@ import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import { BROWSER_LOCAL_CAPABILITIES } from '../lib/provider.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import type { LoroStoreLike } from './use-browser-local-canvas-controller.js'
 
@@ -76,21 +77,6 @@ const snap: CanvasSnapshot = {
   id: 'c1',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
-}
-
-// React's warning text for an unguarded/cross-component setState-during-render
-// violation. Distinct from the sanctioned "adjust state during render for the
-// current component" pattern (see CanvasThumb's guarded prevSrc reset), which
-// never triggers this. Wording has drifted across React 18/19 point releases,
-// so the match stays tolerant of both phrasings.
-const REACT_SETSTATE_IN_RENDER_RE =
-  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
-
-function assertNoSetStateInRenderWarning(errorSpy: ReturnType<typeof vi.spyOn>): void {
-  const matchingCalls = (errorSpy.mock.calls as unknown[][]).filter((args) =>
-    args.some((arg) => typeof arg === 'string' && REACT_SETSTATE_IN_RENDER_RE.test(arg)),
-  )
-  expect(matchingCalls).toEqual([])
 }
 
 describe('BrowserLocalCanvasPage', () => {

--- a/apps/web/src/test-utils/no-setstate-in-render.test.ts
+++ b/apps/web/src/test-utils/no-setstate-in-render.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assertNoSetStateInRenderWarning } from './no-setstate-in-render.js'
+
+function spyWithCalls(calls: unknown[][]): ReturnType<typeof vi.spyOn> {
+  const target = { error: (..._args: unknown[]) => {} }
+  const spy = vi.spyOn(target, 'error')
+  for (const args of calls) {
+    target.error(...args)
+  }
+  return spy
+}
+
+describe('assertNoSetStateInRenderWarning', () => {
+  it('passes when no console.error calls were captured', () => {
+    const spy = spyWithCalls([])
+
+    expect(() => assertNoSetStateInRenderWarning(spy)).not.toThrow()
+  })
+
+  it('passes when an unrelated console.error call was captured', () => {
+    const spy = spyWithCalls([['Warning: Failed prop type: some other warning']])
+
+    expect(() => assertNoSetStateInRenderWarning(spy)).not.toThrow()
+  })
+
+  it('fails on the "Cannot update a component while rendering a different component" phrasing', () => {
+    const spy = spyWithCalls([
+      [
+        'Warning: Cannot update a component (`CanvasList`) while rendering a different component (`CanvasThumb`).',
+      ],
+    ])
+
+    expect(() => assertNoSetStateInRenderWarning(spy)).toThrow()
+  })
+
+  it('fails on the "Cannot update a component while rendering a different component" phrasing without a backtick-quoted component name', () => {
+    const spy = spyWithCalls([['Cannot update a component while rendering a different component.']])
+
+    expect(() => assertNoSetStateInRenderWarning(spy)).toThrow()
+  })
+
+  it('fails on the generic "setState ... during ... render" phrasing', () => {
+    const spy = spyWithCalls([
+      ['Warning: Cannot update state (via setState) during an existing render.'],
+    ])
+
+    expect(() => assertNoSetStateInRenderWarning(spy)).toThrow()
+  })
+})

--- a/apps/web/src/test-utils/no-setstate-in-render.ts
+++ b/apps/web/src/test-utils/no-setstate-in-render.ts
@@ -6,7 +6,7 @@ import { expect, vi } from 'vitest'
 // never triggers this. Wording has drifted across React 18/19 point releases,
 // so the match stays tolerant of both phrasings.
 const REACT_SETSTATE_IN_RENDER_RE =
-  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
+  /Cannot update a component .*?while rendering a different component|Warning:.*setState.*during.*render/i
 
 /**
  * Asserts that none of the `console.error` calls captured by `errorSpy` were a

--- a/apps/web/src/test-utils/no-setstate-in-render.ts
+++ b/apps/web/src/test-utils/no-setstate-in-render.ts
@@ -1,0 +1,21 @@
+import { expect, vi } from 'vitest'
+
+// React's warning text for an unguarded/cross-component setState-during-render
+// violation. Distinct from the sanctioned "adjust state during render for the
+// current component" pattern (e.g. CanvasThumb's guarded prevSrc reset), which
+// never triggers this. Wording has drifted across React 18/19 point releases,
+// so the match stays tolerant of both phrasings.
+const REACT_SETSTATE_IN_RENDER_RE =
+  /Cannot update a component (\(`[^`]*`\) )?while rendering a different component|Warning:.*setState.*during.*render/i
+
+/**
+ * Asserts that none of the `console.error` calls captured by `errorSpy` were a
+ * React setState-in-render warning. Scoped to that specific warning (not "zero
+ * console.error calls") so intentional error logging on other paths is allowed.
+ */
+export function assertNoSetStateInRenderWarning(errorSpy: ReturnType<typeof vi.spyOn>): void {
+  const matchingCalls = (errorSpy.mock.calls as unknown[][]).filter((args) =>
+    args.some((arg) => typeof arg === 'string' && REACT_SETSTATE_IN_RENDER_RE.test(arg)),
+  )
+  expect(matchingCalls).toEqual([])
+}


### PR DESCRIPTION
## Summary

Backlog closure with a twist: the alleged setState-in-render defect in BrowserLocalCanvasPage turned out to be a false positive — no render-phase setState exists there, and CanvasThumb's guarded prevSrc reset is the React-sanctioned same-component pattern. Instead of a production change, this locks the property with regression tests:

- Shared `assertNoSetStateInRenderWarning` helper (console.error spy scoped to React's cross-component/render-phase warning regex — NOT zero-console.error, which would false-fail the intentional listCanvases-failure log)
- BrowserLocalCanvasPage: mount, canvas switch, create flow → zero matching warnings
- CanvasThumb: src-prop change drives the guarded reset branch → zero matching warnings (negative control proving the matcher doesn't flag the sanctioned pattern)
- Mutation-checked: an injected unguarded render-phase setState turns the assertion red

## Test plan
- [x] 35/35 green (both suites), typecheck green
- [x] Mutation check executed (positive red / negative green), not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure canvas thumbnail updates do not produce React render warnings.
  * Added integration coverage for switching canvases and creating a canvas without warnings.
  * Added validation for detecting common React “setState during render” warnings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->