### PR TITLE
refactor(mcp-server): data-driven tool registration via a type-preserving defineTool helper

### DIFF
--- a/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
@@ -5,7 +5,9 @@
 // the registrations independently, then cross-check their counts.
 //
 // TOOL_PROFILES lives in tool-profiles.ts.
-// registerToolWithAnnotations calls live in tool-registration.ts.
+// Tool registrations live in tool-registration.ts as `defineTool({...})`
+// entries in a data-driven array (each one calls registerToolWithAnnotations
+// through the defineTool identity helper).
 
 import { readFileSync, existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
@@ -35,11 +37,11 @@ function extractProfileKeys(src: string): string[] {
 }
 
 function countRegisterCalls(src: string): number {
-  return (src.match(/registerToolWithAnnotations\(\s*server\s*,/g) ?? []).length
+  return (src.match(/^\s*defineTool\(\{/gm) ?? []).length
 }
 
 describe('MCP tool annotations coverage', () => {
-  it('matches TOOL_PROFILES entry count to registerToolWithAnnotations call count', () => {
+  it('matches TOOL_PROFILES entry count to defineTool registration entry count', () => {
     const profileKeys = extractProfileKeys(profilesSrc)
     const callCount = countRegisterCalls(registrationSrc)
     expect(profileKeys.length).toBe(callCount)

--- a/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-annotations.test.ts
@@ -37,7 +37,7 @@ function extractProfileKeys(src: string): string[] {
 }
 
 function countRegisterCalls(src: string): number {
-  return (src.match(/^\s*defineTool\(\{/gm) ?? []).length
+  return (src.match(/^\s*defineTool\(\s*\{/gm) ?? []).length
 }
 
 describe('MCP tool annotations coverage', () => {

--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -123,7 +123,9 @@ type RegisteredTool = (server: McpServer) => unknown
 // registerToolWithAnnotations call. Do not widen I/O to `unknown` or cast
 // around this signature; that would silently defeat the check.
 function defineTool<
-  I extends z.ZodRawShape,
+  // Default {} so an entry omitting inputSchema types its handler args as an
+  // empty object, not Record<string, any>.
+  I extends z.ZodRawShape = Record<string, never>,
   O extends z.ZodTypeAny | undefined = undefined,
 >(entry: {
   name: string

--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -1,7 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { createDaemonClient } from './daemon-client.js'
-import { registerToolWithAnnotations, structuredJsonResult } from './tool-support.js'
+import {
+  registerToolWithAnnotations,
+  structuredJsonResult,
+  type ToolHandlerReturn,
+} from './tool-support.js'
 import { annotateBatchOutputSchema, annotateBatchTool } from './tools/annotate-batch.js'
 import { annotateOutputSchema, annotateTool } from './tools/annotate.js'
 import { canvasAutoLayoutOutputSchema, canvasAutoLayoutTool } from './tools/canvas-auto-layout.js'
@@ -103,6 +107,47 @@ import {
 } from './tools/template.js'
 import { viewportSetOutputSchema, viewportSetTool } from './tools/viewport.js'
 
+// A registered-tool entry, already bound to McpServer at construction time.
+// The array below is necessarily heterogeneous (48 different I/O generic
+// pairs), so this is the erased/existential form of each entry — but the
+// erasure happens only AFTER defineTool() below has type-checked the
+// handler against ToolHandlerReturn<O> for that specific entry.
+type RegisteredTool = (server: McpServer) => unknown
+
+// Identity helper that captures a tool's I/O generics at its call site
+// before they are erased into RegisteredTool. Because defineTool itself
+// stays generic over <I, O>, passing an object literal here still lets
+// TypeScript check `handler`'s return type against
+// ToolHandlerReturn<O> — a handler returning the wrong structuredContent
+// shape fails to compile here exactly as it would with a direct
+// registerToolWithAnnotations call. Do not widen I/O to `unknown` or cast
+// around this signature; that would silently defeat the check.
+function defineTool<
+  I extends z.ZodRawShape,
+  O extends z.ZodTypeAny | undefined = undefined,
+>(entry: {
+  name: string
+  description?: string
+  inputSchema?: I
+  outputSchema?: O
+  handler: (
+    args: { [K in keyof I]: z.infer<I[K]> },
+    extra: Parameters<Parameters<McpServer['registerTool']>[2]>[1],
+  ) => Promise<ToolHandlerReturn<O>> | ToolHandlerReturn<O>
+}): RegisteredTool {
+  return (server) =>
+    registerToolWithAnnotations(
+      server,
+      entry.name,
+      {
+        description: entry.description,
+        inputSchema: entry.inputSchema,
+        outputSchema: entry.outputSchema,
+      },
+      entry.handler,
+    )
+}
+
 // Registers all MCP tools on the given server instance. withDaemon is a
 // helper that opens a daemon client for the duration of a single tool call.
 export function registerAllTools(
@@ -159,10 +204,9 @@ export function registerAllTools(
   const versionList = versionListTool()
   const pairingLink = pairingLinkTool()
 
-  registerToolWithAnnotations(
-    server,
-    canvasTool.name,
-    {
+  const tools: RegisteredTool[] = [
+    defineTool({
+      name: canvasTool.name,
       description: canvasTool.description,
       inputSchema: {
         slug: z
@@ -184,19 +228,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: canvasCreateOutputSchema,
-    },
-    async ({ slug, issueNumber, overwrite }) => {
-      const result = await withDaemon((client) =>
-        canvasTool.execute({ slug, issueNumber, overwrite }, workspaceId, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ slug, issueNumber, overwrite }) => {
+        const result = await withDaemon((client) =>
+          canvasTool.execute({ slug, issueNumber, overwrite }, workspaceId, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    listTool.name,
-    {
+    defineTool({
+      name: listTool.name,
       description: listTool.description,
       inputSchema: {
         slugContains: z
@@ -207,17 +248,14 @@ export function registerAllTools(
           ),
       },
       outputSchema: canvasListOutputSchema,
-    },
-    async ({ slugContains }) => {
-      const result = await withDaemon((client) => listTool.execute({ slugContains }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ slugContains }) => {
+        const result = await withDaemon((client) => listTool.execute({ slugContains }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    openTool.name,
-    {
+    defineTool({
+      name: openTool.name,
       description: openTool.description,
       inputSchema: {
         id: z
@@ -245,19 +283,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: canvasOpenOutputSchema,
-    },
-    async ({ id, fullscreen, waitForClient, waitTimeoutMs }) => {
-      const result = await withDaemon((client) =>
-        openTool.execute({ id, fullscreen, waitForClient, waitTimeoutMs }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ id, fullscreen, waitForClient, waitTimeoutMs }) => {
+        const result = await withDaemon((client) =>
+          openTool.execute({ id, fullscreen, waitForClient, waitTimeoutMs }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    optimizeTool.name,
-    {
+    defineTool({
+      name: optimizeTool.name,
       description: optimizeTool.description,
       inputSchema: {
         slug: z
@@ -268,19 +303,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: optimizeCanvasesOutputSchema,
-    },
-    async ({ slug }) => {
-      const result = await withDaemon((client) =>
-        optimizeTool.execute({ slug }, workspaceId, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ slug }) => {
+        const result = await withDaemon((client) =>
+          optimizeTool.execute({ slug }, workspaceId, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    loadTool.name,
-    {
+    defineTool({
+      name: loadTool.name,
       description: loadTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -297,19 +329,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: loadImageOutputSchema,
-    },
-    async ({ canvasId, imagePath, position }) => {
-      const result = await withDaemon((client) =>
-        loadTool.execute({ canvasId, imagePath, position }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, imagePath, position }) => {
+        const result = await withDaemon((client) =>
+          loadTool.execute({ canvasId, imagePath, position }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    annotateToolDef.name,
-    {
+    defineTool({
+      name: annotateToolDef.name,
       description: annotateToolDef.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -447,78 +476,75 @@ export function registerAllTools(
           .describe('For type="group": extra padding (px) around the member bbox. Default 16.'),
       },
       outputSchema: annotateOutputSchema,
-    },
-    async ({
-      canvasId,
-      type,
-      imageId,
-      coords,
-      target,
-      text,
-      title,
-      subText,
-      subTextPosition,
-      autoFit,
-      color,
-      backgroundColor,
-      fillStyle,
-      strokeWidth,
-      fontFamily,
-      fontSize,
-      width,
-      height,
-      align,
-      endTarget,
-      startBoxId,
-      endBoxId,
-      label,
-      labelOffset,
-      labelSide,
-      memberIds,
-      padding,
-    }) => {
-      const result = await withDaemon((client) =>
-        annotateToolDef.execute(
-          {
-            canvasId,
-            type,
-            imageId,
-            coords,
-            target,
-            text,
-            title,
-            subText,
-            subTextPosition,
-            autoFit,
-            color,
-            backgroundColor,
-            fillStyle,
-            strokeWidth,
-            fontFamily,
-            fontSize,
-            width,
-            height,
-            align,
-            endTarget,
-            startBoxId,
-            endBoxId,
-            label,
-            labelOffset,
-            labelSide,
-            memberIds,
-            padding,
-          },
-          client,
-        ),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({
+        canvasId,
+        type,
+        imageId,
+        coords,
+        target,
+        text,
+        title,
+        subText,
+        subTextPosition,
+        autoFit,
+        color,
+        backgroundColor,
+        fillStyle,
+        strokeWidth,
+        fontFamily,
+        fontSize,
+        width,
+        height,
+        align,
+        endTarget,
+        startBoxId,
+        endBoxId,
+        label,
+        labelOffset,
+        labelSide,
+        memberIds,
+        padding,
+      }) => {
+        const result = await withDaemon((client) =>
+          annotateToolDef.execute(
+            {
+              canvasId,
+              type,
+              imageId,
+              coords,
+              target,
+              text,
+              title,
+              subText,
+              subTextPosition,
+              autoFit,
+              color,
+              backgroundColor,
+              fillStyle,
+              strokeWidth,
+              fontFamily,
+              fontSize,
+              width,
+              height,
+              align,
+              endTarget,
+              startBoxId,
+              endBoxId,
+              label,
+              labelOffset,
+              labelSide,
+              memberIds,
+              padding,
+            },
+            client,
+          ),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    annotateBatchToolDef.name,
-    {
+    defineTool({
+      name: annotateBatchToolDef.name,
       description: annotateBatchToolDef.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -655,36 +681,30 @@ export function registerAllTools(
           ),
       },
       outputSchema: annotateBatchOutputSchema,
-    },
-    async ({ canvasId, annotations, layout, dryRun, overlapThreshold, groupAs }) => {
-      const result = await withDaemon((client) =>
-        annotateBatchToolDef.execute(
-          { canvasId, annotations, layout, dryRun, overlapThreshold, groupAs },
-          client,
-        ),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, annotations, layout, dryRun, overlapThreshold, groupAs }) => {
+        const result = await withDaemon((client) =>
+          annotateBatchToolDef.execute(
+            { canvasId, annotations, layout, dryRun, overlapThreshold, groupAs },
+            client,
+          ),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    paletteGet.name,
-    {
+    defineTool({
+      name: paletteGet.name,
       description: paletteGet.description,
       inputSchema: { workspaceId: z.string() },
       outputSchema: paletteOutputSchema,
-    },
-    async ({ workspaceId }) => {
-      const result = await withDaemon((client) => paletteGet.execute({ workspaceId }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ workspaceId }) => {
+        const result = await withDaemon((client) => paletteGet.execute({ workspaceId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    paletteSet.name,
-    {
+    defineTool({
+      name: paletteSet.name,
       description: paletteSet.description,
       inputSchema: {
         workspaceId: z
@@ -699,35 +719,29 @@ export function registerAllTools(
           ),
       },
       outputSchema: paletteOutputSchema,
-    },
-    async ({ workspaceId, entries }) => {
-      const result = await withDaemon((client) =>
-        paletteSet.execute({ workspaceId, entries }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ workspaceId, entries }) => {
+        const result = await withDaemon((client) =>
+          paletteSet.execute({ workspaceId, entries }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    paletteDelete.name,
-    {
+    defineTool({
+      name: paletteDelete.name,
       description: paletteDelete.description,
       inputSchema: { workspaceId: z.string(), keys: z.array(z.string()).min(1) },
       outputSchema: paletteOutputSchema,
-    },
-    async ({ workspaceId, keys }) => {
-      const result = await withDaemon((client) =>
-        paletteDelete.execute({ workspaceId, keys }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ workspaceId, keys }) => {
+        const result = await withDaemon((client) =>
+          paletteDelete.execute({ workspaceId, keys }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    exportTool.name,
-    {
+    defineTool({
+      name: exportTool.name,
       description: exportTool.description,
       inputSchema: {
         canvasId: z
@@ -779,31 +793,37 @@ export function registerAllTools(
           ),
       },
       outputSchema: exportPngOutputSchema,
-    },
-    async ({ canvasId, padding, scale, minFontPx, frameId, outputPath, overwrite, theme }) => {
-      const result = await withDaemon((client) =>
-        exportTool.execute(
-          { canvasId, padding, scale, minFontPx, frameId, outputPath, overwrite, theme },
-          client,
-        ),
-      )
-      // Return filePath in the text block and attach the image payload as a
-      // separate ImageContent block. If reading fails, omit the image block and
-      // fall back to returning only filePath.
-      const content: Array<
-        { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
-      > = [{ type: 'text', text: JSON.stringify({ filePath: result.filePath }) }]
-      if (result.imageBase64) {
-        content.push({ type: 'image', data: result.imageBase64, mimeType: 'image/png' })
-      }
-      return { structuredContent: result, content }
-    },
-  )
+      handler: async ({
+        canvasId,
+        padding,
+        scale,
+        minFontPx,
+        frameId,
+        outputPath,
+        overwrite,
+        theme,
+      }) => {
+        const result = await withDaemon((client) =>
+          exportTool.execute(
+            { canvasId, padding, scale, minFontPx, frameId, outputPath, overwrite, theme },
+            client,
+          ),
+        )
+        // Return filePath in the text block and attach the image payload as a
+        // separate ImageContent block. If reading fails, omit the image block and
+        // fall back to returning only filePath.
+        const content: Array<
+          { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+        > = [{ type: 'text', text: JSON.stringify({ filePath: result.filePath }) }]
+        if (result.imageBase64) {
+          content.push({ type: 'image', data: result.imageBase64, mimeType: 'image/png' })
+        }
+        return { structuredContent: result, content }
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    viewportTool.name,
-    {
+    defineTool({
+      name: viewportTool.name,
       description: viewportTool.description,
       inputSchema: {
         canvasId: z
@@ -834,17 +854,14 @@ export function registerAllTools(
         zoom: z.number().optional().describe('Absolute zoom (1.0 = 100%) for mode="move".'),
       },
       outputSchema: viewportSetOutputSchema,
-    },
-    async (args) => {
-      const result = await withDaemon((client) => viewportTool.execute(args, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async (args) => {
+        const result = await withDaemon((client) => viewportTool.execute(args, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    exportJsonTool.name,
-    {
+    defineTool({
+      name: exportJsonTool.name,
       description: exportJsonTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -856,19 +873,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: canvasExportJsonOutputSchema,
-    },
-    async ({ canvasId, includeCustomFields }) => {
-      const result = await withDaemon((client) =>
-        exportJsonTool.execute({ canvasId, includeCustomFields }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, includeCustomFields }) => {
+        const result = await withDaemon((client) =>
+          exportJsonTool.execute({ canvasId, includeCustomFields }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    autoLayoutTool.name,
-    {
+    defineTool({
+      name: autoLayoutTool.name,
       description: autoLayoutTool.description,
       inputSchema: {
         canvasId: z.string(),
@@ -902,17 +916,14 @@ export function registerAllTools(
         groupGap: z.number().optional(),
       },
       outputSchema: canvasAutoLayoutOutputSchema,
-    },
-    async (args) => {
-      const result = await withDaemon((client) => autoLayoutTool.execute(args, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async (args) => {
+        const result = await withDaemon((client) => autoLayoutTool.execute(args, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libListTool.name,
-    {
+    defineTool({
+      name: libListTool.name,
       description: libListTool.description,
       inputSchema: {
         libraryUrl: z.string().optional(),
@@ -920,19 +931,16 @@ export function registerAllTools(
         userLibraryName: z.string().optional(),
       },
       outputSchema: libraryListItemsOutputSchema,
-    },
-    async ({ libraryUrl, libraryPath, userLibraryName }) => {
-      const result = await withDaemon((client) =>
-        libListTool.execute({ libraryUrl, libraryPath, userLibraryName }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ libraryUrl, libraryPath, userLibraryName }) => {
+        const result = await withDaemon((client) =>
+          libListTool.execute({ libraryUrl, libraryPath, userLibraryName }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libInsertTool.name,
-    {
+    defineTool({
+      name: libInsertTool.name,
       description: libInsertTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -970,22 +978,27 @@ export function registerAllTools(
           ),
       },
       outputSchema: libInsertItemOutputSchema,
-    },
-    async ({ canvasId, libraryUrl, libraryPath, userLibraryName, itemIndex, target, scale }) => {
-      const result = await withDaemon((client) =>
-        libInsertTool.execute(
-          { canvasId, libraryUrl, libraryPath, userLibraryName, itemIndex, target, scale },
-          client,
-        ),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({
+        canvasId,
+        libraryUrl,
+        libraryPath,
+        userLibraryName,
+        itemIndex,
+        target,
+        scale,
+      }) => {
+        const result = await withDaemon((client) =>
+          libInsertTool.execute(
+            { canvasId, libraryUrl, libraryPath, userLibraryName, itemIndex, target, scale },
+            client,
+          ),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libInsertBatch.name,
-    {
+    defineTool({
+      name: libInsertBatch.name,
       description: libInsertBatch.description,
       inputSchema: {
         canvasId: z.string(),
@@ -1006,22 +1019,27 @@ export function registerAllTools(
           .min(1),
       },
       outputSchema: libraryInsertBatchOutputSchema,
-    },
-    async ({ canvasId, libraryUrl, libraryPath, userLibraryName, groupAs, scale, items }) => {
-      const result = await withDaemon((client) =>
-        libInsertBatch.execute(
-          { canvasId, libraryUrl, libraryPath, userLibraryName, groupAs, scale, items },
-          client,
-        ),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({
+        canvasId,
+        libraryUrl,
+        libraryPath,
+        userLibraryName,
+        groupAs,
+        scale,
+        items,
+      }) => {
+        const result = await withDaemon((client) =>
+          libInsertBatch.execute(
+            { canvasId, libraryUrl, libraryPath, userLibraryName, groupAs, scale, items },
+            client,
+          ),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libInstall.name,
-    {
+    defineTool({
+      name: libInstall.name,
       description: libInstall.description,
       inputSchema: {
         libraryUrl: z
@@ -1031,59 +1049,47 @@ export function registerAllTools(
           ),
       },
       outputSchema: libraryInstallOutputSchema,
-    },
-    async ({ libraryUrl }) => {
-      const result = await withDaemon((client) => libInstall.execute({ libraryUrl }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ libraryUrl }) => {
+        const result = await withDaemon((client) => libInstall.execute({ libraryUrl }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libUninstall.name,
-    {
+    defineTool({
+      name: libUninstall.name,
       description: libUninstall.description,
       inputSchema: { libraryUrl: z.string() },
       outputSchema: installedUrlsOutputSchema,
-    },
-    async ({ libraryUrl }) => {
-      const result = await withDaemon((client) => libUninstall.execute({ libraryUrl }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ libraryUrl }) => {
+        const result = await withDaemon((client) => libUninstall.execute({ libraryUrl }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libListInstalled.name,
-    {
+    defineTool({
+      name: libListInstalled.name,
       description: libListInstalled.description,
       inputSchema: {},
       outputSchema: installedUrlsOutputSchema,
-    },
-    async () => {
-      const result = await withDaemon((client) => libListInstalled.execute({}, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async () => {
+        const result = await withDaemon((client) => libListInstalled.execute({}, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    libCatalog.name,
-    {
+    defineTool({
+      name: libCatalog.name,
       description: libCatalog.description,
       inputSchema: { query: z.string().optional(), limit: z.number().optional() },
       outputSchema: libraryCatalogListOutputSchema,
-    },
-    async ({ query, limit }) => {
-      const result = await libCatalog.execute({ query, limit })
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ query, limit }) => {
+        const result = await libCatalog.execute({ query, limit })
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibSave.name,
-    {
+    defineTool({
+      name: userLibSave.name,
       description: userLibSave.description,
       inputSchema: {
         name: z.string(),
@@ -1091,61 +1097,49 @@ export function registerAllTools(
         content: z.record(z.string(), z.unknown()).optional(),
       },
       outputSchema: userLibrarySaveOutputSchema,
-    },
-    async ({ name, fromUrl, content }) => {
-      const result = await withDaemon((client) =>
-        userLibSave.execute({ name, fromUrl, content }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ name, fromUrl, content }) => {
+        const result = await withDaemon((client) =>
+          userLibSave.execute({ name, fromUrl, content }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibList.name,
-    {
+    defineTool({
+      name: userLibList.name,
       description: userLibList.description,
       inputSchema: {},
       outputSchema: userLibraryListOutputSchema,
-    },
-    async () => {
-      const result = await withDaemon((client) => userLibList.execute({}, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async () => {
+        const result = await withDaemon((client) => userLibList.execute({}, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibRemove.name,
-    {
+    defineTool({
+      name: userLibRemove.name,
       description: userLibRemove.description,
       inputSchema: { name: z.string() },
       outputSchema: userLibraryRemoveOutputSchema,
-    },
-    async ({ name }) => {
-      const result = await withDaemon((client) => userLibRemove.execute({ name }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ name }) => {
+        const result = await withDaemon((client) => userLibRemove.execute({ name }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibMetadataGet.name,
-    {
+    defineTool({
+      name: userLibMetadataGet.name,
       description: userLibMetadataGet.description,
       inputSchema: { name: z.string() },
       outputSchema: userLibraryMetadataManifestSchema,
-    },
-    async ({ name }) => {
-      const result = await withDaemon((client) => userLibMetadataGet.execute({ name }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ name }) => {
+        const result = await withDaemon((client) => userLibMetadataGet.execute({ name }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibMetadataSet.name,
-    {
+    defineTool({
+      name: userLibMetadataSet.name,
       description: userLibMetadataSet.description,
       inputSchema: {
         name: z.string(),
@@ -1155,19 +1149,16 @@ export function registerAllTools(
         scales: z.record(z.string(), z.number()).optional(),
       },
       outputSchema: userLibraryMetadataManifestSchema,
-    },
-    async ({ name, revision, aliases, notes, scales }) => {
-      const result = await withDaemon((client) =>
-        userLibMetadataSet.execute({ name, revision, aliases, notes, scales }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ name, revision, aliases, notes, scales }) => {
+        const result = await withDaemon((client) =>
+          userLibMetadataSet.execute({ name, revision, aliases, notes, scales }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    userLibMetadataDelete.name,
-    {
+    defineTool({
+      name: userLibMetadataDelete.name,
       description: userLibMetadataDelete.description,
       inputSchema: {
         name: z.string(),
@@ -1177,19 +1168,16 @@ export function registerAllTools(
         scaleKeys: z.array(z.string()).optional(),
       },
       outputSchema: userLibraryMetadataManifestSchema,
-    },
-    async ({ name, revision, aliasKeys, noteKeys, scaleKeys }) => {
-      const result = await withDaemon((client) =>
-        userLibMetadataDelete.execute({ name, revision, aliasKeys, noteKeys, scaleKeys }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ name, revision, aliasKeys, noteKeys, scaleKeys }) => {
+        const result = await withDaemon((client) =>
+          userLibMetadataDelete.execute({ name, revision, aliasKeys, noteKeys, scaleKeys }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    inspectTool.name,
-    {
+    defineTool({
+      name: inspectTool.name,
       description: inspectTool.description,
       inputSchema: {
         canvasId: z
@@ -1199,31 +1187,25 @@ export function registerAllTools(
           ),
       },
       outputSchema: canvasInspectOutputSchema,
-    },
-    async ({ canvasId }) => {
-      const result = await withDaemon((client) => inspectTool.execute({ canvasId }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId }) => {
+        const result = await withDaemon((client) => inspectTool.execute({ canvasId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    listTemplates.name,
-    {
+    defineTool({
+      name: listTemplates.name,
       description: listTemplates.description,
       inputSchema: {},
       outputSchema: templateListOutputSchema,
-    },
-    async () => {
-      const result = await listTemplates.execute()
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async () => {
+        const result = await listTemplates.execute()
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    insertTemplate.name,
-    {
+    defineTool({
+      name: insertTemplate.name,
       description: insertTemplate.description,
       inputSchema: {
         canvasId: z.string(),
@@ -1234,22 +1216,19 @@ export function registerAllTools(
         variables: z.record(z.string(), z.string()).optional(),
       },
       outputSchema: templateInsertOutputSchema,
-    },
-    async ({ canvasId, templateId, templatePath, target, scale, variables }) => {
-      const result = await withDaemon((client) =>
-        insertTemplate.execute(
-          { canvasId, templateId, templatePath, target, scale, variables },
-          client,
-        ),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, templateId, templatePath, target, scale, variables }) => {
+        const result = await withDaemon((client) =>
+          insertTemplate.execute(
+            { canvasId, templateId, templatePath, target, scale, variables },
+            client,
+          ),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    updateTool.name,
-    {
+    defineTool({
+      name: updateTool.name,
       description: updateTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1265,19 +1244,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: elementIdOutputSchema,
-    },
-    async ({ canvasId, elementId, patch }) => {
-      const result = await withDaemon((client) =>
-        updateTool.execute({ canvasId, elementId, patch }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementId, patch }) => {
+        const result = await withDaemon((client) =>
+          updateTool.execute({ canvasId, elementId, patch }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    deleteTool.name,
-    {
+    defineTool({
+      name: deleteTool.name,
       description: deleteTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1288,19 +1264,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: elementIdOutputSchema,
-    },
-    async ({ canvasId, elementId }) => {
-      const result = await withDaemon((client) =>
-        deleteTool.execute({ canvasId, elementId }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementId }) => {
+        const result = await withDaemon((client) =>
+          deleteTool.execute({ canvasId, elementId }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    deleteManyTool.name,
-    {
+    defineTool({
+      name: deleteManyTool.name,
       description: deleteManyTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1312,19 +1285,16 @@ export function registerAllTools(
           ),
       },
       outputSchema: deletedElementsOutputSchema,
-    },
-    async ({ canvasId, elementIds }) => {
-      const result = await withDaemon((client) =>
-        deleteManyTool.execute({ canvasId, elementIds }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementIds }) => {
+        const result = await withDaemon((client) =>
+          deleteManyTool.execute({ canvasId, elementIds }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    assignGroupTool.name,
-    {
+    defineTool({
+      name: assignGroupTool.name,
       description: assignGroupTool.description,
       inputSchema: {
         canvasId: z.string(),
@@ -1332,49 +1302,40 @@ export function registerAllTools(
         elementIds: z.array(z.string()).min(1),
       },
       outputSchema: assignGroupOutputSchema,
-    },
-    async ({ canvasId, groupId, elementIds }) => {
-      const result = await withDaemon((client) =>
-        assignGroupTool.execute({ canvasId, groupId, elementIds }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, groupId, elementIds }) => {
+        const result = await withDaemon((client) =>
+          assignGroupTool.execute({ canvasId, groupId, elementIds }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    deleteGroupT.name,
-    {
+    defineTool({
+      name: deleteGroupT.name,
       description: deleteGroupT.description,
       inputSchema: { canvasId: z.string(), groupId: z.string() },
       outputSchema: deletedElementsOutputSchema,
-    },
-    async ({ canvasId, groupId }) => {
-      const result = await withDaemon((client) =>
-        deleteGroupT.execute({ canvasId, groupId }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, groupId }) => {
+        const result = await withDaemon((client) =>
+          deleteGroupT.execute({ canvasId, groupId }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    listGroupsT.name,
-    {
+    defineTool({
+      name: listGroupsT.name,
       description: listGroupsT.description,
       inputSchema: { canvasId: z.string() },
       outputSchema: listGroupsOutputSchema,
-    },
-    async ({ canvasId }) => {
-      const result = await withDaemon((client) => listGroupsT.execute({ canvasId }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId }) => {
+        const result = await withDaemon((client) => listGroupsT.execute({ canvasId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    moveTool.name,
-    {
+    defineTool({
+      name: moveTool.name,
       description: moveTool.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1390,54 +1351,45 @@ export function registerAllTools(
         dy: z.number().describe('Vertical translation in world coordinates (px). Negative = up.'),
       },
       outputSchema: elementIdsOutputSchema,
-    },
-    async ({ canvasId, elementIds, dx, dy }) => {
-      const result = await withDaemon((client) =>
-        moveTool.execute({ canvasId, elementIds, dx, dy }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementIds, dx, dy }) => {
+        const result = await withDaemon((client) =>
+          moveTool.execute({ canvasId, elementIds, dx, dy }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    alignTool.name,
-    {
+    defineTool({
+      name: alignTool.name,
       description: alignTool.description,
       // Input + output schemas come from element-ops-tools.ts as the single
       // source of truth — execute()'s arg type is z.infer<typeof
       // alignInputSchema> there, so registration and runtime stay in sync.
       inputSchema: alignInputSchema.shape,
       outputSchema: alignOutputSchema,
-    },
-    async ({ canvasId, elementIds, alignment }) => {
-      const result = await withDaemon((client) =>
-        alignTool.execute({ canvasId, elementIds, alignment }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementIds, alignment }) => {
+        const result = await withDaemon((client) =>
+          alignTool.execute({ canvasId, elementIds, alignment }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    distributeTool.name,
-    {
+    defineTool({
+      name: distributeTool.name,
       description: distributeTool.description,
       inputSchema: distributeInputSchema.shape,
       outputSchema: distributeOutputSchema,
-    },
-    async ({ canvasId, elementIds, direction }) => {
-      const result = await withDaemon((client) =>
-        distributeTool.execute({ canvasId, elementIds, direction }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementIds, direction }) => {
+        const result = await withDaemon((client) =>
+          distributeTool.execute({ canvasId, elementIds, direction }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    reorderTool.name,
-    {
+    defineTool({
+      name: reorderTool.name,
       description: reorderTool.description,
       inputSchema: {
         canvasId: z.string(),
@@ -1445,33 +1397,27 @@ export function registerAllTools(
         action: z.enum(['front', 'back']),
       },
       outputSchema: reorderOutputSchema,
-    },
-    async ({ canvasId, elementIds, action }) => {
-      const result = await withDaemon((client) =>
-        reorderTool.execute({ canvasId, elementIds, action }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, elementIds, action }) => {
+        const result = await withDaemon((client) =>
+          reorderTool.execute({ canvasId, elementIds, action }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    clearTool.name,
-    {
+    defineTool({
+      name: clearTool.name,
       description: clearTool.description,
       inputSchema: { canvasId: z.string() },
       outputSchema: clearedCountOutputSchema,
-    },
-    async ({ canvasId }) => {
-      const result = await withDaemon((client) => clearTool.execute({ canvasId }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId }) => {
+        const result = await withDaemon((client) => clearTool.execute({ canvasId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    versionSave.name,
-    {
+    defineTool({
+      name: versionSave.name,
       description: versionSave.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1481,17 +1427,16 @@ export function registerAllTools(
           .describe('Optional human-readable label shown in the History panel.'),
       },
       outputSchema: versionSaveOutputSchema,
-    },
-    async ({ canvasId, label }) => {
-      const result = await withDaemon((client) => versionSave.execute({ canvasId, label }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, label }) => {
+        const result = await withDaemon((client) =>
+          versionSave.execute({ canvasId, label }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    versionRestore.name,
-    {
+    defineTool({
+      name: versionRestore.name,
       description: versionRestore.description,
       inputSchema: {
         canvasId: z.string().describe('Source canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1510,35 +1455,29 @@ export function registerAllTools(
           ),
       },
       outputSchema: versionRestoreOutputSchema,
-    },
-    async ({ canvasId, versionId, targetSlug, overwrite }) => {
-      const result = await withDaemon((client) =>
-        versionRestore.execute({ canvasId, versionId, targetSlug, overwrite }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, versionId, targetSlug, overwrite }) => {
+        const result = await withDaemon((client) =>
+          versionRestore.execute({ canvasId, versionId, targetSlug, overwrite }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    versionList.name,
-    {
+    defineTool({
+      name: versionList.name,
       description: versionList.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
       },
       outputSchema: versionListOutputSchema,
-    },
-    async ({ canvasId }) => {
-      const result = await withDaemon((client) => versionList.execute({ canvasId }, client))
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId }) => {
+        const result = await withDaemon((client) => versionList.execute({ canvasId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    frameCreate.name,
-    {
+    defineTool({
+      name: frameCreate.name,
       description: frameCreate.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1575,19 +1514,16 @@ export function registerAllTools(
           .describe('Padding (px) around the member bbox when memberIds is set. Default 24.'),
       },
       outputSchema: createFrameOutputSchema,
-    },
-    async ({ canvasId, x, y, width, height, name, memberIds, padding }) => {
-      const result = await withDaemon((client) =>
-        frameCreate.execute({ canvasId, x, y, width, height, name, memberIds, padding }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, x, y, width, height, name, memberIds, padding }) => {
+        const result = await withDaemon((client) =>
+          frameCreate.execute({ canvasId, x, y, width, height, name, memberIds, padding }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    frameUpdateMembers.name,
-    {
+    defineTool({
+      name: frameUpdateMembers.name,
       description: frameUpdateMembers.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1612,19 +1548,16 @@ export function registerAllTools(
           .describe('Padding (px) around the resulting member bbox. Default 24.'),
       },
       outputSchema: updateFrameMembersOutputSchema,
-    },
-    async ({ canvasId, frameId, add, remove, padding }) => {
-      const result = await withDaemon((client) =>
-        frameUpdateMembers.execute({ canvasId, frameId, add, remove, padding }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, frameId, add, remove, padding }) => {
+        const result = await withDaemon((client) =>
+          frameUpdateMembers.execute({ canvasId, frameId, add, remove, padding }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    embedCreate.name,
-    {
+    defineTool({
+      name: embedCreate.name,
       description: embedCreate.description,
       inputSchema: {
         canvasId: z.string().describe('Canvas ID in "{workspaceId}/{slug}" form.'),
@@ -1639,35 +1572,36 @@ export function registerAllTools(
         height: z.number().optional().describe('Embed height (px). Default 320.'),
       },
       outputSchema: createEmbedOutputSchema,
-    },
-    async ({ canvasId, url, x, y, width, height }) => {
-      const result = await withDaemon((client) =>
-        embedCreate.execute({ canvasId, url, x, y, width, height }, client),
-      )
-      return structuredJsonResult(result)
-    },
-  )
+      handler: async ({ canvasId, url, x, y, width, height }) => {
+        const result = await withDaemon((client) =>
+          embedCreate.execute({ canvasId, url, x, y, width, height }, client),
+        )
+        return structuredJsonResult(result)
+      },
+    }),
 
-  registerToolWithAnnotations(
-    server,
-    pairingLink.name,
-    {
+    defineTool({
+      name: pairingLink.name,
       description: pairingLink.description,
       inputSchema: createPairingLinkInputShape,
       outputSchema: createPairingLinkOutputSchema,
-    },
-    async (args) => {
-      const result = await withDaemon((client) => pairingLink.execute(args, client))
-      // content[0] stays JSON (the structuredJsonResult convention every other
-      // tool follows, and what callers/smoke parse as the primary payload); the
-      // credential note travels as a second text block instead of overwriting it.
-      return {
-        structuredContent: result,
-        content: [
-          { type: 'text' as const, text: JSON.stringify(result) },
-          { type: 'text' as const, text: buildPairingLinkText(result, result.webOrigin) },
-        ],
-      }
-    },
-  )
+      handler: async (args) => {
+        const result = await withDaemon((client) => pairingLink.execute(args, client))
+        // content[0] stays JSON (the structuredJsonResult convention every other
+        // tool follows, and what callers/smoke parse as the primary payload); the
+        // credential note travels as a second text block instead of overwriting it.
+        return {
+          structuredContent: result,
+          content: [
+            { type: 'text' as const, text: JSON.stringify(result) },
+            { type: 'text' as const, text: buildPairingLinkText(result, result.webOrigin) },
+          ],
+        }
+      },
+    }),
+  ]
+
+  for (const register of tools) {
+    register(server)
+  }
 }


### PR DESCRIPTION
## Summary

`tool-registration.ts` carried 48 near-identical `registerToolWithAnnotations` calls plus 48 single-use tool variables. They are now a config array built through a `defineTool<I,O>` identity helper and registered by a single loop.

The helper is the load-bearing part: a naive heterogeneous array would erase the per-tool `O` generic and let a handler silently return the wrong shape. `defineTool` captures the generics at each entry's construction, so `ToolHandlerReturn<O>` still constrains every handler individually (mutation-checked below).

Line count honesty: 1673 → 1573. The original ~300-400 target assumed the bulk was registration boilerplate, but most of the file is inline Zod input shapes, which this behavior-preserving pass deliberately does not touch (moving them next to their tools/*.ts, as #190 did for annotate, is filed as a follow-up).

Zero changes to tools/*.ts, schemas, handler logic, or tool names/descriptions/annotations. `tool-annotations.test.ts`'s registration-count detection pattern was updated to count `defineTool({` — the invariant it asserts (TOOL_PROFILES count == registered tools) is unchanged.

## Test plan

- [x] Mutation check: a wrong handler return shape fails `typecheck` with TS2322, restored to green — the generic binding survives the array
- [x] Registered tool inventory diffed against the pre-refactor file: 48 entries, identical names and order
- [x] `src/server/mcp/` suite 665/665; full mcp-node 2918 passed; build green
- [x] `pnpm smoke:e2e` ALL OK (real end-to-end calls across create/annotate/versions/export/pairing tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the consistency and maintainability of MCP tool registration.
  * Standardized tool responses while preserving existing functionality.

* **Bug Fixes**
  * Ensured PNG export results continue to include file details and available image previews.
  * Preserved pairing-link responses with structured information and credential guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->