### PR TITLE
fix(web): give unsupported-browser notice an escape hatch to the daemon origin

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -2,7 +2,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonProbeResult, ProbeDaemonOptions } from '../../lib/daemon-probe.js'
 import { createUserSettingsStore, type UserSettingsStore } from '../../lib/user-settings-store.js'
-import { DaemonDetectedBanner, HOW_TO_CONNECT_URL } from './DaemonDetectedBanner.js'
+import {
+  DaemonDetectedBanner,
+  HOW_TO_CONNECT_URL,
+  UNSUPPORTED_BROWSER_NOTICE,
+} from './DaemonDetectedBanner.js'
 
 function makeStore(): UserSettingsStore {
   localStorage.clear()
@@ -238,7 +242,7 @@ describe('DaemonDetectedBanner', () => {
     expect(screen.queryByRole('button', { name: /forget this daemon/i })).toBeNull()
   })
 
-  it('shows the honest unsupported notice instead of the CTA when the probe proves the browser blocked it', async () => {
+  it('shows the honest unsupported notice with an escape-hatch link when the probe proves the browser blocked it', async () => {
     const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'blocked' })
     render(
       <DaemonDetectedBanner
@@ -251,10 +255,39 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
-    await screen.findByText(
-      'Your browser cannot connect to a local daemon; canvases stay in this browser.',
-    )
+    await screen.findByText(UNSUPPORTED_BROWSER_NOTICE)
     expect(screen.queryByRole('button', { name: /check for local daemon/i })).toBeNull()
+
+    // The way out: a normal top-level navigation to the daemon's own origin
+    // is not subject to the fetch-level block that produced this notice.
+    const openLink = screen.getByRole('link', { name: /open the local app/i })
+    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099')
+  })
+
+  it('deep-links the unsupported-notice escape hatch to the last-connected workspace when known', async () => {
+    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'blocked' })
+    const store = makeStore()
+    store.update((current) => ({
+      ...current,
+      storage: {
+        ...current.storage,
+        lastConnectedWorkspaceId: 'w1',
+        lastConnectedSlug: 'main',
+      },
+    }))
+    render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    const openLink = await screen.findByRole('link', { name: /open the local app/i })
+    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
   })
 
   it('keeps the CTA affordance when the probe fails inconclusively (not proven blocked)', async () => {
@@ -272,11 +305,8 @@ describe('DaemonDetectedBanner', () => {
 
     await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
     expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
-    expect(
-      screen.queryByText(
-        'Your browser cannot connect to a local daemon; canvases stay in this browser.',
-      ),
-    ).toBeNull()
+    expect(screen.queryByText(UNSUPPORTED_BROWSER_NOTICE)).toBeNull()
+    expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()
   })
 
   it('aborts the in-flight probe on unmount and never sets state after unmount', async () => {

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -12,8 +12,14 @@ import { shouldShowDaemonCta } from './daemon-cta-visibility.js'
 // Shown only once a probe PROVES the browser blocked the request (tier
 // 'tier2-blocked') — never on a merely inconclusive failure. Honesty
 // discipline: an unproven guess is worse than no notice at all.
+//
+// This is deliberately not a dead end: the daemon serves the same app at
+// its own origin, and a top-level navigation there is a normal link click,
+// not a fetch — it is not subject to the mixed-content/private-network
+// gate that produced this notice in the first place. The "Open the local
+// app" link below is the escape hatch.
 export const UNSUPPORTED_BROWSER_NOTICE =
-  'Your browser cannot connect to a local daemon; canvases stay in this browser.'
+  'This browser blocks the hosted app from reaching a local daemon over the network, so canvases stay saved in this browser only.'
 
 // Docs are not served from apps/web (no /docs route), so the banner links to
 // the source-of-truth GitHub blob rather than fabricating a local route.
@@ -167,7 +173,12 @@ export function DaemonDetectedBanner({
   return (
     <>
       {showUnsupportedNotice && (
-        <span className="text-xs text-muted-foreground">{UNSUPPORTED_BROWSER_NOTICE}</span>
+        <>
+          <span className="text-xs text-muted-foreground">{UNSUPPORTED_BROWSER_NOTICE}</span>
+          <a href={openLocalAppUrl} className="text-xs font-medium underline">
+            Open the local app
+          </a>
+        </>
       )}
       {showManualAffordance && (
         <button

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -76,11 +76,23 @@ depends on capability, not a fixed version list:
 - **Safari/WebKit on a hosted `https:` origin cannot reach the daemon.**
   WebKit blocks the request as mixed content with no override. On this
   browser, canvases stay in this browser (IndexedDB) — the app shows an
-  explicit notice instead of a silently missing "connect" option.
+  explicit notice instead of a silently missing "connect" option, with a
+  link to open the local app directly (see below).
 
 This is determined by probing the daemon, not by inspecting your browser's
 identity string: the app only shows the "not supported" notice once a probe
 has actually proven the browser blocked the request.
+
+**The way out on an unsupported browser: open the daemon's own origin.** The
+mixed-content/private-network block above applies only to the background
+`fetch` the app uses to detect a daemon — it does not apply to a normal
+top-level navigation. So on Safari (or any future engine with the same
+restriction), click the "Open the local app" link in the notice, or type the
+daemon's address directly into the address bar (`http://127.0.0.1:3099` by
+default). That loads the same `apps/web` build served same-origin by the
+daemon, described in
+[Opening the daemon's own UI directly](#opening-the-daemons-own-ui-directly)
+above, where every feature — including live daemon sync — works normally.
 
 ## How pairing works
 


### PR DESCRIPTION
## Summary

- Safari/WebKit blocks a hosted `https:` page from fetching a loopback daemon (no mixed-content exemption). ADR-0002's addendum measured this for real; the capability probe (`classifyFetchRejection` in `daemon-probe.ts`) already classifies WebKit's `TypeError: Load failed` as `'blocked'`, which `deriveCapabilityTier` maps to `tier2-blocked` — the tier that renders the unsupported-browser notice. So Safari's block already reaches the honest notice today; the fix is that the notice was a dead end.
- The notice now includes an "Open the local app" link that reuses the banner's existing `openLocalAppUrl` (same URL/deep-link logic as the detected-daemon CTA) — a top-level navigation to the daemon's own origin is a normal link click, not a `fetch`, so it is unaffected by the mixed-content block that produced the notice.
- No UA sniffing anywhere — the probe result (proven block vs. inconclusive failure) remains the sole source of truth, per the existing honesty discipline in `capability-tier.ts`.
- `docs/how-to/connect-to-local-daemon.md`: added an explicit "way out" paragraph under the existing per-engine browser-support table, pointing Safari users at the daemon's own origin. README had no browser-support claims to update.

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test -- DaemonDetectedBanner` (red confirmed before the fix, green after)
- [x] `pnpm --filter @kamiazya/whiteboard-web test` (full suite, jsdom + node configs)
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @kamiazya/whiteboard-web build`
- [x] pre-push gate (`typecheck` + `mcp-node` + `noconsole`)