### PR TITLE
fix(mcp-server): make export outputPath rejections name the allowed sandbox root

### DIFF
--- a/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
@@ -23,9 +23,7 @@ describe('canvas_export_json', () => {
   it('delegates export to the daemon route', async () => {
     const tool = canvasExportJsonTool()
     globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
-      expect(input.toString()).toBe(
-        'http://localhost:3099/api/canvas/sid/canvas-a/export-json',
-      )
+      expect(input.toString()).toBe('http://localhost:3099/api/canvas/sid/canvas-a/export-json')
       expect(init?.method).toBe('POST')
       expect(init?.headers).toEqual({ 'Content-Type': 'application/json' })
       expect(init?.body).toBe(JSON.stringify({ includeCustomFields: false }))
@@ -70,10 +68,9 @@ describe('canvas_export_json', () => {
     let captured: unknown
     globalThis.fetch = vi.fn(async (_input: string | URL, init?: RequestInit) => {
       captured = init?.body !== undefined ? JSON.parse(init.body as string) : undefined
-      return new Response(
-        JSON.stringify({ filePath: '/abs/out.excalidraw', elementCount: 0 }),
-        { status: 200 },
-      )
+      return new Response(JSON.stringify({ filePath: '/abs/out.excalidraw', elementCount: 0 }), {
+        status: 200,
+      })
     }) as typeof globalThis.fetch
 
     await tool.execute(
@@ -100,11 +97,15 @@ describe('canvas_export_json', () => {
     }) as typeof globalThis.fetch
 
     await expect(
-      tool.execute(
-        { canvasId: 'sid/canvas-a', outputPath: 'relative.json' },
-        client,
-      ),
+      tool.execute({ canvasId: 'sid/canvas-a', outputPath: 'relative.json' }, client),
     ).rejects.toThrow(/absolute path/)
+  })
+
+  it("documents the outputPath sandbox constraint in the tool's inputSchema description", () => {
+    const tool = canvasExportJsonTool()
+    const description = tool.inputSchema.properties.outputPath.description
+    expect(description).toMatch(/exports directory/)
+    expect(description).toMatch(/WHITEBOARD_DATA_DIR/)
   })
 
   it('surfaces output_exists errors when overwrite is omitted', async () => {
@@ -120,10 +121,7 @@ describe('canvas_export_json', () => {
     }) as typeof globalThis.fetch
 
     await expect(
-      tool.execute(
-        { canvasId: 'sid/canvas-a', outputPath: '/abs/out.json' },
-        client,
-      ),
+      tool.execute({ canvasId: 'sid/canvas-a', outputPath: '/abs/out.json' }, client),
     ).rejects.toThrow(/already exists/)
   })
 

--- a/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-export-json.test.ts
@@ -87,10 +87,13 @@ describe('canvas_export_json', () => {
   it('surfaces invalid_output_path errors from the daemon route as a clear message', async () => {
     const tool = canvasExportJsonTool()
     globalThis.fetch = vi.fn(async () => {
+      // Mirrors the real daemon body: toCanvasOutputPathErrorBody maps
+      // invalid_output_path to the workspace-scoped exports-directory message.
       return new Response(
         JSON.stringify({
           error: 'invalid_output_path',
-          message: 'outputPath must be an absolute path (received: relative.json)',
+          message:
+            "Invalid output path. outputPath must be inside this workspace's exports directory (~/.whiteboard/sid/exports, or $WHITEBOARD_DATA_DIR/sid/exports if that env var is set). Omit outputPath to write there automatically.",
         }),
         { status: 400 },
       )
@@ -98,7 +101,7 @@ describe('canvas_export_json', () => {
 
     await expect(
       tool.execute({ canvasId: 'sid/canvas-a', outputPath: 'relative.json' }, client),
-    ).rejects.toThrow(/absolute path/)
+    ).rejects.toThrow(/exports directory/)
   })
 
   it("documents the outputPath sandbox constraint in the tool's inputSchema description", () => {

--- a/packages/mcp-server/src/server/mcp/tools/canvas-export-json.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-export-json.ts
@@ -31,7 +31,7 @@ export function canvasExportJsonTool() {
         outputPath: {
           type: 'string',
           description:
-            'Absolute path to write the .excalidraw file to. Must be inside the workspace exports directory. Parent directories are created as needed. When omitted, write to the workspace exports directory.',
+            "Absolute path to write the .excalidraw file to. Must be inside this workspace's exports directory (~/.whiteboard/<workspaceId>/exports, or $WHITEBOARD_DATA_DIR/<workspaceId>/exports if that env var is set) — paths outside it are rejected with invalid_output_path. Parent directories inside that root are created as needed. Omit outputPath to write to the default location there automatically.",
         },
         overwrite: {
           type: 'boolean',
@@ -41,7 +41,10 @@ export function canvasExportJsonTool() {
       },
       required: ['canvasId'],
     },
-    execute: async (args: CanvasExportJsonArgs, client: DaemonClient): Promise<z.infer<typeof canvasExportJsonOutputSchema>> => {
+    execute: async (
+      args: CanvasExportJsonArgs,
+      client: DaemonClient,
+    ): Promise<z.infer<typeof canvasExportJsonOutputSchema>> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
       const body: {
         includeCustomFields: boolean
@@ -62,9 +65,10 @@ export function canvasExportJsonTool() {
         },
       )
       if (!res.ok) {
-        const errBody = (await res.json().catch(() => null)) as
-          | { error?: string; message?: string }
-          | null
+        const errBody = (await res.json().catch(() => null)) as {
+          error?: string
+          message?: string
+        } | null
         // Prefer the human-readable message so the LLM sees enough context to
         // adjust outputPath instead of a bare error code.
         throw new Error(

--- a/packages/mcp-server/src/server/mcp/tools/export.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export.test.ts
@@ -65,7 +65,10 @@ describe('exportPngTool execute', () => {
   it('case 368', async () => {
     fetchMock.mockImplementation(async (input: string | URL) => {
       const url = input.toString()
-      if (url === 'http://localhost:3099/api/canvas/sid/slug/export' && fetchMock.mock.calls.length === 1) {
+      if (
+        url === 'http://localhost:3099/api/canvas/sid/slug/export' &&
+        fetchMock.mock.calls.length === 1
+      ) {
         return new Response(
           JSON.stringify({
             error: 'no_client',
@@ -132,10 +135,10 @@ describe('exportPngTool execute', () => {
 
   it('case 370', async () => {
     fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ error: 'timeout', message: 'Export timed out after 10s.' }),
-        { status: 504, headers: { 'Content-Type': 'application/json' } },
-      ),
+      new Response(JSON.stringify({ error: 'timeout', message: 'Export timed out after 10s.' }), {
+        status: 504,
+        headers: { 'Content-Type': 'application/json' },
+      }),
     )
 
     const { exportPngTool } = await import('./export.js')
@@ -161,9 +164,7 @@ describe('exportPngTool execute', () => {
   })
 
   it('case 372', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response('not json', { status: 500 }),
-    )
+    fetchMock.mockResolvedValueOnce(new Response('not json', { status: 500 }))
 
     const { exportPngTool } = await import('./export.js')
     const tool = exportPngTool()
@@ -213,10 +214,7 @@ describe('exportPngTool execute', () => {
 
     const { exportPngTool } = await import('./export.js')
     const tool = exportPngTool()
-    await tool.execute(
-      { canvasId: 'sid/slug', padding: 32, scale: 2, minFontPx: 14 },
-      client,
-    )
+    await tool.execute({ canvasId: 'sid/slug', padding: 32, scale: 2, minFontPx: 14 }, client)
 
     const [, init] = fetchMock.mock.calls[0]
     expect(JSON.parse(init?.body as string)).toEqual({
@@ -390,11 +388,35 @@ describe('exportPngTool execute', () => {
     const { exportPngTool } = await import('./export.js')
     const tool = exportPngTool()
     await expect(
-      tool.execute(
-        { canvasId: 'sid/slug', outputPath: 'relative.png' },
-        client,
-      ),
+      tool.execute({ canvasId: 'sid/slug', outputPath: 'relative.png' }, client),
     ).rejects.toThrow(/absolute path/)
+  })
+
+  it('surfaces an invalid_output_path rejection that names the allowed exports root', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: 'invalid_output_path',
+          message:
+            "Invalid output path. outputPath must be inside this workspace's exports directory (~/.whiteboard/sid/exports, or $WHITEBOARD_DATA_DIR/sid/exports if that env var is set). Omit outputPath to write there automatically.",
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const { exportPngTool } = await import('./export.js')
+    const tool = exportPngTool()
+    await expect(
+      tool.execute({ canvasId: 'sid/slug', outputPath: '/elsewhere/canvas.png' }, client),
+    ).rejects.toThrow(/exports directory/)
+  })
+
+  it("documents the outputPath sandbox constraint in the tool's inputSchema description", async () => {
+    const { exportPngTool } = await import('./export.js')
+    const tool = exportPngTool()
+    const description = tool.inputSchema.properties.outputPath.description
+    expect(description).toMatch(/exports directory/)
+    expect(description).toMatch(/WHITEBOARD_DATA_DIR/)
   })
 
   it('surfaces output_exists when the target file already exists', async () => {
@@ -402,8 +424,7 @@ describe('exportPngTool execute', () => {
       new Response(
         JSON.stringify({
           error: 'output_exists',
-          message:
-            'outputPath already exists. Pass overwrite=true to replace it: /abs/canvas.png',
+          message: 'outputPath already exists. Pass overwrite=true to replace it: /abs/canvas.png',
         }),
         { status: 409, headers: { 'Content-Type': 'application/json' } },
       ),
@@ -412,10 +433,7 @@ describe('exportPngTool execute', () => {
     const { exportPngTool } = await import('./export.js')
     const tool = exportPngTool()
     await expect(
-      tool.execute(
-        { canvasId: 'sid/slug', outputPath: '/abs/canvas.png' },
-        client,
-      ),
+      tool.execute({ canvasId: 'sid/slug', outputPath: '/abs/canvas.png' }, client),
     ).rejects.toThrow(/already exists/)
   })
 })

--- a/packages/mcp-server/src/server/mcp/tools/export.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export.test.ts
@@ -374,24 +374,6 @@ describe('exportPngTool execute', () => {
     })
   })
 
-  it('surfaces invalid_output_path errors from the export route', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          error: 'invalid_output_path',
-          message: 'outputPath must be an absolute path (received: relative.png)',
-        }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } },
-      ),
-    )
-
-    const { exportPngTool } = await import('./export.js')
-    const tool = exportPngTool()
-    await expect(
-      tool.execute({ canvasId: 'sid/slug', outputPath: 'relative.png' }, client),
-    ).rejects.toThrow(/absolute path/)
-  })
-
   it('surfaces an invalid_output_path rejection that names the allowed exports root', async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(

--- a/packages/mcp-server/src/server/mcp/tools/export.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export.ts
@@ -145,7 +145,7 @@ export function exportPngTool() {
         outputPath: {
           type: 'string',
           description:
-            'Absolute path to write the PNG to. Useful for placing the export next to a source asset. Parent directories are created as needed. When omitted, write to the workspace exports directory.',
+            "Absolute path to write the PNG to. Must be inside this workspace's exports directory (~/.whiteboard/<workspaceId>/exports, or $WHITEBOARD_DATA_DIR/<workspaceId>/exports if that env var is set) — paths outside it are rejected with invalid_output_path. Parent directories inside that root are created as needed. Omit outputPath to write to the default location there automatically.",
         },
         overwrite: {
           type: 'boolean',

--- a/packages/mcp-server/src/server/routes/canvas-output-path-error.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas-output-path-error.test.ts
@@ -7,7 +7,7 @@ const RAW_PATH = '/home/user/secret/project.excalidraw'
 describe('toCanvasOutputPathErrorBody', () => {
   it('maps output_exists → 409 with fixed message', () => {
     const err = new OutputPathError('output_exists', `${RAW_PATH} already exists`)
-    const { status, body } = toCanvasOutputPathErrorBody(err)
+    const { status, body } = toCanvasOutputPathErrorBody(err, 'ws1')
     expect(status).toBe(409)
     expect(body.error).toBe('output_exists')
     expect(body.message).toBe('Output file already exists.')

--- a/packages/mcp-server/src/server/routes/canvas-output-path-error.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas-output-path-error.test.ts
@@ -14,25 +14,30 @@ describe('toCanvasOutputPathErrorBody', () => {
     expect(body.message).not.toContain(RAW_PATH)
   })
 
-  it('maps invalid_output_path → 400 with fixed message', () => {
+  it('maps invalid_output_path → 400 naming the allowed workspace exports root, without leaking the rejected path', () => {
     const err = new OutputPathError('invalid_output_path', `${RAW_PATH} is outside allowed dir`)
-    const { status, body } = toCanvasOutputPathErrorBody(err)
+    const { status, body } = toCanvasOutputPathErrorBody(err, 'ws1')
     expect(status).toBe(400)
     expect(body.error).toBe('invalid_output_path')
-    expect(body.message).toBe('Invalid output path.')
+    expect(body.message).toContain('ws1/exports')
     expect(body.message).not.toContain(RAW_PATH)
   })
 
   it('falls back to 400 + generic message for an unrecognized code', () => {
     const err = { code: 'future_code', message: RAW_PATH } as unknown as OutputPathError
-    const { status, body } = toCanvasOutputPathErrorBody(err)
+    const { status, body } = toCanvasOutputPathErrorBody(err, 'ws1')
     expect(status).toBe(400)
     expect(body.message).toBe('Export output path rejected.')
     expect(body.message).not.toContain(RAW_PATH)
   })
 
   it('preserves err.code in body.error for each known code', () => {
-    expect(toCanvasOutputPathErrorBody(new OutputPathError('output_exists', 'x')).body.error).toBe('output_exists')
-    expect(toCanvasOutputPathErrorBody(new OutputPathError('invalid_output_path', 'x')).body.error).toBe('invalid_output_path')
+    expect(
+      toCanvasOutputPathErrorBody(new OutputPathError('output_exists', 'x'), 'ws1').body.error,
+    ).toBe('output_exists')
+    expect(
+      toCanvasOutputPathErrorBody(new OutputPathError('invalid_output_path', 'x'), 'ws1').body
+        .error,
+    ).toBe('invalid_output_path')
   })
 })

--- a/packages/mcp-server/src/server/routes/canvas-output-path-error.ts
+++ b/packages/mcp-server/src/server/routes/canvas-output-path-error.ts
@@ -5,12 +5,27 @@ export type CanvasOutputPathErrorBody = {
   body: { error: string; message: string }
 }
 
-export function toCanvasOutputPathErrorBody(err: OutputPathError): CanvasOutputPathErrorBody {
+// The fixed messages below intentionally never echo err.message: it can
+// contain the caller-supplied outputPath, which may point anywhere on disk
+// (e.g. into another user's home directory) and would leak that layout back
+// to the caller. workspaceId is safe to include — the caller already knows
+// it, since it is part of the request URL — and naming the allowed root
+// turns "Invalid output path." from a dead end into an actionable message.
+export function toCanvasOutputPathErrorBody(
+  err: OutputPathError,
+  workspaceId: string,
+): CanvasOutputPathErrorBody {
   if (err.code === 'output_exists') {
     return { status: 409, body: { error: err.code, message: 'Output file already exists.' } }
   }
   if (err.code === 'invalid_output_path') {
-    return { status: 400, body: { error: err.code, message: 'Invalid output path.' } }
+    return {
+      status: 400,
+      body: {
+        error: err.code,
+        message: `Invalid output path. outputPath must be inside this workspace's exports directory (~/.whiteboard/${workspaceId}/exports, or $WHITEBOARD_DATA_DIR/${workspaceId}/exports if that env var is set). Omit outputPath to write there automatically.`,
+      },
+    }
   }
   return { status: 400, body: { error: err.code, message: 'Export output path rejected.' } }
 }

--- a/packages/mcp-server/src/server/routes/canvas.ts
+++ b/packages/mcp-server/src/server/routes/canvas.ts
@@ -638,7 +638,7 @@ export function createCanvasRouter(options: CanvasRouterOptions = {}) {
       )
     } catch (err) {
       if (err instanceof OutputPathError) {
-        const { status, body } = toCanvasOutputPathErrorBody(err)
+        const { status, body } = toCanvasOutputPathErrorBody(err, workspaceId)
         return c.json(body, status)
       }
       throw err

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -85,10 +85,14 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
     let outputPath: string | undefined
     if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
       try {
-        await validateOutputPath(body.outputPath, body.overwrite === true, join(DATA_DIR, workspaceId, 'exports'))
+        await validateOutputPath(
+          body.outputPath,
+          body.overwrite === true,
+          join(DATA_DIR, workspaceId, 'exports'),
+        )
       } catch (err) {
         if (err instanceof OutputPathError) {
-          const { status, body: errBody } = toCanvasOutputPathErrorBody(err)
+          const { status, body: errBody } = toCanvasOutputPathErrorBody(err, workspaceId)
           return c.json(errBody as ExportErrorBody, status)
         }
         throw err
@@ -217,7 +221,10 @@ function defaultExportPath(workspaceId: string, slug: string): string {
 }
 
 class ExportError extends Error {
-  constructor(public readonly kind: 'browser_export_failed' | 'headless_export_failed', cause: unknown) {
+  constructor(
+    public readonly kind: 'browser_export_failed' | 'headless_export_failed',
+    cause: unknown,
+  ) {
     const inner = cause instanceof Error ? cause.message : String(cause)
     super(inner)
     this.name = 'ExportError'
@@ -238,7 +245,11 @@ function toErrorBody(err: unknown, timeoutMs: number): ExportErrorBody {
 }
 
 function errorStatus(err: unknown): 500 | 504 {
-  if (err instanceof ExportError && err.kind === 'browser_export_failed' && err.message === 'timeout') {
+  if (
+    err instanceof ExportError &&
+    err.kind === 'browser_export_failed' &&
+    err.message === 'timeout'
+  ) {
     return 504
   }
   return 500


### PR DESCRIPTION
## Summary

`export_png` / `export_json` rejected an out-of-sandbox `outputPath` with an opaque `Invalid output path.` — no hint of the allowed roots, while the tool description implied arbitrary absolute paths work.

The write sandbox itself is **unchanged** (`output-path.ts` untouched — outputs stay confined to `<DATA_DIR>/<workspaceId>/exports` with symlink-escape protection). What changed:

- `toCanvasOutputPathErrorBody` now names the allowed root for `invalid_output_path` as a **pattern** (`~/.whiteboard/<workspaceId>/exports`, or `$WHITEBOARD_DATA_DIR/...` when overridden) — deliberately NOT the resolved absolute path, preserving the existing don't-leak-filesystem-layout property that the route tests assert (`output_exists` and unknown-code fallback unchanged; export_json shares the helper and gets the fix for free).
- Both tools' `outputPath` inputSchema descriptions now state the sandbox constraint and the `WHITEBOARD_DATA_DIR` seam instead of implying arbitrary paths work.

## Test plan

- [x] Red-first: error-message assertion (`toContain('ws1/exports')`, still `not.toContain(<raw path>)`), execute-path propagation test, schema-description assertions for both tools
- [x] 104/104 across canvas-output-path-error / export / canvas route tests + both tool tests
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export tools now document valid output locations, default paths, and automatic parent-directory creation.
  * Error responses identify the permitted workspace exports directory when an output path is invalid.

* **Bug Fixes**
  * Invalid-path errors no longer expose rejected filesystem paths.
  * Export errors provide clearer status codes and messages while preserving existing-file protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->