### PR TITLE
fix: close the open CodeQL alerts (ReDoS + case-insensitive tag matching)

### DIFF
--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -108,12 +108,15 @@ if (!existsSync(indexHtmlPath)) {
     return m ? (m[2] ?? m[3] ?? m[4]) : undefined
   }
   const entryScripts = []
-  for (const [tag] of html.matchAll(/<script\b[^>]*>/g)) {
+  // Case-insensitive: HTML tag names are case-insensitive per the spec, and a
+  // hand-rolled tag matcher that only matches lower case silently stops
+  // finding entries if any producer ever emits upper/mixed case tags.
+  for (const [tag] of html.matchAll(/<script\b[^>]*>/gi)) {
     const src = attr(tag, 'src')
     if (src?.startsWith('/assets/') && src.endsWith('.js')) entryScripts.push(src)
   }
   const modulepreloads = []
-  for (const [tag] of html.matchAll(/<link\b[^>]*>/g)) {
+  for (const [tag] of html.matchAll(/<link\b[^>]*>/gi)) {
     const href = attr(tag, 'href')
     if (
       attr(tag, 'rel') === 'modulepreload' &&

--- a/apps/web/scripts/smoke-bundle-size.mjs
+++ b/apps/web/scripts/smoke-bundle-size.mjs
@@ -56,65 +56,22 @@ const BUDGETS = [
 // unavoidable critical-path cost of addressable URLs. Measured 114.0 KB.
 const CRITICAL_PATH_BUDGET_KB = 126
 
-let failures = 0
-
-function gzipSize(path) {
-  return gzipSync(readFileSync(path)).length
+// Attribute-order-, quote-style-, and case-insensitive: extract each tag
+// first, then match attributes independently, so a Vite/minifier formatting
+// change (or a producer that emits upper/mixed-case tags or attributes —
+// both HTML tag names and attribute names are case-insensitive per spec)
+// cannot silently zero out the file list and let the budget pass vacuously.
+export function attr(tag, name) {
+  const m = tag.match(new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i'))
+  return m ? (m[2] ?? m[3] ?? m[4]) : undefined
 }
 
-if (!existsSync(ASSETS)) {
-  console.error(`  FAIL  dist/assets not found at ${ASSETS} — run \`pnpm build\` first`)
-  process.exit(1)
-}
-
-const files = readdirSync(ASSETS)
-for (const { label, pattern, limit, required } of BUDGETS) {
-  const matches = files.filter((f) => pattern.test(f))
-  if (matches.length === 0) {
-    if (required) {
-      console.error(`  FAIL  ${label}: no file matching ${pattern} in dist/assets`)
-      failures++
-    } else {
-      console.log(`  skip  ${label}: no matching chunk yet`)
-    }
-    continue
-  }
-  for (const f of matches) {
-    const size = gzipSize(join(ASSETS, f))
-    const sizeKb = (size / KB).toFixed(1)
-    const limitKb = (limit / KB).toFixed(0)
-    if (size > limit) {
-      console.error(`  FAIL  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
-      failures++
-    } else {
-      console.log(`  pass  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
-    }
-  }
-}
-
-// Critical-path total: entry script + every modulepreloaded JS chunk, as
-// listed in dist/index.html. This is what actually determines first-paint
-// transfer size — see the module comment above for why the per-file
-// entry-JS budget above cannot catch a regression here (e.g. a statically
-// imported Excalidraw/loro-crdt page would inflate this total without ever
-// growing index-*.js itself).
-const indexHtmlPath = join(DIST, 'index.html')
-if (!existsSync(indexHtmlPath)) {
-  console.error(`  FAIL  dist/index.html not found at ${indexHtmlPath} — run \`pnpm build\` first`)
-  failures++
-} else {
-  const html = readFileSync(indexHtmlPath, 'utf8')
-  // Attribute-order- and quote-style-insensitive: extract each tag first,
-  // then match attributes independently, so a Vite/minifier formatting change
-  // cannot silently zero out the file list and let the budget pass vacuously.
-  const attr = (tag, name) => {
-    const m = tag.match(new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`))
-    return m ? (m[2] ?? m[3] ?? m[4]) : undefined
-  }
+// Extracts every entry <script src> and modulepreload <link href> JS file
+// referenced from a built index.html — the critical-path payload a fresh
+// visitor downloads before first paint. Tag names, attribute names, and the
+// `rel` attribute value are all matched case-insensitively per the HTML spec.
+export function extractCriticalPathFiles(html) {
   const entryScripts = []
-  // Case-insensitive: HTML tag names are case-insensitive per the spec, and a
-  // hand-rolled tag matcher that only matches lower case silently stops
-  // finding entries if any producer ever emits upper/mixed case tags.
   for (const [tag] of html.matchAll(/<script\b[^>]*>/gi)) {
     const src = attr(tag, 'src')
     if (src?.startsWith('/assets/') && src.endsWith('.js')) entryScripts.push(src)
@@ -122,40 +79,103 @@ if (!existsSync(indexHtmlPath)) {
   const modulepreloads = []
   for (const [tag] of html.matchAll(/<link\b[^>]*>/gi)) {
     const href = attr(tag, 'href')
+    const rel = attr(tag, 'rel')
     if (
-      attr(tag, 'rel') === 'modulepreload' &&
+      rel?.toLowerCase() === 'modulepreload' &&
       href?.startsWith('/assets/') &&
       href.endsWith('.js')
     ) {
       modulepreloads.push(href)
     }
   }
-  const criticalPathFiles = [...new Set([...entryScripts, ...modulepreloads])]
-  if (criticalPathFiles.length === 0) {
-    console.error(
-      '  FAIL  no entry <script src> or <link rel="modulepreload"> JS found in dist/index.html — the parser is broken or the build output changed shape; refusing to pass a vacuous budget',
-    )
-    failures++
+  return [...new Set([...entryScripts, ...modulepreloads])]
+}
+
+function gzipSize(path) {
+  return gzipSync(readFileSync(path)).length
+}
+
+// Guarded behind the import.meta.url check below so importing this module
+// (e.g. from smoke-bundle-size.test.ts to exercise extractCriticalPathFiles)
+// never runs the gate or calls process.exit as an import side effect.
+function main() {
+  let failures = 0
+
+  if (!existsSync(ASSETS)) {
+    console.error(`  FAIL  dist/assets not found at ${ASSETS} — run \`pnpm build\` first`)
+    process.exit(1)
   }
-  let criticalPathBytes = 0
-  for (const href of criticalPathFiles) {
-    criticalPathBytes += gzipSize(join(DIST, href.replace(/^\//, '')))
+
+  const files = readdirSync(ASSETS)
+  for (const { label, pattern, limit, required } of BUDGETS) {
+    const matches = files.filter((f) => pattern.test(f))
+    if (matches.length === 0) {
+      if (required) {
+        console.error(`  FAIL  ${label}: no file matching ${pattern} in dist/assets`)
+        failures++
+      } else {
+        console.log(`  skip  ${label}: no matching chunk yet`)
+      }
+      continue
+    }
+    for (const f of matches) {
+      const size = gzipSize(join(ASSETS, f))
+      const sizeKb = (size / KB).toFixed(1)
+      const limitKb = (limit / KB).toFixed(0)
+      if (size > limit) {
+        console.error(`  FAIL  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
+        failures++
+      } else {
+        console.log(`  pass  ${label}: ${f} is ${sizeKb} KB gzip (budget ${limitKb} KB)`)
+      }
+    }
   }
-  const criticalPathKb = (criticalPathBytes / KB).toFixed(1)
-  if (criticalPathBytes > CRITICAL_PATH_BUDGET_KB * KB) {
+
+  // Critical-path total: entry script + every modulepreloaded JS chunk, as
+  // listed in dist/index.html. This is what actually determines first-paint
+  // transfer size — see the module comment above for why the per-file
+  // entry-JS budget above cannot catch a regression here (e.g. a statically
+  // imported Excalidraw/loro-crdt page would inflate this total without ever
+  // growing index-*.js itself).
+  const indexHtmlPath = join(DIST, 'index.html')
+  if (!existsSync(indexHtmlPath)) {
     console.error(
-      `  FAIL  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
+      `  FAIL  dist/index.html not found at ${indexHtmlPath} — run \`pnpm build\` first`,
     )
     failures++
   } else {
-    console.log(
-      `  pass  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
-    )
+    const html = readFileSync(indexHtmlPath, 'utf8')
+    const criticalPathFiles = extractCriticalPathFiles(html)
+    if (criticalPathFiles.length === 0) {
+      console.error(
+        '  FAIL  no entry <script src> or <link rel="modulepreload"> JS found in dist/index.html — the parser is broken or the build output changed shape; refusing to pass a vacuous budget',
+      )
+      failures++
+    }
+    let criticalPathBytes = 0
+    for (const href of criticalPathFiles) {
+      criticalPathBytes += gzipSize(join(DIST, href.replace(/^\//, '')))
+    }
+    const criticalPathKb = (criticalPathBytes / KB).toFixed(1)
+    if (criticalPathBytes > CRITICAL_PATH_BUDGET_KB * KB) {
+      console.error(
+        `  FAIL  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
+      )
+      failures++
+    } else {
+      console.log(
+        `  pass  critical-path JS (entry + modulepreload, ${criticalPathFiles.length} files): ${criticalPathKb} KB gzip (budget ${CRITICAL_PATH_BUDGET_KB} KB)`,
+      )
+    }
   }
+
+  if (failures > 0) {
+    console.error(`\nbundle-size gate: ${failures} failure(s)`)
+    process.exit(1)
+  }
+  console.log('\nbundle-size gate: OK')
 }
 
-if (failures > 0) {
-  console.error(`\nbundle-size gate: ${failures} failure(s)`)
-  process.exit(1)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
 }
-console.log('\nbundle-size gate: OK')

--- a/apps/web/scripts/smoke-bundle-size.test.ts
+++ b/apps/web/scripts/smoke-bundle-size.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { extractCriticalPathFiles } from './smoke-bundle-size.mjs'
+
+describe('extractCriticalPathFiles', () => {
+  it('finds the entry script and modulepreload chunks with lowercase tags/attrs', () => {
+    const html = [
+      '<script type="module" crossorigin src="/assets/index-abc123.js"></script>',
+      '<link rel="modulepreload" crossorigin href="/assets/vendor-react-def456.js">',
+    ].join('\n')
+
+    expect(extractCriticalPathFiles(html)).toEqual([
+      '/assets/index-abc123.js',
+      '/assets/vendor-react-def456.js',
+    ])
+  })
+
+  it('finds the same files when tag names, attribute names, and rel value are upper/mixed case', () => {
+    const html = [
+      '<SCRIPT TYPE="module" CROSSORIGIN SRC="/assets/index-abc123.js"></SCRIPT>',
+      '<LINK REL="MODULEPRELOAD" CROSSORIGIN HREF="/assets/vendor-react-def456.js">',
+    ].join('\n')
+
+    expect(extractCriticalPathFiles(html)).toEqual([
+      '/assets/index-abc123.js',
+      '/assets/vendor-react-def456.js',
+    ])
+  })
+})

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -29,6 +29,38 @@ const APPS_WEB_SRC_DIR = resolve(REPO_ROOT, 'apps/web/src')
 // explicitly rather than relying on collectBrowserAppFiles's real scan roots.
 const FIXTURE_BROWSER_APP_DIR = resolve(PACKAGE_SRC_DIR, '__fixture-browser-app__')
 
+/**
+ * Check whether a GitHub Actions job body declares `environment: production-web`,
+ * either as the short string form or the `name:`/`url:` mapping form (in any key
+ * order, quotes optional).
+ *
+ * This walks lines instead of using a single combined regex. A prior version
+ * used one alternation with a lazy-repeated inner group
+ * (`(?:\s+[\w-]+:[^\n]*\r?\n)*?`) whose `\s+` could itself consume the
+ * following `\r?\n`, giving the engine exponentially many ways to partition a
+ * non-matching input and triggering catastrophic backtracking (CodeQL
+ * js/redos). Scanning line-by-line makes each step O(1) with no backtracking.
+ */
+function matchesEnvironmentProductionWeb(jobSection: string): boolean {
+  const stripQuotes = (s: string) => s.trim().replace(/^['"]|['"]$/g, '')
+  const lines = jobSection.split(/\r?\n/)
+  const envIndex = lines.findIndex((line) => /^\s*environment:\s*(.*)$/.test(line))
+  if (envIndex === -1) return false
+
+  const inlineValue = lines[envIndex].match(/^\s*environment:\s*(.*)$/)?.[1] ?? ''
+  if (inlineValue !== '' && stripQuotes(inlineValue) === 'production-web') return true
+
+  // Mapping form: `environment:` on its own line, followed by an indented
+  // block of `key: value` entries (any order) until the block ends.
+  for (let i = envIndex + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (!/^\s+[\w-]+:/.test(line)) break
+    const nameMatch = line.match(/^\s+name:\s*(.*)$/)
+    if (nameMatch && stripQuotes(nameMatch[1]) === 'production-web') return true
+  }
+  return false
+}
+
 function collectTsFiles(dir: string): string[] {
   const results: string[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -665,11 +697,9 @@ describe('apps/web Cloudflare deploy secrets guard', () => {
       'CLOUDFLARE_ACCOUNT_ID',
     )
     expect(
-      deployWebSection,
+      matchesEnvironmentProductionWeb(deployWebSection),
       'deploy-web job must declare the production-web environment (secrets scoped to tag-protected env); the string form and the name/url mapping form are both valid, with optional quotes and any key order',
-    ).toMatch(
-      /environment:\s*(?:['"]?production-web['"]?\s*(?:\r?\n|$)|\r?\n(?:\s+[\w-]+:[^\n]*\r?\n)*?\s+name:\s*['"]?production-web['"]?)/,
-    )
+    ).toBe(true)
   })
 
   it('deploy-web avoids the wrangler-action npm-install fallback (catalog: is pnpm-only)', () => {

--- a/packages/mcp-server/src/server/release/web-app-boundary.test.ts
+++ b/packages/mcp-server/src/server/release/web-app-boundary.test.ts
@@ -32,7 +32,7 @@ const FIXTURE_BROWSER_APP_DIR = resolve(PACKAGE_SRC_DIR, '__fixture-browser-app_
 /**
  * Check whether a GitHub Actions job body declares `environment: production-web`,
  * either as the short string form or the `name:`/`url:` mapping form (in any key
- * order, quotes optional).
+ * order, quotes optional, with or without a trailing YAML comment).
  *
  * This walks lines instead of using a single combined regex. A prior version
  * used one alternation with a lazy-repeated inner group
@@ -40,26 +40,66 @@ const FIXTURE_BROWSER_APP_DIR = resolve(PACKAGE_SRC_DIR, '__fixture-browser-app_
  * following `\r?\n`, giving the engine exponentially many ways to partition a
  * non-matching input and triggering catastrophic backtracking (CodeQL
  * js/redos). Scanning line-by-line makes each step O(1) with no backtracking.
+ *
+ * Comments are stripped before matching so a trailing `# ...` on either the
+ * `environment:` line or a `name:` line inside the mapping form doesn't leak
+ * into the compared value. The scalar form also returns immediately once a
+ * non-empty inline value is present: a value that isn't `production-web`
+ * (e.g. `environment: development`) must not fall through to scan the
+ * mapping-form block below it, or a `name: production-web` line belonging to
+ * an unrelated nested key could produce a false positive.
  */
 function matchesEnvironmentProductionWeb(jobSection: string): boolean {
   const stripQuotes = (s: string) => s.trim().replace(/^['"]|['"]$/g, '')
-  const lines = jobSection.split(/\r?\n/)
-  const envIndex = lines.findIndex((line) => /^\s*environment:\s*(.*)$/.test(line))
+  const lines = jobSection.split(/\r?\n/).map((line) => line.replace(/#.*$/, ''))
+  const envIndex = lines.findIndex((line) => /^\s*environment:\s*/.test(line))
   if (envIndex === -1) return false
 
-  const inlineValue = lines[envIndex].match(/^\s*environment:\s*(.*)$/)?.[1] ?? ''
-  if (inlineValue !== '' && stripQuotes(inlineValue) === 'production-web') return true
+  const envLine = lines[envIndex]
+  const inlineValue = envLine.match(/^\s*environment:\s*(.*)$/)?.[1]?.trim() ?? ''
+  if (inlineValue !== '') return stripQuotes(inlineValue) === 'production-web'
 
   // Mapping form: `environment:` on its own line, followed by an indented
-  // block of `key: value` entries (any order) until the block ends.
+  // block of `key: value` entries (any order) until the block ends (a line
+  // at or below the `environment:` line's own indentation, or a non-key line).
+  const envIndent = envLine.match(/^(\s*)/)?.[1]?.length ?? 0
   for (let i = envIndex + 1; i < lines.length; i++) {
     const line = lines[i]
+    if (line.trim() === '') continue
+    const indent = line.match(/^(\s*)/)?.[1]?.length ?? 0
+    if (indent <= envIndent) break
     if (!/^\s+[\w-]+:/.test(line)) break
     const nameMatch = line.match(/^\s+name:\s*(.*)$/)
     if (nameMatch && stripQuotes(nameMatch[1]) === 'production-web') return true
   }
   return false
 }
+
+describe('matchesEnvironmentProductionWeb edge cases', () => {
+  it('matches the inline scalar form with a trailing YAML comment', () => {
+    expect(
+      matchesEnvironmentProductionWeb(
+        'deploy-web:\n    environment: production-web  # deploy target\n',
+      ),
+    ).toBe(true)
+  })
+
+  it('matches the mapping form with a trailing YAML comment on the name: line', () => {
+    expect(
+      matchesEnvironmentProductionWeb(
+        'deploy-web:\n    environment:\n      name: production-web  # deploy target\n      url: https://example.com\n',
+      ),
+    ).toBe(true)
+  })
+
+  it('does not fall through to a later name: line when the inline scalar does not match', () => {
+    expect(
+      matchesEnvironmentProductionWeb(
+        'deploy-web:\n    environment: development\n  name: production-web\n',
+      ),
+    ).toBe(false)
+  })
+})
 
 function collectTsFiles(dir: string): string[] {
   const results: string[] = []


### PR DESCRIPTION
Closes all 10 open CodeQL alerts: 2 fixed here, 8 dismissed with a written reason (checked against the code, not waved through).

## Fixed

**`js/redos` — `release/web-app-boundary.test.ts`.** The regex had a lazy-repeated group whose `\s+` could itself consume the trailing newline, so a non-matching input had exponentially many ways to be partitioned — catastrophic backtracking. Replaced with a linear line-by-line scan (`matchesEnvironmentProductionWeb()`) that keeps both the string form and the `name:` mapping form covered. Mutation-checked: string / quoted / mapping forms still match, wrong value and missing key still don't.

**`js/bad-tag-filter` — `apps/web/scripts/smoke-bundle-size.mjs`.** The tag regexes only matched lower-case `<script>` / `<link>`, but HTML tag names are case-insensitive by spec — a Vite/minifier change emitting `<SCRIPT>` would have silently zeroed out the file list and let the bundle budget pass vacuously (which is exactly the failure the gate already guards against elsewhere). Added the `i` flag. Verified against a real build: the gate still finds all 10 critical-path files and passes.

## Dismissed (false positive)

**`js/incomplete-url-substring-sanitization` ×5** — every flagged `.includes()` is a *test assertion* on a known literal fixture (e.g. "was `:443` stripped from `allowedOrigins`", "did the raw hostname leak into stdout"). None gates a security, access, or redirect decision on untrusted input, so substring-bypass semantics don't apply.

**`js/clear-text-logging` ×3** — traced each to its sink (the shared `fail(msg, ctx)` smoke helper's `console.error`). The only tainted value reaching it is a fetch `Response.status` — a numeric HTTP status, never a body, header, or token. Response bodies always route through `assertNoLeak()` first, which throws without echoing the text.

**No real secret leak was found** — nothing here printed a credential into CI logs, so nothing needs rotating.

## Verification

`pnpm test --project mcp-node` 3074 passed · `pnpm -r typecheck` clean · `pnpm --filter @kamiazya/whiteboard-web build` + `node apps/web/scripts/smoke-bundle-size.mjs` green.

The Docker-based and full-distribution smokes were not run locally (they need Docker / a published tarball); the dismissed alerts in those files were verified by reading the code, not by executing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
