### PR TITLE
feat(web): surface PNG/SVG export from the canvas header

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -537,6 +537,107 @@ describe('WorkspaceTopBar — daemon-context-aware fetch, remaining call sites (
   })
 })
 
+describe('WorkspaceTopBar — export affordance (RED-first)', () => {
+  async function openCanvasActions() {
+    const canvasActions = screen.getByLabelText('Canvas actions')
+    fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+    await screen.findByText('Rename canvas')
+  }
+
+  it('does not render export menu items when onExport is not provided', async () => {
+    renderBar()
+    await openCanvasActions()
+
+    expect(screen.queryByText('Export as PNG')).toBeNull()
+    expect(screen.queryByText('Export as SVG')).toBeNull()
+  })
+
+  it('invokes onExport with "png" from the Canvas actions menu and triggers a download', async () => {
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    const onExport = vi.fn().mockResolvedValue(blob)
+    const createObjectURL = vi.fn(() => 'blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const pngItem = await screen.findByText('Export as PNG')
+    fireEvent.pointerUp(pngItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledWith(blob))
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+    vi.unstubAllGlobals()
+  })
+
+  it('invokes onExport with "svg" from the Canvas actions menu', async () => {
+    const blob = new Blob(['<svg></svg>'], { type: 'image/svg+xml' })
+    const onExport = vi.fn().mockResolvedValue(blob)
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock-url'),
+      revokeObjectURL: vi.fn(),
+    })
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const svgItem = await screen.findByText('Export as SVG')
+    fireEvent.pointerUp(svgItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('svg'))
+
+    vi.unstubAllGlobals()
+  })
+
+  it('does not throw when onExport resolves null (export unavailable)', async () => {
+    const onExport = vi.fn().mockResolvedValue(null)
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const pngItem = await screen.findByText('Export as PNG')
+    fireEvent.pointerUp(pngItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
+  })
+})
+
 describe('WorkspaceTopBar — ~400px collapse (RED-first)', () => {
   it('marks the exposed right-side action group and the More-actions kebab trigger with responsive collapse classes', () => {
     renderBar()

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -636,6 +636,108 @@ describe('WorkspaceTopBar — export affordance (RED-first)', () => {
 
     await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
   })
+
+  it('surfaces a visible error when onExport resolves null (export unavailable)', async () => {
+    const onExport = vi.fn().mockResolvedValue(null)
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const pngItem = await screen.findByText('Export as PNG')
+    fireEvent.pointerUp(pngItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
+    expect((await screen.findByRole('alert')).textContent).toMatch(/export/i)
+  })
+
+  it('surfaces a visible error when onExport rejects', async () => {
+    const onExport = vi.fn().mockRejectedValue(new Error('boom'))
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const pngItem = await screen.findByText('Export as PNG')
+    fireEvent.pointerUp(pngItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
+    expect((await screen.findByRole('alert')).textContent).toMatch(/export/i)
+  })
+
+  // RED-first: Firefox (and per the HTML spec generally) does not start a
+  // download from a synthetic .click() on an <a> that was never attached to
+  // the document — the exact "looks like it worked but does nothing" defect
+  // this export affordance exists to avoid. Assert the anchor is actually in
+  // the document at click time, and removed again afterward.
+  it('attaches the download anchor to the document before clicking it, then removes it', async () => {
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    const onExport = vi.fn().mockResolvedValue(blob)
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock-url'),
+      revokeObjectURL: vi.fn(),
+    })
+
+    let anchorConnectedAtClick: boolean | null = null
+    const realCreateElement = document.createElement.bind(document)
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string, ...rest) => {
+        const el = realCreateElement(tagName, ...rest)
+        if (tagName === 'a') {
+          const realClick = el.click.bind(el)
+          el.click = () => {
+            anchorConnectedAtClick = el.isConnected
+            realClick()
+          }
+        }
+        return el
+      })
+
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onEnterFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        onExport={onExport}
+      />,
+      { container: document.body },
+    )
+
+    await openCanvasActions()
+    const pngItem = await screen.findByText('Export as PNG')
+    fireEvent.pointerUp(pngItem)
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('png'))
+    await waitFor(() => expect(anchorConnectedAtClick).toBe(true))
+
+    createElementSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
 })
 
 describe('WorkspaceTopBar — ~400px collapse (RED-first)', () => {

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronDown,
   ChevronLeft,
   Copy,
+  Download,
   EllipsisVertical,
   FilePlus2,
   FileText,
@@ -197,6 +198,13 @@ interface Props {
   // a host page can keep its own "Save version" button + status message
   // without this component needing to know about it.
   versionPanelExtra?: ReactNode
+  // Renders the scene through the same export utility Excalidraw's own
+  // (harder-to-discover) hamburger-menu export dialog uses. Omitted (the
+  // default) hides the "Export as PNG/SVG" menu items entirely rather than
+  // wiring a control to a capability the host page hasn't set up — there is
+  // deliberately no PDF option here because no export path (this app's or
+  // Excalidraw's own) produces one.
+  onExport?: (format: 'png' | 'svg') => Promise<Blob | null>
 }
 
 // Give the canvas visual priority and keep the surrounding chrome lightweight.
@@ -225,6 +233,7 @@ export default function WorkspaceTopBar({
   branchRefreshSignal,
   versionRefreshSignal,
   versionPanelExtra,
+  onExport,
 }: Props) {
   const isLocalMode = dataMode === 'local'
   const versionsEnabled = capabilities?.versions ?? true
@@ -592,6 +601,26 @@ export default function WorkspaceTopBar({
     }
   }
 
+  // A trailing slash-segment (the canvas leaf) makes the safest download
+  // filename; falling back to the raw slug covers the ungrouped case.
+  const exportFilenameBase = (canvasFlat ?? canvasLeaf ?? slug).replace(/[\\/:*?"<>|]/g, '-')
+
+  const handleExport = async (format: 'png' | 'svg') => {
+    if (!onExport) return
+    try {
+      const blob = await onExport(format)
+      if (!blob) return
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = `${exportFilenameBase}.${format}`
+      anchor.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      log.error('canvas export failed:', err)
+    }
+  }
+
   return (
     <header className="relative z-30 flex h-12 shrink-0 items-center justify-between gap-3 border-b bg-background px-3">
       {/* Left side: back button, workspace name, and canvas switcher. */}
@@ -760,6 +789,18 @@ export default function WorkspaceTopBar({
               <Copy className="size-3.5" />
               Copy canvas URL
             </DropdownMenuItem>
+            {onExport && (
+              <>
+                <DropdownMenuItem onSelect={() => void handleExport('png')} className="gap-2">
+                  <Download className="size-3.5" />
+                  Export as PNG
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => void handleExport('svg')} className="gap-2">
+                  <Download className="size-3.5" />
+                  Export as SVG
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -348,6 +348,10 @@ export default function WorkspaceTopBar({
   const [newCanvasError, setNewCanvasError] = useState<string | null>(null)
   const [newCanvasBusy, setNewCanvasBusy] = useState(false)
 
+  // Export has no dialog of its own (it's a plain dropdown action), so a
+  // failed or unavailable export is surfaced next to the trigger instead.
+  const [exportError, setExportError] = useState<string | null>(null)
+
   // Load display names. Guard against a stale response for a previous
   // workspaceId landing after a newer request already resolved.
   useEffect(() => {
@@ -607,17 +611,30 @@ export default function WorkspaceTopBar({
 
   const handleExport = async (format: 'png' | 'svg') => {
     if (!onExport) return
+    setExportError(null)
     try {
       const blob = await onExport(format)
-      if (!blob) return
+      if (!blob) {
+        setExportError(`Export as ${format.toUpperCase()} failed: no data to export.`)
+        return
+      }
       const url = URL.createObjectURL(blob)
       const anchor = document.createElement('a')
       anchor.href = url
       anchor.download = `${exportFilenameBase}.${format}`
+      // Firefox (and the HTML spec generally) will not start a download from
+      // a synthetic click() on an <a> that isn't attached to the document —
+      // it must be appended before clicking and can be removed right after.
+      document.body.appendChild(anchor)
       anchor.click()
-      URL.revokeObjectURL(url)
+      document.body.removeChild(anchor)
+      // Revoking synchronously can race the browser's download manager in
+      // Chrome/Safari before it has read the blob URL; deferring past the
+      // current task lets the download start first.
+      setTimeout(() => URL.revokeObjectURL(url), 0)
     } catch (err) {
       log.error('canvas export failed:', err)
+      setExportError(`Export as ${format.toUpperCase()} failed.`)
     }
   }
 
@@ -839,6 +856,14 @@ export default function WorkspaceTopBar({
         {isLocalMode && newCanvasError && (
           <span className="truncate text-xs text-destructive" role="alert">
             {newCanvasError}
+          </span>
+        )}
+
+        {/* Export is a plain dropdown action with no dialog of its own, so a
+            failed or unavailable export is surfaced here instead. */}
+        {exportError && (
+          <span className="truncate text-xs text-destructive" role="alert">
+            {exportError}
           </span>
         )}
 

--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -20,10 +20,15 @@ vi.mock('@excalidraw/excalidraw', () => ({
   restoreElements: (els: unknown[]) => els,
   CaptureUpdateAction: { NEVER: 'NEVER' },
   exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+  exportToSvg: vi.fn(async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('data-testid', 'exported-svg')
+    return svg
+  }),
 }))
 
 // eslint-disable-next-line import/first
-import { exportToBlob } from '@excalidraw/excalidraw'
+import { exportToBlob, exportToSvg } from '@excalidraw/excalidraw'
 // eslint-disable-next-line import/first
 import { useCanvasSync } from './useCanvasSync.js'
 
@@ -34,6 +39,7 @@ function makeApiStub() {
     addFiles: vi.fn(),
     getSceneElements: vi.fn(() => []),
     getAppState: vi.fn(() => ({ scrollX: 0, scrollY: 0, zoom: { value: 1 } })),
+    getFiles: vi.fn(() => ({})),
   }
 }
 
@@ -1783,6 +1789,62 @@ describe('useCanvasSync', () => {
       rerender({ id: { workspaceId: 'ws-2', slug: 'canvas-c' } })
 
       expect(connectSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('exportScene', () => {
+    beforeEach(() => {
+      vi.mocked(exportToBlob).mockClear()
+      vi.mocked(exportToSvg).mockClear()
+    })
+
+    it('returns null when no excalidraw API is registered yet', async () => {
+      const backend = makeFakeBackend()
+      const { result } = renderHook(() => useCanvasSync(backend))
+
+      const blob = await result.current.exportScene('png')
+
+      expect(blob).toBeNull()
+      expect(exportToBlob).not.toHaveBeenCalled()
+    })
+
+    it('exports a PNG blob via exportToBlob using the live scene', async () => {
+      const backend = makeFakeBackend()
+      const api = makeApiStub()
+      const { result } = renderHook(() => useCanvasSync(backend))
+
+      act(() => {
+        result.current.setExcalidrawAPI(api as never)
+      })
+
+      const blob = await result.current.exportScene('png')
+
+      expect(exportToBlob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elements: api.getSceneElements(),
+          files: api.getFiles(),
+        }),
+      )
+      expect(blob).not.toBeNull()
+      expect(blob!.type).toBe('image/png')
+    })
+
+    it("exports an SVG blob by serializing exportToSvg's SVGSVGElement", async () => {
+      const backend = makeFakeBackend()
+      const api = makeApiStub()
+      const { result } = renderHook(() => useCanvasSync(backend))
+
+      act(() => {
+        result.current.setExcalidrawAPI(api as never)
+      })
+
+      const blob = await result.current.exportScene('svg')
+
+      expect(exportToSvg).toHaveBeenCalled()
+      expect(blob).not.toBeNull()
+      expect(blob!.type).toBe('image/svg+xml')
+      const text = await blob!.text()
+      expect(text).toContain('data-testid="exported-svg"')
     })
   })
 })

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -1,4 +1,9 @@
-import { CaptureUpdateAction, exportToBlob, restoreElements } from '@excalidraw/excalidraw'
+import {
+  CaptureUpdateAction,
+  exportToBlob,
+  exportToSvg,
+  restoreElements,
+} from '@excalidraw/excalidraw'
 import type { ExcalidrawElement, FileId } from '@excalidraw/excalidraw/element/types'
 import type {
   AppState,
@@ -33,6 +38,10 @@ const log = getAppLogger('canvas-sync')
 
 export type SyncStatus = 'idle' | 'connected' | 'error'
 
+// Raster/vector are the only formats the underlying @excalidraw/excalidraw
+// export utilities support; there is no PDF export anywhere in the library.
+export type SceneExportFormat = 'png' | 'svg'
+
 // Daemon-only callback seam. Every member is stored in a ref (see optionsRef
 // below) so passing a fresh inline object on every render never forces a
 // backend reconnect. A browser-local backend never fires any of these
@@ -65,6 +74,10 @@ export interface UseCanvasSyncResult {
   restoreInProgress: boolean
   restoreLabel: string | null
   clearLocalUndo: () => void
+  // null when no ExcalidrawImperativeAPI is registered yet (mount race) —
+  // callers treat that the same as "export unavailable right now" rather
+  // than throwing.
+  exportScene: (format: SceneExportFormat) => Promise<Blob | null>
 }
 
 // Upper bound on waiting for a file upload before committing anyway. A hung
@@ -686,6 +699,24 @@ export function useCanvasSync(
     return true
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Renders the live scene through the same exportToBlob/exportToSvg utilities
+  // Excalidraw's own (harder-to-discover) hamburger-menu export dialog uses,
+  // so a header-driven "Export" affordance produces byte-identical output
+  // without duplicating export logic.
+  const exportScene = useCallback(async (format: SceneExportFormat): Promise<Blob | null> => {
+    const api = excalidrawAPIRef.current
+    if (!api) return null
+    const elements = api.getSceneElements()
+    const appState = api.getAppState()
+    const files = api.getFiles()
+    if (format === 'png') {
+      return exportToBlob({ elements, appState, files, exportPadding: 10 })
+    }
+    const svg = await exportToSvg({ elements, appState, files, exportPadding: 10 })
+    const serialized = new XMLSerializer().serializeToString(svg)
+    return new Blob([serialized], { type: 'image/svg+xml' })
+  }, [])
+
   const loroRedo = useCallback(() => {
     const um = undoManagerRef.current
     const doc = docRef.current
@@ -780,5 +811,6 @@ export function useCanvasSync(
     restoreInProgress,
     restoreLabel,
     clearLocalUndo,
+    exportScene,
   }
 }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.history-nav.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.history-nav.browser.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@excalidraw/excalidraw', () => ({
   restoreElements: (els: unknown[]) => els,
   CaptureUpdateAction: { NEVER: 'never' },
   exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+  exportToSvg: vi.fn(async () => document.createElementNS('http://www.w3.org/2000/svg', 'svg')),
 }))
 
 const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@excalidraw/excalidraw', () => ({
   restoreElements: (els: unknown[]) => els,
   CaptureUpdateAction: { NEVER: 'never' },
   exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+  exportToSvg: vi.fn(async () => document.createElementNS('http://www.w3.org/2000/svg', 'svg')),
 }))
 
 const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@excalidraw/excalidraw', () => ({
   restoreElements: (els: unknown[]) => els,
   CaptureUpdateAction: { NEVER: 'never' },
   exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+  exportToSvg: vi.fn(async () => document.createElementNS('http://www.w3.org/2000/svg', 'svg')),
 }))
 
 const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -225,7 +225,7 @@ export function BrowserLocalCanvasPage({
   // useCanvasSync tolerates a null backend (idle, no writes) and reconnects
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.
-  const { setExcalidrawAPI, onChange } = useCanvasSync(backend)
+  const { setExcalidrawAPI, onChange, exportScene } = useCanvasSync(backend)
 
   // The option list refreshes asynchronously (see the effect above) while the
   // selected id changes synchronously on switch/create. Synthesize a
@@ -323,6 +323,7 @@ export function BrowserLocalCanvasPage({
             branches: capabilities.branches,
             merge: capabilities.merge,
           }}
+          onExport={exportScene}
         />
       </Suspense>
       {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -131,7 +131,7 @@ export function DaemonCanvasPage({
     if (backend) setAuthError(false)
   }, [backend])
 
-  const { setExcalidrawAPI, onChange, clearLocalUndo } = useCanvasSync(backend, {
+  const { setExcalidrawAPI, onChange, clearLocalUndo, exportScene } = useCanvasSync(backend, {
     onAuthError: () => setAuthError(true),
     onHeadChanged: () => setBranchRefreshSignal((n) => n + 1),
     onVersionCreated: () => setVersionRefreshSignal((n) => n + 1),
@@ -292,6 +292,7 @@ export function DaemonCanvasPage({
             onRestored={clearLocalUndo}
             versionPanelExtra={versionPanelExtra}
             onNavigateBack={onNavigateBack}
+            onExport={exportScene}
           />
         )}
         {capabilities.branches && canvas && (


### PR DESCRIPTION
## Summary

- The canvas header had no export affordance at all; Excalidraw's own PNG/SVG export was only reachable via its internal hamburger menu inside the canvas (three clicks deep, no hint it existed).
- Added "Export as PNG" / "Export as SVG" to the existing "Canvas actions" kebab menu (the same menu that already hosts Rename canvas / Copy canvas URL) on both `BrowserLocalCanvasPage` and `DaemonCanvasPage`.
- New `useCanvasSync().exportScene(format)` renders the live scene through the same `exportToBlob`/`exportToSvg` utilities Excalidraw's own dialog uses — no export logic is duplicated.

## Capability inventory (before building anything)

- **Excalidraw's built-in export** (PNG/SVG via `exportToBlob`/`exportToSvg`) is available in both `BrowserLocalCanvasPage` and `DaemonCanvasPage` — neither page overrides `UIOptions`/`MainMenu`, so Excalidraw's own hamburger menu already offers "Export image…" in both modes. This is the exact capability the two backlog notes said was "buried".
- **Daemon-mode MCP export** — `useCanvasSync`'s `onExportRequest`/`canvas-sync-export.ts` already wires a machine-initiated PNG export (an MCP tool calling over the websocket). This is not a human-facing UI affordance and is unaffected by this change.
- **PDF export does not exist anywhere** — not in this app, not in `@excalidraw/excalidraw` (`exportToBlob`/`exportToSvg`/`exportToCanvas` only; no PDF utility in the library). Confirmed by inspecting the installed package's type declarations.

## What this PR surfaces

- "Export as PNG" and "Export as SVG" menu items in the header's Canvas actions kebab, consistently on both the browser-local and daemon-backed pages (same `WorkspaceTopBar` component, same `onExport` prop).
- Clicking either triggers a real browser download (`URL.createObjectURL` + anchor click), named after the canvas.

## What was deliberately NOT surfaced

- **PDF.** Since no export path (this app's or Excalidraw's own) produces a PDF, adding a menu entry for it would point at a capability that doesn't exist — worse than no menu item. Left a backlog note (`tmp/issues/canvas-export-pdf-not-discoverable.md`, private/local) documenting that PDF would need net-new work (e.g. client-side SVG→PDF conversion) before it can be added honestly.
- Did not touch Excalidraw's own hamburger menu — it stays available as a secondary path; this PR just gives the header its own shortcut to the same capability.

## Visual repro

Canvas actions kebab opened, showing the new "Export as PNG" / "Export as SVG" items alongside the existing Rename/Copy URL:

![ui-export-affordance-after-menu-open.png](https://github.com/user-attachments/assets/20ec8f63-acba-4eed-8993-57d362c3011d)

## Manual verification

Ran the real app against the local dev server (`pnpm dev`) with a scripted real-browser (Playwright/Chromium) session — not a mock: drew a rectangle on the browser-local canvas, opened the Canvas actions menu, clicked "Export as PNG" and confirmed a real file download (`untitled.png`, 121 bytes), then clicked "Export as SVG" and confirmed a real download containing valid `<svg>` markup with the Excalidraw source comment. Both downloads succeeded through the real `window.showSaveFilePicker`-free download flow. Daemon-mode wiring is identical (same `WorkspaceTopBar`/`useCanvasSync` plumbing) and covered by the automated test suite, but was not separately dogfooded against a live daemon in this pass — noted here rather than claimed as verified.

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test` (891 unit/jsdom tests + browser-mode suite) — all green
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @kamiazya/whiteboard-web build` + `node scripts/smoke-bundle-size.mjs` (budget gate passes)
- [x] Real-browser manual verification (Playwright/Chromium against `pnpm dev`) confirming actual PNG/SVG downloads
- [ ] Live daemon-mode dogfood of the same flow (not done in this pass — same code path as browser-local, covered by automated tests only)
