### PR TITLE
fix(mcp-server): clear request-timeout timers on early resolve in viewport/export routes

### DIFF
--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -24,9 +24,10 @@ type MockedExportOptions = {
   theme?: 'light' | 'dark'
 }
 const mockGetClientCount = vi.fn<(workspaceId: string, slug: string) => number>()
-const mockSendExportRequest = vi.fn<
-  (workspaceId: string, slug: string, requestId: string, options?: MockedExportOptions) => void
->()
+const mockSendExportRequest =
+  vi.fn<
+    (workspaceId: string, slug: string, requestId: string, options?: MockedExportOptions) => void
+  >()
 
 vi.mock('./ws.js', () => ({
   getClientCount: (workspaceId: string, slug: string) => mockGetClientCount(workspaceId, slug),
@@ -152,6 +153,29 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(body.message).toMatch(/0s|timed out/i)
   })
 
+  it('clears the timeout timer once the WS client resolves early', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
+      queueMicrotask(() => {
+        resolveExportRequest(
+          requestId,
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+        )
+      })
+    })
+    const app = makeApp({ timeoutMs: 5_000 })
+
+    vi.useFakeTimers()
+    try {
+      const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+      expect(res.status).toBe(200)
+      // A leaked timer would still be pending here, ticking until timeoutMs.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('passes padding through to sendExportRequest options', async () => {
     mockGetClientCount.mockReturnValue(1)
     mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
@@ -170,12 +194,9 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ padding: 48 }),
     })
     expect(res.status).toBe(200)
-    expect(mockSendExportRequest).toHaveBeenCalledWith(
-      's1',
-      'canvas-a',
-      expect.any(String),
-      { padding: 48 },
-    )
+    expect(mockSendExportRequest).toHaveBeenCalledWith('s1', 'canvas-a', expect.any(String), {
+      padding: 48,
+    })
   })
 
   it('leaves options undefined when the body is missing or padding is omitted', async () => {
@@ -389,7 +410,9 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const app = makeApp()
 
     // MCP sends the slug through encodeURIComponent, so it arrives as one segment with `%2F`.
-    const res = await app.request('/api/canvas/s1/architecture%2Foverview/export', { method: 'POST' })
+    const res = await app.request('/api/canvas/s1/architecture%2Foverview/export', {
+      method: 'POST',
+    })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
     expect(body.filePath).toMatch(/exports\/architecture\/overview-.*\.png$/)
@@ -489,7 +512,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ outputPath: join(tempDir, 'daemon.json') }),
     })
     expect(res.status).toBe(400)
-    const body = await res.json() as { error: string; message: string }
+    const body = (await res.json()) as { error: string; message: string }
     expect(body.error).toBe('invalid_output_path')
     expect(body.message).not.toContain(tempDir)
     expect(body.message).not.toContain('daemon.json')
@@ -507,7 +530,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ outputPath }),
     })
     expect(res.status).toBe(409)
-    const body = await res.json() as { error: string; message: string }
+    const body = (await res.json()) as { error: string; message: string }
     expect(body.error).toBe('output_exists')
     expect(body.message).not.toContain(tempDir)
     expect(body.message).not.toContain('exists.png')

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -85,7 +85,11 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
     let outputPath: string | undefined
     if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
       try {
-        await validateOutputPath(body.outputPath, body.overwrite === true, join(DATA_DIR, workspaceId, 'exports'))
+        await validateOutputPath(
+          body.outputPath,
+          body.overwrite === true,
+          join(DATA_DIR, workspaceId, 'exports'),
+        )
       } catch (err) {
         if (err instanceof OutputPathError) {
           const { status, body: errBody } = toCanvasOutputPathErrorBody(err)
@@ -188,11 +192,12 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
     timeoutMs: number,
   ): Promise<Buffer> {
     const requestId = nanoid()
+    let timer: ReturnType<typeof setTimeout> | undefined
     try {
       const base64Data = await new Promise<string>((resolve, reject) => {
         pendingExports.set(requestId, { resolve, reject })
         sendExportRequest(workspaceId, slug, requestId, hasOptions ? options : undefined)
-        setTimeout(() => {
+        timer = setTimeout(() => {
           if (pendingExports.has(requestId)) {
             pendingExports.delete(requestId)
             reject(new Error('timeout'))
@@ -200,6 +205,7 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
         }, timeoutMs)
       }).finally(() => {
         pendingExports.delete(requestId)
+        clearTimeout(timer)
       })
       return Buffer.from(base64Data.replace(/^data:image\/\w+;base64,/, ''), 'base64')
     } catch (err) {
@@ -217,7 +223,10 @@ function defaultExportPath(workspaceId: string, slug: string): string {
 }
 
 class ExportError extends Error {
-  constructor(public readonly kind: 'browser_export_failed' | 'headless_export_failed', cause: unknown) {
+  constructor(
+    public readonly kind: 'browser_export_failed' | 'headless_export_failed',
+    cause: unknown,
+  ) {
     const inner = cause instanceof Error ? cause.message : String(cause)
     super(inner)
     this.name = 'ExportError'
@@ -238,7 +247,11 @@ function toErrorBody(err: unknown, timeoutMs: number): ExportErrorBody {
 }
 
 function errorStatus(err: unknown): 500 | 504 {
-  if (err instanceof ExportError && err.kind === 'browser_export_failed' && err.message === 'timeout') {
+  if (
+    err instanceof ExportError &&
+    err.kind === 'browser_export_failed' &&
+    err.message === 'timeout'
+  ) {
     return 504
   }
   return 500

--- a/packages/mcp-server/src/server/routes/viewport.test.ts
+++ b/packages/mcp-server/src/server/routes/viewport.test.ts
@@ -17,14 +17,10 @@ vi.mock('../config.js', () => ({
 
 // Mock ws.ts so each test can control getClientCount and sendViewportRequest.
 const mockGetClientCount = vi.fn<(workspaceId: string, slug: string) => number>()
-const mockSendViewportRequest = vi.fn<
-  (
-    workspaceId: string,
-    slug: string,
-    requestId: string,
-    params: Record<string, unknown>,
-  ) => void
->()
+const mockSendViewportRequest =
+  vi.fn<
+    (workspaceId: string, slug: string, requestId: string, params: Record<string, unknown>) => void
+  >()
 
 vi.mock('./ws.js', () => ({
   getClientCount: (workspaceId: string, slug: string) => mockGetClientCount(workspaceId, slug),
@@ -112,12 +108,12 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     const body = (await res.json()) as { ok: boolean }
     expect(body.ok).toBe(true)
 
-    expect(mockSendViewportRequest).toHaveBeenCalledWith(
-      's1',
-      'canvas-a',
-      expect.any(String),
-      { mode: 'fit', elementIds: ['a', 'b'], padding: 40, animate: true },
-    )
+    expect(mockSendViewportRequest).toHaveBeenCalledWith('s1', 'canvas-a', expect.any(String), {
+      mode: 'fit',
+      elementIds: ['a', 'b'],
+      padding: 40,
+      animate: true,
+    })
   })
 
   it('forwards mode="move", scrollX, scrollY, and zoom to sendViewportRequest', async () => {
@@ -156,6 +152,24 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     expect(call[1]).toBe('canvas-a')
     // At minimum, an empty object should be forwarded.
     expect(call[3]).toBeDefined()
+  })
+
+  it('clears the timeout timer once the WS client resolves early', async () => {
+    mockGetClientCount.mockReturnValue(1)
+    mockSendViewportRequest.mockImplementation((_sid, _slug, requestId) => {
+      queueMicrotask(() => resolveViewportRequest(requestId))
+    })
+    const app = makeApp({ timeoutMs: 5_000 })
+
+    vi.useFakeTimers()
+    try {
+      const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+      expect(res.status).toBe(200)
+      // A leaked timer would still be pending here, ticking until timeoutMs.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('returns 400 for invalid workspaceId or slug without reaching WS', async () => {

--- a/packages/mcp-server/src/server/routes/viewport.ts
+++ b/packages/mcp-server/src/server/routes/viewport.ts
@@ -9,10 +9,7 @@ import { validationErrorBody, validateWorkspaceId, validateSlug } from '../valid
 
 // requestId -> { resolve, reject }
 // viewport does not return payload data, only an ACK, so it reuses the export-style pending map.
-const pendingViewport = new Map<
-  string,
-  { resolve: () => void; reject: (err: Error) => void }
->()
+const pendingViewport = new Map<string, { resolve: () => void; reject: (err: Error) => void }>()
 
 // Receives WS viewport_response messages from ws.ts.
 export function resolveViewportRequest(requestId: string): void {
@@ -59,12 +56,13 @@ export function createViewportRouter(options: CreateViewportRouterOptions = {}) 
 
     const requestId = nanoid()
 
+    let timer: ReturnType<typeof setTimeout> | undefined
     try {
       await new Promise<void>((resolve, reject) => {
         pendingViewport.set(requestId, { resolve, reject })
         sendViewportRequest(workspaceId, slug, requestId, body)
 
-        setTimeout(() => {
+        timer = setTimeout(() => {
           if (pendingViewport.has(requestId)) {
             pendingViewport.delete(requestId)
             reject(new Error('timeout'))
@@ -72,6 +70,7 @@ export function createViewportRouter(options: CreateViewportRouterOptions = {}) 
         }, timeoutMs)
       }).finally(() => {
         pendingViewport.delete(requestId)
+        clearTimeout(timer)
       })
 
       const ok: ViewportResponse = { ok: true }


### PR DESCRIPTION
## Summary

`routes/viewport.ts` and `routes/export.ts` each guard a pending-request map entry with a `setTimeout(..., timeoutMs)` rejection, but never cleared the timer on the success path — so a stray timer kept ticking until `timeoutMs` after the request had already resolved (harmless no-op when it fired, but an avoidable leaked handle per request). Same defect class as the auto-compact debounce fixed in #182, swept from tmp backlog.

The timer handle is now captured and `clearTimeout`'d in the existing shared `.finally()` alongside the map-entry delete.

## Test plan

- [x] Red-first regression tests in both `viewport.test.ts` and `export.test.ts` (`vi.useFakeTimers` + `vi.getTimerCount()` — confirmed 1 leaked timer before the fix, 0 after)
- [x] `pnpm vitest run --project mcp-node src/server/routes/` → 256/256
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean