### PR TITLE
feat(web): render the real daemon editor for the local-daemon provider state

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -101,6 +101,21 @@ describe('App backend configuration chip', () => {
     expect(screen.queryByText('Browser only')).toBeNull()
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
   })
+
+  it('lets the browser-local escape override invalid-config after a failed pairing', () => {
+    // A pairing error can coexist with an invalid runtime config; clicking
+    // "Continue in browser-local" must land on the browser-local page, not
+    // bounce the user onto the invalid-config error page.
+    mockDaemonConnectionResult = { status: 'error', detail: 'malformed fragment' }
+    try {
+      render(<App providerState={INVALID_CONFIG_STATE} />)
+      fireEvent.click(screen.getByRole('button', { name: /continue in browser-local/i }))
+      expect(screen.getByTestId('browser-local-canvas-page')).toBeTruthy()
+      expect(screen.queryByText('Runtime configuration is invalid.')).toBeNull()
+    } finally {
+      mockDaemonConnectionResult = { status: 'none' }
+    }
+  })
 })
 
 describe('App capability wiring', () => {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,9 +1,14 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { resetTokenStoreForTests } from '@kamiazya/whiteboard-mcp/api-client'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
-import type { ProviderState, WhiteboardCapabilities } from './lib/provider.js'
+import {
+  BROWSER_LOCAL_CAPABILITIES,
+  type ProviderState,
+  type WhiteboardCapabilities,
+} from './lib/provider.js'
 
 afterEach(cleanup)
 
@@ -178,6 +183,75 @@ describe('App daemon-pairing routing', () => {
     render(<App providerState={BROWSER_LOCAL_STATE} />)
     expect(screen.getByTestId('browser-local-canvas-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
+  })
+})
+
+describe('App local-daemon provider state', () => {
+  beforeEach(() => {
+    receivedDaemonPageProps = undefined
+    resetTokenStoreForTests()
+    delete (window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__
+  })
+  afterEach(() => {
+    resetTokenStoreForTests()
+    delete (window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__
+  })
+
+  it('mounts DaemonCanvasPage instead of the placeholder, with no workspaceId/slug', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(screen.queryByTestId('browser-local-canvas-page')).toBeNull()
+    expect(screen.queryByText('Whiteboard')).toBeNull()
+    expect(receivedDaemonPageProps?.daemonBaseUrl).toBe(LOCAL_DAEMON_STATE.daemonBaseUrl)
+    expect(receivedDaemonPageProps?.workspaceId).toBeUndefined()
+    expect(receivedDaemonPageProps?.slug).toBeUndefined()
+    expect(receivedDaemonPageProps?.capabilities).toEqual(LOCAL_DAEMON_STATE.capabilities)
+    expect(receivedDaemonPageProps?.browserLocalStore).toBeDefined()
+    expect(receivedDaemonPageProps?.onContinueBrowserLocal).toBeInstanceOf(Function)
+  })
+
+  it('passes the daemon-injected token when present', async () => {
+    ;(window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__ = 'tok-x'
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(receivedDaemonPageProps?.token).toBe('tok-x')
+  })
+
+  it('mounts gracefully with token undefined when the daemon has not injected one', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(receivedDaemonPageProps?.token).toBeUndefined()
+  })
+
+  it('escapes to browser-local with BROWSER_LOCAL_CAPABILITIES and neutral chip/banner copy', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-canvas-page')
+    const onContinueBrowserLocal = receivedDaemonPageProps?.onContinueBrowserLocal as () => void
+    act(() => {
+      onContinueBrowserLocal()
+    })
+    expect(screen.getByTestId('browser-local-canvas-page')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
+    expect(receivedCapabilities).toEqual(BROWSER_LOCAL_CAPABILITIES)
+    expect(screen.getByText('Browser only')).toBeTruthy()
+    expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
+    expect(
+      screen.getByText('Beta preview — your data is stored only in this browser.'),
+    ).toBeTruthy()
+    expect(screen.queryByText('Beta preview — features may be incomplete.')).toBeNull()
+  })
+
+  it('catches an error surfacing through the local-daemon lazy path (boundary outside Suspense)', async () => {
+    throwInDaemonCanvasPage = true
+    const reportSpy = vi.spyOn(errorBoundaryLog, 'report').mockImplementation(() => {})
+    try {
+      render(<App providerState={LOCAL_DAEMON_STATE} />)
+      expect(await screen.findByText('Something went wrong')).toBeTruthy()
+      expect(reportSpy).toHaveBeenCalled()
+    } finally {
+      throwInDaemonCanvasPage = false
+      reportSpy.mockRestore()
+    }
   })
 })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,15 +1,22 @@
+import { readDaemonTokenOnce } from '@kamiazya/whiteboard-mcp/api-client'
 import { lazy, Suspense, useState } from 'react'
 import { BetaBanner } from './components/BetaBanner.js'
 import { ErrorBoundary } from './components/ErrorBoundary.js'
 import { useDaemonConnection } from './hooks/useDaemonConnection.js'
 import { IndexedDBStore } from './lib/browser-local-store.js'
-import { type ProviderState, resolveHostedProviderStateFromRaw } from './lib/provider.js'
+import {
+  BROWSER_LOCAL_CAPABILITIES,
+  type ProviderState,
+  resolveHostedProviderStateFromRaw,
+} from './lib/provider.js'
 import { createUserSettingsStore } from './lib/user-settings-store.js'
 import { BrowserLocalCanvasPage } from './pages/BrowserLocalCanvasPage.js'
 
 // Lazy so the daemon stack (DaemonBackend, ws-protocol, api client) stays out
-// of the entry chunk — only sessions arriving via a #wb= pairing fragment pay
-// for it, keeping the browser-local entry under the bundle-size budget.
+// of the entry chunk — sessions arriving via a #wb= pairing fragment AND
+// sessions with a runtime-config local-daemon provider state pay for it;
+// pure browser-local sessions never import it, keeping that entry under the
+// bundle-size budget.
 const DaemonCanvasPage = lazy(() =>
   import('./pages/DaemonCanvasPage.js').then((m) => ({ default: m.DaemonCanvasPage })),
 )
@@ -135,17 +142,47 @@ export function App({ providerState }: AppProps) {
     )
   }
 
-  if (state.kind === 'local-daemon') {
+  // The 'Continue in browser-local' escape hatch collapses a local-daemon
+  // state to browser-local capabilities, so every downstream consumer (chip,
+  // banner, canvas page) reads this effective state rather than the raw one
+  // — otherwise the escape could leave daemon capabilities or copy leaking
+  // into a mode the user explicitly opted out of.
+  const effectiveState =
+    forcedBrowserLocal && state.kind === 'local-daemon'
+      ? { kind: 'browser-local' as const, capabilities: BROWSER_LOCAL_CAPABILITIES }
+      : state
+
+  if (effectiveState.kind === 'local-daemon') {
     return (
       <ErrorBoundary>
-        <main data-provider="local-daemon" data-status="placeholder">
+        <div className="flex h-dvh flex-col">
           <BetaBanner
             store={userSettingsStore}
             message="Beta preview — features may be incomplete."
           />
-          <BackendConfigChip state={state} />
-          <h1>Whiteboard</h1>
-        </main>
+          <BackendConfigChip state={effectiveState} />
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <Suspense
+              fallback={
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="flex h-full items-center justify-center text-sm text-muted-foreground"
+                >
+                  Connecting to daemon…
+                </div>
+              }
+            >
+              <DaemonCanvasPage
+                daemonBaseUrl={effectiveState.daemonBaseUrl}
+                capabilities={effectiveState.capabilities}
+                token={readDaemonTokenOnce() ?? undefined}
+                browserLocalStore={browserLocalStore}
+                onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+              />
+            </Suspense>
+          </div>
+        </div>
       </ErrorBoundary>
     )
   }
@@ -161,9 +198,12 @@ export function App({ providerState }: AppProps) {
           store={userSettingsStore}
           message="Beta preview — your data is stored only in this browser."
         />
-        <BackendConfigChip state={state} />
+        <BackendConfigChip state={effectiveState} />
         <div className="min-h-0 flex-1 overflow-hidden">
-          <BrowserLocalCanvasPage store={browserLocalStore} capabilities={state.capabilities} />
+          <BrowserLocalCanvasPage
+            store={browserLocalStore}
+            capabilities={effectiveState.capabilities}
+          />
         </div>
       </div>
     </ErrorBoundary>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,6 +42,22 @@ interface BackendConfigChipProps {
   state: Exclude<ProviderState, { kind: 'invalid-config' }>
 }
 
+// Suspense fallback while the lazy daemon chunk loads. The height class
+// differs by mount site (root fills the viewport; the local-daemon branch
+// fills the flex row under the banner), so it's a prop; the copy stays shared
+// so the two mount sites can't drift.
+function DaemonConnectingFallback({ heightClass }: { heightClass: string }) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`flex ${heightClass} items-center justify-center text-sm text-muted-foreground`}
+    >
+      Connecting to daemon…
+    </div>
+  )
+}
+
 // Reports the configured storage backend only — this reflects runtime
 // config, not a live connection/detection probe. Do not claim 'Connected'
 // or 'Daemon unavailable' here; that needs an actual live probe.
@@ -81,17 +97,7 @@ export function App({ providerState }: AppProps) {
         // propagates through Suspense's own error path to the nearest
         // boundary, which must be here to catch it.
         <ErrorBoundary>
-          <Suspense
-            fallback={
-              <div
-                role="status"
-                aria-live="polite"
-                className="flex h-dvh items-center justify-center text-sm text-muted-foreground"
-              >
-                Connecting to daemon…
-              </div>
-            }
-          >
+          <Suspense fallback={<DaemonConnectingFallback heightClass="h-dvh" />}>
             <DaemonCanvasPage
               daemonBaseUrl={payload.baseUrl}
               workspaceId={payload.workspaceId}
@@ -162,17 +168,7 @@ export function App({ providerState }: AppProps) {
           />
           <BackendConfigChip state={effectiveState} />
           <div className="min-h-0 flex-1 overflow-hidden">
-            <Suspense
-              fallback={
-                <div
-                  role="status"
-                  aria-live="polite"
-                  className="flex h-full items-center justify-center text-sm text-muted-foreground"
-                >
-                  Connecting to daemon…
-                </div>
-              }
-            >
+            <Suspense fallback={<DaemonConnectingFallback heightClass="h-full" />}>
               <DaemonCanvasPage
                 daemonBaseUrl={effectiveState.daemonBaseUrl}
                 capabilities={effectiveState.capabilities}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -86,6 +86,10 @@ export function App({ providerState }: AppProps) {
   // fragment) falls through to that existing resolution unchanged.
   const daemonConnection = useDaemonConnection()
   const [forcedBrowserLocal, setForcedBrowserLocal] = useState(false)
+  // Lazy initializer: readDaemonTokenOnce() consumes (deletes) the injected
+  // global, so it must run exactly once per mount — calling it in the render
+  // body would let StrictMode's double-render read-then-lose the token.
+  const [daemonToken] = useState(() => readDaemonTokenOnce() ?? undefined)
 
   // The 'Continue in browser-local' escape hatch opts out of the pairing
   // fragment entirely, so once it's set both daemon branches are skipped.
@@ -138,25 +142,26 @@ export function App({ providerState }: AppProps) {
 
   const state = providerState ?? _defaultProviderState
 
-  if (state.kind === 'invalid-config') {
+  // The 'Continue in browser-local' escape hatch collapses a local-daemon OR
+  // invalid-config state to browser-local capabilities, so every downstream
+  // consumer (chip, banner, canvas page) reads this effective state rather
+  // than the raw one — otherwise the escape could leave daemon capabilities
+  // or copy leaking into a mode the user explicitly opted out of, or bounce
+  // a failed-pairing escape onto the invalid-config error page.
+  const effectiveState =
+    forcedBrowserLocal && (state.kind === 'local-daemon' || state.kind === 'invalid-config')
+      ? { kind: 'browser-local' as const, capabilities: BROWSER_LOCAL_CAPABILITIES }
+      : state
+
+  if (effectiveState.kind === 'invalid-config') {
     return (
       <ErrorBoundary>
         <main data-provider="invalid-config">
-          <p>{state.message}</p>
+          <p>{effectiveState.message}</p>
         </main>
       </ErrorBoundary>
     )
   }
-
-  // The 'Continue in browser-local' escape hatch collapses a local-daemon
-  // state to browser-local capabilities, so every downstream consumer (chip,
-  // banner, canvas page) reads this effective state rather than the raw one
-  // — otherwise the escape could leave daemon capabilities or copy leaking
-  // into a mode the user explicitly opted out of.
-  const effectiveState =
-    forcedBrowserLocal && state.kind === 'local-daemon'
-      ? { kind: 'browser-local' as const, capabilities: BROWSER_LOCAL_CAPABILITIES }
-      : state
 
   if (effectiveState.kind === 'local-daemon') {
     return (
@@ -172,7 +177,7 @@ export function App({ providerState }: AppProps) {
               <DaemonCanvasPage
                 daemonBaseUrl={effectiveState.daemonBaseUrl}
                 capabilities={effectiveState.capabilities}
-                token={readDaemonTokenOnce() ?? undefined}
+                token={daemonToken}
                 browserLocalStore={browserLocalStore}
                 onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
               />


### PR DESCRIPTION
## Summary

MCP-UI retirement slice R1 (parity audit CRITICAL): when a daemon injects `daemonBaseUrl` into runtime config, apps/web rendered only a placeholder `<main data-status="placeholder">` — serving apps/web from the daemon would have replaced the working editor with a stub.

- The local-daemon branch now mounts the real lazy `DaemonCanvasPage` (same ErrorBoundary-outside-Suspense pattern as the paired branch): `daemonBaseUrl` from provider state, token read at render time via `readDaemonTokenOnce()` (daemon's own out-of-band global; token-absent renders fine — loopback authMode none), no workspaceId/slug so the workspace/canvas pickers show, browser-local import disclosure wired.\n- 'Continue in browser-local' escape computes an effective provider state (collapses to `browser-local` + `BROWSER_LOCAL_CAPABILITIES`) consumed by ALL downstream UI — chip, banner, capabilities — so post-escape nothing half-claims daemon mode.\n- `#wb=` pairing precedence over the local-daemon state is asserted by test so a refactor can't reorder it.\n\nR3 note: daemon-side same-origin serving must inject `__WHITEBOARD_RUNTIME_CONFIG__.daemonBaseUrl` + `__WHITEBOARD_DAEMON_TOKEN__` (mirroring app.ts:887-898) — packages/mcp-server untouched here by design.

## Test plan
- [x] Red-first App.test.tsx rewrite: real-mount assertions, token-global setup/teardown, post-escape semantics (capabilities+chip+banner), pairing-precedence guard — 17/17 green
- [x] typecheck green; provider.ts and all other files byte-identical (diff = App.tsx + App.test.tsx only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local-daemon canvas rendering with daemon capabilities and token support.
  * Added a “Continue in browser-local” option when daemon access is unavailable.
  * Added loading and error states for daemon connection and canvas startup.
  * Improved browser-local and local-daemon status messaging and capability display.

* **Bug Fixes**
  * Ensured browser-local fallback uses the correct page, capabilities, and status indicators.
  * Improved handling when daemon token injection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->