### PR TITLE
perf(web): cut apps/web critical-path JS from 555KB to 119KB gz and fix the bundle gate to measure it

### DIFF
--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -27,7 +27,11 @@ const ASSETS = resolve(DIST, 'assets')
 
 const KB = 1024
 const BUDGETS = [
-  { label: 'entry JS (index-*.js)', pattern: /^index-.*\.js$/, limit: 560 * KB, required: true },
+  // The entry file itself is now a thin bootstrap (~5 KB gz) now that both
+  // canvas pages are React.lazy — 30 KB leaves headroom for App.tsx growth
+  // without going back to the old 560 KB ceiling, which stopped meaning
+  // anything once the entry stopped containing Excalidraw/loro-crdt.
+  { label: 'entry JS (index-*.js)', pattern: /^index-.*\.js$/, limit: 30 * KB, required: true },
   { label: 'CSS (index-*.css)', pattern: /^index-.*\.css$/, limit: 30 * KB, required: true },
   {
     label: 'daemon lazy chunk (daemon-canvas-*.js)',
@@ -37,12 +41,17 @@ const BUDGETS = [
   },
 ]
 
-// Regression stop at today's measured critical-path size (~555 KB, both
-// canvas pages statically imported — Excalidraw + loro-crdt ship in every
-// page load). This is deliberately NOT the <300 KB app-page target; it is
-// the honest current baseline plus headroom, tightened as
-// tmp/issues/apps-web-entry-bundle-over-budget.md's staged plan lands.
-const CRITICAL_PATH_BUDGET_KB = 570
+// Regression stop at today's measured critical-path size (~119 KB) after
+// Stage 2 of tmp/issues/apps-web-entry-bundle-over-budget.md's plan:
+// React.lazy on both canvas pages (BrowserLocalCanvasPage and the earlier
+// DaemonCanvasPage) keeps Excalidraw's ~400 KB out of the initial paint
+// entirely. vendor-loro-crdt (~23 KB) still ships eagerly — some module in
+// App.tsx's static import graph reaches it, and vite-plugin-top-level-await
+// propagates a synchronous import for any TLA-using chunk up to whichever
+// entry point reaches it, even through code that itself only calls into
+// loro-crdt from a lazy branch. ~10% headroom over the measured number, not
+// the aspirational floor.
+const CRITICAL_PATH_BUDGET_KB = 135
 
 let failures = 0
 

--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -7,16 +7,23 @@
 // chunkFileNames so it can never leak into first paint unnoticed — this
 // budget is `required: true` because the chunk exists as of this gate.
 //
-// The entry ceiling is a regression stop at today's measured size (~541 KB),
-// not an endorsement: shrinking it toward the <300 KB app budget needs
-// loro/Excalidraw first-paint splitting, tracked separately.
+// The per-file entry-JS budget checks ONLY the literal index-*.js file, which
+// is misleading on its own: Vite/Rollup splits shared dependencies (React,
+// loro-crdt, Excalidraw...) into separate chunk files, and index.html
+// <link rel="modulepreload"> forces the browser to fetch every one of them
+// alongside the entry script before first paint — so they are part of the
+// same critical-path payload even though they live in different files. The
+// CRITICAL_PATH_BUDGET below sums entry + every modulepreloaded JS chunk
+// referenced from dist/index.html, which is the number that actually
+// reflects what a fresh visitor downloads before the app can render.
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gzipSync } from 'node:zlib'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const ASSETS = resolve(ROOT, 'dist', 'assets')
+const DIST = resolve(ROOT, 'dist')
+const ASSETS = resolve(DIST, 'assets')
 
 const KB = 1024
 const BUDGETS = [
@@ -29,6 +36,13 @@ const BUDGETS = [
     required: true,
   },
 ]
+
+// Regression stop at today's measured critical-path size (~555 KB, both
+// canvas pages statically imported — Excalidraw + loro-crdt ship in every
+// page load). This is deliberately NOT the <300 KB app-page target; it is
+// the honest current baseline plus headroom, tightened as
+// tmp/issues/apps-web-entry-bundle-over-budget.md's staged plan lands.
+const CRITICAL_PATH_BUDGET_KB = 570
 
 let failures = 0
 
@@ -63,6 +77,42 @@ for (const { label, pattern, limit, required } of BUDGETS) {
     } else {
       console.log(`  pass  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
     }
+  }
+}
+
+// Critical-path total: entry script + every modulepreloaded JS chunk, as
+// listed in dist/index.html. This is what actually determines first-paint
+// transfer size — see the module comment above for why the per-file
+// entry-JS budget above cannot catch a regression here (e.g. a statically
+// imported Excalidraw/loro-crdt page would inflate this total without ever
+// growing index-*.js itself).
+const indexHtmlPath = join(DIST, 'index.html')
+if (!existsSync(indexHtmlPath)) {
+  console.error(`  FAIL  dist/index.html not found at ${indexHtmlPath} — run \`pnpm build\` first`)
+  failures++
+} else {
+  const html = readFileSync(indexHtmlPath, 'utf8')
+  const entryScripts = [...html.matchAll(/<script[^>]*\ssrc="(\/assets\/[^"]+\.js)"/g)].map(
+    (m) => m[1],
+  )
+  const modulepreloads = [
+    ...html.matchAll(/<link[^>]*\srel="modulepreload"[^>]*\shref="(\/assets\/[^"]+\.js)"/g),
+  ].map((m) => m[1])
+  const criticalPathFiles = [...new Set([...entryScripts, ...modulepreloads])]
+  let criticalPathBytes = 0
+  for (const href of criticalPathFiles) {
+    criticalPathBytes += gzipSize(join(DIST, href.replace(/^\//, '')))
+  }
+  const criticalPathKb = (criticalPathBytes / KB).toFixed(1)
+  if (criticalPathBytes > CRITICAL_PATH_BUDGET_KB * KB) {
+    console.error(
+      `  FAIL  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
+    )
+    failures++
+  } else {
+    console.log(
+      `  pass  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
+    )
   }
 }
 

--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -101,13 +101,36 @@ if (!existsSync(indexHtmlPath)) {
   failures++
 } else {
   const html = readFileSync(indexHtmlPath, 'utf8')
-  const entryScripts = [...html.matchAll(/<script[^>]*\ssrc="(\/assets\/[^"]+\.js)"/g)].map(
-    (m) => m[1],
-  )
-  const modulepreloads = [
-    ...html.matchAll(/<link[^>]*\srel="modulepreload"[^>]*\shref="(\/assets\/[^"]+\.js)"/g),
-  ].map((m) => m[1])
+  // Attribute-order- and quote-style-insensitive: extract each tag first,
+  // then match attributes independently, so a Vite/minifier formatting change
+  // cannot silently zero out the file list and let the budget pass vacuously.
+  const attr = (tag, name) => {
+    const m = tag.match(new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`))
+    return m ? (m[2] ?? m[3] ?? m[4]) : undefined
+  }
+  const entryScripts = []
+  for (const [tag] of html.matchAll(/<script\b[^>]*>/g)) {
+    const src = attr(tag, 'src')
+    if (src?.startsWith('/assets/') && src.endsWith('.js')) entryScripts.push(src)
+  }
+  const modulepreloads = []
+  for (const [tag] of html.matchAll(/<link\b[^>]*>/g)) {
+    const href = attr(tag, 'href')
+    if (
+      attr(tag, 'rel') === 'modulepreload' &&
+      href?.startsWith('/assets/') &&
+      href.endsWith('.js')
+    ) {
+      modulepreloads.push(href)
+    }
+  }
   const criticalPathFiles = [...new Set([...entryScripts, ...modulepreloads])]
+  if (criticalPathFiles.length === 0) {
+    console.error(
+      '  FAIL  no entry <script src> or <link rel="modulepreload"> JS found in dist/index.html — the parser is broken or the build output changed shape; refusing to pass a vacuous budget',
+    )
+    failures++
+  }
   let criticalPathBytes = 0
   for (const href of criticalPathFiles) {
     criticalPathBytes += gzipSize(join(DIST, href.replace(/^\//, '')))

--- a/apps/web/scripts/smoke-preview-origin.mjs
+++ b/apps/web/scripts/smoke-preview-origin.mjs
@@ -78,9 +78,15 @@ try {
 
   await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: 'networkidle' })
 
+  // Wait for the element rather than sampling count() immediately after
+  // networkidle: React mounts <main> asynchronously (and the page components
+  // are lazy-loaded), so an instant count races the hydration and flakes.
   const invalidConfig = page.locator('main[data-provider="invalid-config"]')
-  const count = await invalidConfig.count()
-  if (count > 0) {
+  const appeared = await invalidConfig
+    .waitFor({ state: 'attached', timeout: 15_000 })
+    .then(() => true)
+    .catch(() => false)
+  if (appeared) {
     console.log('  pass  App renders data-provider="invalid-config" for preview publicOrigin')
   } else {
     const provider = await page

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,6 @@ import {
   resolveHostedProviderStateFromRaw,
 } from './lib/provider.js'
 import { createUserSettingsStore } from './lib/user-settings-store.js'
-import { BrowserLocalCanvasPage } from './pages/BrowserLocalCanvasPage.js'
 
 // Lazy so the daemon stack (DaemonBackend, ws-protocol, api client) stays out
 // of the entry chunk — sessions arriving via a #wb= pairing fragment AND
@@ -19,6 +18,18 @@ import { BrowserLocalCanvasPage } from './pages/BrowserLocalCanvasPage.js'
 // bundle-size budget.
 const DaemonCanvasPage = lazy(() =>
   import('./pages/DaemonCanvasPage.js').then((m) => ({ default: m.DaemonCanvasPage })),
+)
+
+// Lazy for the same reason: BrowserLocalCanvasPage statically imports
+// Excalidraw + useCanvasSync (which imports loro-crdt), and it is the
+// default render path (no daemon, no pairing fragment) — so it was the one
+// making Excalidraw/loro-crdt part of every session's initial paint even
+// though DaemonCanvasPage above was already lazy. Module-scope side effects
+// that must run before React lifecycle begins (browserLocalStore,
+// userSettingsStore, provider-state resolution just below) stay at THIS
+// file's module scope, unaffected by which page component is lazy.
+const BrowserLocalCanvasPage = lazy(() =>
+  import('./pages/BrowserLocalCanvasPage.js').then((m) => ({ default: m.BrowserLocalCanvasPage })),
 )
 
 const browserLocalStore = new IndexedDBStore()
@@ -42,18 +53,20 @@ interface BackendConfigChipProps {
   state: Exclude<ProviderState, { kind: 'invalid-config' }>
 }
 
-// Suspense fallback while the lazy daemon chunk loads. The height class
-// differs by mount site (root fills the viewport; the local-daemon branch
-// fills the flex row under the banner), so it's a prop; the copy stays shared
-// so the two mount sites can't drift.
-function DaemonConnectingFallback({ heightClass }: { heightClass: string }) {
+// Suspense fallback shared by every lazy page chunk (DaemonCanvasPage and
+// BrowserLocalCanvasPage). The height class differs by mount site (root
+// fills the viewport; the in-banner branches fill the flex row under it), so
+// it's a prop; message is also a prop so the daemon-specific and
+// backend-agnostic mount sites show accurate copy without duplicating this
+// component.
+function LazyPageFallback({ heightClass, message }: { heightClass: string; message: string }) {
   return (
     <div
       role="status"
       aria-live="polite"
       className={`flex ${heightClass} items-center justify-center text-sm text-muted-foreground`}
     >
-      Connecting to daemon…
+      {message}
     </div>
   )
 }
@@ -101,7 +114,9 @@ export function App({ providerState }: AppProps) {
         // propagates through Suspense's own error path to the nearest
         // boundary, which must be here to catch it.
         <ErrorBoundary>
-          <Suspense fallback={<DaemonConnectingFallback heightClass="h-dvh" />}>
+          <Suspense
+            fallback={<LazyPageFallback heightClass="h-dvh" message="Connecting to daemon…" />}
+          >
             <DaemonCanvasPage
               daemonBaseUrl={payload.baseUrl}
               workspaceId={payload.workspaceId}
@@ -173,7 +188,9 @@ export function App({ providerState }: AppProps) {
           />
           <BackendConfigChip state={effectiveState} />
           <div className="min-h-0 flex-1 overflow-hidden">
-            <Suspense fallback={<DaemonConnectingFallback heightClass="h-full" />}>
+            <Suspense
+              fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
+            >
               <DaemonCanvasPage
                 daemonBaseUrl={effectiveState.daemonBaseUrl}
                 capabilities={effectiveState.capabilities}
@@ -201,10 +218,12 @@ export function App({ providerState }: AppProps) {
         />
         <BackendConfigChip state={effectiveState} />
         <div className="min-h-0 flex-1 overflow-hidden">
-          <BrowserLocalCanvasPage
-            store={browserLocalStore}
-            capabilities={effectiveState.capabilities}
-          />
+          <Suspense fallback={<LazyPageFallback heightClass="h-full" message="Loading…" />}>
+            <BrowserLocalCanvasPage
+              store={browserLocalStore}
+              capabilities={effectiveState.capabilities}
+            />
+          </Suspense>
         </div>
       </div>
     </ErrorBoundary>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -120,6 +120,32 @@ export default defineConfig({
           chunkInfo.name === 'DaemonCanvasPage'
             ? 'assets/daemon-canvas-[hash].js'
             : 'assets/[name]-[hash].js',
+        // Isolate loro-crdt and React into their own named vendor chunks
+        // instead of letting Rollup's automatic chunking scatter them across
+        // shared chunks. This does not shrink total transfer on its own — it
+        // separates what changes (app code) from what doesn't (vendor code),
+        // so a deploy that only touches app code doesn't invalidate the
+        // (much larger) vendor caches.
+        //
+        // Deliberately NOT grouping @excalidraw/* the same way: Excalidraw's
+        // own dist already dynamically imports its heavy optional features
+        // (mermaid-to-excalidraw's parser, cytoscape, katex — the various
+        // *Diagram-*.js / cytoscape.esm-*.js / katex-*.js chunks visible in
+        // the build output). A blanket `id.includes('@excalidraw')` rule
+        // merges those into one eager multi-MB chunk regardless of import
+        // kind, which both defeats Excalidraw's own lazy split and blows
+        // past vite-plugin-pwa's 2 MiB precache-per-file limit. Leave
+        // Excalidraw's core module to whichever automatic chunk it lands in;
+        // Stage 2 (deferring the whole editor page behind React.lazy) is
+        // what actually keeps it out of the initial paint.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (id.includes('loro-crdt')) return 'vendor-loro-crdt'
+          if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('scheduler')) {
+            return 'vendor-react'
+          }
+          return undefined
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

The <300KB app-page budget was being violated (~555KB gz) but the gate never saw it: `smoke-bundle-size.mjs` measured only the literal `index-*.js` file (8.6KB), while the real payload hid in `index.html`'s `<link rel="modulepreload">` chunks, which the browser fetches immediately alongside the entry.

1. **Gate fix**: the smoke now sums entry + all modulepreloaded JS from `index.html` ("critical-path JS") — this is what reproduced the reported ~541KB (measured 554.7KB).
2. **Vendor split**: `manualChunks` isolates `loro-crdt` and `react`/`react-dom`. `@excalidraw/*` is deliberately NOT forced into one chunk — Excalidraw's dist already lazy-imports its heavy optional features (mermaid parser, cytoscape, katex), and a blanket rule merged them into a 6.35MB eager chunk that broke the PWA 2MiB precache limit.
3. **Lazy default page**: `BrowserLocalCanvasPage` (the default render path) was still statically imported, dragging Excalidraw + loro-crdt into every session's first paint. It now uses the same React.lazy + Suspense pattern as `DaemonCanvasPage` (shared fallback generalized to `LazyPageFallback`). Provider-state resolution and `IndexedDBStore` init at App.tsx module scope are untouched, so pairing/#wb= init order is unchanged.

**Result: 554.7KB → 119.3KB gz critical path (-78%), under the 300KB budget.** New enforced budgets: critical-path 135KB, entry-JS 30KB (measured 5.0KB).

Known non-blocking loose end (filed locally): `vendor-loro-crdt` (~23KB) is still eagerly modulepreloaded, likely via vite-plugin-top-level-await's TLA propagation.

## Test plan

- [x] typecheck clean; `pnpm vitest run` 779/779; `pnpm test:browser` 104/104 incl. #wb= pairing and browser-local flows
- [x] Gate mutation-checked both directions: 100KB budget correctly fails at 119.3KB; reverting the lazy-load change reproduces the 554.7KB failure against the 135KB budget
- [x] Pre-existing Excalidraw console.error confirmed identical with/without the change (git stash A/B)