### PR TITLE
fix(web): confirm copy-canvas-URL success/failure instead of failing silently

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -564,4 +564,34 @@ describe('WorkspaceTopBar browser mode', () => {
     const headerAfter = screen.getByRole('banner')
     expect(headerAfter.getBoundingClientRect().height).toBeCloseTo(48, 0)
   })
+
+  it('announces a failed copy without nesting the alert inside the real role="menu" element', async () => {
+    // Real Chromium rendering (not jsdom) of the Radix menu — the layer where
+    // the ARIA tree axe/AccessLint inspects actually exists.
+    const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    renderTopBar()
+
+    await page.getByRole('button', { name: 'Canvas actions' }).click()
+    await page.getByText('Copy canvas URL').click()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain("Couldn't copy automatically")
+
+    const menu = screen.getByRole('menu')
+    expect(menu.contains(alert)).toBe(false)
+
+    // The announcement is still reachable in the accessibility tree even
+    // though it is no longer a DOM child of the menu.
+    const status = screen.getByRole('status')
+    expect(status.textContent).toContain("Couldn't copy the canvas URL automatically.")
+    expect(menu.contains(status)).toBe(false)
+
+    // @ts-expect-error -- test-only cleanup of a property defined above
+    delete navigator.clipboard
+  })
 })

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -894,6 +894,71 @@ describe('WorkspaceTopBar — workspaceId URL encoding', () => {
   })
 })
 
+describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
+  function openCanvasActionsMenu() {
+    const canvasActions = screen.getByLabelText('Canvas actions')
+    fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+    return screen.findByText('Copy canvas URL')
+  }
+
+  afterEach(() => {
+    // @ts-expect-error -- test-only cleanup of a property defined per-test below
+    delete navigator.clipboard
+  })
+
+  it('shows a "Copied!" confirmation after a successful copy, then reverts', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    try {
+      renderBar()
+      const copyItem = await openCanvasActionsMenu()
+      fireEvent.pointerUp(copyItem)
+
+      await vi.waitFor(() => expect(screen.getByText('Copied!')).toBeTruthy())
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/canvas/ws_1/canvas-a'))
+      // Screen-reader-visible announcement, independent of the visible label.
+      expect(screen.getByRole('status').textContent).toContain('Canvas URL copied to clipboard.')
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+      await vi.waitFor(() => expect(screen.queryByText('Copied!')).toBeNull())
+      expect(screen.getByText('Copy canvas URL')).toBeTruthy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces a rejected clipboard write as a visible error instead of a false success', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    renderBar()
+    const copyItem = await openCanvasActionsMenu()
+    fireEvent.pointerUp(copyItem)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain("Couldn't copy automatically")
+    expect(screen.queryByText('Copied!')).toBeNull()
+    expect(screen.getByRole('status').textContent).toContain(
+      "Couldn't copy the canvas URL automatically.",
+    )
+
+    // Fallback: the URL is still available as selectable text.
+    const fallbackInput = screen.getByLabelText('Canvas URL') as HTMLInputElement
+    expect(fallbackInput.value).toContain('/canvas/ws_1/canvas-a')
+    expect(fallbackInput.readOnly).toBe(true)
+  })
+})
+
 describe('WorkspaceTopBar — dataMode="local"', () => {
   it('never calls the daemon fetch: mount, open the canvas switcher, and open the actions area', async () => {
     render(

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -957,6 +957,30 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
     expect(fallbackInput.value).toContain('/canvas/ws_1/canvas-a')
     expect(fallbackInput.readOnly).toBe(true)
   })
+
+  it('does not nest the live-region announcement or the error fallback inside the role="menu" container', async () => {
+    // WAI-ARIA menu pattern: an element with role="menu" may only own
+    // menuitem/menuitemcheckbox/menuitemradio/group descendants. A
+    // role="status"/role="alert" live region nested directly inside it
+    // violates that contract (axe/AccessLint: aria-required-children) even
+    // though the text itself is never focusable or selectable via arrow keys.
+    const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    renderBar()
+    const copyItem = await openCanvasActionsMenu()
+    fireEvent.pointerUp(copyItem)
+
+    const alert = await screen.findByRole('alert')
+    const status = screen.getByRole('status')
+    const menu = screen.getByRole('menu')
+
+    expect(menu.contains(alert)).toBe(false)
+    expect(menu.contains(status)).toBe(false)
+  })
 })
 
 describe('WorkspaceTopBar — dataMode="local"', () => {

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -5,6 +5,7 @@ import {
   workspaceNamesSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import {
+  Check,
   ChevronDown,
   ChevronLeft,
   Copy,
@@ -251,6 +252,11 @@ export default function WorkspaceTopBar({
   const [versionOpen, setVersionOpen] = useState(false)
   const [canvasSearch, setCanvasSearch] = useState('')
   const versionPanelRef = useRef<HTMLDivElement | null>(null)
+  // Copy-URL confirmation: the button itself reports success/failure instead
+  // of a separate toast, since the affordance already has a fixed home (the
+  // canvas actions menu) and a transient label swap is enough signal.
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle')
+  const copyStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Save state: dirty dot + Cmd/Ctrl+S only.
   // No beforeunload guard: every Excalidraw edit flows through useWhiteboardSync
@@ -394,6 +400,7 @@ export default function WorkspaceTopBar({
   useEffect(
     () => () => {
       mountedRef.current = false
+      if (copyStatusTimeoutRef.current) clearTimeout(copyStatusTimeoutRef.current)
     },
     [],
   )
@@ -596,12 +603,33 @@ export default function WorkspaceTopBar({
     }
   }
 
+  // Kept outside copyCanvasUrl so the failure-path fallback can render the
+  // same URL as selectable text without recomputing it.
+  const canvasUrl = `${window.location.origin}/canvas/${workspaceId}/${encodeURIComponent(slug)}`
+
+  const scheduleCopyStatusReset = (delayMs: number) => {
+    if (copyStatusTimeoutRef.current) clearTimeout(copyStatusTimeoutRef.current)
+    copyStatusTimeoutRef.current = setTimeout(() => {
+      if (mountedRef.current) setCopyStatus('idle')
+    }, delayMs)
+  }
+
   const copyCanvasUrl = async () => {
     try {
-      const url = `${window.location.origin}/canvas/${workspaceId}/${encodeURIComponent(slug)}`
-      await navigator.clipboard.writeText(url)
-    } catch {
-      /* ignore */
+      await navigator.clipboard.writeText(canvasUrl)
+      if (!mountedRef.current) return
+      setCopyStatus('copied')
+      scheduleCopyStatusReset(2000)
+    } catch (err) {
+      // A silent catch here is exactly the bug this fixes — clipboard access
+      // can be denied (permissions, insecure context, browser refusal) and
+      // must surface as a visible failure, not a false "copied" success.
+      log.error('failed to copy canvas URL to clipboard:', err)
+      if (!mountedRef.current) return
+      setCopyStatus('error')
+      // Longer than the success state: the user needs time to read the
+      // fallback instructions and select the URL manually.
+      scheduleCopyStatusReset(8000)
     }
   }
 
@@ -781,7 +809,13 @@ export default function WorkspaceTopBar({
         </DropdownMenu>
 
         {/* Canvas-specific actions such as rename and copy URL. */}
-        <DropdownMenu>
+        <DropdownMenu
+          onOpenChange={(open) => {
+            // Every fresh open starts from a clean confirmation state rather
+            // than showing a stale "Copied!"/error from a previous visit.
+            if (open) setCopyStatus('idle')
+          }}
+        >
           <DropdownMenuTrigger asChild>
             <button
               type="button"
@@ -802,9 +836,22 @@ export default function WorkspaceTopBar({
               <Pencil className="size-3.5" />
               Rename canvas
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={copyCanvasUrl} className="gap-2">
-              <Copy className="size-3.5" />
-              Copy canvas URL
+            <DropdownMenuItem
+              onSelect={(e) => {
+                // Keep the menu open so the "Copied!"/error confirmation is
+                // actually visible — Radix closes the menu on select by
+                // default, which is exactly the silent-feedback bug.
+                e.preventDefault()
+                void copyCanvasUrl()
+              }}
+              className="gap-2"
+            >
+              {copyStatus === 'copied' ? (
+                <Check className="size-3.5 text-emerald-600" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+              {copyStatus === 'copied' ? 'Copied!' : 'Copy canvas URL'}
             </DropdownMenuItem>
             {onExport && (
               <>
@@ -817,6 +864,28 @@ export default function WorkspaceTopBar({
                   Export as SVG
                 </DropdownMenuItem>
               </>
+            )}
+            {/* Visually hidden so screen readers announce the outcome even
+                though focus stays on the menu item above. */}
+            <div aria-live="polite" role="status" className="sr-only">
+              {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
+              {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
+            </div>
+            {copyStatus === 'error' && (
+              <div className="px-2 py-1.5 text-xs text-destructive" role="alert">
+                <p>Couldn't copy automatically. Select and copy the link below:</p>
+                <Input
+                  readOnly
+                  value={canvasUrl}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    e.currentTarget.select()
+                  }}
+                  onFocus={(e) => e.currentTarget.select()}
+                  aria-label="Canvas URL"
+                  className="mt-1 h-7 font-mono text-[11px]"
+                />
+              </div>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -257,6 +258,11 @@ export default function WorkspaceTopBar({
   // canvas actions menu) and a transient label swap is enough signal.
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle')
   const copyStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Anchor for the portaled copy-error fallback box below — it can no longer
+  // rely on CSS `position: absolute` relative to this wrapper once it's
+  // portaled to document.body, so its on-screen position is computed from
+  // this element's own rect instead.
+  const canvasActionsRef = useRef<HTMLDivElement | null>(null)
 
   // Save state: dirty dot + Cmd/Ctrl+S only.
   // No beforeunload guard: every Excalidraw edit flows through useWhiteboardSync
@@ -809,7 +815,7 @@ export default function WorkspaceTopBar({
         </DropdownMenu>
 
         {/* Canvas-specific actions such as rename and copy URL. */}
-        <div className="relative">
+        <div ref={canvasActionsRef} className="relative">
           <DropdownMenu
             onOpenChange={(open) => {
               // Every fresh open starts from a clean confirmation state rather
@@ -868,36 +874,67 @@ export default function WorkspaceTopBar({
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-          {/* Rendered as a sibling of the Radix menu (role="menu"), not a
-              descendant of it: the WAI-ARIA menu pattern only allows
-              menuitem/menuitemcheckbox/menuitemradio/group as owned elements,
-              and a live region nested directly inside role="menu" fails that
-              contract (axe/AccessLint: aria-required-children). aria-live and
-              role="alert" are announced wherever they sit in the document, so
-              moving them outside the menu subtree does not silence them. */}
-          <div aria-live="polite" role="status" className="sr-only">
-            {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
-            {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
-          </div>
-          {copyStatus === 'error' && (
-            <div
-              role="alert"
-              className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover px-2 py-1.5 text-xs text-destructive shadow-md"
-            >
-              <p>Couldn't copy automatically. Select and copy the link below:</p>
-              <Input
-                readOnly
-                value={canvasUrl}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  e.currentTarget.select()
-                }}
-                onFocus={(e) => e.currentTarget.select()}
-                aria-label="Canvas URL"
-                className="mt-1 h-7 font-mono text-[11px]"
-              />
-            </div>
-          )}
+          {/* Both the live-region announcement and the error fallback below
+              are portaled straight to document.body rather than rendered as
+              siblings in this subtree, for two independent reasons:
+              1. WAI-ARIA menu pattern: an element with role="menu" may only
+                 own menuitem/menuitemcheckbox/menuitemradio/group
+                 descendants, so neither can live inside the Radix menu
+                 content (axe/AccessLint: aria-required-children).
+              2. copyCanvasUrl's onSelect handler below deliberately keeps
+                 this menu open on both success and failure so the
+                 confirmation is visible, and Radix's DismissableLayer inerts
+                 (aria-hides) the rest of the page for as long as the menu
+                 stays open. Rendering these two as ordinary siblings here —
+                 i.e. nested under this page's own <header>/<main> — meant
+                 their on-again-off-again presence changed *which* ancestor
+                 chain that inerting walk kept visible on every open/close of
+                 this menu, which went on to corrupt the hide/unhide
+                 bookkeeping for unrelated siblings elsewhere on the page
+                 (observed as BrowserLocalCanvasPage's destructive-action
+                 toolbar staying permanently aria-hidden after this menu had
+                 already closed). Portaling both directly to body gives each
+                 an ancestor chain of just `document.body`, so they can never
+                 again be nested inside — or, by omission, un-inert — any of
+                 this page's own DOM. */}
+          {typeof document !== 'undefined' &&
+            createPortal(
+              <div aria-live="polite" role="status" className="sr-only">
+                {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
+                {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
+              </div>,
+              document.body,
+            )}
+          {typeof document !== 'undefined' &&
+            copyStatus === 'error' &&
+            createPortal(
+              <div
+                role="alert"
+                style={(() => {
+                  const rect = canvasActionsRef.current?.getBoundingClientRect()
+                  return {
+                    position: 'fixed',
+                    top: (rect?.bottom ?? 0) + 4,
+                    left: rect?.left ?? 0,
+                  }
+                })()}
+                className="z-50 w-72 rounded-md border bg-popover px-2 py-1.5 text-xs text-destructive shadow-md"
+              >
+                <p>Couldn't copy automatically. Select and copy the link below:</p>
+                <Input
+                  readOnly
+                  value={canvasUrl}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    e.currentTarget.select()
+                  }}
+                  onFocus={(e) => e.currentTarget.select()}
+                  aria-label="Canvas URL"
+                  className="mt-1 h-7 font-mono text-[11px]"
+                />
+              </div>,
+              document.body,
+            )}
         </div>
 
         {/* Inline canvas rename input. */}

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -809,86 +809,96 @@ export default function WorkspaceTopBar({
         </DropdownMenu>
 
         {/* Canvas-specific actions such as rename and copy URL. */}
-        <DropdownMenu
-          onOpenChange={(open) => {
-            // Every fresh open starts from a clean confirmation state rather
-            // than showing a stale "Copied!"/error from a previous visit.
-            if (open) setCopyStatus('idle')
-          }}
-        >
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-              aria-label="Canvas actions"
-            >
-              <Pencil className="size-3.5" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem
-              onSelect={() => {
-                setDraft(effectiveNames.canvases[slug] ?? '')
-                setRenamingCanvas(true)
-              }}
-              className="gap-2"
-            >
-              <Pencil className="size-3.5" />
-              Rename canvas
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={(e) => {
-                // Keep the menu open so the "Copied!"/error confirmation is
-                // actually visible — Radix closes the menu on select by
-                // default, which is exactly the silent-feedback bug.
-                e.preventDefault()
-                void copyCanvasUrl()
-              }}
-              className="gap-2"
-            >
-              {copyStatus === 'copied' ? (
-                <Check className="size-3.5 text-emerald-600" />
-              ) : (
-                <Copy className="size-3.5" />
+        <div className="relative">
+          <DropdownMenu
+            onOpenChange={(open) => {
+              // Every fresh open starts from a clean confirmation state rather
+              // than showing a stale "Copied!"/error from a previous visit.
+              if (open) setCopyStatus('idle')
+            }}
+          >
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label="Canvas actions"
+              >
+                <Pencil className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem
+                onSelect={() => {
+                  setDraft(effectiveNames.canvases[slug] ?? '')
+                  setRenamingCanvas(true)
+                }}
+                className="gap-2"
+              >
+                <Pencil className="size-3.5" />
+                Rename canvas
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  // Keep the menu open so the "Copied!"/error confirmation is
+                  // actually visible — Radix closes the menu on select by
+                  // default, which is exactly the silent-feedback bug.
+                  e.preventDefault()
+                  void copyCanvasUrl()
+                }}
+                className="gap-2"
+              >
+                {copyStatus === 'copied' ? (
+                  <Check className="size-3.5 text-emerald-600" />
+                ) : (
+                  <Copy className="size-3.5" />
+                )}
+                {copyStatus === 'copied' ? 'Copied!' : 'Copy canvas URL'}
+              </DropdownMenuItem>
+              {onExport && (
+                <>
+                  <DropdownMenuItem onSelect={() => void handleExport('png')} className="gap-2">
+                    <Download className="size-3.5" />
+                    Export as PNG
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleExport('svg')} className="gap-2">
+                    <Download className="size-3.5" />
+                    Export as SVG
+                  </DropdownMenuItem>
+                </>
               )}
-              {copyStatus === 'copied' ? 'Copied!' : 'Copy canvas URL'}
-            </DropdownMenuItem>
-            {onExport && (
-              <>
-                <DropdownMenuItem onSelect={() => void handleExport('png')} className="gap-2">
-                  <Download className="size-3.5" />
-                  Export as PNG
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => void handleExport('svg')} className="gap-2">
-                  <Download className="size-3.5" />
-                  Export as SVG
-                </DropdownMenuItem>
-              </>
-            )}
-            {/* Visually hidden so screen readers announce the outcome even
-                though focus stays on the menu item above. */}
-            <div aria-live="polite" role="status" className="sr-only">
-              {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
-              {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {/* Rendered as a sibling of the Radix menu (role="menu"), not a
+              descendant of it: the WAI-ARIA menu pattern only allows
+              menuitem/menuitemcheckbox/menuitemradio/group as owned elements,
+              and a live region nested directly inside role="menu" fails that
+              contract (axe/AccessLint: aria-required-children). aria-live and
+              role="alert" are announced wherever they sit in the document, so
+              moving them outside the menu subtree does not silence them. */}
+          <div aria-live="polite" role="status" className="sr-only">
+            {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
+            {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
+          </div>
+          {copyStatus === 'error' && (
+            <div
+              role="alert"
+              className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover px-2 py-1.5 text-xs text-destructive shadow-md"
+            >
+              <p>Couldn't copy automatically. Select and copy the link below:</p>
+              <Input
+                readOnly
+                value={canvasUrl}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  e.currentTarget.select()
+                }}
+                onFocus={(e) => e.currentTarget.select()}
+                aria-label="Canvas URL"
+                className="mt-1 h-7 font-mono text-[11px]"
+              />
             </div>
-            {copyStatus === 'error' && (
-              <div className="px-2 py-1.5 text-xs text-destructive" role="alert">
-                <p>Couldn't copy automatically. Select and copy the link below:</p>
-                <Input
-                  readOnly
-                  value={canvasUrl}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    e.currentTarget.select()
-                  }}
-                  onFocus={(e) => e.currentTarget.select()}
-                  aria-label="Canvas URL"
-                  className="mt-1 h-7 font-mono text-[11px]"
-                />
-              </div>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          )}
+        </div>
 
         {/* Inline canvas rename input. */}
         {renamingCanvas && (


### PR DESCRIPTION
## Summary

- The only clipboard affordance in `apps/web` (canvas actions menu → "Copy canvas URL", `WorkspaceTopBar.tsx`) copied to the clipboard and closed the menu with no confirmation at all — clicking it gave no signal whether it worked. Fixes `tmp/issues/canvas-copy-url-no-toast-feedback.md` and `tmp/issues/copy-canvas-url-no-feedback.md` (duplicate reports of the same bug).
- The menu item itself now reports the outcome instead of introducing a second notification system: it stays open and swaps to a checkmark "Copied!" label for 2s on success.
- A rejected `navigator.clipboard.writeText` (permissions, insecure context, browser refusal) now surfaces a visible `role="alert"` error with the URL rendered as a selectable, read-only fallback input — no silent failure, and no false "Copied" success either.
- An `aria-live="polite"` / `role="status"` region announces both outcomes to screen readers, since focus stays on the menu item and a plain text swap isn't guaranteed to be announced.

## Visual repro

Success (checkmark + "Copied!"):
![copy-success.png](https://github.com/user-attachments/assets/161a7222-0442-4166-af49-029ea7a4868b)

Failure (inline alert + selectable fallback URL):
![copy-failure.png](https://github.com/user-attachments/assets/e7f620ce-c375-452c-8679-76034a2930ae)

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web` unit tests (jsdom) — added two new tests asserting the success confirmation + revert, and the rejected-copy error + fallback input; mutation-checked against the pre-fix implementation (both fail as expected).
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @kamiazya/whiteboard-web build`
- [x] Manual verification against a real Chromium browser (Playwright, headless) driving the running `vite` dev server at `/local/:canvasId` with a stubbed `navigator.clipboard` for both the success and rejection paths — screenshots above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear confirmation feedback after successfully copying a canvas URL.
  * Added accessible status announcements for copy results.

* **Bug Fixes**
  * Copy failures now display an actionable message instructing users to copy the URL manually.
  * The actions menu remains open when copying fails, keeping feedback visible.
  * Improved accessibility by placing alerts and announcements outside the actions menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->