### PR TITLE
fix(mcp-server): reject update_element text patches on arrows instead of lying ok:true

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -265,6 +265,34 @@ async function main() {
     `[e2e] annotate_batch → arrow with text-as-label alias (labelId=${batchArrow.annotations[0].labelId})`,
   )
 
+  // update_element must reject `text` patches targeting an arrow's own
+  // element (arrows label via a separate bound text element, not a `text`
+  // field on the arrow) instead of returning ok:true for a no-op.
+  await expectRejected(
+    callTool('update_element', {
+      canvasId: created.id,
+      elementId: batchArrow.annotations[0].arrowId,
+      patch: { text: 'should not silently no-op' },
+    }),
+    /label/i,
+    'update_element text patch on an arrow element',
+  )
+  console.log('[e2e] update_element → rejects text patch on arrow OK')
+
+  // update_element on the arrow's own separately-tracked label element must
+  // still work — this is the actual supported way to edit an existing label.
+  const updatedLabel = await callTool('update_element', {
+    canvasId: created.id,
+    elementId: batchArrow.annotations[0].labelId,
+    patch: { text: 'smoke-label-updated' },
+  })
+  if (updatedLabel.elementId !== batchArrow.annotations[0].labelId) {
+    throw new Error(
+      `update_element on label returned unexpected shape: ${JSON.stringify(updatedLabel)}`,
+    )
+  }
+  console.log('[e2e] update_element → updates arrow label element text OK')
+
   // Exercise create_frame so any drift between its zod outputSchema
   // (assignedMembers etc.) and the runtime payload trips the SDK's structured-
   // content validator at this layer instead of leaking out to MCP clients.

--- a/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
@@ -88,7 +88,7 @@ export const updateElementInputShape = {
   patch: z
     .record(z.string(), z.unknown())
     .describe(
-      'Partial element fields to merge (e.g. { text: "...", strokeColor: "#1971c2", x: 100, width: 200 }). Only valid Excalidraw element fields are applied; unknown keys are ignored.',
+      'Partial element fields to merge (e.g. { strokeColor: "#1971c2", x: 100, width: 200 }). Only valid Excalidraw element fields are applied; unknown keys are ignored. For text/box_with_label elements, `text` replaces the element\'s own body text. For arrow elements, `text` is REJECTED (throws) rather than silently ignored: an arrow\'s label is a separate bound text element, not a `text` field on the arrow — use annotate (type="arrow", label=...) to add one, or target that label element\'s own id here to edit it.',
     ),
 } satisfies z.ZodRawShape
 
@@ -98,7 +98,7 @@ export function updateElementTool() {
   return {
     name: 'update_element',
     description:
-      'Patch fields of an existing element in-place (e.g., change text, strokeColor, x/y/width/height). Any Excalidraw element field can be set via patch.',
+      'Patch fields of an existing element in-place (e.g., change text, strokeColor, x/y/width/height). Any Excalidraw element field can be set via patch, except `text` on arrow elements — arrows label via a separate bound text element (see annotate), so that combination throws instead of silently doing nothing.',
     // Derived from the Zod shape so the JSON-Schema view can never drift from
     // what registerToolWithAnnotations actually validates against.
     inputSchema: z.toJSONSchema(z.object(updateElementInputShape)) as {

--- a/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops-tools.ts
@@ -88,7 +88,7 @@ export const updateElementInputShape = {
   patch: z
     .record(z.string(), z.unknown())
     .describe(
-      'Partial element fields to merge (e.g. { strokeColor: "#1971c2", x: 100, width: 200 }). Only valid Excalidraw element fields are applied; unknown keys are ignored. For text/box_with_label elements, `text` replaces the element\'s own body text. For arrow elements, `text` is REJECTED (throws) rather than silently ignored: an arrow\'s label is a separate bound text element, not a `text` field on the arrow — use annotate (type="arrow", label=...) to add one, or target that label element\'s own id here to edit it.',
+      'Partial element fields to merge (e.g. { strokeColor: "#1971c2", x: 100, width: 200 }). Keys are written to the element as-is; there is no allowlist, so a misspelled or made-up key is stored without producing any visible effect — only real Excalidraw element fields change rendering. `box_with_label` is a composite of a rectangle plus separate text/title elements (from annotate); there is no single `box_with_label` element to patch, so target the specific sub-element\'s own id (e.g. its text or title id, not the rectangle\'s id) to change its `text`. For arrow elements, `text` is REJECTED (throws) rather than silently ignored: an arrow\'s label is a separate bound text element, not a `text` field on the arrow — use annotate (type="arrow", label=...) to add one, or target that label element\'s own id here to edit it.',
     ),
 } satisfies z.ZodRawShape
 

--- a/packages/mcp-server/src/server/mcp/tools/element-ops.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops.test.ts
@@ -37,7 +37,14 @@ describe('applyUpdate', () => {
   let doc: LoroDoc
   beforeEach(() => {
     doc = new LoroDoc()
-    seedElement(doc, 'r1', { type: 'rectangle', x: 10, y: 20, width: 100, height: 50, strokeColor: '#000' })
+    seedElement(doc, 'r1', {
+      type: 'rectangle',
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      strokeColor: '#000',
+    })
   })
 
   it('case 162', () => {
@@ -54,7 +61,11 @@ describe('applyUpdate', () => {
   it('case 164', () => {
     applyUpdate(doc, 'r1', { strokeColor: '#0000ff' })
     expect(readElement(doc, 'r1')).toMatchObject({
-      x: 10, y: 20, width: 100, height: 50, strokeColor: '#0000ff',
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      strokeColor: '#0000ff',
     })
   })
 
@@ -65,6 +76,38 @@ describe('applyUpdate', () => {
   it('case 166', () => {
     expect(() => applyUpdate(doc, 'r1', {})).not.toThrow()
     expect(readElement(doc, 'r1')).toMatchObject({ x: 10, y: 20 })
+  })
+})
+
+describe('applyUpdate on arrow elements', () => {
+  let doc: LoroDoc
+  beforeEach(() => {
+    doc = new LoroDoc()
+    seedElement(doc, 'a1', {
+      type: 'arrow',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 0,
+      points: [
+        [0, 0],
+        [100, 0],
+      ],
+    })
+  })
+
+  it('rejects a text patch on an arrow instead of silently no-op-ing', () => {
+    // Arrows render a label as a separate bound text element (see annotate's
+    // arrow label mechanism), not via a `text` field on the arrow itself.
+    // Silently accepting `text` here would report ok:true while adding no
+    // visible label, so this must fail loudly instead.
+    expect(() => applyUpdate(doc, 'a1', { text: 'shipped' })).toThrow(/label/i)
+    expect(readElement(doc, 'a1')).not.toHaveProperty('text')
+  })
+
+  it('still allows non-text geometry/style patches on arrows', () => {
+    expect(() => applyUpdate(doc, 'a1', { strokeColor: '#ff0000' })).not.toThrow()
+    expect(readElement(doc, 'a1')).toMatchObject({ strokeColor: '#ff0000' })
   })
 })
 
@@ -487,7 +530,10 @@ describe('applyAlign', () => {
       y: 35,
       width: 100,
       height: 0,
-      points: [[0, 0], [100, 0]],
+      points: [
+        [0, 0],
+        [100, 0],
+      ],
       startBoxId: 'a',
       endBoxId: 'b',
     })

--- a/packages/mcp-server/src/server/mcp/tools/element-ops.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops.test.ts
@@ -77,6 +77,16 @@ describe('applyUpdate', () => {
     expect(() => applyUpdate(doc, 'r1', {})).not.toThrow()
     expect(readElement(doc, 'r1')).toMatchObject({ x: 10, y: 20 })
   })
+
+  it('writes a key that is not a real Excalidraw element field instead of filtering it out', () => {
+    // applyUpdate has no per-type field allowlist (building one would need the
+    // full Excalidraw element schema across every element variant), so a
+    // misspelled or made-up key is stored as-is rather than silently dropped.
+    // The tool description must say this plainly rather than claim filtering
+    // that does not happen.
+    applyUpdate(doc, 'r1', { notARealExcalidrawField: 'value' })
+    expect(readElement(doc, 'r1')).toMatchObject({ notARealExcalidrawField: 'value' })
+  })
 })
 
 describe('applyUpdate on arrow elements', () => {

--- a/packages/mcp-server/src/server/mcp/tools/element-ops.ts
+++ b/packages/mcp-server/src/server/mcp/tools/element-ops.ts
@@ -62,15 +62,25 @@ function readBoundArrowIds(map: LoroMap): string[] {
     .map((value) => value.id)
 }
 
+// Excalidraw arrows never render a `text` field directly — a label is a
+// separate bound text element positioned near the arrow's midpoint (the same
+// mechanism `annotate` type="arrow" + label uses). Silently writing `text`
+// onto an arrow's own map would report success while adding no visible
+// label, so that patch key is rejected instead of accepted as a no-op.
+function assertNoArrowTextPatch(map: LoroMap, patch: Record<string, unknown>): void {
+  if (map.get('type') !== 'arrow') return
+  if (!('text' in patch)) return
+  throw new Error(
+    'update_element cannot set `text` on an arrow element: arrows render a label via a separate bound text element, not a `text` field on the arrow itself. Use annotate (type="arrow", label=...) to add a label, or update_element on that label\'s own elementId to edit an existing one.',
+  )
+}
+
 // Apply an arbitrary field patch to a single element.
 // This assumes known Excalidraw element fields (x/y/width/height/strokeColor/...),
 // while value validation is delegated to the caller (the MCP tool schema).
-export function applyUpdate(
-  doc: LoroDoc,
-  elementId: string,
-  patch: Record<string, unknown>,
-): void {
+export function applyUpdate(doc: LoroDoc, elementId: string, patch: Record<string, unknown>): void {
   const map = requireElementMap(doc, elementId)
+  assertNoArrowTextPatch(map, patch)
   for (const [k, v] of Object.entries(patch)) {
     map.set(k, v as never)
   }
@@ -134,11 +144,7 @@ function readGroupIds(map: LoroMap): string[] {
 }
 
 // Append groupId to every member's groupIds array. Existing membership is a no-op.
-export function applyAssignToGroup(
-  doc: LoroDoc,
-  groupId: string,
-  memberIds: string[],
-): void {
+export function applyAssignToGroup(doc: LoroDoc, groupId: string, memberIds: string[]): void {
   if (memberIds.length === 0) return
   const maps = memberIds.map((id) => requireElementMap(doc, id))
   for (const map of maps) {
@@ -192,12 +198,7 @@ export function applyDeleteGroup(doc: LoroDoc, groupId: string): string[] {
 }
 
 // Move multiple elements by the same dx/dy in one all-or-nothing operation.
-export function applyMove(
-  doc: LoroDoc,
-  elementIds: string[],
-  dx: number,
-  dy: number,
-): void {
+export function applyMove(doc: LoroDoc, elementIds: string[], dx: number, dy: number): void {
   // Pre-check that every id exists before mutating the doc.
   const maps: LoroMap[] = elementIds.map((id) => requireElementMap(doc, id))
   if (dx === 0 && dy === 0) return
@@ -243,13 +244,10 @@ export function applyMove(
     })
     arrowMap.set('x', snapped.start.x)
     arrowMap.set('y', snapped.start.y)
-    arrowMap.set(
-      'points',
-      [
-        [0, 0],
-        [snapped.end.x - snapped.start.x, snapped.end.y - snapped.start.y],
-      ] as Parameters<LoroMap['set']>[1],
-    )
+    arrowMap.set('points', [
+      [0, 0],
+      [snapped.end.x - snapped.start.x, snapped.end.y - snapped.start.y],
+    ] as Parameters<LoroMap['set']>[1])
     arrowMap.set('width', Math.abs(snapped.end.x - snapped.start.x))
     arrowMap.set('height', Math.abs(snapped.end.y - snapped.start.y))
   }
@@ -257,11 +255,7 @@ export function applyMove(
 
 // Reorder z-index while preserving the selected ids' current relative order,
 // moving them together to the back or front without creating extra tombstones.
-export function applyReorder(
-  doc: LoroDoc,
-  elementIds: string[],
-  action: 'front' | 'back',
-): void {
+export function applyReorder(doc: LoroDoc, elementIds: string[], action: 'front' | 'back'): void {
   if (elementIds.length === 0) return
   // Pre-check.
   for (const id of elementIds) requireElementMap(doc, id)
@@ -307,11 +301,7 @@ export type AlignAxis = 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom
 // Snap a set of elements to a shared axis. Each element is shifted into place
 // by reusing applyMove with a single-id call so that bound arrows re-snap to
 // the new box centres exactly the way move_elements does.
-export function applyAlign(
-  doc: LoroDoc,
-  elementIds: string[],
-  alignment: AlignAxis,
-): void {
+export function applyAlign(doc: LoroDoc, elementIds: string[], alignment: AlignAxis): void {
   // Drop duplicate ids before any geometry is computed; otherwise an id
   // listed twice would participate in min/max/centroid math twice and
   // applyMove() would shift it twice. Preserve first-occurrence order so
@@ -391,9 +381,7 @@ export function applyDistribute(
   // Sort by leading edge along the chosen axis. Build (originalId, rect) pairs
   // so we can apply moves back to the right element after sorting.
   const indexed = elementIds.map((id, i) => ({ id, rect: rects[i] }))
-  indexed.sort((a, b) =>
-    direction === 'horizontal' ? a.rect.x - b.rect.x : a.rect.y - b.rect.y,
-  )
+  indexed.sort((a, b) => (direction === 'horizontal' ? a.rect.x - b.rect.x : a.rect.y - b.rect.y))
 
   if (direction === 'horizontal') {
     const first = indexed[0].rect


### PR DESCRIPTION
## Summary
- `update_element` accepted a `text` patch on an existing arrow, wrote it to a field Excalidraw ignores, and returned `ok:true` even though no label appeared on the canvas.
- Arrows never render their own `text` field — a label is a separate bound text element positioned at the arrow's midpoint, the same mechanism `annotate` (type="arrow", `label`) already uses on the create path.
- `applyUpdate` now throws when a `text` key targets an arrow element, pointing the caller at `annotate` to add a label, or at the label element's own id to edit an existing one.
- Verified the create path (`annotate` / `annotate_batch`) does not have the twin bug — it already aliases `text` to `label` correctly for arrows.
- Extended `pnpm smoke:e2e` to exercise both the rejection and the correct arrow-label-update path (via the label element's own id).

## Mechanism confirmed
- `appendAnnotationToDoc` (annotate.ts) treats arrow `text` as an alias for `label` and creates a separate midpoint text element tagged `isArrowLabel: true` — there is no `containerId`/`boundElements` link back from the label to the arrow itself, so there's no persistent way for `update_element` to "find the arrow's label" from the arrow id alone. That's why the contract chosen here is fail-loud rather than attempting to auto-locate/replace a label.

## Test plan
- [x] `pnpm vitest run --project mcp-node packages/mcp-server/src/server/mcp/tools/element-ops.test.ts` (new red→green tests)
- [x] `pnpm test --project mcp-node` (3090 passed)
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck`
- [x] `pnpm build`
- [x] `pnpm smoke:e2e` (new update_element arrow-text-reject + label-update steps pass)
- [x] Mutation-check: reverted the `applyUpdate` guard, confirmed both the new unit test and `smoke:e2e` fail, restored the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Arrow label updates now return a clear error instead of being silently ignored.
  * Arrow styling and other non-text updates continue to work as expected.
  * Existing arrow labels can now be edited by updating their associated label element.

* **Documentation**
  * Clarified how arrow labels should be created and updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->