### PR TITLE
fix(web): route apps/web diagnostics through app-logger and guard console with Biome

### DIFF
--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -109,12 +109,12 @@ describe('ErrorBoundary', () => {
     seamSpy.mockRestore()
   })
 
-  // The seam is routed through app-logger (see ErrorBoundary.tsx), so a caught
-  // render crash is only visible in dev builds. These two tests lock in that
-  // deliberate choice: dev builds must still surface the crash, and prod
-  // builds must not leak console noise, rather than either regressing
-  // silently the next time app-logger's dev/prod gate changes.
-  describe('app-logger dev/prod gate', () => {
+  // The seam is routed through app-logger's `reportCrash` channel (see
+  // ErrorBoundary.tsx), which is deliberately NOT gated by the dev/prod
+  // no-op that every other app-logger level uses. These tests lock in that
+  // a caught render crash is surfaced in BOTH dev and prod builds, rather
+  // than regressing silently the next time app-logger's channels change.
+  describe('app-logger crash-report gate', () => {
     afterEach(() => {
       vi.unstubAllGlobals()
     })
@@ -133,7 +133,7 @@ describe('ErrorBoundary', () => {
       expect(call?.[0]).toContain('[error-boundary]')
     })
 
-    it('stays silent in a prod build (app-logger no-ops there)', () => {
+    it('still reports the caught error in a prod build (reportCrash survives production on purpose)', () => {
       vi.stubGlobal('import.meta', { env: { DEV: false } })
       const spy = vi.fn()
       console.error = spy
@@ -142,11 +142,13 @@ describe('ErrorBoundary', () => {
           <Bomb trigger />
         </ErrorBoundary>,
       )
-      // React's own error-boundary dev warning also calls console.error and
-      // is outside this seam's control — only assert that OUR seam (tagged
-      // '[error-boundary]') stayed silent.
-      const ownCall = spy.mock.calls.find((c) => String(c[0]).includes('[error-boundary]'))
-      expect(ownCall).toBeUndefined()
+      const call = spy.mock.calls.find((c) => String(c[0]).includes('ErrorBoundary caught:'))
+      expect(call).toBeTruthy()
+      expect(call?.[0]).toContain('[error-boundary]')
+      const context = call?.[1] as { error: Error; componentStack?: string | null }
+      expect(context.error).toBeInstanceOf(Error)
+      expect(context.error.message).toBe('boom')
+      expect(context.componentStack).toBeTruthy()
     })
   })
 })

--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -108,4 +108,45 @@ describe('ErrorBoundary', () => {
     expect((context as { error: Error }).error.message).toBe('boom')
     seamSpy.mockRestore()
   })
+
+  // The seam is routed through app-logger (see ErrorBoundary.tsx), so a caught
+  // render crash is only visible in dev builds. These two tests lock in that
+  // deliberate choice: dev builds must still surface the crash, and prod
+  // builds must not leak console noise, rather than either regressing
+  // silently the next time app-logger's dev/prod gate changes.
+  describe('app-logger dev/prod gate', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('forwards the caught error to console in a dev build (real seam, not mocked)', () => {
+      vi.stubGlobal('import.meta', { env: { DEV: true } })
+      const spy = vi.fn()
+      console.error = spy
+      render(
+        <ErrorBoundary>
+          <Bomb trigger />
+        </ErrorBoundary>,
+      )
+      const call = spy.mock.calls.find((c) => String(c[0]).includes('ErrorBoundary caught:'))
+      expect(call).toBeTruthy()
+      expect(call?.[0]).toContain('[error-boundary]')
+    })
+
+    it('stays silent in a prod build (app-logger no-ops there)', () => {
+      vi.stubGlobal('import.meta', { env: { DEV: false } })
+      const spy = vi.fn()
+      console.error = spy
+      render(
+        <ErrorBoundary>
+          <Bomb trigger />
+        </ErrorBoundary>,
+      )
+      // React's own error-boundary dev warning also calls console.error and
+      // is outside this seam's control — only assert that OUR seam (tagged
+      // '[error-boundary]') stayed silent.
+      const ownCall = spy.mock.calls.find((c) => String(c[0]).includes('[error-boundary]'))
+      expect(ownCall).toBeUndefined()
+    })
+  })
 })

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,19 +1,23 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { getAppLogger } from '../lib/app-logger.js'
 
 // React error boundary for the whiteboard surface.
 // Keep the app recoverable instead of letting an Excalidraw, Loro, or routing error blank the whole root.
 // This is intentionally minimal; richer recovery actions can be added later if needed.
 
+const log = getAppLogger('error-boundary')
+
 // Module-local logging seam: kept separate from the boundary's render logic so
-// componentDidCatch has a single, mockable call site. The body is a stand-in
-// until apps/web gains a shared app-logger (tracked in tmp/issues); the
-// signature (message + structured context) is chosen so swapping the body for
-// a real logger later is a body-only change, not an interface change. Exposed
-// as an object (not a bare function) so tests can `vi.spyOn` the property —
-// spying a same-module function binding does not intercept direct calls.
+// componentDidCatch has a single, mockable call site. Routed through the
+// shared app-logger, which means a caught render crash is only reported in
+// dev builds — app-logger no-ops in production, so this is deliberately NOT
+// a substitute for a production error-reporting integration (Sentry or
+// similar), should one be added later. Exposed as an object (not a bare
+// function) so tests can `vi.spyOn` the property — spying a same-module
+// function binding does not intercept direct calls.
 export const errorBoundaryLog = {
   report(message: string, context: Record<string, unknown>): void {
-    console.error(message, context)
+    log.error(message, context)
   },
 }
 

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,23 +1,23 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { getAppLogger } from '../lib/app-logger.js'
+import { reportCrash } from '../lib/app-logger.js'
 
 // React error boundary for the whiteboard surface.
 // Keep the app recoverable instead of letting an Excalidraw, Loro, or routing error blank the whole root.
 // This is intentionally minimal; richer recovery actions can be added later if needed.
 
-const log = getAppLogger('error-boundary')
-
 // Module-local logging seam: kept separate from the boundary's render logic so
-// componentDidCatch has a single, mockable call site. Routed through the
-// shared app-logger, which means a caught render crash is only reported in
-// dev builds — app-logger no-ops in production, so this is deliberately NOT
-// a substitute for a production error-reporting integration (Sentry or
-// similar), should one be added later. Exposed as an object (not a bare
-// function) so tests can `vi.spyOn` the property — spying a same-module
-// function binding does not intercept direct calls.
+// componentDidCatch has a single, mockable call site. Routed through
+// app-logger's `reportCrash` channel, which — unlike every other app-logger
+// level — is NOT a dev-only no-op: once React has torn down the tree and
+// shown the fallback UI, this is the user's last chance to get a stack trace
+// they can paste into a bug report. This is still not a substitute for a
+// production error-reporting integration (Sentry or similar), should one be
+// added later. Exposed as an object (not a bare function) so tests can
+// `vi.spyOn` the property — spying a same-module function binding does not
+// intercept direct calls.
 export const errorBoundaryLog = {
   report(message: string, context: Record<string, unknown>): void {
-    log.error(message, context)
+    reportCrash('error-boundary', message, context)
   },
 }
 

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react'
-import { DEFAULT_DAEMON_BASE_URL } from '../../lib/daemon-probe.js'
+import { getAppLogger } from '../../lib/app-logger.js'
 import type { BrowserLocalStore } from '../../lib/browser-local-store.js'
+import { DEFAULT_DAEMON_BASE_URL } from '../../lib/daemon-probe.js'
 import type { LoroLoadResult } from '../../lib/loro-store.js'
 import type { UserSettingsStore } from '../../lib/user-settings-store.js'
 import type { CanvasSnapshot } from '../../lib/whiteboard-client.js'
 import { importOneCanvas } from './import-browser-local.js'
+
+const log = getAppLogger('import-browser-local-panel')
 
 // Minimal surface this panel needs from LoroStore — narrower than the full
 // class so tests can inject a plain object instead of touching IndexedDB.
@@ -54,7 +57,7 @@ export function ImportBrowserLocalPanel({
       .catch((err: unknown) => {
         // A blocked/corrupt IndexedDB must not leave the panel in the
         // loading state forever — degrade to the empty state.
-        console.error('listCanvases failed', err)
+        log.error('listCanvases failed', err)
         if (!cancelled) setCanvases([])
       })
     return () => {

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -1014,13 +1014,18 @@ describe('useCanvasSync', () => {
         }),
       ).resolves.not.toThrow()
 
-      // Routed through app-logger, which prefixes the message with its
-      // '[canvas-sync]' name tag.
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[canvas-sync] onExportRequest failed',
-        expect.any(Error),
-      )
-      consoleErrorSpy.mockRestore()
+      try {
+        // Routed through app-logger, which prefixes the message with its
+        // '[canvas-sync]' name tag.
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[canvas-sync] onExportRequest failed',
+          expect.any(Error),
+        )
+      } finally {
+        // Restore even when the assertion throws: a leaked console.error mock
+        // would silently swallow diagnostics in every later test in this file.
+        consoleErrorSpy.mockRestore()
+      }
     })
   })
 

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -1014,7 +1014,12 @@ describe('useCanvasSync', () => {
         }),
       ).resolves.not.toThrow()
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('onExportRequest failed', expect.any(Error))
+      // Routed through app-logger, which prefixes the message with its
+      // '[canvas-sync]' name tag.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[canvas-sync] onExportRequest failed',
+        expect.any(Error),
+      )
       consoleErrorSpy.mockRestore()
     })
   })

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -21,12 +21,15 @@ import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap, UndoManager } from 'loro-crdt'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { z } from 'zod'
+import { getAppLogger } from '../lib/app-logger.js'
 import {
   type ExportRequestHandlerDeps,
   flushPendingExportRequests,
   handleIncomingExportRequest,
 } from './canvas-sync-export.js'
 import type { DirtyEventDetail } from './useDirtyState.js'
+
+const log = getAppLogger('canvas-sync')
 
 export type SyncStatus = 'idle' | 'connected' | 'error'
 
@@ -379,7 +382,7 @@ export function useCanvasSync(
           try {
             commitElements()
           } catch (err) {
-            console.error('scene commit failed; skipping this firing', err)
+            log.error('scene commit failed; skipping this firing', err)
           }
         }
         const runThisFiring = async (): Promise<void> => {
@@ -406,16 +409,16 @@ export function useCanvasSync(
               try {
                 optionsRef.current.onFileUploadSucceeded?.()
               } catch (err) {
-                console.error('onFileUploadSucceeded callback threw', err)
+                log.error('onFileUploadSucceeded callback threw', err)
               }
             }
           } catch (err) {
-            console.error('putFile failed', err)
+            log.error('putFile failed', err)
             if (connectionGenerationRef.current === connGen) {
               try {
                 optionsRef.current.onFileUploadFailed?.()
               } catch (callbackErr) {
-                console.error('onFileUploadFailed callback threw', callbackErr)
+                log.error('onFileUploadFailed callback threw', callbackErr)
               }
             }
           } finally {
@@ -536,7 +539,7 @@ export function useCanvasSync(
         try {
           optionsRef.current.onVersionCreated?.(payload)
         } catch (err) {
-          console.error('onVersionCreated callback threw', err)
+          log.error('onVersionCreated callback threw', err)
         }
       },
 
@@ -558,7 +561,7 @@ export function useCanvasSync(
         try {
           optionsRef.current.onHeadChanged?.(payload)
         } catch (err) {
-          console.error('onHeadChanged callback threw', err)
+          log.error('onHeadChanged callback threw', err)
         }
       },
 
@@ -612,7 +615,7 @@ export function useCanvasSync(
         try {
           await handleIncomingExportRequest(payload, buildExportDeps(bk))
         } catch (err) {
-          console.error('onExportRequest failed', err)
+          log.error('onExportRequest failed', err)
         }
       },
 
@@ -622,7 +625,7 @@ export function useCanvasSync(
         try {
           optionsRef.current.onAuthError?.()
         } catch (err) {
-          console.error('onAuthError callback threw', err)
+          log.error('onAuthError callback threw', err)
         }
       },
 
@@ -663,7 +666,7 @@ export function useCanvasSync(
     bk?.sendClientReady()
     if (!bk) return
     void flushPendingExportRequests(buildExportDeps(bk)).catch((err: unknown) => {
-      console.error('flushPendingExportRequests failed', err)
+      log.error('flushPendingExportRequests failed', err)
     })
   }, [apiReady, buildExportDeps])
 

--- a/apps/web/src/lib/app-logger.test.ts
+++ b/apps/web/src/lib/app-logger.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getAppLogger } from './app-logger.js'
+import { getAppLogger, reportCrash } from './app-logger.js'
 
 describe('getAppLogger', () => {
   afterEach(() => {
@@ -119,6 +119,41 @@ describe('getAppLogger', () => {
       const loggerA = getAppLogger('a')
       const loggerB = getAppLogger('b')
       expect(loggerA).not.toBe(loggerB)
+    })
+  })
+
+  // reportCrash is the one app-logger channel that is NOT gated by
+  // dev/prod: it exists so ErrorBoundary can still surface a crash report
+  // after a real production build. These tests pin the contrast against the
+  // ordinary levels, which stay silent in prod by design (see the PROD path
+  // suite above).
+  describe('reportCrash (production-visible crash channel)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.restoreAllMocks()
+    })
+
+    it('emits in a dev build', () => {
+      vi.stubGlobal('import.meta', { env: { DEV: true } })
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      reportCrash('crash-name', 'boom happened', { detail: 'x' })
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('[crash-name]')
+      expect(spy.mock.calls[0][0]).toContain('boom happened')
+      expect(spy.mock.calls[0][1]).toEqual({ detail: 'x' })
+    })
+
+    it('still emits in a prod build, unlike every other AppLogger level', () => {
+      vi.stubGlobal('import.meta', { env: { DEV: false } })
+      const crashSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      reportCrash('crash-name', 'boom happened', { detail: 'x' })
+      expect(crashSpy).toHaveBeenCalledTimes(1)
+      expect(crashSpy.mock.calls[0][0]).toContain('[crash-name]')
+
+      crashSpy.mockClear()
+      const logger = getAppLogger('ordinary-diagnostic')
+      logger.error('routine diagnostic, e.g. a debounced scene-sync retry')
+      expect(crashSpy).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/apps/web/src/lib/app-logger.ts
+++ b/apps/web/src/lib/app-logger.ts
@@ -35,7 +35,7 @@ export function getAppLogger(name: string): AppLogger {
       | undefined
     const isDev = importMeta?.['env']?.['DEV'] === true
     if (isDev) {
-      // eslint-disable-next-line no-console
+      // biome-ignore lint/suspicious/noConsole: this is the one intended sink apps/web routes diagnostics through
       console[level](`${tag} ${message}`, ...context)
     }
   }

--- a/apps/web/src/lib/app-logger.ts
+++ b/apps/web/src/lib/app-logger.ts
@@ -55,3 +55,21 @@ export function getAppLogger(name: string): AppLogger {
     },
   }
 }
+
+/**
+ * Reports an unrecoverable failure through a channel that survives the
+ * production build — the deliberate exception to every level on
+ * `AppLogger`, which is dev-only diagnostic noise by design (it no-ops in
+ * prod so routine failures like a debounced scene-sync retry never reach a
+ * user's console).
+ *
+ * `reportCrash` exists for `ErrorBoundary.componentDidCatch` only: once
+ * React has torn down the tree and shown the fallback UI, a silent prod
+ * build leaves the user with nothing to paste into a bug report. If a
+ * second call site wants this channel, treat that as a deliberate review
+ * conversation, not a default to reach for.
+ */
+export function reportCrash(name: string, message: string, context: Record<string, unknown>): void {
+  // biome-ignore lint/suspicious/noConsole: intentional production-visible sink for unrecoverable crash reports — see the doc comment above
+  console.error(`[${name}] ${message}`, context)
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '../components/ui/alert-dialog.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
+import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
@@ -50,6 +51,8 @@ const WorkspaceTopBar = lazy(() => import('../components/WorkspaceTopBar.js'))
 // Fixed height so the lazy WorkspaceTopBar chunk resolving after first paint
 // causes no layout shift.
 const TOP_BAR_FALLBACK_HEIGHT = 'h-12'
+
+const log = getAppLogger('browser-local-canvas-page')
 
 interface BrowserLocalCanvasPageProps {
   store: BrowserLocalStore
@@ -206,7 +209,7 @@ export function BrowserLocalCanvasPage({
       .catch((err: unknown) => {
         // A stale/failed list refresh must not surface as an unhandled
         // rejection; the switcher just keeps showing its last-known list.
-        console.error('listCanvases failed', err)
+        log.error('listCanvases failed', err)
       })
   }, [canvasId, currentUpdatedAt, listCanvases])
 

--- a/biome.json
+++ b/biome.json
@@ -76,6 +76,21 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "apps/web/src/**/*.ts",
+        "apps/web/src/**/*.tsx",
+        "!apps/web/src/**/*.test.ts",
+        "!apps/web/src/**/*.test.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "error"
+          }
+        }
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "intent:list": "npx @tanstack/intent@latest list",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "lint:noconsole": "biome lint --only=lint/suspicious/noConsole --diagnostic-level=error packages/mcp-server/src/server",
+    "lint:noconsole": "biome lint --only=lint/suspicious/noConsole --diagnostic-level=error packages/mcp-server/src/server apps/web/src",
     "secretlint": "secretlint --secretlintignore .secretlintignore \"**/*\"",
     "test:scripts": "node --test .claude/scripts/*.test.mjs",
     "prepare": "lefthook install || true"


### PR DESCRIPTION
## Summary

- Biome's `noConsole` rule was `off` globally, `error` only under `packages/mcp-server/src/server/**`. `apps/web/src` had 10 raw, unguarded `console.error` calls that shipped straight to production browsers (`vite.config.ts` strips nothing at build time).
- Migrated all 10 call sites to the existing dev-only `apps/web/src/lib/app-logger.ts` seam:
  - `apps/web/src/hooks/useCanvasSync.ts` — 9 call sites (scene commit / putFile / callback-threw / export paths). These are noisy-by-design diagnostics (e.g. a debounced scene-sync retry) and are correctly dev-only.
  - `apps/web/src/components/ErrorBoundary.tsx` — `componentDidCatch` reporter.
  - `apps/web/src/components/migration/ImportBrowserLocalPanel.tsx` and `apps/web/src/pages/BrowserLocalCanvasPage.tsx` — `listCanvases failed` handlers.
- Extended `biome.json`'s `noConsole: "error"` override to `apps/web/src/**` (mirroring the mcp-server precedent), guarded by exactly **two** scoped `biome-ignore` lines inside `app-logger.ts` (its own dev-only sink, and the new production crash sink below) — no blanket file exclusion.
- Extended `lint:noconsole` in `package.json` to also check `apps/web/src`, so the rule is actually run by the same gate `lefthook` pre-push and CI already invoke.

## ErrorBoundary: crash reports now survive production (follow-up fix)

An earlier revision of this PR routed `ErrorBoundary`'s crash reporter through the same dev-only `app-logger` seam as the noisy `useCanvasSync` diagnostics. That was wrong: a caught render crash is fundamentally different from routine diagnostic noise — React has already torn down the tree, the user sees the fallback UI, and with the dev-only seam there was nothing left in their console to paste into a bug report. Suppressing debug chatter is the goal of this PR; silencing crash reports was an observability regression it introduced.

Fixed by adding a second, explicit channel to `app-logger.ts`: `reportCrash(name, message, context)`. Unlike every `AppLogger` level (`error`/`warn`/`info`/`debug`), which stays dev-only, `reportCrash` is **not** gated by `import.meta.env.DEV` — it always calls `console.error`, in every build. `ErrorBoundary.tsx` is the only call site, and the doc comment on `reportCrash` says so explicitly: a second call site should be a deliberate review conversation, not a default to reach for. It's still not a substitute for a real production error-reporting integration (Sentry or similar), should one be added later — it only guarantees the console isn't empty.

Also removed the stale comment in `ErrorBoundary.tsx` referencing `tmp/issues` (repo rule: no `tmp/` references in source comments) since `app-logger` now exists and the migration is done.

### Tests (inverted, not deleted)

The prior tests asserted the opposite of the desired behavior (`ErrorBoundary` stays silent in prod). Those assertions are now inverted to prove the crash channel emits in prod, with a new counterpart test proving ordinary diagnostic levels still don't:

- `apps/web/src/components/ErrorBoundary.test.tsx` — `still reports the caught error in a prod build (reportCrash survives production on purpose)`, asserting the tagged log line, the real `Error`, and the component stack are all present.
- `apps/web/src/lib/app-logger.test.ts` — new `reportCrash (production-visible crash channel)` suite: emits in dev, still emits in prod, and directly contrasts an ordinary `AppLogger.error` call (e.g. a `useCanvasSync`-style diagnostic) staying silent in the same prod build.
- Confirmed the new prod-crash test fails for the right reason before the fix (both `reportCrash` calls and the inverted assertion), then re-verified green after.

## Verification

- `pnpm lint:noconsole` — covers `packages/mcp-server/src/server` + `apps/web/src`, passes clean.
- Mutation-checked the guard again after this fix: appended a throwaway `console.log(...)` inside `app-logger.ts`, confirmed `pnpm lint:noconsole` failed with exactly that violation, then reverted — no leftover debug code, and `reportCrash` was still intact afterward.
- `pnpm vitest run apps/web` — 87 files / 1015 tests passed, including the inverted `ErrorBoundary` prod-crash test and the new `reportCrash` suite.
- `pnpm -r typecheck` — clean (`packages/mcp-server`, `apps/web`).
- `pnpm --filter @kamiazya/whiteboard-web build` — succeeds.
- Pre-push `lefthook` gate (`noconsole` + `test-node` + `typecheck`) passed on push.

## Test plan

- [x] `pnpm lint:noconsole` (+ mutation check: stray `console.log` fails the gate, then removed)
- [x] `pnpm vitest run apps/web`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @kamiazya/whiteboard-web build`
