### PR TITLE
chore: enable pnpm's global virtual store

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,8 @@ overrides:
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.11: ^3.4.11
 
+packageExtensionsChecksum: sha256-ICm0XOgzaaEym0DZSOTIerb9HsLfT82DBCp4qQLWbRA=
+
 importers:
 
   .:
@@ -85,7 +87,7 @@ importers:
     dependencies:
       '@excalidraw/excalidraw':
         specifier: ^0.18.1
-        version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@excalidraw/utils':
         specifier: 0.1.3-test32
         version: 0.1.3-test32
@@ -206,7 +208,7 @@ importers:
     dependencies:
       '@excalidraw/excalidraw':
         specifier: ^0.18.1
-        version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@excalidraw/utils':
         specifier: 0.1.3-test32
         version: 0.1.3-test32
@@ -465,10 +467,6 @@ packages:
   '@azu/style-format@1.0.1':
     resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -554,10 +552,6 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -3732,9 +3726,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -3992,11 +3983,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.32:
-    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.10.42:
     resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
@@ -4043,11 +4029,6 @@ packages:
   browser-fs-access@0.29.1:
     resolution: {integrity: sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -4090,9 +4071,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
@@ -4542,9 +4520,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.364:
-    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
-
   electron-to-chromium@1.5.387:
     resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
 
@@ -4614,10 +4589,6 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -4930,10 +4901,6 @@ packages:
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -5549,10 +5516,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.3.5:
-    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -5779,10 +5742,6 @@ packages:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
-
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
-    engines: {node: '>=18'}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -7293,12 +7252,6 @@ snapshots:
     dependencies:
       '@azu/format-text': 1.0.2
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -7343,7 +7296,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -7435,8 +7388,6 @@ snapshots:
       - supports-color
 
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -8254,7 +8205,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@excalidraw/excalidraw@0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@excalidraw/excalidraw@0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@braintree/sanitize-url': 6.0.2
       '@excalidraw/laser-pointer': 1.3.1
@@ -8262,6 +8213,7 @@ snapshots:
       '@excalidraw/random-username': 1.1.0
       '@radix-ui/react-popover': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tabs': 1.0.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react': 19.2.14
       browser-fs-access: 0.29.1
       canvas-roundrect-polyfill: 0.0.1
       clsx: 1.1.1
@@ -8288,9 +8240,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       roughjs: 4.6.4
       sass: 1.51.0
-      tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.2.5)
+      tunnel-rat: 0.1.2(@types/react@19.2.14)
     transitivePeerDependencies:
-      - '@types/react'
       - '@types/react-dom'
       - immer
 
@@ -10139,7 +10090,12 @@ snapshots:
 
   '@secretlint/profiler@13.0.2': {}
 
-  '@secretlint/resolver@13.0.2': {}
+  '@secretlint/resolver@13.0.2':
+    dependencies:
+      '@secretlint/secretlint-rule-pattern': 13.0.2
+      '@secretlint/secretlint-rule-preset-recommend': 13.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@secretlint/secretlint-rule-pattern@13.0.2':
     dependencies:
@@ -10399,8 +10355,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -10592,8 +10548,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -10605,7 +10559,6 @@ snapshots:
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
-    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -10930,8 +10883,6 @@ snapshots:
   base64-js@1.5.1:
     optional: true
 
-  baseline-browser-mapping@2.10.32: {}
-
   baseline-browser-mapping@2.10.42: {}
 
   bidi-js@1.0.3:
@@ -10987,14 +10938,6 @@ snapshots:
       fill-range: 7.1.1
 
   browser-fs-access@0.29.1: {}
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.32
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.364
-      node-releases: 2.0.46
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   browserslist@4.28.4:
     dependencies:
@@ -11054,8 +10997,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  caniuse-lite@1.0.30001793: {}
 
   caniuse-lite@1.0.30001800: {}
 
@@ -11513,8 +11454,6 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.364: {}
-
   electron-to-chromium@1.5.387: {}
 
   emoji-regex@10.6.0: {}
@@ -11628,10 +11567,6 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -11695,7 +11630,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -11904,12 +11839,12 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -11919,7 +11854,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stream@9.0.1:
     dependencies:
@@ -11976,7 +11911,7 @@ snapshots:
 
   happy-dom@20.9.0:
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.13.1
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -12005,10 +11940,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.4:
     dependencies:
@@ -12356,7 +12287,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
+      lru-cache: 11.5.1
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -12576,8 +12507,6 @@ snapshots:
 
   lru-cache@10.4.3:
     optional: true
-
-  lru-cache@11.3.5: {}
 
   lru-cache@11.5.1: {}
 
@@ -12887,8 +12816,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  node-releases@2.0.46: {}
 
   node-releases@2.0.50: {}
 
@@ -13980,13 +13907,14 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
-  tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.5):
+  tunnel-rat@0.1.2(@types/react@19.2.14):
     dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
       zustand: 4.5.7(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
       - '@types/react'
       - immer
-      - react
 
   tunnel@0.0.6: {}
 
@@ -14069,8 +13997,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.18.2:
-    optional: true
+  undici-types@7.18.2: {}
 
   undici@7.28.0: {}
 
@@ -14115,12 +14042,6 @@ snapshots:
     optional: true
 
   upath@1.2.0: {}
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
@@ -14218,7 +14139,7 @@ snapshots:
   vite@8.1.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.15
       rolldown: 1.1.3
       tinyglobby: 0.2.17
@@ -14234,7 +14155,7 @@ snapshots:
   vite@8.1.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.15
       rolldown: 1.1.3
       tinyglobby: 0.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,33 +56,51 @@ overrides:
 # worktree (~1GB each), which has caused real disk exhaustion. A shared
 # global virtual store lets every worktree's node_modules symlink into one
 # on-disk store instead of duplicating it. Requires pnpm >= 11.
+enableGlobalVirtualStore: true
+
+# GVS gives every global-store package its own node_modules/ containing only
+# that package's *declared* dependencies (lockfileToDepGraph.ts). In standard
+# mode, .pnpm/<depPath>/node_modules/ is instead a merged view that also
+# includes the consumer's devDependencies as siblings — so a package that
+# references a type or a runtime module without declaring it as a real
+# dependency still resolves one under standard mode, but not under GVS.
+# These two entries patch packages in the @excalidraw/excalidraw dependency
+# chain that hit exactly that gap:
 #
-# Currently left OFF: enabling it makes apps/web/node_modules/@excalidraw/excalidraw
-# resolve through a much deeper external symlink chain (into
-# ~/Library/pnpm/store/v11/links/...), and TypeScript's "bundler"
-# moduleResolution then reports a spurious structural mismatch for
-# useCanvasSync.ts's Excalidraw AppState mapped type (TS2740), even though
-# the underlying package files are byte-identical and not duplicated.
+# - @excalidraw/excalidraw's own AppState/MutableAppState mapped types
+#   reference React's types without declaring @types/react. Under GVS,
+#   TypeScript resolves a *different* React type identity through
+#   @excalidraw/excalidraw than the one apps/web uses directly, and the two
+#   AppState shapes stop being structurally assignable (TS2740).
+# - tunnel-rat (a transitive dep of @excalidraw/excalidraw) only lists
+#   react/react-dom under devDependencies, not dependencies or
+#   peerDependencies, even though its runtime code imports "react". Under
+#   GVS the bundler (Vite/Rolldown) can no longer find react as a sibling
+#   and fails to resolve the import at build time.
 #
-# Re-verified 2026-07-12 on pnpm 11.12.0 (this repo's pinned version, which
-# already ships the pnpm/pnpm#9739 fix for stale hoisted-symlink residue
-# from a prior non-GVS install): a fully clean install — every node_modules
-# in the worktree removed, then `pnpm install --force` from scratch with
-# this flag on from the start — still reproduces TS2740. So the failure is
-# not #9739 residue; it is a distinct symlink-depth interaction between
-# TypeScript's mapped-type structural check and pnpm's GVS link chain.
+# Both entries inject the missing dependency edge so pnpm links the
+# workspace's own react / @types/react into the offending package's
+# node_modules, restoring a single shared module/type identity.
 #
-# `publicHoistPattern` does not help: @excalidraw/excalidraw is a *direct*
-# dependency of apps/web, already at the top of its node_modules, so the
-# hoisting setting (which only relocates transitive deps) has no effect on
-# it — confirmed by identical `readlink` output and identical TS2740 before
-# and after adding the pattern.
-#
-# The same tsc run passes cleanly with this flag off, and also passes with
-# moduleResolution switched to node16 (an unrelated wider change, not
-# adopted here). Re-enable once this TypeScript/pnpm interaction is
-# understood or fixed upstream.
-enableGlobalVirtualStore: false
+# @secretlint/resolver hits the same class of gap for a different reason:
+# its tryResolve() falls back to `createRequire(import.meta.url).resolve(...)`
+# scoped to @secretlint/resolver's own module location (no resolve hook is
+# registered anywhere in this call chain), so every rule package configured
+# in .secretlintrc.json (e.g. "@secretlint/secretlint-rule-pattern") must be
+# a real sibling of @secretlint/resolver itself, not merely available
+# somewhere in the workspace's devDependencies.
+packageExtensions:
+  "@excalidraw/excalidraw":
+    dependencies:
+      "@types/react": "*"
+  "tunnel-rat":
+    dependencies:
+      react: "*"
+      react-dom: "*"
+  "@secretlint/resolver":
+    dependencies:
+      "@secretlint/secretlint-rule-pattern": "*"
+      "@secretlint/secretlint-rule-preset-recommend": "*"
 
 # pnpm v11 blocks all build scripts by default (security-by-default);
 # allowBuilds is the v11 replacement for the removed onlyBuiltDependencies /


### PR DESCRIPTION
## Summary

Enables `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml`. This repo
routinely runs 3-5 concurrent agent-driven git worktrees, and standard pnpm
materializes a full `node_modules/.pnpm` copy per worktree — GVS instead
symlinks every worktree's `node_modules` into one shared on-disk store.

**Measured, this machine:**

| | before (standard) | after (GVS) |
|---|---|---|
| `node_modules` size (fresh worktree) | ~1.1GB (baseline, historical) / 3.6GB (this worktree's stale pre-clean state) | **1.5MB** |
| clean `pnpm install` wall time | ~6.5s baseline | **1.85s** (fresh worktree, warm global store) |
| `node_modules/.pnpm` materialized per worktree | full package copies | **792K**, only symlink/metadata entries (verified: 2 entries, 0 real dirs) |

GVS was left off previously because it made `apps/web`'s typecheck fail with
a spurious `TS2740` on `@excalidraw/excalidraw`'s `AppState` in
`useCanvasSync.ts`.

## Root cause

In **standard** pnpm mode, `.pnpm/<depPath>/node_modules/` is a *merged*
view — it contains a package's own declared deps **plus** any `@types/*` (or
other packages) pulled in as siblings from the *consumer's* devDependencies.
In **GVS** mode, each global-store entry's `node_modules/` contains **only
that package's own declared dependencies**. Any package that relies on the
merged view without declaring its own dependency breaks under GVS. Three
packages in the `@excalidraw/excalidraw` chain hit exactly that gap:

- **`@excalidraw/excalidraw`**: its own `AppState`/`MutableAppState` mapped
  types reference React's types without declaring `@types/react`. Under
  GVS, TypeScript resolves a *different* React type identity through
  `@excalidraw/excalidraw` than the one `apps/web` uses directly, so the two
  `AppState` shapes stop being structurally assignable (`TS2740`).
- **`tunnel-rat`** (a transitive dep of `@excalidraw/excalidraw`): imports
  `"react"` at runtime but only lists it under `devDependencies`. Under
  GVS, Rolldown/Vite can no longer resolve `"react"` as a sibling and the
  production build fails.
- **`@secretlint/resolver`**: resolves each rule package configured in
  `.secretlintrc.json` (e.g. `@secretlint/secretlint-rule-pattern`) via
  `createRequire(import.meta.url).resolve(...)` scoped to its own module
  location — no resolve hook is registered anywhere in the call chain — so
  the rule packages must be its own siblings, not merely available
  somewhere in the workspace's devDependencies. Under GVS, `secretlint`
  failed to load its own configured rules entirely.

## Fix

`packageExtensions` in `pnpm-workspace.yaml` injects the missing dependency
edge for each of the three packages, so pnpm links a single shared
module/type instance into their own `node_modules` under GVS. Comment in
the file explains the why for future readers.

## Verification

- Clean install (`rm -rf` every `node_modules`, `pnpm install --force`)
  reproduced the baseline `TS2740` failure before the fix.
- After the `packageExtensions` fix, clean install + full gate all green:
  - `pnpm -r typecheck` — clean
  - `pnpm build` — clean (previously failed on the `tunnel-rat`/react
    Rolldown resolution error, fixed by the same mechanism)
  - `pnpm test` — 288 files / 4123 tests passed, 2 skipped (expected)
  - `pnpm lint:noconsole` — clean
  - `pnpm smoke:e2e` — all OK
- Fresh throwaway worktree install measured (`git worktree add --detach`,
  `pnpm install`, then removed): 1.85s wall time, 1.5MB `node_modules`, only
  792K of symlink/metadata under `node_modules/.pnpm` (no real package
  copies materialized).

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (full suite)
- [x] `pnpm lint:noconsole`
- [x] `pnpm smoke:e2e`
- [x] Fresh-worktree install size/time measurement

## Developer action after pulling this

Existing sibling worktrees were installed under the old (non-GVS) layout.
Re-running `pnpm install` in each is sufficient to switch them onto the
global virtual store — no manual `node_modules` cleanup is required, though
removing the stale `node_modules/.pnpm` first will reclaim the disk space
sooner.
