### PR TITLE
perf(web): drop the loro-crdt manualChunks rule that dragged it into the entry's critical path

### DIFF
--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -41,17 +41,16 @@ const BUDGETS = [
   },
 ]
 
-// Regression stop at today's measured critical-path size (~119 KB) after
-// Stage 2 of tmp/issues/apps-web-entry-bundle-over-budget.md's plan:
-// React.lazy on both canvas pages (BrowserLocalCanvasPage and the earlier
-// DaemonCanvasPage) keeps Excalidraw's ~400 KB out of the initial paint
-// entirely. vendor-loro-crdt (~23 KB) still ships eagerly — some module in
-// App.tsx's static import graph reaches it, and vite-plugin-top-level-await
-// propagates a synchronous import for any TLA-using chunk up to whichever
-// entry point reaches it, even through code that itself only calls into
-// loro-crdt from a lazy branch. ~10% headroom over the measured number, not
-// the aspirational floor.
-const CRITICAL_PATH_BUDGET_KB = 135
+// Regression stop at today's measured critical-path size (~97.7 KB) after
+// Stage 2 of tmp/issues/apps-web-entry-bundle-over-budget.md's plan
+// (React.lazy on both canvas pages keeps Excalidraw's ~400 KB out of the
+// initial paint) plus dropping vendor-loro-crdt's own manualChunks bucket
+// (tmp/issues/vendor-loro-eager-modulepreload.md): that bucket had been
+// accidentally co-locating vite's shared dynamic-import helper with loro's
+// WASM bindings, forcing the entry to eagerly load ~23 KB it never uses on
+// the critical path. ~10% headroom over the measured number, not the
+// aspirational floor.
+const CRITICAL_PATH_BUDGET_KB = 108
 
 let failures = 0
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -120,12 +120,31 @@ export default defineConfig({
           chunkInfo.name === 'DaemonCanvasPage'
             ? 'assets/daemon-canvas-[hash].js'
             : 'assets/[name]-[hash].js',
-        // Isolate loro-crdt and React into their own named vendor chunks
-        // instead of letting Rollup's automatic chunking scatter them across
-        // shared chunks. This does not shrink total transfer on its own — it
-        // separates what changes (app code) from what doesn't (vendor code),
-        // so a deploy that only touches app code doesn't invalidate the
-        // (much larger) vendor caches.
+        // Isolate React into its own named vendor chunk instead of letting
+        // Rollup's automatic chunking scatter it across shared chunks. This
+        // does not shrink total transfer on its own — it separates what
+        // changes (app code) from what doesn't (vendor code), so a deploy
+        // that only touches app code doesn't invalidate the (much larger)
+        // vendor cache.
+        //
+        // Deliberately NOT doing the same for loro-crdt (dropped after
+        // apps/web/scripts/smoke-bundle-size.mjs caught it regressing the
+        // critical path back to ~120KB): loro-crdt is only ever imported from
+        // lazy-reachable modules (useCanvasSync, browser-local-backend, the
+        // migration import panel), so Rollup's automatic chunking already
+        // isolates it into a chunk those lazy consumers share — no manual
+        // rule needed. Forcing it into one named `vendor-loro-crdt` chunk
+        // made vite-plugin-top-level-await's own shared dynamic-import
+        // helper (used to sequence every React.lazy() call against any
+        // in-flight top-level await) land in the SAME physical chunk as
+        // loro's WASM bindings, because that helper has no manual-chunk
+        // assignment of its own and Rollup co-locates unassigned shared
+        // modules with whichever named chunk also needs them. Since the
+        // entry imports that helper synchronously for its own React.lazy()
+        // calls, and the top-level-await plugin requires every importer of
+        // a TLA-bearing chunk to also import (and await) its `__tla` export,
+        // the entry ended up eagerly loading the whole vendor-loro-crdt
+        // chunk through a dependency that had nothing to do with loro.
         //
         // Deliberately NOT grouping @excalidraw/* the same way: Excalidraw's
         // own dist already dynamically imports its heavy optional features
@@ -140,7 +159,6 @@ export default defineConfig({
         // what actually keeps it out of the initial paint.
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined
-          if (id.includes('loro-crdt')) return 'vendor-loro-crdt'
           if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('scheduler')) {
             return 'vendor-react'
           }


### PR DESCRIPTION
## Summary

After #192, `vendor-loro-crdt` (~23KB gz) was still eagerly modulepreloaded from the entry even though every loro importer is lazy-reachable-only. Root cause was NOT top-level-await propagation per se: the `manualChunks` substring rule (`id.includes('loro-crdt')`) forced loro into a named chunk, and Rollup co-located Vite's shared `preload-helper.js` (used by every `React.lazy` call site, unmatched by any manualChunks rule) into that same chunk. `vite-plugin-top-level-await` then required the entry's synchronous preload-helper import to also await that chunk's `__tla` — dragging the whole loro WASM binding chunk into the entry's modulepreload list.

Fix: remove the loro-crdt branch from `manualChunks` (vendor-react stays). Rollup's automatic chunking already splits loro into a single shared lazy chunk across its three lazy consumers; the entry's static import disappears and `preload-helper` gets its own tiny chunk.

**Critical path: 119.8KB → 97.7KB gz.** Budget tightened 135KB → 108KB (+10% headroom over measurement).

Build-config-only change — no lazy-loading semantics or loro init timing touched.

## Test plan

- [x] Mutation-checked both ways: reverting the fix fails the tightened gate at 119.8KB; restoring passes at 97.7KB
- [x] vendor-loro-crdt gone from index.html's modulepreload list (gate file-list verified)
- [x] apps/web vitest 808/808; web-browser 104/104 incl. #wb= pairing and browser-local flows; typecheck clean