### PR TITLE
docs(adr): re-measure WebSocket LNA gating, add reusable cross-engine harness

### DIFF
--- a/docs/contributing/adr/0002-browser-to-daemon-transport.md
+++ b/docs/contributing/adr/0002-browser-to-daemon-transport.md
@@ -139,9 +139,56 @@ The remaining blocker for hosted pairing is therefore **this repo's own
 daemon policy**, not the browser: with a `pages.dev` Origin the daemon
 returns no `Access-Control-Allow-Origin` on `/api/*`, 403 on `/mcp`, and
 rejects the WS upgrade (loopback-hostname Origin gate) — all verified
-against a running daemon. Chromium's LNA gating for WebSocket is not yet
-shipped (tracked upstream), so WS behavior must be re-verified when it
-lands.
+against a running daemon.
+
+### Re-measured (2026-07-12): WebSocket is still not LNA-gated
+
+The remaining unknown from the addendum above — whether Chromium's LNA
+gating had been extended to the WebSocket upgrade — has been re-measured
+with a committed, reusable harness
+(`packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs`, run via
+`pnpm smoke:lna-transport`). It drives all three engines against the same
+real `https://kamiazya-whiteboard.pages.dev` origin, this time probing both
+a `fetch` (baseline re-confirmation) and a `new WebSocket(...)` upgrade to a
+throwaway, fully CORS-permissive loopback probe server — not this repo's own
+daemon, so the daemon's own origin gate (F4 above) cannot mask browser-level
+behavior.
+
+| Engine (tested build) | `fetch` (no LNA grant) | `fetch` (LNA granted) | WS upgrade (no LNA grant) | WS upgrade (LNA granted) |
+|---|---|---|---|---|
+| Chromium 147.0.7727.15 (Playwright bundled) | Fails fast (`TypeError: Failed to fetch`, ~25ms; `permissions.query` reports `prompt`) | Succeeds | **Succeeds** | Succeeds |
+| Firefox 148.0.2 (Playwright build v1511) | Succeeds (no permission concept applies) | n/a | Succeeds | n/a |
+| WebKit (Playwright build 2272, macOS 26.4) | Blocked (`TypeError: Load failed`) | n/a | Blocked | n/a |
+
+Two findings, both load-bearing for ADR-0005's connection-ticket design:
+
+1. **The WebSocket upgrade is *not* gated behind Local Network Access on
+   this Chromium build, even with no permission granted at all.** A page
+   with an undecided (`prompt`) LNA permission state can still open a raw
+   loopback WebSocket while its `fetch` to the same loopback origin is
+   blocked outright. This means the earlier open question — "does a grant
+   covering the ticket `fetch` also cover the socket open, or is a separate
+   grant required?" — does not yet arise in practice: **no grant is
+   required for the socket at all**, only for the `fetch` that mints the
+   ticket. This is a **currently-observed gap** (Chromium's LNA WebSocket
+   gating is still tracked upstream, not yet shipped), not a guaranteed
+   permanent exemption — the connection-ticket flow must not depend on it
+   staying this way, and should still surface a denied/blocked LNA grant on
+   the ticket `fetch` as an explicit error per ADR-0005, rather than assume
+   the socket will silently succeed forever.
+2. **The undecided-permission `fetch` failure is fast, not a hang, in this
+   automated build** (~25ms, not the addendum's previously observed 5-second
+   silent timeout). Automation does not surface the real permission-prompt
+   UI, so this is consistent with — not a contradiction of — the addendum's
+   standing caveat that "the real user-facing prompt UX" remains unverified
+   by this harness; a fast rejection here plausibly corresponds to an
+   automated context resolving the prompt as denied rather than leaving it
+   pending, which a real interactive user would instead see as a visible
+   permission prompt. This nuance should be re-checked with manual/real
+   browser verification before the connection-ticket UX is finalized.
+
+Re-run `pnpm --filter @kamiazya/whiteboard-mcp smoke:lna-transport` whenever
+a browser build moves, to catch the day Chromium's WS gating ships.
 
 ### Decision (supersedes the Approach A/B framing above)
 
@@ -193,6 +240,7 @@ lands.
   loopback — usable as a regression check for the transport assumptions in
   this ADR.
 - Unverified remainder, to re-check before shipping hosted pairing: the real
-  user-facing prompt UX (automation bypasses the prompt), WS behavior once
-  Chromium gates it behind LNA, and LNA rollout changes (origin trial /
-  enterprise policy knobs).
+  user-facing prompt UX (automation bypasses the prompt), and LNA rollout
+  changes (origin trial / enterprise policy knobs). WS behavior has been
+  re-measured (2026-07-12, above): still not LNA-gated on the tested
+  Chromium build, but re-run the harness when Chromium ships WS gating.

--- a/docs/contributing/adr/0005-hosted-origin-authorization.md
+++ b/docs/contributing/adr/0005-hosted-origin-authorization.md
@@ -1,0 +1,139 @@
+# ADR-0005: Authorizing a hosted origin against the local daemon
+
+**Status:** Accepted — not yet implemented. Revised twice after adversarial review; the *Corrections* section records what the earlier drafts got wrong.
+
+**Builds on ADR-0002 (browser-to-daemon transport), which already decided:**
+
+- **The transport works.** Its addendum measured a real hosted HTTPS page against a loopback daemon: **Chromium succeeds** once the Local Network Access permission is granted, **Firefox succeeds** with no prompt, **WebKit/Safari is blocked** (it applies no loopback mixed-content exemption). Hosted↔loopback is therefore viable on Chromium and Gecko and *not* on Safari; mkcert/HTTPS-daemon is the WebKit-compatibility option, not a prerequisite.
+- **Token carriers are restricted to two channels** — the WS subprotocol and the HTTP `Authorization: Bearer` header. URL query parameters, `runtimeConfig`, and build artifacts are prohibited. The daemon-served app receives its token through a dedicated `window.__WHITEBOARD_DAEMON_TOKEN__` global, read once into an in-memory store; ADR-0002 is explicit that this is a serialization-surface reduction, **not** a security boundary.
+- **Canvas/asset `GET` is deliberately tokenless** in local-daemon mode, relying on loopback bind + Host-loopback check + hard-to-guess ids, so `<img src>` thumbnails keep working. ADR-0002 records the residual risk (another localhost page can read canvases via reflected CORS) and names an origin allowlist as the mitigation.
+
+This ADR decides the part ADR-0002 left open: **how a hosted origin is authorized**, rather than how its bytes reach the daemon.
+
+## Context
+
+The product's value is this: **open the familiar hosted URL, keep every byte of your data on your own machine, and edit with an AI agent.** The daemon is what makes that possible — it holds the canvases locally, speaks MCP to the agent, and syncs the browser over a WebSocket. It is also what will make offline editing and AI/human edit-conflict recovery possible, because the canvas is a Loro CRDT that can merge divergent edits rather than clobbering them.
+
+That value statement decides the architecture. The hosted origin is **the entry point users know**. Sending them to `http://127.0.0.1:3099` instead is not a workaround — it is abandoning the product. So a hosted HTTPS page **must** be able to talk to a loopback daemon, and the authorization design has to earn that safely rather than route around it.
+
+Today only one connection mechanism exists: an AI agent calls the `create_pairing_link` MCP tool, which mints `https://<hosted-origin>/#wb=<payload>` carrying the daemon's **bootstrap token in the URL fragment**. The page consumes the fragment (`history.replaceState` strips it) and holds a raw bearer token. Hosted origins must appear in `WHITEBOARD_ALLOWED_WEB_ORIGINS`.
+
+Two problems follow.
+
+**A human without an AI agent has no path at all.** Dogfooding lands the user in Browser-only mode with no way forward; "ask your agent for a pairing link" is a dead end. This is the whole of the `daemon-auto-discovery-negotiation` finding.
+
+**The credential travels as a URL.** A raw bearer token in a fragment is usable the instant it leaks — an extension reading `location.hash` before the app strips it, a screenshot, a paste into a chat window. Nothing binds it to the page it was minted for, to a scope, or to a lifetime.
+
+## Decision
+
+Three connection paths.
+
+### 1. Local human, no hosted page → the daemon's own origin
+
+On startup, an interactive daemon **opens the user's default browser at its own origin**, where it serves the same `apps/web` build and injects the token server-side into the HTML. **No token appears in any URL**, and there is no pairing step.
+
+This is not "no credential exposure": the token lands in `window.__WHITEBOARD_DAEMON_TOKEN__` (`app.ts`), so a same-origin XSS or a malicious extension can read it. It is *URL* exposure that is eliminated.
+
+Suppressed whenever a browser would be nonsense: no interactive TTY, `CI` set, inside a container, server-mode, non-loopback bind, or opted out.
+
+### 2. Hosted origin → daemon (the product's main path)
+
+The daemon becomes an OAuth 2.1 Authorization Server for its own API:
+
+- `GET /.well-known/oauth-protected-resource` (RFC 9728) and `GET /.well-known/oauth-authorization-server` (RFC 8414).
+- `GET /authorize` — a **local approval surface served by the daemon at its own origin**. The user approves *there*, on a surface the requesting page cannot draw, frame, or click.
+- `POST /token` — authorization-code exchange with **PKCE (S256)**, enforced at both issuance and redemption: `code_challenge` required, verifier compared exactly, code single-use with a short TTL, and a request without `code_verifier` **rejected server-side**. `state` is required as well — PKCE is not a substitute for it, and the hosted client is responsible for storing and comparing it.
+
+**The identity shown on the approval screen is derived from the registered `redirect_uri` — never from `Origin`, `Referer`, or any request parameter.** With a fixed public `client_id`, *any* site can navigate the user to `/authorize` supplying the registered callback and its own PKCE challenge; the daemon cannot infer who initiated a top-level navigation. Deriving the displayed identity from anything the requester controls would let an attacker put a trusted name on their own consent prompt.
+
+**Approval binds to the authorization transaction, not to the origin.** The persisted record carries: an opaque high-entropy transaction id; the client id; the exact raw registered redirect URI; the canonical requested scope set; the PKCE challenge and explicit `S256` method; creation and expiry; the daemon-instance/issuer identity; a status (`pending` → `approved` | `denied` → `code-issued` → `redeemed` | `expired`); an approval-session/CSRF binding for the approval POST (possession of a transaction id must not authorize a cross-site POST); and the authorization code stored **only as a hash**, single-use.
+
+Redemption is a **compare-and-swap** state transition, not check-then-mark — otherwise two concurrent `/token` calls can both redeem the same code. Two tabs produce two distinct transactions. **A daemon restart has an explicit rule**: either pending transactions survive durably, or every outstanding one is invalidated and the user is told the daemon restarted and to start again. An approval screen that outlives its backing transaction is an authorization bug.
+
+**No dynamic client registration (RFC 7591).** A fixed `client_id`, and `redirect_uri` validated by **byte-for-byte comparison against a dedicated exact-URI registry** — *not* derived from `WHITEBOARD_ALLOWED_WEB_ORIGINS`, which stores origins only and permits wildcards (`https://*.pages.dev` would otherwise admit every Cloudflare Pages project).
+
+**Tokens: short-lived access token + a rotating, revocable renewal grant.** A creative tool is left open for hours; short-lived tokens with no renewal path would force the user through a loopback approval flow mid-session, and the pressure from that cliff would produce an unsafe exemption later. So renewal is designed now, not deferred: absolute *and* idle expiry, rotation on every use, reuse detection that revokes the whole grant family, and a visible local grant-management screen where the user can see and revoke what they granted. Sender-constraining the token (DPoP with a non-extractable WebCrypto key) is worth evaluating to blunt simple replay. Saying "no refresh token" would not create a security property — it would just push renewal into an undefined future mechanism.
+
+**The terminal code is a headless-only fallback.** "Read me the six digits to finish setup" is an easy support-scam script, and a first-run ritual teaches users to relay it. Keep the printed code only where no approval surface can be shown.
+
+### 3. Deliberate credential handoff → the existing `#wb=` link
+
+`create_pairing_link` stays, correctly described: it embeds `client.baseUrl`, which is normally the sender's **loopback** URL. Opening it on another device points at *that device's* loopback, not the sender's daemon. It is therefore a handoff to **another browser or profile on the same machine** — cross-device only if a separately reachable daemon URL or tunnel exists. It is an explicitly dangerous, deliberate act, and its copy should say so.
+
+## Why this shape
+
+**The hosted origin is not negotiable.** An independent review argued that a loopback authorization server — LNA, CORS, redirects, consent UI, token storage, WebSocket auth — is a lot of security-critical surface merely to avoid sending users to the daemon's origin. That argument is correct in the abstract and wrong here: "the usual URL, with your data staying local" *is* the product. The surface is the cost of the value, not an accident.
+
+**PKCE is worth having, and buys less than its branding suggests.** A stolen authorization code cannot be redeemed without the verifier, and the response is bound to the transaction that started it — a real improvement over today's `#wb=` token, which is live the moment it leaks. It does **not** protect against same-origin XSS at an approved origin, against a stolen access token, or against a user who approves an attacker.
+
+**The local approval surface is containment, not prevention — say it that way.** Moving "Allow" to the daemon's origin stops the requesting page from drawing, framing, or silently clicking it. It does **not** stop an attacker from sending the user there; a page served by localhost may even *look* more trustworthy. What actually contains the damage is that the code is delivered only to the exact registered callback and is worthless without the PKCE verifier — an attacker who wins the click still cannot receive or redeem it. The approval screen's job is to make the decision legible: the relying party's identity derived from the registered callback (never a name the requester supplies), explicit scopes, an unmistakable consequence ("this grants `https://whiteboard.pages.dev` read/write access to your local workspace data until …" — not a generic "Connect"), default-deny, no pre-checked "always allow", rate-limited attempts, unframeable (`frame-ancestors 'none'`), and a CSRF-resistant approval POST. A deceived click is still a granted click.
+
+**Prior art converges on origin allowlists, not OAuth** (Ollama's `OLLAMA_ORIGINS`, Figma's font helper accepting only `figma.com`, Open WebUI proxying through its own backend, Tailscale's socket + step-up). We adopt OAuth's shape for MCP-ecosystem compatibility and PKCE's leak resistance, and we keep the allowlist for browser-origin admission — but we do not pretend the allowlist is doing OAuth's job, or vice versa.
+
+## Constraints the implementation must respect
+
+These are the places a correct-looking implementation silently loses a property claimed above.
+
+**The guards do not extend for free.** `api-host-guard` (the Host-header check that defeats DNS rebinding — CORS alone does not) and the CORS/LNA middleware are currently applied to `/api/*` only. `/authorize` and `/token` must have them wired explicitly; a cross-origin `POST /token` will not inherit anything by being mounted "near" the API routes.
+
+**The resource-server half does not already exist.** `oauth-resource-strategy.ts` is a typed *seam* — it says so in its own header comment — with no signature verification and no JWKS behaviour. Reusing the `AuthDecision` vocabulary is worth something; treating the validator as done is not.
+
+**The WebSocket is a second bearer channel, and the access token must not simply be pasted into it.** Live sync authenticates today with the raw daemon token in `Sec-WebSocket-Protocol` (`ws-auth.ts`) — which exists because the browser's WebSocket API cannot set an `Authorization` header. Putting the OAuth access token there instead would expose it to upgrade logging, middleware, and any intermediary that records headers.
+
+The shape that works: an authenticated `fetch` mints an **opaque, single-use connection ticket** (bound to the daemon instance, the workspace, the granted scopes, and an expiry of tens of seconds). Only the ticket travels through the upgrade; it is **consumed atomically** at upgrade, and the resulting authorization context is attached to the socket. **Scope is then enforced on every WebSocket operation, not just at upgrade** — a socket that is authenticated once and then accepts everything is how a `workspace:read` token ends up writing.
+
+Expiry mid-session has to be designed, not discovered: warn before expiry, stop accepting mutations at expiry, hold edits in a local CRDT outbox, mint a fresh ticket after renewal, reconnect with bounded exponential backoff, then merge and replay. **Do not cut a stroke in half.** Without this, the predictable failures are: a token expiring mid-draw and the canvas looking lost; every tab expiring together and stampeding the ticket endpoint; a reconnect loop racing ticket consumption so one-shot tickets look flaky.
+
+Live sync *is* this product. Moving REST to OAuth while leaving the canvas channel on the bootstrap token would be self-deception, not a migration.
+
+**Scopes are cosmetic until enforced.** The real scope vocabulary is `workspace:read` / `workspace:write` plus runtime/files/versions scopes (`auth-strategy.ts`) — there is no `workspace:admin`. Claiming scoped tokens requires first assigning and enforcing a scope on every REST route and every WebSocket operation.
+
+**The tokenless-`GET` carve-out has to be revisited for hosted origins.** ADR-0002 deliberately left canvas/asset `GET` unauthenticated in local-daemon mode — a considered trade for working `<img src>` thumbnails, with loopback-only reachability as the containing assumption. That assumption dies the moment a *hosted* origin is a first-class client: an approved-looking page — or any page that gets past the origin allowlist — could then read every canvas without holding a token at all, which would make the whole scoped-token exercise theatre on the read path. Either the carve-out ends for cross-origin callers (thumbnails move to a token-bearing fetch), or reads stay open and we say so out loud instead of claiming `canvas:read` means anything. This decision is not made here; it is a prerequisite slice.
+
+**The origin allowlist is not authentication.** It gates browser-origin admission. A missing `Origin` header is accepted by the MCP HTTP path and by WebSocket upgrades — non-browser callers are authenticated by the token, not the allowlist.
+
+**Local Network Access is the browser gate, and Safari does not open it.** Per ADR-0002's measurements: Chromium reaches the loopback daemon only after the user grants the LNA permission, Firefox reaches it with no prompt, and **WebKit blocks it outright**. So the ticket-minting `fetch` must run **inside a user gesture**, a denied or ignored prompt must surface an explicit error rather than a silent hang, and **Safari users cannot use the hosted↔daemon path at all** — they get browser-local mode, or the daemon's own origin, until an HTTPS daemon (mkcert) exists. That is a product limitation to state plainly in the UI, not to paper over.
+
+**Re-measured (2026-07-12): the WebSocket upgrade is not currently gated behind LNA, on the tested Chromium build (147.0.7727.15).** ADR-0002's addendum had left this open — Chromium's WS gating "was not yet shipped" as of the 2026-07-08 measurement. A committed harness (`pnpm --filter @kamiazya/whiteboard-mcp smoke:lna-transport`) re-drove all three engines against the real hosted origin, this time probing a `WebSocket` upgrade to a loopback target alongside `fetch`. Result: a page whose LNA permission state is still `prompt` (never granted, `fetch` to the same loopback target fails) can nonetheless open a raw loopback WebSocket successfully. **So the connection-ticket `fetch` and the socket open do *not* currently need to sit inside the same granted permission — no permission is required for the socket at all.** This is a currently-observed gap in Chromium's rollout (tracked upstream as unshipped), not a property the design should assume permanently: the ticket-minting `fetch` must still surface a denied/blocked LNA grant as an explicit error (per the paragraph above), and the harness should be re-run whenever a Chromium version bump lands, in case WS gating ships and starts requiring the same grant the `fetch` needed. Firefox and WebKit behave as ADR-0002 already described for `fetch` (Firefox: no gating either way; WebKit: blocked either way).
+
+**The daemon-served app is not the hosted client.** It receives a raw injected token and attaches it to same-origin requests. It must stay out of the OAuth state, storage, callback, and refresh paths entirely — not merely carry a different `client_id`.
+
+## The most likely way this ships broken
+
+**Scope bypass on live sync.** OAuth works in the REST demo, the WebSocket authenticates once at upgrade and then accepts every message, and a `workspace:read` token writes freely — or the raw bootstrap token stays accepted "for compatibility" forever. This is the likely failure precisely because scopes are the part that is easy to *claim* and tedious to *enforce*, and because the socket is where enforcement is least visible.
+
+So the acceptance gate is adversarial, not demonstrative. Before this can be called done, browser-level tests must prove:
+
+- a `workspace:read` token **cannot** emit a CRDT mutation over the socket;
+- an expired socket **cannot** mutate;
+- an already-consumed connection ticket **cannot** reconnect;
+- a raw bootstrap token **cannot** authenticate a hosted-origin socket;
+- an authorization code **cannot** be redeemed twice under concurrent `/token` calls;
+- a request without `code_verifier` is rejected;
+- `/authorize` **cannot** be framed, and its approval POST **cannot** be ridden cross-site.
+
+Each of these is a way the design silently degrades into the thing it replaced.
+
+## Consequences
+
+The `#wb=` mechanism narrows to a deliberate, explicitly-dangerous handoff and stops being what a human is told to use.
+
+The daemon gains a real authorization-server surface: two metadata documents, an approval UI, two endpoints, a transaction-bound consent record, an exact redirect-URI registry, and scope plumbing across REST *and* WebSocket. This is more work than the first draft of this ADR assumed.
+
+**What this does not fix:** a user who approves a malicious origin has approved it. We should not tell ourselves the protocol solved that.
+
+## Corrections to the first draft
+
+Recorded because they were wrong in ways the code plainly contradicted, and the same mistakes are easy to repeat:
+
+- `#wb=` was described as cross-device sharing. It embeds the sender's loopback URL; it is same-machine handoff unless remote reachability exists.
+- `workspace:admin` was invented; the codebase has no such scope.
+- `oauth-resource-strategy.ts` was described as an existing resource-server implementation. It is a seam with no validator.
+- The WebSocket bearer channel was not accounted for at all.
+- `redirect_uri` exact-path matching was to be derived from the origin allowlist, which stores no paths and permits wildcards — structurally impossible.
+- The terminal code was called "the only control that defeats social engineering." It is a possession check that a support scam can talk through, and a first-run ritual teaches relaying it.
+- The approval surface was presented as a social-engineering *defence*. It is containment: it stops the requesting page from drawing or clicking the prompt, but not from sending the user to it. What makes a won click useless to the attacker is the registered callback plus PKCE, not the screen.
+- The identity to display was left unspecified, which would have let an attacker supply it. It must be derived from the registered `redirect_uri` alone.
+- "No refresh token" was adopted as a security property. It is not one — it merely defers renewal to an undefined mechanism, and a tool people leave open for hours would have forced an unsafe exemption later.
+- The WebSocket was named but not designed. Pasting the access token into `Sec-WebSocket-Protocol` would have exposed it to upgrade logging; a one-shot connection ticket plus per-operation scope enforcement is the shape that works.
+- **Two drafts were written without reading ADR-0002**, which had already decided the transport, measured LNA across all three engines (including Safari being blocked), fixed the permitted token carriers, and deliberately left canvas `GET` tokenless. "Reads are unguarded" was reported here as a discovery; it is a documented, accepted trade-off — one that nonetheless has to be revisited before a hosted origin can be a first-class client.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -153,6 +153,7 @@
     "smoke:claude": "node scripts/smoke/mcp-claude-cli-smoke.mjs",
     "smoke:codex": "node scripts/smoke/mcp-codex-cli-smoke.mjs",
     "smoke:daemon-origin": "node --import tsx/esm scripts/smoke/mcp-daemon-origin-smoke.mjs",
+    "smoke:lna-transport": "node scripts/smoke/mcp-lna-transport-smoke.mjs",
     "smoke:all": "pnpm smoke:e2e && pnpm smoke:template && pnpm smoke:claude",
     "prepublishOnly": "test -x dist/cli/index.js",
     "prepack": "node scripts/verify-web-app-dist.mjs"

--- a/packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Cross-engine, real-browser measurement of whether a hosted HTTPS page can
+// reach a loopback origin — the harness ADR-0002's addendum promised as
+// "a reproducible cross-engine harness" but never committed. This is that
+// harness, committed so the next person can re-run it in one command
+// (`pnpm smoke:lna-transport`) when a browser version moves.
+//
+// It measures two questions per engine, against the real hosted origin used
+// by the original 2026-07-08 measurement (https://kamiazya-whiteboard.pages.dev):
+//   1. fetch()  — re-confirms the ADR-0002 addendum baseline.
+//   2. WebSocket upgrade — the addendum explicitly left this unmeasured
+//      ("Chromium's LNA gating for WebSocket is not yet shipped"). This is
+//      the re-check ADR-0005's constraints section calls for before the
+//      connection-ticket design is finalised.
+//
+// The probe target is a throwaway, fully permissive Node HTTP+WS server on
+// 127.0.0.1 — NOT this repo's own daemon — so a failure is attributable to
+// the browser/engine, not to this repo's own origin-allowlist or ws-auth
+// gate (those are separately, and already, measured in
+// mcp-daemon-origin-smoke.mjs and the origin-validation test suite).
+//
+// Requires network access to the real hosted origin and all three Playwright
+// browser channels installed (`pnpm --filter @kamiazya/whiteboard-mcp exec
+// playwright install chromium firefox webkit`).
+import http from 'node:http'
+import { chromium, firefox, webkit } from 'playwright'
+import { WebSocketServer } from 'ws'
+
+const HOSTED_ORIGIN =
+  process.env.WHITEBOARD_LNA_HOSTED_ORIGIN ?? 'https://kamiazya-whiteboard.pages.dev'
+
+// A fully permissive probe server: reflects any Origin on both the HTTP
+// response and the WS handshake, and never demands PNA header presence, so
+// engine-level gating (not this repo's own guards) is the only variable.
+function startProbeServer() {
+  return new Promise((resolvePromise) => {
+    const server = http.createServer((req, res) => {
+      const origin = req.headers.origin ?? '*'
+      res.setHeader('Access-Control-Allow-Origin', origin)
+      res.setHeader('Access-Control-Allow-Private-Network', 'true')
+      res.setHeader('Vary', 'Origin')
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204)
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, probe: 'lna-ws-measure', origin }))
+    })
+    const wss = new WebSocketServer({ server, path: '/ws-echo' })
+    wss.on('connection', (socket) => {
+      socket.send('hello')
+      socket.on('message', (data) => socket.send(data))
+    })
+    server.listen(0, '127.0.0.1', () => resolvePromise(server))
+  })
+}
+
+function probeUrls(server) {
+  const { port } = server.address()
+  return {
+    fetchUrl: `http://127.0.0.1:${port}/ping`,
+    wsUrl: `ws://127.0.0.1:${port}/ws-echo`,
+  }
+}
+
+// Runs inside the page context. Returns a small serializable result rather
+// than throwing, so a hung/rejected promise on one probe doesn't abort the
+// other in the same page.
+async function queryLnaPermissionState(page) {
+  return page
+    .evaluate(async () => {
+      try {
+        const status = await navigator.permissions.query({ name: 'local-network-access' })
+        return status.state
+      } catch (err) {
+        return `unsupported: ${String(err)}`
+      }
+    })
+    .catch((err) => `query-error: ${String(err)}`)
+}
+
+async function runProbes(page, { fetchUrl, wsUrl }) {
+  const fetchResult = await page
+    .evaluate(async (url) => {
+      try {
+        const res = await fetch(url, {
+          signal: AbortSignal.timeout(6000),
+        })
+        return { outcome: res.ok ? 'succeeded' : `http-${res.status}` }
+      } catch (err) {
+        return { outcome: 'failed', detail: String(err) }
+      }
+    }, fetchUrl)
+    .catch((err) => ({ outcome: 'page-evaluate-error', detail: String(err) }))
+
+  const wsResult = await page
+    .evaluate(
+      (url) =>
+        new Promise((resolveWs) => {
+          const timer = setTimeout(() => resolveWs({ outcome: 'timeout' }), 6000)
+          try {
+            const socket = new WebSocket(url)
+            socket.onopen = () => {
+              clearTimeout(timer)
+              socket.close()
+              resolveWs({ outcome: 'succeeded' })
+            }
+            socket.onerror = () => {
+              clearTimeout(timer)
+              resolveWs({ outcome: 'failed' })
+            }
+          } catch (err) {
+            clearTimeout(timer)
+            resolveWs({ outcome: 'failed', detail: String(err) })
+          }
+        }),
+      wsUrl,
+    )
+    .catch((err) => ({ outcome: 'page-evaluate-error', detail: String(err) }))
+
+  return { fetchResult, wsResult }
+}
+
+async function measureChromium(probe) {
+  const browser = await chromium.launch({ headless: true })
+  const results = {}
+  try {
+    // Undecided/denied permission state: never call grantPermissions.
+    const denyContext = await browser.newContext()
+    const denyPage = await denyContext.newPage()
+    await denyPage.goto(HOSTED_ORIGIN, { waitUntil: 'domcontentloaded' })
+    results.permissionDenied = {
+      permissionState: await queryLnaPermissionState(denyPage),
+      ...(await runProbes(denyPage, probe)),
+    }
+    await denyContext.close()
+
+    // Granted permission state.
+    const grantContext = await browser.newContext()
+    await grantContext.grantPermissions(['local-network-access'], { origin: HOSTED_ORIGIN })
+    const grantPage = await grantContext.newPage()
+    await grantPage.goto(HOSTED_ORIGIN, { waitUntil: 'domcontentloaded' })
+    results.permissionGranted = {
+      permissionState: await queryLnaPermissionState(grantPage),
+      ...(await runProbes(grantPage, probe)),
+    }
+    await grantContext.close()
+  } finally {
+    await browser.close()
+  }
+  return results
+}
+
+async function measureSimple(engine, probe) {
+  const browser = await engine.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.goto(HOSTED_ORIGIN, { waitUntil: 'domcontentloaded' })
+    return { default: await runProbes(page, probe) }
+  } finally {
+    await browser.close()
+  }
+}
+
+const server = await startProbeServer()
+const probe = probeUrls(server)
+
+let failed = false
+const report = {}
+
+try {
+  console.log(`[mcp-lna-transport-smoke] hosted origin: ${HOSTED_ORIGIN}`)
+  console.log(`[mcp-lna-transport-smoke] loopback probe: ${probe.fetchUrl} / ${probe.wsUrl}`)
+
+  report.chromium = await measureChromium(probe)
+  report.firefox = await measureSimple(firefox, probe)
+  report.webkit = await measureSimple(webkit, probe)
+
+  console.log('\n[mcp-lna-transport-smoke] results:')
+  console.log(JSON.stringify(report, null, 2))
+} catch (err) {
+  console.error('[mcp-lna-transport-smoke] FAIL: measurement threw', err)
+  failed = true
+} finally {
+  await new Promise((resolveClose) => server.close(resolveClose))
+}
+
+if (failed) {
+  console.error('[mcp-lna-transport-smoke] FAIL')
+  process.exit(1)
+}
+console.log(
+  '[mcp-lna-transport-smoke] passed (measurement completed — interpret the table above manually)',
+)

--- a/packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs
@@ -52,7 +52,7 @@ function startProbeServer() {
       socket.send('hello')
       socket.on('message', (data) => socket.send(data))
     })
-    server.listen(0, '127.0.0.1', () => resolvePromise(server))
+    server.listen(0, '127.0.0.1', () => resolvePromise({ server, wss }))
   })
 }
 
@@ -163,7 +163,7 @@ async function measureSimple(engine, probe) {
   }
 }
 
-const server = await startProbeServer()
+const { server, wss } = await startProbeServer()
 const probe = probeUrls(server)
 
 let failed = false
@@ -183,6 +183,10 @@ try {
   console.error('[mcp-lna-transport-smoke] FAIL: measurement threw', err)
   failed = true
 } finally {
+  // The probe sockets stay open, and `server.close()` only stops new
+  // connections — it waits for the live ones. Terminating the WebSocket server
+  // first is what lets this harness exit instead of hanging.
+  await new Promise((resolveClose) => wss.close(resolveClose))
   await new Promise((resolveClose) => server.close(resolveClose))
 }
 


### PR DESCRIPTION
## Summary

ADR-0002's addendum (2026-07-08) measured hosted-HTTPS-to-loopback `fetch` across Chromium/Firefox/WebKit, but explicitly left WebSocket-upgrade behavior under Local Network Access unmeasured ("must be re-verified when it lands"). ADR-0005's connection-ticket design depends on the answer.

Re-measured with a new, committed, reusable harness (`pnpm --filter @kamiazya/whiteboard-mcp smoke:lna-transport`) driving real Chromium/Firefox/WebKit against the real hosted origin (`https://kamiazya-whiteboard.pages.dev`), probing both `fetch` (baseline re-confirmation) and a `WebSocket` upgrade to a throwaway, fully CORS-permissive loopback probe server.

### Measured table

| Engine (build) | fetch (no LNA grant) | fetch (LNA granted) | WS upgrade (no LNA grant) | WS upgrade (LNA granted) |
|---|---|---|---|---|
| Chromium 147.0.7727.15 | Fails fast (~25ms, `permissions.query` → `prompt`) | Succeeds | **Succeeds** | Succeeds |
| Firefox 148.0.2 | Succeeds | n/a | Succeeds | n/a |
| WebKit 2272 (macOS 26.4) | Blocked | n/a | Blocked | n/a |

### Key finding

**The WebSocket upgrade is not currently gated behind LNA on Chromium**, even with an undecided (`prompt`) permission state — a page whose `fetch` to loopback is blocked can still open a raw loopback WebSocket. This means the connection-ticket `fetch` and the socket open do **not** currently need to sit inside the same granted permission — no permission is required for the socket at all today. This is a currently-observed gap in Chromium's rollout (tracked upstream, not yet shipped), not a property the design should assume permanently: the ticket-minting `fetch` must still surface a denied/blocked LNA grant as an explicit error, and the harness should be re-run whenever Chromium moves.

Also noted: the undecided-permission `fetch` failure is now fast (~25ms) rather than the addendum's previously observed 5-second hang — plausibly an automation-specific fast-deny rather than the real interactive prompt UX, which remains unverified by this harness (flagged as such in the doc).

## Changes

- `packages/mcp-server/scripts/smoke/mcp-lna-transport-smoke.mjs` — new committed harness (the one the ADR-0002 addendum promised but never checked in), runnable via `pnpm smoke:lna-transport`.
- `docs/contributing/adr/0002-browser-to-daemon-transport.md` — adds the re-measured WS row/table to the existing addendum.
- `docs/contributing/adr/0005-hosted-origin-authorization.md` — replaces the "must be re-measured" WS note in the LNA constraint section with the actual measured answer.

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-mcp smoke:lna-transport` (manual, real browsers, real hosted origin) — see table above.
- [x] `pnpm -r typecheck`
- [x] `pnpm test --project mcp-node` (206 files, 3154 passed)
- [x] `pnpm lint:noconsole`
- [x] `biome check` on new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)