### PR TITLE
feat(mcp-server): auto-load .whiteboardrc / .whiteboard/config.yaml config files for the local daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ version history, branches, and merge, with live sync over WebSocket.
   reads the separate `WHITEBOARD_SERVER_ALLOWED_ORIGINS` variable instead.
 - Treat the pairing link like a credential: anyone who has it can pair with
   your daemon until the token is rotated.
+- Prefer a config file over exporting env vars by hand? See
+  [Configuration → Config file](docs/reference/configuration.md#config-file-local-daemon)
+  for the `.whiteboardrc` / `.whiteboard/config.yaml` auto-load and
+  precedence rules.
 
 See [Connect to a local daemon](docs/how-to/connect-to-local-daemon.md) for
 the full flow, including copy-first import of browser-local canvases.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,7 +13,7 @@ Runtime environment variables and sandbox quirks.
 | `WHITEBOARD_MCP_RESOURCE` | Canonical MCP resource URL exposed in metadata. If unset, `/mcp` is derived from the incoming request URL. | unset |
 | `WHITEBOARD_MCP_SCOPES_SUPPORTED` | Comma-separated list of scopes exposed in metadata. | unset |
 | `MCP_HTTP_DEBUG` | When set to `1`, the HTTP MCP server logs `[mcp-http:init]` / `[mcp-http]` events to help diagnose request flow. | unset |
-| `WHITEBOARD_ALLOWED_WEB_ORIGINS` | Comma-separated list of extra hosted origins admitted alongside the fixed loopback set (`localhost`, `127.0.0.1`, `::1`) on `/api/*` CORS, `/mcp`, and WS upgrade — **local-daemon mode only**. Each entry must be an exact `https://` origin (no path/query/fragment/credentials); wildcards are rejected. Matching is case-insensitive on the host and normalizes the default `:443` port, but any other port is significant. An invalid entry aborts daemon startup with a logged error naming the offending entry's index (the raw value is never echoed). | unset (loopback-only, unchanged) |
+| `WHITEBOARD_ALLOWED_WEB_ORIGINS` | Comma-separated list of extra hosted origins admitted alongside the fixed loopback set (`localhost`, `127.0.0.1`, `::1`) on `/api/*` CORS, `/mcp`, and WS upgrade — **local-daemon mode only**. Each entry must be an exact `https://` origin (no path/query/fragment/credentials); wildcards are rejected. Matching is case-insensitive on the host and normalizes the default `:443` port, but any other port is significant. An invalid entry aborts daemon startup with a logged error naming the offending entry's index (the raw value is never echoed). Can also be set via a [config file](#config-file-local-daemon)'s `allowedWebOrigins` key; this env var always wins. | unset (loopback-only, unchanged) |
 
 Setting `WHITEBOARD_ALLOWED_WEB_ORIGINS` only widens which browser *origins*
 the daemon will talk to over CORS/WS — it does not change authentication.
@@ -22,6 +22,65 @@ still requires its own auth regardless of origin. Only add an origin you
 control; the hosted pairing flow this enables also depends on the browser's
 own Local Network Access permission prompt (Chrome), which is a separate,
 per-user consent step.
+
+## Config file (local daemon)
+
+As an alternative to exporting env vars by hand, the local daemon (`whiteboard
+daemon run`, and the `server/index.ts` HTTP entrypoint) auto-loads a config
+file. The first match wins, searched in this order while walking up from the
+current directory:
+
+1. `.whiteboardrc`
+2. `.whiteboardrc.json`
+3. `.whiteboardrc.yaml`
+4. `.whiteboardrc.yml`
+5. `.whiteboard/config.yaml`
+6. `.whiteboard/config.yml`
+7. `whiteboard.config.json`
+8. `package.json` (`"whiteboard"` field)
+
+If nothing is found from the current directory upward, `~/.whiteboard/config.yaml`
+is consulted as a per-machine fallback. Only declarative JSON/YAML/rc formats
+are supported — `whiteboard.config.js` and similar JS loaders are deliberately
+NOT searched, so a config file can never execute code at daemon startup.
+
+Example `.whiteboard/config.yaml`:
+
+```yaml
+allowedWebOrigins:
+  - https://kamiazya-whiteboard.pages.dev
+port: 3123
+logLevel: info
+```
+
+Supported keys: `allowedWebOrigins` (string array), `port` (1-65535),
+`token`, `logLevel` (`debug` / `info` / `notice` / `warning` / `error` /
+`critical` / `alert` / `emergency`), and `dataDir`. Unknown keys are logged
+as a warning and dropped rather than silently ignored; an invalid value
+(wrong type, out-of-range port, etc.) aborts startup with an error naming
+the file path and the offending key.
+
+**Precedence: environment variable > config file > built-in default.** Any
+`WHITEBOARD_*` env var that is already set always wins over the same value
+in a config file. The daemon logs which config file it loaded (path only,
+never the token value) at startup.
+
+Two scoped exceptions worth knowing:
+
+- **`port`**: a config-file port behaves exactly like an explicit `--port` —
+  the daemon does not auto-scan for another free port if that one is busy,
+  it fails hard and names the port and the config file. Auto-scan from 3099
+  only happens when neither `--port` nor a config-file port is set.
+- **`dataDir`**: honored on the `whiteboard daemon run` CLI path only. The
+  `server/index.ts` HTTP entrypoint resolves its data directory at module
+  import time, before a config file can be loaded, so a `dataDir` key there
+  produces a startup warning instead of silently doing nothing — use
+  `WHITEBOARD_DATA_DIR` on that entrypoint instead.
+
+**Security note:** a `token` value in a config file is a dev-only
+convenience — treat it like a `.env` file with a secret in it (do not commit
+it, restrict its file permissions). Prefer `WHITEBOARD_TOKEN` /
+`WHITEBOARD_DAEMON_TOKEN` for anything beyond local development.
 
 ## Codex sandbox constraints
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -182,6 +182,7 @@
     "@opentelemetry/sdk-trace-web": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@resvg/resvg-js": "^2.6.2",
+    "cosmiconfig": "^9.0.0",
     "happy-dom": "^20.9.0",
     "hono": "^4.12.27",
     "image-size": "^2",

--- a/packages/mcp-server/src/cli/daemon-run.ts
+++ b/packages/mcp-server/src/cli/daemon-run.ts
@@ -141,7 +141,11 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
       return { kind: 'input-error', message: 'Token read from stdin was empty.' }
     }
   } else {
-    token = process.env.WHITEBOARD_DAEMON_TOKEN ?? nanoid(32)
+    // Read through options.env (defaulting to process.env) rather than
+    // process.env directly so config-file-layered values (applied by the
+    // dispatcher before this is called) and test overrides share one seam
+    // with the allowedWebOrigins read above.
+    token = (options.env ?? process.env).WHITEBOARD_DAEMON_TOKEN ?? nanoid(32)
   }
 
   return await withDaemonStartupLock(dataDir, async () => {

--- a/packages/mcp-server/src/cli/dispatcher-config-file.test.ts
+++ b/packages/mcp-server/src/cli/dispatcher-config-file.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { captureLogsForTests } from '../server/log.js'
+
+// Exercises the REAL dispatcher path (`whiteboard daemon run`) with a config
+// file on disk, mocking only `daemon-run.js` so we can inspect exactly what
+// options the dispatcher resolved (port / dataDir) without booting a server.
+
+const runDaemonRun = vi.fn(async () => ({
+  kind: 'refused' as const,
+  message: 'stubbed',
+}))
+vi.mock('./daemon-run.js', () => ({ runDaemonRun }))
+
+const { main } = await import('./dispatcher.js')
+
+let dir: string
+let originalCwd: string
+const ENV_KEYS = [
+  'WHITEBOARD_ALLOWED_WEB_ORIGINS',
+  'WHITEBOARD_TOKEN',
+  'WHITEBOARD_DAEMON_TOKEN',
+  'WHITEBOARD_LOG_LEVEL',
+  'WHITEBOARD_DATA_DIR',
+] as const
+let savedEnv: Record<string, string | undefined>
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'whiteboard-dispatcher-config-'))
+  originalCwd = process.cwd()
+  process.chdir(dir)
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]))
+  for (const key of ENV_KEYS) delete process.env[key]
+  runDaemonRun.mockClear()
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  rmSync(dir, { recursive: true, force: true })
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+})
+
+describe('whiteboard daemon run — config file wiring', () => {
+  it('threads config-file port, dataDir, token, and allowedWebOrigins into the run', async () => {
+    writeFileSync(
+      join(dir, '.whiteboardrc.json'),
+      JSON.stringify({
+        port: 4321,
+        dataDir: join(dir, 'data'),
+        token: 'file-token-value',
+        allowedWebOrigins: ['https://allowed.example'],
+      }),
+    )
+
+    const capture = captureLogsForTests()
+    try {
+      await main(['daemon', 'run', '--json'])
+    } finally {
+      capture.restore()
+    }
+
+    expect(runDaemonRun).toHaveBeenCalledTimes(1)
+    const options = runDaemonRun.mock.calls[0][0]
+    expect(options.port).toBe(4321)
+    expect(process.env.WHITEBOARD_DATA_DIR).toBe(join(dir, 'data'))
+    expect(process.env.WHITEBOARD_TOKEN).toBe('file-token-value')
+    expect(process.env.WHITEBOARD_DAEMON_TOKEN).toBe('file-token-value')
+    expect(process.env.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe('https://allowed.example')
+
+    const loadRecord = capture.records.find((r) => r.msg.includes('loaded whiteboard config file'))
+    expect(loadRecord).toBeDefined()
+    expect(loadRecord?.data?.filepath).toMatch(/\.whiteboardrc\.json$/)
+    expect(JSON.stringify(capture.records)).not.toContain('file-token-value')
+  })
+
+  it('--port on the CLI beats the config file port', async () => {
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 4321 }))
+    await main(['daemon', 'run', '--json', '--port=5555'])
+    const options = runDaemonRun.mock.calls[0][0]
+    expect(options.port).toBe(5555)
+  })
+
+  it('--data-dir on the CLI beats the config file dataDir', async () => {
+    writeFileSync(
+      join(dir, '.whiteboardrc.json'),
+      JSON.stringify({ dataDir: join(dir, 'from-file') }),
+    )
+    await main(['daemon', 'run', '--json', `--data-dir=${join(dir, 'from-cli')}`])
+    expect(process.env.WHITEBOARD_DATA_DIR).toBe(join(dir, 'from-cli'))
+  })
+
+  it('leaves options.port undefined (auto-scan) when neither CLI nor file specify a port', async () => {
+    await main(['daemon', 'run', '--json'])
+    const options = runDaemonRun.mock.calls[0][0]
+    expect(options.port).toBeUndefined()
+  })
+})

--- a/packages/mcp-server/src/cli/dispatcher-config-file.test.ts
+++ b/packages/mcp-server/src/cli/dispatcher-config-file.test.ts
@@ -99,4 +99,19 @@ describe('whiteboard daemon run — config file wiring', () => {
     const options = runDaemonRun.mock.calls[0][0]
     expect(options.port).toBeUndefined()
   })
+
+  it('reports an invalid config file as a clean exit-1 error instead of an unhandled rejection', async () => {
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 'not-a-number' }))
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      const exitCode = await main(['daemon', 'run', '--json'])
+      expect(exitCode).toBe(1)
+      expect(runDaemonRun).not.toHaveBeenCalled()
+      const written = stderrSpy.mock.calls.map((call) => String(call[0])).join('')
+      expect(written).toContain('.whiteboardrc.json')
+      expect(written).not.toMatch(/\n\s*at /) // no raw stack trace frame
+    } finally {
+      stderrSpy.mockRestore()
+    }
+  })
 })

--- a/packages/mcp-server/src/cli/dispatcher.ts
+++ b/packages/mcp-server/src/cli/dispatcher.ts
@@ -387,19 +387,33 @@ async function dispatchServerSupportBundle(rest: readonly string[]): Promise<num
   return exitCode
 }
 
+type ConfigFileEnvResult =
+  | { kind: 'ok'; port: number | undefined }
+  | { kind: 'error'; message: string }
+
 // Loads the nearest whiteboard config file (if any), layers its values
 // under process.env (env-over-file precedence, see config-file.ts), logs
 // the file path at info level, and returns the file's `port` (if set) so
 // the caller can thread it into daemon-run's own port precedence — file
 // port is otherwise NOT a set-if-unset env key, unlike the other fields.
-function applyLoadedConfigFileToDispatcherEnv(): number | undefined {
-  const loaded = loadConfigFile()
-  if (loaded === null) return undefined
+// loadConfigFile throws on a malformed file (by design, see config-file.ts);
+// that throw is caught here and turned into the same structured
+// stderr + exit-1 contract every other startup validation failure in this
+// dispatcher follows, instead of an unhandled rejection with a raw stack.
+function applyLoadedConfigFileToDispatcherEnv(): ConfigFileEnvResult {
+  let loaded: ReturnType<typeof loadConfigFile>
+  try {
+    loaded = loadConfigFile()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { kind: 'error', message: `whiteboard config file error: ${message}` }
+  }
+  if (loaded === null) return { kind: 'ok', port: undefined }
 
   applyConfigFileToEnvAndLogLevel(loaded.config, process.env)
   getLogger('cli-dispatcher').info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
 
-  return loaded.config.port
+  return { kind: 'ok', port: loaded.config.port }
 }
 
 async function dispatchRun(rest: readonly string[]): Promise<number> {
@@ -426,14 +440,18 @@ async function dispatchRun(rest: readonly string[]): Promise<number> {
   // shared/data-dir-secure.ts import-time DATA_DIR snapshot (pulled in via
   // daemon-run.js) sees the layered value. Config-file port is threaded
   // through separately (below) since --port and env don't share one seam.
-  const configFilePort = applyLoadedConfigFileToDispatcherEnv()
+  const configFileResult = applyLoadedConfigFileToDispatcherEnv()
+  if (configFileResult.kind === 'error') {
+    process.stderr.write(`${configFileResult.message}\n`)
+    return 1
+  }
 
   // Dynamic import keeps `server/config` (and its mkdirSync probe
   // at module load) out of the read-only command path.
   const { runDaemonRun } = await import('./daemon-run.js')
   const outcome = await runDaemonRun({
     host: parsed.host,
-    port: parsed.port ?? configFilePort,
+    port: parsed.port ?? configFileResult.port,
     dataDir: runDataDir,
     tokenStdin: parsed.tokenStdin,
   })

--- a/packages/mcp-server/src/cli/dispatcher.ts
+++ b/packages/mcp-server/src/cli/dispatcher.ts
@@ -16,6 +16,8 @@
 
 import { resolve } from 'node:path'
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
+import { applyConfigFileToEnv, loadConfigFile } from '../server/config-file.js'
+import { getLogger, parseLogLevel, setLogLevel } from '../server/log.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import {
   parseDaemonRunArgs,
@@ -385,6 +387,29 @@ async function dispatchServerSupportBundle(rest: readonly string[]): Promise<num
   return exitCode
 }
 
+// Loads the nearest whiteboard config file (if any), layers its values
+// under process.env (env-over-file precedence, see config-file.ts), logs
+// the file path at info level, and returns the file's `port` (if set) so
+// the caller can thread it into daemon-run's own port precedence — file
+// port is otherwise NOT a set-if-unset env key, unlike the other fields.
+function applyLoadedConfigFileToDispatcherEnv(): number | undefined {
+  const loaded = loadConfigFile()
+  if (loaded === null) return undefined
+
+  const envLogLevelWasUnset = process.env.WHITEBOARD_LOG_LEVEL === undefined
+  applyConfigFileToEnv(loaded.config, process.env)
+  getLogger('cli-dispatcher').info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
+
+  // log.ts freezes its level at import time, so a file-provided logLevel
+  // must be applied explicitly rather than relying on the env write above.
+  if (envLogLevelWasUnset && loaded.config.logLevel !== undefined) {
+    const level = parseLogLevel(loaded.config.logLevel)
+    if (level !== null) setLogLevel(level)
+  }
+
+  return loaded.config.port
+}
+
 async function dispatchRun(rest: readonly string[]): Promise<number> {
   const parsed = parseDaemonRunArgs(rest)
   if (parsed.kind === 'usage-error') {
@@ -402,12 +427,21 @@ async function dispatchRun(rest: readonly string[]): Promise<number> {
   if (runDataDir !== undefined) {
     process.env.WHITEBOARD_DATA_DIR = runDataDir
   }
+
+  // Load+apply the config file AFTER the --data-dir env write above and
+  // BEFORE the dynamic daemon-run import below, so file dataDir only wins
+  // when neither --data-dir nor WHITEBOARD_DATA_DIR is already set, and the
+  // shared/data-dir-secure.ts import-time DATA_DIR snapshot (pulled in via
+  // daemon-run.js) sees the layered value. Config-file port is threaded
+  // through separately (below) since --port and env don't share one seam.
+  const configFilePort = applyLoadedConfigFileToDispatcherEnv()
+
   // Dynamic import keeps `server/config` (and its mkdirSync probe
   // at module load) out of the read-only command path.
   const { runDaemonRun } = await import('./daemon-run.js')
   const outcome = await runDaemonRun({
     host: parsed.host,
-    port: parsed.port,
+    port: parsed.port ?? configFilePort,
     dataDir: runDataDir,
     tokenStdin: parsed.tokenStdin,
   })

--- a/packages/mcp-server/src/cli/dispatcher.ts
+++ b/packages/mcp-server/src/cli/dispatcher.ts
@@ -16,8 +16,8 @@
 
 import { resolve } from 'node:path'
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
-import { applyConfigFileToEnv, loadConfigFile } from '../server/config-file.js'
-import { getLogger, parseLogLevel, setLogLevel } from '../server/log.js'
+import { applyConfigFileToEnvAndLogLevel, loadConfigFile } from '../server/config-file.js'
+import { getLogger } from '../server/log.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import {
   parseDaemonRunArgs,
@@ -396,16 +396,8 @@ function applyLoadedConfigFileToDispatcherEnv(): number | undefined {
   const loaded = loadConfigFile()
   if (loaded === null) return undefined
 
-  const envLogLevelWasUnset = process.env.WHITEBOARD_LOG_LEVEL === undefined
-  applyConfigFileToEnv(loaded.config, process.env)
+  applyConfigFileToEnvAndLogLevel(loaded.config, process.env)
   getLogger('cli-dispatcher').info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
-
-  // log.ts freezes its level at import time, so a file-provided logLevel
-  // must be applied explicitly rather than relying on the env write above.
-  if (envLogLevelWasUnset && loaded.config.logLevel !== undefined) {
-    const level = parseLogLevel(loaded.config.logLevel)
-    if (level !== null) setLogLevel(level)
-  }
 
   return loaded.config.port
 }

--- a/packages/mcp-server/src/server/config-file.test.ts
+++ b/packages/mcp-server/src/server/config-file.test.ts
@@ -1,9 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { captureLogsForTests } from './log.js'
-import { applyConfigFileToEnv, loadConfigFile } from './config-file.js'
+import { captureLogsForTests, getLogLevel, isLogLevelEnabled, setLogLevel } from './log.js'
+import {
+  applyConfigFileToEnv,
+  applyConfigFileToEnvAndLogLevel,
+  loadConfigFile,
+} from './config-file.js'
 
 let dir: string
 
@@ -121,6 +125,28 @@ describe('loadConfigFile', () => {
       expect(String(err)).not.toContain('super-secret-token')
     }
   })
+
+  it('never executes JS reached via a config $import, even though $import can point anywhere', () => {
+    const sentinel = join(dir, 'sentinel.txt')
+    writeFileSync(
+      join(dir, 'evil.js'),
+      `require('node:fs').writeFileSync(${JSON.stringify(sentinel)}, 'executed'); module.exports = { token: 'pwned' }`,
+    )
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ $import: './evil.js' }))
+    expect(() => loadConfigFile(dir)).toThrow()
+    expect(existsSync(sentinel)).toBe(false)
+  })
+
+  it('propagates a parse error from the home fallback config instead of silently returning null', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'whiteboard-config-home-'))
+    try {
+      mkdirSync(join(homeDir, '.whiteboard'), { recursive: true })
+      writeFileSync(join(homeDir, '.whiteboard', 'config.yaml'), 'port: [1, 2\n')
+      expect(() => loadConfigFile(dir, { homeDir })).toThrow()
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('applyConfigFileToEnv', () => {
@@ -170,5 +196,32 @@ describe('applyConfigFileToEnv', () => {
     const env: Record<string, string | undefined> = {}
     applyConfigFileToEnv({}, env)
     expect(env).toEqual({})
+  })
+})
+
+describe('applyConfigFileToEnvAndLogLevel', () => {
+  it('applies a file logLevel to the running logger when WHITEBOARD_LOG_LEVEL is unset', () => {
+    const env: Record<string, string | undefined> = {}
+    const previousLevel = getLogLevel()
+    try {
+      applyConfigFileToEnvAndLogLevel({ logLevel: 'debug' }, env)
+      expect(getLogLevel()).toBe('debug')
+      expect(isLogLevelEnabled('debug')).toBe(true)
+    } finally {
+      setLogLevel(previousLevel)
+    }
+  })
+
+  it('leaves the running logger level untouched when WHITEBOARD_LOG_LEVEL is already set (env wins)', () => {
+    const env: Record<string, string | undefined> = { WHITEBOARD_LOG_LEVEL: 'error' }
+    const previousLevel = getLogLevel()
+    setLogLevel('warning')
+    try {
+      applyConfigFileToEnvAndLogLevel({ logLevel: 'debug' }, env)
+      expect(getLogLevel()).toBe('warning')
+      expect(env.WHITEBOARD_LOG_LEVEL).toBe('error')
+    } finally {
+      setLogLevel(previousLevel)
+    }
   })
 })

--- a/packages/mcp-server/src/server/config-file.test.ts
+++ b/packages/mcp-server/src/server/config-file.test.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureLogsForTests } from './log.js'
+import { applyConfigFileToEnv, loadConfigFile } from './config-file.js'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'whiteboard-config-file-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('loadConfigFile', () => {
+  it('returns null when no config file exists anywhere', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'whiteboard-config-home-'))
+    try {
+      expect(loadConfigFile(dir, { homeDir })).toBeNull()
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  it('parses a .whiteboardrc.json file', () => {
+    writeFileSync(
+      join(dir, '.whiteboardrc.json'),
+      JSON.stringify({ allowedWebOrigins: ['https://a.example'], port: 4000 }),
+    )
+    const loaded = loadConfigFile(dir)
+    expect(loaded?.config).toEqual({ allowedWebOrigins: ['https://a.example'], port: 4000 })
+    expect(loaded?.filepath).toBe(join(dir, '.whiteboardrc.json'))
+  })
+
+  it('parses YAML from .whiteboard/config.yaml', () => {
+    mkdirSync(join(dir, '.whiteboard'))
+    writeFileSync(
+      join(dir, '.whiteboard', 'config.yaml'),
+      'allowedWebOrigins:\n  - https://a.example\nport: 4001\n',
+    )
+    const loaded = loadConfigFile(dir)
+    expect(loaded?.config).toEqual({ allowedWebOrigins: ['https://a.example'], port: 4001 })
+  })
+
+  it('parses an extensionless .whiteboardrc (JSON body)', () => {
+    writeFileSync(join(dir, '.whiteboardrc'), JSON.stringify({ port: 4002 }))
+    const loaded = loadConfigFile(dir)
+    expect(loaded?.config).toEqual({ port: 4002 })
+  })
+
+  it('reads package.json#whiteboard when nothing else matches', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'x', whiteboard: { port: 4003 } }),
+    )
+    const loaded = loadConfigFile(dir)
+    expect(loaded?.config).toEqual({ port: 4003 })
+  })
+
+  it('prefers .whiteboardrc over .whiteboardrc.yaml and package.json in the same directory', () => {
+    writeFileSync(join(dir, '.whiteboardrc'), JSON.stringify({ port: 1 }))
+    writeFileSync(join(dir, '.whiteboardrc.yaml'), 'port: 2\n')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', whiteboard: { port: 3 } }))
+    const loaded = loadConfigFile(dir)
+    expect(loaded?.config.port).toBe(1)
+  })
+
+  it('walks up from a nested cwd to find a config in a parent directory', () => {
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 4004 }))
+    const nested = join(dir, 'a', 'b', 'c')
+    mkdirSync(nested, { recursive: true })
+    const loaded = loadConfigFile(nested)
+    expect(loaded?.config.port).toBe(4004)
+  })
+
+  it('falls back to ~/.whiteboard/config.yaml when nothing is found from cwd', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'whiteboard-config-home-'))
+    try {
+      mkdirSync(join(homeDir, '.whiteboard'), { recursive: true })
+      writeFileSync(join(homeDir, '.whiteboard', 'config.yaml'), 'port: 4005\n')
+      const loaded = loadConfigFile(dir, { homeDir })
+      expect(loaded?.config).toEqual({ port: 4005 })
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  it('warns and drops unknown keys but still loads known ones', () => {
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 4006, extraKey: 'nope' }))
+    const capture = captureLogsForTests()
+    try {
+      const loaded = loadConfigFile(dir)
+      expect(loaded?.config).toEqual({ port: 4006 })
+      const warning = capture.records.find((r) => r.msg.includes('unknown whiteboard config'))
+      expect(warning).toBeDefined()
+      expect(warning?.data?.filepath).toBe(join(dir, '.whiteboardrc.json'))
+      expect(warning?.data?.unknownKeys).toEqual(['extraKey'])
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('fails fast with the file path and key on an invalid value', () => {
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 'not-a-number' }))
+    expect(() => loadConfigFile(dir)).toThrow(/\.whiteboardrc\.json/)
+    expect(() => loadConfigFile(dir)).toThrow(/port/)
+  })
+
+  it('never includes the token value in a thrown validation message for another key', () => {
+    writeFileSync(
+      join(dir, '.whiteboardrc.json'),
+      JSON.stringify({ token: 'super-secret-token', port: 'bad' }),
+    )
+    try {
+      loadConfigFile(dir)
+      throw new Error('expected loadConfigFile to throw')
+    } catch (err) {
+      expect(String(err)).not.toContain('super-secret-token')
+    }
+  })
+})
+
+describe('applyConfigFileToEnv', () => {
+  it('sets unset WHITEBOARD_* keys from the file config', () => {
+    const env: Record<string, string | undefined> = {}
+    applyConfigFileToEnv(
+      {
+        allowedWebOrigins: ['https://a.example', 'https://b.example'],
+        token: 'file-token',
+        logLevel: 'debug',
+        dataDir: '/tmp/whiteboard-data',
+      },
+      env,
+    )
+    expect(env.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe('https://a.example,https://b.example')
+    expect(env.WHITEBOARD_TOKEN).toBe('file-token')
+    expect(env.WHITEBOARD_DAEMON_TOKEN).toBe('file-token')
+    expect(env.WHITEBOARD_LOG_LEVEL).toBe('debug')
+    expect(env.WHITEBOARD_DATA_DIR).toBe('/tmp/whiteboard-data')
+  })
+
+  it('never overwrites an already-set env key (env wins over file)', () => {
+    const env: Record<string, string | undefined> = {
+      WHITEBOARD_ALLOWED_WEB_ORIGINS: 'https://env.example',
+      WHITEBOARD_TOKEN: 'env-token',
+      WHITEBOARD_DAEMON_TOKEN: 'env-daemon-token',
+      WHITEBOARD_LOG_LEVEL: 'error',
+      WHITEBOARD_DATA_DIR: '/env/data',
+    }
+    applyConfigFileToEnv(
+      {
+        allowedWebOrigins: ['https://file.example'],
+        token: 'file-token',
+        logLevel: 'debug',
+        dataDir: '/file/data',
+      },
+      env,
+    )
+    expect(env.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe('https://env.example')
+    expect(env.WHITEBOARD_TOKEN).toBe('env-token')
+    expect(env.WHITEBOARD_DAEMON_TOKEN).toBe('env-daemon-token')
+    expect(env.WHITEBOARD_LOG_LEVEL).toBe('error')
+    expect(env.WHITEBOARD_DATA_DIR).toBe('/env/data')
+  })
+
+  it('does not touch process.env when the config has no relevant keys', () => {
+    const env: Record<string, string | undefined> = {}
+    applyConfigFileToEnv({}, env)
+    expect(env).toEqual({})
+  })
+})

--- a/packages/mcp-server/src/server/config-file.test.ts
+++ b/packages/mcp-server/src/server/config-file.test.ts
@@ -174,6 +174,23 @@ describe('applyConfigFileToEnv', () => {
     expect(env.WHITEBOARD_DATA_DIR).toBe('/tmp/whiteboard-data')
   })
 
+  it('leaves BOTH token seams alone when either one is already set in the env', () => {
+    // Filling only the unset seam would give the daemon and the server
+    // entrypoint two different tokens (env value on one side, file value on
+    // the other) — a mismatch worse than not applying the file token at all.
+    const tokenOnly: Record<string, string | undefined> = { WHITEBOARD_TOKEN: 'env-token' }
+    applyConfigFileToEnv({ token: 'file-token' }, tokenOnly)
+    expect(tokenOnly.WHITEBOARD_TOKEN).toBe('env-token')
+    expect(tokenOnly.WHITEBOARD_DAEMON_TOKEN).toBeUndefined()
+
+    const daemonOnly: Record<string, string | undefined> = {
+      WHITEBOARD_DAEMON_TOKEN: 'env-daemon-token',
+    }
+    applyConfigFileToEnv({ token: 'file-token' }, daemonOnly)
+    expect(daemonOnly.WHITEBOARD_DAEMON_TOKEN).toBe('env-daemon-token')
+    expect(daemonOnly.WHITEBOARD_TOKEN).toBeUndefined()
+  })
+
   it('never overwrites an already-set env key (env wins over file)', () => {
     const env: Record<string, string | undefined> = {
       WHITEBOARD_ALLOWED_WEB_ORIGINS: 'https://env.example',

--- a/packages/mcp-server/src/server/config-file.test.ts
+++ b/packages/mcp-server/src/server/config-file.test.ts
@@ -72,12 +72,18 @@ describe('loadConfigFile', () => {
     expect(loaded?.config.port).toBe(1)
   })
 
-  it('walks up from a nested cwd to find a config in a parent directory', () => {
+  it('does NOT walk up to a parent directory: a config file above cwd is ignored', () => {
+    // An ancestor directory (e.g. the root of an untrusted cloned repo) must
+    // not be able to plant a config that a nested cwd picks up implicitly.
     writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 4004 }))
     const nested = join(dir, 'a', 'b', 'c')
     mkdirSync(nested, { recursive: true })
-    const loaded = loadConfigFile(nested)
-    expect(loaded?.config.port).toBe(4004)
+    const homeDir = mkdtempSync(join(tmpdir(), 'whiteboard-config-home-'))
+    try {
+      expect(loadConfigFile(nested, { homeDir })).toBeNull()
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+    }
   })
 
   it('falls back to ~/.whiteboard/config.yaml when nothing is found from cwd', () => {

--- a/packages/mcp-server/src/server/config-file.ts
+++ b/packages/mcp-server/src/server/config-file.ts
@@ -1,0 +1,177 @@
+// Auto-loads .whiteboardrc / whiteboard.config.json / .whiteboard/config.yaml
+// (and a package.json#whiteboard field) for the LOCAL DAEMON, so operators can
+// keep WHITEBOARD_ALLOWED_WEB_ORIGINS / port / token / logLevel / dataDir in a
+// checked-in-or-dotfile config instead of exporting env vars by hand.
+//
+// cosmiconfig (not lilconfig) is used deliberately: the user's actual ask was
+// YAML support, and cosmiconfig bundles a YAML loader out of the box while
+// lilconfig does not. JS loaders (whiteboard.config.js/.cjs/.mjs) are
+// deliberately EXCLUDED from searchPlaces below — loading arbitrary JS at
+// daemon startup would let a config file execute code, which a declarative
+// JSON/YAML/rc format must never do.
+//
+// Server-mode env config (security/server-mode-env-config.ts) is out of
+// scope here: that surface is env-first by design for hosted operators.
+
+import { homedir } from 'node:os'
+import { cosmiconfigSync } from 'cosmiconfig'
+import { z } from 'zod'
+import { getLogger, LOG_LEVELS } from './log.js'
+
+const log = getLogger('config-file')
+
+// Order matters: cosmiconfig checks these, in this order, in each directory
+// while walking up from cwd. JSON/YAML/rc-without-extension formats only.
+export const CONFIG_FILE_SEARCH_PLACES = [
+  '.whiteboardrc',
+  '.whiteboardrc.json',
+  '.whiteboardrc.yaml',
+  '.whiteboardrc.yml',
+  '.whiteboard/config.yaml',
+  '.whiteboard/config.yml',
+  'whiteboard.config.json',
+  'package.json',
+] as const
+
+// Fallback file consulted when nothing is found walking up from cwd, so a
+// single per-user default can apply across every project on a machine.
+export const HOME_CONFIG_FILE_RELATIVE_PATH = '.whiteboard/config.yaml'
+
+const KNOWN_KEYS = ['allowedWebOrigins', 'port', 'token', 'logLevel', 'dataDir'] as const
+type KnownKey = (typeof KNOWN_KEYS)[number]
+
+// token is intentionally a plain string: file-stored tokens are a dev-only
+// convenience (the same footgun as committing a .env with a secret in it).
+// Docs must say so; this module never logs the value.
+export const whiteboardConfigFileSchema = z
+  .object({
+    allowedWebOrigins: z.array(z.string()).optional(),
+    port: z.number().int().min(1).max(65535).optional(),
+    token: z.string().optional(),
+    logLevel: z.enum(LOG_LEVELS).optional(),
+    dataDir: z.string().optional(),
+  })
+  .strict()
+
+export type WhiteboardConfigFile = z.infer<typeof whiteboardConfigFileSchema>
+
+export interface LoadedConfigFile {
+  readonly filepath: string
+  readonly config: WhiteboardConfigFile
+}
+
+export interface LoadConfigFileOptions {
+  // Overridable for tests; defaults to the real home directory.
+  homeDir?: string
+}
+
+function isKnownKey(key: string): key is KnownKey {
+  return (KNOWN_KEYS as readonly string[]).includes(key)
+}
+
+function describeIssuePath(path: readonly PropertyKey[]): string {
+  return path.length > 0 ? path.map(String).join('.') : '(root)'
+}
+
+// Splits the raw parsed file object into known keys (validated below) and
+// unknown ones (warned about, then dropped) so a typo like `allowdWebOrigins`
+// is loud instead of silently doing nothing.
+function partitionKnownKeys(
+  raw: Record<string, unknown>,
+  filepath: string,
+): Record<string, unknown> {
+  const unknownKeys = Object.keys(raw).filter((key) => !isKnownKey(key))
+  if (unknownKeys.length > 0) {
+    log.warning({ filepath, unknownKeys }, 'ignoring unknown whiteboard config key(s)')
+  }
+  const known: Record<string, unknown> = {}
+  for (const key of KNOWN_KEYS) {
+    if (key in raw) known[key] = raw[key]
+  }
+  return known
+}
+
+function parseKnownConfig(known: Record<string, unknown>, filepath: string): WhiteboardConfigFile {
+  const result = whiteboardConfigFileSchema.safeParse(known)
+  if (result.success) return result.data
+  const issue = result.error.issues[0]
+  const key = describeIssuePath(issue.path)
+  throw new Error(`Invalid whiteboard config at ${filepath}: key "${key}" ${issue.message}`)
+}
+
+function validateLoadedConfig(rawConfig: unknown, filepath: string): WhiteboardConfigFile {
+  if (typeof rawConfig !== 'object' || rawConfig === null || Array.isArray(rawConfig)) {
+    throw new Error(`Invalid whiteboard config at ${filepath}: expected an object at the root`)
+  }
+  const known = partitionKnownKeys(rawConfig as Record<string, unknown>, filepath)
+  return parseKnownConfig(known, filepath)
+}
+
+// Loads the nearest whiteboard config file, walking up from `cwd`. Falls
+// back to `~/.whiteboard/config.yaml` when nothing is found. Returns null
+// when no file exists anywhere — daemon behavior must stay byte-identical
+// in that case.
+export function loadConfigFile(
+  cwd: string = process.cwd(),
+  options: LoadConfigFileOptions = {},
+): LoadedConfigFile | null {
+  // cosmiconfig v9 defaults to searchStrategy 'none' (single directory, no
+  // walk-up) unless a stopDir is given. Passing the filesystem root opts
+  // back into walking up from cwd, matching the spec's "walking up" ask.
+  const explorer = cosmiconfigSync('whiteboard', {
+    searchPlaces: [...CONFIG_FILE_SEARCH_PLACES],
+    searchStrategy: 'global',
+    stopDir: '/',
+  })
+
+  const found = explorer.search(cwd)
+  if (found && !found.isEmpty) {
+    return { filepath: found.filepath, config: validateLoadedConfig(found.config, found.filepath) }
+  }
+
+  const homeDir = options.homeDir ?? homedir()
+  const homeConfigExplorer = cosmiconfigSync('whiteboard', {
+    searchPlaces: [HOME_CONFIG_FILE_RELATIVE_PATH],
+    searchStrategy: 'global',
+    stopDir: homeDir,
+  })
+  let homeFound: ReturnType<typeof homeConfigExplorer.search>
+  try {
+    homeFound = homeConfigExplorer.search(homeDir)
+  } catch {
+    return null
+  }
+  if (!homeFound || homeFound.isEmpty) return null
+  return {
+    filepath: homeFound.filepath,
+    config: validateLoadedConfig(homeFound.config, homeFound.filepath),
+  }
+}
+
+// Layers validated config-file values under process.env, dotenv-style: only
+// sets a WHITEBOARD_* key that is CURRENTLY UNSET. This is a deliberate,
+// narrow exception to the repo's immutability discipline — every existing
+// env reader (web-origin-allowlist, resolveToken, the daemon-run token read,
+// data-dir-secure) already treats process.env as its seam, so layering file
+// values here gives them env-over-file precedence for free without touching
+// each seam individually. `port` is excluded: its own precedence chain
+// (CLI --port > file port > auto-scan) is not a simple set-if-unset case, so
+// callers read `config.port` directly instead.
+export function applyConfigFileToEnv(
+  config: WhiteboardConfigFile,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  if (config.allowedWebOrigins !== undefined && env.WHITEBOARD_ALLOWED_WEB_ORIGINS === undefined) {
+    env.WHITEBOARD_ALLOWED_WEB_ORIGINS = config.allowedWebOrigins.join(',')
+  }
+  if (config.token !== undefined) {
+    if (env.WHITEBOARD_TOKEN === undefined) env.WHITEBOARD_TOKEN = config.token
+    if (env.WHITEBOARD_DAEMON_TOKEN === undefined) env.WHITEBOARD_DAEMON_TOKEN = config.token
+  }
+  if (config.logLevel !== undefined && env.WHITEBOARD_LOG_LEVEL === undefined) {
+    env.WHITEBOARD_LOG_LEVEL = config.logLevel
+  }
+  if (config.dataDir !== undefined && env.WHITEBOARD_DATA_DIR === undefined) {
+    env.WHITEBOARD_DATA_DIR = config.dataDir
+  }
+}

--- a/packages/mcp-server/src/server/config-file.ts
+++ b/packages/mcp-server/src/server/config-file.ts
@@ -16,7 +16,7 @@
 import { homedir } from 'node:os'
 import { cosmiconfigSync } from 'cosmiconfig'
 import { z } from 'zod'
-import { getLogger, LOG_LEVELS } from './log.js'
+import { getLogger, LOG_LEVELS, parseLogLevel, setLogLevel } from './log.js'
 
 const log = getLogger('config-file')
 
@@ -173,5 +173,23 @@ export function applyConfigFileToEnv(
   }
   if (config.dataDir !== undefined && env.WHITEBOARD_DATA_DIR === undefined) {
     env.WHITEBOARD_DATA_DIR = config.dataDir
+  }
+}
+
+// Layers config-file values under env (via applyConfigFileToEnv) AND applies a
+// file-provided logLevel through setLogLevel. The explicit setLogLevel is
+// required because log.ts freezes its level at import time, so the env write
+// alone is too late for an already-loaded logger. `WHITEBOARD_LOG_LEVEL` must
+// be sampled BEFORE applyConfigFileToEnv (which sets it), so env-over-file
+// precedence still holds: a level already in the env wins over the file's.
+export function applyConfigFileToEnvAndLogLevel(
+  config: WhiteboardConfigFile,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const envLogLevelWasUnset = env.WHITEBOARD_LOG_LEVEL === undefined
+  applyConfigFileToEnv(config, env)
+  if (envLogLevelWasUnset && config.logLevel !== undefined) {
+    const level = parseLogLevel(config.logLevel)
+    if (level !== null) setLogLevel(level)
   }
 }

--- a/packages/mcp-server/src/server/config-file.ts
+++ b/packages/mcp-server/src/server/config-file.ts
@@ -8,12 +8,17 @@
 // lilconfig does not. JS loaders (whiteboard.config.js/.cjs/.mjs) are
 // deliberately EXCLUDED from searchPlaces below, but that alone does not stop
 // code execution: cosmiconfig's `$import` key resolves through its `loaders`
-// map regardless of searchPlaces, and `searchStrategy: 'global'` additionally
-// probes an OS-level global config directory whose default search places
-// include `config.js`. SAFE_LOADERS below is what actually enforces "a
-// config file can never execute code" — omitting `.js`/`.cjs`/`.mjs`/`.ts`
-// from the loaders map makes cosmiconfig throw rather than execute whenever
-// any of those paths is reached.
+// map regardless of searchPlaces. SAFE_LOADERS below is what actually
+// enforces "a config file can never execute code" — omitting
+// `.js`/`.cjs`/`.mjs`/`.ts` from the loaders map makes cosmiconfig throw
+// rather than execute whenever any of those paths is reached.
+//
+// Trust boundary: `loadConfigFile` only ever consults the given `cwd`
+// itself (searchStrategy 'none', no ancestor walk-up, no OS-level global
+// config directory) and the explicit `~/.whiteboard/config.yaml` fallback.
+// An ancestor of cwd — e.g. the root of an untrusted cloned repo — must
+// never be able to plant a config that injects `token` or
+// `allowedWebOrigins` into a nested project's daemon.
 //
 // Server-mode env config (security/server-mode-env-config.ts) is out of
 // scope here: that surface is env-first by design for hosted operators.
@@ -25,8 +30,9 @@ import { getLogger, LOG_LEVELS, parseLogLevel, setLogLevel } from './log.js'
 
 const log = getLogger('config-file')
 
-// Order matters: cosmiconfig checks these, in this order, in each directory
-// while walking up from cwd. JSON/YAML/rc-without-extension formats only.
+// Order matters: cosmiconfig checks these, in this order, in the single
+// directory searched (cwd; no ancestor walk-up). JSON/YAML/rc-without-extension
+// formats only.
 export const CONFIG_FILE_SEARCH_PLACES = [
   '.whiteboardrc',
   '.whiteboardrc.json',
@@ -136,21 +142,24 @@ function validateLoadedConfig(rawConfig: unknown, filepath: string): WhiteboardC
   return parseKnownConfig(known, filepath)
 }
 
-// Loads the nearest whiteboard config file, walking up from `cwd`. Falls
-// back to `~/.whiteboard/config.yaml` when nothing is found. Returns null
-// when no file exists anywhere — daemon behavior must stay byte-identical
-// in that case.
+// Loads a whiteboard config file from `cwd` itself (no ancestor walk-up).
+// Falls back to `~/.whiteboard/config.yaml` when nothing is found there.
+// Returns null when no file exists anywhere — daemon behavior must stay
+// byte-identical in that case.
 export function loadConfigFile(
   cwd: string = process.cwd(),
   options: LoadConfigFileOptions = {},
 ): LoadedConfigFile | null {
-  // cosmiconfig v9 defaults to searchStrategy 'none' (single directory, no
-  // walk-up) unless a stopDir is given. Passing the filesystem root opts
-  // back into walking up from cwd, matching the spec's "walking up" ask.
+  // searchStrategy 'none' checks ONLY the given directory: no walk-up
+  // through ancestors and no probe of an OS-level global config directory.
+  // This is a deliberate trust-boundary choice, not cosmiconfig's default —
+  // an ancestor of cwd (e.g. the root of an untrusted cloned repo) must not
+  // be able to plant a config that injects `token` / `allowedWebOrigins`
+  // into a nested project's daemon. The only other place consulted is the
+  // explicit home-directory fallback below.
   const explorer = cosmiconfigSync('whiteboard', {
     searchPlaces: [...CONFIG_FILE_SEARCH_PLACES],
-    searchStrategy: 'global',
-    stopDir: '/',
+    searchStrategy: 'none',
     loaders: SAFE_LOADERS,
   })
 
@@ -162,8 +171,7 @@ export function loadConfigFile(
   const homeDir = options.homeDir ?? homedir()
   const homeConfigExplorer = cosmiconfigSync('whiteboard', {
     searchPlaces: [HOME_CONFIG_FILE_RELATIVE_PATH],
-    searchStrategy: 'global',
-    stopDir: homeDir,
+    searchStrategy: 'none',
     loaders: SAFE_LOADERS,
   })
   // No try/catch here, matching the cwd-side explorer above: cosmiconfig

--- a/packages/mcp-server/src/server/config-file.ts
+++ b/packages/mcp-server/src/server/config-file.ts
@@ -6,15 +6,20 @@
 // cosmiconfig (not lilconfig) is used deliberately: the user's actual ask was
 // YAML support, and cosmiconfig bundles a YAML loader out of the box while
 // lilconfig does not. JS loaders (whiteboard.config.js/.cjs/.mjs) are
-// deliberately EXCLUDED from searchPlaces below — loading arbitrary JS at
-// daemon startup would let a config file execute code, which a declarative
-// JSON/YAML/rc format must never do.
+// deliberately EXCLUDED from searchPlaces below, but that alone does not stop
+// code execution: cosmiconfig's `$import` key resolves through its `loaders`
+// map regardless of searchPlaces, and `searchStrategy: 'global'` additionally
+// probes an OS-level global config directory whose default search places
+// include `config.js`. SAFE_LOADERS below is what actually enforces "a
+// config file can never execute code" — omitting `.js`/`.cjs`/`.mjs`/`.ts`
+// from the loaders map makes cosmiconfig throw rather than execute whenever
+// any of those paths is reached.
 //
 // Server-mode env config (security/server-mode-env-config.ts) is out of
 // scope here: that surface is env-first by design for hosted operators.
 
 import { homedir } from 'node:os'
-import { cosmiconfigSync } from 'cosmiconfig'
+import { cosmiconfigSync, defaultLoadersSync, type LoadersSync } from 'cosmiconfig'
 import { z } from 'zod'
 import { getLogger, LOG_LEVELS, parseLogLevel, setLogLevel } from './log.js'
 
@@ -36,6 +41,30 @@ export const CONFIG_FILE_SEARCH_PLACES = [
 // Fallback file consulted when nothing is found walking up from cwd, so a
 // single per-user default can apply across every project on a machine.
 export const HOME_CONFIG_FILE_RELATIVE_PATH = '.whiteboard/config.yaml'
+
+// cosmiconfig merges a caller's `loaders` option ON TOP of its own defaults
+// (`{...defaults.loaders, ...options.loaders}`), so merely omitting the JS
+// extensions here would leave cosmiconfig's built-in JS loaders in place.
+// Each dangerous extension must be explicitly overridden with a loader that
+// refuses to run, so a path reaching it — via a search place, `$import`, or
+// the OS-level global config directory probed by `searchStrategy: 'global'`
+// — throws instead of executing.
+function refuseCodeLoader(filepath: string): never {
+  throw new Error(
+    `Refusing to load "${filepath}": whiteboard config files must be declarative JSON/YAML and must never execute code.`,
+  )
+}
+
+const SAFE_LOADERS: LoadersSync = {
+  '.json': defaultLoadersSync['.json'],
+  '.yaml': defaultLoadersSync['.yaml'],
+  '.yml': defaultLoadersSync['.yml'],
+  noExt: defaultLoadersSync.noExt,
+  '.js': refuseCodeLoader,
+  '.cjs': refuseCodeLoader,
+  '.mjs': refuseCodeLoader,
+  '.ts': refuseCodeLoader,
+}
 
 const KNOWN_KEYS = ['allowedWebOrigins', 'port', 'token', 'logLevel', 'dataDir'] as const
 type KnownKey = (typeof KNOWN_KEYS)[number]
@@ -122,6 +151,7 @@ export function loadConfigFile(
     searchPlaces: [...CONFIG_FILE_SEARCH_PLACES],
     searchStrategy: 'global',
     stopDir: '/',
+    loaders: SAFE_LOADERS,
   })
 
   const found = explorer.search(cwd)
@@ -134,13 +164,14 @@ export function loadConfigFile(
     searchPlaces: [HOME_CONFIG_FILE_RELATIVE_PATH],
     searchStrategy: 'global',
     stopDir: homeDir,
+    loaders: SAFE_LOADERS,
   })
-  let homeFound: ReturnType<typeof homeConfigExplorer.search>
-  try {
-    homeFound = homeConfigExplorer.search(homeDir)
-  } catch {
-    return null
-  }
+  // No try/catch here, matching the cwd-side explorer above: cosmiconfig
+  // already swallows "not found" errors (ENOENT/EISDIR/ENOTDIR/EACCES)
+  // internally, so anything that reaches this call site is a real parse or
+  // loader error that must abort startup, not be silently treated as "no
+  // config file".
+  const homeFound = homeConfigExplorer.search(homeDir)
   if (!homeFound || homeFound.isEmpty) return null
   return {
     filepath: homeFound.filepath,

--- a/packages/mcp-server/src/server/config-file.ts
+++ b/packages/mcp-server/src/server/config-file.ts
@@ -203,9 +203,16 @@ export function applyConfigFileToEnv(
   if (config.allowedWebOrigins !== undefined && env.WHITEBOARD_ALLOWED_WEB_ORIGINS === undefined) {
     env.WHITEBOARD_ALLOWED_WEB_ORIGINS = config.allowedWebOrigins.join(',')
   }
-  if (config.token !== undefined) {
-    if (env.WHITEBOARD_TOKEN === undefined) env.WHITEBOARD_TOKEN = config.token
-    if (env.WHITEBOARD_DAEMON_TOKEN === undefined) env.WHITEBOARD_DAEMON_TOKEN = config.token
+  // The file token feeds BOTH env seams or NEITHER: filling only the unset
+  // one would leave the daemon and the server entrypoint holding two
+  // different tokens (env value on one side, file value on the other).
+  if (
+    config.token !== undefined &&
+    env.WHITEBOARD_TOKEN === undefined &&
+    env.WHITEBOARD_DAEMON_TOKEN === undefined
+  ) {
+    env.WHITEBOARD_TOKEN = config.token
+    env.WHITEBOARD_DAEMON_TOKEN = config.token
   }
   if (config.logLevel !== undefined && env.WHITEBOARD_LOG_LEVEL === undefined) {
     env.WHITEBOARD_LOG_LEVEL = config.logLevel

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -176,14 +176,15 @@ describe('server/index main() config-file wiring', () => {
     const capture = captureLogsForTests()
     try {
       await main()
-      // The env var may still be written (applyConfigFileToEnv is a general
-      // helper), but DATA_DIR (shared/data-dir-secure.ts) was already
-      // resolved at module import time, so it never sees this value — the
-      // warning below is the only signal an operator gets.
       const warning = capture.records.find(
         (r) => r.scope === 'server-index' && r.msg.includes('dataDir is not honored'),
       )
       expect(warning).toBeDefined()
+      // DATA_DIR (shared/data-dir-secure.ts) was resolved at module import
+      // time and never sees the file value, so writing it to the env anyway
+      // would give later env readers a dataDir the running server is NOT
+      // using. The entrypoint must not apply it at all.
+      expect(process.env.WHITEBOARD_DATA_DIR).toBeUndefined()
     } finally {
       capture.restore()
       exitSpy.mockRestore()

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -135,6 +135,29 @@ describe('server/index main() config-file wiring', () => {
     }
   })
 
+  it('aborts cleanly with a structured log record on an invalid config file, instead of an unhandled throw', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'whiteboard-index-config-'))
+    originalCwd = process.cwd()
+    process.chdir(dir)
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ port: 'not-a-number' }))
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const capture = captureLogsForTests()
+    try {
+      await expect(main()).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(startHttpServerMock).not.toHaveBeenCalled()
+      const record = capture.records.find((r) => r.scope === 'server-index' && r.level === 'error')
+      expect(record).toBeDefined()
+      expect(JSON.stringify(capture.records)).not.toMatch(/\n\s*at /)
+    } finally {
+      capture.restore()
+      exitSpy.mockRestore()
+    }
+  })
+
   it('warns instead of honoring a config-file dataDir on this entrypoint', async () => {
     dir = mkdtempSync(join(tmpdir(), 'whiteboard-index-config-'))
     originalCwd = process.cwd()

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { captureLogsForTests } from './log.js'
 
@@ -95,6 +98,73 @@ describe('server/index main() WHITEBOARD_ALLOWED_WEB_ORIGINS startup gate', () =
       exitSpy.mockRestore()
       stdoutSpy.mockRestore()
       delete process.env.WHITEBOARD_TOKEN
+    }
+  })
+})
+
+describe('server/index main() config-file wiring', () => {
+  let dir: string
+  let originalCwd: string
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete process.env.WHITEBOARD_TOKEN
+    delete process.env.WHITEBOARD_DATA_DIR
+    if (originalCwd) process.chdir(originalCwd)
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('loads a config-file token into WHITEBOARD_TOKEN (env still wins if set)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'whiteboard-index-config-'))
+    originalCwd = process.cwd()
+    process.chdir(dir)
+    writeFileSync(join(dir, '.whiteboardrc.json'), JSON.stringify({ token: 'file-token' }))
+    delete process.env.WHITEBOARD_TOKEN
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await main()
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(process.env.WHITEBOARD_TOKEN).toBe('file-token')
+    } finally {
+      exitSpy.mockRestore()
+      stdoutSpy.mockRestore()
+    }
+  })
+
+  it('warns instead of honoring a config-file dataDir on this entrypoint', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'whiteboard-index-config-'))
+    originalCwd = process.cwd()
+    process.chdir(dir)
+    writeFileSync(
+      join(dir, '.whiteboardrc.json'),
+      JSON.stringify({ token: 'file-token', dataDir: join(dir, 'data') }),
+    )
+    delete process.env.WHITEBOARD_TOKEN
+    delete process.env.WHITEBOARD_DATA_DIR
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const capture = captureLogsForTests()
+    try {
+      await main()
+      // The env var may still be written (applyConfigFileToEnv is a general
+      // helper), but DATA_DIR (shared/data-dir-secure.ts) was already
+      // resolved at module import time, so it never sees this value — the
+      // warning below is the only signal an operator gets.
+      const warning = capture.records.find(
+        (r) => r.scope === 'server-index' && r.msg.includes('dataDir is not honored'),
+      )
+      expect(warning).toBeDefined()
+    } finally {
+      capture.restore()
+      exitSpy.mockRestore()
+      stdoutSpy.mockRestore()
     }
   })
 })

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -9,7 +9,8 @@ import {
 import { isDirectEntryPoint } from './entrypoint.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
-import { getLogger } from './log.js'
+import { applyConfigFileToEnv, loadConfigFile } from './config-file.js'
+import { getLogger, parseLogLevel, setLogLevel } from './log.js'
 
 function readArg(name: string, fallback?: string): string | undefined {
   const prefix = `--${name}=`
@@ -44,8 +45,42 @@ export function resolveToken(
 export { createApp } from './app.js'
 export { startHttpServer } from './http-server.js'
 
+// Loads the nearest whiteboard config file (if any) and layers its values
+// under process.env before any other startup reads (allowlist, token,
+// logLevel). Must run first: log.ts freezes its level at import time, so a
+// file-provided logLevel needs the explicit setLogLevel call below, and
+// every other env reader in this function reads process.env directly.
+// dataDir is deliberately NOT applied here — DATA_DIR (shared/data-dir-secure.ts)
+// is a static-import-time snapshot on this entrypoint, so a file dataDir key
+// would be silently too-late; warn instead of pretending it worked.
+function applyLoadedConfigFileForServerEntrypoint(): number | undefined {
+  const loaded = loadConfigFile()
+  if (loaded === null) return undefined
+
+  const envLogLevelWasUnset = process.env.WHITEBOARD_LOG_LEVEL === undefined
+  applyConfigFileToEnv(loaded.config, process.env)
+  const log = getLogger('server-index')
+  log.info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
+
+  if (envLogLevelWasUnset && loaded.config.logLevel !== undefined) {
+    const level = parseLogLevel(loaded.config.logLevel)
+    if (level !== null) setLogLevel(level)
+  }
+
+  if (loaded.config.dataDir !== undefined) {
+    log.warning(
+      { filepath: loaded.filepath },
+      'config file dataDir is not honored on this entrypoint; set WHITEBOARD_DATA_DIR instead',
+    )
+  }
+
+  return loaded.config.port
+}
+
 export async function main() {
-  const port = parseInt(readArg('port', '3099') ?? '3099', 10)
+  const configFilePort = applyLoadedConfigFileForServerEntrypoint()
+
+  const port = parseInt(readArg('port') ?? String(configFilePort ?? 3099), 10)
   const host = readArg('host', '127.0.0.1') ?? '127.0.0.1'
   const token = resolveToken(process.argv, process.env)
   const idleTimeoutMs = parseInt(

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -53,8 +53,24 @@ export { startHttpServer } from './http-server.js'
 // dataDir is deliberately NOT applied here — DATA_DIR (shared/data-dir-secure.ts)
 // is a static-import-time snapshot on this entrypoint, so a file dataDir key
 // would be silently too-late; warn instead of pretending it worked.
+//
+// loadConfigFile throws on a malformed file (by design). Catch it here and
+// fail the same way the WHITEBOARD_ALLOWED_WEB_ORIGINS gate below does
+// (structured getLogger record + process.exit(1)) instead of letting the
+// throw propagate to the generic top-level `main().catch` at the bottom of
+// this file, which would echo the raw error/stack on stderr unredacted.
 function applyLoadedConfigFileForServerEntrypoint(): number | undefined {
-  const loaded = loadConfigFile()
+  let loaded: ReturnType<typeof loadConfigFile>
+  try {
+    loaded = loadConfigFile()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    getLogger('server-index').error(
+      { message },
+      'invalid whiteboard config file; refusing to start',
+    )
+    process.exit(1)
+  }
   if (loaded === null) return undefined
 
   applyConfigFileToEnvAndLogLevel(loaded.config, process.env)

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -9,8 +9,8 @@ import {
 import { isDirectEntryPoint } from './entrypoint.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
-import { applyConfigFileToEnv, loadConfigFile } from './config-file.js'
-import { getLogger, parseLogLevel, setLogLevel } from './log.js'
+import { applyConfigFileToEnvAndLogLevel, loadConfigFile } from './config-file.js'
+import { getLogger } from './log.js'
 
 function readArg(name: string, fallback?: string): string | undefined {
   const prefix = `--${name}=`
@@ -57,15 +57,9 @@ function applyLoadedConfigFileForServerEntrypoint(): number | undefined {
   const loaded = loadConfigFile()
   if (loaded === null) return undefined
 
-  const envLogLevelWasUnset = process.env.WHITEBOARD_LOG_LEVEL === undefined
-  applyConfigFileToEnv(loaded.config, process.env)
+  applyConfigFileToEnvAndLogLevel(loaded.config, process.env)
   const log = getLogger('server-index')
   log.info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
-
-  if (envLogLevelWasUnset && loaded.config.logLevel !== undefined) {
-    const level = parseLogLevel(loaded.config.logLevel)
-    if (level !== null) setLogLevel(level)
-  }
 
   if (loaded.config.dataDir !== undefined) {
     log.warning(

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -73,7 +73,12 @@ function applyLoadedConfigFileForServerEntrypoint(): number | undefined {
   }
   if (loaded === null) return undefined
 
-  applyConfigFileToEnvAndLogLevel(loaded.config, process.env)
+  // dataDir is dropped before applying: DATA_DIR (shared/data-dir-secure.ts)
+  // was resolved at module import time on this entrypoint, so writing the
+  // file value into the env would hand later env readers a dataDir the
+  // running server is not actually using.
+  const { dataDir: _ignoredDataDir, ...applicableConfig } = loaded.config
+  applyConfigFileToEnvAndLogLevel(applicableConfig, process.env)
   const log = getLogger('server-index')
   log.info({ filepath: loaded.filepath }, 'loaded whiteboard config file')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
+      cosmiconfig:
+        specifier: ^9.0.0
+        version: 9.0.2(typescript@6.0.3)
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -4215,6 +4218,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -4350,6 +4357,15 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   crc-32@0.3.0:
     resolution: {integrity: sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==}
@@ -4698,6 +4714,9 @@ packages:
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -5120,6 +5139,10 @@ packages:
   immutable@4.3.8:
     resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
@@ -5160,6 +5183,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -5416,6 +5442,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-rpc-2.0@1.7.1:
     resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
@@ -5610,6 +5639,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -5958,6 +5990,14 @@ packages:
   pako@2.0.3:
     resolution: {integrity: sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -6291,6 +6331,10 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -8481,7 +8525,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.9)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -10876,9 +10920,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -11195,6 +11239,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001793: {}
 
   canvas-roundrect-polyfill@0.0.1: {}
@@ -11321,6 +11367,15 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   crc-32@0.3.0: {}
 
@@ -11672,13 +11727,16 @@ snapshots:
 
   entities@8.0.0: {}
 
-  env-paths@2.2.1:
-    optional: true
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
   err-code@2.0.3:
     optional: true
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error-stack-parser-es@1.0.5: {}
 
@@ -12243,6 +12301,11 @@ snapshots:
 
   immutable@4.3.8: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.16.0
@@ -12279,6 +12342,8 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -12524,6 +12589,8 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -12695,6 +12762,8 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4: {}
 
   lodash-es@4.18.1: {}
 
@@ -13109,6 +13178,17 @@ snapshots:
 
   pako@2.0.3: {}
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -13465,6 +13545,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds file-based configuration for the **local daemon**: `.whiteboardrc` / `.whiteboardrc.{json,yaml,yml}` / `.whiteboard/config.{yaml,yml}` / `whiteboard.config.json` / `package.json#whiteboard` are auto-loaded via cosmiconfig, with a `~/.whiteboard/config.yaml` per-machine fallback.

- **Precedence: env var > config file > built-in default.** File values are layered under `process.env` dotenv-style (only unset keys are written), so every existing env reader inherits precedence unchanged.
- Supported keys (Zod-strict, single source of truth): `allowedWebOrigins`, `port`, `token`, `logLevel`, `dataDir`. Unknown keys warn loudly; invalid values abort startup naming the file and key (never echoing the token).
- `logLevel` additionally calls `setLogLevel()` because `log.ts` freezes its level at import time.
- `port` from a file behaves like an explicit `--port` (hard-fail when busy, no auto-scan). `dataDir` is CLI-path only; the server entrypoint warns instead of silently ignoring it.

## Security hardening (from the review gate)

- **Config files can never execute code**: only declarative JSON/YAML loaders are registered, and cosmiconfig `$import` resolution is refused loudly (regression-tested with a sentinel that proves no JS runs).
- **No ancestor walk-up**: only the current working directory and the home fallback are searched (`searchStrategy: 'none'`), so a `.whiteboardrc.json` planted in a parent directory of an untrusted clone cannot inject a daemon token or widen the CORS allowlist.
- Malformed config files fail as clean structured errors on both entrypoints (CLI: one stderr line + exit 1; server: redacted `getLogger` record + exit 1) instead of raw unhandled-rejection stack traces.
- Home-fallback parse errors are loud, matching the cwd path (no silent swallow).

## Docs

`docs/reference/configuration.md` gains a "Config file (local daemon)" section (locations, YAML example, precedence, port/dataDir caveats, dev-only token note), cross-referenced from the env-var table and the connect/self-host how-tos.

## Test plan

- [x] `config-file.test.ts` + `dispatcher-config-file.test.ts` + `index.test.ts`: 29/29 green (discovery order, precedence, unknown-key warning, fail-fast, home fallback, $import refusal, parent-dir non-loading, clean CLI/server error paths, setLogLevel layering)
- [x] Broader `mcp-node` sweep over `src/cli` + touched server files: 413/413 green
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean
- [x] QA smoke (`pnpm smoke`, `pnpm smoke:e2e`) pass
