### PR TITLE
fix(mcp-server): make auto-compact disposal deterministic against mid-disposal reschedules

### DIFF
--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -27,6 +27,7 @@ const {
   setAutoCompactTrigger,
   disposeAutoCompact,
   _inFlightAutoCompactCountForTests,
+  _isDisposingAutoCompactForTests,
 } = await import('./canvas-store.js')
 const { captureLogsForTests } = await import('../log.js')
 const { FileVersionStore } = await import('./version-store.js')
@@ -877,14 +878,21 @@ describe('auto-compact disposal', () => {
     expect(await readLastCompactedAt()).not.toBeNull()
   })
 
-  it('disposeAutoCompact cancels a timer rescheduled by an in-flight compaction instead of leaving it dangling', async () => {
+  it('disposeAutoCompact refuses a reschedule attempted while disposal is in progress, instead of racing a timer against the next clear pass', async () => {
     const store = await buildCompactableCanvas('reentrant')
 
     // Simulates loadCanvas()'s legacy-migration path resuming mid-compaction
     // and calling saveCanvas(), which re-invokes the auto-compact trigger and
-    // schedules a fresh timer *while disposeAutoCompact is already awaiting
-    // this in-flight compaction*. A single clear-then-await pass would clear
-    // the timer map before this reschedule happens and miss it.
+    // attempts to schedule a fresh timer. The reschedule is gated on an
+    // explicit signal (not a wall-clock delay) so it fires deterministically
+    // once _isDisposingAutoCompactForTests() is confirmed true, rather than
+    // hoping a fixed sleep lands inside disposeAutoCompact's await window —
+    // that race is what made the previous version of this test flaky under
+    // load (CI run 29162596104).
+    let releaseReschedule: () => void = () => undefined
+    const rescheduleGate = new Promise<void>((resolve) => {
+      releaseReschedule = resolve
+    })
     const rescheduleCallCount = { count: 0 }
     const countingStore = new Proxy(store, {
       get(target, prop, receiver) {
@@ -901,8 +909,8 @@ describe('auto-compact disposal', () => {
       get(target, prop, receiver) {
         if (prop === 'earliestFrontiers') {
           return async (workspaceId: string, slug: string) => {
-            await new Promise((r) => setTimeout(r, 50))
-            scheduleAutoCompact('session1', 'reentrant', countingStore, { debounceMs: 20 })
+            await rescheduleGate
+            scheduleAutoCompact('session1', 'reentrant', countingStore, { debounceMs: 0 })
             return target.earliestFrontiers(workspaceId, slug)
           }
         }
@@ -918,12 +926,24 @@ describe('auto-compact disposal', () => {
       { timeout: 2000 },
     )
 
-    await disposeAutoCompact()
+    const disposePromise = disposeAutoCompact()
+    // Confirm disposal has actually begun (and is blocked awaiting the
+    // in-flight compaction above) before letting the reschedule proceed —
+    // this is the exact interleaving the original bug report depended on
+    // luck to hit.
+    await vi.waitFor(
+      () => {
+        expect(_isDisposingAutoCompactForTests()).toBe(true)
+      },
+      { timeout: 2000 },
+    )
+    releaseReschedule()
+    await disposePromise
 
     expect(_inFlightAutoCompactCountForTests()).toBe(0)
-    // Wait past the rescheduled timer's debounce window and confirm it was
-    // cancelled rather than merely not-yet-fired.
-    await new Promise((r) => setTimeout(r, 100))
+    // debounceMs: 0 still yields a macrotask tick before firing; give it a
+    // chance to fire if it were ever going to, then confirm it didn't.
+    await new Promise((r) => setTimeout(r, 20))
     expect(rescheduleCallCount.count).toBe(0)
   })
 

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -342,7 +342,11 @@ const inFlightAutoCompacts = new Set<Promise<unknown>>()
 // compaction that wins that race, so this was never a leak, but the outcome
 // was nondeterministic. Refusing new timers for the whole disposal removes
 // the race instead of relying on winning it.
-let disposingAutoCompact = false
+// A counter rather than a boolean: overlapping disposeAutoCompact() calls
+// (parallel DB dispose hooks, test teardown racing an explicit call) must not
+// let the first finisher drop the guard while another disposal is still
+// draining.
+let disposingAutoCompactCount = 0
 
 export function scheduleAutoCompact(
   workspaceId: string,
@@ -350,7 +354,7 @@ export function scheduleAutoCompact(
   versionStore: VersionStore,
   options: { debounceMs?: number } = {},
 ): void {
-  if (disposingAutoCompact) return
+  if (disposingAutoCompactCount > 0) return
   const key = `${workspaceId}/${slug}`
   const existing = autoCompactTimers.get(key)
   if (existing) clearTimeout(existing)
@@ -396,13 +400,13 @@ export function scheduleAutoCompact(
 // nothing pending simply resolves immediately, and scheduleAutoCompact works
 // again afterward (a fresh call re-populates both trackers).
 export async function disposeAutoCompact(): Promise<void> {
-  disposingAutoCompact = true
+  disposingAutoCompactCount++
   try {
     // A single clear-then-await pass is not enough: an in-flight compaction's
     // loadCanvas() can run legacy migration, which calls saveCanvas(), which
     // re-invokes the registered auto-compact trigger *while we are still
     // awaiting the first batch*. scheduleAutoCompact refuses that reschedule
-    // outright (disposingAutoCompact is true for this whole call), so this
+    // outright (the guard counter is non-zero for this whole call), so this
     // loop's job is just to drain whatever was already in flight or already
     // timer-scheduled before disposal began.
     for (;;) {
@@ -412,7 +416,7 @@ export async function disposeAutoCompact(): Promise<void> {
       await Promise.allSettled(inFlight)
     }
   } finally {
-    disposingAutoCompact = false
+    disposingAutoCompactCount--
   }
 }
 
@@ -428,7 +432,7 @@ export function _inFlightAutoCompactCountForTests(): number {
 // before triggering a reschedule attempt, instead of racing a wall-clock
 // delay against dispose's await window.
 export function _isDisposingAutoCompactForTests(): boolean {
-  return disposingAutoCompact
+  return disposingAutoCompactCount > 0
 }
 
 registerDbDisposeHook(disposeAutoCompact)

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -330,12 +330,27 @@ const autoCompactTimers = new Map<string, ReturnType<typeof setTimeout>>()
 // dropped by an unrelated compaction for the same key finishing first.
 const inFlightAutoCompacts = new Set<Promise<unknown>>()
 
+// True only for the duration of a disposeAutoCompact() call. An in-flight
+// compaction's loadCanvas() can run legacy migration, which calls
+// saveCanvas(), which re-invokes the registered auto-compact trigger and
+// tries to schedule a fresh timer for the same key — see disposeAutoCompact's
+// loop comment below. Without this guard, that reschedule's timer and
+// disposeAutoCompact's next clear-and-recheck pass race each other: whichever
+// one is scheduled first on the event loop wins, and under load the timer
+// can fire (starting a real compaction) before the loop gets back around to
+// cancel it. disposeAutoCompact's own loop still correctly waits for a
+// compaction that wins that race, so this was never a leak, but the outcome
+// was nondeterministic. Refusing new timers for the whole disposal removes
+// the race instead of relying on winning it.
+let disposingAutoCompact = false
+
 export function scheduleAutoCompact(
   workspaceId: string,
   slug: string,
   versionStore: VersionStore,
   options: { debounceMs?: number } = {},
 ): void {
+  if (disposingAutoCompact) return
   const key = `${workspaceId}/${slug}`
   const existing = autoCompactTimers.get(key)
   if (existing) clearTimeout(existing)
@@ -381,17 +396,23 @@ export function scheduleAutoCompact(
 // nothing pending simply resolves immediately, and scheduleAutoCompact works
 // again afterward (a fresh call re-populates both trackers).
 export async function disposeAutoCompact(): Promise<void> {
-  // A single clear-then-await pass is not enough: an in-flight compaction's
-  // loadCanvas() can run legacy migration, which calls saveCanvas(), which
-  // re-invokes the registered auto-compact trigger and schedules a fresh
-  // timer *while we are still awaiting the first batch*. Loop until a pass
-  // starts with nothing in flight, so the timer map and in-flight set are
-  // both guaranteed empty by the time this resolves.
-  for (;;) {
-    clearAllAutoCompactTimers()
-    const inFlight = Array.from(inFlightAutoCompacts)
-    if (inFlight.length === 0) break
-    await Promise.allSettled(inFlight)
+  disposingAutoCompact = true
+  try {
+    // A single clear-then-await pass is not enough: an in-flight compaction's
+    // loadCanvas() can run legacy migration, which calls saveCanvas(), which
+    // re-invokes the registered auto-compact trigger *while we are still
+    // awaiting the first batch*. scheduleAutoCompact refuses that reschedule
+    // outright (disposingAutoCompact is true for this whole call), so this
+    // loop's job is just to drain whatever was already in flight or already
+    // timer-scheduled before disposal began.
+    for (;;) {
+      clearAllAutoCompactTimers()
+      const inFlight = Array.from(inFlightAutoCompacts)
+      if (inFlight.length === 0) break
+      await Promise.allSettled(inFlight)
+    }
+  } finally {
+    disposingAutoCompact = false
   }
 }
 
@@ -400,6 +421,14 @@ export async function disposeAutoCompact(): Promise<void> {
 // without a bespoke gate inside compactCanvas itself.
 export function _inFlightAutoCompactCountForTests(): number {
   return inFlightAutoCompacts.size
+}
+
+// Test-only introspection: lets a test deterministically wait until
+// disposeAutoCompact() has begun (and is therefore refusing reschedules)
+// before triggering a reschedule attempt, instead of racing a wall-clock
+// delay against dispose's await window.
+export function _isDisposingAutoCompactForTests(): boolean {
+  return disposingAutoCompact
 }
 
 registerDbDisposeHook(disposeAutoCompact)


### PR DESCRIPTION
## Summary

The CI-flaky test "disposeAutoCompact cancels a timer rescheduled by an in-flight compaction" was catching a real (if benign-outcome) race in `disposeAutoCompact()`: when an in-flight compaction rescheduled a timer mid-disposal, whether that reschedule got cleanly cancelled or fired a real second compaction before dispose returned depended purely on CPU timing. No timer or DB access ever survived past dispose (the loop re-snapshots the in-flight Set until empty), but the behavior was nondeterministic under load — and a future caller assuming "no auto-compact work happens after dispose is called" would be almost-but-not-always right.

- `scheduleAutoCompact()` now refuses to arm a timer while `disposeAutoCompact()` is running (module-level flag), removing the race outright instead of depending on winning it.
- The flaky wall-clock repro (fixed 50ms sleep hoping to land in the window) is replaced with a deterministic interleaving gated on a test-only introspection export, exercising the exact race window on every run.

## Test plan

- [x] New deterministic test 25/25 green locally (was the CI flake, run 29162596104)
- [x] Mutation-checked: reverting the one-line guard fails the deterministic test 100% of the time with the original assertion
- [x] canvas-store 53/53, `src/server/store/` sweep 191/191, typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic compaction cleanup to prevent new compaction work from being scheduled while disposal is in progress.
  - Ensured pending and in-progress compaction tasks are fully drained during shutdown, reducing race conditions and flaky behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->