### PR TITLE
feat(web): daemon canvas gallery page with Storage tab and working back navigation

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -53,6 +53,14 @@ vi.mock('./pages/DaemonCanvasPage.js', () => ({
   },
 }))
 
+let receivedDaemonIndexPageProps: Record<string, unknown> | undefined
+vi.mock('./pages/DaemonIndexPage.js', () => ({
+  DaemonIndexPage: (props: Record<string, unknown>) => {
+    receivedDaemonIndexPageProps = props
+    return <div data-testid="daemon-index-page" />
+  },
+}))
+
 const BROWSER_LOCAL_STATE: ProviderState = {
   kind: 'browser-local',
   capabilities: {
@@ -204,6 +212,7 @@ describe('App daemon-pairing routing', () => {
 describe('App local-daemon provider state', () => {
   beforeEach(() => {
     receivedDaemonPageProps = undefined
+    receivedDaemonIndexPageProps = undefined
     resetTokenStoreForTests()
     delete (window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__
   })
@@ -212,34 +221,104 @@ describe('App local-daemon provider state', () => {
     delete (window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__
   })
 
-  it('mounts DaemonCanvasPage instead of the placeholder, with no workspaceId/slug', async () => {
+  it('mounts DaemonIndexPage (the gallery) instead of auto-opening a canvas', async () => {
     render(<App providerState={LOCAL_DAEMON_STATE} />)
-    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
     expect(screen.queryByTestId('browser-local-canvas-page')).toBeNull()
     expect(screen.queryByText('Whiteboard')).toBeNull()
-    expect(receivedDaemonPageProps?.daemonBaseUrl).toBe(LOCAL_DAEMON_STATE.daemonBaseUrl)
-    expect(receivedDaemonPageProps?.workspaceId).toBeUndefined()
-    expect(receivedDaemonPageProps?.slug).toBeUndefined()
+    expect(receivedDaemonIndexPageProps?.daemonBaseUrl).toBe(LOCAL_DAEMON_STATE.daemonBaseUrl)
+    expect(receivedDaemonIndexPageProps?.onOpenCanvas).toBeInstanceOf(Function)
+  })
+
+  it('mounts DaemonCanvasPage with the opened canvas identity after a gallery selection', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
+    const onOpenCanvas = receivedDaemonIndexPageProps?.onOpenCanvas as (
+      workspaceId: string,
+      slug: string,
+    ) => void
+    act(() => {
+      onOpenCanvas('w1', 'main')
+    })
+    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-index-page')).toBeNull()
+    expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
+    expect(receivedDaemonPageProps?.slug).toBe('main')
     expect(receivedDaemonPageProps?.capabilities).toEqual(LOCAL_DAEMON_STATE.capabilities)
     expect(receivedDaemonPageProps?.browserLocalStore).toBeDefined()
     expect(receivedDaemonPageProps?.onContinueBrowserLocal).toBeInstanceOf(Function)
+    expect(receivedDaemonPageProps?.onNavigateBack).toBeInstanceOf(Function)
   })
 
   it('passes the daemon-injected token when present', async () => {
     ;(window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__ = 'tok-x'
     render(<App providerState={LOCAL_DAEMON_STATE} />)
-    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
-    expect(receivedDaemonPageProps?.token).toBe('tok-x')
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(receivedDaemonIndexPageProps?.token).toBe('tok-x')
   })
 
   it('mounts gracefully with token undefined when the daemon has not injected one', async () => {
     render(<App providerState={LOCAL_DAEMON_STATE} />)
-    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
-    expect(receivedDaemonPageProps?.token).toBeUndefined()
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(receivedDaemonIndexPageProps?.token).toBeUndefined()
+  })
+
+  it('returns to the index when DaemonCanvasPage invokes onNavigateBack', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
+    act(() => {
+      ;(receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void)(
+        'w1',
+        'main',
+      )
+    })
+    await screen.findByTestId('daemon-canvas-page')
+    const onNavigateBack = receivedDaemonPageProps?.onNavigateBack as () => void
+    act(() => {
+      onNavigateBack()
+    })
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
+  })
+
+  it('remounts DaemonCanvasPage cleanly when opening a different canvas after returning to the index', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
+    act(() => {
+      ;(receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void)(
+        'w1',
+        'canvas-a',
+      )
+    })
+    await screen.findByTestId('daemon-canvas-page')
+    expect(receivedDaemonPageProps?.slug).toBe('canvas-a')
+
+    const onNavigateBack = receivedDaemonPageProps?.onNavigateBack as () => void
+    act(() => {
+      onNavigateBack()
+    })
+    await screen.findByTestId('daemon-index-page')
+
+    act(() => {
+      ;(receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void)(
+        'w1',
+        'canvas-b',
+      )
+    })
+    await screen.findByTestId('daemon-canvas-page')
+    expect(receivedDaemonPageProps?.slug).toBe('canvas-b')
   })
 
   it('escapes to browser-local with BROWSER_LOCAL_CAPABILITIES and neutral chip/banner copy', async () => {
     render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
+    act(() => {
+      ;(receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void)(
+        'w1',
+        'main',
+      )
+    })
     await screen.findByTestId('daemon-canvas-page')
     const onContinueBrowserLocal = receivedDaemonPageProps?.onContinueBrowserLocal as () => void
     act(() => {
@@ -258,15 +337,48 @@ describe('App local-daemon provider state', () => {
 
   it('catches an error surfacing through the local-daemon lazy path (boundary outside Suspense)', async () => {
     throwInDaemonCanvasPage = true
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
     const reportSpy = vi.spyOn(errorBoundaryLog, 'report').mockImplementation(() => {})
     try {
-      render(<App providerState={LOCAL_DAEMON_STATE} />)
+      act(() => {
+        ;(
+          receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void
+        )('w1', 'main')
+      })
       expect(await screen.findByText('Something went wrong')).toBeTruthy()
       expect(reportSpy).toHaveBeenCalled()
     } finally {
       throwInDaemonCanvasPage = false
       reportSpy.mockRestore()
     }
+  })
+})
+
+describe('App daemon-pairing routing (index vs canvas)', () => {
+  beforeEach(() => {
+    receivedDaemonPageProps = undefined
+    receivedDaemonIndexPageProps = undefined
+    mockDaemonConnectionResult = { status: 'none' }
+  })
+  afterEach(() => {
+    mockDaemonConnectionResult = { status: 'none' }
+  })
+
+  it('lands on the index when the #wb= payload has no slug', async () => {
+    mockDaemonConnectionResult = {
+      status: 'paired',
+      payload: {
+        baseUrl: 'http://127.0.0.1:3099',
+        workspaceId: undefined,
+        slug: undefined,
+        authMode: 'bootstrap',
+        bootstrapToken: 'tok',
+      },
+    }
+    render(<App providerState={BROWSER_LOCAL_STATE} />)
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
   })
 })
 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -380,6 +380,22 @@ describe('App daemon-pairing routing (index vs canvas)', () => {
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
   })
+
+  it('forwards the payload workspaceId as initialWorkspaceId when the #wb= payload has a workspace but no slug', async () => {
+    mockDaemonConnectionResult = {
+      status: 'paired',
+      payload: {
+        baseUrl: 'http://127.0.0.1:3099',
+        workspaceId: 'workspace-b',
+        slug: undefined,
+        authMode: 'bootstrap',
+        bootstrapToken: 'tok',
+      },
+    }
+    render(<App providerState={BROWSER_LOCAL_STATE} />)
+    expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
+    expect(receivedDaemonIndexPageProps?.initialWorkspaceId).toBe('workspace-b')
+  })
 })
 
 describe('App error boundary', () => {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -282,6 +282,24 @@ describe('App local-daemon provider state', () => {
     expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
   })
 
+  it('preserves the opened canvas workspaceId as initialWorkspaceId when navigating back to the index', async () => {
+    render(<App providerState={LOCAL_DAEMON_STATE} />)
+    await screen.findByTestId('daemon-index-page')
+    act(() => {
+      ;(receivedDaemonIndexPageProps?.onOpenCanvas as (workspaceId: string, slug: string) => void)(
+        'workspace-b',
+        'main',
+      )
+    })
+    await screen.findByTestId('daemon-canvas-page')
+    const onNavigateBack = receivedDaemonPageProps?.onNavigateBack as () => void
+    act(() => {
+      onNavigateBack()
+    })
+    await screen.findByTestId('daemon-index-page')
+    expect(receivedDaemonIndexPageProps?.initialWorkspaceId).toBe('workspace-b')
+  })
+
   it('remounts DaemonCanvasPage cleanly when opening a different canvas after returning to the index', async () => {
     render(<App providerState={LOCAL_DAEMON_STATE} />)
     await screen.findByTestId('daemon-index-page')

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,19 @@ const DaemonCanvasPage = lazy(() =>
   import('./pages/DaemonCanvasPage.js').then((m) => ({ default: m.DaemonCanvasPage })),
 )
 
+// Same lazy-chunk rationale as DaemonCanvasPage above — the gallery only
+// matters once a daemon connection exists.
+const DaemonIndexPage = lazy(() =>
+  import('./pages/DaemonIndexPage.js').then((m) => ({ default: m.DaemonIndexPage })),
+)
+
+// Which daemon-mode view is showing: the canvas gallery, or a specific open
+// canvas. A #wb= fragment with a slug skips straight to 'canvas'; local-daemon
+// and slug-less pairing start on 'index'. `key` on the DaemonCanvasPage mount
+// forces a clean remount (fresh controller/backend) on every index -> canvas
+// transition instead of reusing a previous canvas's identity.
+type DaemonView = { kind: 'index' } | { kind: 'canvas'; workspaceId: string; slug: string }
+
 const browserLocalStore = new IndexedDBStore()
 const userSettingsStore = createUserSettingsStore()
 
@@ -91,25 +104,59 @@ export function App({ providerState }: AppProps) {
   // body would let StrictMode's double-render read-then-lose the token.
   const [daemonToken] = useState(() => readDaemonTokenOnce() ?? undefined)
 
+  // A #wb= fragment carrying both workspaceId+slug skips straight to the
+  // canvas (the existing deep-link contract); a slug-less fragment (or
+  // local-daemon's runtime-config path, which never has a fragment at all)
+  // starts on the gallery. Lazy initializer: daemonConnection's payload is
+  // fixed for the life of the mount, so this never needs to react to it
+  // changing after the fact.
+  const [daemonView, setDaemonView] = useState<DaemonView>(() => {
+    if (
+      daemonConnection.status === 'paired' &&
+      daemonConnection.payload.workspaceId &&
+      daemonConnection.payload.slug
+    ) {
+      return {
+        kind: 'canvas',
+        workspaceId: daemonConnection.payload.workspaceId,
+        slug: daemonConnection.payload.slug,
+      }
+    }
+    return { kind: 'index' }
+  })
+
   // The 'Continue in browser-local' escape hatch opts out of the pairing
   // fragment entirely, so once it's set both daemon branches are skipped.
   if (!forcedBrowserLocal) {
     if (daemonConnection.status === 'paired') {
       const { payload } = daemonConnection
+      const pairedToken = payload.authMode === 'bootstrap' ? payload.bootstrapToken : undefined
       return (
         // ErrorBoundary sits outside Suspense: a lazy-chunk load failure
         // propagates through Suspense's own error path to the nearest
         // boundary, which must be here to catch it.
         <ErrorBoundary>
           <Suspense fallback={<DaemonConnectingFallback heightClass="h-dvh" />}>
-            <DaemonCanvasPage
-              daemonBaseUrl={payload.baseUrl}
-              workspaceId={payload.workspaceId}
-              slug={payload.slug}
-              token={payload.authMode === 'bootstrap' ? payload.bootstrapToken : undefined}
-              onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-              browserLocalStore={browserLocalStore}
-            />
+            {daemonView.kind === 'index' ? (
+              <DaemonIndexPage
+                daemonBaseUrl={payload.baseUrl}
+                token={pairedToken}
+                onOpenCanvas={(workspaceId, slug) =>
+                  setDaemonView({ kind: 'canvas', workspaceId, slug })
+                }
+              />
+            ) : (
+              <DaemonCanvasPage
+                key={`${daemonView.workspaceId}:${daemonView.slug}`}
+                daemonBaseUrl={payload.baseUrl}
+                workspaceId={daemonView.workspaceId}
+                slug={daemonView.slug}
+                token={pairedToken}
+                onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+                browserLocalStore={browserLocalStore}
+                onNavigateBack={() => setDaemonView({ kind: 'index' })}
+              />
+            )}
           </Suspense>
         </ErrorBoundary>
       )
@@ -174,13 +221,27 @@ export function App({ providerState }: AppProps) {
           <BackendConfigChip state={effectiveState} />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Suspense fallback={<DaemonConnectingFallback heightClass="h-full" />}>
-              <DaemonCanvasPage
-                daemonBaseUrl={effectiveState.daemonBaseUrl}
-                capabilities={effectiveState.capabilities}
-                token={daemonToken}
-                browserLocalStore={browserLocalStore}
-                onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-              />
+              {daemonView.kind === 'index' ? (
+                <DaemonIndexPage
+                  daemonBaseUrl={effectiveState.daemonBaseUrl}
+                  token={daemonToken}
+                  onOpenCanvas={(workspaceId, slug) =>
+                    setDaemonView({ kind: 'canvas', workspaceId, slug })
+                  }
+                />
+              ) : (
+                <DaemonCanvasPage
+                  key={`${daemonView.workspaceId}:${daemonView.slug}`}
+                  daemonBaseUrl={effectiveState.daemonBaseUrl}
+                  workspaceId={daemonView.workspaceId}
+                  slug={daemonView.slug}
+                  capabilities={effectiveState.capabilities}
+                  token={daemonToken}
+                  browserLocalStore={browserLocalStore}
+                  onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+                  onNavigateBack={() => setDaemonView({ kind: 'index' })}
+                />
+              )}
             </Suspense>
           </div>
         </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -152,7 +152,9 @@ export function App({ providerState }: AppProps) {
                 token={pairedToken}
                 onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
                 browserLocalStore={browserLocalStore}
-                onNavigateBack={() => setDaemonView({ kind: 'index' })}
+                onNavigateBack={() =>
+                  setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
+                }
               />
             )}
           </Suspense>
@@ -223,6 +225,7 @@ export function App({ providerState }: AppProps) {
                 <DaemonIndexPage
                   daemonBaseUrl={effectiveState.daemonBaseUrl}
                   token={daemonToken}
+                  initialWorkspaceId={daemonView.workspaceId}
                   onOpenCanvas={(workspaceId, slug) =>
                     setDaemonView({ kind: 'canvas', workspaceId, slug })
                   }
@@ -237,7 +240,9 @@ export function App({ providerState }: AppProps) {
                   token={daemonToken}
                   browserLocalStore={browserLocalStore}
                   onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-                  onNavigateBack={() => setDaemonView({ kind: 'index' })}
+                  onNavigateBack={() =>
+                    setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
+                  }
                 />
               )}
             </Suspense>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,7 +32,9 @@ const DaemonIndexPage = lazy(() =>
 // and slug-less pairing start on 'index'. `key` on the DaemonCanvasPage mount
 // forces a clean remount (fresh controller/backend) on every index -> canvas
 // transition instead of reusing a previous canvas's identity.
-type DaemonView = { kind: 'index' } | { kind: 'canvas'; workspaceId: string; slug: string }
+type DaemonView =
+  | { kind: 'index'; workspaceId?: string }
+  | { kind: 'canvas'; workspaceId: string; slug: string }
 
 const browserLocalStore = new IndexedDBStore()
 const userSettingsStore = createUserSettingsStore()
@@ -105,24 +107,19 @@ export function App({ providerState }: AppProps) {
   const [daemonToken] = useState(() => readDaemonTokenOnce() ?? undefined)
 
   // A #wb= fragment carrying both workspaceId+slug skips straight to the
-  // canvas (the existing deep-link contract); a slug-less fragment (or
-  // local-daemon's runtime-config path, which never has a fragment at all)
-  // starts on the gallery. Lazy initializer: daemonConnection's payload is
-  // fixed for the life of the mount, so this never needs to react to it
-  // changing after the fact.
+  // canvas (the existing deep-link contract); a workspace-only fragment is
+  // still a valid target (see daemon-connection-payload.ts's refine) and
+  // starts on the gallery pre-scoped to that workspace rather than
+  // whichever workspace the daemon happens to list first. A slug-less AND
+  // workspace-less fragment (or local-daemon's runtime-config path, which
+  // never has a fragment at all) starts on the gallery unscoped. Lazy
+  // initializer: daemonConnection's payload is fixed for the life of the
+  // mount, so this never needs to react to it changing after the fact.
   const [daemonView, setDaemonView] = useState<DaemonView>(() => {
-    if (
-      daemonConnection.status === 'paired' &&
-      daemonConnection.payload.workspaceId &&
-      daemonConnection.payload.slug
-    ) {
-      return {
-        kind: 'canvas',
-        workspaceId: daemonConnection.payload.workspaceId,
-        slug: daemonConnection.payload.slug,
-      }
-    }
-    return { kind: 'index' }
+    if (daemonConnection.status !== 'paired') return { kind: 'index' }
+    const { workspaceId, slug } = daemonConnection.payload
+    if (workspaceId && slug) return { kind: 'canvas', workspaceId, slug }
+    return { kind: 'index', workspaceId }
   })
 
   // The 'Continue in browser-local' escape hatch opts out of the pairing
@@ -141,6 +138,7 @@ export function App({ providerState }: AppProps) {
               <DaemonIndexPage
                 daemonBaseUrl={payload.baseUrl}
                 token={pairedToken}
+                initialWorkspaceId={daemonView.workspaceId}
                 onOpenCanvas={(workspaceId, slug) =>
                   setDaemonView({ kind: 'canvas', workspaceId, slug })
                 }

--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -67,14 +67,58 @@ describe('CanvasThumb', () => {
     }
   })
 
-  it('renders the fallback placeholder instead of an <img> when a DaemonApiContext provider is mounted (cross-origin)', () => {
-    const daemonFetch = vi.fn()
+  it('fetches the thumbnail through the daemon fetch and renders a blob-backed <img> when a provider is mounted', async () => {
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    const daemonFetch = vi.fn().mockResolvedValue(new Response(blob, { status: 200 }))
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
+    try {
+      const { container, findByRole } = render(
+        <DaemonApiContext.Provider value={daemonFetch}>
+          <CanvasThumb workspaceId="ws-1" slug="a" />
+        </DaemonApiContext.Provider>,
+      )
+      const img = (await findByRole('presentation')) as HTMLImageElement
+      expect(img.getAttribute('src')).toBe('blob:mock-url')
+      expect(daemonFetch).toHaveBeenCalledWith('/api/workspaces/ws-1/canvases/a/latest-thumbnail')
+      expect(container.querySelector('svg')).toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('renders the fallback icon when the daemon fetch fails', async () => {
+    const daemonFetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
     const { container } = render(
       <DaemonApiContext.Provider value={daemonFetch}>
         <CanvasThumb workspaceId="ws-1" slug="a" />
       </DaemonApiContext.Provider>,
     )
+    await vi.waitFor(() => expect(container.querySelector('svg')).not.toBeNull())
     expect(container.querySelector('img')).toBeNull()
-    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('revokes the previous object URL when the slug identity changes', async () => {
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    const daemonFetch = vi.fn().mockResolvedValue(new Response(blob, { status: 200 }))
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:mock-url'), revokeObjectURL })
+    try {
+      const { rerender, findByRole } = render(
+        <DaemonApiContext.Provider value={daemonFetch}>
+          <CanvasThumb workspaceId="ws-1" slug="canvas-a" />
+        </DaemonApiContext.Provider>,
+      )
+      await findByRole('presentation')
+      rerender(
+        <DaemonApiContext.Provider value={daemonFetch}>
+          <CanvasThumb workspaceId="ws-1" slug="canvas-b" />
+        </DaemonApiContext.Provider>,
+      )
+      await vi.waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url'))
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -69,10 +69,10 @@ export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }:
       cancelled = true
       if (createdUrl) URL.revokeObjectURL(createdUrl)
     }
-    // daemonFetch is the context-provided function and is not expected to
-    // change identity independently of hasDaemonApi.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [src, hasDaemonApi])
+    // daemonFetch is stable per provider identity, so including it does not
+    // refetch per render — and a genuinely new fetch identity (base URL or
+    // token change) must refetch rather than reuse stale credentials.
+  }, [src, hasDaemonApi, daemonFetch])
 
   const wrapperClasses =
     size === 'card'

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -1,6 +1,6 @@
 import { FileText } from 'lucide-react'
-import { useState } from 'react'
-import { useHasDaemonApi } from '@/contexts/DaemonApiContext'
+import { useEffect, useState } from 'react'
+import { useDaemonApi, useHasDaemonApi } from '@/contexts/DaemonApiContext'
 import { cn } from '@/lib/utils'
 
 // Latest-thumbnail surface for a canvas.
@@ -24,11 +24,13 @@ interface CanvasThumbProps {
 export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }: CanvasThumbProps) {
   // A plain <img src> cannot carry the daemon's own origin or Authorization
   // bearer header, so a cross-origin daemon (a DaemonApiContext provider
-  // mounted) always falls back to the placeholder icon instead of a broken
-  // image request. See VersionThumbnail for the equivalent fetch-and-blob
-  // treatment where an authorized image is worth the extra bookkeeping.
+  // mounted) fetches the image bytes through that authorized fetch and
+  // renders them via an object URL instead — mirroring VersionThumbnail's
+  // fetch-and-blob treatment.
   const hasDaemonApi = useHasDaemonApi()
+  const daemonFetch = useDaemonApi()
   const [failed, setFailed] = useState(false)
+  const [objectUrl, setObjectUrl] = useState<string | null>(null)
   const src = `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
   // Instances are reused across re-renders with a new slug/workspaceId (e.g.
   // the canvas switcher dropdown), so a stale `failed` flag from a previous
@@ -38,17 +40,61 @@ export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }:
   if (prevSrc !== src) {
     setPrevSrc(src)
     setFailed(false)
+    setObjectUrl(null)
   }
+
+  useEffect(() => {
+    if (!hasDaemonApi) return
+    let cancelled = false
+    let createdUrl: string | null = null
+
+    async function load(): Promise<void> {
+      try {
+        const res = await daemonFetch(src)
+        if (!res.ok) {
+          if (!cancelled) setFailed(true)
+          return
+        }
+        const blob = await res.blob()
+        if (cancelled) return
+        createdUrl = URL.createObjectURL(blob)
+        setObjectUrl(createdUrl)
+      } catch {
+        if (!cancelled) setFailed(true)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+      if (createdUrl) URL.revokeObjectURL(createdUrl)
+    }
+    // daemonFetch is the context-provided function and is not expected to
+    // change identity independently of hasDaemonApi.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [src, hasDaemonApi])
+
   const wrapperClasses =
     size === 'card'
       ? 'flex aspect-[16/9] w-full items-center justify-center overflow-hidden rounded-md border bg-muted/40'
       : 'flex h-9 w-14 shrink-0 items-center justify-center overflow-hidden rounded border bg-muted/40'
   const fallbackIconSize = size === 'card' ? 'size-8' : 'size-4'
+
+  const showFallback = hasDaemonApi ? failed || !objectUrl : failed
+
   return (
     <div className={cn(wrapperClasses, className)}>
-      {failed || hasDaemonApi ? (
+      {showFallback ? (
         // No thumbnail yet — generic icon instead of an empty gray box.
         <FileText className={cn(fallbackIconSize, 'text-muted-foreground/50')} />
+      ) : hasDaemonApi ? (
+        <img
+          src={objectUrl ?? undefined}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-contain"
+        />
       ) : (
         <img
           src={src}

--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -1,5 +1,6 @@
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DaemonApiContext } from '@/contexts/DaemonApiContext'
 import { STATUS_CLEAR_MS, StorageReportCard } from './StorageReportCard.js'
 
 const PAYLOAD = {
@@ -35,6 +36,31 @@ afterEach(() => {
 })
 
 describe('StorageReportCard', () => {
+  it('routes requests through the daemon fetch when a DaemonApiContext provider is mounted', async () => {
+    const daemonFetch = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/runtime/storage')) return Promise.resolve(jsonResponse(PAYLOAD))
+      if (url.endsWith('/api/runtime/logs/prune')) {
+        return Promise.resolve(jsonResponse({ purgedCount: 1, purgedBytes: 512 }))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+    const { getByRole } = render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <StorageReportCard />
+      </DaemonApiContext.Provider>,
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(daemonFetch).toHaveBeenCalledWith('/api/runtime/storage')
+    fireEvent.click(getByRole('button', { name: 'Prune old daemon logs' }))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(daemonFetch).toHaveBeenCalledWith('/api/runtime/logs/prune', { method: 'POST' })
+  })
+
   it('renders each storage category as its own row so future actions can hang off objects', async () => {
     const { container } = render(<StorageReportCard />)
     // Eight rows render synchronously from the static descriptor list:

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -1,4 +1,3 @@
-import { apiFetch } from '@kamiazya/whiteboard-mcp/api-client'
 import {
   listWorkspacesResponseSchema,
   optimizeAllCanvasesResponseSchema,
@@ -19,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { formatBytes } from '../lib/format-bytes.js'
 
 // Mirrors userLibrarySummarySchema / listUserLibrariesResponseSchema in
@@ -120,6 +120,9 @@ function humanizeAge(seconds: number): string {
 }
 
 export function StorageReportCard() {
+  // Falls back to the same-origin apiFetch when no DaemonApiContext provider
+  // is mounted, so mcp-server / same-origin usage is unchanged.
+  const fetchApi = useDaemonApi()
   const [report, setReport] = useState<StorageReportPayload | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -164,7 +167,7 @@ export function StorageReportCard() {
     setError(null)
     const start = Date.now()
     try {
-      const res = await apiFetch('/api/runtime/storage')
+      const res = await fetchApi('/api/runtime/storage')
       if (!mountedRef.current) return
       if (!res.ok) {
         setError(`HTTP ${res.status}`)
@@ -188,7 +191,7 @@ export function StorageReportCard() {
         setLoading(false)
       }
     }
-  }, [])
+  }, [fetchApi])
 
   useEffect(() => {
     void refresh()
@@ -204,7 +207,7 @@ export function StorageReportCard() {
     setOptimizing(true)
     setOptimizeStatus('Optimizing…')
     try {
-      const wsRes = await apiFetch('/api/workspaces')
+      const wsRes = await fetchApi('/api/workspaces')
       if (!mountedRef.current) return
       if (!wsRes.ok) {
         setOptimizeStatus('Optimize failed')
@@ -214,7 +217,7 @@ export function StorageReportCard() {
       let savings = 0
       let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
-        const res = await apiFetch(`/api/workspaces/${workspaceId}/canvases/optimize-all`, {
+        const res = await fetchApi(`/api/workspaces/${workspaceId}/canvases/optimize-all`, {
           method: 'POST',
         })
         if (!res.ok) {
@@ -244,7 +247,7 @@ export function StorageReportCard() {
         scheduleStatusClear(() => setOptimizeStatus(null))
       }
     }
-  }, [refresh, scheduleStatusClear])
+  }, [refresh, scheduleStatusClear, fetchApi])
 
   // User libraries management dialog. Surfaces installed libraries with
   // per-pack size and item count, plus a per-row Remove that maps to the
@@ -257,7 +260,7 @@ export function StorageReportCard() {
     setLibsLoading(true)
     setLibsError(null)
     try {
-      const res = await apiFetch('/api/user-libraries')
+      const res = await fetchApi('/api/user-libraries')
       if (!mountedRef.current) return
       if (!res.ok) {
         setLibsError(`HTTP ${res.status}`)
@@ -273,13 +276,13 @@ export function StorageReportCard() {
     } finally {
       if (mountedRef.current) setLibsLoading(false)
     }
-  }, [])
+  }, [fetchApi])
   const removeLib = useCallback(
     async (name: string) => {
       // Callers fire-and-forget this (void removeLib(...)), so a thrown fetch
       // must be converted to state here or it becomes an unhandled rejection.
       try {
-        const res = await apiFetch(`/api/user-libraries/${encodeURIComponent(name)}`, {
+        const res = await fetchApi(`/api/user-libraries/${encodeURIComponent(name)}`, {
           method: 'DELETE',
         })
         if (!mountedRef.current) return
@@ -299,7 +302,7 @@ export function StorageReportCard() {
         }
       }
     },
-    [fetchLibs, refresh],
+    [fetchLibs, refresh, fetchApi],
   )
 
   // Daemon-log rotation override. Logs are also pruned fire-and-forget
@@ -311,7 +314,7 @@ export function StorageReportCard() {
     setPruningLogs(true)
     setPruneLogsStatus('Pruning…')
     try {
-      const res = await apiFetch('/api/runtime/logs/prune', { method: 'POST' })
+      const res = await fetchApi('/api/runtime/logs/prune', { method: 'POST' })
       if (!mountedRef.current) return
       if (!res.ok) {
         setPruneLogsStatus('Prune failed')
@@ -333,7 +336,7 @@ export function StorageReportCard() {
         scheduleStatusClear(() => setPruneLogsStatus(null))
       }
     }
-  }, [refresh, scheduleStatusClear])
+  }, [refresh, scheduleStatusClear, fetchApi])
 
   // Sandwiched auto-version prune. Manual versions are explicit user
   // save-points; autos between any two manuals add no rollback value and
@@ -344,7 +347,7 @@ export function StorageReportCard() {
     setPruningVersions(true)
     setPruneVersionsStatus('Cleaning…')
     try {
-      const wsRes = await apiFetch('/api/workspaces')
+      const wsRes = await fetchApi('/api/workspaces')
       if (!mountedRef.current) return
       if (!wsRes.ok) {
         setPruneVersionsStatus('Cleanup failed')
@@ -354,7 +357,7 @@ export function StorageReportCard() {
       let totalDeleted = 0
       let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
-        const res = await apiFetch(`/api/workspaces/${workspaceId}/versions/prune-sandwiched`, {
+        const res = await fetchApi(`/api/workspaces/${workspaceId}/versions/prune-sandwiched`, {
           method: 'POST',
         })
         if (!res.ok) {
@@ -380,7 +383,7 @@ export function StorageReportCard() {
         scheduleStatusClear(() => setPruneVersionsStatus(null))
       }
     }
-  }, [refresh, scheduleStatusClear])
+  }, [refresh, scheduleStatusClear, fetchApi])
 
   // Dangling-files cleanup. Same workspace-iterating pattern as Optimize
   // all — call the per-workspace purge endpoint, sum the freed bytes, and
@@ -391,7 +394,7 @@ export function StorageReportCard() {
     setCleaningFiles(true)
     setCleanFilesStatus('Cleaning…')
     try {
-      const wsRes = await apiFetch('/api/workspaces')
+      const wsRes = await fetchApi('/api/workspaces')
       if (!mountedRef.current) return
       if (!wsRes.ok) {
         setCleanFilesStatus('Cleanup failed')
@@ -402,7 +405,7 @@ export function StorageReportCard() {
       let purgedCount = 0
       let failedWorkspaces = 0
       for (const { workspaceId } of workspaces) {
-        const res = await apiFetch(`/api/workspaces/${workspaceId}/files/purge-dangling`, {
+        const res = await fetchApi(`/api/workspaces/${workspaceId}/files/purge-dangling`, {
           method: 'POST',
         })
         if (!res.ok) {
@@ -431,7 +434,7 @@ export function StorageReportCard() {
         scheduleStatusClear(() => setCleanFilesStatus(null))
       }
     }
-  }, [refresh, scheduleStatusClear])
+  }, [refresh, scheduleStatusClear, fetchApi])
 
   const ageSeconds = updatedAt === null ? null : Math.max(0, Math.floor((now - updatedAt) / 1000))
 

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -1461,6 +1461,25 @@ describe('DaemonCanvasPage', () => {
       expect(screen.queryByRole('button', { name: 'Back to canvas list' })).toBeNull()
     })
 
+    it('renders "Back to canvas list" and invokes onNavigateBack when provided', async () => {
+      const onNavigateBack = vi.fn()
+      await act(async () => {
+        render(
+          <DaemonCanvasPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            createBackend={makeCreateBackend()}
+            onNavigateBack={onNavigateBack}
+          />,
+          { container: document.body },
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const button = screen.getByRole('button', { name: 'Back to canvas list' })
+      fireEvent.click(button)
+      expect(onNavigateBack).toHaveBeenCalledTimes(1)
+    })
+
     it('performs exactly one POST /versions on a single Cmd/Ctrl+S keydown', async () => {
       const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
         (input, init) => {

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -1480,6 +1480,30 @@ describe('DaemonCanvasPage', () => {
       expect(onNavigateBack).toHaveBeenCalledTimes(1)
     })
 
+    it('renders "Back to canvas list" in the zero-canvases branch, where WorkspaceTopBar does not mount', async () => {
+      mockListCanvases.mockResolvedValue({ canvases: [] })
+      const onNavigateBack = vi.fn()
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            createBackend={makeCreateBackend()}
+            onNavigateBack={onNavigateBack}
+          />,
+          { container: document.body },
+        )
+      })
+
+      await waitFor(() =>
+        expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
+      )
+
+      const button = screen.getByRole('button', { name: 'Back to canvas list' })
+      fireEvent.click(button)
+      expect(onNavigateBack).toHaveBeenCalledTimes(1)
+    })
+
     it('performs exactly one POST /versions on a single Cmd/Ctrl+S keydown', async () => {
       const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
         (input, init) => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -363,6 +363,19 @@ export function DaemonCanvasPage({
         )}
         {controller.canvases.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+            {/* WorkspaceTopBar (the usual home for this button) only mounts once
+                a canvas is selected, so a workspace that resolves to zero
+                canvases — an empty workspace, or a gallery row whose canvas was
+                deleted by another client — needs its own back affordance here. */}
+            {onNavigateBack && (
+              <button
+                type="button"
+                onClick={onNavigateBack}
+                className="self-start rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <span aria-hidden="true">← </span>Back to canvas list
+              </button>
+            )}
             <p className="text-sm text-muted-foreground">This workspace has no canvases yet.</p>
             {controller.createError && (
               <div role="alert" aria-live="assertive" className="text-xs text-destructive">

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -50,6 +50,10 @@ export interface DaemonCanvasPageProps {
   // previously worked browser-local can copy those canvases onto this
   // daemon workspace. Absent in tests/embedders that don't need the flow.
   browserLocalStore?: BrowserLocalStore
+  // Wired to WorkspaceTopBar's own "Back to canvas list" button. Absent
+  // (the default) hides that button — callers that own an index view (the
+  // daemon gallery) pass this to return there.
+  onNavigateBack?: () => void
 }
 
 export function DaemonCanvasPage({
@@ -61,6 +65,7 @@ export function DaemonCanvasPage({
   onContinueBrowserLocal,
   createBackend,
   browserLocalStore,
+  onNavigateBack,
 }: DaemonCanvasPageProps) {
   // Stable across the page's lifetime: daemonBaseUrl/token come from a fixed
   // pairing payload, so this never needs to change once mounted.
@@ -286,6 +291,7 @@ export function DaemonCanvasPage({
             versionRefreshSignal={versionRefreshSignal}
             onRestored={clearLocalUndo}
             versionPanelExtra={versionPanelExtra}
+            onNavigateBack={onNavigateBack}
           />
         )}
         {capabilities.branches && canvas && (

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1,0 +1,215 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DaemonIndexPage } from './DaemonIndexPage.js'
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+interface MockRoutes {
+  workspaces: Array<{ workspaceId: string }>
+  canvasesByWorkspace: Record<string, Array<{ slug: string; updatedAt: string }>>
+  namesByWorkspace?: Record<
+    string,
+    { workspace?: string; canvases: Record<string, string>; pinned: string[] } | 'fail'
+  >
+  onCreateCanvas?: (workspaceId: string, slug: string) => void
+}
+
+function installFetchMock(routes: MockRoutes) {
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
+      return Promise.resolve(jsonResponse({ workspaces: routes.workspaces }))
+    }
+    const canvasesMatch = url.match(/\/api\/workspaces\/([^/]+)\/canvases$/)
+    if (canvasesMatch && (!init || init.method === undefined)) {
+      const workspaceId = decodeURIComponent(canvasesMatch[1])
+      const canvases = routes.canvasesByWorkspace[workspaceId]
+      if (!canvases) return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+      return Promise.resolve(jsonResponse({ canvases }))
+    }
+    if (canvasesMatch && init?.method === 'POST') {
+      const workspaceId = decodeURIComponent(canvasesMatch[1])
+      const body = JSON.parse(String(init.body)) as { slug: string }
+      routes.onCreateCanvas?.(workspaceId, body.slug)
+      return Promise.resolve(jsonResponse({ slug: body.slug }))
+    }
+    const namesMatch = url.match(/\/api\/workspaces\/([^/]+)\/names$/)
+    if (namesMatch) {
+      const workspaceId = decodeURIComponent(namesMatch[1])
+      const names = routes.namesByWorkspace?.[workspaceId]
+      if (names === 'fail' || !names) {
+        return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+      }
+      return Promise.resolve(jsonResponse(names))
+    }
+    return Promise.resolve(jsonResponse({}, 404))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('DaemonIndexPage', () => {
+  it('renders one card per canvas of the selected workspace with display name and relative updatedAt', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-b': [{ slug: 'beta', updatedAt: new Date().toISOString() }],
+      },
+      namesByWorkspace: {
+        'ws-a': { canvases: { alpha: 'Alpha Board' }, pinned: [] },
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    expect(await screen.findByText('Alpha Board')).toBeTruthy()
+    expect(screen.queryByText('beta')).toBeNull()
+  })
+
+  it('switching the workspace selector replaces the visible cards', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-b': [{ slug: 'beta', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    expect(await screen.findByText('alpha')).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-b' } })
+
+    expect(await screen.findByText('beta')).toBeTruthy()
+    expect(screen.queryByText('alpha')).toBeNull()
+  })
+
+  it('sorts pinned canvases before unpinned, and unpinned by updatedAt desc', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [
+          { slug: 'old', updatedAt: '2020-01-01T00:00:00Z' },
+          { slug: 'new', updatedAt: '2026-01-01T00:00:00Z' },
+          { slug: 'pinned-one', updatedAt: '2019-01-01T00:00:00Z' },
+        ],
+      },
+      namesByWorkspace: {
+        'ws-a': { canvases: {}, pinned: ['pinned-one'] },
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('pinned-one')
+
+    const cards = screen.getAllByTestId('daemon-index-canvas-card')
+    const slugs = cards.map((c) => within(c).getByTestId('canvas-slug').textContent)
+    expect(slugs).toEqual(['pinned-one', 'new', 'old'])
+  })
+
+  it('filters cards by search input matching slug or display name', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [
+          { slug: 'alpha', updatedAt: new Date().toISOString() },
+          { slug: 'beta', updatedAt: new Date().toISOString() },
+        ],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    fireEvent.change(screen.getByLabelText('Search canvases'), { target: { value: 'bet' } })
+
+    expect(screen.queryByText('alpha')).toBeNull()
+    expect(screen.getByText('beta')).toBeTruthy()
+  })
+
+  it('degrades gracefully to unpinned/slug-only when the names fetch fails', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      namesByWorkspace: { 'ws-a': 'fail' },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    expect(await screen.findByText('alpha')).toBeTruthy()
+  })
+
+  it('shows an alert (not a blank page) when listCanvases fails for the selected workspace', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {},
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    expect(await screen.findByRole('alert')).toBeTruthy()
+  })
+
+  it('calls onOpenCanvas with the card identity on click', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+    })
+    const onOpenCanvas = vi.fn()
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={onOpenCanvas} />)
+    const card = await screen.findByTestId('daemon-index-canvas-card')
+    fireEvent.click(card)
+
+    expect(onOpenCanvas).toHaveBeenCalledExactlyOnceWith('ws-a', 'alpha')
+  })
+
+  it('creates a canvas via New canvas and opens it', async () => {
+    const created: Array<[string, string]> = []
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [] },
+      onCreateCanvas: (workspaceId, slug) => created.push([workspaceId, slug]),
+    })
+    const onOpenCanvas = vi.fn()
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={onOpenCanvas} />)
+    await waitFor(() => expect(screen.getByLabelText('New canvas name')).toBeTruthy())
+
+    fireEvent.change(screen.getByLabelText('New canvas name'), { target: { value: 'fresh' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create canvas' }))
+
+    await waitFor(() => expect(onOpenCanvas).toHaveBeenCalledWith('ws-a', 'fresh'))
+    expect(created).toEqual([['ws-a', 'fresh']])
+  })
+
+  it('mounts StorageReportCard when the Storage tab is selected', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }] },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Storage' }))
+
+    expect(await screen.findByText('Storage usage')).toBeTruthy()
+    expect(screen.queryByTestId('daemon-index-canvas-card')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -163,6 +163,53 @@ describe('DaemonIndexPage', () => {
     expect(await screen.findByRole('alert')).toBeTruthy()
   })
 
+  it('shows an alert when the initial workspace list fails to load', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse({ message: 'boom' }, 500))),
+    )
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    expect((await screen.findByRole('alert')).textContent).toBe('Failed to load workspaces.')
+  })
+
+  it('does not apply a slower, stale workspace response after switching to a newer workspace', async () => {
+    let resolveA: ((res: Response) => void) | undefined
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces')) {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }] }),
+        )
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases')) {
+        return new Promise<Response>((resolve) => {
+          resolveA = resolve
+        })
+      }
+      if (url.endsWith('/api/workspaces/ws-b/canvases')) {
+        return Promise.resolve(
+          jsonResponse({ canvases: [{ slug: 'beta', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByLabelText('Workspace')).toBeTruthy())
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-b' } })
+    expect(await screen.findByText('beta')).toBeTruthy()
+
+    resolveA?.(jsonResponse({ canvases: [{ slug: 'alpha', updatedAt: new Date().toISOString() }] }))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(screen.queryByText('alpha')).toBeNull()
+    expect(screen.getByText('beta')).toBeTruthy()
+  })
+
   it('calls onOpenCanvas with the card identity on click', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }],
@@ -196,6 +243,33 @@ describe('DaemonIndexPage', () => {
 
     await waitFor(() => expect(onOpenCanvas).toHaveBeenCalledWith('ws-a', 'fresh'))
     expect(created).toEqual([['ws-a', 'fresh']])
+  })
+
+  it('shows an alert when create canvas fails', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces')) {
+        return Promise.resolve(jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }] }))
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases') && init?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ message: 'boom' }, 500))
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases')) {
+        return Promise.resolve(jsonResponse({ canvases: [] }))
+      }
+      return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onOpenCanvas = vi.fn()
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={onOpenCanvas} />)
+    await waitFor(() => expect(screen.getByLabelText('New canvas name')).toBeTruthy())
+
+    fireEvent.change(screen.getByLabelText('New canvas name'), { target: { value: 'fresh' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create canvas' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe('Failed to create canvas.')
+    expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 
   it('mounts StorageReportCard when the Storage tab is selected', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -79,6 +79,48 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByText('beta')).toBeNull()
   })
 
+  it('honors initialWorkspaceId over the daemon-listed first workspace', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-b': [{ slug: 'beta', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(
+      <DaemonIndexPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        initialWorkspaceId="ws-b"
+        onOpenCanvas={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByText('beta')).toBeTruthy()
+    expect(screen.queryByText('alpha')).toBeNull()
+    expect((screen.getByLabelText('Workspace') as HTMLSelectElement).value).toBe('ws-b')
+  })
+
+  it('falls back to the first-listed workspace when initialWorkspaceId is not in the daemon list', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-b': [{ slug: 'beta', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(
+      <DaemonIndexPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        initialWorkspaceId="stale-deleted-workspace"
+        onOpenCanvas={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByText('alpha')).toBeTruthy()
+  })
+
   it('switching the workspace selector replaces the visible cards', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -139,6 +139,52 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByText('alpha')).toBeNull()
   })
 
+  it("clears the previous workspace's cards immediately on switch, before the new load resolves", async () => {
+    // A stale card clicked in the switch window would pair the NEW workspace
+    // id with the OLD workspace's slug — a mismatched identity.
+    // Each pending call gets its own deferred + fresh Response (a Response
+    // body is single-use, and the load may retry/refire).
+    const waiters: Array<() => void> = []
+    const releaseB = () => {
+      for (const w of waiters.splice(0)) w()
+    }
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces')) {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }] }),
+        )
+      }
+      if (url.includes('/ws-a/canvases')) {
+        return Promise.resolve(
+          jsonResponse({ canvases: [{ slug: 'alpha', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      if (url.includes('/ws-b/canvases')) {
+        return new Promise<Response>((resolve) => {
+          waiters.push(() =>
+            resolve(
+              jsonResponse({ canvases: [{ slug: 'beta', updatedAt: new Date().toISOString() }] }),
+            ),
+          )
+        })
+      }
+      return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    expect(await screen.findByText('alpha')).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-b' } })
+
+    // ws-b's canvases request is still pending — the old grid must be gone NOW.
+    expect(screen.queryByText('alpha')).toBeNull()
+
+    releaseB()
+    expect(await screen.findByText('beta')).toBeTruthy()
+  })
+
   it('sorts pinned canvases before unpinned, and unpinned by updatedAt desc', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }],
@@ -310,7 +356,8 @@ describe('DaemonIndexPage', () => {
     fireEvent.change(screen.getByLabelText('New canvas name'), { target: { value: 'fresh' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create canvas' }))
 
-    expect((await screen.findByRole('alert')).textContent).toBe('Failed to create canvas.')
+    expect((await screen.findByRole('alert')).textContent).toBe('Request failed (500).')
+    expect(screen.queryByText(/boom/)).toBeNull()
     expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -1,0 +1,296 @@
+import { workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { CanvasThumb } from '../components/CanvasThumb.js'
+import { StorageReportCard } from '../components/StorageReportCard.js'
+import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import {
+  createCanvas,
+  createDaemonFetch,
+  listCanvases,
+  listWorkspaces,
+} from '../lib/daemon-api-client.js'
+import type { WhiteboardCapabilities } from '../lib/provider.js'
+
+// A gallery for a connected daemon, scoped to ONE workspace at a time — the
+// workspace selector picks which workspace's canvases populate the grid.
+// Modeled on packages/mcp-server/src/app/pages/IndexPage.tsx's
+// filter/sort/pin logic, but single-workspace rather than the all-workspace
+// flat list that IndexPage renders (see the design note for why).
+
+export interface DaemonIndexPageProps {
+  daemonBaseUrl: string
+  token?: string
+  capabilities?: WhiteboardCapabilities
+  onOpenCanvas: (workspaceId: string, slug: string) => void
+}
+
+interface CanvasRow {
+  slug: string
+  displayName: string
+  updatedAt: string
+  pinned: boolean
+  pinOrder: number
+}
+
+// GET /api/workspaces/:id/names is not yet in daemon-api-client.ts (that
+// module only exports the canvas-listing/creation trio). Kept local to this
+// page rather than duplicated as a hand-written interface: hydrated through
+// workspaceNamesSchema so pinned-order and display-name derivation can never
+// drift from the wire contract.
+async function fetchWorkspaceNames(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+): Promise<{ canvases: Record<string, string>; pinned: string[] } | null> {
+  try {
+    const res = await fetchFn(
+      `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/names`,
+    )
+    if (!res.ok) return null
+    const parsed = workspaceNamesSchema.safeParse(await res.json())
+    if (!parsed.success) return null
+    return parsed.data
+  } catch {
+    return null
+  }
+}
+
+function filterRows(rows: CanvasRow[], search: string): CanvasRow[] {
+  const needle = search.trim().toLowerCase()
+  if (!needle) return rows
+  return rows.filter(
+    (r) => r.displayName.toLowerCase().includes(needle) || r.slug.toLowerCase().includes(needle),
+  )
+}
+
+function sortRows(rows: CanvasRow[]): CanvasRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+    if (a.pinned && b.pinned) return a.pinOrder - b.pinOrder
+    if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
+    return 0
+  })
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return ''
+  const diff = Math.floor((Date.now() - t) / 1000)
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+type TabKey = 'canvases' | 'storage'
+
+export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIndexPageProps) {
+  const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
+
+  const [tab, setTab] = useState<TabKey>('canvases')
+  const [workspaces, setWorkspaces] = useState<string[]>([])
+  const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
+  const [rows, setRows] = useState<CanvasRow[]>([])
+  const [search, setSearch] = useState('')
+  const [newCanvasSlug, setNewCanvasSlug] = useState('')
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    listWorkspaces(daemonFetch, daemonBaseUrl)
+      .then((res) => {
+        if (cancelled) return
+        const ids = res.workspaces.map((w) => w.workspaceId)
+        setWorkspaces(ids)
+        setSelectedWorkspace((current) => current ?? ids[0] ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError('Failed to load workspaces.')
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [daemonBaseUrl])
+
+  const loadWorkspace = useCallback(
+    async (workspaceId: string) => {
+      setLoadError(null)
+      try {
+        const [canvasesRes, names] = await Promise.all([
+          listCanvases(daemonFetch, daemonBaseUrl, workspaceId),
+          fetchWorkspaceNames(daemonFetch, daemonBaseUrl, workspaceId),
+        ])
+        const pinIndex = new Map((names?.pinned ?? []).map((slug, i) => [slug, i]))
+        const nextRows: CanvasRow[] = canvasesRes.canvases.map((c) => {
+          const pinOrder = pinIndex.get(c.slug)
+          return {
+            slug: c.slug,
+            displayName: names?.canvases[c.slug] ?? c.slug,
+            updatedAt: c.updatedAt,
+            pinned: pinOrder !== undefined,
+            pinOrder: pinOrder ?? Number.POSITIVE_INFINITY,
+          }
+        })
+        setRows(sortRows(nextRows))
+      } catch {
+        setRows([])
+        setLoadError('Failed to load canvases for this workspace.')
+      }
+    },
+    [daemonFetch, daemonBaseUrl],
+  )
+
+  useEffect(() => {
+    if (selectedWorkspace) void loadWorkspace(selectedWorkspace)
+  }, [selectedWorkspace, loadWorkspace])
+
+  const visible = useMemo(() => filterRows(rows, search), [rows, search])
+
+  const handleCreate = useCallback(async () => {
+    if (!selectedWorkspace || !newCanvasSlug.trim()) return
+    setCreateError(null)
+    try {
+      const created = await createCanvas(
+        daemonFetch,
+        daemonBaseUrl,
+        selectedWorkspace,
+        newCanvasSlug.trim(),
+      )
+      setNewCanvasSlug('')
+      onOpenCanvas(selectedWorkspace, created.slug)
+    } catch {
+      setCreateError('Failed to create canvas.')
+    }
+  }, [daemonFetch, daemonBaseUrl, selectedWorkspace, newCanvasSlug, onOpenCanvas])
+
+  return (
+    <DaemonApiContext.Provider value={daemonFetch}>
+      <div className="flex h-dvh flex-col overflow-y-auto p-4">
+        <h1 className="sr-only">Canvases</h1>
+        <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
+          <div
+            role="tablist"
+            aria-label="Daemon index tabs"
+            className="flex items-center gap-1 rounded-md border p-0.5"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'canvases'}
+              onClick={() => setTab('canvases')}
+              className="rounded px-3 py-1 text-sm font-medium data-[selected=true]:bg-accent"
+              data-selected={tab === 'canvases'}
+            >
+              Canvases
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'storage'}
+              onClick={() => setTab('storage')}
+              className="rounded px-3 py-1 text-sm font-medium data-[selected=true]:bg-accent"
+              data-selected={tab === 'storage'}
+            >
+              Storage
+            </button>
+          </div>
+          {tab === 'canvases' && workspaces.length > 0 && (
+            <select
+              aria-label="Workspace"
+              value={selectedWorkspace ?? ''}
+              onChange={(event) => setSelectedWorkspace(event.target.value)}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {workspaces.map((w) => (
+                <option key={w} value={w}>
+                  {w}
+                </option>
+              ))}
+            </select>
+          )}
+          {tab === 'canvases' && (
+            <input
+              aria-label="Search canvases"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search…"
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            />
+          )}
+          {tab === 'canvases' && (
+            <form
+              className="flex items-center gap-2"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void handleCreate()
+              }}
+            >
+              <input
+                aria-label="New canvas name"
+                value={newCanvasSlug}
+                onChange={(event) => setNewCanvasSlug(event.target.value)}
+                className="rounded-md border bg-background px-2 py-1 text-sm"
+              />
+              <button
+                type="submit"
+                className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
+              >
+                Create canvas
+              </button>
+            </form>
+          )}
+        </div>
+
+        {createError && (
+          <div role="alert" className="mb-2 text-sm text-destructive">
+            {createError}
+          </div>
+        )}
+
+        {tab === 'storage' ? (
+          <StorageReportCard />
+        ) : loadError ? (
+          <div role="alert" className="text-sm text-destructive">
+            {loadError}
+          </div>
+        ) : visible.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No canvases match.</p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            {visible.map((row) => (
+              <button
+                key={row.slug}
+                type="button"
+                data-testid="daemon-index-canvas-card"
+                onClick={() => selectedWorkspace && onOpenCanvas(selectedWorkspace, row.slug)}
+                className="flex flex-col gap-2 rounded-lg border p-2 text-left hover:bg-accent"
+              >
+                <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
+                <div className="min-w-0">
+                  {row.displayName !== row.slug && (
+                    <div className="truncate text-sm font-medium">{row.displayName}</div>
+                  )}
+                  <div
+                    data-testid="canvas-slug"
+                    className={
+                      row.displayName !== row.slug
+                        ? 'truncate text-xs text-muted-foreground'
+                        : 'truncate text-sm font-medium'
+                    }
+                  >
+                    {row.slug}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatRelative(row.updatedAt)}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </DaemonApiContext.Provider>
+  )
+}

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -196,50 +196,50 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
               Storage
             </button>
           </div>
-          {tab === 'canvases' && workspaces.length > 0 && (
-            <select
-              aria-label="Workspace"
-              value={selectedWorkspace ?? ''}
-              onChange={(event) => setSelectedWorkspace(event.target.value)}
-              className="rounded-md border bg-background px-2 py-1 text-sm"
-            >
-              {workspaces.map((w) => (
-                <option key={w} value={w}>
-                  {w}
-                </option>
-              ))}
-            </select>
-          )}
           {tab === 'canvases' && (
-            <input
-              aria-label="Search canvases"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search…"
-              className="rounded-md border bg-background px-2 py-1 text-sm"
-            />
-          )}
-          {tab === 'canvases' && (
-            <form
-              className="flex items-center gap-2"
-              onSubmit={(event) => {
-                event.preventDefault()
-                void handleCreate()
-              }}
-            >
+            <>
+              {workspaces.length > 0 && (
+                <select
+                  aria-label="Workspace"
+                  value={selectedWorkspace ?? ''}
+                  onChange={(event) => setSelectedWorkspace(event.target.value)}
+                  className="rounded-md border bg-background px-2 py-1 text-sm"
+                >
+                  {workspaces.map((w) => (
+                    <option key={w} value={w}>
+                      {w}
+                    </option>
+                  ))}
+                </select>
+              )}
               <input
-                aria-label="New canvas name"
-                value={newCanvasSlug}
-                onChange={(event) => setNewCanvasSlug(event.target.value)}
+                aria-label="Search canvases"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search…"
                 className="rounded-md border bg-background px-2 py-1 text-sm"
               />
-              <button
-                type="submit"
-                className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
+              <form
+                className="flex items-center gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void handleCreate()
+                }}
               >
-                Create canvas
-              </button>
-            </form>
+                <input
+                  aria-label="New canvas name"
+                  value={newCanvasSlug}
+                  onChange={(event) => setNewCanvasSlug(event.target.value)}
+                  className="rounded-md border bg-background px-2 py-1 text-sm"
+                />
+                <button
+                  type="submit"
+                  className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
+                >
+                  Create canvas
+                </button>
+              </form>
+            </>
           )}
         </div>
 
@@ -259,35 +259,38 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
           <p className="text-sm text-muted-foreground">No canvases match.</p>
         ) : (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-            {visible.map((row) => (
-              <button
-                key={row.slug}
-                type="button"
-                data-testid="daemon-index-canvas-card"
-                onClick={() => selectedWorkspace && onOpenCanvas(selectedWorkspace, row.slug)}
-                className="flex flex-col gap-2 rounded-lg border p-2 text-left hover:bg-accent"
-              >
-                <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
-                <div className="min-w-0">
-                  {row.displayName !== row.slug && (
-                    <div className="truncate text-sm font-medium">{row.displayName}</div>
-                  )}
-                  <div
-                    data-testid="canvas-slug"
-                    className={
-                      row.displayName !== row.slug
-                        ? 'truncate text-xs text-muted-foreground'
-                        : 'truncate text-sm font-medium'
-                    }
-                  >
-                    {row.slug}
+            {visible.map((row) => {
+              const hasDisplayName = row.displayName !== row.slug
+              return (
+                <button
+                  key={row.slug}
+                  type="button"
+                  data-testid="daemon-index-canvas-card"
+                  onClick={() => selectedWorkspace && onOpenCanvas(selectedWorkspace, row.slug)}
+                  className="flex flex-col gap-2 rounded-lg border p-2 text-left hover:bg-accent"
+                >
+                  <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
+                  <div className="min-w-0">
+                    {hasDisplayName && (
+                      <div className="truncate text-sm font-medium">{row.displayName}</div>
+                    )}
+                    <div
+                      data-testid="canvas-slug"
+                      className={
+                        hasDisplayName
+                          ? 'truncate text-xs text-muted-foreground'
+                          : 'truncate text-sm font-medium'
+                      }
+                    >
+                      {row.slug}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatRelative(row.updatedAt)}
+                    </div>
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    {formatRelative(row.updatedAt)}
-                  </div>
-                </div>
-              </button>
-            ))}
+                </button>
+              )
+            })}
           </div>
         )}
       </div>

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -1,4 +1,5 @@
 import { workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import type { z } from 'zod'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { CanvasThumb } from '../components/CanvasThumb.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
@@ -41,7 +42,7 @@ async function fetchWorkspaceNames(
   fetchFn: typeof globalThis.fetch,
   daemonBaseUrl: string,
   workspaceId: string,
-): Promise<{ canvases: Record<string, string>; pinned: string[] } | null> {
+): Promise<z.infer<typeof workspaceNamesSchema> | null> {
   try {
     const res = await fetchFn(
       `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/names`,
@@ -115,13 +116,14 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
   }, [daemonBaseUrl])
 
   const loadWorkspace = useCallback(
-    async (workspaceId: string) => {
+    async (workspaceId: string, isStale: () => boolean) => {
       setLoadError(null)
       try {
         const [canvasesRes, names] = await Promise.all([
           listCanvases(daemonFetch, daemonBaseUrl, workspaceId),
           fetchWorkspaceNames(daemonFetch, daemonBaseUrl, workspaceId),
         ])
+        if (isStale()) return
         const pinIndex = new Map((names?.pinned ?? []).map((slug, i) => [slug, i]))
         const nextRows: CanvasRow[] = canvasesRes.canvases.map((c) => {
           const pinOrder = pinIndex.get(c.slug)
@@ -135,6 +137,7 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
         })
         setRows(sortRows(nextRows))
       } catch {
+        if (isStale()) return
         setRows([])
         setLoadError('Failed to load canvases for this workspace.')
       }
@@ -143,7 +146,12 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
   )
 
   useEffect(() => {
-    if (selectedWorkspace) void loadWorkspace(selectedWorkspace)
+    if (!selectedWorkspace) return
+    let cancelled = false
+    void loadWorkspace(selectedWorkspace, () => cancelled)
+    return () => {
+      cancelled = true
+    }
   }, [selectedWorkspace, loadWorkspace])
 
   const visible = useMemo(() => filterRows(rows, search), [rows, search])

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -22,6 +22,10 @@ export interface DaemonIndexPageProps {
   daemonBaseUrl: string
   token?: string
   capabilities?: WhiteboardCapabilities
+  // A workspace-level pairing link (#wb= with workspaceId but no slug) names
+  // a specific workspace to land on; falls back to the daemon's first-listed
+  // workspace when absent, or when the named workspace isn't in the list.
+  initialWorkspaceId?: string
   onOpenCanvas: (workspaceId: string, slug: string) => void
 }
 
@@ -85,7 +89,12 @@ function formatRelative(iso: string): string {
 
 type TabKey = 'canvases' | 'storage'
 
-export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIndexPageProps) {
+export function DaemonIndexPage({
+  daemonBaseUrl,
+  token,
+  initialWorkspaceId,
+  onOpenCanvas,
+}: DaemonIndexPageProps) {
   const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
 
   const [tab, setTab] = useState<TabKey>('canvases')
@@ -104,7 +113,9 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
         if (cancelled) return
         const ids = res.workspaces.map((w) => w.workspaceId)
         setWorkspaces(ids)
-        setSelectedWorkspace((current) => current ?? ids[0] ?? null)
+        const targeted =
+          initialWorkspaceId && ids.includes(initialWorkspaceId) ? initialWorkspaceId : undefined
+        setSelectedWorkspace((current) => current ?? targeted ?? ids[0] ?? null)
       })
       .catch(() => {
         if (!cancelled) setLoadError('Failed to load workspaces.')
@@ -112,6 +123,9 @@ export function DaemonIndexPage({ daemonBaseUrl, token, onOpenCanvas }: DaemonIn
     return () => {
       cancelled = true
     }
+    // initialWorkspaceId is fixed for the page's lifetime (set once from the
+    // pairing payload App.tsx resolved at mount) — it deliberately isn't a
+    // dependency so this effect stays load-once, matching daemonBaseUrl.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [daemonBaseUrl])
 

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -80,7 +80,9 @@ function sortRows(rows: CanvasRow[]): CanvasRow[] {
 function formatRelative(iso: string): string {
   const t = new Date(iso).getTime()
   if (!Number.isFinite(t)) return ''
-  const diff = Math.floor((Date.now() - t) / 1000)
+  // Clock drift between client and daemon can make (now - t) negative;
+  // clamp so the label never reads "-5s ago".
+  const diff = Math.max(0, Math.floor((Date.now() - t) / 1000))
   if (diff < 60) return `${diff}s ago`
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
@@ -143,7 +145,7 @@ export function DaemonIndexPage({
           const pinOrder = pinIndex.get(c.slug)
           return {
             slug: c.slug,
-            displayName: names?.canvases[c.slug] ?? c.slug,
+            displayName: names?.canvases?.[c.slug] ?? c.slug,
             updatedAt: c.updatedAt,
             pinned: pinOrder !== undefined,
             pinOrder: pinOrder ?? Number.POSITIVE_INFINITY,
@@ -162,6 +164,11 @@ export function DaemonIndexPage({
   useEffect(() => {
     if (!selectedWorkspace) return
     let cancelled = false
+    // Clear synchronously BEFORE the async load: leaving the previous
+    // workspace's rows visible during the switch lets a click pair the new
+    // workspace id with an old workspace's slug — a mismatched identity.
+    setRows([])
+    setLoadError(null)
     void loadWorkspace(selectedWorkspace, () => cancelled)
     return () => {
       cancelled = true
@@ -182,8 +189,10 @@ export function DaemonIndexPage({
       )
       setNewCanvasSlug('')
       onOpenCanvas(selectedWorkspace, created.slug)
-    } catch {
-      setCreateError('Failed to create canvas.')
+    } catch (err) {
+      // daemon-api-client errors are already sanitized (Problem Details
+      // title or a generic status message) — safe to surface directly.
+      setCreateError(err instanceof Error ? err.message : 'Failed to create canvas.')
     }
   }, [daemonFetch, daemonBaseUrl, selectedWorkspace, newCanvasSlug, onOpenCanvas])
 

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -689,10 +689,16 @@ describe('auto-compact', () => {
     // Nothing has fired yet.
     expect(await readLastCompactedAt()).toBeNull()
 
-    // Wait past the debounce + the async compactCanvas write.
-    await new Promise((r) => setTimeout(r, 250))
-    const stamp = await readLastCompactedAt()
-    expect(stamp).not.toBeNull()
+    // Wait past the debounce + the async compactCanvas write. Poll instead of
+    // a fixed sleep so this does not flake on a slow CI runner.
+    const stamp = await vi.waitFor(
+      async () => {
+        const value = await readLastCompactedAt()
+        expect(value).not.toBeNull()
+        return value
+      },
+      { timeout: 2000 },
+    )
     const settled = stamp!
 
     // Further idle time without a new trigger must NOT re-compact.
@@ -734,11 +740,16 @@ describe('auto-compact', () => {
     expect(peekDoc('session1', 'cached')).toBeDefined()
 
     scheduleAutoCompact('session1', 'cached', store, { debounceMs: 50 })
-    await new Promise((r) => setTimeout(r, 250))
 
-    // The whole point of this test: after the scheduled compaction lands,
-    // the cache must be empty for that key so the next save reloads the
-    // compacted file as its base.
-    expect(peekDoc('session1', 'cached')).toBeUndefined()
+    // Poll instead of a fixed sleep so this does not flake on a slow CI
+    // runner. The whole point of this test: after the scheduled compaction
+    // lands, the cache must be empty for that key so the next save reloads
+    // the compacted file as its base.
+    await vi.waitFor(
+      () => {
+        expect(peekDoc('session1', 'cached')).toBeUndefined()
+      },
+      { timeout: 2000 },
+    )
   })
 })


### PR DESCRIPTION
## Summary

MCP-UI retirement slice R2 (parity audit HIGHs ×3): apps/web daemon mode had no way to browse canvases (single #wb= target only), the top bar's 'Back to canvas list' button was dead, and StorageReportCard was built but unwired. This also directly answers the user-reported gap 'MCP版にあったセッション一覧にアクセスできない'.

- **DaemonIndexPage** (lazy chunk): workspace selector, canvas card grid (blob-fetched authorized thumbnails via the daemon fetch — a plain `<img src>` can't carry the bearer token), search, pinned-first ordering (names-endpoint failure degrades gracefully), New canvas.
- **Tabs: Canvases | Storage** — Storage tab finally mounts StorageReportCard; its requests now route through `useDaemonApi()` (falls back to `apiFetch` when no provider — same-origin usage behavior-preserving).
- **Navigation**: daemon modes open on the gallery when no canvas is targeted; card click → DaemonCanvasPage (keyed remount); `onNavigateBack` wired so the back button works and returns to the same workspace. `#wb=` deep links with slug still land directly on the canvas; workspace-only links honor the target workspace.
- Includes a small flake-hardening follow-up to #182's auto-compact test (fixed sleep → vi.waitFor), consistent with the CI-reliability policy.

## Test plan
- [x] Red-first jsdom: gallery render/search/pinned order, card→canvas, back→same workspace, Storage tab, deep-link precedence, stale-response guard — 331-line new suite
- [x] Full suite 321 files / 4169 tests green; typecheck; entry 9.2 KB gzip (budget 560 KB)
- Gallery screenshots to follow in a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a daemon canvas gallery with workspace selection, search, sorting, pinned canvases, and canvas creation.
  - Added a Storage tab for viewing storage details and managing daemon logs.
  - Added navigation between the canvas gallery and individual canvases.
  - Added clearer loading, empty, and error states.

- **Improvements**
  - Canvas thumbnails now load reliably through the daemon connection, with graceful fallbacks when unavailable.
  - Storage and cleanup actions now work consistently across daemon-connected environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->