### PR TITLE
chore: add a testable seam and CI-wired regression tests for cleanup-worktrees

### DIFF
--- a/.claude/scripts/cleanup-worktrees.mjs
+++ b/.claude/scripts/cleanup-worktrees.mjs
@@ -15,7 +15,11 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const repoRoot = resolve(__dirname, '../..')
+// Overridable so tests can point the script at a throwaway git repo instead
+// of the real one this file lives in.
+const repoRoot = process.env.CLEANUP_WORKTREES_REPO_ROOT
+  ? resolve(process.env.CLEANUP_WORKTREES_REPO_ROOT)
+  : resolve(__dirname, '../..')
 const worktreesDir = join(repoRoot, '.claude', 'worktrees')
 const dryRun = process.argv.includes('--dry-run')
 const storePrune = process.argv.includes('--store-prune')
@@ -72,55 +76,60 @@ for (const entry of entries) {
     continue
   }
 
-  // A tip that is an ancestor of origin/main means the lane has NO unique
-  // commits — either freshly created from the current tip, or created from
-  // an older main that has since advanced. This repo squash-merges, so
-  // ancestry is NEVER evidence of a fold: a genuinely merged lane's tip is
-  // not reachable from main. Such no-unique-work lanes may still host a
-  // RUNNING dev-loop that just hasn't committed yet, so keep them unless
+  // A tip that is an ancestor of origin/main (including tip === mainTip) has
+  // no unique commits ahead of main — that covers both a freshly-created
+  // lane with no work yet AND a "stale-base" lane branched from an older
+  // origin/main that has since advanced. Either way there may still be a
+  // RUNNING dev-loop that just hasn't committed yet, so keep it unless
   // --include-fresh explicitly opts in.
-  let isAncestor = false
+  let noUniqueCommits = false
   try {
-    git(['merge-base', '--is-ancestor', tip, 'origin/main'])
-    isAncestor = true
+    execFileSync('git', ['merge-base', '--is-ancestor', tip, 'origin/main'], { cwd: repoRoot })
+    noUniqueCommits = true
   } catch {
-    /* has unique commits */
+    noUniqueCommits = false
   }
-  if (isAncestor && !includeFresh) {
-    console.log(
-      `keep ${entry.name}: no unique commits (fresh/stale-base lane; use --include-fresh to remove)`,
-    )
+
+  if (noUniqueCommits && !includeFresh) {
+    console.log(`keep ${entry.name}: no unique commits ahead of origin/main (fresh/stale-base lane; use --include-fresh to remove)`)
     kept++
     continue
   }
 
-  let merged = isAncestor // only reachable with --include-fresh
-  if (!merged && branch) {
-    // The only trustworthy fold signal in a squash-merge flow: the branch was
-    // published (git push -u records upstream = its own name on origin) and
-    // the remote side has since been deleted (gh merge --delete-branch and
-    // our PR flow both do that on merge). A lane that was NEVER published
-    // also has no remote ref — deleting it would destroy
-    // committed-but-unpushed work, so it does not count.
-    let wasPublished = false
-    try {
-      const mergeRef = git(['config', '--get', `branch.${branch}.merge`])
-      // Also require the upstream REMOTE to be origin: in a fork workflow
-      // the upstream may live on another remote, whose refs we neither
-      // fetch nor prune here — treating its absence under origin/ as
-      // "deleted" would force-delete a live lane. (Creating a lane from
+  let merged = noUniqueCommits
+  if (!merged) {
+    // Squash-merged branches are not ancestors of main; fall back to
+    // "remote branch deleted" as the merged signal (gh merge --delete-branch
+    // and our PR flow both delete the remote ref on merge). But a lane that
+    // was NEVER published (new-worktree.mjs creates the branch locally; only
+    // `git push -u` sets an upstream) also has no remote ref — deleting it
+    // would destroy committed-but-unpushed work. Only treat a missing remote
+    // ref as "folded" when the branch had an upstream configured, i.e. it
+    // was pushed at some point and the remote side has since been deleted.
+    if (branch) {
+      // "Published" means the upstream points at the branch's own name on the
+      // remote (what `git push -u` records). Creating a lane from
       // origin/main auto-sets upstream to refs/heads/main via
-      // branch.autoSetupMerge, so a bare "has upstream" check is not enough.)
-      const remote = git(['config', '--get', `branch.${branch}.remote`])
-      wasPublished = mergeRef === `refs/heads/${branch}` && remote === 'origin'
-    } catch {
-      /* never published */
-    }
-    if (wasPublished) {
+      // branch.autoSetupMerge, so a bare "has upstream" check would misread
+      // every never-pushed lane as published.
+      let wasPublished = false
       try {
-        git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`])
+        const mergeRef = git(['config', '--get', `branch.${branch}.merge`])
+        // Also require the upstream REMOTE to be origin: in a fork workflow
+        // the upstream may live on another remote, whose refs we neither
+        // fetch nor prune here — treating its absence under origin/ as
+        // "deleted" would force-delete a live lane.
+        const remote = git(['config', '--get', `branch.${branch}.remote`])
+        wasPublished = mergeRef === `refs/heads/${branch}` && remote === 'origin'
       } catch {
-        merged = true // was published, remote gone → folded
+        /* never published */
+      }
+      if (wasPublished) {
+        try {
+          git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`])
+        } catch {
+          merged = true // was published, remote gone → folded
+        }
       }
     }
   }

--- a/.claude/scripts/cleanup-worktrees.mjs
+++ b/.claude/scripts/cleanup-worktrees.mjs
@@ -84,7 +84,7 @@ for (const entry of entries) {
   // --include-fresh explicitly opts in.
   let noUniqueCommits = false
   try {
-    execFileSync('git', ['merge-base', '--is-ancestor', tip, 'origin/main'], { cwd: repoRoot })
+    git(['merge-base', '--is-ancestor', tip, 'origin/main'])
     noUniqueCommits = true
   } catch {
     noUniqueCommits = false

--- a/.claude/scripts/cleanup-worktrees.test.mjs
+++ b/.claude/scripts/cleanup-worktrees.test.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Regression coverage for cleanup-worktrees.mjs's merged/fresh detection.
+// Run with: node --test .claude/scripts/cleanup-worktrees.test.mjs
+//
+// Builds a throwaway "origin" + working repo pair per test (not the real
+// repo) and points the script at it via CLEANUP_WORKTREES_REPO_ROOT.
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { after, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const scriptPath = resolve(__dirname, 'cleanup-worktrees.mjs')
+
+const scratchDirs = []
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim()
+}
+
+function makeScratch() {
+  const dir = mkdtempSync(join(tmpdir(), 'cleanup-worktrees-test-'))
+  scratchDirs.push(dir)
+  return dir
+}
+
+/** Sets up: bare origin, a "seed" clone used to author commits, and a
+ * "repo" clone that owns .claude/worktrees (the thing under test). */
+function setupRepos(scratch) {
+  const originDir = join(scratch, 'origin.git')
+  const seedDir = join(scratch, 'seed')
+  const repoDir = join(scratch, 'repo')
+
+  git(scratch, ['init', '--bare', '--quiet', originDir])
+  git(scratch, ['clone', '--quiet', originDir, seedDir])
+  git(seedDir, ['config', 'user.email', 't@example.com'])
+  git(seedDir, ['config', 'user.name', 'Test'])
+  git(seedDir, ['commit', '--allow-empty', '--quiet', '-m', 'A'])
+  git(seedDir, ['branch', '-M', 'main'])
+  git(seedDir, ['push', '--quiet', 'origin', 'main'])
+
+  git(scratch, ['clone', '--quiet', originDir, repoDir])
+  git(repoDir, ['config', 'user.email', 't@example.com'])
+  git(repoDir, ['config', 'user.name', 'Test'])
+  mkdirSync(join(repoDir, '.claude', 'worktrees'), { recursive: true })
+
+  return { originDir, seedDir, repoDir }
+}
+
+function runCleanup(repoDir, extraArgs = []) {
+  return execFileSync('node', [scriptPath, '--dry-run', ...extraArgs], {
+    cwd: repoDir,
+    encoding: 'utf-8',
+    env: { ...process.env, CLEANUP_WORKTREES_REPO_ROOT: repoDir },
+  })
+}
+
+after(() => {
+  for (const dir of scratchDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('keeps a stale-base fresh lane (no unique commits, but origin/main advanced) unless --include-fresh', () => {
+  const scratch = makeScratch()
+  const { seedDir, repoDir } = setupRepos(scratch)
+
+  const laneDir = join(repoDir, '.claude', 'worktrees', 'lane-x')
+  git(repoDir, ['worktree', 'add', '--quiet', '-b', 'lane-x', laneDir, 'origin/main'])
+
+  // origin/main advances past the lane's branch point — the lane's tip is a
+  // strict ancestor of origin/main, not equal to it, but still has no
+  // unique commits of its own.
+  git(seedDir, ['commit', '--allow-empty', '--quiet', '-m', 'B'])
+  git(seedDir, ['push', '--quiet', 'origin', 'main'])
+
+  const withoutFlag = runCleanup(repoDir)
+  assert.match(withoutFlag, /keep lane-x/, 'stale-base fresh lane must be kept without --include-fresh')
+  assert.doesNotMatch(withoutFlag, /would remove lane-x/)
+
+  const withFlag = runCleanup(repoDir, ['--include-fresh'])
+  assert.match(withFlag, /would remove lane-x/, '--include-fresh should still allow removing it')
+})
+
+test('removes a squash-merged lane whose remote branch was deleted after merge (unique commits, not an ancestor)', () => {
+  const scratch = makeScratch()
+  const { seedDir, repoDir } = setupRepos(scratch)
+
+  const laneDir = join(repoDir, '.claude', 'worktrees', 'lane-squashed')
+  git(repoDir, ['worktree', 'add', '--quiet', '-b', 'lane-squashed', laneDir, 'origin/main'])
+  git(laneDir, ['config', 'user.email', 't@example.com'])
+  git(laneDir, ['config', 'user.name', 'Test'])
+  git(laneDir, ['commit', '--allow-empty', '--quiet', '-m', 'lane work'])
+  // git push -u records upstream = refs/heads/lane-squashed on origin, which
+  // is what marks the branch as "published" for the fallback signal below.
+  git(repoDir, ['push', '--quiet', '-u', 'origin', 'lane-squashed'])
+
+  // Simulate a squash-merge: origin/main gets a brand new commit (not an
+  // ancestor-preserving merge) and the PR flow deletes the remote branch.
+  git(seedDir, ['commit', '--allow-empty', '--quiet', '-m', 'squash-merged lane work'])
+  git(seedDir, ['push', '--quiet', 'origin', 'main'])
+  git(seedDir, ['push', '--quiet', 'origin', '--delete', 'lane-squashed'])
+
+  const output = runCleanup(repoDir)
+  assert.match(
+    output,
+    /would remove lane-squashed/,
+    'a published lane whose remote branch was deleted after a squash-merge should be removable without --include-fresh'
+  )
+})

--- a/.claude/scripts/cleanup-worktrees.test.mjs
+++ b/.claude/scripts/cleanup-worktrees.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Regression coverage for cleanup-worktrees.mjs's merged/fresh detection.
-// Run with: node --test .claude/scripts/cleanup-worktrees.test.mjs
+// Run with: pnpm test:scripts (also wired into the CI "check" job).
 //
 // Builds a throwaway "origin" + working repo pair per test (not the real
 // repo) and points the script at it via CLEANUP_WORKTREES_REPO_ROOT.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Secret scan (secretlint)
         run: pnpm secretlint
 
+      # cleanup-worktrees.mjs can force-remove worktrees and delete local
+      # branches; keep its regression test enforced in the same gate as the
+      # other repo-hygiene tooling checks.
+      - name: Test dev scripts (node --test)
+        run: pnpm test:scripts
+
       # Staged biome adoption: enforce the AGENTS.md "no console.* in server
       # runtime" rule in CI. Full biome check is not wired yet (the repo still
       # carries pre-existing format/organizeImports violations); this gate stops

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lint:fix": "biome check --write .",
     "lint:noconsole": "biome lint --only=lint/suspicious/noConsole --diagnostic-level=error packages/mcp-server/src/server",
     "secretlint": "secretlint --secretlintignore .secretlintignore \"**/*\"",
+    "test:scripts": "node --test .claude/scripts/*.test.mjs",
     "prepare": "lefthook install || true"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Follow-up hardening for the cleanup script after #177 (an active lane was force-deleted before that fix):

- `CLEANUP_WORKTREES_REPO_ROOT` env override so tests can point the script at a throwaway git repo instead of the real one
- node:test regression suite covering the keep-by-default ancestry policy (fresh/stale-base lanes kept, published+remote-deleted lanes removed)
- `test:scripts` wired into the CI check job so future drift in the delete policy fails a merge gate instead of deleting someone's lane

Semantics are identical to #177 (ancestor ⇒ keep unless `--include-fresh`; published+remote-gone is the sole default fold signal).

## Test plan
- [x] `node --test .claude/scripts/cleanup-worktrees.test.mjs` → 2/2 pass
- [x] Keep-by-default guard verified present post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)