### PR TITLE
fix(mcp-server): correct box_with_label wrapping and expose frame names in canvas_inspect

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -371,6 +371,17 @@ async function main() {
   if (insBefore.elementCount < 1)
     throw new Error(`source canvas missing element: ${JSON.stringify(insBefore)}`)
 
+  // canvas_inspect must surface the frame's name, otherwise a caller can see a
+  // frame exists but not what it is called. Cross-checks the elementSummarySchema
+  // `name` field against the real create_frame({ name: 'e2e-frame' }) payload above.
+  const inspectedFrame = insBefore.elements.find((e) => e.id === frame.elementId)
+  if (!inspectedFrame || inspectedFrame.name !== 'e2e-frame') {
+    throw new Error(
+      `canvas_inspect missing/incorrect frame name: ${JSON.stringify(inspectedFrame)}`,
+    )
+  }
+  console.log(`[e2e] canvas_inspect → frame name "${inspectedFrame.name}" OK`)
+
   // version_save labels the current state and returns a versionId. The
   // restore-as-new-canvas flow (formerly the checkpoint pair) is now
   // version_restore with targetSlug.

--- a/packages/mcp-server/src/server/mcp/tools/summarize-canvas.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/summarize-canvas.test.ts
@@ -124,6 +124,30 @@ describe('suite 15', () => {
   })
 })
 
+describe('suite 17', () => {
+  it('includes the frame name so a caller can identify a frame without re-deriving it from geometry', () => {
+    const doc = new LoroDoc()
+    appendElement(doc, {
+      id: 'frame-1',
+      type: 'frame',
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+      name: 'WAVE 0 Onboarding',
+    })
+    const summary = summarizeCanvas(doc)
+    expect(summary.elements[0]!.name).toBe('WAVE 0 Onboarding')
+  })
+
+  it('omits name for element types that never set it', () => {
+    const doc = new LoroDoc()
+    appendElement(doc, { id: 'rect-1', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 })
+    const summary = summarizeCanvas(doc)
+    expect(summary.elements[0]!.name).toBeUndefined()
+  })
+})
+
 describe('suite 16', () => {
   const LIMIT = 80
 

--- a/packages/mcp-server/src/server/mcp/tools/summarize-canvas.ts
+++ b/packages/mcp-server/src/server/mcp/tools/summarize-canvas.ts
@@ -10,36 +10,60 @@ import { z } from 'zod'
 // canvas field wastes tokens and includes noisy data like image dataURLs, so the
 // summary keeps only this minimal identification and geometry set.
 const elementSummarySchema = z.object({
-  id: z.string(),
-  type: z.string(),
-  x: z.number().optional(),
-  y: z.number().optional(),
-  width: z.number().optional(),
-  height: z.number().optional(),
-  angle: z.number().optional(),
-  fileId: z.string().optional(),
-  text: z.string().optional(),
-  strokeColor: z.string().optional(),
-  backgroundColor: z.string().optional(),
-  isDeleted: z.boolean().optional(),
+  id: z.string().describe('Element id.'),
+  type: z.string().describe('Excalidraw element type (e.g. rectangle, text, frame, image).'),
+  x: z.number().optional().describe('Left position.'),
+  y: z.number().optional().describe('Top position.'),
+  width: z.number().optional().describe('Element width.'),
+  height: z.number().optional().describe('Element height.'),
+  angle: z.number().optional().describe('Rotation angle in radians.'),
+  fileId: z.string().optional().describe('Referenced binary file id, for image elements.'),
+  text: z
+    .string()
+    .optional()
+    .describe(
+      'Text preview (collapsed to one line, truncated to 80 characters), for text elements.',
+    ),
+  strokeColor: z.string().optional().describe('Stroke/border color.'),
+  backgroundColor: z.string().optional().describe('Fill color.'),
+  isDeleted: z
+    .boolean()
+    .optional()
+    .describe('True when this slot is a tombstone from a deleted element.'),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      'Frame name as set via create_frame, present only for frame elements. Lets a caller identify a frame without re-deriving it from geometry.',
+    ),
 })
 
 export const canvasInspectOutputSchema = z.object({
   // Total slots in the LoroList, including deleted tombstones. Useful for
   // understanding the full history footprint of the canvas.
-  nodeCount: z.number(),
+  nodeCount: z
+    .number()
+    .describe('Total slots in the underlying element list, including deleted tombstones.'),
   // Number of live raw Excalidraw nodes (isDeleted !== true). Composite
   // annotations like box_with_label expand into multiple nodes (e.g. rect + text),
   // so this count is higher than the number of logical annotate() calls when
   // composites are used. Equals logicalCount only when no composites are present.
-  elementCount: z.number(),
+  elementCount: z
+    .number()
+    .describe(
+      'Number of live (non-deleted) raw Excalidraw nodes. Composite annotations like box_with_label expand into multiple nodes, so this exceeds the number of annotate() calls when composites are used.',
+    ),
   // Stable alias for elementCount. Use this field when sanity-checking how many
   // visible elements the canvas holds; the name makes the intent explicit.
   // Note: composite annotations (box_with_label) still expand to multiple raw nodes
   // each, so this will exceed the number of annotate() calls when composites are used.
-  logicalCount: z.number(),
+  logicalCount: z
+    .number()
+    .describe('Stable alias for elementCount, provided so callers can be explicit about intent.'),
   // Elements in LoroList insertion order, including tombstones for history context.
-  elements: z.array(elementSummarySchema),
+  elements: z
+    .array(elementSummarySchema)
+    .describe('Per-element summaries in insertion order, including tombstones.'),
 })
 
 export type ElementSummary = z.infer<typeof elementSummarySchema>

--- a/packages/mcp-server/src/server/mcp/tools/wrap-text-to-width.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/wrap-text-to-width.test.ts
@@ -63,4 +63,28 @@ describe('wrapTextToWidth', () => {
     const lines = wrapTextToWidth('abc', 0, 20)
     expect(lines).toEqual(['a', 'b', 'c'])
   })
+
+  it('breaks a hyphenated service identifier at its existing hyphen, not mid-word', () => {
+    // 'payment-' (8 chars * 11) = 88, 'service' (7 chars * 11) = 77; both fit
+    // under 120 individually but 'payment-service' (176) does not.
+    const lines = wrapTextToWidth('payment-service', 120, 20)
+    expect(lines).toEqual(['payment-', 'service'])
+    // No fabricated hyphen: rejoining the lines must reproduce the identifier exactly.
+    expect(lines.join('')).toBe('payment-service')
+  })
+
+  it('greedily keeps multiple hyphen segments together while still breaking at a hyphen boundary', () => {
+    // 'in-' (3*11=33) + 'memory-' (7*11=77) = 110 fits under 130, but adding
+    // 'cache' (5*11=55) would push it to 165, which does not.
+    const lines = wrapTextToWidth('in-memory-cache', 130, 20)
+    expect(lines).toEqual(['in-memory-', 'cache'])
+  })
+
+  it('falls back to a character break without inserting a fabricated hyphen when a single segment is still wider than the box', () => {
+    const lines = wrapTextToWidth('fraud-detectionengine', 90, 20)
+    for (const line of lines) {
+      expect(estimateTextWidth(line, 20)).toBeLessThanOrEqual(90)
+    }
+    expect(lines.join('')).toBe('fraud-detectionengine')
+  })
 })

--- a/packages/mcp-server/src/server/mcp/tools/wrap-text-to-width.ts
+++ b/packages/mcp-server/src/server/mcp/tools/wrap-text-to-width.ts
@@ -46,7 +46,11 @@ function tokenize(text: string): string[] {
   return tokens
 }
 
-// Force-split tokens that are wider than maxWidth.
+// Last-resort break for a token (or hyphen segment) that is still wider than
+// maxWidth on its own: break at character boundaries without inserting a
+// hyphen. Fabricating a hyphen here would misrepresent the identifier as
+// containing a character it doesn't have, which is worse than an unmarked
+// break.
 function splitTokenByWidth(token: string, maxWidth: number, fontSize: number): string[] {
   const out: string[] = []
   let cur = ''
@@ -63,6 +67,49 @@ function splitTokenByWidth(token: string, maxWidth: number, fontSize: number): s
   return out
 }
 
+// Split a token at its existing hyphens, keeping each hyphen attached to the
+// segment it follows (e.g. 'payment-service' -> ['payment-', 'service']).
+// Returns a single-element array when there is no internal hyphen to break
+// at, or when the token is hyphens only.
+function splitAtHyphens(token: string): string[] {
+  const parts = token.split('-')
+  if (parts.length <= 1) return [token]
+  return parts
+    .map((part, i) => (i < parts.length - 1 ? `${part}-` : part))
+    .filter((part) => part !== '')
+}
+
+// A wrapped fragment of a single over-wide token. `attached` marks fragments
+// that continue the same original word (via an existing hyphen or a forced
+// character break) and must never gain a space separator from the caller.
+interface TokenFragment {
+  text: string
+  attached: boolean
+}
+
+// Force-split a token that doesn't fit maxWidth. Prefers breaking at an
+// existing hyphen boundary over an arbitrary character boundary, so a break
+// lands where the identifier itself already has one instead of fabricating
+// a new break point mid-word.
+function splitOversizedToken(token: string, maxWidth: number, fontSize: number): TokenFragment[] {
+  const hyphenParts = splitAtHyphens(token)
+  if (hyphenParts.length <= 1) {
+    return splitTokenByWidth(token, maxWidth, fontSize).map((text, i) => ({
+      text,
+      attached: i > 0,
+    }))
+  }
+  return hyphenParts.flatMap((part, i) => {
+    if (estimateTextWidth(part, fontSize) <= maxWidth) {
+      return [{ text: part, attached: i > 0 }]
+    }
+    return splitTokenByWidth(part, maxWidth, fontSize).map((text, j) => ({
+      text,
+      attached: i > 0 || j > 0,
+    }))
+  })
+}
+
 // Pack tokens greedily into wrapped lines. Narrow-token joins use a single space;
 // wide-character joins use no separator.
 function isNarrowToken(tok: string): boolean {
@@ -74,24 +121,23 @@ function joiner(prev: string, next: string): string {
   return isNarrowToken(prev) && isNarrowToken(next) ? ' ' : ''
 }
 
-function packLine(
-  tokens: string[],
-  maxWidth: number,
-  fontSize: number,
-): string[] {
+function packLine(tokens: string[], maxWidth: number, fontSize: number): string[] {
   const lines: string[] = []
   let cur = ''
   for (const rawTok of tokens) {
-    // Split over-wide tokens at character boundaries.
-    const pieces = estimateTextWidth(rawTok, fontSize) <= maxWidth
-      ? [rawTok]
-      : splitTokenByWidth(rawTok, maxWidth, fontSize)
-    for (const tok of pieces) {
+    // Split over-wide tokens, preferring an existing hyphen boundary over an
+    // arbitrary character break.
+    const pieces: TokenFragment[] =
+      estimateTextWidth(rawTok, fontSize) <= maxWidth
+        ? [{ text: rawTok, attached: false }]
+        : splitOversizedToken(rawTok, maxWidth, fontSize)
+    for (const { text: tok, attached } of pieces) {
       if (!cur) {
         cur = tok
         continue
       }
-      const candidate = cur + joiner(cur.slice(-1), tok) + tok
+      const separator = attached ? '' : joiner(cur.slice(-1), tok)
+      const candidate = cur + separator + tok
       if (estimateTextWidth(candidate, fontSize) <= maxWidth) {
         cur = candidate
       } else {
@@ -104,11 +150,7 @@ function packLine(
   return lines
 }
 
-export function wrapTextToWidth(
-  text: string,
-  maxWidth: number,
-  fontSize: number = 20,
-): string[] {
+export function wrapTextToWidth(text: string, maxWidth: number, fontSize: number = 20): string[] {
   if (text === '') return ['']
   if (maxWidth <= 0) return splitPerChar(text)
 


### PR DESCRIPTION
## Summary
- `box_with_label` titles were force-split at arbitrary character boundaries when a service identifier didn't fit the box (e.g. `payment-service` -> `payment-serv` / `ice`). Wrapping now prefers an existing hyphen boundary, greedily packing hyphen segments onto one line when they fit, and only falls back to a character break (never a fabricated hyphen) when a single segment alone is still too wide.
- `canvas_inspect` did not return a frame's `name`, so a caller could see a frame exists but not what it's called. Added `name` to the shared `elementSummarySchema` (Zod single source of truth, `.describe()`d) — the Loro map already stores it under the same `name` key `create_frame` writes to, so no runtime remapping was needed.

## Test plan
- [x] `pnpm test --project mcp-node` (198 files / 3096 passed)
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck`
- [x] `pnpm build`
- [x] `pnpm smoke:e2e` — extended to assert a real `create_frame({ name: 'e2e-frame' })` round-trips through `canvas_inspect`
- [x] Mutation-checked both fixes: reverted each production change, confirmed the new tests fail, restored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas summaries now include frame names when available, making inspected layouts easier to identify.
* **Bug Fixes**
  * Improved text wrapping for hyphenated identifiers and long terms.
  * Hyphenated text now breaks at existing hyphens where possible, preserving readability and original content.
  * Oversized segments still wrap safely at character boundaries when necessary, without adding unwanted hyphens or spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->