### PR TITLE
fix(mcp-server): cancel auto-compact debounce timers and in-flight work on DB dispose

### DIFF
--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -25,7 +25,10 @@ const {
   compactCanvas,
   scheduleAutoCompact,
   setAutoCompactTrigger,
+  disposeAutoCompact,
+  _inFlightAutoCompactCountForTests,
 } = await import('./canvas-store.js')
+const { captureLogsForTests } = await import('../log.js')
 const { FileVersionStore } = await import('./version-store.js')
 const { createIsolatedDb } = await import('./db/test-helpers.js')
 
@@ -631,6 +634,7 @@ describe('auto-compact', () => {
 
   afterEach(async () => {
     setAutoCompactTrigger(null)
+    await disposeAutoCompact()
     await teardownIsolatedDb()
     await rm(tempDir, { recursive: true, force: true })
   })
@@ -689,13 +693,21 @@ describe('auto-compact', () => {
     // Nothing has fired yet.
     expect(await readLastCompactedAt()).toBeNull()
 
-    // Wait past the debounce + the async compactCanvas write.
-    await new Promise((r) => setTimeout(r, 250))
-    const stamp = await readLastCompactedAt()
-    expect(stamp).not.toBeNull()
+    // Wait past the debounce + the async compactCanvas write. Poll instead of
+    // a fixed sleep so this does not flake on a slow CI runner.
+    const stamp = await vi.waitFor(
+      async () => {
+        const value = await readLastCompactedAt()
+        expect(value).not.toBeNull()
+        return value
+      },
+      { timeout: 2000 },
+    )
     const settled = stamp!
 
-    // Further idle time without a new trigger must NOT re-compact.
+    // Further idle time without a new trigger must NOT re-compact. This half
+    // is an inherently bounded negative wait — keep it real rather than
+    // deleting the assertion.
     await new Promise((r) => setTimeout(r, 150))
     expect(await readLastCompactedAt()).toBe(settled)
   })
@@ -734,11 +746,194 @@ describe('auto-compact', () => {
     expect(peekDoc('session1', 'cached')).toBeDefined()
 
     scheduleAutoCompact('session1', 'cached', store, { debounceMs: 50 })
-    await new Promise((r) => setTimeout(r, 250))
 
-    // The whole point of this test: after the scheduled compaction lands,
-    // the cache must be empty for that key so the next save reloads the
-    // compacted file as its base.
-    expect(peekDoc('session1', 'cached')).toBeUndefined()
+    // Poll instead of a fixed sleep so this does not flake on a slow CI
+    // runner. The whole point of this test: after the scheduled compaction
+    // lands, the cache must be empty for that key so the next save reloads
+    // the compacted file as its base.
+    await vi.waitFor(
+      () => {
+        expect(peekDoc('session1', 'cached')).toBeUndefined()
+      },
+      { timeout: 2000 },
+    )
+  })
+})
+
+describe('auto-compact disposal', () => {
+  let disposedDb = false
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-auto-compact-dispose-test-'))
+    await setupIsolatedDb()
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(tempDir, 'session1'), { recursive: true })
+    disposedDb = false
+  })
+
+  afterEach(async () => {
+    setAutoCompactTrigger(null)
+    await disposeAutoCompact()
+    if (!disposedDb) {
+      await teardownIsolatedDb()
+    }
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  async function buildCompactableCanvas(
+    slug: string,
+  ): Promise<InstanceType<typeof FileVersionStore>> {
+    const { LoroMap } = await import('loro-crdt')
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    for (let i = 0; i < 30; i++) {
+      const m = list.insertContainer(list.length, new LoroMap())
+      m.set('id', `e-${i}`)
+    }
+    doc.commit()
+    await saveCanvas('session1', slug, doc)
+    const store = new FileVersionStore()
+    await store.save('session1', slug, doc, { auto: true })
+    for (let i = 0; i < 30; i++) {
+      const m = list.insertContainer(list.length, new LoroMap())
+      m.set('id', `x-${i}`)
+    }
+    doc.commit()
+    await saveCanvas('session1', slug, doc, { overwrite: true })
+    return store
+  }
+
+  // compactCanvas normally settles fast enough (in-memory DB, tiny fixture)
+  // that polling for "in flight" would race the compaction to zero. Delay
+  // just the earliestFrontiers lookup — the first await compactCanvas makes
+  // — so tests can deterministically observe the in-flight window instead of
+  // depending on real-clock luck.
+  function withDelayedEarliestFrontiers(
+    store: InstanceType<typeof FileVersionStore>,
+    delayMs: number,
+  ): InstanceType<typeof FileVersionStore> {
+    return new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'earliestFrontiers') {
+          return async (workspaceId: string, slug: string) => {
+            await new Promise((r) => setTimeout(r, delayMs))
+            return target.earliestFrontiers(workspaceId, slug)
+          }
+        }
+        return Reflect.get(target, prop, receiver)
+      },
+    })
+  }
+
+  it('cancels the pending debounce when the DB is disposed before it fires, instead of touching the destroyed driver', async () => {
+    const store = await buildCompactableCanvas('big')
+    const logs = captureLogsForTests('warning')
+
+    // Do NOT call setAutoCompactTrigger(null) here — the point of this test
+    // is that DB disposal alone (without that manual call) must cancel the
+    // pending timer.
+    scheduleAutoCompact('session1', 'big', store, { debounceMs: 20 })
+    await teardownIsolatedDb()
+    disposedDb = true
+
+    // Wait past the debounce window. If the timer was not cancelled, its
+    // fired compactCanvas call would hit the destroyed driver and log a
+    // 'failed' warning.
+    await new Promise((r) => setTimeout(r, 150))
+    logs.restore()
+
+    const autoCompactRecords = logs.records.filter((r) => r.scope === 'auto-compact')
+    expect(autoCompactRecords).toHaveLength(0)
+  })
+
+  it('disposeAutoCompact awaits an already-fired in-flight compaction before resolving', async () => {
+    const store = await buildCompactableCanvas('cached')
+    const { getDb } = await import('./db/index.js')
+
+    async function readLastCompactedAt(): Promise<number | null> {
+      const db = await getDb(tempDir)
+      const row = await db
+        .selectFrom('canvases')
+        .select(['lastCompactedAt'])
+        .where('workspaceId', '=', 'session1')
+        .where('slug', '=', 'cached')
+        .executeTakeFirst()
+      return row?.lastCompactedAt ?? null
+    }
+
+    scheduleAutoCompact('session1', 'cached', withDelayedEarliestFrontiers(store, 100), {
+      debounceMs: 1,
+    })
+    await vi.waitFor(
+      () => {
+        expect(_inFlightAutoCompactCountForTests()).toBeGreaterThan(0)
+      },
+      { timeout: 2000 },
+    )
+
+    await disposeAutoCompact()
+
+    expect(_inFlightAutoCompactCountForTests()).toBe(0)
+    expect(await readLastCompactedAt()).not.toBeNull()
+  })
+
+  it('is idempotent, and scheduleAutoCompact still works after a dispose', async () => {
+    const store = await buildCompactableCanvas('again')
+    const { getDb } = await import('./db/index.js')
+
+    async function readLastCompactedAt(): Promise<number | null> {
+      const db = await getDb(tempDir)
+      const row = await db
+        .selectFrom('canvases')
+        .select(['lastCompactedAt'])
+        .where('workspaceId', '=', 'session1')
+        .where('slug', '=', 'again')
+        .executeTakeFirst()
+      return row?.lastCompactedAt ?? null
+    }
+
+    await disposeAutoCompact()
+    await disposeAutoCompact()
+
+    scheduleAutoCompact('session1', 'again', store, { debounceMs: 20 })
+    await vi.waitFor(
+      async () => {
+        expect(await readLastCompactedAt()).not.toBeNull()
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  it('composes with setAutoCompactTrigger(null) in either order without dropping in-flight work', async () => {
+    const store = await buildCompactableCanvas('composed')
+    const { getDb } = await import('./db/index.js')
+
+    async function readLastCompactedAt(): Promise<number | null> {
+      const db = await getDb(tempDir)
+      const row = await db
+        .selectFrom('canvases')
+        .select(['lastCompactedAt'])
+        .where('workspaceId', '=', 'session1')
+        .where('slug', '=', 'composed')
+        .executeTakeFirst()
+      return row?.lastCompactedAt ?? null
+    }
+
+    scheduleAutoCompact('session1', 'composed', withDelayedEarliestFrontiers(store, 100), {
+      debounceMs: 1,
+    })
+    await vi.waitFor(
+      () => {
+        expect(_inFlightAutoCompactCountForTests()).toBeGreaterThan(0)
+      },
+      { timeout: 2000 },
+    )
+
+    // setAutoCompactTrigger(null) stays synchronous and timer-only: it must
+    // not swallow the in-flight compaction that is already running.
+    setAutoCompactTrigger(null)
+    await disposeAutoCompact()
+
+    expect(await readLastCompactedAt()).not.toBeNull()
   })
 })

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -877,6 +877,95 @@ describe('auto-compact disposal', () => {
     expect(await readLastCompactedAt()).not.toBeNull()
   })
 
+  it('disposeAutoCompact cancels a timer rescheduled by an in-flight compaction instead of leaving it dangling', async () => {
+    const store = await buildCompactableCanvas('reentrant')
+
+    // Simulates loadCanvas()'s legacy-migration path resuming mid-compaction
+    // and calling saveCanvas(), which re-invokes the auto-compact trigger and
+    // schedules a fresh timer *while disposeAutoCompact is already awaiting
+    // this in-flight compaction*. A single clear-then-await pass would clear
+    // the timer map before this reschedule happens and miss it.
+    const rescheduleCallCount = { count: 0 }
+    const countingStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'earliestFrontiers') {
+          return async (workspaceId: string, slug: string) => {
+            rescheduleCallCount.count += 1
+            return target.earliestFrontiers(workspaceId, slug)
+          }
+        }
+        return Reflect.get(target, prop, receiver)
+      },
+    })
+    const reentrantStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'earliestFrontiers') {
+          return async (workspaceId: string, slug: string) => {
+            await new Promise((r) => setTimeout(r, 50))
+            scheduleAutoCompact('session1', 'reentrant', countingStore, { debounceMs: 20 })
+            return target.earliestFrontiers(workspaceId, slug)
+          }
+        }
+        return Reflect.get(target, prop, receiver)
+      },
+    })
+
+    scheduleAutoCompact('session1', 'reentrant', reentrantStore, { debounceMs: 1 })
+    await vi.waitFor(
+      () => {
+        expect(_inFlightAutoCompactCountForTests()).toBeGreaterThan(0)
+      },
+      { timeout: 2000 },
+    )
+
+    await disposeAutoCompact()
+
+    expect(_inFlightAutoCompactCountForTests()).toBe(0)
+    // Wait past the rescheduled timer's debounce window and confirm it was
+    // cancelled rather than merely not-yet-fired.
+    await new Promise((r) => setTimeout(r, 100))
+    expect(rescheduleCallCount.count).toBe(0)
+  })
+
+  it('disposes through the real DB lifecycle (createIsolatedDb().dispose()) without spinning up a replacement connection for a re-entrant getDb() call', async () => {
+    const store = await buildCompactableCanvas('lifecycle')
+    const { getDb } = await import('./db/index.js')
+    let reentrantDb: Awaited<ReturnType<typeof getDb>> | null = null
+
+    const reentrantStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'earliestFrontiers') {
+          return async (workspaceId: string, slug: string) => {
+            await new Promise((r) => setTimeout(r, 100))
+            // Mirrors a compaction resuming and touching the DB again
+            // (e.g. via loadCanvas()) while teardown is draining hooks.
+            reentrantDb = await getDb(tempDir)
+            return target.earliestFrontiers(workspaceId, slug)
+          }
+        }
+        return Reflect.get(target, prop, receiver)
+      },
+    })
+
+    scheduleAutoCompact('session1', 'lifecycle', reentrantStore, { debounceMs: 1 })
+    await vi.waitFor(
+      () => {
+        expect(_inFlightAutoCompactCountForTests()).toBeGreaterThan(0)
+      },
+      { timeout: 2000 },
+    )
+
+    const disposingDb = handle.db
+    // Exercise the actual DB lifecycle API (createIsolatedDb().dispose(),
+    // mirroring closeDb() in production) rather than calling
+    // disposeAutoCompact() directly, so the cache-removal-vs-hook-ordering
+    // fix in db/index.ts is covered from this store's perspective too.
+    await teardownIsolatedDb()
+    disposedDb = true
+
+    expect(reentrantDb).toBe(disposingDb)
+  })
+
   it('is idempotent, and scheduleAutoCompact still works after a dispose', async () => {
     const store = await buildCompactableCanvas('again')
     const { getDb } = await import('./db/index.js')

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -11,7 +11,7 @@ import {
   isCorruptStoredDataError,
   isMissingFileError,
 } from './corrupt-stored-data.js'
-import { getDb } from './db/index.js'
+import { getDb, registerDbDisposeHook } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getCanvasIdBySlug, upsertWorkspaceRow } from './db/upsert-workspace.js'
 import type { VersionStore } from './version-store.js'
@@ -73,73 +73,73 @@ export async function saveCanvas(
   // workspace lock ensures it sees this save as either fully applied or
   // not yet started.
   return withWorkspaceWriteLock(workspaceId, async () => {
-  const overwrite = options.overwrite ?? false
-  const db = await dbReady()
-  const existingCanvasId = await getCanvasIdBySlug(db, workspaceId, slug)
-  if (existingCanvasId && !overwrite) {
-    throw new ConflictError(
-      `Canvas "${workspaceId}/${slug}" already exists. Pass { overwrite: true } to replace it.`,
-    )
-  }
-  // Pre-allocate the canvasId for new canvases so the blob can be written
-  // before any metadata row commits. If the FS write fails (ENOSPC, EACCES,
-  // transient corruption) we leave no DB row behind, so a retry can succeed
-  // instead of hitting a phantom ConflictError on the orphan.
-  const canvasId = existingCanvasId ?? nanoid(12)
-  const path = canvasBlobPath(workspaceId, canvasId)
-  await mkdir(dirname(path), { recursive: true })
-  const snapshot = doc.export({ mode: 'snapshot' })
-  await writeFile(path, snapshot)
-  await upsertWorkspaceRow(db, workspaceId)
-  if (existingCanvasId) {
-    await db
-      .updateTable('canvases')
-      .set({ updatedAt: Date.now() })
-      .where('id', '=', canvasId)
-      .execute()
-  } else {
-    const now = Date.now()
-    await db
-      .insertInto('canvases')
-      .values({
-        id: canvasId,
-        workspaceId,
-        slug,
-        displayName: null,
-        isPinned: 0,
-        pinOrder: null,
-        currentBranch: 'main',
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflict((oc) => oc.columns(['workspaceId', 'slug']).doUpdateSet({ updatedAt: now }))
-      .execute()
-  }
-  if (snapshot.byteLength > SNAPSHOT_WARN_BYTES) {
-    const key = `${workspaceId}/${slug}`
-    if (!warnedSnapshots.has(key)) {
-      warnedSnapshots.add(key)
-      getLogger('canvas-store').warning(
-        {
-          workspaceId,
-          slug,
-          bytes: snapshot.byteLength,
-          thresholdBytes: SNAPSHOT_WARN_BYTES,
-        },
-        'snapshot exceeds soft cap; consider compactCanvas() to GC op-log',
+    const overwrite = options.overwrite ?? false
+    const db = await dbReady()
+    const existingCanvasId = await getCanvasIdBySlug(db, workspaceId, slug)
+    if (existingCanvasId && !overwrite) {
+      throw new ConflictError(
+        `Canvas "${workspaceId}/${slug}" already exists. Pass { overwrite: true } to replace it.`,
       )
     }
-  }
-  // Hand off to the auto-compact debouncer when one is registered. Wired
-  // by the route layer (where versionStore is in scope) so this module
-  // does not depend on the version-store concrete type.
-  if (autoCompactTrigger) {
-    try {
-      autoCompactTrigger(workspaceId, slug)
-    } catch (err) {
-      getLogger('canvas-store').warning({ workspaceId, slug, err }, 'autoCompactTrigger threw')
+    // Pre-allocate the canvasId for new canvases so the blob can be written
+    // before any metadata row commits. If the FS write fails (ENOSPC, EACCES,
+    // transient corruption) we leave no DB row behind, so a retry can succeed
+    // instead of hitting a phantom ConflictError on the orphan.
+    const canvasId = existingCanvasId ?? nanoid(12)
+    const path = canvasBlobPath(workspaceId, canvasId)
+    await mkdir(dirname(path), { recursive: true })
+    const snapshot = doc.export({ mode: 'snapshot' })
+    await writeFile(path, snapshot)
+    await upsertWorkspaceRow(db, workspaceId)
+    if (existingCanvasId) {
+      await db
+        .updateTable('canvases')
+        .set({ updatedAt: Date.now() })
+        .where('id', '=', canvasId)
+        .execute()
+    } else {
+      const now = Date.now()
+      await db
+        .insertInto('canvases')
+        .values({
+          id: canvasId,
+          workspaceId,
+          slug,
+          displayName: null,
+          isPinned: 0,
+          pinOrder: null,
+          currentBranch: 'main',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflict((oc) => oc.columns(['workspaceId', 'slug']).doUpdateSet({ updatedAt: now }))
+        .execute()
     }
-  }
+    if (snapshot.byteLength > SNAPSHOT_WARN_BYTES) {
+      const key = `${workspaceId}/${slug}`
+      if (!warnedSnapshots.has(key)) {
+        warnedSnapshots.add(key)
+        getLogger('canvas-store').warning(
+          {
+            workspaceId,
+            slug,
+            bytes: snapshot.byteLength,
+            thresholdBytes: SNAPSHOT_WARN_BYTES,
+          },
+          'snapshot exceeds soft cap; consider compactCanvas() to GC op-log',
+        )
+      }
+    }
+    // Hand off to the auto-compact debouncer when one is registered. Wired
+    // by the route layer (where versionStore is in scope) so this module
+    // does not depend on the version-store concrete type.
+    if (autoCompactTrigger) {
+      try {
+        autoCompactTrigger(workspaceId, slug)
+      } catch (err) {
+        getLogger('canvas-store').warning({ workspaceId, slug, err }, 'autoCompactTrigger threw')
+      }
+    }
   })
 }
 
@@ -300,19 +300,35 @@ export async function readLatestCompactedAt(): Promise<number | null> {
 type AutoCompactTrigger = (workspaceId: string, slug: string) => void
 let autoCompactTrigger: AutoCompactTrigger | null = null
 
+// Shared by setAutoCompactTrigger(null) and disposeAutoCompact() so the two
+// cancellation paths can never drift out of sync with each other.
+function clearAllAutoCompactTimers(): void {
+  for (const t of autoCompactTimers.values()) clearTimeout(t)
+  autoCompactTimers.clear()
+}
+
 // Resetting the trigger to null also drains any pending debounced timers so
 // a subsequent test's tempDir is not surprised by a stray compactCanvas
-// firing on a removed directory.
+// firing on a removed directory. This stays synchronous by contract — it
+// cancels only timers that have not fired yet, and deliberately does not
+// await in-flight compactions (see disposeAutoCompact for that superset).
 export function setAutoCompactTrigger(fn: AutoCompactTrigger | null): void {
   if (fn === null) {
-    for (const t of autoCompactTimers.values()) clearTimeout(t)
-    autoCompactTimers.clear()
+    clearAllAutoCompactTimers()
   }
   autoCompactTrigger = fn
 }
 
 const AUTO_COMPACT_DEBOUNCE_MS = 30_000
 const autoCompactTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+// Tracks compactCanvas() calls that have already fired but not yet settled.
+// A Set of the promises themselves (not a Map keyed by workspaceId/slug) is
+// required: two overlapping compactions for the same key must both stay
+// tracked until they individually settle, since a keyed map with an
+// unconditional delete-on-settle would let a still-in-flight entry get
+// dropped by an unrelated compaction for the same key finishing first.
+const inFlightAutoCompacts = new Set<Promise<unknown>>()
 
 export function scheduleAutoCompact(
   workspaceId: string,
@@ -325,7 +341,7 @@ export function scheduleAutoCompact(
   if (existing) clearTimeout(existing)
   const timer = setTimeout(() => {
     autoCompactTimers.delete(key)
-    void compactCanvas(workspaceId, slug, versionStore)
+    const compaction = compactCanvas(workspaceId, slug, versionStore)
       .then((result) => {
         if (result.compacted) {
           getLogger('auto-compact').info(
@@ -342,6 +358,10 @@ export function scheduleAutoCompact(
       .catch((err) => {
         getLogger('auto-compact').warning({ workspaceId, slug, err }, 'failed')
       })
+      .finally(() => {
+        inFlightAutoCompacts.delete(compaction)
+      })
+    inFlightAutoCompacts.add(compaction)
   }, options.debounceMs ?? AUTO_COMPACT_DEBOUNCE_MS)
   // Do not keep the event loop alive just for this debounce. Node will
   // still flush the compaction if anything else (HTTP, WS) holds the
@@ -351,6 +371,28 @@ export function scheduleAutoCompact(
   }
   autoCompactTimers.set(key, timer)
 }
+
+// Awaitable superset of setAutoCompactTrigger(null): cancels every pending
+// timer AND waits for every already-fired compaction to settle, so a caller
+// that awaits this is guaranteed no compactCanvas call can still reach the
+// DB driver afterward. Registered as a DB dispose hook (below) so disposing
+// a store's DB always drains this state first, without every dispose call
+// site having to remember to call it manually. Idempotent: calling it with
+// nothing pending simply resolves immediately, and scheduleAutoCompact works
+// again afterward (a fresh call re-populates both trackers).
+export async function disposeAutoCompact(): Promise<void> {
+  clearAllAutoCompactTimers()
+  await Promise.allSettled(Array.from(inFlightAutoCompacts))
+}
+
+// Test-only introspection, matching the `_destinationCountForTests` pattern
+// in log.ts: lets tests poll for "a compaction has fired and is mid-flight"
+// without a bespoke gate inside compactCanvas itself.
+export function _inFlightAutoCompactCountForTests(): number {
+  return inFlightAutoCompacts.size
+}
+
+registerDbDisposeHook(disposeAutoCompact)
 
 // ── list workspaces from the workspaces table ──
 export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -381,8 +381,18 @@ export function scheduleAutoCompact(
 // nothing pending simply resolves immediately, and scheduleAutoCompact works
 // again afterward (a fresh call re-populates both trackers).
 export async function disposeAutoCompact(): Promise<void> {
-  clearAllAutoCompactTimers()
-  await Promise.allSettled(Array.from(inFlightAutoCompacts))
+  // A single clear-then-await pass is not enough: an in-flight compaction's
+  // loadCanvas() can run legacy migration, which calls saveCanvas(), which
+  // re-invokes the registered auto-compact trigger and schedules a fresh
+  // timer *while we are still awaiting the first batch*. Loop until a pass
+  // starts with nothing in flight, so the timer map and in-flight set are
+  // both guaranteed empty by the time this resolves.
+  for (;;) {
+    clearAllAutoCompactTimers()
+    const inFlight = Array.from(inFlightAutoCompacts)
+    if (inFlight.length === 0) break
+    await Promise.allSettled(inFlight)
+  }
 }
 
 // Test-only introspection, matching the `_destinationCountForTests` pattern

--- a/packages/mcp-server/src/server/store/db/index.test.ts
+++ b/packages/mcp-server/src/server/store/db/index.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { sql } from 'kysely'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Bench tests for the connection-cache + per-connection FK pragma. These were
@@ -19,20 +20,31 @@ vi.mock('../../config.js', () => ({
   DIST_APP_DIR: '/tmp/whiteboard/dist/app',
 }))
 
-const { getDb, closeDb, clearDbCache } = await import('./index.js')
+const { getDb, closeDb, clearDbCache, registerDbDisposeHook } = await import('./index.js')
 const { prepareDataDir, clearPrepareCache } = await import('./prepare.js')
+
+// registerDbDisposeHook has no unregister counterpart, so this file registers
+// exactly one hook at module scope and routes it through a swappable
+// indirection instead of calling registerDbDisposeHook per test (which would
+// pile up hooks that outlive the test that registered them).
+let activeHookRun: (() => Promise<void>) | null = null
+registerDbDisposeHook(async () => {
+  if (activeHookRun) await activeHookRun()
+})
 
 describe('getDb / closeDb', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-db-index-test-'))
     clearDbCache()
     clearPrepareCache()
+    activeHookRun = null
   })
 
   afterEach(async () => {
     await closeDb(tempDir).catch(() => {})
     clearDbCache()
     clearPrepareCache()
+    activeHookRun = null
     await rm(tempDir, { recursive: true, force: true })
   })
 
@@ -122,5 +134,109 @@ describe('getDb / closeDb', () => {
       .where('canvasId', '=', 'cv-fk')
       .execute()
     expect(remaining).toEqual([])
+  })
+})
+
+describe('dispose hooks (registerDbDisposeHook / runDbDisposeHooks)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-db-index-hooks-test-'))
+    clearDbCache()
+    clearPrepareCache()
+    activeHookRun = null
+  })
+
+  afterEach(async () => {
+    await closeDb(tempDir).catch(() => {})
+    clearDbCache()
+    clearPrepareCache()
+    activeHookRun = null
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('closeDb() runs registered dispose hooks while the connection is still open, then destroys it', async () => {
+    const db = await getDb(tempDir)
+    let queriedDuringHook = false
+    activeHookRun = async () => {
+      // The connection must still be usable from inside the hook — proves
+      // hooks run before destroy(), not after.
+      await sql`SELECT 1`.execute(db)
+      queriedDuringHook = true
+    }
+
+    await closeDb(tempDir)
+
+    expect(queriedDuringHook).toBe(true)
+    await expect(sql`SELECT 1`.execute(db)).rejects.toThrow()
+  })
+
+  it('closeDb() keeps the cache entry live while hooks run, so a re-entrant getDb() reuses the disposing connection instead of building a replacement', async () => {
+    const db = await getDb(tempDir)
+    let reentrantDb: Awaited<ReturnType<typeof getDb>> | null = null
+    activeHookRun = async () => {
+      // Simulates an auto-compact hook whose in-flight work resumes and
+      // calls back into getDb() for the same dataDir while draining.
+      reentrantDb = await getDb(tempDir)
+    }
+
+    await closeDb(tempDir)
+
+    expect(reentrantDb).toBe(db)
+  })
+
+  it('closeDb() swallows a throwing/rejecting dispose hook instead of blocking teardown', async () => {
+    await getDb(tempDir)
+    activeHookRun = async () => {
+      throw new Error('boom')
+    }
+
+    await expect(closeDb(tempDir)).resolves.toBeUndefined()
+  })
+
+  it('clearDbCache() runs registered dispose hooks before destroying the cached connection', async () => {
+    const db = await getDb(tempDir)
+    let queriedDuringHook = false
+    activeHookRun = async () => {
+      await sql`SELECT 1`.execute(db)
+      queriedDuringHook = true
+    }
+
+    clearDbCache()
+
+    await vi.waitFor(() => {
+      expect(queriedDuringHook).toBe(true)
+    })
+    await vi.waitFor(async () => {
+      await expect(sql`SELECT 1`.execute(db)).rejects.toThrow()
+    })
+  })
+
+  it('clearDbCache() keeps the cache entry live while hooks run, so a re-entrant getDb() reuses the disposing connection instead of building a replacement', async () => {
+    const db = await getDb(tempDir)
+    let reentrantDb: Awaited<ReturnType<typeof getDb>> | null = null
+    activeHookRun = async () => {
+      reentrantDb = await getDb(tempDir)
+    }
+
+    clearDbCache()
+
+    await vi.waitFor(() => {
+      expect(reentrantDb).toBe(db)
+    })
+  })
+
+  it('clearDbCache() tolerates a throwing/rejecting dispose hook and still destroys the connection', async () => {
+    const db = await getDb(tempDir)
+    activeHookRun = async () => {
+      throw new Error('boom')
+    }
+
+    clearDbCache()
+
+    // runDbDisposeHooks() (Promise.allSettled internally) must swallow the
+    // throw so clearDbCache's chain still reaches destroy() instead of
+    // leaving the connection cached and alive forever.
+    await vi.waitFor(async () => {
+      await expect(sql`SELECT 1`.execute(db)).rejects.toThrow()
+    })
   })
 })

--- a/packages/mcp-server/src/server/store/db/index.test.ts
+++ b/packages/mcp-server/src/server/store/db/index.test.ts
@@ -20,7 +20,9 @@ vi.mock('../../config.js', () => ({
   DIST_APP_DIR: '/tmp/whiteboard/dist/app',
 }))
 
-const { getDb, closeDb, clearDbCache, registerDbDisposeHook } = await import('./index.js')
+const { getDb, closeDb, clearDbCache, registerDbDisposeHook, runDbDisposeHooks } = await import(
+  './index.js'
+)
 const { prepareDataDir, clearPrepareCache } = await import('./prepare.js')
 
 // registerDbDisposeHook has no unregister counterpart, so this file registers
@@ -32,12 +34,26 @@ registerDbDisposeHook(async () => {
   if (activeHookRun) await activeHookRun()
 })
 
+// A second hook, registered without an `async` wrapper, so a configured throw
+// happens synchronously inside the `disposeHooks.map((fn) => fn())` call
+// rather than surfacing as a rejected promise. Kept separate from
+// activeHookRun above because that hook's own `async` keyword would convert
+// any throw inside it into a rejection before runDbDisposeHooks ever sees it.
+let throwSynchronouslyOnDispose = false
+registerDbDisposeHook(() => {
+  if (throwSynchronouslyOnDispose) {
+    throw new Error('sync dispose hook boom')
+  }
+  return Promise.resolve()
+})
+
 describe('getDb / closeDb', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-db-index-test-'))
     clearDbCache()
     clearPrepareCache()
     activeHookRun = null
+    throwSynchronouslyOnDispose = false
   })
 
   afterEach(async () => {
@@ -45,6 +61,7 @@ describe('getDb / closeDb', () => {
     clearDbCache()
     clearPrepareCache()
     activeHookRun = null
+    throwSynchronouslyOnDispose = false
     await rm(tempDir, { recursive: true, force: true })
   })
 
@@ -143,6 +160,7 @@ describe('dispose hooks (registerDbDisposeHook / runDbDisposeHooks)', () => {
     clearDbCache()
     clearPrepareCache()
     activeHookRun = null
+    throwSynchronouslyOnDispose = false
   })
 
   afterEach(async () => {
@@ -150,6 +168,7 @@ describe('dispose hooks (registerDbDisposeHook / runDbDisposeHooks)', () => {
     clearDbCache()
     clearPrepareCache()
     activeHookRun = null
+    throwSynchronouslyOnDispose = false
     await rm(tempDir, { recursive: true, force: true })
   })
 
@@ -235,6 +254,26 @@ describe('dispose hooks (registerDbDisposeHook / runDbDisposeHooks)', () => {
     // runDbDisposeHooks() (Promise.allSettled internally) must swallow the
     // throw so clearDbCache's chain still reaches destroy() instead of
     // leaving the connection cached and alive forever.
+    await vi.waitFor(async () => {
+      await expect(sql`SELECT 1`.execute(db)).rejects.toThrow()
+    })
+  })
+
+  it('runDbDisposeHooks() swallows a hook that throws synchronously before returning a promise', async () => {
+    throwSynchronouslyOnDispose = true
+
+    await expect(runDbDisposeHooks()).resolves.toBeUndefined()
+  })
+
+  it('clearDbCache() still destroys the connection when a dispose hook throws synchronously', async () => {
+    const db = await getDb(tempDir)
+    throwSynchronouslyOnDispose = true
+
+    clearDbCache()
+
+    // A hook that throws synchronously (rather than returning a rejected
+    // promise) must not make clearDbCache's chain reject before reaching
+    // db.destroy() — that would leave the connection cached-but-orphaned.
     await vi.waitFor(async () => {
       await expect(sql`SELECT 1`.execute(db)).rejects.toThrow()
     })

--- a/packages/mcp-server/src/server/store/db/index.ts
+++ b/packages/mcp-server/src/server/store/db/index.ts
@@ -70,8 +70,19 @@ export function registerDbDisposeHook(fn: () => Promise<void>): void {
 // so the test-only createIsolatedDb() teardown path (test-helpers.ts) can
 // run the same hooks before destroying its db, matching production's
 // closeDb()/clearDbCache() behavior.
+//
+// Hooks are invoked through a wrapper that catches synchronous throws, not
+// just rejected promises. A hook that throws before returning a promise would
+// otherwise make the `disposeHooks.map((fn) => fn())` call itself throw,
+// which propagates past Promise.allSettled entirely and breaks the
+// never-rejects contract for callers like clearDbCache() that depend on it to
+// still reach db.destroy().
 export async function runDbDisposeHooks(): Promise<void> {
-  await Promise.allSettled(disposeHooks.map((fn) => fn()))
+  await Promise.allSettled(
+    disposeHooks.map(async (fn) => {
+      await fn()
+    }),
+  )
 }
 
 export async function closeDb(dataDir: string = DATA_DIR): Promise<void> {

--- a/packages/mcp-server/src/server/store/db/index.ts
+++ b/packages/mcp-server/src/server/store/db/index.ts
@@ -62,8 +62,17 @@ export function getDb(dataDir: string = DATA_DIR): Promise<Database> {
 // inverts the dependency instead.
 const disposeHooks: Array<() => Promise<void>> = []
 
-export function registerDbDisposeHook(fn: () => Promise<void>): void {
+// Returns an unregister function so dynamically-registered hooks (tests,
+// short-lived owners) can remove themselves instead of accumulating in the
+// module-scope registry.
+export function registerDbDisposeHook(fn: () => Promise<void>): () => void {
   disposeHooks.push(fn)
+  return () => {
+    const index = disposeHooks.indexOf(fn)
+    if (index !== -1) {
+      disposeHooks.splice(index, 1)
+    }
+  }
 }
 
 // Never rejects: a misbehaving hook must not block driver teardown. Exported

--- a/packages/mcp-server/src/server/store/db/index.ts
+++ b/packages/mcp-server/src/server/store/db/index.ts
@@ -53,10 +53,32 @@ export function getDb(dataDir: string = DATA_DIR): Promise<Database> {
   return pending
 }
 
+// ── dispose-hook registry ─────────────────────────────────────────────
+// Modules that own state keyed off a live DB connection (e.g. the
+// canvas-store auto-compact debouncer) register a hook here so their
+// pending timers / in-flight work are drained before the driver is
+// destroyed. db/index.ts cannot import those modules directly (they import
+// getDb from here, so importing back would create a cycle) — the registry
+// inverts the dependency instead.
+const disposeHooks: Array<() => Promise<void>> = []
+
+export function registerDbDisposeHook(fn: () => Promise<void>): void {
+  disposeHooks.push(fn)
+}
+
+// Never rejects: a misbehaving hook must not block driver teardown. Exported
+// so the test-only createIsolatedDb() teardown path (test-helpers.ts) can
+// run the same hooks before destroying its db, matching production's
+// closeDb()/clearDbCache() behavior.
+export async function runDbDisposeHooks(): Promise<void> {
+  await Promise.allSettled(disposeHooks.map((fn) => fn()))
+}
+
 export async function closeDb(dataDir: string = DATA_DIR): Promise<void> {
   const pending = cache.get(dataDir)
   if (!pending) return
   cache.delete(dataDir)
+  await runDbDisposeHooks()
   const db = await pending.catch(() => null)
   if (db) await db.destroy()
 }
@@ -65,9 +87,20 @@ export async function closeDb(dataDir: string = DATA_DIR): Promise<void> {
 // without awaiting destroy() so the test setup can swap DATA_DIR without leaking
 // connections. Production code should prefer closeDb() to release the underlying
 // libsql connection cleanly.
+//
+// This function is itself synchronous and fire-and-forget, so a caller that
+// only calls clearDbCache() still cannot await quiescence of the disposed
+// connections or their dispose hooks — use closeDb() (or, in tests,
+// createIsolatedDb's handle.dispose()) when the caller needs to await
+// teardown completing before proceeding.
 export function clearDbCache(): void {
   for (const pending of cache.values()) {
-    void pending.then((db) => db.destroy()).catch(() => {})
+    void pending
+      .then(async (db) => {
+        await runDbDisposeHooks()
+        await db.destroy()
+      })
+      .catch(() => {})
   }
   cache.clear()
 }

--- a/packages/mcp-server/src/server/store/db/index.ts
+++ b/packages/mcp-server/src/server/store/db/index.ts
@@ -77,8 +77,12 @@ export async function runDbDisposeHooks(): Promise<void> {
 export async function closeDb(dataDir: string = DATA_DIR): Promise<void> {
   const pending = cache.get(dataDir)
   if (!pending) return
-  cache.delete(dataDir)
+  // Run hooks BEFORE removing the cache entry. A hook (e.g. an already-fired
+  // auto-compact) can re-enter getDb(dataDir) while draining; leaving the
+  // entry cached lets that re-entrant call reuse the connection being
+  // disposed instead of racing a replacement connection into the cache.
   await runDbDisposeHooks()
+  cache.delete(dataDir)
   const db = await pending.catch(() => null)
   if (db) await db.destroy()
 }
@@ -94,15 +98,22 @@ export async function closeDb(dataDir: string = DATA_DIR): Promise<void> {
 // createIsolatedDb's handle.dispose()) when the caller needs to await
 // teardown completing before proceeding.
 export function clearDbCache(): void {
-  for (const pending of cache.values()) {
+  // Snapshot the entries and remove each one only after its own dispose
+  // hooks have run (not eagerly via a synchronous cache.clear()). Clearing
+  // the whole cache up front would let a hook's re-entrant getDb() call for
+  // the same dataDir find no cached entry and build a replacement connection
+  // while the original is still being drained.
+  for (const [dataDir, pending] of cache.entries()) {
     void pending
       .then(async (db) => {
         await runDbDisposeHooks()
+        cache.delete(dataDir)
         await db.destroy()
       })
-      .catch(() => {})
+      .catch(() => {
+        cache.delete(dataDir)
+      })
   }
-  cache.clear()
 }
 
 // Test-only seam. `createIsolatedDb` registers a memory-backed Database under

--- a/packages/mcp-server/src/server/store/db/test-helpers.ts
+++ b/packages/mcp-server/src/server/store/db/test-helpers.ts
@@ -18,14 +18,15 @@ import { Kysely, SqliteDialect, sql } from 'kysely'
 // open a fresh empty in-memory DB. The native Database keeps a single handle
 // for the lifetime of the instance, which is what `:memory:` needs.
 import LibsqlNativeDatabase from 'libsql'
-import { clearPrepareCache } from './prepare.js'
 import {
   type Database,
   DB_FILENAME,
   injectCachedDb,
   removeCachedDb,
+  runDbDisposeHooks,
 } from './index.js'
 import { runMigrations } from './migrator.js'
+import { clearPrepareCache } from './prepare.js'
 import type { DatabaseSchema } from './schema.js'
 
 export interface CreateIsolatedDbOptions {
@@ -87,6 +88,11 @@ export async function createIsolatedDb(
       // prepareDataDir memoizes per-dataDir; clearing keeps the next test free
       // to call prepareDataDir again without picking up the disposed promise.
       clearPrepareCache()
+      // Drain registered dispose hooks (e.g. canvas-store's pending
+      // auto-compact timers/in-flight compactions) before destroying the
+      // driver, matching production's closeDb()/clearDbCache() ordering so
+      // no hook can reach a destroyed connection.
+      await runDbDisposeHooks()
       await db.destroy()
     },
   }

--- a/packages/mcp-server/src/server/store/db/test-helpers.ts
+++ b/packages/mcp-server/src/server/store/db/test-helpers.ts
@@ -84,15 +84,17 @@ export async function createIsolatedDb(
   return {
     db,
     async dispose() {
+      // Drain registered dispose hooks (e.g. canvas-store's pending
+      // auto-compact timers/in-flight compactions) before removing the cache
+      // entry or destroying the driver, matching production's
+      // closeDb()/clearDbCache() ordering. Removing the cache entry first
+      // would let a hook's re-entrant getDb(dataDir) call race a replacement
+      // connection into the cache while this one is still being drained.
+      await runDbDisposeHooks()
       removeCachedDb(dataDir)
       // prepareDataDir memoizes per-dataDir; clearing keeps the next test free
       // to call prepareDataDir again without picking up the disposed promise.
       clearPrepareCache()
-      // Drain registered dispose hooks (e.g. canvas-store's pending
-      // auto-compact timers/in-flight compactions) before destroying the
-      // driver, matching production's closeDb()/clearDbCache() ordering so
-      // no hook can reach a destroyed connection.
-      await runDbDisposeHooks()
       await db.destroy()
     },
   }


### PR DESCRIPTION
## Summary

Third recurring CI flake, root-fixed: the canvas-store auto-compact debounce timer outlived the test DB — kysely threw 'driver has already been destroyed' from a post-teardown compaction (hit PR #179, an unrelated .claude-scripts diff).

- `disposeAutoCompact()`: cancels all pending debounce timers AND awaits all in-flight compactions (tracked as a `Set<Promise>` — a keyed map would let an older settle drop a newer in-flight entry for the same canvas), looping until fully quiesced.
- DB lifecycle wiring via a dispose-hook registry in store/db (avoids the canvas-store↔db import cycle): `closeDb` awaits hooks before driver destroy; the isolated-test-DB handle runs them in `dispose()`; the cache entry stays live while hooks drain.
- `setAutoCompactTrigger(null)` keeps its synchronous timer-only contract; `disposeAutoCompact()` is the awaitable superset — both idempotent/composable, shared clear helper.
- Existing debounce test de-flaked (deterministic waits, assertions un-weakened). Follow-up ticket filed for the routes/viewport+export timeout timers (intentionally not swept here).

## Test plan
- [x] Red-first: teardown race, fired-but-in-flight window, same-key overlap (fails vs keyed-map impl) — all proven red then green
- [x] canvas-store.test.ts 53/53; full mcp-node green; typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)