### PR TITLE
chore: upgrade to pnpm 11 and enable the global virtual store

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -37,9 +37,15 @@ runs:
     # operator to search for 'integrity' in undefined"). corepack never
     # invokes pnpm's self-update — it fetches and shims the target version
     # directly — so it sidesteps the bug entirely.
+    #
+    # Corepack is being unbundled from Node (nodejs/node#57825): Node 25+
+    # ships without it. This action must keep working once the runner's
+    # Node no longer includes it, so install corepack from npm first when
+    # the runner doesn't already have it on PATH.
     - name: Activate pnpm via corepack
       shell: bash
       run: |
+        command -v corepack >/dev/null 2>&1 || npm install -g corepack
         corepack enable
         corepack prepare --activate
 

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,30 @@
+name: Setup Node and pnpm
+description: >-
+  Install the packageManager-pinned pnpm via pnpm/action-setup, then Node with
+  pnpm store caching. Centralizes pnpm setup so a pnpm/tooling version bump
+  only needs to land here once instead of at every workflow call site.
+
+inputs:
+  node-version:
+    description: >-
+      Node version to install. Overrides node-version-file when set — used by
+      the publish-mcp release job, which checks out an old tag whose tree may
+      predate .node-version and must pin Node inline instead.
+    required: false
+    default: ''
+  registry-url:
+    description: npm registry URL to configure (passed through to actions/setup-node).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version == '' && '.node-version' || '' }}
+        registry-url: ${{ inputs.registry-url }}
+        cache: pnpm

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,8 +1,8 @@
 name: Setup Node and pnpm
 description: >-
-  Install the packageManager-pinned pnpm via pnpm/action-setup, then Node with
-  pnpm store caching. Centralizes pnpm setup so a pnpm/tooling version bump
-  only needs to land here once instead of at every workflow call site.
+  Install Node per .node-version and activate the packageManager-pinned pnpm
+  via corepack, with pnpm store caching. Centralizes pnpm setup so a pnpm
+  version bump or tooling fix only needs to land here once.
 
 inputs:
   node-version:
@@ -20,11 +20,38 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version == '' && '.node-version' || '' }}
         registry-url: ${{ inputs.registry-url }}
-        cache: pnpm
+
+    # corepack prepare (no argument) reads packageManager from package.json
+    # and downloads that exact pnpm build directly from the npm registry.
+    # This avoids pnpm/action-setup's self-install path, which bundles an
+    # older pnpm and asks IT to `pnpm add -g` the pinned version — that
+    # self-update codepath breaks on pnpm 11.12.0 regardless of the action's
+    # `standalone` input (both variants still shell out to the same broken
+    # `pnpm self-update <version>`; see
+    # https://github.com/pnpm/action-setup/issues/276: "Cannot use 'in'
+    # operator to search for 'integrity' in undefined"). corepack never
+    # invokes pnpm's self-update — it fetches and shims the target version
+    # directly — so it sidesteps the bug entirely.
+    - name: Activate pnpm via corepack
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare --activate
+
+    - name: Resolve pnpm store directory
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Validate PR title
         if: ${{ github.event_name == 'pull_request' }}
@@ -70,12 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -91,12 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -113,12 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -137,12 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -165,12 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -237,12 +207,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -271,12 +236,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,18 @@ jobs:
       - name: Generate npm SBOM
         run: pnpm --filter @kamiazya/whiteboard-mcp generate:sbom:npm
 
+      # generate:sbom:npm runs `pnpm deploy --legacy --prod` to produce an
+      # isolated production-only copy for the SBOM tool. That --legacy deploy
+      # writes its "production, no dev deps" settings into the *workspace's*
+      # shared install-state record (not just the deploy target's), so pnpm's
+      # pre-run dependency check on the next command believes the whole
+      # workspace was last installed with --production and "corrects" it by
+      # reinstalling without devDependencies (vitest included) before running.
+      # Re-running the frozen-lockfile install resets that shared state back
+      # to a normal (dev-included) install before vitest needs to resolve.
+      - name: Restore full dependency install (undo deploy's prod-only state)
+        run: pnpm install --frozen-lockfile
+
       # These tests run conditionally on the generated artifact and assert it
       # is non-empty and contains real production components (not silently
       # empty/partial from a swallowed or fatal npm ls error).

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -35,11 +35,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build apps/web

--- a/.github/workflows/preview-pr-build.yml
+++ b/.github/workflows/preview-pr-build.yml
@@ -26,11 +26,7 @@ jobs:
           # This job runs untrusted PR code; don't leave the git credential in
           # .git/config where pnpm install/build scripts could read it.
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build apps/web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,16 +112,13 @@ jobs:
         with:
           ref: ${{ inputs.force_publish_tag != '' && inputs.force_publish_tag || needs.release-please.outputs.mcp_tag_name }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-pnpm
         with:
           # Pinned inline (not via .node-version) because publish-mcp checks out an old tag whose
           # source tree may predate .node-version. Node 24 ships with npm 11.x which already meets
           # Trusted Publishing's >= 11.5.1 requirement and avoids the `npm i -g npm@latest` bug.
           # Keep this in sync with .node-version manually.
           node-version: 24
-          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies (workspace root)
@@ -218,12 +215,9 @@ jobs:
         with:
           ref: ${{ inputs.force_publish_tag != '' && inputs.force_publish_tag || needs.release-please.outputs.mcp_tag_name }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-pnpm
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -284,12 +278,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -26,7 +26,7 @@
 # ── Stage 1: build ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS build
 
-RUN corepack enable && corepack prepare pnpm@11.11.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
 
 WORKDIR /workspace
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -26,7 +26,7 @@
 # ── Stage 1: build ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS build
 
-RUN corepack enable && corepack prepare pnpm@10.4.1 --activate
+RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
 
 WORKDIR /workspace
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -26,7 +26,7 @@
 # ── Stage 1: build ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS build
 
-RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.11.0 --activate
 
 WORKDIR /workspace
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Claude Code and Codex plugin wrapper surfaces for the whiteboard MCP server and shared skills.",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/kamiazya/whiteboard.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Claude Code and Codex plugin wrapper surfaces for the whiteboard MCP server and shared skills.",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@11.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/kamiazya/whiteboard.git"
@@ -72,22 +72,5 @@
     "secretlint": "13.0.2",
     "vite-plugin-pwa": "1.3.0",
     "vitest": "catalog:"
-  },
-  "pnpm": {
-    "overrides": {
-      "lodash-es@<4.18.0": "^4.18.0",
-      "nanoid@<3.3.8": "^3.3.8",
-      "nanoid@>=4.0.0 <5.0.9": "^5.0.9",
-      "protobufjs@<8.6.0": "^8.6.0",
-      "fast-uri@<3.1.2": "^3.1.2",
-      "kysely@<0.28.17": "^0.28.17",
-      "@grpc/grpc-js@<1.14.4": "^1.14.4",
-      "shell-quote@<1.8.4": "^1.8.4",
-      "uuid@<11.1.1": "^11.1.1",
-      "qs@>=6.11.1 <6.15.2": "^6.15.2",
-      "ip-address@<=10.1.0": "^10.1.1",
-      "mermaid@<11.15.0": "^11.16.0",
-      "dompurify@<3.4.11": "^3.4.11"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Claude Code and Codex plugin wrapper surfaces for the whiteboard MCP server and shared skills.",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.11.0",
+  "packageManager": "pnpm@11.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/kamiazya/whiteboard.git"

--- a/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
@@ -127,9 +127,22 @@ export async function runPackedTarballSmoke({
     console.log(`[tarball-smoke] pack → ${packedTarballPath}`)
     console.log(`[tarball-smoke] install dir → ${installDir}`)
 
+    // --ignore-scripts: this installs into a disposable scratch directory to
+    // check that the packed tarball's entrypoint runs, not to exercise any
+    // dependency's native build step. Without it, pnpm 11's default-deny
+    // build-script policy makes `pnpm add` exit non-zero (ERR_PNPM_IGNORED_BUILDS)
+    // whenever a transitive dependency ships an ignored postinstall script
+    // (e.g. protobufjs) — a real behavior change from pnpm 10, where the same
+    // situation was only a warning.
     spawnChecked(
       'pnpm',
-      ['add', '--prefer-offline', '--package-import-method=copy', packedTarballPath],
+      [
+        'add',
+        '--prefer-offline',
+        '--package-import-method=copy',
+        '--ignore-scripts',
+        packedTarballPath,
+      ],
       { cwd: installDir, env },
     )
 

--- a/packages/mcp-server/src/server/release/publish-dry-run-policy.test.ts
+++ b/packages/mcp-server/src/server/release/publish-dry-run-policy.test.ts
@@ -206,17 +206,15 @@ describe('implementedNow is false — locally-runnable gate not yet wired', () =
 
 describe('ci.yml dry-run jobs exist (consolidated from publish-dry-run.yml)', () => {
   it('dry-run-npm job exists in ci.yml', () => {
-    expect(
-      readWorkflow(CI_WORKFLOW),
-      'dry-run-npm job must exist in ci.yml',
-    ).toContain('  dry-run-npm:')
+    expect(readWorkflow(CI_WORKFLOW), 'dry-run-npm job must exist in ci.yml').toContain(
+      '  dry-run-npm:',
+    )
   })
 
   it('dry-run-docker job exists in ci.yml', () => {
-    expect(
-      readWorkflow(CI_WORKFLOW),
-      'dry-run-docker job must exist in ci.yml',
-    ).toContain('  dry-run-docker:')
+    expect(readWorkflow(CI_WORKFLOW), 'dry-run-docker job must exist in ci.yml').toContain(
+      '  dry-run-docker:',
+    )
   })
 
   it('dry-run-npm job references publish:dry-run:npm', () => {
@@ -265,7 +263,9 @@ describe('ci.yml dry-run jobs upload artifacts', () => {
 
   it('dry-run-docker artifact path is the docker metadata JSON', () => {
     const section = jobSection(readWorkflow(CI_WORKFLOW), 'dry-run-docker')
-    expect(section).toContain('path: packages/mcp-server/tmp/publish-dry-run/docker-image-metadata.json')
+    expect(section).toContain(
+      'path: packages/mcp-server/tmp/publish-dry-run/docker-image-metadata.json',
+    )
   })
 
   it('dry-run-docker artifact upload warns if no files are found (metadata may be absent for unchanged images)', () => {
@@ -313,7 +313,10 @@ describe('ci.yml cleanliness (no publish/sign/OIDC capabilities)', () => {
 describe('publish:dry-run aggregate contract', () => {
   function dryRunSegments(): string[] {
     const script = packageScripts['publish:dry-run'] ?? ''
-    return script.split('&&').map((s) => s.trim()).filter(Boolean)
+    return script
+      .split('&&')
+      .map((s) => s.trim())
+      .filter(Boolean)
   }
 
   it('publish:dry-run contains pnpm publish:dry-run:npm', () => {
@@ -339,12 +342,8 @@ describe('publish:dry-run aggregate contract', () => {
 describe('dry-run-docker job setup drift (ci.yml)', () => {
   const dockerSection = () => jobSection(readWorkflow(CI_WORKFLOW), 'dry-run-docker')
 
-  it('docker dry-run job uses pnpm/action-setup', () => {
-    expect(dockerSection()).toContain('pnpm/action-setup')
-  })
-
-  it('docker dry-run job uses actions/setup-node', () => {
-    expect(dockerSection()).toContain('actions/setup-node')
+  it('docker dry-run job uses the shared setup-pnpm composite action', () => {
+    expect(dockerSection()).toContain('./.github/actions/setup-pnpm')
   })
 
   it('docker dry-run job runs pnpm install --frozen-lockfile', () => {
@@ -352,19 +351,14 @@ describe('dry-run-docker job setup drift (ci.yml)', () => {
   })
 
   it('docker dry-run job does not push to registry', () => {
-    expect(
-      dockerSection(),
-      'docker dry-run must not push to registry',
-    ).not.toContain('push: true')
+    expect(dockerSection(), 'docker dry-run must not push to registry').not.toContain('push: true')
   })
 })
 
 // ── validateFutureGateCoverage PBT ───────────────────────────────────────────
 
 describe('validateFutureGateCoverage PBT', () => {
-  const nonEmptyStr = fc
-    .string({ minLength: 1, maxLength: 32 })
-    .filter((s) => s.trim().length > 0)
+  const nonEmptyStr = fc.string({ minLength: 1, maxLength: 32 }).filter((s) => s.trim().length > 0)
 
   fcTest.prop(
     [
@@ -413,9 +407,7 @@ describe('validateFutureGateCoverage PBT', () => {
       const sanitisedScripts = Object.fromEntries(
         Object.entries(scripts).filter(([k]) => k !== artifact.futureGateId),
       )
-      expect(
-        validateFutureGateCoverage(artifact, sanitisedScripts, gateIds).ok,
-      ).toBe(false)
+      expect(validateFutureGateCoverage(artifact, sanitisedScripts, gateIds).ok).toBe(false)
     },
   )
 
@@ -427,14 +419,11 @@ describe('validateFutureGateCoverage PBT', () => {
       }),
     ],
     withDefaults(),
-  )(
-    'deferred artifact whose futureGateId is already in matrix fails',
-    (artifact) => {
-      const scripts = { [artifact.futureGateId]: 'some-command' }
-      const matrixIds = [artifact.futureGateId]
-      expect(validateFutureGateCoverage(artifact, scripts, matrixIds).ok).toBe(false)
-    },
-  )
+  )('deferred artifact whose futureGateId is already in matrix fails', (artifact) => {
+    const scripts = { [artifact.futureGateId]: 'some-command' }
+    const matrixIds = [artifact.futureGateId]
+    expect(validateFutureGateCoverage(artifact, scripts, matrixIds).ok).toBe(false)
+  })
 })
 
 // ── validateCiWorkflowPolicy PBT ──────────────────────────────────────────────

--- a/packages/mcp-server/src/shared/ci-policy.test.ts
+++ b/packages/mcp-server/src/shared/ci-policy.test.ts
@@ -10,12 +10,33 @@ const COMMIT_SHA_RE = /^[0-9a-f]{40}$/
 
 describe('release.yml — action pinning policy', () => {
   it('every uses: entry is pinned to a 40-char commit SHA (no mutable tags)', async () => {
-    const text = await readFile(
-      join(REPO_ROOT, '.github/workflows/release.yml'),
-      'utf-8',
-    )
+    const text = await readFile(join(REPO_ROOT, '.github/workflows/release.yml'), 'utf-8')
 
-    // Extract all `uses: owner/repo@ref` values.
+    // Extract all `uses: owner/repo@ref` values. Local composite actions
+    // (relative paths starting with "./") are excluded: they are not external
+    // supply-chain dependencies — the checked-out commit itself already pins
+    // their contents, so there is no separate ref to SHA-pin.
+    const usesRefs = [...text.matchAll(/uses:\s+(\S+)/g)]
+      .map((m) => m[1])
+      .filter((ref) => !ref.startsWith('./'))
+    expect(usesRefs.length).toBeGreaterThan(0)
+
+    for (const ref of usesRefs) {
+      const at = ref.lastIndexOf('@')
+      expect(at, `${ref}: missing @ separator`).toBeGreaterThan(0)
+      const sha = ref.slice(at + 1)
+      expect(
+        COMMIT_SHA_RE.test(sha),
+        `Action ${ref} uses mutable ref "${sha}" — pin to a 40-char commit SHA`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe('setup-pnpm composite action — pinning policy', () => {
+  it('every uses: entry is pinned to a 40-char commit SHA (no mutable tags)', async () => {
+    const text = await readFile(join(REPO_ROOT, '.github/actions/setup-pnpm/action.yml'), 'utf-8')
+
     const usesRefs = [...text.matchAll(/uses:\s+(\S+)/g)].map((m) => m[1])
     expect(usesRefs.length).toBeGreaterThan(0)
 
@@ -33,10 +54,7 @@ describe('release.yml — action pinning policy', () => {
 
 describe('release.yml — root permissions policy', () => {
   it('packages: write is absent from the workflow root permissions block', async () => {
-    const text = await readFile(
-      join(REPO_ROOT, '.github/workflows/release.yml'),
-      'utf-8',
-    )
+    const text = await readFile(join(REPO_ROOT, '.github/workflows/release.yml'), 'utf-8')
 
     // Everything before `jobs:` is the workflow preamble (root-level keys).
     // `packages: write` with 2-space indent is a root-level permissions entry.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,8 +64,8 @@ overrides:
 # useCanvasSync.ts's Excalidraw AppState mapped type (TS2740), even though
 # the underlying package files are byte-identical and not duplicated.
 #
-# Re-verified 2026-07-12 on pnpm 11.12.0 (a pnpm 11.x release that already
-# ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
+# Re-verified 2026-07-12 on pnpm 11.12.0 (this repo's pinned version, which
+# already ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
 # from a prior non-GVS install): a fully clean install — every node_modules
 # in the worktree removed, then `pnpm install --force` from scratch with
 # this flag on from the start — still reproduces TS2740. So the failure is

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,3 +42,55 @@ minimumReleaseAgeStrict: true
 # files, which is why warm cache runs succeed even with the postinstall blocked.
 onlyBuiltDependencies:
   - esbuild
+
+# Patched versions for known-vulnerable transitive deps. Moved here from the
+# package.json "pnpm.overrides" key: pnpm v11 no longer reads settings from
+# package.json's "pnpm" field (see https://pnpm.io/settings).
+overrides:
+  lodash-es@<4.18.0: ^4.18.0
+  nanoid@<3.3.8: ^3.3.8
+  nanoid@>=4.0.0 <5.0.9: ^5.0.9
+  protobufjs@<8.6.0: ^8.6.0
+  fast-uri@<3.1.2: ^3.1.2
+  kysely@<0.28.17: ^0.28.17
+  "@grpc/grpc-js@<1.14.4": ^1.14.4
+  shell-quote@<1.8.4: ^1.8.4
+  uuid@<11.1.1: ^11.1.1
+  qs@>=6.11.1 <6.15.2: ^6.15.2
+  ip-address@<=10.1.0: ^10.1.1
+  mermaid@<11.15.0: ^11.16.0
+  dompurify@<3.4.11: ^3.4.11
+
+# Multiple concurrent agent-driven git worktrees are routine in this repo;
+# without this, pnpm materializes a full node_modules/.pnpm copy per
+# worktree (~1GB each), which has caused real disk exhaustion. A shared
+# global virtual store lets every worktree's node_modules symlink into one
+# on-disk store instead of duplicating it. Requires pnpm >= 11.
+#
+# Currently left OFF: enabling it makes `apps/web` node_modules resolve
+# through a much deeper external symlink chain (into
+# ~/Library/pnpm/store/v11/links/...), and TypeScript's "bundler"
+# moduleResolution then reports a spurious structural mismatch for
+# useCanvasSync.ts's Excalidraw AppState mapped type (TS2740), even though
+# the underlying package files are byte-identical and not duplicated
+# (verified: single physical instance of every package involved). The same
+# tsc run passes cleanly with this flag off, and also passes with
+# moduleResolution switched to node16 (an unrelated wider change, not
+# adopted here). Re-enable once this TypeScript/pnpm interaction is
+# understood or fixed upstream.
+enableGlobalVirtualStore: false
+
+# pnpm already ignored build scripts for these transitive deps under pnpm 10
+# (verified: same "Ignored build scripts" warning appears on a clean pnpm 10
+# install). Only esbuild's postinstall is load-bearing (see above), so only
+# esbuild is allowed here — this preserves existing behavior rather than
+# newly enabling native builds pnpm was already skipping.
+allowBuilds:
+  '@swc/core': false
+  canvas: false
+  esbuild: true
+  lefthook: false
+  libxmljs2: false
+  msw: false
+  sharp: false
+  workerd: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,16 +33,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeStrict: true
 
-# pnpm v11 blocks all build scripts by default (security-by-default).
-# esbuild's postinstall (install.js) must run: it writes the absolute path of the
-# @esbuild/linux-x64 native binary into lib/main.js. Without this, the JS API
-# cannot locate the binary and Vite's dep optimizer hangs indefinitely when the
-# pnpm store cache is cold (lockfile change → cache miss → fresh install).
-# With a warm pnpm store cache the previously-written path survives in cached
-# files, which is why warm cache runs succeed even with the postinstall blocked.
-onlyBuiltDependencies:
-  - esbuild
-
 # Patched versions for known-vulnerable transitive deps. Moved here from the
 # package.json "pnpm.overrides" key: pnpm v11 no longer reads settings from
 # package.json's "pnpm" field (see https://pnpm.io/settings).
@@ -74,8 +64,8 @@ overrides:
 # useCanvasSync.ts's Excalidraw AppState mapped type (TS2740), even though
 # the underlying package files are byte-identical and not duplicated.
 #
-# Re-verified 2026-07-12 on pnpm 11.12.0 (this repo's pinned version, which
-# already ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
+# Re-verified 2026-07-12 on pnpm 11.12.0 (a pnpm 11.x release that already
+# ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
 # from a prior non-GVS install): a fully clean install — every node_modules
 # in the worktree removed, then `pnpm install --force` from scratch with
 # this flag on from the start — still reproduces TS2740. So the failure is
@@ -94,11 +84,18 @@ overrides:
 # understood or fixed upstream.
 enableGlobalVirtualStore: false
 
-# pnpm already ignored build scripts for these transitive deps under pnpm 10
-# (verified: same "Ignored build scripts" warning appears on a clean pnpm 10
-# install). Only esbuild's postinstall is load-bearing (see above), so only
-# esbuild is allowed here — this preserves existing behavior rather than
-# newly enabling native builds pnpm was already skipping.
+# pnpm v11 blocks all build scripts by default (security-by-default);
+# allowBuilds is the v11 replacement for the removed onlyBuiltDependencies /
+# neverBuiltDependencies / ignoredBuiltDependencies keys (see
+# https://pnpm.io/settings#allowbuilds). Esbuild's postinstall (install.js)
+# is load-bearing: on a cold store it resolves the platform-specific
+# @esbuild/<platform> optionalDependency and hardlinks its native binary into
+# bin/esbuild — without that, esbuild falls back to spawning the binary via a
+# slower JS wrapper. pnpm already ignored build scripts for the deps below
+# under pnpm 10 (verified: same "Ignored build scripts" warning appears on a
+# clean pnpm 10 install), so only esbuild is allowed here — this preserves
+# existing behavior rather than newly enabling native builds pnpm was already
+# skipping.
 allowBuilds:
   '@swc/core': false
   canvas: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,14 +67,28 @@ overrides:
 # global virtual store lets every worktree's node_modules symlink into one
 # on-disk store instead of duplicating it. Requires pnpm >= 11.
 #
-# Currently left OFF: enabling it makes `apps/web` node_modules resolve
-# through a much deeper external symlink chain (into
+# Currently left OFF: enabling it makes apps/web/node_modules/@excalidraw/excalidraw
+# resolve through a much deeper external symlink chain (into
 # ~/Library/pnpm/store/v11/links/...), and TypeScript's "bundler"
 # moduleResolution then reports a spurious structural mismatch for
 # useCanvasSync.ts's Excalidraw AppState mapped type (TS2740), even though
-# the underlying package files are byte-identical and not duplicated
-# (verified: single physical instance of every package involved). The same
-# tsc run passes cleanly with this flag off, and also passes with
+# the underlying package files are byte-identical and not duplicated.
+#
+# Re-verified 2026-07-12 on pnpm 11.12.0 (this repo's pinned version, which
+# already ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
+# from a prior non-GVS install): a fully clean install — every node_modules
+# in the worktree removed, then `pnpm install --force` from scratch with
+# this flag on from the start — still reproduces TS2740. So the failure is
+# not #9739 residue; it is a distinct symlink-depth interaction between
+# TypeScript's mapped-type structural check and pnpm's GVS link chain.
+#
+# `publicHoistPattern` does not help: @excalidraw/excalidraw is a *direct*
+# dependency of apps/web, already at the top of its node_modules, so the
+# hoisting setting (which only relocates transitive deps) has no effect on
+# it — confirmed by identical `readlink` output and identical TS2740 before
+# and after adding the pattern.
+#
+# The same tsc run passes cleanly with this flag off, and also passes with
 # moduleResolution switched to node16 (an unrelated wider change, not
 # adopted here). Re-enable once this TypeScript/pnpm interaction is
 # understood or fixed upstream.


### PR DESCRIPTION
## Summary

Upgrades pnpm 10.29.3 → 11.12.0 across `packageManager`, `Dockerfile.server`'s corepack pin, and migrates `package.json`'s `pnpm.overrides` into `pnpm-workspace.yaml` (pnpm 11 no longer reads settings from package.json's `pnpm` field).

**`enableGlobalVirtualStore` is added to `pnpm-workspace.yaml` but shipped OFF.** This is the actual ask of this task (shared virtual store across concurrent agent git worktrees, avoiding the ~1GB-per-worktree `node_modules/.pnpm` copy that has caused real disk exhaustion) — but enabling it breaks `apps/web` typecheck with a reproducible TypeScript structural-typing regression. Full writeup and blocker below.

### Measured with the flag ON (before the blocker was found)

- Fresh `node_modules` after a clean install: **1.5 MB** (all symlinks) vs the pnpm-10 baseline of **~1.1 GB**.
- Clean reinstall after `rm -rf node_modules`: **<1s** (vs ~7-13s for a normal populated install).
- `node_modules/@excalidraw/excalidraw` (and every other package checked) resolves to a single shared hash under `~/Library/pnpm/store/v11/links/...` — confirmed no duplication.

This is a real, working feature — it just isn't safe to ship yet.

### The blocker (`enableGlobalVirtualStore: true`)

`pnpm -r typecheck` fails on `apps/web` only when the flag is on:

```
src/hooks/useCanvasSync.ts(604,13): error TS2740: Type 'MutableAppState' is missing the
following properties from type 'Pick<AppState, keyof AppState>': name, scrollX, scrollY,
zoom, and 85 more.
```

Reproduced in isolation (minimal repro file, not just the real call site). Ruled out:
- **Duplicate package instances** — `pnpm why @excalidraw/excalidraw`, `@excalidraw/utils`, `@types/react`, and `react` each show exactly one physical copy; the global store's own hash-keyed link directories confirm a single hash per package.
- **Byte-identical files** — checksummed the entire `@excalidraw/excalidraw/types` directory between the flag-on and flag-off installs: identical.
- **TypeScript version** — reproduces identically on TypeScript 6.0.3 (the repo's pinned catalog version) and 7.0.2 (current latest).
- **Confirmed root trigger** — switching `apps/web/tsconfig.json`'s `moduleResolution` from `bundler` to `node16` makes the error disappear (replaced by unrelated pre-existing issues from that broader change, so not adopted). This isolates the cause to TypeScript's `bundler` moduleResolution's wildcard `package.json#exports` handling (`"./*": {"types": "./dist/types/excalidraw/*.d.ts"}`) interacting badly with the deep, external symlink chain the global virtual store introduces (`apps/web/node_modules/@excalidraw/excalidraw` → 11 `../` segments → `~/Library/pnpm/store/v11/links/...`), rather than a dependency-hoisting bug pnpm itself could fix.

Per this repo's own instruction ("if any gate regresses in a way you cannot fix cleanly, stop and report rather than papering over it"), I'm shipping with the flag documented but off, rather than forcing a broad `moduleResolution` change or a type-cast workaround in production code. `pnpm-workspace.yaml` has the full writeup inline so the next person doesn't have to re-derive it.

### Two smaller pnpm-11 behavior changes found and fixed along the way

- `allowBuilds` (pnpm 11's replacement for the interactive `pnpm approve-builds` prompt) needed to be populated for `@swc/core`, `canvas`, `lefthook`, `libxmljs2`, `msw`, `sharp`, `workerd` — **all set to `false`**, because a clean install under the *unmodified* pnpm 10.29.3 baseline shows the exact same "Ignored build scripts" warning for these packages. Only `esbuild` was ever load-bearing here, so this preserves existing behavior rather than newly enabling native builds pnpm was already skipping.
- `pnpm add` (not `pnpm install`) now exits non-zero (`ERR_PNPM_IGNORED_BUILDS`) instead of just warning when an added package has an ignored build script. This broke `smoke:tarball` (the packed-tarball install, which pulls in `protobufjs` transitively) — fixed by adding `--ignore-scripts` to that scratch install, since it only needs the entrypoint to run, not any dependency's native build step.

### Lockfile

`pnpm-lock.yaml` is **unchanged** (`git diff --stat pnpm-lock.yaml` is empty) — `lockfileVersion` stayed `9.0` and content is byte-identical. No format bump, so the currently-open `web-noconsole` PR does **not** need to rebase because of this change.

### Migration note for existing worktrees

Existing sibling worktrees (installed under pnpm 10) are unaffected until they sync with `main`. Volta reads `packageManager` from `package.json` and auto-fetches pnpm 11 transparently the next time `pnpm install` runs in a worktree that has this commit — no manual pnpm version management needed, and (per the lockfile point above) no reinstall-format surprises.

## Test plan

- [x] `pnpm install` (clean, `CI=true`) — no ignored-build warnings, no pnpm-field warning
- [x] `pnpm -r typecheck` — green (with `enableGlobalVirtualStore: false`)
- [x] `pnpm build` — green
- [x] `pnpm test` — 288 test files / 4102 tests passed, 2 skipped
- [x] `pnpm lint:noconsole` — green
- [x] `pnpm smoke:e2e` — green
- [x] `pnpm test:e2e:distribution` — green except `smoke:codex`, which spawns the real `codex` CLI against the running MCP daemon and fails inside this nested-agent sandbox; the script's own comment already documents this as a known sandbox limitation ("If that happens, run it outside the sandbox"), unrelated to this change
- [x] `docker build -f Dockerfile.server` (both the `build` stage and the full multi-stage image) — succeeds with `corepack prepare pnpm@11.12.0`
- [x] Fresh-worktree install timing/size comparison (see above)
- [ ] `smoke:codex` — needs to be re-verified outside a nested-agent sandbox by a human or CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
