### PR TITLE
feat(web,mcp-server): rename branch/merge UI copy to Variation/Combine

### DIFF
--- a/apps/web/src/components/HeaderBranchBanner.test.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.test.tsx
@@ -74,7 +74,7 @@ describe('HeaderBranchBanner', () => {
     await waitFor(() => {
       expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
     })
-    expect(screen.getByText(/changes not yet merged into/)).toBeTruthy()
+    expect(screen.getByText(/changes not yet combined into/)).toBeTruthy()
     expect(screen.getByText(/3/)).toBeTruthy()
     expect(screen.getByTestId('header-branch-banner-merge')).toBeTruthy()
   })

--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import type { MergeResult } from '@/hooks/useBranches'
 import { useBranches } from '@/hooks/useBranches'
 import { MERGE_COMMITTED_EVENT, parseMergeCommittedEvent } from '@/lib/merge-committed-event'
+import { displayBranchName } from '@/lib/utils'
 import { MergeDialog } from './MergeDialog'
 
 // Show a banner under the header when the current branch is ahead of main.
@@ -82,8 +83,8 @@ export function HeaderBranchBanner({
       >
         <AlertTriangle className="size-3.5 shrink-0 text-amber-600" aria-hidden />
         <span className="min-w-0 flex-1 truncate">
-          Branch «<strong>{head}</strong>» has <strong>{unmergedCommits}</strong> changes not yet
-          merged into main
+          Variation “<strong>{displayBranchName(head)}</strong>” has{' '}
+          <strong>{unmergedCommits}</strong> changes not yet combined into “Main”
         </span>
         <Button
           type="button"
@@ -94,7 +95,7 @@ export function HeaderBranchBanner({
           onClick={() => setMergeOpen(true)}
         >
           <GitMerge className="size-3.5" />
-          Merge into main
+          Combine into “Main”
         </Button>
       </div>
       <MergeDialog

--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -83,8 +83,8 @@ export function HeaderBranchBanner({
       >
         <AlertTriangle className="size-3.5 shrink-0 text-amber-600" aria-hidden />
         <span className="min-w-0 flex-1 truncate">
-          Variation “<strong>{displayBranchName(head)}</strong>” has{' '}
-          <strong>{unmergedCommits}</strong> changes not yet combined into “Main”
+          Variation «<strong>{displayBranchName(head)}</strong>» has{' '}
+          <strong>{unmergedCommits}</strong> changes not yet combined into «Main»
         </span>
         <Button
           type="button"
@@ -95,7 +95,7 @@ export function HeaderBranchBanner({
           onClick={() => setMergeOpen(true)}
         >
           <GitMerge className="size-3.5" />
-          Combine into “Main”
+          Combine into «Main»
         </Button>
       </div>
       <MergeDialog

--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -92,7 +92,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     const deleteItem = await screen.findByText(/Delete/)
     await userEvent.click(deleteItem)
 
-    await screen.findByText(/unmerged commits remain/)
+    await screen.findByText(/changes not yet combined remain/)
 
     const confirmButton = await screen.findByRole('button', { name: 'Delete' })
     await userEvent.click(confirmButton)
@@ -100,15 +100,15 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     expect(stateHolder.current.deleteBranch).toHaveBeenCalledWith('feature-x')
   })
 
-  it('inline "New branch…" form submits createBranch with the typed name', async () => {
+  it('inline "New variation…" form submits createBranch with the typed name', async () => {
     render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
     const chip = screen.getByTestId('header-branch-chip')
     await userEvent.click(chip)
 
-    const newBranchItem = await screen.findByText(/New branch/)
+    const newBranchItem = await screen.findByText(/New variation/)
     await userEvent.click(newBranchItem)
 
-    const input = await screen.findByPlaceholderText('New branch name')
+    const input = await screen.findByPlaceholderText('New variation name')
     await userEvent.type(input, 'my-new-branch{Enter}')
 
     expect(stateHolder.current.createBranch).toHaveBeenCalledWith({ name: 'my-new-branch' })
@@ -120,10 +120,10 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     const chip = screen.getByTestId('header-branch-chip')
     await userEvent.click(chip)
 
-    const newBranchItem = await screen.findByText(/New branch/)
+    const newBranchItem = await screen.findByText(/New variation/)
     await userEvent.click(newBranchItem)
 
-    const input = await screen.findByPlaceholderText('New branch name')
+    const input = await screen.findByPlaceholderText('New variation name')
     await userEvent.type(input, 'my-new-branch{Enter}')
 
     // The dropdown stays open on error so the user can retry; the error must
@@ -131,7 +131,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     // aria-hidden'd background wrapper — a plain (non-hidden) query proves
     // it is actually visible/announced.
     const alert = await screen.findByRole('alert')
-    expect(alert.textContent).toContain('Failed to create branch')
+    expect(alert.textContent).toContain('Failed to create variation')
   })
 
   it('surfaces setHead rejection as a role=alert with the safe error copy', async () => {
@@ -144,7 +144,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await userEvent.click(option)
 
     const alert = await screen.findByRole('alert')
-    expect(alert.textContent).toContain('Failed to switch branch')
+    expect(alert.textContent).toContain('Failed to switch variation')
   })
 
   it('surfaces renameBranch rejection as a role=alert with the safe error copy', async () => {
@@ -164,7 +164,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     // The rename dialog stays open on error; the error must render inside the
     // still-open dialog content, so a plain (non-hidden) query must find it.
     const alert = await screen.findByRole('alert')
-    expect(alert.textContent).toContain('Failed to rename branch')
+    expect(alert.textContent).toContain('Failed to rename variation')
   })
 
   it('surfaces deleteBranch rejection as a role=alert with the safe error copy', async () => {
@@ -181,7 +181,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await userEvent.click(confirmButton)
 
     const alert = await screen.findByRole('alert', { hidden: true })
-    expect(alert.textContent).toContain('Failed to delete branch')
+    expect(alert.textContent).toContain('Failed to delete variation')
   })
 
   it('kebab -> merge opens MergeDialog with the chosen source and current HEAD as target', async () => {
@@ -210,7 +210,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     const kebab = screen.getByTestId('header-branch-kebab')
     await userEvent.click(kebab)
 
-    const unavailable = await screen.findByText('Merge unavailable')
+    const unavailable = await screen.findByText('Combine unavailable')
     expect(unavailable.getAttribute('data-disabled')).not.toBeNull()
 
     // The branch that would normally be a mergeable source must not appear
@@ -269,7 +269,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await userEvent.click(deleteItem)
 
     await screen.findByText(/Delete «feature-x»\?/)
-    expect(screen.queryByText(/unmerged commits remain/)).toBeNull()
+    expect(screen.queryByText(/changes not yet combined remain/)).toBeNull()
 
     const confirmButton = await screen.findByRole('button', { name: 'Delete' })
     await userEvent.click(confirmButton)

--- a/apps/web/src/components/HeaderBranchChip.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.test.tsx
@@ -65,10 +65,10 @@ afterEach(() => {
 useBranchesMock.mockImplementation(() => state.current)
 
 describe('HeaderBranchChip', () => {
-  it('renders the HEAD name in the chip trigger', () => {
+  it('renders the HEAD name in the chip trigger, capitalized for the default variation', () => {
     renderChip()
     const chip = screen.getByTestId('header-branch-chip')
-    expect(chip.textContent).toContain('main')
+    expect(chip.textContent).toContain('Main')
   })
 
   it('updates chip text when HEAD changes', () => {
@@ -94,14 +94,14 @@ describe('HeaderBranchChip', () => {
   it('uses an English aria-label on the chip trigger', () => {
     renderChip()
     const chip = screen.getByTestId('header-branch-chip')
-    expect(chip.getAttribute('aria-label')).toContain('Switch branch')
+    expect(chip.getAttribute('aria-label')).toContain('Switch variation')
     expect(chip.getAttribute('aria-label')).toContain('current: main')
   })
 
   it('uses an English aria-label on the kebab trigger', () => {
     renderChip()
     const kebab = screen.getByTestId('header-branch-kebab')
-    expect(kebab.getAttribute('aria-label')).toBe('Branch actions')
+    expect(kebab.getAttribute('aria-label')).toBe('Variation actions')
   })
 })
 

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -42,7 +42,7 @@ import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import type { MergeResult } from '@/hooks/useBranches'
 import { useBranches } from '@/hooks/useBranches'
 import { safeErrorCopy } from '@/lib/error-copy'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 
 // MergeDialog pulls in its own thumbnail-fetch effect and a second Dialog
 // surface; loading it on demand keeps it out of the daemon-canvas chunk
@@ -50,14 +50,17 @@ import { cn } from '@/lib/utils'
 const MergeDialog = lazy(() => import('./MergeDialog').then((m) => ({ default: m.MergeDialog })))
 
 // Consolidate branch operations into a single `●branch▾` chip in the header.
+// UI copy uses the Variation/Combine vocabulary; the underlying data model,
+// hook, and MCP tool calls keep their git-derived identifiers (branch, merge)
+// unchanged.
 //
 // Behavior:
-//   - Left trigger: switch branches from a dropdown
-//   - Right kebab: rename, delete, or merge from another branch
-//   - New branch: inline form inside the dropdown
+//   - Left trigger: switch variations from a dropdown
+//   - Right kebab: rename, delete, or combine from another variation
+//   - New variation: inline form inside the dropdown
 //
 // Unlike the old tab layout, there is always exactly one visible chip for HEAD.
-// Other branches are managed through the dropdown and kebab menu.
+// Other variations are managed through the dropdown and kebab menu.
 
 export interface HeaderBranchChipProps {
   workspaceId: string
@@ -129,7 +132,7 @@ export function HeaderBranchChip({
       setCreateOpen(false)
       setErrorMessage(null)
     } catch (err) {
-      setErrorMessage(safeErrorCopy(err, 'Failed to create branch'))
+      setErrorMessage(safeErrorCopy(err, 'Failed to create variation'))
     }
   }
 
@@ -160,7 +163,7 @@ export function HeaderBranchChip({
       setRenameOpen(false)
       setErrorMessage(null)
     } catch (err) {
-      setErrorMessage(safeErrorCopy(err, 'Failed to rename branch'))
+      setErrorMessage(safeErrorCopy(err, 'Failed to rename variation'))
     }
   }
 
@@ -240,7 +243,7 @@ export function HeaderBranchChip({
               <button
                 type="button"
                 disabled={disabled}
-                aria-label={`Switch branch (current: ${head})`}
+                aria-label={`Switch variation (current: ${head})`}
                 data-testid="header-branch-chip"
                 className={cn(
                   'flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium',
@@ -254,27 +257,27 @@ export function HeaderBranchChip({
                   style={{ background: chipColor }}
                 />
                 <span className="truncate" title={head}>
-                  {head}
+                  {displayBranchName(head)}
                 </span>
                 <ChevronDown className="size-3 shrink-0 opacity-70" aria-hidden />
               </button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent>Branch</TooltipContent>
+          <TooltipContent>Variation</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="start" className="w-[240px]">
           <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
             <GitBranch className="size-3" />
-            Switch branch
+            Switch variation
           </DropdownMenuLabel>
-          {/* Show HEAD first and mark it as the current branch. */}
+          {/* Show HEAD first and mark it as the current variation. */}
           <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="gap-2" disabled>
             <span
               aria-hidden
               className="inline-block size-2 rounded-full"
               style={{ background: chipColor }}
             />
-            <span className="truncate">{head}</span>
+            <span className="truncate">{displayBranchName(head)}</span>
             <span className="ml-auto text-[10px] text-muted-foreground">Current</span>
           </DropdownMenuItem>
           {otherBranches.map((b) => (
@@ -282,7 +285,7 @@ export function HeaderBranchChip({
               key={b.name}
               onSelect={() => {
                 setHead(b.name).catch((err: unknown) => {
-                  setErrorMessage(safeErrorCopy(err, 'Failed to switch branch'))
+                  setErrorMessage(safeErrorCopy(err, 'Failed to switch variation'))
                 })
               }}
               className="gap-2"
@@ -293,7 +296,7 @@ export function HeaderBranchChip({
                 style={{ background: b.color }}
               />
               <span className="truncate" title={b.name}>
-                {b.name}
+                {displayBranchName(b.name)}
               </span>
             </DropdownMenuItem>
           ))}
@@ -310,9 +313,9 @@ export function HeaderBranchChip({
                 <Input
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
-                  placeholder="New branch name"
+                  placeholder="New variation name"
                   autoFocus
-                  aria-label="New branch name"
+                  aria-label="New variation name"
                   className="h-7 text-xs"
                   maxLength={80}
                 />
@@ -349,7 +352,7 @@ export function HeaderBranchChip({
               className="gap-2"
             >
               <Plus className="size-3.5" />
-              New branch…
+              New variation…
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>
@@ -363,7 +366,7 @@ export function HeaderBranchChip({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label="Branch actions"
+            aria-label="Variation actions"
             data-testid="header-branch-kebab"
             disabled={disabled}
             className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
@@ -374,15 +377,15 @@ export function HeaderBranchChip({
         <DropdownMenuContent align="end" className="w-[240px]">
           <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
             <GitMerge className="size-3" />
-            Merge into «{head}»
+            Combine into «{displayBranchName(head)}»
           </DropdownMenuLabel>
           {!mergeEnabled ? (
             <DropdownMenuItem disabled className="text-xs text-muted-foreground">
-              Merge unavailable
+              Combine unavailable
             </DropdownMenuItem>
           ) : otherBranches.length === 0 ? (
             <DropdownMenuItem disabled className="text-xs text-muted-foreground">
-              No other branches
+              No other variations
             </DropdownMenuItem>
           ) : (
             otherBranches.map((b) => (
@@ -402,7 +405,7 @@ export function HeaderBranchChip({
                   className="inline-block size-2 rounded-full"
                   style={{ background: b.color }}
                 />
-                <span className="truncate">{b.name}</span>
+                <span className="truncate">{displayBranchName(b.name)}</span>
               </DropdownMenuItem>
             ))
           )}
@@ -416,7 +419,7 @@ export function HeaderBranchChip({
             className="gap-2"
           >
             <Pencil className="size-3.5" />
-            Rename «{head}»…
+            Rename «{displayBranchName(head)}»…
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={head === 'main'}
@@ -431,7 +434,7 @@ export function HeaderBranchChip({
             }}
           >
             <Trash2 className="size-3.5" />
-            Delete «{head}»…
+            Delete «{displayBranchName(head)}»…
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -452,9 +455,9 @@ export function HeaderBranchChip({
       >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Rename «{renameTarget?.name ?? head}»</DialogTitle>
+            <DialogTitle>Rename «{displayBranchName(renameTarget?.name ?? head)}»</DialogTitle>
             <DialogDescription>
-              Enter a new name. Every saved version on this branch will be relinked to it.
+              Enter a new name. Every saved version on this variation will be relinked to it.
             </DialogDescription>
           </DialogHeader>
           <Input
@@ -494,15 +497,17 @@ export function HeaderBranchChip({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete «{pendingDelete?.name ?? ''}»?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Delete «{displayBranchName(pendingDelete?.name ?? '')}»?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              This deletes the branch. Saved versions stay in version history, but the branch will
-              no longer be reachable from branch navigation.
+              This deletes the variation. Saved versions stay in version history, but the variation
+              will no longer be reachable from variation navigation.
               {pendingStats && pendingStats.unmergedCommits > 0 ? (
                 <>
                   <br />
                   <strong className="text-destructive">
-                    ⚠ {pendingStats.unmergedCommits} unmerged commits remain
+                    ⚠ {pendingStats.unmergedCommits} changes not yet combined remain
                   </strong>
                 </>
               ) : null}
@@ -521,7 +526,7 @@ export function HeaderBranchChip({
                   setErrorMessage(null)
                   setPendingDelete(null)
                 } catch (err) {
-                  setErrorMessage(safeErrorCopy(err, 'Failed to delete branch'))
+                  setErrorMessage(safeErrorCopy(err, 'Failed to delete variation'))
                   setPendingDelete(null)
                 } finally {
                   setDeleting(false)

--- a/apps/web/src/components/MergeDialog.test.tsx
+++ b/apps/web/src/components/MergeDialog.test.tsx
@@ -348,7 +348,7 @@ describe('MergeDialog', () => {
     await screen.findByText(/branch already exists/i)
   })
 
-  it('renders a complete, correctly-ordered merge title', async () => {
+  it('renders a complete, correctly-ordered combine title, capitalizing the default variation', async () => {
     const runMerge = vi
       .fn<(source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResponse>>()
       .mockResolvedValue({ badges: [], preview: { elementCount: 5 } })
@@ -361,8 +361,8 @@ describe('MergeDialog', () => {
         runMerge={runMerge}
       />,
     )
-    const title = await screen.findByText(/Merge changes from/)
-    expect(title.textContent).toBe('Merge changes from «feature» into «main»')
+    const title = await screen.findByText(/Combine.*into/)
+    expect(title.textContent).toBe('Combine «feature» into «Main»')
   })
 
   it('shows the post-merge side-effect notice for a non-main source', async () => {
@@ -379,7 +379,7 @@ describe('MergeDialog', () => {
       />,
     )
     const notice = await screen.findByTestId('merge-side-effect-notice')
-    expect(notice.textContent).toContain('main')
+    expect(notice.textContent).toContain('Main')
     expect(notice.textContent).toContain('feature')
   })
 

--- a/apps/web/src/components/MergeDialog.tsx
+++ b/apps/web/src/components/MergeDialog.tsx
@@ -17,7 +17,7 @@ import { type JSX, useEffect, useMemo, useState } from 'react'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { safeErrorCopy } from '@/lib/error-copy'
 import { dispatchMergeCommitted } from '@/lib/merge-committed-event'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 import { Button } from './ui/button.js'
 import {
   Dialog,
@@ -325,7 +325,7 @@ export function MergeDialog({
       }
       onClose()
     } catch (err) {
-      setError(safeErrorCopy(err, 'Merge failed.'))
+      setError(safeErrorCopy(err, 'Combine failed.'))
     } finally {
       setCommitting(false)
     }
@@ -361,13 +361,13 @@ export function MergeDialog({
           <DialogTitle className="flex items-center gap-2">
             <GitMerge className="h-4 w-4" />
             <span>
-              Merge changes from{' '}
+              Combine{' '}
               <span style={{ color: source?.color ?? undefined }} className="font-semibold">
-                «{source?.name ?? '?'}»
+                «{source ? displayBranchName(source.name) : '?'}»
               </span>{' '}
               into{' '}
               <span style={{ color: target?.color ?? undefined }} className="font-semibold">
-                «{target?.name ?? '?'}»
+                «{target ? displayBranchName(target.name) : '?'}»
               </span>
             </span>
           </DialogTitle>
@@ -428,7 +428,7 @@ export function MergeDialog({
                   className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
                 />
                 <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
-                  Merged preview
+                  Combined preview
                 </span>
               </div>
               <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
@@ -454,7 +454,8 @@ export function MergeDialog({
                   <div className="text-center text-xs">
                     <div>{previewElementCount > 0 ? 'No preview image yet' : 'No elements'}</div>
                     <div className="mt-1 text-[10px] opacity-80">
-                      Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+                      Save «{source ? displayBranchName(source.name) : '?'}» with ⌘S to generate a
+                      preview image
                     </div>
                   </div>
                 </div>
@@ -478,7 +479,8 @@ export function MergeDialog({
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="size-4 text-emerald-600" />
                 <span>
-                  <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
+                  <strong className="text-emerald-700">No conflicts</strong> - ready to combine
+                  as-is
                 </span>
               </div>
             ) : (
@@ -524,9 +526,9 @@ export function MergeDialog({
               className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
               data-testid="merge-side-effect-notice"
             >
-              <strong>After merge:</strong> switch automatically to "
-              <span className="font-semibold">{target.name}</span>" and delete "
-              <span className="font-semibold">{source.name}</span>
+              <strong>After combining:</strong> switch automatically to "
+              <span className="font-semibold">{displayBranchName(target.name)}</span>" and delete "
+              <span className="font-semibold">{displayBranchName(source.name)}</span>
               ".
             </div>
           )}
@@ -545,12 +547,12 @@ export function MergeDialog({
             {committing ? (
               <>
                 <Loader2 className="size-3.5 animate-spin" />
-                Merging…
+                Combining…
               </>
             ) : (
               <>
                 <GitMerge className="size-3.5" />
-                Merge
+                Combine
               </>
             )}
           </Button>

--- a/apps/web/src/components/MergeToast.test.tsx
+++ b/apps/web/src/components/MergeToast.test.tsx
@@ -40,7 +40,7 @@ describe('MergeToast', () => {
     expect(screen.queryByTestId('merge-toast')).toBeNull()
     act(() => dispatchMergeCommitted(baseDetail))
     expect(screen.getByTestId('merge-toast')).toBeTruthy()
-    expect(screen.getByText(/Merged changes from «feature-a»/)).toBeTruthy()
+    expect(screen.getByText(/Combined changes from «feature-a»/)).toBeTruthy()
     expect(screen.getByText(/2 added · 1 changed/)).toBeTruthy()
   })
 

--- a/apps/web/src/components/MergeToast.tsx
+++ b/apps/web/src/components/MergeToast.tsx
@@ -157,9 +157,9 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
         </div>
         {(switchedHead || deletedSource) && (
           <div className="text-[11px] text-muted-foreground/90">
-            {switchedHead ? `Switched to "${displayBranchName(switchedHead.to)}"` : null}
+            {switchedHead ? `Switched to «${displayBranchName(switchedHead.to)}»` : null}
             {switchedHead && deletedSource ? ' · ' : null}
-            {deletedSource ? `Deleted "${displayBranchName(deletedSource)}"` : null}
+            {deletedSource ? `Deleted «${displayBranchName(deletedSource)}»` : null}
           </div>
         )}
         {canUndo && (

--- a/apps/web/src/components/MergeToast.tsx
+++ b/apps/web/src/components/MergeToast.tsx
@@ -8,7 +8,7 @@ import {
   type MergeCommittedDetail,
   parseMergeCommittedEvent,
 } from '@/lib/merge-committed-event'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 import { Button } from './ui/button.js'
 
 const log = getAppLogger('merge-toast')
@@ -143,7 +143,9 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
     >
       <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-600" aria-hidden />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <div className="text-sm font-medium">Merged changes from «{sourceName}»</div>
+        <div className="text-sm font-medium">
+          Combined changes from «{displayBranchName(sourceName)}»
+        </div>
         <div className="text-xs text-muted-foreground">
           {[
             newCount > 0 ? `${newCount} added` : null,
@@ -155,9 +157,9 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
         </div>
         {(switchedHead || deletedSource) && (
           <div className="text-[11px] text-muted-foreground/90">
-            {switchedHead ? `Switched to "${switchedHead.to}"` : null}
+            {switchedHead ? `Switched to "${displayBranchName(switchedHead.to)}"` : null}
             {switchedHead && deletedSource ? ' · ' : null}
-            {deletedSource ? `Deleted "${deletedSource}"` : null}
+            {deletedSource ? `Deleted "${displayBranchName(deletedSource)}"` : null}
           </div>
         )}
         {canUndo && (

--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/lib/app-logger', () => ({
 // Cover the current VersionTimeline contract:
 // - filter versions by the active branch (HEAD)
 // - render the mini-graph lane for each row
-// - place the "branched ->" label at the matching baseVersionId row
+// - place the "variation ->" label at the matching baseVersionId row
 //
 // Branch actions and save controls live in the header now, so VersionTimeline should not render tabs or save buttons.
 
@@ -260,9 +260,9 @@ describe('VersionTimeline', () => {
 
   it('renders the branchOut label on the row matching baseVersionId', async () => {
     render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
-    // "branched -> feature" should appear on the v-mid row.
+    // "variation -> feature" should appear on the v-mid row.
     await waitFor(() => {
-      expect(screen.getByText(/branched → feature/)).toBeTruthy()
+      expect(screen.getByText(/variation → feature/)).toBeTruthy()
     })
   })
 

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -21,6 +21,7 @@ import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { useBranches } from '@/hooks/useBranches'
 import { getAppLogger } from '@/lib/app-logger'
 import { buildMiniGraph } from '@/lib/mini-graph'
+import { displayBranchName } from '@/lib/utils'
 import { VersionThumbnail } from './VersionThumbnail.js'
 
 const log = getAppLogger('VersionTimeline')
@@ -312,7 +313,9 @@ export default function VersionTimeline({ workspaceId, slug, onRestored, refresh
                           {row?.branchOut ? (
                             <>
                               {' · '}
-                              <span className="text-primary">branched → {row.branchOut}</span>
+                              <span className="text-primary">
+                                variation → {displayBranchName(row.branchOut)}
+                              </span>
                             </>
                           ) : null}
                         </span>

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -101,7 +101,7 @@ describe('DaemonDetectedBanner', () => {
     )
 
     await screen.findByText(
-      'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, branches, and merge.',
+      'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, variations, and combining changes.',
     )
     const link = screen.getByRole('link', { name: /connect/i })
     expect(link.getAttribute('href')).toBe(HOW_TO_CONNECT_URL)
@@ -123,7 +123,7 @@ describe('DaemonDetectedBanner', () => {
 
     expect(
       screen.queryByText(
-        'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, branches, and merge.',
+        'A local whiteboard daemon is running. Ask your AI agent for a pairing link (create_pairing_link) to unlock versions, variations, and combining changes.',
       ),
     ).toBeNull()
 

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -138,7 +138,7 @@ export function DaemonDetectedBanner({
         >
           <span>
             A local whiteboard daemon is running. Ask your AI agent for a pairing link
-            (create_pairing_link) to unlock versions, branches, and merge.
+            (create_pairing_link) to unlock versions, variations, and combining changes.
           </span>
           <a
             href={HOW_TO_CONNECT_URL}

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { displayBranchName } from './utils'
+
+describe('displayBranchName', () => {
+  it('capitalizes the literal "main" identifier for display', () => {
+    expect(displayBranchName('main')).toBe('Main')
+  })
+
+  it('leaves non-main branch names unchanged', () => {
+    expect(displayBranchName('feature-x')).toBe('feature-x')
+  })
+
+  it('is case-sensitive and does not capitalize case variants of main', () => {
+    expect(displayBranchName('Main')).toBe('Main')
+    expect(displayBranchName('MAIN')).toBe('MAIN')
+  })
+})

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -6,3 +6,11 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Display-only capitalization of the default branch identifier for the
+// Variation/Combine UI vocabulary. The identifier itself ('main') must keep
+// flowing unchanged through comparisons and API payloads — only call this
+// where a name is rendered as label text.
+export function displayBranchName(name: string): string {
+  return name === 'main' ? 'Main' : name
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -560,7 +560,7 @@ describe('BrowserLocalCanvasPage', () => {
 
   describe('daemon-only capability messaging', () => {
     const CTA_TEXT =
-      'Connect a local daemon (MCP) to unlock version history, workspaces, branches, and merge'
+      'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
 
     it('shows a single compact CTA line instead of the four daemon-only teaser buttons', async () => {
       const store = new MemoryStore()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -259,7 +259,8 @@ export function BrowserLocalCanvasPage({
           </div>
         )}
         <span className="ml-auto text-muted-foreground">
-          Connect a local daemon (MCP) to unlock version history, workspaces, branches, and merge
+          Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
+          combining changes
         </span>
         <AlertDialog>
           <AlertDialogTrigger asChild>

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -1152,7 +1152,7 @@ describe('DaemonCanvasPage', () => {
           ),
         ).toBe(true)
       })
-      expect(screen.queryByText('Branches')).toBeNull()
+      expect(screen.queryByText('Variations')).toBeNull()
 
       vi.unstubAllGlobals()
     })
@@ -1179,8 +1179,8 @@ describe('DaemonCanvasPage', () => {
       await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
 
       expect(screen.queryByTestId('header-branch-chip')).toBeNull()
-      expect(screen.getByText('Branches')).toBeTruthy()
-      expect(screen.getByText('Merge')).toBeTruthy()
+      expect(screen.getByText('Variations')).toBeTruthy()
+      expect(screen.getByText('Combine')).toBeTruthy()
     })
 
     it('refetches the branch list when the backend reports an externally observed HEAD change', async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -315,9 +315,9 @@ export function DaemonCanvasPage({
             <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
           )}
           {!capabilities.branches && (
-            <CapabilityTeaser label="Branches" enabled={capabilities.branches} />
+            <CapabilityTeaser label="Variations" enabled={capabilities.branches} />
           )}
-          {!capabilities.merge && <CapabilityTeaser label="Merge" enabled={false} />}
+          {!capabilities.merge && <CapabilityTeaser label="Combine" enabled={false} />}
         </div>
         {canvas && browserLocalStore && (
           <details

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -6,6 +6,11 @@ covers what happens once a local daemon (started via `whiteboard mcp` or an
 MCP client) is also running on the same machine, and how to move a
 browser-local canvas onto it.
 
+The web app UI calls these "variations" and "combining changes," but the
+underlying MCP tools your AI agent calls (`create_branch`, `merge`, and so
+on) intentionally keep their git-derived names — the UI vocabulary is a
+presentation-layer choice and does not change the tool contract.
+
 ## How detection works
 
 The web app probes `GET /api/runtime/ping` on the daemon's default loopback

--- a/packages/mcp-server/src/app/components/HeaderBranchBanner.test.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchBanner.test.tsx
@@ -31,9 +31,8 @@ const state: { current: UseBranchesResult } = {
 }
 
 vi.mock('../hooks/useBranches.js', async () => {
-  const actual = await vi.importActual<typeof import('../hooks/useBranches.js')>(
-    '../hooks/useBranches.js',
-  )
+  const actual =
+    await vi.importActual<typeof import('../hooks/useBranches.js')>('../hooks/useBranches.js')
   return {
     ...actual,
     useBranches: () => state.current,
@@ -64,7 +63,7 @@ describe('HeaderBranchBanner', () => {
     await waitFor(() => {
       expect(screen.getByTestId('header-branch-banner')).toBeTruthy()
     })
-    expect(screen.getByText(/changes not yet merged into/)).toBeTruthy()
+    expect(screen.getByText(/changes not yet combined into/)).toBeTruthy()
     expect(screen.getByText(/3/)).toBeTruthy()
     expect(screen.getByTestId('header-branch-banner-merge')).toBeTruthy()
   })

--- a/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
@@ -86,8 +86,8 @@ export function HeaderBranchBanner({
       >
         <AlertTriangle className="size-3.5 shrink-0 text-amber-600" aria-hidden />
         <span className="min-w-0 flex-1 truncate">
-          Variation “<strong>{displayBranchName(head)}</strong>” has{' '}
-          <strong>{unmergedCommits}</strong> changes not yet combined into “Main”
+          Variation «<strong>{displayBranchName(head)}</strong>» has{' '}
+          <strong>{unmergedCommits}</strong> changes not yet combined into «Main»
         </span>
         <Button
           type="button"
@@ -98,7 +98,7 @@ export function HeaderBranchBanner({
           onClick={() => setMergeOpen(true)}
         >
           <GitMerge className="size-3.5" />
-          Combine into “Main”
+          Combine into «Main»
         </Button>
       </div>
       <MergeDialog

--- a/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchBanner.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button.js'
 import { MergeDialog } from './MergeDialog.js'
 import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
 import { useBranches } from '../hooks/useBranches.js'
+import { displayBranchName } from '@/lib/utils'
 
 // Show a banner under the header when the current branch is ahead of main.
 // - Condition: HEAD !== 'main' and getBranchStats(HEAD).unmergedCommits > 0
@@ -85,8 +86,8 @@ export function HeaderBranchBanner({
       >
         <AlertTriangle className="size-3.5 shrink-0 text-amber-600" aria-hidden />
         <span className="min-w-0 flex-1 truncate">
-          Branch «<strong>{head}</strong>» has <strong>{unmergedCommits}</strong> changes not yet merged into
-          {' '}main
+          Variation “<strong>{displayBranchName(head)}</strong>” has{' '}
+          <strong>{unmergedCommits}</strong> changes not yet combined into “Main”
         </span>
         <Button
           type="button"
@@ -97,7 +98,7 @@ export function HeaderBranchBanner({
           onClick={() => setMergeOpen(true)}
         >
           <GitMerge className="size-3.5" />
-          Merge into main
+          Combine into “Main”
         </Button>
       </div>
       <MergeDialog

--- a/packages/mcp-server/src/app/components/HeaderBranchChip.test.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchChip.test.tsx
@@ -34,9 +34,8 @@ const state: { current: UseBranchesResult } = {
 }
 
 vi.mock('../hooks/useBranches.js', async () => {
-  const actual = await vi.importActual<typeof import('../hooks/useBranches.js')>(
-    '../hooks/useBranches.js',
-  )
+  const actual =
+    await vi.importActual<typeof import('../hooks/useBranches.js')>('../hooks/useBranches.js')
   return {
     ...actual,
     useBranches: () => state.current,
@@ -59,10 +58,10 @@ afterEach(() => {
 })
 
 describe('HeaderBranchChip', () => {
-  it('renders the HEAD name in the chip trigger', () => {
+  it('renders the HEAD name in the chip trigger, capitalized for the default variation', () => {
     renderChip()
     const chip = screen.getByTestId('header-branch-chip')
-    expect(chip.textContent).toContain('main')
+    expect(chip.textContent).toContain('Main')
   })
 
   it('updates chip text when HEAD changes', () => {
@@ -88,13 +87,13 @@ describe('HeaderBranchChip', () => {
   it('uses an English aria-label on the chip trigger', () => {
     renderChip()
     const chip = screen.getByTestId('header-branch-chip')
-    expect(chip.getAttribute('aria-label')).toContain('Switch branch')
+    expect(chip.getAttribute('aria-label')).toContain('Switch variation')
     expect(chip.getAttribute('aria-label')).toContain('current: main')
   })
 
   it('uses an English aria-label on the kebab trigger', () => {
     renderChip()
     const kebab = screen.getByTestId('header-branch-kebab')
-    expect(kebab.getAttribute('aria-label')).toBe('Branch actions')
+    expect(kebab.getAttribute('aria-label')).toBe('Variation actions')
   })
 })

--- a/packages/mcp-server/src/app/components/HeaderBranchChip.tsx
+++ b/packages/mcp-server/src/app/components/HeaderBranchChip.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState, type JSX } from 'react'
-import { ChevronDown, GitBranch, GitMerge, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
+import {
+  ChevronDown,
+  GitBranch,
+  GitMerge,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+} from 'lucide-react'
 import { Button } from './ui/button.js'
 import {
   DropdownMenu,
@@ -29,21 +37,24 @@ import {
 } from './ui/dialog.js'
 import { Input } from './ui/input.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 import { safeErrorCopy } from '../lib/error-copy.js'
 import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
 import { useBranches } from '../hooks/useBranches.js'
 import { MergeDialog } from './MergeDialog.js'
 
 // Consolidate branch operations into a single `●branch▾` chip in the header.
+// UI copy uses the Variation/Combine vocabulary; the underlying data model,
+// hook, and MCP tool calls keep their git-derived identifiers (branch, merge)
+// unchanged.
 //
 // Behavior:
-//   - Left trigger: switch branches from a dropdown
-//   - Right kebab: rename, delete, or merge from another branch
-//   - New branch: inline form inside the dropdown
+//   - Left trigger: switch variations from a dropdown
+//   - Right kebab: rename, delete, or combine from another variation
+//   - New variation: inline form inside the dropdown
 //
 // Unlike the old tab layout, there is always exactly one visible chip for HEAD.
-// Other branches are managed through the dropdown and kebab menu.
+// Other variations are managed through the dropdown and kebab menu.
 
 export interface HeaderBranchChipProps {
   workspaceId: string
@@ -85,7 +96,7 @@ export function HeaderBranchChip({
       setCreateOpen(false)
       setErrorMessage(null)
     } catch (err) {
-      setErrorMessage(safeErrorCopy(err, 'Failed to create branch'))
+      setErrorMessage(safeErrorCopy(err, 'Failed to create variation'))
     }
   }
 
@@ -107,7 +118,7 @@ export function HeaderBranchChip({
       setRenameOpen(false)
       setErrorMessage(null)
     } catch (err) {
-      setErrorMessage(safeErrorCopy(err, 'Failed to rename branch'))
+      setErrorMessage(safeErrorCopy(err, 'Failed to rename variation'))
     }
   }
 
@@ -150,7 +161,7 @@ export function HeaderBranchChip({
               <button
                 type="button"
                 disabled={disabled}
-                aria-label={`Switch branch (current: ${head})`}
+                aria-label={`Switch variation (current: ${head})`}
                 data-testid="header-branch-chip"
                 className={cn(
                   'flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium',
@@ -158,27 +169,33 @@ export function HeaderBranchChip({
                 )}
                 style={{ borderColor: chipColor, color: chipColor }}
               >
-                <span aria-hidden className="inline-block size-2 shrink-0 rounded-full" style={{ background: chipColor }} />
-                <span className="truncate" title={head}>{head}</span>
+                <span
+                  aria-hidden
+                  className="inline-block size-2 shrink-0 rounded-full"
+                  style={{ background: chipColor }}
+                />
+                <span className="truncate" title={head}>
+                  {displayBranchName(head)}
+                </span>
                 <ChevronDown className="size-3 shrink-0 opacity-70" aria-hidden />
               </button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent>Branch</TooltipContent>
+          <TooltipContent>Variation</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="start" className="w-[240px]">
           <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
             <GitBranch className="size-3" />
-            Switch branch
+            Switch variation
           </DropdownMenuLabel>
-          {/* Show HEAD first and mark it as the current branch. */}
-          <DropdownMenuItem
-            onSelect={(e) => e.preventDefault()}
-            className="gap-2"
-            disabled
-          >
-            <span aria-hidden className="inline-block size-2 rounded-full" style={{ background: chipColor }} />
-            <span className="truncate">{head}</span>
+          {/* Show HEAD first and mark it as the current variation. */}
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="gap-2" disabled>
+            <span
+              aria-hidden
+              className="inline-block size-2 rounded-full"
+              style={{ background: chipColor }}
+            />
+            <span className="truncate">{displayBranchName(head)}</span>
             <span className="ml-auto text-[10px] text-muted-foreground">Current</span>
           </DropdownMenuItem>
           {otherBranches.map((b) => (
@@ -186,13 +203,19 @@ export function HeaderBranchChip({
               key={b.name}
               onSelect={() => {
                 setHead(b.name).catch((err: unknown) => {
-                  setErrorMessage(safeErrorCopy(err, 'Failed to switch branch'))
+                  setErrorMessage(safeErrorCopy(err, 'Failed to switch variation'))
                 })
               }}
               className="gap-2"
             >
-              <span aria-hidden className="inline-block size-2 rounded-full" style={{ background: b.color }} />
-              <span className="truncate" title={b.name}>{b.name}</span>
+              <span
+                aria-hidden
+                className="inline-block size-2 rounded-full"
+                style={{ background: b.color }}
+              />
+              <span className="truncate" title={b.name}>
+                {displayBranchName(b.name)}
+              </span>
             </DropdownMenuItem>
           ))}
           <DropdownMenuSeparator />
@@ -207,9 +230,9 @@ export function HeaderBranchChip({
               <Input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
-                placeholder="New branch name"
+                placeholder="New variation name"
                 autoFocus
-                aria-label="New branch name"
+                aria-label="New variation name"
                 className="h-7 text-xs"
               />
               <Button type="submit" size="sm" variant="outline" className="h-7 px-2 text-xs">
@@ -237,7 +260,7 @@ export function HeaderBranchChip({
               className="gap-2"
             >
               <Plus className="size-3.5" />
-              New branch…
+              New variation…
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>
@@ -251,7 +274,7 @@ export function HeaderBranchChip({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label="Branch actions"
+            aria-label="Variation actions"
             data-testid="header-branch-kebab"
             disabled={disabled}
             className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
@@ -262,11 +285,11 @@ export function HeaderBranchChip({
         <DropdownMenuContent align="end" className="w-[240px]">
           <DropdownMenuLabel className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider">
             <GitMerge className="size-3" />
-            Merge into «{head}»
+            Combine into «{displayBranchName(head)}»
           </DropdownMenuLabel>
           {otherBranches.length === 0 ? (
             <DropdownMenuItem disabled className="text-xs text-muted-foreground">
-              No other branches
+              No other variations
             </DropdownMenuItem>
           ) : (
             otherBranches.map((b) => (
@@ -275,8 +298,12 @@ export function HeaderBranchChip({
                 onSelect={() => setMergeSource(b)}
                 className="gap-2"
               >
-                <span aria-hidden className="inline-block size-2 rounded-full" style={{ background: b.color }} />
-                <span className="truncate">{b.name}</span>
+                <span
+                  aria-hidden
+                  className="inline-block size-2 rounded-full"
+                  style={{ background: b.color }}
+                />
+                <span className="truncate">{displayBranchName(b.name)}</span>
               </DropdownMenuItem>
             ))
           )}
@@ -290,7 +317,7 @@ export function HeaderBranchChip({
             className="gap-2"
           >
             <Pencil className="size-3.5" />
-            Rename «{head}»…
+            Rename «{displayBranchName(head)}»…
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={head === 'main'}
@@ -301,7 +328,7 @@ export function HeaderBranchChip({
             }}
           >
             <Trash2 className="size-3.5" />
-            Delete «{head}»…
+            Delete «{displayBranchName(head)}»…
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -312,7 +339,9 @@ export function HeaderBranchChip({
           className="flex max-w-[200px] items-center gap-1 text-[11px] text-destructive"
         >
           <span aria-hidden>⚠</span>
-          <span className="truncate" title={errorMessage}>{errorMessage}</span>
+          <span className="truncate" title={errorMessage}>
+            {errorMessage}
+          </span>
           <button
             type="button"
             className="ml-auto text-muted-foreground hover:text-foreground"
@@ -328,9 +357,9 @@ export function HeaderBranchChip({
       <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Rename «{head}»</DialogTitle>
+            <DialogTitle>Rename «{displayBranchName(head)}»</DialogTitle>
             <DialogDescription>
-              Enter a new name. Every saved version on this branch will be relinked to it.
+              Enter a new name. Every saved version on this variation will be relinked to it.
             </DialogDescription>
           </DialogHeader>
           <Input
@@ -364,15 +393,17 @@ export function HeaderBranchChip({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete «{pendingDelete?.name ?? ''}»?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Delete «{displayBranchName(pendingDelete?.name ?? '')}»?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              This deletes the branch. Saved versions stay in version history, but the branch will no
-              longer be reachable from branch navigation.
+              This deletes the variation. Saved versions stay in version history, but the variation
+              will no longer be reachable from variation navigation.
               {pendingStats && pendingStats.unmergedCommits > 0 ? (
                 <>
                   <br />
                   <strong className="text-destructive">
-                    ⚠ {pendingStats.unmergedCommits} unmerged commits remain
+                    ⚠ {pendingStats.unmergedCommits} changes not yet combined remain
                   </strong>
                 </>
               ) : null}
@@ -391,7 +422,7 @@ export function HeaderBranchChip({
                   setErrorMessage(null)
                   setPendingDelete(null)
                 } catch (err) {
-                  setErrorMessage(safeErrorCopy(err, 'Failed to delete branch'))
+                  setErrorMessage(safeErrorCopy(err, 'Failed to delete variation'))
                   setPendingDelete(null)
                 } finally {
                   setDeleting(false)

--- a/packages/mcp-server/src/app/components/MergeDialog.tsx
+++ b/packages/mcp-server/src/app/components/MergeDialog.tsx
@@ -8,7 +8,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import { type JSX, useEffect, useMemo, useState } from 'react'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 import { listVersionsResponseSchema } from '../../shared/api-contracts/canvas.js'
 import type { BranchMeta, MergeResult } from '../hooks/useBranches.js'
 import { apiFetch } from '../lib/api-client.js'
@@ -314,7 +314,7 @@ export function MergeDialog({
       }
       onClose()
     } catch (err) {
-      setError(safeErrorCopy(err, 'Merge failed.'))
+      setError(safeErrorCopy(err, 'Combine failed.'))
     } finally {
       setCommitting(false)
     }
@@ -352,14 +352,14 @@ export function MergeDialog({
           <DialogTitle className="flex items-center gap-2">
             <GitMerge className="h-4 w-4" />
             <span>
+              Combine{' '}
               <span style={{ color: source?.color ?? undefined }} className="font-semibold">
-                «{source?.name ?? '?'}»
+                «{source ? displayBranchName(source.name) : '?'}»
               </span>{' '}
-              changes from{' '}
+              into{' '}
               <span style={{ color: target?.color ?? undefined }} className="font-semibold">
-                «{target?.name ?? '?'}»
-              </span>{' '}
-              into
+                «{target ? displayBranchName(target.name) : '?'}»
+              </span>
             </span>
           </DialogTitle>
           <DialogDescription>
@@ -415,7 +415,7 @@ export function MergeDialog({
                   className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
                 />
                 <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
-                  Merged preview
+                  Combined preview
                 </span>
               </div>
               <div className="text-xs text-muted-foreground">{previewCount ?? '—'} elements</div>
@@ -430,7 +430,7 @@ export function MergeDialog({
                 // Show the latest source-branch thumbnail as a practical preview fallback.
                 <img
                   src={thumbs.source}
-                  alt={`${source?.name ?? ''} merged preview`}
+                  alt={`${source ? displayBranchName(source.name) : ''} combined preview`}
                   className="h-full w-full object-contain"
                 />
               ) : (
@@ -439,7 +439,8 @@ export function MergeDialog({
                   <div className="text-center text-xs">
                     <div>{previewElementCount > 0 ? 'No preview image yet' : 'No elements'}</div>
                     <div className="mt-1 text-[10px] opacity-80">
-                      Save «{source?.name ?? '?'}» with ⌘S to generate a preview image
+                      Save «{source ? displayBranchName(source.name) : '?'}» with ⌘S to generate a
+                      preview image
                     </div>
                   </div>
                 </div>
@@ -458,7 +459,8 @@ export function MergeDialog({
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="size-4 text-emerald-600" />
                 <span>
-                  <strong className="text-emerald-700">No conflicts</strong> - ready to merge as-is
+                  <strong className="text-emerald-700">No conflicts</strong> - ready to combine
+                  as-is
                 </span>
               </div>
             ) : (
@@ -504,9 +506,9 @@ export function MergeDialog({
               className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-900"
               data-testid="merge-side-effect-notice"
             >
-              <strong>After merge:</strong> switch automatically to "
-              <span className="font-semibold">{target.name}</span>" and delete "
-              <span className="font-semibold">{source.name}</span>
+              <strong>After combining:</strong> switch automatically to "
+              <span className="font-semibold">{displayBranchName(target.name)}</span>" and delete "
+              <span className="font-semibold">{displayBranchName(source.name)}</span>
               ".
             </div>
           )}
@@ -525,12 +527,12 @@ export function MergeDialog({
             {committing ? (
               <>
                 <Loader2 className="size-3.5 animate-spin" />
-                Merging…
+                Combining…
               </>
             ) : (
               <>
                 <GitMerge className="size-3.5" />
-                Merge
+                Combine
               </>
             )}
           </Button>

--- a/packages/mcp-server/src/app/components/MergeToast.test.tsx
+++ b/packages/mcp-server/src/app/components/MergeToast.test.tsx
@@ -18,7 +18,9 @@ const baseDetail: MergeToastEventDetail = {
 }
 
 beforeEach(() => {
-  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
   vi.stubGlobal('fetch', fetchMock)
 })
 
@@ -34,7 +36,7 @@ describe('MergeToast', () => {
     expect(screen.queryByTestId('merge-toast')).toBeNull()
     act(() => dispatchMergeCommitted(baseDetail))
     expect(screen.getByTestId('merge-toast')).toBeTruthy()
-    expect(screen.getByText(/Merged changes from «feature-a»/)).toBeTruthy()
+    expect(screen.getByText(/Combined changes from «feature-a»/)).toBeTruthy()
     expect(screen.getByText(/2 added · 1 changed/)).toBeTruthy()
   })
 

--- a/packages/mcp-server/src/app/components/MergeToast.tsx
+++ b/packages/mcp-server/src/app/components/MergeToast.tsx
@@ -139,9 +139,9 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
         </div>
         {(switchedHead || deletedSource) && (
           <div className="text-[11px] text-muted-foreground/90">
-            {switchedHead ? `Switched to "${displayBranchName(switchedHead.to)}"` : null}
+            {switchedHead ? `Switched to «${displayBranchName(switchedHead.to)}»` : null}
             {switchedHead && deletedSource ? ' · ' : null}
-            {deletedSource ? `Deleted "${displayBranchName(deletedSource)}"` : null}
+            {deletedSource ? `Deleted «${displayBranchName(deletedSource)}»` : null}
           </div>
         )}
         {canUndo && (

--- a/packages/mcp-server/src/app/components/MergeToast.tsx
+++ b/packages/mcp-server/src/app/components/MergeToast.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
 import { CheckCircle2, Undo2, X } from 'lucide-react'
 import { Button } from './ui/button.js'
-import { cn } from '@/lib/utils'
+import { cn, displayBranchName } from '@/lib/utils'
 import { apiFetch } from '../lib/api-client.js'
 
 // Short-lived toast shown in the bottom-right after merge completes.
@@ -126,7 +126,7 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
       <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-600" aria-hidden />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="text-sm font-medium">
-          Merged changes from «{sourceName}»
+          Combined changes from «{displayBranchName(sourceName)}»
         </div>
         <div className="text-xs text-muted-foreground">
           {[
@@ -139,9 +139,9 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
         </div>
         {(switchedHead || deletedSource) && (
           <div className="text-[11px] text-muted-foreground/90">
-            {switchedHead ? `Switched to "${switchedHead.to}"` : null}
+            {switchedHead ? `Switched to "${displayBranchName(switchedHead.to)}"` : null}
             {switchedHead && deletedSource ? ' · ' : null}
-            {deletedSource ? `Deleted "${deletedSource}"` : null}
+            {deletedSource ? `Deleted "${displayBranchName(deletedSource)}"` : null}
           </div>
         )}
         {canUndo && (

--- a/packages/mcp-server/src/app/components/VersionTimeline.test.tsx
+++ b/packages/mcp-server/src/app/components/VersionTimeline.test.tsx
@@ -5,7 +5,7 @@ import VersionTimeline from './VersionTimeline.js'
 // Cover the current VersionTimeline contract:
 // - filter versions by the active branch (HEAD)
 // - render the mini-graph lane for each row
-// - place the "branched ->" label at the matching baseVersionId row
+// - place the "variation ->" label at the matching baseVersionId row
 //
 // Branch actions and save controls live in the header now, so VersionTimeline should not render tabs or save buttons.
 
@@ -84,7 +84,8 @@ function mkVersionsResponse(): Response {
 
 beforeEach(() => {
   const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
     if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
     if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
     return Promise.resolve(new Response('{}', { status: 200 }))
@@ -119,9 +120,9 @@ describe('VersionTimeline', () => {
 
   it('renders the branchOut label on the row matching baseVersionId', async () => {
     render(<VersionTimeline workspaceId="sess_1" slug="canvas-a" />)
-    // "branched -> feature" should appear on the v-mid row.
+    // "variation -> feature" should appear on the v-mid row.
     await waitFor(() => {
-      expect(screen.getByText(/branched → feature/)).toBeTruthy()
+      expect(screen.getByText(/variation → feature/)).toBeTruthy()
     })
   })
 
@@ -144,7 +145,8 @@ describe('VersionTimeline', () => {
   it('legacy row without operator renders system fallback', async () => {
     vi.unstubAllGlobals()
     const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
       if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
       if (url.includes('/versions')) {
         return Promise.resolve(
@@ -179,15 +181,26 @@ describe('VersionTimeline', () => {
   it('renders the empty state when the active branch has no versions', async () => {
     vi.unstubAllGlobals()
     const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
       if (url.includes('/branches')) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
               head: 'feature',
               branches: [
-                { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
-                { name: 'feature', tipFrontiers: '', color: '#9333ea', createdAt: '2026-04-23T01:00:00Z' },
+                {
+                  name: 'main',
+                  tipFrontiers: '',
+                  color: '#1971c2',
+                  createdAt: '2026-04-23T00:00:00Z',
+                },
+                {
+                  name: 'feature',
+                  tipFrontiers: '',
+                  color: '#9333ea',
+                  createdAt: '2026-04-23T01:00:00Z',
+                },
               ],
             }),
             { status: 200 },
@@ -195,12 +208,7 @@ describe('VersionTimeline', () => {
         )
       }
       if (url.includes('/versions')) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({ versions: [] }),
-            { status: 200 },
-          ),
-        )
+        return Promise.resolve(new Response(JSON.stringify({ versions: [] }), { status: 200 }))
       }
       return Promise.resolve(new Response('{}', { status: 200 }))
     })
@@ -220,8 +228,8 @@ describe('VersionTimeline', () => {
     })
 
     expect(container.firstElementChild?.className).toContain('min-h-0')
-    expect(
-      container.querySelector('[data-slot="scroll-area"]')?.className ?? '',
-    ).toContain('min-h-0')
+    expect(container.querySelector('[data-slot="scroll-area"]')?.className ?? '').toContain(
+      'min-h-0',
+    )
   })
 })

--- a/packages/mcp-server/src/app/components/VersionTimeline.tsx
+++ b/packages/mcp-server/src/app/components/VersionTimeline.tsx
@@ -20,6 +20,7 @@ import {
 import { apiFetch } from '../lib/api-client.js'
 import { useBranches } from '../hooks/useBranches.js'
 import { buildMiniGraph } from '../lib/mini-graph.js'
+import { displayBranchName } from '@/lib/utils'
 
 interface Props {
   workspaceId: string
@@ -53,11 +54,7 @@ function getOperatorAffordance(operator?: OperatorInfo): { icon: string; label: 
 
 // Branch operations and save controls live in the header.
 // VersionTimeline is responsible only for the version list, mini-graph, and restore flow.
-export default function VersionTimeline({
-  workspaceId,
-  slug,
-  onRestored,
-}: Props) {
+export default function VersionTimeline({ workspaceId, slug, onRestored }: Props) {
   const [versions, setVersions] = useState<VersionEntry[]>([])
   const [loading, setLoading] = useState(false)
   const [pendingRestore, setPendingRestore] = useState<VersionEntry | null>(null)
@@ -109,9 +106,7 @@ export default function VersionTimeline({
   const { state: branchesState } = useBranches(workspaceId, slug)
   const head = branchesState.head
 
-  const visibleVersions = versions.filter(
-    (v) => (v.branchName ?? 'main') === head,
-  )
+  const visibleVersions = versions.filter((v) => (v.branchName ?? 'main') === head)
   const miniGraphRows = buildMiniGraph({
     head,
     branches: branchesState.branches,
@@ -150,13 +145,7 @@ export default function VersionTimeline({
               return (
                 <div key={v.id} className="flex items-stretch gap-1.5">
                   {/* Mini-graph lane. */}
-                  <svg
-                    className="shrink-0"
-                    width={24}
-                    height={36}
-                    viewBox="0 0 24 36"
-                    aria-hidden
-                  >
+                  <svg className="shrink-0" width={24} height={36} viewBox="0 0 24 36" aria-hidden>
                     {row?.connectorBefore ? (
                       <line
                         x1={12}
@@ -215,7 +204,7 @@ export default function VersionTimeline({
                             <>
                               {' · '}
                               <span className="text-primary">
-                                branched → {row.branchOut}
+                                variation → {displayBranchName(row.branchOut)}
                               </span>
                             </>
                           ) : null}
@@ -235,17 +224,23 @@ export default function VersionTimeline({
         </div>
       </ScrollArea>
 
-      <AlertDialog open={!!pendingRestore} onOpenChange={(open) => !open && setPendingRestore(null)}>
+      <AlertDialog
+        open={!!pendingRestore}
+        onOpenChange={(open) => !open && setPendingRestore(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Restore this version?</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingRestore && (
                 <>
-                  Restoring <strong>{pendingRestore.label || (pendingRestore.auto ? 'Auto-save' : 'Manual')}</strong>{' '}
-                  ({formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount} elements) will merge
-                  that state into the current canvas and broadcast the change to every connected tab. Per-peer
-                  Ctrl+Z history is cleared.
+                  Restoring{' '}
+                  <strong>
+                    {pendingRestore.label || (pendingRestore.auto ? 'Auto-save' : 'Manual')}
+                  </strong>{' '}
+                  ({formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount}{' '}
+                  elements) will merge that state into the current canvas and broadcast the change
+                  to every connected tab. Per-peer Ctrl+Z history is cleared.
                 </>
               )}
             </AlertDialogDescription>

--- a/packages/mcp-server/src/app/lib/utils.test.ts
+++ b/packages/mcp-server/src/app/lib/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { displayBranchName } from './utils'
+
+describe('displayBranchName', () => {
+  it('capitalizes the literal "main" identifier for display', () => {
+    expect(displayBranchName('main')).toBe('Main')
+  })
+
+  it('leaves non-main branch names unchanged', () => {
+    expect(displayBranchName('feature-x')).toBe('feature-x')
+  })
+
+  it('is case-sensitive and does not capitalize case variants of main', () => {
+    expect(displayBranchName('Main')).toBe('Main')
+    expect(displayBranchName('MAIN')).toBe('MAIN')
+  })
+})

--- a/packages/mcp-server/src/app/lib/utils.ts
+++ b/packages/mcp-server/src/app/lib/utils.ts
@@ -6,3 +6,11 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Display-only capitalization of the default branch identifier for the
+// Variation/Combine UI vocabulary. The identifier itself ('main') must keep
+// flowing unchanged through comparisons and API payloads — only call this
+// where a name is rendered as label text.
+export function displayBranchName(name: string): string {
+  return name === 'main' ? 'Main' : name
+}

--- a/packages/mcp-server/src/server/validators.test.ts
+++ b/packages/mcp-server/src/server/validators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  validateBranchName,
   validateExternalUrl,
   validateFileId,
   validateWorkspaceId,
@@ -29,6 +30,20 @@ describe('shared validators', () => {
     expect(() => validateVersionId('bad.id')).toThrow(/Invalid version id/)
     expect(() => validateFileId('bad/id')).toThrow(/Invalid file id/)
     expect(() => validateUserLibraryName('../icons')).toThrow(/Invalid user library name/)
+  })
+
+  it('accepts the canonical "main" branch name and normal branch names', () => {
+    expect(validateBranchName('main')).toBe('main')
+    expect(validateBranchName('feature-1')).toBe('feature-1')
+  })
+
+  it('rejects branch names that only differ from "main" by letter case', () => {
+    // displayBranchName() renders exactly 'main' as 'Main'; a real branch
+    // literally named 'Main' (or 'MAIN') would render identically and be
+    // indistinguishable from the default branch in switch/rename/delete UI.
+    expect(() => validateBranchName('Main')).toThrow(/Invalid branch name/)
+    expect(() => validateBranchName('MAIN')).toThrow(/Invalid branch name/)
+    expect(() => validateBranchName('mAin')).toThrow(/Invalid branch name/)
   })
 
   it('rejects unsafe external urls before fetch', async () => {

--- a/packages/mcp-server/src/server/validators.ts
+++ b/packages/mcp-server/src/server/validators.ts
@@ -156,6 +156,16 @@ export function validateBranchName(name: string): string {
       `Invalid branch name "${name}": kebab-case ASCII only`,
     )
   }
+  // The UI renders exactly 'main' as 'Main' for display. Allowing a
+  // case-variant like 'Main' or 'MAIN' as a real branch name would make it
+  // render identically to (and thus indistinguishable from) the default
+  // branch across switch/rename/delete/combine surfaces.
+  if (name !== 'main' && name.toLowerCase() === 'main') {
+    throw new ValidationError(
+      'invalid_branch_name',
+      `Invalid branch name "${name}": reserved (conflicts with "main")`,
+    )
+  }
   return name
 }
 


### PR DESCRIPTION
## Summary

User-approved product vocabulary (system B): the branch UI no longer speaks raw git. UI copy only — MCP tool names/params (`create_branch`, `merge`), API/schema identifiers, testids, and the `main` identifier are all unchanged; AI agents keep seeing git vocabulary in tool calls (one explanatory sentence added where the two vocabularies meet in the how-to).

- Branch → **Variation**, Merge → **Combine** across both apps: HeaderBranchChip (switch/new/combine menu, rename/delete dialogs, aria-labels), MergeDialog (title/preview/confirm 'Combine'/'Combining…'), HeaderBranchBanner, MergeToast, VersionTimeline mini-graph, capability teasers, daemon-detected/CTA copy
- `displayBranchName()` helper: identifier `main` stays lowercase in ALL logic/API; display shows 'Main'
- Guard: server-side validator now rejects branch names differing from 'main' only by case — a variation literally named 'Main' would visually collide with the display alias
- Identifier-guard grep script run against the final diff (no protected identifier/testid/tool-name renames); GitBranch/GitMerge icons deliberately unchanged (visual identity is a separate decision)

## Test plan
- [x] Both apps' suites updated 1:1 (string assertions only; behavior assertions un-weakened) — all green
- [x] displayBranchName unit-pinned; case-collision validator red-first
- [x] Docs: only the intentional MCP-vocabulary sentence added; Loro/CRDT technical 'merge' wording untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)