### PR TITLE
fix(mcp-server,web): root-fix the two recurring CI test flakes

### DIFF
--- a/apps/web/src/lib/browser-local-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-local-backend.browser.test.tsx
@@ -9,6 +9,12 @@ import { BrowserLocalBackend } from './browser-local-backend.js'
 import { DB_VERSION } from './browser-idb.js'
 import type { CanvasBackendHandlers } from '@kamiazya/whiteboard-mcp/browser-contract'
 
+// Generous timeout: async IDB reads under CI load can take well over the
+// 200ms fixed sleeps this file used to rely on. Waiting on the concrete
+// handler call (instead of wall-clock time) keeps the test both fast on a
+// healthy machine and stable under CI load.
+const WAIT_TIMEOUT = 10_000
+
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
     const req = indexedDB.deleteDatabase('whiteboard')
@@ -51,8 +57,12 @@ describe('BrowserLocalBackend', () => {
     const handlers = makeHandlers()
     const backend = new BrowserLocalBackend('canvas-1')
     backend.connect(handlers)
-    // Give async IDB reads a moment
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
     expect(handlers.onConnected).toHaveBeenCalledTimes(1)
     expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
     const snapshotBytes = (handlers.onSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0]
@@ -67,16 +77,26 @@ describe('BrowserLocalBackend', () => {
     const seedBackend = new BrowserLocalBackend('canvas-1')
     const seedHandlers = makeHandlers()
     seedBackend.connect(seedHandlers)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(seedHandlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
+    // pushLocalUpdate is awaited to completion, so the write is durable
+    // before disconnect() — no additional wait needed here.
     await seedBackend.pushLocalUpdate(initial)
     seedBackend.disconnect()
-
-    await new Promise((r) => setTimeout(r, 200))
 
     const handlers = makeHandlers()
     const backend = new BrowserLocalBackend('canvas-1')
     backend.connect(handlers)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
     expect(handlers.onRemoteUpdate).not.toHaveBeenCalled()
@@ -95,19 +115,29 @@ describe('BrowserLocalBackend', () => {
     const backend1 = new BrowserLocalBackend('canvas-1')
     const h1 = makeHandlers()
     backend1.connect(h1)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(h1.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
-    // Push snapshot then delta
+    // Push snapshot then delta — both awaited, so both writes are durable
+    // before disconnect().
     await backend1.pushLocalUpdate(snapshot)
     await backend1.pushLocalUpdate(delta)
     backend1.disconnect()
-    await new Promise((r) => setTimeout(r, 200))
 
     // Reload
     const backend2 = new BrowserLocalBackend('canvas-1')
     const h2 = makeHandlers()
     backend2.connect(h2)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(h2.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     expect(h2.onSnapshot).toHaveBeenCalledTimes(1)
     // Delta replayed as onRemoteUpdate
@@ -128,14 +158,12 @@ describe('BrowserLocalBackend', () => {
     const handlers = makeHandlers()
     backend.connect(handlers)
     backend.disconnect()
-    await new Promise((r) => setTimeout(r, 300))
-    // onConnected fires synchronously before disconnect in this test,
-    // so we only assert onSnapshot does not fire after disconnect.
-    const snapshotCallCount = (handlers.onSnapshot as ReturnType<typeof vi.fn>).mock.calls.length
-    await new Promise((r) => setTimeout(r, 300))
-    expect((handlers.onSnapshot as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
-      snapshotCallCount,
-    )
+    // Absence assertion: vi.waitFor can only prove a callback DID fire, not
+    // that it never will, so this is the one deliberately bounded drain
+    // left in this file — long enough for the in-flight IDB read started
+    // by connect() to settle before we assert it produced no callback.
+    await new Promise((r) => setTimeout(r, 250))
+    expect(handlers.onSnapshot).not.toHaveBeenCalled()
   })
 
   it('getFile returns null (deferred OPFS — not implemented in 3-C)', async () => {
@@ -176,7 +204,12 @@ describe('BrowserLocalBackend', () => {
     const backend = new BrowserLocalBackend('canvas-1')
     const handlers = makeHandlers()
     backend.connect(handlers)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
     // Empty bytes: early return, no throw, no onError
     await expect(backend.pushLocalUpdate(new Uint8Array(0))).resolves.toBeUndefined()
     expect(handlers.onError).not.toHaveBeenCalled()
@@ -190,9 +223,17 @@ describe('BrowserLocalBackend', () => {
     const handlers = makeHandlers()
     const backend = new BrowserLocalBackend('canvas-corrupt')
     backend.connect(handlers)
-    await new Promise((r) => setTimeout(r, 200))
+    // connect()'s own load surfaces the corrupt record as onError first.
+    await vi.waitFor(
+      () => {
+        expect(handlers.onError).toHaveBeenCalled()
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
-    // Push a delta — should detect corrupt existing and route to onError
+    // Push a delta — should detect corrupt existing and route to onError.
+    // pushLocalUpdate is awaited, so the resulting onError call is
+    // synchronous with the resolved promise; no additional wait needed.
     const delta = new Uint8Array([1, 2, 3])
     await backend.pushLocalUpdate(delta)
     expect(handlers.onError).toHaveBeenCalledWith('storage-failure')
@@ -214,7 +255,12 @@ describe('BrowserLocalBackend', () => {
     const backend = new BrowserLocalBackend('canvas-race')
     const handlers = makeHandlers()
     backend.connect(handlers)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     // Push snapshot first to establish the record
     await backend.pushLocalUpdate(snapshot)
@@ -226,7 +272,12 @@ describe('BrowserLocalBackend', () => {
     const backend2 = new BrowserLocalBackend('canvas-race')
     const h2 = makeHandlers()
     backend2.connect(h2)
-    await new Promise((r) => setTimeout(r, 300))
+    await vi.waitFor(
+      () => {
+        expect(h2.onRemoteUpdate).toHaveBeenCalledTimes(2)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
     expect(h2.onRemoteUpdate).toHaveBeenCalledTimes(2)
     backend2.disconnect()
   })
@@ -238,7 +289,12 @@ describe('BrowserLocalBackend', () => {
     const h2 = makeHandlers()
     const backend2 = new BrowserLocalBackend('canvas-v99')
     backend2.connect(h2)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(h2.onError).toHaveBeenCalledWith('unsupported-version')
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     expect(h2.onError).toHaveBeenCalledWith('unsupported-version')
     expect(h2.onSnapshot).not.toHaveBeenCalled()
@@ -251,7 +307,12 @@ describe('BrowserLocalBackend', () => {
     const h = makeHandlers()
     const backend = new BrowserLocalBackend('canvas-bad-bytes')
     backend.connect(h)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(h.onError).toHaveBeenCalledWith('corrupt-snapshot')
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     expect(h.onError).toHaveBeenCalledWith('corrupt-snapshot')
     expect(h.onSnapshot).not.toHaveBeenCalled()
@@ -268,7 +329,12 @@ describe('BrowserLocalBackend', () => {
     const h = makeHandlers()
     const backend = new BrowserLocalBackend('canvas-bad-delta')
     backend.connect(h)
-    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(
+      () => {
+        expect(h.onError).toHaveBeenCalledWith('corrupt-delta')
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
 
     expect(h.onError).toHaveBeenCalledWith('corrupt-delta')
     expect(h.onSnapshot).not.toHaveBeenCalled()

--- a/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.test.tsx
@@ -259,6 +259,87 @@ describe('StorageReportCard', () => {
     STATUS_CLEAR_MS + 5000,
   )
 
+  it('clears the pending status-clear timer on unmount so no fake timer survives teardown', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') return Promise.resolve(jsonResponse(PAYLOAD))
+      if (url === '/api/workspaces') return Promise.resolve(jsonResponse({ workspaces: [] }))
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    const { container, unmount } = render(<StorageReportCard />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    const blobsActions = container.querySelector('[data-storage-actions="blobs"]')!
+    const button = blobsActions.querySelector('button')!
+    fireEvent.click(button)
+    await act(async () => {
+      // Let optimizeAll settle (empty workspace list resolves immediately)
+      // so its finally block schedules a STATUS_CLEAR_MS timer.
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears every in-flight status-clear timer on unmount, even when multiple actions overlap', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url === '/api/runtime/storage') return Promise.resolve(jsonResponse(PAYLOAD))
+      if (url === '/api/workspaces') return Promise.resolve(jsonResponse({ workspaces: [] }))
+      if (init?.method === 'POST' && url === '/api/runtime/logs/prune') {
+        return Promise.resolve(jsonResponse({ purgedCount: 0, purgedBytes: 0 }))
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+
+    const { container, unmount } = render(<StorageReportCard />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    // Trigger two independent status-clear call sites (Optimize + Prune
+    // logs) before either one's timer has fired, so two pending
+    // STATUS_CLEAR_MS timeouts are in flight simultaneously. A single
+    // scalar ref for the last-scheduled id would overwrite the first and
+    // leak it — this test fails against that shape.
+    const blobsButton = container.querySelector('[data-storage-actions="blobs"] button')!
+    fireEvent.click(blobsButton)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    const logsButton = container.querySelector('[data-storage-actions="logs"] button')!
+    fireEvent.click(logsButton)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears the in-flight min-refresh timer immediately on unmount, before it would naturally fire', async () => {
+    const { unmount } = render(<StorageReportCard />)
+    // Flush the initial mount-time refresh()'s fetch microtask so it
+    // reaches the finally block and schedules the MIN_REFRESH_MS delay
+    // timer, without letting that delay elapse yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    unmount()
+    // The MIN_REFRESH_MS delay has not elapsed yet — without an explicit
+    // clearTimeout on unmount this timer would still be pending here.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('humanises the "Updated …" line and ticks across humanise boundaries without per-second flicker', async () => {
     const { container } = render(<StorageReportCard />)
     // Settle the initial fetch + min-refresh delay. The fresh fetch lands

--- a/packages/mcp-server/src/app/components/StorageReportCard.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.tsx
@@ -172,21 +172,21 @@ export function StorageReportCard() {
     } finally {
       const elapsed = Date.now() - start
       const remaining = MIN_REFRESH_MS - elapsed
-      if (remaining > 0) {
-        // This setTimeout is scheduled inside `finally`, so it always runs
-        // even when refresh() was invoked on a since-unmounted component
-        // (unmount cannot pre-empt the finally block of an already-awaited
-        // try) — this scheduling can happen well after unmount, once the
-        // environment itself (jsdom `window`) may already be torn down.
+      // The mountedRef guard matters: this `finally` can run AFTER unmount
+      // (unmount cannot pre-empt the finally of an already-awaited try), and
+      // by then the cleanup effect has already flushed pendingTimersRef — a
+      // timer scheduled here would never be cleared. Post-unmount the delay
+      // is pointless anyway (it only rate-limits visible refreshes), so skip
+      // straight through.
+      if (remaining > 0 && mountedRef.current) {
         // Use the bare global setTimeout/clearTimeout here, NOT
         // `window.setTimeout` — referencing `window` at call time throws
-        // "window is not defined" once it has been torn down, whereas the
+        // "window is not defined" once a jsdom env is torn down, whereas the
         // global timer functions do not depend on `window` existing. Track
         // the id in the same pendingTimersRef Set so a just-in-time unmount
-        // still clears it. If unmount races ahead of this line, the promise
-        // below is left forever-pending — harmless, since the resumed
-        // setLoading(false) is guarded by mountedRef and the whole closure
-        // becomes GC-eligible once unreachable.
+        // still clears it; the then-forever-pending promise is harmless
+        // (setLoading below is mountedRef-guarded, closure becomes
+        // GC-eligible).
         await new Promise<void>((resolve) => {
           const id = setTimeout(() => {
             pendingTimersRef.current.delete(id)

--- a/packages/mcp-server/src/app/components/StorageReportCard.tsx
+++ b/packages/mcp-server/src/app/components/StorageReportCard.tsx
@@ -109,19 +109,37 @@ export function StorageReportCard() {
   // the callback resumes (e.g. end-of-test-file jsdom teardown racing a
   // pending setTimeout), the same call throws.
   const mountedRef = useRef(true)
+  // Tracks every window.setTimeout id this component has scheduled but not
+  // yet seen fire (status-clear timers from four independent call sites,
+  // plus refresh()'s MIN_REFRESH_MS delay). A single scalar ref cannot hold
+  // this: two actions (e.g. Optimize then Prune logs) can each have their
+  // own status-clear timer pending at once, and a scalar would silently
+  // overwrite the first id, leaking it. Cleared on unmount so no timer
+  // survives to fire after the surrounding test/page environment is torn
+  // down.
+  const pendingTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
+      // Bare clearTimeout (not window.clearTimeout) for the same reason as
+      // the MIN_REFRESH_MS scheduling below — it must not assume `window`
+      // is still around.
+      for (const id of pendingTimersRef.current) {
+        clearTimeout(id)
+      }
+      pendingTimersRef.current.clear()
     }
   }, [])
 
   // Clear a transient action status after STATUS_CLEAR_MS, skipping the
   // setState if the component unmounted while the timer was pending.
   const scheduleStatusClear = useCallback((clear: () => void) => {
-    window.setTimeout(() => {
+    const id = setTimeout(() => {
+      pendingTimersRef.current.delete(id)
       if (mountedRef.current) clear()
     }, STATUS_CLEAR_MS)
+    pendingTimersRef.current.add(id)
   }, [])
 
   // Coarse tick so the "Updated …" / "Auto-optimised …" lines stay live
@@ -155,7 +173,27 @@ export function StorageReportCard() {
       const elapsed = Date.now() - start
       const remaining = MIN_REFRESH_MS - elapsed
       if (remaining > 0) {
-        await new Promise((resolve) => setTimeout(resolve, remaining))
+        // This setTimeout is scheduled inside `finally`, so it always runs
+        // even when refresh() was invoked on a since-unmounted component
+        // (unmount cannot pre-empt the finally block of an already-awaited
+        // try) — this scheduling can happen well after unmount, once the
+        // environment itself (jsdom `window`) may already be torn down.
+        // Use the bare global setTimeout/clearTimeout here, NOT
+        // `window.setTimeout` — referencing `window` at call time throws
+        // "window is not defined" once it has been torn down, whereas the
+        // global timer functions do not depend on `window` existing. Track
+        // the id in the same pendingTimersRef Set so a just-in-time unmount
+        // still clears it. If unmount races ahead of this line, the promise
+        // below is left forever-pending — harmless, since the resumed
+        // setLoading(false) is guarded by mountedRef and the whole closure
+        // becomes GC-eligible once unreachable.
+        await new Promise<void>((resolve) => {
+          const id = setTimeout(() => {
+            pendingTimersRef.current.delete(id)
+            resolve()
+          }, remaining)
+          pendingTimersRef.current.add(id)
+        })
       }
       if (mountedRef.current) {
         setLoading(false)


### PR DESCRIPTION
## Summary

Two flakes hit 3 different PRs today; both root-fixed:

**Flake 1 — browser-local-backend.browser.test.tsx (failed CI twice: 'expected 1 call, got 0')**
All 16 fixed `setTimeout(200|300)` sleeps replaced with deterministic waits: assertion-preceding sleeps → `vi.waitFor` on the concrete handler then the UNCHANGED original assertions; flow-sequencing sleeps → waits on the preceding completion signal. Only the post-disconnect negative test keeps one documented bounded drain (absence cannot be waited for).

**Flake 2 — mcp-jsdom post-run 'ReferenceError: window is not defined' (job failed with 293/293 tests passing)**
Root cause: StorageReportCard leaked timers — `scheduleStatusClear` discarded ids from 4 call sites, and `refresh()`'s MIN_REFRESH_MS delay awaited an uncancellable Promise-wrapped setTimeout. Fix: a pending-timers Set (self-removing on fire) covering both sources, cleared in the existing mount-guard effect's cleanup. Red-first regression tests incl. the multi-action case that fails against a scalar-ref implementation.

## Test plan
- [x] Converted browser file: 5 consecutive green runs (14/14 each)
- [x] mcp-jsdom: 301/301, no post-run unhandled error
- [x] typecheck green; no assertions weakened

🤖 Generated with [Claude Code](https://claude.com/claude-code)