### PR TITLE
fix(mcp-server): make restore overwrite reconcile onto the target instead of replacing it

### DIFF
--- a/packages/mcp-server/src/server/mcp/tools/version.ts
+++ b/packages/mcp-server/src/server/mcp/tools/version.ts
@@ -106,13 +106,13 @@ export const versionRestoreInputShape = {
     .string()
     .optional()
     .describe(
-      'When set, restore as a new canvas under this slug in the same workspace. Original canvas is left untouched.',
+      'When set, restore into this slug in the same workspace instead of the source canvas. Creates it if new; source canvas is left untouched either way.',
     ),
   overwrite: z
     .boolean()
     .optional()
     .describe(
-      'Only used with targetSlug. When true, replace an existing canvas at targetSlug. Default false.',
+      'Only used with targetSlug. When true and targetSlug already exists, reconciles the past version onto that canvas (same merge semantics as in-place restore, applied to the target). Default false — an existing target slug otherwise fails with output_exists.',
     ),
 } satisfies z.ZodRawShape
 
@@ -120,7 +120,7 @@ export function versionRestoreTool() {
   return {
     name: 'version_restore',
     description:
-      'Restore a saved version. Default = in-place reconcile against the source canvas. Pass targetSlug to instead write the past doc as a brand-new canvas in the same workspace (replaces the deleted checkpoint_restore flow).',
+      'Restore a saved version. Default = in-place reconcile against the source canvas. Pass targetSlug to restore into a different canvas in the same workspace instead (new if it does not exist, reconciled onto it if it does and overwrite is set; replaces the deleted checkpoint_restore flow).',
     // Derived from the Zod shape so the JSON-Schema view can never drift from
     // what registerToolWithAnnotations actually validates against.
     inputSchema: z.toJSONSchema(z.object(versionRestoreInputShape)) as {

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -834,6 +834,62 @@ describe('versions API', () => {
     expect(ids).toEqual(['added-after-v1', 'keep-me'])
   })
 
+  it('evicts the cached doc when reconcile/commit itself fails during in-place restore, not only when saveCanvas fails', async () => {
+    const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+    const initial = new LoroDoc()
+    const vv0 = initial.version()
+    const list = initial.getMovableList('elements')
+    const m0 = list.insertContainer(0, new LoroMap())
+    m0.set('id', 'keep-me')
+    initial.commit()
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: initial.export({ mode: 'update', from: vv0 }),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+    const vv1 = initial.version()
+    const m1 = list.insertContainer(list.length, new LoroMap())
+    m1.set('id', 'added-after-v1')
+    initial.commit()
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: initial.export({ mode: 'update', from: vv1 }),
+    })
+
+    expect(peekDoc('session1', 'canvas-a')).toBeDefined()
+
+    // reconcileElementsOnDoc already mutated the live cached doc by the time
+    // doc.commit() runs, so a throw here must still evict the cache -- not
+    // only the saveCanvas failure path further down.
+    const commitSpy = vi.spyOn(LoroDoc.prototype, 'commit').mockImplementationOnce(() => {
+      throw new Error('simulated commit failure')
+    })
+
+    const restoreRes = await app.request(
+      `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+      { method: 'POST' },
+    )
+    commitSpy.mockRestore()
+
+    expect(restoreRes.status).toBe(500)
+    expect(peekDoc('session1', 'canvas-a')).toBeUndefined()
+
+    const reloaded = await getDoc('session1', 'canvas-a')
+    const ids = (reloaded.getMovableList('elements').toJSON() as Array<{ id: string }>)
+      .map((el) => el.id)
+      .sort()
+    expect(ids).toEqual(['added-after-v1', 'keep-me'])
+  })
+
   it('returns 404 when restoring a missing version id', async () => {
     const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
     const res = await app.request(
@@ -926,6 +982,40 @@ describe('versions API', () => {
       }>
       const alive = elements.filter((e) => !e.isDeleted).map((e) => e.id)
       expect(alive).toEqual(['keep-me'])
+    })
+
+    it('targetSlug === slug WITHOUT overwrite still restores in place (same-slug is never treated as a distinct target)', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      const initial = new LoroDoc()
+      const vv0 = initial.version()
+      const list = initial.getMovableList('elements')
+      const m0 = list.insertContainer(0, new LoroMap())
+      m0.set('id', 'keep-me')
+      initial.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: initial.export({ mode: 'update', from: vv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-a' }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+      const body = (await restoreRes.json()) as { ok: boolean }
+      expect(body.ok).toBe(true)
     })
 
     it('restoring into a different existing canvas reconciles that canvas and broadcasts to it, not the source', async () => {

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -26,6 +26,7 @@ vi.mock('../store/doc-cache.js', async () => {
 const { clearCache, peekDoc, getDoc } = await import('../store/doc-cache.js')
 const { saveCanvas } = await import('../store/canvas-store.js')
 const { corruptStoredData } = await import('../store/corrupt-stored-data.js')
+const { setBroadcastFn } = await import('./canvas/shared.js')
 
 // Dynamically import the Hono app.
 const { createCanvasRouter, createAutoVersionTrigger } = await import('./canvas.js')
@@ -849,6 +850,321 @@ describe('versions API', () => {
       { method: 'POST' },
     )
     expect(res.status).toBe(400)
+  })
+
+  // targetSlug + overwrite must reconcile onto the target's LIVE cached doc
+  // instead of replacing persistence, so connected clients stay on the same
+  // CRDT lineage and converge through the normal update broadcast.
+  describe('overwrite restore reconciles instead of replacing', () => {
+    afterEach(() => {
+      setBroadcastFn(() => {})
+    })
+
+    it('targetSlug === slug with overwrite:true reconciles the live doc in place and broadcasts an update', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      // v1: one element.
+      const initial = new LoroDoc()
+      const vv0 = initial.version()
+      const list = initial.getMovableList('elements')
+      const m0 = list.insertContainer(0, new LoroMap())
+      m0.set('id', 'keep-me')
+      initial.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: initial.export({ mode: 'update', from: vv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      // Add a second element after v1.
+      const vv1 = initial.version()
+      const m1 = list.insertContainer(list.length, new LoroMap())
+      m1.set('id', 'added-after-v1')
+      initial.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: initial.export({ mode: 'update', from: vv1 }),
+      })
+
+      const docBefore = peekDoc('session1', 'canvas-a')
+      expect(docBefore).toBeDefined()
+
+      const broadcastCalls: Array<{ workspaceId: string; slug: string; byteLength: number }> = []
+      setBroadcastFn((workspaceId, slug, update) => {
+        broadcastCalls.push({ workspaceId, slug, byteLength: update.byteLength })
+      })
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-a', overwrite: true }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+
+      // Same object identity: the cached doc was mutated in place, not
+      // replaced by a differently-lineaged document loaded from `past`.
+      expect(peekDoc('session1', 'canvas-a')).toBe(docBefore)
+
+      expect(broadcastCalls).toHaveLength(1)
+      expect(broadcastCalls[0]?.workspaceId).toBe('session1')
+      expect(broadcastCalls[0]?.slug).toBe('canvas-a')
+      expect(broadcastCalls[0]?.byteLength).toBeGreaterThan(0)
+
+      const elements = docBefore?.getMovableList('elements').toJSON() as Array<{
+        id: string
+        isDeleted?: boolean
+      }>
+      const alive = elements.filter((e) => !e.isDeleted).map((e) => e.id)
+      expect(alive).toEqual(['keep-me'])
+    })
+
+    it('restoring into a different existing canvas reconciles that canvas and broadcasts to it, not the source', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      // Source canvas-a: v1 has only "keep-me".
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      const sourceList = sourceDoc.getMovableList('elements')
+      const sm0 = sourceList.insertContainer(0, new LoroMap())
+      sm0.set('id', 'keep-me')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      // Target canvas-b already exists with an unrelated element.
+      const targetDoc = new LoroDoc()
+      const tvv0 = targetDoc.version()
+      const targetList = targetDoc.getMovableList('elements')
+      const tm0 = targetList.insertContainer(0, new LoroMap())
+      tm0.set('id', 'b-only')
+      targetDoc.commit()
+      await app.request('/api/canvas/session1/canvas-b/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: targetDoc.export({ mode: 'update', from: tvv0 }),
+      })
+
+      const broadcastCalls: Array<{ slug: string }> = []
+      setBroadcastFn((_workspaceId, slug) => {
+        broadcastCalls.push({ slug })
+      })
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-b', overwrite: true }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+      const restoreBody = (await restoreRes.json()) as { canvasId: string; elementCount: number }
+      expect(restoreBody.canvasId).toBe('session1/canvas-b')
+
+      expect(broadcastCalls).toHaveLength(1)
+      expect(broadcastCalls[0]?.slug).toBe('canvas-b')
+
+      clearCache()
+      const { loadCanvas } = await import('../store/canvas-store.js')
+      const reloadedTarget = await loadCanvas('session1', 'canvas-b')
+      const targetElements = reloadedTarget.getMovableList('elements').toJSON() as Array<{
+        id: string
+        isDeleted?: boolean
+      }>
+      const aliveTarget = targetElements.filter((e) => !e.isDeleted).map((e) => e.id)
+      expect(aliveTarget).toEqual(['keep-me'])
+
+      // Source canvas-a is untouched.
+      const reloadedSource = await loadCanvas('session1', 'canvas-a')
+      const sourceElements = reloadedSource.getMovableList('elements').toJSON() as Array<{
+        id: string
+        isDeleted?: boolean
+      }>
+      const aliveSource = sourceElements.filter((e) => !e.isDeleted).map((e) => e.id)
+      expect(aliveSource).toEqual(['keep-me'])
+    })
+
+    it('a stale client update applied after the overwrite does not resurrect the tombstoned element', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      const sourceList = sourceDoc.getMovableList('elements')
+      const sm0 = sourceList.insertContainer(0, new LoroMap())
+      sm0.set('id', 'keep-me')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      const targetDoc = new LoroDoc()
+      const tvv0 = targetDoc.version()
+      const targetList = targetDoc.getMovableList('elements')
+      const tm0 = targetList.insertContainer(0, new LoroMap())
+      tm0.set('id', 'b-only')
+      targetDoc.commit()
+      await app.request('/api/canvas/session1/canvas-b/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: targetDoc.export({ mode: 'update', from: tvv0 }),
+      })
+
+      // Simulate a connected browser client's in-memory copy of canvas-b,
+      // captured just before the overwrite lands (same content, independent
+      // peer id via import — the same mechanism a real client uses to sync).
+      const staleClientDoc = new LoroDoc()
+      staleClientDoc.import(targetDoc.export({ mode: 'snapshot' }))
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-b', overwrite: true }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+
+      // The stale client, unaware of the restore, edits the field it still
+      // believes is alive and sends its own incremental update.
+      const staleVV = staleClientDoc.version()
+      const staleList = staleClientDoc.getMovableList('elements')
+      const staleEl = staleList.get(0) as unknown as InstanceType<typeof LoroMap>
+      staleEl.set('x', 42)
+      staleClientDoc.commit()
+      const staleUpdate = staleClientDoc.export({ mode: 'update', from: staleVV })
+
+      const updateRes = await app.request('/api/canvas/session1/canvas-b/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: staleUpdate,
+      })
+      expect(updateRes.status).toBe(200)
+
+      clearCache()
+      const { loadCanvas } = await import('../store/canvas-store.js')
+      const reloadedTarget = await loadCanvas('session1', 'canvas-b')
+      const targetElements = reloadedTarget.getMovableList('elements').toJSON() as Array<{
+        id: string
+        isDeleted?: boolean
+      }>
+      const bOnly = targetElements.find((e) => e.id === 'b-only')
+      // Because the reconcile mutated the SAME live doc lineage (rather than
+      // swapping in a differently-lineaged replacement document), the stale
+      // client's field-level edit merges without reviving the tombstone the
+      // restore set. This is the exact resurrection the old
+      // replace-persistence path allowed: a stale client's update crossing
+      // into a foreign CRDT lineage has no well-defined merge and could
+      // silently undo the restore.
+      expect(bOnly?.isDeleted).toBe(true)
+    })
+
+    it('restoring into a new (non-existent) target slug still creates it', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      const sourceList = sourceDoc.getMovableList('elements')
+      const sm0 = sourceList.insertContainer(0, new LoroMap())
+      sm0.set('id', 'keep-me')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-new' }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+      const restoreBody = (await restoreRes.json()) as { canvasId: string; elementCount: number }
+      expect(restoreBody.canvasId).toBe('session1/canvas-new')
+      expect(restoreBody.elementCount).toBe(1)
+
+      const { loadCanvas } = await import('../store/canvas-store.js')
+      const created = await loadCanvas('session1', 'canvas-new')
+      const createdElements = created.getMovableList('elements').toJSON() as Array<{ id: string }>
+      expect(createdElements.map((e) => e.id)).toEqual(['keep-me'])
+    })
+
+    it('restoring into an existing target slug WITHOUT overwrite returns 409 output_exists', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      const sourceList = sourceDoc.getMovableList('elements')
+      const sm0 = sourceList.insertContainer(0, new LoroMap())
+      sm0.set('id', 'keep-me')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      await app.request('/api/canvas/session1/canvas-b/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-b' }),
+        },
+      )
+      expect(restoreRes.status).toBe(409)
+      const body = (await restoreRes.json()) as { error: string }
+      expect(body.error).toBe('output_exists')
+    })
   })
 
   // Thumbnail PUT/GET endpoint coverage.

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -43,15 +43,15 @@ async function reconcileCommitSaveBroadcast(
   sendRestoreEvent(workspaceId, targetSlug, 'started', label)
   try {
     const prevVV = doc.version()
-    reconcileElementsOnDoc(doc, past)
-    doc.commit()
     try {
+      reconcileElementsOnDoc(doc, past)
+      doc.commit()
       await saveCanvas(workspaceId, targetSlug, doc, { overwrite: true })
     } catch (err) {
-      // reconcileElementsOnDoc + commit above already mutated the cached
-      // doc, so a failed save would otherwise leave the cache ahead of
-      // durable state. Evict it so the next read reloads the last
-      // successfully persisted snapshot.
+      // reconcileElementsOnDoc mutates the cached doc in place before
+      // commit/save run, so any failure in this block (reconcile, commit,
+      // or save) leaves the cache ahead of durable state. Evict it so the
+      // next read reloads the last successfully persisted snapshot.
       evictDoc(workspaceId, targetSlug)
       throw err
     }
@@ -126,7 +126,10 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
       }
 
       // Restore-as-new-canvas / overwrite-existing-canvas branch.
-      if (targetSlug !== undefined) {
+      // targetSlug === slug is the same document as the in-place restore
+      // below, so route it there directly instead of forcing callers to
+      // pass overwrite:true against their own canvas.
+      if (targetSlug !== undefined && targetSlug !== slug) {
         try {
           validateSlug(targetSlug)
         } catch (err) {

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import type { LoroDoc } from 'loro-crdt'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/canvas.js'
 import { reconcileElementsOnDoc } from '../../../shared/reconcile-elements.js'
-import { ConflictError, saveCanvas } from '../../store/canvas-store.js'
+import { canvasExists, ConflictError, saveCanvas } from '../../store/canvas-store.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
 import {
@@ -26,6 +26,45 @@ function countElements(doc: LoroDoc): number {
   }
 }
 
+// Reconciles `past` onto `doc` (the LIVE cached doc for workspaceId/targetSlug),
+// commits, persists, and broadcasts the resulting update. Shared by both the
+// in-place restore and the overwrite-an-existing-canvas restore, because both
+// must mutate the same document instance any connected client already holds:
+// a delta broadcast only means something against the doc it was diffed from,
+// so "overwrite" cannot be a file swap without breaking every connected peer.
+async function reconcileCommitSaveBroadcast(
+  workspaceId: string,
+  targetSlug: string,
+  doc: LoroDoc,
+  past: LoroDoc,
+  label: string | undefined,
+): Promise<void> {
+  const { sendRestoreEvent } = await import('../ws.js')
+  sendRestoreEvent(workspaceId, targetSlug, 'started', label)
+  try {
+    const prevVV = doc.version()
+    reconcileElementsOnDoc(doc, past)
+    doc.commit()
+    try {
+      await saveCanvas(workspaceId, targetSlug, doc, { overwrite: true })
+    } catch (err) {
+      // reconcileElementsOnDoc + commit above already mutated the cached
+      // doc, so a failed save would otherwise leave the cache ahead of
+      // durable state. Evict it so the next read reloads the last
+      // successfully persisted snapshot.
+      evictDoc(workspaceId, targetSlug)
+      throw err
+    }
+    const update = doc.export({ mode: 'update', from: prevVV }) as Uint8Array
+    if (update.byteLength > 0) {
+      getBroadcastFn()(workspaceId, targetSlug, update)
+    }
+  } finally {
+    // Always send complete, even on error, or the client overlay can stay locked forever.
+    sendRestoreEvent(workspaceId, targetSlug, 'complete')
+  }
+}
+
 // POST /api/workspaces/:workspaceId/canvases/:slug/versions/:id/restore
 //
 // Two modes share this endpoint:
@@ -37,10 +76,15 @@ function countElements(doc: LoroDoc): number {
 //        only in current -> set isDeleted=true (tombstone)
 //        in both         -> copy differing fields from past onto current
 //
-//   2. Restore-as-new-canvas — body `{ targetSlug, overwrite? }`.
-//      Writes the past doc as a brand-new canvas under `targetSlug` in the
-//      same workspace. The original canvas / live doc / WS clients are not
-//      touched. Replaces the deleted `checkpoint_restore` flow.
+//   2. Restore into `targetSlug` — body `{ targetSlug, overwrite? }`.
+//      If `targetSlug` does not yet exist, this writes the past doc as a
+//      brand-new canvas; the source canvas is untouched. If `targetSlug`
+//      already exists, `overwrite: true` is required, and the restore goes
+//      through the SAME reconcile-onto-the-live-doc path as mode 1, applied
+//      to the target's live doc instead of the source's — never a straight
+//      file replacement. `targetSlug === slug` collapses into mode 1.
+//      Without `overwrite`, an existing target returns 409 `output_exists`.
+//      Replaces the deleted `checkpoint_restore` flow.
 export function createRestoreRouter(options: RestoreRouterOptions) {
   const app = new Hono()
   const { versionStore } = options
@@ -81,7 +125,7 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
         return c.json({ error: 'not_found' }, 404)
       }
 
-      // Restore-as-new-canvas branch.
+      // Restore-as-new-canvas / overwrite-existing-canvas branch.
       if (targetSlug !== undefined) {
         try {
           validateSlug(targetSlug)
@@ -90,8 +134,36 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
           if (body) return c.json(body, 400)
           throw err
         }
+
+        const targetAlreadyExists = await canvasExists(workspaceId, targetSlug)
+        if (targetAlreadyExists && !overwrite) {
+          return c.json(
+            {
+              error: 'output_exists',
+              message: `Target canvas "${targetSlug}" already exists. Pass overwrite=true to replace it.`,
+            },
+            409,
+          )
+        }
+
+        if (targetAlreadyExists) {
+          // The version id belongs to the SOURCE canvas's history, so its
+          // label lives in the source's version list even though we are
+          // about to reconcile it onto the target.
+          const all = await versionStore.list(workspaceId, slug)
+          const label = all.find((v) => v.id === id)?.label
+          const targetDoc = await getDoc(workspaceId, targetSlug)
+          await reconcileCommitSaveBroadcast(workspaceId, targetSlug, targetDoc, past, label)
+          return c.json({
+            canvasId: `${workspaceId}/${targetSlug}`,
+            elementCount: countElements(targetDoc),
+          })
+        }
+
+        // Genuinely new canvas: no live doc and no connected clients, so
+        // there is nothing to reconcile against.
         try {
-          await saveCanvas(workspaceId, targetSlug, past, { overwrite })
+          await saveCanvas(workspaceId, targetSlug, past, { overwrite: false })
         } catch (err) {
           if (err instanceof ConflictError) {
             return c.json(
@@ -104,6 +176,8 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
           }
           throw err
         }
+        // Guard against a stale cache entry from a since-deleted canvas at
+        // this slug being served instead of the just-written snapshot.
         evictDoc(workspaceId, targetSlug)
         return c.json({
           canvasId: `${workspaceId}/${targetSlug}`,
@@ -114,30 +188,7 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
       // In-place reconcile branch (default).
       const all = await versionStore.list(workspaceId, slug)
       const label = all.find((v) => v.id === id)?.label
-      const { sendRestoreEvent } = await import('../ws.js')
-      sendRestoreEvent(workspaceId, slug, 'started', label)
-      try {
-        const prevVV = doc.version()
-        reconcileElementsOnDoc(doc, past)
-        doc.commit()
-        try {
-          await saveCanvas(workspaceId, slug, doc, { overwrite: true })
-        } catch (err) {
-          // reconcileElementsOnDoc + commit above already mutated the cached
-          // doc, so a failed save would otherwise leave the cache ahead of
-          // durable state. Evict it so the next read reloads the last
-          // successfully persisted snapshot.
-          evictDoc(workspaceId, slug)
-          throw err
-        }
-        const update = doc.export({ mode: 'update', from: prevVV }) as Uint8Array
-        if (update.byteLength > 0) {
-          getBroadcastFn()(workspaceId, slug, update)
-        }
-      } finally {
-        // Always send complete, even on error, or the client overlay can stay locked forever.
-        sendRestoreEvent(workspaceId, slug, 'complete')
-      }
+      await reconcileCommitSaveBroadcast(workspaceId, slug, doc, past, label)
       return c.json({ ok: true })
     } catch (err) {
       const issue = handleCorruptStoredData(err)

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -43,8 +43,11 @@ export const saveVersionRequestSchema = z.object({
 // Body is optional. Two restore modes share the same endpoint:
 //   • body absent or `targetSlug` absent — in-place reconcile against the
 //     current canvas (default; what the History panel uses).
-//   • `targetSlug` set — write the past doc as a new canvas under that slug
-//     in the same workspace. Overwrites only when `overwrite: true`.
+//   • `targetSlug` set — restore into that slug in the same workspace. If it
+//     does not exist yet, this creates it. If it already exists, `overwrite:
+//     true` is required, and the restore reconciles onto the target's live
+//     doc (same semantics as the default mode, not a persistence swap) so
+//     any client connected to that canvas stays on the same CRDT lineage.
 //     Replaces what the now-removed `checkpoint_restore` flow did.
 export const restoreVersionRequestSchema = z.object({
   targetSlug: z.string().trim().min(1).optional(),


### PR DESCRIPTION
> Stacked on #206 (base is `canvas-route-split`). GitHub will retarget this to `main` once #206 merges.

## Problem

`restore` had two branches with different semantics, and one of them was unsound.

The **in-place** restore (no `targetSlug`) reconciles the past version onto the *live* Loro doc, commits, saves, and broadcasts the resulting CRDT delta — history stays continuous and connected clients converge.

The **restore-as-new-canvas** branch (`targetSlug` + `overwrite: true`) instead *replaced persistence wholesale* with a brand-new document and merely evicted the server cache. Whenever the target was open in someone's browser — including `targetSlug === slug`, restoring a canvas onto itself, which silently bypassed the in-place path entirely — that client kept the **old** Loro doc in memory. The replacement is a different CRDT (different peer/version vectors), so the client's next edit arrives based on the old history, gets merged server-side, and **resurrects the very elements the restore removed**. Broadcasting a delta can't fix that: a delta from doc A is meaningless against doc B.

## Change

`overwrite` now means *make the target canvas's content match this version*, not *replace the file on disk*. Reconcile/merge is the one restore semantic:

- `reconcileCommitSaveBroadcast(...)` is extracted as the single reconcile → commit → save → broadcast → `sendRestoreEvent` implementation, used by both paths.
- Target does not exist → created, exactly as before.
- Target exists **without** `overwrite` → 409 `output_exists`, exactly as before.
- Target exists **with** `overwrite` → its live doc is reconciled onto (one CRDT lineage), and the update is broadcast to *that* canvas. `targetSlug === slug` now collapses into the in-place case instead of being a hole.
- The failure-path cache eviction added in #206 is preserved.

Tool descriptions and the request-schema doc comment were corrected — they described the old replace semantics. The wire contract is unchanged.

## Verification (red first)

Five new `mcp-node` tests, each confirmed failing against the old code first:

1. `targetSlug === slug` + `overwrite` reconciles in place — the cached doc is the *same object* afterwards (no lineage swap) and one non-empty update is broadcast.
2. Restoring into a different existing canvas reconciles *that* canvas's live doc, broadcasts to it (not the source), and its content matches the restored version; the source is untouched.
3. **The resurrection bug itself**: an independent `LoroDoc` imported from the target's pre-restore snapshot (modelling a real connected browser client) sends its stale-history update *after* the restore — the tombstoned element stays dead. This is what the old file-replace path allowed.
4. New target still creates the canvas; existing target without `overwrite` still returns 409.

`pnpm test --project mcp-node` 3028 passed / 2 skipped · `pnpm -r typecheck` clean · `pnpm build` green.

## Known follow-up

`versionRestoreOutputSchema.restoredAs` is still `'in-place' | 'new-canvas'`, so a reconcile onto an *existing* target reports `'new-canvas'` even though nothing new was created. No consumer distinguishes them today, so the wire contract was left alone; a third value (`'target-reconciled'`) is worth adding if that distinction ever becomes user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restore a saved version into a specified canvas.
  - Overwrite existing target canvases while preserving live document history.
  - Create a new canvas when the target slug does not exist.

- **Bug Fixes**
  - Prevent accidental overwrites by returning a conflict when `overwrite` is not enabled.
  - Preserve source canvases during cross-canvas restores.
  - Improve update broadcasts and cache handling during restore operations.

- **Documentation**
  - Clarified restore behavior for target canvases and overwrite scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->