### PR TITLE
feat(web): add Duplicate canvas to the browser-local page and the daemon gallery

### DIFF
--- a/apps/web/src/lib/daemon-api-client.test.ts
+++ b/apps/web/src/lib/daemon-api-client.test.ts
@@ -2,8 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createCanvas,
   createDaemonFetch,
+  getCanvasSnapshot,
   listCanvases,
   listWorkspaces,
+  setCanvasName,
+  updateCanvas,
 } from './daemon-api-client.js'
 
 const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
@@ -168,5 +171,68 @@ describe('createCanvas', () => {
   it('rejects on a non-2xx response, surfacing problem+json detail', async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ title: 'Conflict' }, 409))
     await expect(createCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'x')).rejects.toThrow(/conflict/i)
+  })
+})
+
+describe('getCanvasSnapshot', () => {
+  it('returns the raw octet-stream body as a Uint8Array', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4])
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    )
+    const result = await getCanvasSnapshot(fetchFn, DAEMON_BASE_URL, 'w1', 'main')
+    expect(new Uint8Array(result)).toEqual(bytes)
+    expect(fetchFn).toHaveBeenCalledWith(`${DAEMON_BASE_URL}/api/canvas/w1/main/snapshot`)
+  })
+
+  it('rejects on a non-2xx response, surfacing problem+json detail', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ title: 'Not found' }, 404))
+    await expect(getCanvasSnapshot(fetchFn, DAEMON_BASE_URL, 'w1', 'main')).rejects.toThrow(
+      /not found/i,
+    )
+  })
+})
+
+describe('updateCanvas', () => {
+  it('POSTs the snapshot bytes as the request body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    const bytes = new Uint8Array([9, 9, 9])
+    const result = await updateCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'main', bytes)
+    expect(result).toEqual({ ok: true })
+    const [urlArg, initArg] = fetchFn.mock.calls[0]
+    expect(String(urlArg)).toBe(`${DAEMON_BASE_URL}/api/canvas/w1/main/update`)
+    expect(initArg?.method).toBe('POST')
+    expect(initArg?.body).toBe(bytes)
+  })
+
+  it('rejects on a non-2xx response, surfacing problem+json detail', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ title: 'Server error' }, 500))
+    await expect(
+      updateCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'main', new Uint8Array()),
+    ).rejects.toThrow(/server error/i)
+  })
+})
+
+describe('setCanvasName', () => {
+  it('PUTs the name and parses the returned WorkspaceNames payload', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ canvases: { main: 'My canvas' }, pinned: [] }))
+    const result = await setCanvasName(fetchFn, DAEMON_BASE_URL, 'w1', 'main', 'My canvas')
+    expect(result).toEqual({ canvases: { main: 'My canvas' }, pinned: [] })
+    const [urlArg, initArg] = fetchFn.mock.calls[0]
+    expect(String(urlArg)).toBe(`${DAEMON_BASE_URL}/api/workspaces/w1/canvases/main/name`)
+    expect(initArg?.method).toBe('PUT')
+    expect(JSON.parse(String(initArg?.body))).toEqual({ name: 'My canvas' })
+  })
+
+  it('rejects on a non-2xx response, surfacing problem+json detail', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ title: 'Bad request' }, 400))
+    await expect(setCanvasName(fetchFn, DAEMON_BASE_URL, 'w1', 'main', 'x')).rejects.toThrow(
+      /bad request/i,
+    )
   })
 })

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -6,6 +6,10 @@ import {
   type ListWorkspacesResponse,
   listWorkspacesResponseSchema,
   problemDetailsErrorSchema,
+  type UpdateCanvasResponse,
+  updateCanvasResponseSchema,
+  type WorkspaceNames,
+  workspaceNamesSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 
 /**
@@ -136,6 +140,57 @@ export function createCanvas(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ slug }),
+    },
+  )
+}
+
+// GET /api/canvas/:workspaceId/:slug/snapshot returns raw Loro bytes
+// (application/octet-stream), not JSON — kept separate from fetchAndParse,
+// which always calls res.json().
+export async function getCanvasSnapshot(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  slug: string,
+): Promise<Uint8Array> {
+  const url = `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}/snapshot`
+  const res = await fetchFn(url)
+  if (!res.ok) {
+    throw new Error(await parseProblemDetails(res))
+  }
+  return new Uint8Array(await res.arrayBuffer())
+}
+
+export function updateCanvas(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  slug: string,
+  snapshot: Uint8Array,
+): Promise<UpdateCanvasResponse> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}/update`,
+    updateCanvasResponseSchema,
+    { method: 'POST', body: snapshot },
+  )
+}
+
+export function setCanvasName(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  slug: string,
+  name: string,
+): Promise<WorkspaceNames> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/name`,
+    workspaceNamesSchema,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
     },
   )
 }

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -172,7 +172,7 @@ export function updateCanvas(
     fetchFn,
     `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}/update`,
     updateCanvasResponseSchema,
-    { method: 'POST', body: snapshot },
+    { method: 'POST', body: snapshot as BodyInit },
   )
 }
 

--- a/apps/web/src/lib/derive-copy-name.test.ts
+++ b/apps/web/src/lib/derive-copy-name.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { deriveCopyName } from './derive-copy-name.js'
+
+describe('deriveCopyName', () => {
+  it('appends " (copy)" when no collision exists', () => {
+    expect(deriveCopyName('Diagram', [])).toBe('Diagram (copy)')
+  })
+
+  it('appends " (copy 2)" when "(copy)" is already taken', () => {
+    expect(deriveCopyName('Diagram', ['Diagram (copy)'])).toBe('Diagram (copy 2)')
+  })
+
+  it('keeps incrementing past multiple existing numbered copies', () => {
+    expect(
+      deriveCopyName('Diagram', ['Diagram (copy)', 'Diagram (copy 2)', 'Diagram (copy 3)']),
+    ).toBe('Diagram (copy 4)')
+  })
+
+  it('does not collide with an unrelated numbered copy of a different base name', () => {
+    expect(deriveCopyName('Diagram', ['Sketch (copy)', 'Sketch (copy 2)'])).toBe('Diagram (copy)')
+  })
+
+  it('fills a gap left by a renamed/deleted numbered copy rather than always picking the max+1', () => {
+    // "Diagram (copy 2)" no longer exists (renamed away or deleted) — the next
+    // duplicate should reuse that name instead of jumping to "(copy 4)".
+    expect(deriveCopyName('Diagram', ['Diagram (copy)', 'Diagram (copy 3)'])).toBe(
+      'Diagram (copy 2)',
+    )
+  })
+
+  it('accepts a Set as well as an array for existing names', () => {
+    expect(deriveCopyName('Diagram', new Set(['Diagram (copy)']))).toBe('Diagram (copy 2)')
+  })
+})

--- a/apps/web/src/lib/derive-copy-name.ts
+++ b/apps/web/src/lib/derive-copy-name.ts
@@ -1,0 +1,16 @@
+// Deterministic "Duplicate" naming shared by both duplicate surfaces
+// (browser-local canvas controller, daemon index gallery): "Foo" -> "Foo
+// (copy)" -> "Foo (copy 2)" -> ... Fills a gap left by a renamed/deleted
+// numbered copy instead of always advancing past the highest number seen, so
+// the sequence stays dense from the caller's point of view.
+export function deriveCopyName(
+  baseName: string,
+  existingNames: ReadonlySet<string> | readonly string[],
+): string {
+  const existing = existingNames instanceof Set ? existingNames : new Set(existingNames)
+  const first = `${baseName} (copy)`
+  if (!existing.has(first)) return first
+  let n = 2
+  while (existing.has(`${baseName} (copy ${n})`)) n++
+  return `${baseName} (copy ${n})`
+}

--- a/apps/web/src/lib/derive-copy-slug.test.ts
+++ b/apps/web/src/lib/derive-copy-slug.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { deriveCopySlug } from './derive-copy-slug.js'
+
+describe('deriveCopySlug', () => {
+  it('appends "-copy" when no collision exists', () => {
+    expect(deriveCopySlug('diagram', [])).toBe('diagram-copy')
+  })
+
+  it('appends "-copy-2" when "-copy" is already taken', () => {
+    expect(deriveCopySlug('diagram', ['diagram-copy'])).toBe('diagram-copy-2')
+  })
+
+  it('keeps incrementing past multiple existing numbered copies', () => {
+    expect(deriveCopySlug('diagram', ['diagram-copy', 'diagram-copy-2', 'diagram-copy-3'])).toBe(
+      'diagram-copy-4',
+    )
+  })
+
+  it('does not collide with an unrelated numbered copy of a different base slug', () => {
+    expect(deriveCopySlug('diagram', ['sketch-copy', 'sketch-copy-2'])).toBe('diagram-copy')
+  })
+
+  it('produces a slug containing only ASCII letters, digits, and hyphens', () => {
+    expect(deriveCopySlug('diagram', [])).toMatch(/^[a-zA-Z0-9-]+$/)
+  })
+})

--- a/apps/web/src/lib/derive-copy-slug.ts
+++ b/apps/web/src/lib/derive-copy-slug.ts
@@ -1,0 +1,14 @@
+// Slug-safe sibling of deriveCopyName: daemon canvas slugs are restricted to
+// ASCII letters, digits, and hyphens (see validateSlug on the server), so the
+// "(copy)" / "(copy N)" display-name suffix can't be reused verbatim here.
+export function deriveCopySlug(
+  baseSlug: string,
+  existingSlugs: ReadonlySet<string> | readonly string[],
+): string {
+  const existing = existingSlugs instanceof Set ? existingSlugs : new Set(existingSlugs)
+  const first = `${baseSlug}-copy`
+  if (!existing.has(first)) return first
+  let n = 2
+  while (existing.has(`${baseSlug}-copy-${n}`)) n++
+  return `${baseSlug}-copy-${n}`
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -1,7 +1,9 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
+import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
@@ -11,9 +13,18 @@ import type { LoroStoreLike } from './use-browser-local-canvas-controller.js'
 // which jsdom does not implement. A fake keeps these page-level tests scoped
 // to the switcher/create UI wiring, matching the controller test's own fake.
 class FakeLoroStore implements LoroStoreLike {
-  async save(): Promise<void> {}
+  private byId = new Map<string, Uint8Array>()
+
+  async save(id: string, bytes: Uint8Array): Promise<void> {
+    this.byId.set(id, bytes)
+  }
   createEmptySnapshot(): Uint8Array {
     return new Uint8Array([1, 2, 3])
+  }
+  async load(id: string): Promise<LoroLoadResult> {
+    const bytes = this.byId.get(id)
+    if (bytes === undefined) return { kind: 'not-found' }
+    return { kind: 'ok', snapshot: bytes }
   }
 }
 
@@ -213,6 +224,27 @@ describe('BrowserLocalCanvasPage', () => {
     expect(screen.queryByTestId('cleanup-completed')).toBeNull()
     expect(screen.queryByRole('alertdialog')).toBeNull()
     expect(screen.getByRole('main')).toBeTruthy()
+  })
+
+  it('duplicates the canvas and switches to the copy when Duplicate is clicked', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const loro = new FakeLoroStore()
+    const seed = new Loro()
+    seed.getList('elements').push({ id: 'rect-1' })
+    await loro.save('c1', seed.export({ mode: 'snapshot' }))
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={loro} />)
+    })
+    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i })
+    await act(async () => {
+      duplicateBtn.click()
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled (copy)')
+    })
   })
 
   it('renders a human-readable save status instead of the raw state enum', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -247,6 +247,65 @@ describe('BrowserLocalCanvasPage', () => {
     })
   })
 
+  it('disables the Duplicate button while a duplicate is in flight, and double-clicking produces exactly one copy', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const loro = new FakeLoroStore()
+    const seed = new Loro()
+    seed.getList('elements').push({ id: 'rect-1' })
+    await loro.save('c1', seed.export({ mode: 'snapshot' }))
+    // Defer the Loro read so the in-flight window is observable and long
+    // enough for a second click to land before the first duplicate resolves.
+    let releaseLoad: (() => void) | undefined
+    const realLoad = loro.load.bind(loro)
+    loro.load = async (id: string) => {
+      await new Promise<void>((resolve) => {
+        releaseLoad = resolve
+      })
+      return realLoad(id)
+    }
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={loro} />)
+    })
+    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i }) as HTMLButtonElement
+    fireEvent.click(duplicateBtn)
+    await waitFor(() => expect(duplicateBtn.disabled).toBe(true))
+    // A second click while disabled must not start a second duplicate.
+    fireEvent.click(duplicateBtn)
+    await act(async () => {
+      releaseLoad?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled (copy)')
+    })
+    expect(duplicateBtn.disabled).toBe(false)
+    const list = await store.listCanvases()
+    expect(list.filter((c) => c.name === 'untitled (copy)')).toHaveLength(1)
+  })
+
+  it('shows an alert and re-enables the Duplicate button when duplicateCanvas fails', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const loro = new FakeLoroStore()
+    await loro.save('c1', new Loro().export({ mode: 'snapshot' }))
+    loro.load = async () => ({ kind: 'corrupt-snapshot' })
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={loro} />)
+    })
+    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i }) as HTMLButtonElement
+    await act(async () => {
+      duplicateBtn.click()
+    })
+    expect((await screen.findByRole('alert')).textContent).toMatch(/duplicat/i)
+    expect(duplicateBtn.disabled).toBe(false)
+    // No switch happened — still on the source canvas.
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+  })
+
   it('renders a human-readable save status instead of the raw state enum', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -91,6 +91,7 @@ export function BrowserLocalCanvasPage({
     listCanvases,
     createCanvas,
     switchCanvas,
+    duplicateCanvas,
   } = useBrowserLocalCanvasController(store, loro)
 
   // Stable across re-renders so DaemonDetectedBanner's dismissal state isn't
@@ -262,6 +263,14 @@ export function BrowserLocalCanvasPage({
           Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
           combining changes
         </span>
+        <button
+          type="button"
+          aria-label="Duplicate canvas"
+          onClick={() => void duplicateCanvas()}
+          className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"
+        >
+          Duplicate
+        </button>
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <button

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -98,6 +98,25 @@ export function BrowserLocalCanvasPage({
   // re-read from localStorage on every render.
   const [settingsStore] = useState(() => createUserSettingsStore())
 
+  // duplicateCanvas() rejects on failure (see the controller hook) rather
+  // than carrying its own error/pending state, so this page owns both: a
+  // disable-while-in-flight guard (a second click during the async
+  // read-then-write must not start a second copy) and the error surface.
+  const [isDuplicating, setIsDuplicating] = useState(false)
+  const [duplicateError, setDuplicateError] = useState<string | null>(null)
+  const handleDuplicate = async () => {
+    if (isDuplicating) return
+    setIsDuplicating(true)
+    setDuplicateError(null)
+    try {
+      await duplicateCanvas()
+    } catch (err) {
+      setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate canvas.')
+    } finally {
+      setIsDuplicating(false)
+    }
+  }
+
   // Owned locally rather than threaded down from App.tsx: useThemeMode already
   // persists to localStorage and applies the <html class="dark"> toggle
   // itself, so there is no App-level state this page needs to share.
@@ -259,6 +278,11 @@ export function BrowserLocalCanvasPage({
             {cleanupError}
           </div>
         )}
+        {duplicateError && (
+          <div role="alert" aria-live="assertive" className="text-destructive">
+            {duplicateError}
+          </div>
+        )}
         <span className="ml-auto text-muted-foreground">
           Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
           combining changes
@@ -266,8 +290,9 @@ export function BrowserLocalCanvasPage({
         <button
           type="button"
           aria-label="Duplicate canvas"
-          onClick={() => void duplicateCanvas()}
-          className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"
+          disabled={isDuplicating}
+          onClick={() => void handleDuplicate()}
+          className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
         >
           Duplicate
         </button>

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -378,6 +378,154 @@ describe('DaemonIndexPage', () => {
     expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 
+  it('disables the card Duplicate button while in flight, and double-clicking produces exactly one copy', async () => {
+    let resolveSnapshot: ((res: Response) => void) | undefined
+    let snapshotCalls = 0
+    const created: Array<[string, string]> = []
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
+        return Promise.resolve(jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }] }))
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          jsonResponse({ canvases: [{ slug: 'alpha', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body)) as { slug: string }
+        created.push(['ws-a', body.slug])
+        return Promise.resolve(jsonResponse({ slug: body.slug }))
+      }
+      if (url.endsWith('/api/workspaces/ws-a/names')) {
+        return Promise.resolve(jsonResponse({ canvases: { alpha: 'Alpha' }, pinned: [] }))
+      }
+      if (url.endsWith('/api/canvas/ws-a/alpha/snapshot')) {
+        snapshotCalls++
+        return new Promise<Response>((resolve) => {
+          resolveSnapshot = resolve
+        })
+      }
+      if (/\/api\/canvas\/ws-a\/[^/]+\/update$/.test(url) && init?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ ok: true }))
+      }
+      if (/\/api\/workspaces\/ws-a\/canvases\/[^/]+\/name$/.test(url) && init?.method === 'PUT') {
+        return Promise.resolve(jsonResponse({ canvases: { alpha: 'Alpha' }, pinned: [] }))
+      }
+      return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    const duplicateBtn = (await screen.findByRole('button', {
+      name: /duplicate/i,
+    })) as HTMLButtonElement
+    fireEvent.click(duplicateBtn)
+    await waitFor(() => expect(duplicateBtn.disabled).toBe(true))
+
+    // A second click while disabled must not start a second duplicate read.
+    fireEvent.click(duplicateBtn)
+    expect(snapshotCalls).toBe(1)
+
+    resolveSnapshot?.(
+      new Response(new Uint8Array([1, 2, 3]) as BodyInit, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    )
+    await waitFor(() => expect(created).toEqual([['ws-a', 'alpha-copy']]))
+    await waitFor(() => expect(duplicateBtn.disabled).toBe(false))
+    vi.unstubAllGlobals()
+  })
+
+  it('shows an alert and re-enables the Duplicate button when duplicating fails', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      namesByWorkspace: { 'ws-a': { canvases: { alpha: 'Alpha' }, pinned: [] } },
+      // No snapshotByCanvas entry for 'alpha' -> the mock 404s the snapshot read.
+    })
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    const duplicateBtn = (await screen.findByRole('button', {
+      name: /duplicate/i,
+    })) as HTMLButtonElement
+    fireEvent.click(duplicateBtn)
+
+    expect((await screen.findByRole('alert')).textContent).toMatch(/not found/i)
+    expect(duplicateBtn.disabled).toBe(false)
+  })
+
+  it('does not apply a stale duplicate completion to a workspace the user has since switched away from', async () => {
+    let resolveSnapshot: ((res: Response) => void) | undefined
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }] }),
+        )
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          jsonResponse({ canvases: [{ slug: 'alpha', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      if (url.endsWith('/api/workspaces/ws-b/canvases') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          jsonResponse({ canvases: [{ slug: 'beta', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      if (url.endsWith('/api/workspaces/ws-a/canvases') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body)) as { slug: string }
+        return Promise.resolve(jsonResponse({ slug: body.slug }))
+      }
+      if (
+        url.endsWith('/api/workspaces/ws-a/names') ||
+        url.endsWith('/api/workspaces/ws-b/names')
+      ) {
+        return Promise.resolve(jsonResponse({ canvases: {}, pinned: [] }))
+      }
+      if (url.endsWith('/api/canvas/ws-a/alpha/snapshot')) {
+        return new Promise<Response>((resolve) => {
+          resolveSnapshot = resolve
+        })
+      }
+      if (/\/api\/canvas\/ws-a\/[^/]+\/update$/.test(url) && init?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ ok: true }))
+      }
+      if (/\/api\/workspaces\/ws-a\/canvases\/[^/]+\/name$/.test(url) && init?.method === 'PUT') {
+        return Promise.resolve(jsonResponse({ canvases: {}, pinned: [] }))
+      }
+      return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    const duplicateBtn = await screen.findByRole('button', { name: /duplicate/i })
+    fireEvent.click(duplicateBtn)
+
+    // Switch workspaces while the duplicate (still reading alpha's snapshot) is in flight.
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-b' } })
+    expect(await screen.findByText('beta')).toBeTruthy()
+
+    resolveSnapshot?.(
+      new Response(new Uint8Array([1, 2, 3]) as BodyInit, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The completed duplicate belongs to ws-a; the visible grid must still be
+    // ws-b's, untouched by ws-a's post-duplicate refresh.
+    expect(screen.getByText('beta')).toBeTruthy()
+    expect(screen.queryByText('alpha')).toBeNull()
+    expect(screen.queryByText('alpha-copy')).toBeNull()
+    vi.unstubAllGlobals()
+  })
+
   it('creates a canvas via New canvas and opens it', async () => {
     const created: Array<[string, string]> = []
     installFetchMock({

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -19,6 +19,9 @@ interface MockRoutes {
     { workspace?: string; canvases: Record<string, string>; pinned: string[] } | 'fail'
   >
   onCreateCanvas?: (workspaceId: string, slug: string) => void
+  snapshotByCanvas?: Record<string, Uint8Array>
+  onUpdateCanvas?: (workspaceId: string, slug: string, bytes: Uint8Array) => void
+  onSetCanvasName?: (workspaceId: string, slug: string, name: string) => void
 }
 
 function installFetchMock(routes: MockRoutes) {
@@ -48,6 +51,37 @@ function installFetchMock(routes: MockRoutes) {
         return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
       }
       return Promise.resolve(jsonResponse(names))
+    }
+    const snapshotMatch = url.match(/\/api\/canvas\/([^/]+)\/([^/]+)\/snapshot$/)
+    if (snapshotMatch) {
+      const slug = decodeURIComponent(snapshotMatch[2])
+      const bytes = routes.snapshotByCanvas?.[slug]
+      if (!bytes) return Promise.resolve(jsonResponse({ title: 'Not found' }, 404))
+      return Promise.resolve(
+        new Response(bytes as BodyInit, {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' },
+        }),
+      )
+    }
+    const updateMatch = url.match(/\/api\/canvas\/([^/]+)\/([^/]+)\/update$/)
+    if (updateMatch && init?.method === 'POST') {
+      const workspaceId = decodeURIComponent(updateMatch[1])
+      const slug = decodeURIComponent(updateMatch[2])
+      routes.onUpdateCanvas?.(workspaceId, slug, new Uint8Array(init.body as ArrayBuffer))
+      return Promise.resolve(jsonResponse({ ok: true }))
+    }
+    const canvasNameMatch = url.match(/\/api\/workspaces\/([^/]+)\/canvases\/([^/]+)\/name$/)
+    if (canvasNameMatch && init?.method === 'PUT') {
+      const workspaceId = decodeURIComponent(canvasNameMatch[1])
+      const slug = decodeURIComponent(canvasNameMatch[2])
+      const body = JSON.parse(String(init.body)) as { name: string }
+      routes.onSetCanvasName?.(workspaceId, slug, body.name)
+      const names = routes.namesByWorkspace?.[workspaceId]
+      const canvases = names && names !== 'fail' ? names.canvases : {}
+      return Promise.resolve(
+        jsonResponse({ canvases: { ...canvases, [slug]: body.name }, pinned: [] }),
+      )
     }
     return Promise.resolve(jsonResponse({}, 404))
   })
@@ -312,6 +346,36 @@ describe('DaemonIndexPage', () => {
     fireEvent.click(card)
 
     expect(onOpenCanvas).toHaveBeenCalledExactlyOnceWith('ws-a', 'alpha')
+  })
+
+  it('duplicates a canvas via its card Duplicate action without opening it', async () => {
+    const updates: Array<[string, string, Uint8Array]> = []
+    const created: Array<[string, string]> = []
+    const names: Array<[string, string, string]> = []
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      namesByWorkspace: { 'ws-a': { canvases: { alpha: 'Alpha' }, pinned: [] } },
+      snapshotByCanvas: { alpha: new Uint8Array([1, 2, 3]) },
+      onCreateCanvas: (workspaceId, slug) => created.push([workspaceId, slug]),
+      onUpdateCanvas: (workspaceId, slug, bytes) => updates.push([workspaceId, slug, bytes]),
+      onSetCanvasName: (workspaceId, slug, name) => names.push([workspaceId, slug, name]),
+    })
+    const onOpenCanvas = vi.fn()
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={onOpenCanvas} />)
+    const duplicateBtn = await screen.findByRole('button', { name: /duplicate/i })
+    fireEvent.click(duplicateBtn)
+
+    await waitFor(() => {
+      expect(created).toEqual([['ws-a', 'alpha-copy']])
+    })
+    expect(updates).toEqual([['ws-a', 'alpha-copy', new Uint8Array([1, 2, 3])]])
+    expect(names).toEqual([['ws-a', 'alpha-copy', 'Alpha (copy)']])
+    // Clicking the Duplicate action must not also open the source canvas.
+    expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 
   it('creates a canvas via New canvas and opens it', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -7,9 +7,14 @@ import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import {
   createCanvas,
   createDaemonFetch,
+  getCanvasSnapshot,
   listCanvases,
   listWorkspaces,
+  setCanvasName,
+  updateCanvas,
 } from '../lib/daemon-api-client.js'
+import { deriveCopyName } from '../lib/derive-copy-name.js'
+import { deriveCopySlug } from '../lib/derive-copy-slug.js'
 import type { WhiteboardCapabilities } from '../lib/provider.js'
 
 // A gallery for a connected daemon, scoped to ONE workspace at a time — the
@@ -107,6 +112,7 @@ export function DaemonIndexPage({
   const [newCanvasSlug, setNewCanvasSlug] = useState('')
   const [loadError, setLoadError] = useState<string | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
+  const [duplicateError, setDuplicateError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -196,6 +202,37 @@ export function DaemonIndexPage({
     }
   }, [daemonFetch, daemonBaseUrl, selectedWorkspace, newCanvasSlug, onOpenCanvas])
 
+  // Client-side copy through EXISTING daemon HTTP endpoints only (read
+  // snapshot -> create canvas -> write snapshot -> rename), matching the
+  // browser-local controller's read-then-write duplicate flow rather than
+  // requiring a dedicated server-side "duplicate" endpoint.
+  const handleDuplicate = useCallback(
+    async (sourceSlug: string) => {
+      if (!selectedWorkspace) return
+      setDuplicateError(null)
+      const sourceRow = rows.find((r) => r.slug === sourceSlug)
+      try {
+        const snapshot = await getCanvasSnapshot(
+          daemonFetch,
+          daemonBaseUrl,
+          selectedWorkspace,
+          sourceSlug,
+        )
+        const existingSlugs = new Set(rows.map((r) => r.slug))
+        const newSlug = deriveCopySlug(sourceSlug, existingSlugs)
+        const created = await createCanvas(daemonFetch, daemonBaseUrl, selectedWorkspace, newSlug)
+        await updateCanvas(daemonFetch, daemonBaseUrl, selectedWorkspace, created.slug, snapshot)
+        const existingNames = new Set(rows.map((r) => r.displayName))
+        const newName = deriveCopyName(sourceRow?.displayName ?? sourceSlug, existingNames)
+        await setCanvasName(daemonFetch, daemonBaseUrl, selectedWorkspace, created.slug, newName)
+        await loadWorkspace(selectedWorkspace, () => false)
+      } catch (err) {
+        setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate canvas.')
+      }
+    },
+    [daemonFetch, daemonBaseUrl, selectedWorkspace, rows, loadWorkspace],
+  )
+
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       <div className="flex h-dvh flex-col overflow-y-auto p-4">
@@ -279,6 +316,11 @@ export function DaemonIndexPage({
             {createError}
           </div>
         )}
+        {duplicateError && (
+          <div role="alert" className="mb-2 text-sm text-destructive">
+            {duplicateError}
+          </div>
+        )}
 
         {tab === 'storage' ? (
           <StorageReportCard />
@@ -293,33 +335,54 @@ export function DaemonIndexPage({
             {visible.map((row) => {
               const hasDisplayName = row.displayName !== row.slug
               return (
-                <button
+                <div
                   key={row.slug}
-                  type="button"
                   data-testid="daemon-index-canvas-card"
                   onClick={() => selectedWorkspace && onOpenCanvas(selectedWorkspace, row.slug)}
-                  className="flex flex-col gap-2 rounded-lg border p-2 text-left hover:bg-accent"
+                  className="group relative rounded-lg border hover:bg-accent"
                 >
-                  <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
-                  <div className="min-w-0">
-                    {hasDisplayName && (
-                      <div className="truncate text-sm font-medium">{row.displayName}</div>
-                    )}
-                    <div
-                      data-testid="canvas-slug"
-                      className={
-                        hasDisplayName
-                          ? 'truncate text-xs text-muted-foreground'
-                          : 'truncate text-sm font-medium'
-                      }
-                    >
-                      {row.slug}
+                  <button
+                    type="button"
+                    onClick={() => selectedWorkspace && onOpenCanvas(selectedWorkspace, row.slug)}
+                    className="flex w-full flex-col gap-2 p-2 text-left"
+                  >
+                    <CanvasThumb
+                      workspaceId={selectedWorkspace ?? ''}
+                      slug={row.slug}
+                      size="card"
+                    />
+                    <div className="min-w-0">
+                      {hasDisplayName && (
+                        <div className="truncate text-sm font-medium">{row.displayName}</div>
+                      )}
+                      <div
+                        data-testid="canvas-slug"
+                        className={
+                          hasDisplayName
+                            ? 'truncate text-xs text-muted-foreground'
+                            : 'truncate text-sm font-medium'
+                        }
+                      >
+                        {row.slug}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatRelative(row.updatedAt)}
+                      </div>
                     </div>
-                    <div className="text-xs text-muted-foreground">
-                      {formatRelative(row.updatedAt)}
-                    </div>
-                  </div>
-                </button>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Duplicate ${hasDisplayName ? row.displayName : row.slug}`}
+                    onClick={(event) => {
+                      // Prevents the click from bubbling to the wrapping open-button.
+                      event.stopPropagation()
+                      void handleDuplicate(row.slug)
+                    }}
+                    className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100"
+                  >
+                    Duplicate
+                  </button>
+                </div>
               )
             })}
           </div>

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -1,6 +1,6 @@
 import { workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { z } from 'zod'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CanvasThumb } from '../components/CanvasThumb.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
@@ -113,6 +113,18 @@ export function DaemonIndexPage({
   const [loadError, setLoadError] = useState<string | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
+  // Which card's Duplicate action is currently in flight — disables just that
+  // card's button (a second click during the async read-then-write must not
+  // start a second copy) rather than a page-wide boolean.
+  const [duplicatingSlug, setDuplicatingSlug] = useState<string | null>(null)
+
+  // Always-current mirror of selectedWorkspace for handleDuplicate's async
+  // completion check below: a plain ref write during render (not inside an
+  // effect) is safe here because it never triggers a re-render itself, and
+  // it must reflect the LATEST selection synchronously, including the very
+  // render that changes it — an effect-synced ref would lag by one render.
+  const selectedWorkspaceRef = useRef(selectedWorkspace)
+  selectedWorkspaceRef.current = selectedWorkspace
 
   useEffect(() => {
     let cancelled = false
@@ -208,29 +220,43 @@ export function DaemonIndexPage({
   // requiring a dedicated server-side "duplicate" endpoint.
   const handleDuplicate = useCallback(
     async (sourceSlug: string) => {
-      if (!selectedWorkspace) return
+      if (duplicatingSlug !== null) return
+      const workspaceAtStart = selectedWorkspace
+      if (!workspaceAtStart) return
+      setDuplicatingSlug(sourceSlug)
       setDuplicateError(null)
       const sourceRow = rows.find((r) => r.slug === sourceSlug)
+      // The whole operation targets workspaceAtStart, not whatever the user
+      // has switched the selector to by the time each await resolves — a
+      // duplicate started in one workspace must finish in that SAME
+      // workspace even if the user has since switched away from it. Applying
+      // its completion (the rows refresh) to the page is gated separately,
+      // below, on whether that workspace is still the one being viewed.
       try {
         const snapshot = await getCanvasSnapshot(
           daemonFetch,
           daemonBaseUrl,
-          selectedWorkspace,
+          workspaceAtStart,
           sourceSlug,
         )
         const existingSlugs = new Set(rows.map((r) => r.slug))
         const newSlug = deriveCopySlug(sourceSlug, existingSlugs)
-        const created = await createCanvas(daemonFetch, daemonBaseUrl, selectedWorkspace, newSlug)
-        await updateCanvas(daemonFetch, daemonBaseUrl, selectedWorkspace, created.slug, snapshot)
+        const created = await createCanvas(daemonFetch, daemonBaseUrl, workspaceAtStart, newSlug)
+        await updateCanvas(daemonFetch, daemonBaseUrl, workspaceAtStart, created.slug, snapshot)
         const existingNames = new Set(rows.map((r) => r.displayName))
         const newName = deriveCopyName(sourceRow?.displayName ?? sourceSlug, existingNames)
-        await setCanvasName(daemonFetch, daemonBaseUrl, selectedWorkspace, created.slug, newName)
-        await loadWorkspace(selectedWorkspace, () => false)
+        await setCanvasName(daemonFetch, daemonBaseUrl, workspaceAtStart, created.slug, newName)
+        const isStale = () => selectedWorkspaceRef.current !== workspaceAtStart
+        if (isStale()) return
+        await loadWorkspace(workspaceAtStart, isStale)
       } catch (err) {
+        if (selectedWorkspaceRef.current !== workspaceAtStart) return
         setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate canvas.')
+      } finally {
+        setDuplicatingSlug((current) => (current === sourceSlug ? null : current))
       }
     },
-    [daemonFetch, daemonBaseUrl, selectedWorkspace, rows, loadWorkspace],
+    [daemonFetch, daemonBaseUrl, selectedWorkspace, rows, loadWorkspace, duplicatingSlug],
   )
 
   return (
@@ -373,12 +399,13 @@ export function DaemonIndexPage({
                   <button
                     type="button"
                     aria-label={`Duplicate ${hasDisplayName ? row.displayName : row.slug}`}
+                    disabled={duplicatingSlug === row.slug}
                     onClick={(event) => {
                       // Prevents the click from bubbling to the wrapping open-button.
                       event.stopPropagation()
                       void handleDuplicate(row.slug)
                     }}
-                    className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100"
+                    className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-100 disabled:cursor-not-allowed"
                   >
                     Duplicate
                   </button>

--- a/apps/web/src/pages/use-browser-local-canvas-controller.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.multi-canvas.browser.test.tsx
@@ -119,4 +119,36 @@ describe('multi-canvas foundation (browser — real IndexedDB)', () => {
     expect(result.current.snapshot?.id).toBe(idA)
     expect(await store.getDefaultCanvasId()).toBe(idA)
   })
+
+  it('duplicateCanvas deep-copies the real IndexedDB-backed Loro doc: later edits to the source never appear in the copy', async () => {
+    const store = new IndexedDBStore()
+    const loro = new LoroStore()
+    const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+    await waitFor(() => expect(result.current.snapshot).not.toBeNull())
+    const sourceId = result.current.snapshot!.id
+    await loro.save(sourceId, snapshotWithElements([{ id: 'original-element' }]))
+
+    let duplicated: Awaited<ReturnType<typeof result.current.duplicateCanvas>> | undefined
+    await act(async () => {
+      duplicated = await result.current.duplicateCanvas()
+    })
+    expect(duplicated?.id).not.toBe(sourceId)
+    expect(result.current.snapshot?.id).toBe(duplicated?.id)
+
+    // Edit the SOURCE canvas's real IndexedDB record after duplicating.
+    const loadedSource = await loro.load(sourceId)
+    expect(loadedSource.kind).toBe('ok')
+    if (loadedSource.kind !== 'ok') return
+    const sourceDoc = new Loro()
+    sourceDoc.import(loadedSource.snapshot)
+    sourceDoc.getList('elements').push({ id: 'added-after-duplicate' })
+    await loro.save(sourceId, sourceDoc.export({ mode: 'snapshot' }))
+
+    const loadedCopy = await loro.load(duplicated!.id)
+    expect(loadedCopy.kind).toBe('ok')
+    if (loadedCopy.kind !== 'ok') return
+    const copyDoc = new Loro()
+    copyDoc.import(loadedCopy.snapshot)
+    expect(copyDoc.getList('elements').toJSON()).toEqual([{ id: 'original-element' }])
+  })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.test.ts
@@ -1,7 +1,9 @@
 import { act, renderHook } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
+import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import {
   type LoroStoreLike,
@@ -11,10 +13,12 @@ import {
 class FakeLoroStore implements LoroStoreLike {
   saved: Array<{ id: string; bytes: Uint8Array }> = []
   shouldThrow = false
+  private byId = new Map<string, Uint8Array>()
 
   async save(id: string, bytes: Uint8Array): Promise<void> {
     if (this.shouldThrow) throw new Error('loro save failed')
     this.saved.push({ id, bytes })
+    this.byId.set(id, bytes)
   }
 
   createEmptySnapshot(): Uint8Array {
@@ -22,6 +26,22 @@ class FakeLoroStore implements LoroStoreLike {
     // the isolation LoroStoreLike is meant to provide to this test file.
     return new Uint8Array([1, 2, 3])
   }
+
+  async load(id: string): Promise<LoroLoadResult> {
+    const bytes = this.byId.get(id)
+    if (bytes === undefined) return { kind: 'not-found' }
+    return { kind: 'ok', snapshot: bytes }
+  }
+}
+
+// duplicateCanvas runs the real loro-crdt merge/export (mergeToSnapshot),
+// so its tests need real Loro bytes rather than the fake's placeholder
+// `[1, 2, 3]` — that would throw when mergeToSnapshot tries to import it.
+function realSnapshotWithElements(elements: unknown[]): Uint8Array {
+  const doc = new Loro()
+  const list = doc.getList('elements')
+  for (const el of elements) list.push(el)
+  return doc.export({ mode: 'snapshot' })
 }
 
 const snap: CanvasSnapshot = {
@@ -860,6 +880,136 @@ describe('useBrowserLocalCanvasController', () => {
         kind: 'ok',
         snapshot: { ...snap, name: 'Second rename', updatedAt: expect.any(String) },
       })
+    })
+  })
+
+  describe('duplicateCanvas', () => {
+    it('creates a new canvas named "<name> (copy)", copies the Loro bytes, and switches to it', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      await loro.save('c1', realSnapshotWithElements([{ id: 'rect-1' }]))
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let duplicated: CanvasSnapshot | undefined
+      await act(async () => {
+        duplicated = await result.current.duplicateCanvas()
+      })
+
+      expect(duplicated?.name).toBe('untitled (copy)')
+      expect(duplicated?.id).not.toBe('c1')
+      // switched to the duplicate
+      expect(result.current.snapshot?.id).toBe(duplicated?.id)
+      expect(await store.getDefaultCanvasId()).toBe(duplicated?.id)
+
+      const copiedLoro = await loro.load(duplicated!.id)
+      expect(copiedLoro.kind).toBe('ok')
+      if (copiedLoro.kind === 'ok') {
+        const doc = new Loro()
+        doc.import(copiedLoro.snapshot)
+        expect(doc.getList('elements').toJSON()).toEqual([{ id: 'rect-1' }])
+      }
+    })
+
+    it('increments the numeric suffix when "(copy)" is already taken', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      await store.save({ id: 'existing-copy', name: 'untitled (copy)', updatedAt: snap.updatedAt })
+      const loro = new FakeLoroStore()
+      await loro.save('c1', realSnapshotWithElements([]))
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let duplicated: CanvasSnapshot | undefined
+      await act(async () => {
+        duplicated = await result.current.duplicateCanvas()
+      })
+
+      expect(duplicated?.name).toBe('untitled (copy 2)')
+    })
+
+    it('flushes a pending rename before duplicating, so the copy is named from the latest title', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      await loro.save('c1', realSnapshotWithElements([]))
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      act(() => {
+        result.current.renameCanvas('Renamed before duplicate')
+      })
+
+      let duplicated: CanvasSnapshot | undefined
+      await act(async () => {
+        duplicated = await result.current.duplicateCanvas()
+      })
+
+      expect(duplicated?.name).toBe('Renamed before duplicate (copy)')
+    })
+
+    it('rolls back the metadata row when the Loro write fails', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      await loro.save('c1', realSnapshotWithElements([]))
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      loro.shouldThrow = true
+      let thrown: unknown
+      await act(async () => {
+        try {
+          await result.current.duplicateCanvas()
+        } catch (err) {
+          thrown = err
+        }
+      })
+      expect(thrown).toBeDefined()
+
+      const list = await store.listCanvases()
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe('c1')
+      // Never switched away from the source canvas on failure.
+      expect(result.current.snapshot?.id).toBe('c1')
+    })
+
+    it('duplicating twice never mutates the original: editing the source after duplicating leaves the copy unchanged', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      await loro.save('c1', realSnapshotWithElements([{ id: 'original-element' }]))
+      const { result } = renderHook(() => useBrowserLocalCanvasController(store, loro))
+      await act(async () => {})
+
+      let duplicated: CanvasSnapshot | undefined
+      await act(async () => {
+        duplicated = await result.current.duplicateCanvas()
+      })
+
+      // Edit the ORIGINAL's stored Loro bytes directly (simulating further
+      // edits to the source canvas after duplicating) and confirm the
+      // duplicate's already-copied bytes are untouched.
+      const loadedOriginal = await loro.load('c1')
+      if (loadedOriginal.kind !== 'ok') throw new Error('unexpected load failure')
+      const originalDoc = new Loro()
+      originalDoc.import(loadedOriginal.snapshot)
+      originalDoc.getList('elements').push({ id: 'added-after-duplicate' })
+      await loro.save('c1', originalDoc.export({ mode: 'snapshot' }))
+
+      const copiedLoro = await loro.load(duplicated!.id)
+      expect(copiedLoro.kind).toBe('ok')
+      if (copiedLoro.kind === 'ok') {
+        const doc = new Loro()
+        doc.import(copiedLoro.snapshot)
+        expect(doc.getList('elements').toJSON()).toEqual([{ id: 'original-element' }])
+      }
     })
   })
 })

--- a/apps/web/src/pages/use-browser-local-canvas-controller.ts
+++ b/apps/web/src/pages/use-browser-local-canvas-controller.ts
@@ -1,14 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { mergeToSnapshot } from '../components/migration/import-browser-local.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { LoroStore } from '../lib/loro-store.js'
+import type { LoroLoadResult } from '../lib/loro-store.js'
+import { deriveCopyName } from '../lib/derive-copy-name.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 
-// Narrow surface used by the controller to seed a new canvas's Loro doc.
-// Injectable so node/jsdom tests can supply an in-memory fake instead of
-// touching real IndexedDB or the loro-crdt library directly.
+// Narrow surface used by the controller to seed a new canvas's Loro doc (and,
+// for duplicateCanvas, to read one back). Injectable so node/jsdom tests can
+// supply an in-memory fake instead of touching real IndexedDB or the
+// loro-crdt library directly.
 export interface LoroStoreLike {
   save(canvasId: string, snapshot: Uint8Array): Promise<void>
   createEmptySnapshot(): Uint8Array
+  load(canvasId: string): Promise<LoroLoadResult>
 }
 
 export type BrowserLocalPersistenceState =
@@ -31,6 +36,10 @@ export interface BrowserLocalCanvasController {
   listCanvases(): Promise<CanvasSnapshot[]>
   createCanvas(name?: string): Promise<CanvasSnapshot>
   switchCanvas(id: string): Promise<void>
+  // Duplicates the CURRENTLY open canvas (flushing any pending edit first so
+  // the copy reflects the latest state) under a derived "<name> (copy)" name,
+  // then switches to it — matching the create-then-open flow the UI expects.
+  duplicateCanvas(): Promise<CanvasSnapshot>
 }
 
 function createCanvasSnapshot(id: string, name?: string): CanvasSnapshot {
@@ -330,6 +339,45 @@ export function useBrowserLocalCanvasController(
     [flushSave],
   )
 
+  // Reads the source canvas's Loro record through mergeToSnapshot (the same
+  // snapshot+delta-log -> single-snapshot collapse the browser-local ->
+  // daemon copy-first import path already uses) so the duplicate is a true
+  // deep copy: a fresh Uint8Array with no shared reference to the source's
+  // bytes, deltas, or underlying LoroDoc.
+  const duplicateCanvas = useCallback(async (): Promise<CanvasSnapshot> => {
+    const flushed = await flushSave()
+    if (!flushed) throw new Error('Failed to save pending changes before duplicating.')
+    const source = snapshotRef.current
+    if (source === null) throw new Error('No canvas is open to duplicate.')
+
+    const loroResult = await loroRef.current.load(source.id)
+    if (loroResult.kind !== 'ok') {
+      throw new Error('The canvas data could not be read for duplication.')
+    }
+    const mergedSnapshot = mergeToSnapshot(loroResult.snapshot, loroResult.deltas ?? [])
+
+    const existingList = await storeRef.current.listCanvases()
+    const existingNames = new Set(existingList.map((c) => c.name))
+    const newName = deriveCopyName(source.name, existingNames)
+
+    const id = storeRef.current.generateId()
+    const fresh = createCanvasSnapshot(id, newName)
+    await storeRef.current.save(fresh)
+    try {
+      await loroRef.current.save(id, mergedSnapshot)
+    } catch (err) {
+      try {
+        await storeRef.current.removeCanvas?.(id)
+      } catch {
+        // Orphan cleanup is best-effort; leaving a stray metadata row is harmless.
+      }
+      throw err
+    }
+
+    await switchCanvas(id)
+    return fresh
+  }, [flushSave, switchCanvas])
+
   return {
     snapshot,
     persistence,
@@ -341,5 +389,6 @@ export function useBrowserLocalCanvasController(
     listCanvases,
     createCanvas,
     switchCanvas,
+    duplicateCanvas,
   }
 }


### PR DESCRIPTION
## Summary

Dogfood-sourced gap (reported by two personas): no way to reuse an existing canvas as a starting point anywhere in the UI.

- **Browser-local**: `duplicateCanvas` on the canvas controller — deep copy via the snapshot-merge path (CRDT-safe), deterministic `deriveCopyName` collision handling ("foo (copy)", "foo (copy 2)"), rollback on failure — with a Duplicate button next to Delete on the page.
- **Daemon gallery**: Duplicate action on each canvas card, implemented client-side over EXISTING daemon endpoints only (read snapshot → create with a `deriveCopySlug`-derived slug (daemon slugs are ASCII-restricted, so display-name and slug derivation are separate helpers) → write bytes → set display name). No new server endpoint. Cards were restructured from a single `<button>` to div+child-buttons to avoid nested-button markup; the whole-card click still opens the canvas.

## Test plan

- [x] Deep-copy independence proven against real IndexedDB (web-browser project): edits to the original after duplication never leak into the copy
- [x] apps/web vitest 832/832; web-browser 105/105; typecheck clean
- [x] Collision handling for both display names and daemon slugs unit-tested