### PR TITLE
fix(mcp-server): remove the unused create_canvas issueNumber slug prefix

### DIFF
--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -272,9 +272,9 @@ export function registerAllTools(
       description: canvasTool.description,
       inputSchema: canvasCreateInputShape,
       outputSchema: canvasCreateOutputSchema,
-      handler: async ({ slug, issueNumber, overwrite }) => {
+      handler: async ({ slug, overwrite }) => {
         const result = await withDaemon((client) =>
-          canvasTool.execute({ slug, issueNumber, overwrite }, workspaceId, client),
+          canvasTool.execute({ slug, overwrite }, workspaceId, client),
         )
         return structuredJsonResult(result)
       },

--- a/packages/mcp-server/src/server/mcp/tools/canvas.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas.test.ts
@@ -49,27 +49,12 @@ describe('canvas_create', () => {
     }) as typeof globalThis.fetch
 
     try {
-      await expect(tool.execute({ slug: 'test-canvas' }, 'test-session-id', client)).resolves.toEqual({
+      await expect(
+        tool.execute({ slug: 'test-canvas' }, 'test-session-id', client),
+      ).resolves.toEqual({
         id: 'test-session-id/test-canvas',
         url: 'http://localhost:3099/canvas/test-session-id/test-canvas',
       })
-    } finally {
-      globalThis.fetch = originalFetch
-    }
-  })
-
-  it('case 98', async () => {
-    const tool = createCanvasTool()
-    const originalFetch = globalThis.fetch
-    globalThis.fetch = vi.fn(async (_input: string | URL, init?: RequestInit) => {
-      expect(init?.body).toBe(JSON.stringify({ slug: '123-my-canvas', overwrite: false }))
-      return new Response(JSON.stringify({ slug: '123-my-canvas' }), { status: 200 })
-    }) as typeof globalThis.fetch
-
-    try {
-      await expect(
-        tool.execute({ slug: 'my-canvas', issueNumber: 123 }, 'test-session-id', client),
-      ).resolves.toMatchObject({ id: 'test-session-id/123-my-canvas' })
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -79,7 +64,10 @@ describe('canvas_create', () => {
     const tool = createCanvasTool()
     const originalFetch = globalThis.fetch
     globalThis.fetch = vi.fn(
-      async () => new Response(JSON.stringify({ message: 'Canvas "duplicate" already exists' }), { status: 409 }),
+      async () =>
+        new Response(JSON.stringify({ message: 'Canvas "duplicate" already exists' }), {
+          status: 409,
+        }),
     ) as typeof globalThis.fetch
 
     try {
@@ -108,10 +96,7 @@ describe('canvas_list', () => {
       if (input.toString() === 'http://localhost:3099/api/workspaces') {
         return new Response(
           JSON.stringify({
-            workspaces: [
-              { workspaceId: 'active-session' },
-              { workspaceId: 'stale-session' },
-            ],
+            workspaces: [{ workspaceId: 'active-session' }, { workspaceId: 'stale-session' }],
           }),
           { status: 200 },
         )
@@ -196,9 +181,7 @@ describe('canvas_open', () => {
     let polls = 0
     const originalFetch = globalThis.fetch
     globalThis.fetch = vi.fn(async (url: string | URL) => {
-      expect(url.toString()).toBe(
-        'http://localhost:3099/api/canvas/sid/slug/client-count',
-      )
+      expect(url.toString()).toBe('http://localhost:3099/api/canvas/sid/slug/client-count')
       polls += 1
       const readyCount = polls >= 3 ? 1 : 0
       return new Response(JSON.stringify({ count: 1, readyCount }), { status: 200 })
@@ -335,8 +318,7 @@ describe('optimize_canvases', () => {
     const tool = optimizeCanvasesTool()
     const originalFetch = globalThis.fetch
     globalThis.fetch = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ message: 'workspace missing' }), { status: 404 }),
+      async () => new Response(JSON.stringify({ message: 'workspace missing' }), { status: 404 }),
     ) as typeof globalThis.fetch
     try {
       await expect(tool.execute({}, 'sid', client)).rejects.toThrow(/optimize|workspace missing/)

--- a/packages/mcp-server/src/server/mcp/tools/canvas.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas.ts
@@ -63,12 +63,6 @@ export const canvasCreateInputShape = {
     .describe(
       'URL-safe canvas slug (a-z, 0-9, hyphen). Used as the canvas identifier within the current workspace. Returned canvasId is "{workspaceId}/{slug}".',
     ),
-  issueNumber: z
-    .number()
-    .optional()
-    .describe(
-      'Optional GitHub issue number prefix. When set, the final slug becomes "{issueNumber}-{slug}" (e.g. issueNumber=42 + slug=login → "42-login").',
-    ),
   overwrite: z
     .boolean()
     .optional()
@@ -85,7 +79,6 @@ export function createCanvasTool() {
       type: 'object' as const,
       properties: {
         slug: { type: 'string', description: 'Canvas identifier (kebab-case)' },
-        issueNumber: { type: 'number', description: 'GitHub issue number (optional prefix)' },
         overwrite: {
           type: 'boolean',
           description:
@@ -95,22 +88,21 @@ export function createCanvasTool() {
       required: ['slug'],
     },
     execute: async (
-      args: { slug: string; issueNumber?: number; overwrite?: boolean },
+      args: { slug: string; overwrite?: boolean },
       workspaceId: string,
       client: DaemonClient,
     ): Promise<z.infer<typeof canvasCreateOutputSchema>> => {
-      const finalSlug = args.issueNumber ? `${args.issueNumber}-${args.slug}` : args.slug
       const res = await client.request(`/api/workspaces/${workspaceId}/canvases`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug: finalSlug, overwrite: args.overwrite ?? false }),
+        body: JSON.stringify({ slug: args.slug, overwrite: args.overwrite ?? false }),
       })
       if (!res.ok) {
         const body = (await res.json().catch(() => null)) as { message?: string } | null
         throw new Error(body?.message ?? `Failed to create canvas: ${res.status}`)
       }
-      const url = daemonUrl(client, `/canvas/${workspaceId}/${finalSlug}`)
-      return { id: `${workspaceId}/${finalSlug}`, url }
+      const url = daemonUrl(client, `/canvas/${workspaceId}/${args.slug}`)
+      return { id: `${workspaceId}/${args.slug}`, url }
     },
   }
 }


### PR DESCRIPTION
## Summary

`create_canvas` accepted an optional `issueNumber` that merely prefixed the slug (`{issueNumber}-{slug}`). It shipped with the initial release, was never surfaced in any UI, is GitHub-specific, and stored no structured link back to an issue — a caller can always compose the prefix themselves. Removed at the user's direction.

**Impact on callers: nothing errors.** The MCP SDK validates tool inputs with a plain `z.object()` (no `.strict()`), which silently strips unknown keys — verified in the SDK source, not assumed. A client still passing `issueNumber` simply has it ignored and the slug used as-is. Callers that relied on the prefix should pass it directly: `slug: "42-login"`.

Deliberately typed `fix:` rather than `feat!:` — release-please is configured with `bump-minor-pre-major`, so a `!`/BREAKING-CHANGE footer would move the 0.0.x line to 0.1.0, which is not warranted for dropping one unused optional field.

## Test plan

- [x] Registered `create_canvas` inputSchema before/after: `{slug, issueNumber, overwrite}` → `{slug, overwrite}` — gone from what MCP clients see
- [x] Repo-wide grep for `issueNumber`: zero matches (code, docs, README, skills, smoke)
- [x] `src/server/mcp/` 673/673; full mcp-node 3020 passed; typecheck clean; build clean; `pnpm smoke:e2e` ALL OK (create_canvas exercised)