### PR TITLE
feat(mcp-server): declare route/WS scopes in one registry, enforce WS scope per message

### DIFF
--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -41,6 +41,7 @@ import {
 import { createMcpHttpAuthMiddleware, createMcpHttpOriginMiddleware } from './security/mcp-http.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { matchOrigin, parseOriginPatterns } from './security/origin-pattern.js'
+import { resolveApiRouteScope } from './security/route-scope-registry.js'
 import { planServerModeAuth } from './security/server-mode-auth-plan.js'
 import {
   BranchNotFoundError,
@@ -217,67 +218,6 @@ export interface ServerModeAppOptions {
 
 export type AppOptions = LocalDaemonAppOptions | ServerModeAppOptions
 
-function resolveServerModeApiScopes(method: string, path: string): readonly AuthScope[] {
-  const isWrite = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE'
-
-  // File routes
-  if (/^\/api\/canvas\/[^/]+\/[^/]+\/file\//.test(path)) {
-    return method === 'PUT' ? ['files:write'] : ['files:read']
-  }
-
-  // Canvas write operations (update, export, export-json are POST but mutate state)
-  if (
-    /^\/api\/canvas\/[^/]+\/[^/]+\/(update|export|export-json)$/.test(path) &&
-    method === 'POST'
-  ) {
-    return ['canvas:write']
-  }
-  if (path === '/api/import-migration-bundle') return ['canvas:write']
-  // Catch-all for remaining /api/canvas/ routes. Honor the write/read split so a mutating
-  // POST (e.g. /viewport) is not authorized with only canvas:read; the specific write routes
-  // above (update/export/export-json) still take precedence.
-  if (path.startsWith('/api/canvas/')) return isWrite ? ['canvas:write'] : ['canvas:read']
-
-  // User library routes — writes mutate workspace-level shared library state
-  if (path.startsWith('/api/user-libraries')) {
-    return isWrite ? ['workspace:write'] : ['canvas:read']
-  }
-
-  // Version history, thumbnails, restore, compact (version-control operations on a canvas)
-  if (
-    /^\/api\/workspaces\/[^/]+\/canvases\/[^/]+\/(versions|latest-thumbnail|compact)/.test(path)
-  ) {
-    return isWrite ? ['versions:write'] : ['versions:read']
-  }
-
-  // Branch and checkpoint routes (version-control operations within a workspace)
-  if (/^\/api\/workspaces\/[^/]+\/canvases\/[^/]+\/branches/.test(path)) {
-    return isWrite ? ['versions:write'] : ['versions:read']
-  }
-  if (/^\/api\/workspaces\/[^/]+\/checkpoints$/.test(path)) {
-    return ['versions:write']
-  }
-
-  // Workspace routes — default write → workspace:write, read → workspace:read
-  if (path.startsWith('/api/workspaces')) {
-    return isWrite ? ['workspace:write'] : ['workspace:read']
-  }
-
-  // touch/shutdown/logs-prune all mutate daemon-managed state (liveness timer,
-  // process lifecycle, on-disk log files) and require the admin tier even
-  // though the HTTP verb for prune is POST like any other write route.
-  if (
-    path === '/api/runtime/touch' ||
-    path === '/api/runtime/shutdown' ||
-    path === '/api/runtime/logs/prune'
-  ) {
-    return ['runtime:admin']
-  }
-  if (path.startsWith('/api/runtime/')) return ['runtime:read']
-
-  return isWrite ? ['canvas:write'] : ['canvas:read']
-}
-
 function buildServerModeAuthFailResponse(decision: {
   status: 401 | 403
   code: string
@@ -295,14 +235,25 @@ function buildServerModeAuthFailResponse(decision: {
 
 function createServerModeApiAuthMiddleware(authStrategy: AsyncAuthStrategy): MiddlewareHandler {
   return async (c, next) => {
-    // Ping is a liveness probe available without credentials
-    if (c.req.path === '/api/runtime/ping') return next()
     const method = c.req.method.toUpperCase()
+    const routeScope = resolveApiRouteScope(method, c.req.path)
+    // No declared decision at all: fail closed rather than silently applying
+    // a guessed scope. Reaching this branch means a route was mounted under
+    // /api/* without an entry in route-scope-registry.ts — the registry-wide
+    // test (route-scope-registry.test.ts) is meant to catch this before it
+    // ships, so a live 500 here means that guard was bypassed or the route
+    // was added after the registry without updating both.
+    if (routeScope === null) {
+      return c.json({ error: 'auth.route-undeclared' }, 500)
+    }
+    // The `public` decision is a deliberate, documented carve-out (currently
+    // only GET /api/runtime/ping — a liveness probe) — never an omission.
+    if (routeScope.kind === 'public') return next()
     const decision = await authStrategy.authorize({
       method,
       path: c.req.path,
       authorizationHeader: c.req.header('authorization'),
-      requiredScopes: resolveServerModeApiScopes(method, c.req.path),
+      requiredScopes: routeScope.scopes,
     })
     if (decision.ok) return next()
     return buildServerModeAuthFailResponse(decision)

--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -2,8 +2,9 @@ import { request } from 'node:http'
 import { afterEach, describe, expect, it } from 'vitest'
 import { findAvailablePort } from '../cli/daemon-run.js'
 import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
+import { type RunningServer, startHttpServer } from './http-server.js'
 import { authorizeWsUpgrade } from './routes/ws-auth.js'
-import { startHttpServer, type RunningServer } from './http-server.js'
+import { ALL_AUTH_SCOPES } from './security/auth-strategy.js'
 
 describe('authorizeWsUpgrade', () => {
   it('rejects websocket upgrade without the daemon subprotocol token when token auth is enabled', () => {
@@ -39,7 +40,7 @@ describe('authorizeWsUpgrade', () => {
         },
         'secret',
       ),
-    ).toEqual({ accept: true, protocol: 'excalidraw-v1' })
+    ).toEqual({ accept: true, protocol: 'excalidraw-v1', scopes: ALL_AUTH_SCOPES })
   })
 
   it('keeps websocket auth disabled when daemon token is unset', () => {
@@ -47,7 +48,7 @@ describe('authorizeWsUpgrade', () => {
       authorizeWsUpgrade({
         host: '127.0.0.1:3099',
       }),
-    ).toEqual({ accept: true, protocol: undefined })
+    ).toEqual({ accept: true, protocol: undefined, scopes: ALL_AUTH_SCOPES })
   })
 
   it('admits cross-name loopback origins but rejects non-loopback ones', () => {
@@ -63,7 +64,7 @@ describe('authorizeWsUpgrade', () => {
         },
         'secret',
       ),
-    ).toEqual({ accept: true, protocol: 'excalidraw-v1' })
+    ).toEqual({ accept: true, protocol: 'excalidraw-v1', scopes: ALL_AUTH_SCOPES })
 
     expect(
       authorizeWsUpgrade(

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -1,21 +1,21 @@
 import { randomUUID } from 'node:crypto'
 import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
-import { join } from 'node:path'
 import type { Socket } from 'node:net'
+import { join } from 'node:path'
 import { serve } from '@hono/node-server'
 import { WebSocketServer } from 'ws'
 import { IdleTimer } from '../daemon/idle-timer.js'
-import { PACKAGE_VERSION } from '../shared/package-version.js'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
-import { createApp } from './app.js'
-import { normalizeBindHost } from './daemon-auth-binding.js'
-import { DATA_DIR, DIST_WEB_APP_DIR } from './config.js'
-import { handleWsUpgrade, getConnectionStats, setRuntimeTouchFn } from './routes/ws.js'
+import { PACKAGE_VERSION } from '../shared/package-version.js'
 import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
+import { createApp } from './app.js'
+import { DATA_DIR, DIST_WEB_APP_DIR } from './config.js'
+import { normalizeBindHost } from './daemon-auth-binding.js'
+import { getConnectionStats, handleWsUpgrade, setRuntimeTouchFn } from './routes/ws.js'
 import { authorizeWsUpgrade } from './routes/ws-auth.js'
-import { validationErrorBody } from './validators.js'
 import { parseWsTargetFromRequestUrl } from './routes/ws-validation.js'
 import type { McpHttpAuthStrategy } from './security/mcp-auth.js'
+import { validationErrorBody } from './validators.js'
 
 export type RuntimeStatus = RuntimeStatusResponse
 
@@ -185,7 +185,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     }
     touch()
     wss.handleUpgrade(req, socket, head, (ws) => {
-      void handleWsUpgrade(req, ws)
+      void handleWsUpgrade(req, ws, decision.scopes)
     })
   })
 

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -3,6 +3,7 @@ import {
   DAEMON_TOKEN_WS_PROTOCOL_PREFIX,
   WHITEBOARD_WS_PROTOCOL,
 } from '../../shared/ws-protocol.js'
+import { ALL_AUTH_SCOPES } from '../security/auth-strategy.js'
 import { authorizeWsUpgrade } from './ws-auth.js'
 
 // authorizeWsUpgrade is the gate between an inbound WS upgrade and the
@@ -30,12 +31,35 @@ describe('authorizeWsUpgrade', () => {
     expect(decision.accept).toBe(true)
   })
 
+  it('an accepted upgrade always carries a `scopes` grant for downstream per-message enforcement', () => {
+    // Today's only WS credential is the single shared daemon token, which —
+    // matching createLocalTokenAuthStrategy's documented single-tenant
+    // concession — grants every scope. This pins that the grant is present
+    // and explicit, not an implicit "everything is allowed" left for
+    // routes/ws.ts to assume.
+    const decision = authorizeWsUpgrade({ host: 'localhost:3099' }, 'secret-token', [])
+    expect(decision.accept).toBe(false) // no protocol/token offered
+    const acceptedDecision = authorizeWsUpgrade(
+      {
+        host: 'localhost:3099',
+        'sec-websocket-protocol': `${WHITEBOARD_WS_PROTOCOL}, ${DAEMON_TOKEN_WS_PROTOCOL_PREFIX}secret-token`,
+      },
+      'secret-token',
+    )
+    expect(acceptedDecision.accept).toBe(true)
+    expect(acceptedDecision.scopes).toEqual(ALL_AUTH_SCOPES)
+  })
+
   it('reports the negotiated subprotocol when the client offers it', () => {
     const decision = authorizeWsUpgrade({
       host: 'localhost:3099',
       'sec-websocket-protocol': WHITEBOARD_WS_PROTOCOL,
     })
-    expect(decision).toEqual({ accept: true, protocol: WHITEBOARD_WS_PROTOCOL })
+    expect(decision).toEqual({
+      accept: true,
+      protocol: WHITEBOARD_WS_PROTOCOL,
+      scopes: ALL_AUTH_SCOPES,
+    })
   })
 
   it('rejects with 401 when token auth is enabled and the protocol header is missing the matching token', () => {
@@ -57,7 +81,11 @@ describe('authorizeWsUpgrade', () => {
       },
       'secret',
     )
-    expect(decision).toEqual({ accept: true, protocol: WHITEBOARD_WS_PROTOCOL })
+    expect(decision).toEqual({
+      accept: true,
+      protocol: WHITEBOARD_WS_PROTOCOL,
+      scopes: ALL_AUTH_SCOPES,
+    })
   })
 
   it('rejects with 403 for a non-loopback Origin even with a valid token (Origin check precedes token check)', () => {

--- a/packages/mcp-server/src/server/routes/ws-auth.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.ts
@@ -3,6 +3,7 @@ import {
   DAEMON_TOKEN_WS_PROTOCOL_PREFIX,
   WHITEBOARD_WS_PROTOCOL,
 } from '../../shared/ws-protocol.js'
+import { ALL_AUTH_SCOPES, type AuthScope } from '../security/auth-strategy.js'
 import {
   isLoopbackHostname,
   normalizeHostHeader,
@@ -56,6 +57,15 @@ export interface WsUpgradeDecision {
   accept: boolean
   statusCode?: number
   protocol?: string
+  // Present only when `accept` is true. Local-daemon's single shared token
+  // is the only credential this upgrade path issues today, and — matching
+  // `createLocalTokenAuthStrategy`'s documented single-tenant concession —
+  // it grants every scope. The field exists so the per-message enforcement
+  // in `routes/ws.ts` has something real to check against now, and so a
+  // future scoped credential (a server-mode connection ticket, per
+  // ADR-0005) has a seam to plug a narrower grant into without changing the
+  // enforcement call site.
+  scopes?: readonly AuthScope[]
 }
 
 export function authorizeWsUpgrade(
@@ -74,6 +84,7 @@ export function authorizeWsUpgrade(
     return {
       accept: true,
       protocol: offeredBaseProtocol ? WHITEBOARD_WS_PROTOCOL : undefined,
+      scopes: ALL_AUTH_SCOPES,
     }
   }
 
@@ -84,5 +95,5 @@ export function authorizeWsUpgrade(
     return { accept: false, statusCode: 401 }
   }
 
-  return { accept: true, protocol: WHITEBOARD_WS_PROTOCOL }
+  return { accept: true, protocol: WHITEBOARD_WS_PROTOCOL, scopes: ALL_AUTH_SCOPES }
 }

--- a/packages/mcp-server/src/server/routes/ws.test.ts
+++ b/packages/mcp-server/src/server/routes/ws.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LoroDoc, LoroMap } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let tempDir: string
 
@@ -410,5 +410,109 @@ describe('handleWsUpgrade ws_trace propagation', () => {
       await provider.shutdown()
       trace.disable()
     }
+  })
+})
+
+describe('handleWsUpgrade per-message scope enforcement (ADR-0005)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-scope-test-'))
+    await mkdir(join(tempDir, 'session1'), { recursive: true })
+    clearCache()
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+    clearCache()
+    setAutoVersionTrigger(() => Promise.resolve(null))
+  })
+
+  it('a canvas:read-only connection cannot emit a CRDT mutation over the socket', async () => {
+    const { peekDoc } = await import('../store/doc-cache.js')
+    setAutoVersionTrigger(() => Promise.resolve(null))
+    const ws = new FakeWebSocket()
+    // Grant only canvas:read — the shape a workspace:read-scoped credential
+    // would hold once scoped WS credentials exist (ADR-0005).
+    await handleWsUpgrade(
+      { url: '/ws/session1/canvas-readonly', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+      ['canvas:read'],
+    )
+
+    const clientDoc = new LoroDoc()
+    const prevVV = clientDoc.version()
+    const list = clientDoc.getMovableList('elements')
+    const map = list.insertContainer(0, new LoroMap())
+    map.set('id', 'should-never-persist')
+    map.set('type', 'rectangle')
+    clientDoc.commit()
+
+    await ws.emitMessage(
+      Buffer.from(clientDoc.export({ mode: 'update', from: prevVV }) as Uint8Array),
+      true,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    // The update was never imported into the server's live doc.
+    const liveDoc = peekDoc('session1', 'canvas-readonly')
+    const elements = liveDoc?.getMovableList('elements').toJSON() as
+      | Array<{ id: string }>
+      | undefined
+    expect(elements ?? []).toEqual([])
+
+    // Nor was it persisted to disk: reading it back yields an empty canvas,
+    // not one containing the rejected element.
+    clearCache()
+    const saved = await loadCanvas('session1', 'canvas-readonly')
+    const savedElements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
+    expect(savedElements).toEqual([])
+
+    ws.emitClose()
+  })
+
+  it('a canvas:write-granted connection can still emit a CRDT mutation (no regression)', async () => {
+    setAutoVersionTrigger(() => Promise.resolve(null))
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      { url: '/ws/session1/canvas-writable', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+      ['canvas:read', 'canvas:write'],
+    )
+
+    const clientDoc = new LoroDoc()
+    const prevVV = clientDoc.version()
+    const list = clientDoc.getMovableList('elements')
+    const map = list.insertContainer(0, new LoroMap())
+    map.set('id', 'persists-fine')
+    map.set('type', 'rectangle')
+    clientDoc.commit()
+
+    await ws.emitMessage(
+      Buffer.from(clientDoc.export({ mode: 'update', from: prevVV }) as Uint8Array),
+      true,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    clearCache()
+    const saved = await loadCanvas('session1', 'canvas-writable')
+    const elements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
+    expect(elements.map((entry) => entry.id)).toEqual(['persists-fine'])
+
+    ws.emitClose()
+  })
+
+  it('a connection with no canvas:read cannot even signal client_ready (control messages gated too)', async () => {
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      { url: '/ws/session1/canvas-noscope', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+      [],
+    )
+
+    const { getReadyClientCount } = await import('./ws.js')
+    await ws.emitMessage(Buffer.from(JSON.stringify({ type: 'client_ready' })), false)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(getReadyClientCount('session1', 'canvas-noscope')).toBe(0)
+    ws.emitClose()
   })
 })

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -1,18 +1,21 @@
-import type { WebSocket, RawData } from 'ws'
 import type { IncomingMessage } from 'node:http'
 import { SpanKind } from '@opentelemetry/api'
 import type { LoroDoc } from 'loro-crdt'
+import type { RawData, WebSocket } from 'ws'
 import type { ServerTextMessage } from '../../shared/ws-messages.js'
 import { getLogger } from '../log.js'
 import { extractContextFromHeaders, getTracer } from '../observability/tracing.js'
-import { getDoc } from '../store/doc-cache.js'
+import { ALL_AUTH_SCOPES, type AuthScope } from '../security/auth-strategy.js'
+import {
+  hasRequiredScopes,
+  requiredScopesForClientTextMessage,
+  WS_BINARY_UPDATE_REQUIRED_SCOPES,
+} from '../security/ws-scope-registry.js'
 import { saveCanvas } from '../store/canvas-store.js'
+import { getDoc } from '../store/doc-cache.js'
 import type { VersionEntry } from '../store/version-store.js'
 import { setBroadcastFn } from './canvas.js'
-import {
-  parseWsClientTextMessage,
-  parseWsTargetFromRequestUrl,
-} from './ws-validation.js'
+import { parseWsClientTextMessage, parseWsTargetFromRequestUrl } from './ws-validation.js'
 
 // Connection registry: key = "workspaceId/slug", value = Set<WebSocket>
 const connections = new Map<string, Set<WebSocket>>()
@@ -39,11 +42,7 @@ function omitUndefined<T extends object>(o: T): Partial<T> {
   return out
 }
 
-function forEachClient(
-  workspaceId: string,
-  slug: string,
-  fn: (ws: WebSocket) => void,
-): void {
+function forEachClient(workspaceId: string, slug: string, fn: (ws: WebSocket) => void): void {
   const clients = connections.get(`${workspaceId}/${slug}`)
   if (!clients) return
   for (const ws of clients) fn(ws)
@@ -54,21 +53,13 @@ function forEachClient(
 // the request is already replayed when the client emits `client_ready`,
 // so broadcasting to non-ready sockets would just deliver the message
 // twice.
-function forEachReadyClient(
-  workspaceId: string,
-  slug: string,
-  fn: (ws: WebSocket) => void,
-): void {
+function forEachReadyClient(workspaceId: string, slug: string, fn: (ws: WebSocket) => void): void {
   const ready = readyConnections.get(`${workspaceId}/${slug}`)
   if (!ready) return
   for (const ws of ready) fn(ws)
 }
 
-function broadcastTextMessage(
-  workspaceId: string,
-  slug: string,
-  message: ServerTextMessage,
-): void {
+function broadcastTextMessage(workspaceId: string, slug: string, message: ServerTextMessage): void {
   const raw = JSON.stringify(message)
   forEachClient(workspaceId, slug, (ws) => ws.send(raw))
 }
@@ -106,11 +97,7 @@ export function setAutoVersionTrigger(fn: AutoVersionTrigger): void {
   autoVersionTrigger = fn
 }
 
-export function sendVersionCreated(
-  workspaceId: string,
-  slug: string,
-  version: VersionEntry,
-): void {
+export function sendVersionCreated(workspaceId: string, slug: string, version: VersionEntry): void {
   broadcastTextMessage(workspaceId, slug, { type: 'version_created', version })
 }
 
@@ -198,8 +185,14 @@ export function getReadyClientCount(workspaceId: string, slug: string): number {
 }
 
 export function getConnectionStats(): { connectedClients: number; readyClients: number } {
-  const connectedClients = Array.from(connections.values()).reduce((sum, clients) => sum + clients.size, 0)
-  const readyClients = Array.from(readyConnections.values()).reduce((sum, clients) => sum + clients.size, 0)
+  const connectedClients = Array.from(connections.values()).reduce(
+    (sum, clients) => sum + clients.size,
+    0,
+  )
+  const readyClients = Array.from(readyConnections.values()).reduce(
+    (sum, clients) => sum + clients.size,
+    0,
+  )
   return { connectedClients, readyClients }
 }
 
@@ -207,7 +200,17 @@ export function getConnectionStats(): { connectedClients: number; readyClients: 
 // URL pattern: /ws/:workspaceId/:slug
 // slug arrives URL-encoded because hierarchical paths may include "/".
 // Example: /ws/abc/621%2Fheader -> workspaceId="abc", slug="621/header"
-export async function handleWsUpgrade(req: IncomingMessage, ws: WebSocket): Promise<void> {
+//
+// `scopes` is the grant the upgrade authorized (see `authorizeWsUpgrade`).
+// Defaults to the full grant set so every existing call site — which
+// predates per-message scope enforcement — keeps its current behavior
+// unchanged; callers that hold a narrower credential pass their real grant
+// explicitly.
+export async function handleWsUpgrade(
+  req: IncomingMessage,
+  ws: WebSocket,
+  scopes: readonly AuthScope[] = ALL_AUTH_SCOPES,
+): Promise<void> {
   let workspaceId = ''
   let slug = ''
   try {
@@ -245,6 +248,13 @@ export async function handleWsUpgrade(req: IncomingMessage, ws: WebSocket): Prom
       const text = Buffer.isBuffer(data) ? data.toString() : String(data)
       const msg = parseWsClientTextMessage(text)
       if (msg === null) return
+      if (!hasRequiredScopes(scopes, requiredScopesForClientTextMessage(msg.type))) {
+        getLogger('ws').warning(
+          { workspaceId, slug, messageType: msg.type },
+          'ws message rejected: insufficient scope',
+        )
+        return
+      }
       if (msg.type === 'client_ready') {
         if (!readyConnections.has(key)) {
           readyConnections.set(key, new Set())
@@ -277,7 +287,18 @@ export async function handleWsUpgrade(req: IncomingMessage, ws: WebSocket): Prom
       return
     }
 
-    // binary frame = Loro update
+    // binary frame = Loro update = a canvas mutation. Enforced here, not just
+    // at upgrade: a socket authorized with only canvas:read must not be able
+    // to import, persist, or broadcast a CRDT update just because it already
+    // completed the handshake.
+    if (!hasRequiredScopes(scopes, WS_BINARY_UPDATE_REQUIRED_SCOPES)) {
+      getLogger('ws').warning(
+        { workspaceId, slug },
+        'ws binary update rejected: insufficient scope',
+      )
+      return
+    }
+
     const bytes = Buffer.isBuffer(data)
       ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
       : data instanceof ArrayBuffer

--- a/packages/mcp-server/src/server/security/auth-strategy.ts
+++ b/packages/mcp-server/src/server/security/auth-strategy.ts
@@ -42,6 +42,26 @@ export type AuthScope =
   | 'runtime:admin'
   | 'mcp:call'
 
+// The full grant set a single-tenant local-token session holds today (see
+// `createLocalTokenAuthStrategy` below: the success path ignores
+// `requiredScopes` entirely). Kept as one literal array so every call site
+// that needs to express "this credential can do anything" — the WS upgrade
+// grant included — derives it from the same list instead of re-typing the
+// scope vocabulary and silently drifting from it.
+export const ALL_AUTH_SCOPES: readonly AuthScope[] = [
+  'canvas:read',
+  'canvas:write',
+  'workspace:read',
+  'workspace:write',
+  'versions:read',
+  'versions:write',
+  'files:read',
+  'files:write',
+  'runtime:read',
+  'runtime:admin',
+  'mcp:call',
+]
+
 export type AuthContext =
   | { kind: 'anonymous' }
   | { kind: 'local-token' }

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -1,0 +1,95 @@
+// Registry-wide guard: every /api/* route actually mounted on the server-mode
+// app must resolve to a declared scope decision here (`scoped` or the
+// documented `public` carve-out) — never fall through silently. Mirrors
+// `mcp/tool-registry-descriptions.test.ts`'s "walk what's actually
+// registered, fail if the registry doesn't cover it" shape, applied to HTTP
+// routes instead of MCP tool schemas.
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { AsyncAuthStrategy } from './oauth-resource-strategy.js'
+import { resolveApiRouteScope } from './route-scope-registry.js'
+
+let tempDir: string
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-route-scope-registry-test-'))
+})
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+const alwaysDeny: AsyncAuthStrategy = {
+  async authorize() {
+    return { ok: false, status: 401, code: 'auth.required', wwwAuthenticate: 'Bearer' }
+  },
+}
+
+describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* routes', () => {
+  it('every /api/* route mounted on the server-mode app resolves to a scope decision', async () => {
+    const { createApp } = await import('../app.js')
+    const app = createApp({
+      authMode: 'server-mode',
+      publicBaseUrl: 'https://example.com',
+      allowedOrigins: ['https://example.com'],
+      authStrategy: alwaysDeny,
+      touch: () => {},
+      getStatus: () => ({
+        ok: true,
+        pid: 1,
+        host: '0.0.0.0',
+        port: 3099,
+        baseUrl: 'https://example.com',
+        version: '0.0.0',
+        startedAt: new Date().toISOString(),
+        uptimeMs: 0,
+        idleForMs: 0,
+        auth: { mode: 'local-token', hasToken: true },
+        storage: { dataDir: tempDir, dataDirWritable: true },
+        app: { served: true, buildPresent: true, ui: 'server-placeholder' },
+        mcp: { httpEnabled: true, endpoint: 'https://example.com/mcp' },
+        clients: { connected: 0, ready: 0 },
+      }),
+      shutdown: () => Promise.resolve(),
+    })
+
+    // `app.routes` conflates middleware mounts (`app.use('/api/*', ...)`,
+    // method 'ALL') with real endpoint handlers registered via `app.all(...)`
+    // (also method 'ALL', e.g. debug.ts's `/api/debug`). Excluding all of
+    // 'ALL' would silently skip those endpoints — the exact class of gap
+    // this guard exists to catch. Distinguish by path shape instead:
+    // middleware mounts use a wildcard suffix (`/api/*`), concrete endpoints
+    // never do.
+    const apiRoutes = app.routes.filter(
+      (route) => route.path.startsWith('/api/') && !route.path.endsWith('*'),
+    )
+    expect(apiRoutes.length).toBeGreaterThan(0)
+
+    const undeclared = apiRoutes
+      .map((route) => ({ ...route, decision: resolveApiRouteScope(route.method, route.path) }))
+      .filter((route) => route.decision === null)
+
+    expect(
+      undeclared,
+      `routes mounted with no scope declaration: ${undeclared
+        .map((r) => `${r.method} ${r.path}`)
+        .join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('an undeclared path resolves to null (fail-closed signal, not a default scope)', () => {
+    expect(resolveApiRouteScope('GET', '/api/some-route-nobody-declared-yet')).toBeNull()
+  })
+
+  it('GET /api/runtime/ping is the sole declared public route', () => {
+    expect(resolveApiRouteScope('GET', '/api/runtime/ping')).toEqual({ kind: 'public' })
+  })
+
+  it('a non-/api path is out of scope for this registry (null, not silently public)', () => {
+    expect(resolveApiRouteScope('GET', '/mcp')).toBeNull()
+    expect(resolveApiRouteScope('GET', '/')).toBeNull()
+  })
+})

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -1,0 +1,122 @@
+// Single declarative place for "what scope does this /api/* route need".
+//
+// Before this module, the mapping lived as a function
+// (`resolveServerModeApiScopes` in app.ts) whose final branch was a
+// catch-all: any path nobody had thought to special-case yet fell through to
+// a default (`canvas:write` / `canvas:read`). That is exactly the shape ADR-
+// 0005 calls out as the likely way scope enforcement ships broken — a route
+// added later silently inherits a guess instead of a decision. This module
+// replaces the catch-all with an explicit `null` ("nobody has declared this
+// route yet") so the caller can fail closed, and a `public` decision so the
+// one deliberately unauthenticated route (`GET /api/runtime/ping`, a
+// liveness probe) reads as a decision instead of an accidental gap.
+//
+// `route-scope-registry.test.ts` walks every route actually mounted on the
+// server-mode Hono app (`app.routes`) and asserts each one resolves to a
+// non-null decision here — the same "registry vs what's actually registered"
+// guard shape as `mcp/tool-registry-descriptions.test.ts`.
+
+import type { AuthScope } from './auth-strategy.js'
+
+export type RouteScopeDecision =
+  | { kind: 'scoped'; scopes: readonly AuthScope[] }
+  | { kind: 'public' }
+
+function isWriteMethod(method: string): boolean {
+  const normalized = method.toUpperCase()
+  return (
+    normalized === 'POST' ||
+    normalized === 'PUT' ||
+    normalized === 'PATCH' ||
+    normalized === 'DELETE'
+  )
+}
+
+// Returns `null` when no rule below claims the path — the signal to fail
+// closed (`auth.route-undeclared`) rather than silently authorizing with a
+// guessed scope.
+export function resolveApiRouteScope(method: string, path: string): RouteScopeDecision | null {
+  if (!path.startsWith('/api/')) return null
+
+  // Deliberate, documented carve-out: an unauthenticated liveness probe used
+  // by daemon-discovery and the mixed-content preflight (ADR-0002). Every
+  // other /api/runtime/* path requires a scope below.
+  if (path === '/api/runtime/ping') return { kind: 'public' }
+
+  const isWrite = isWriteMethod(method)
+
+  // File routes: reading/writing a canvas's attached binary file.
+  if (/^\/api\/canvas\/[^/]+\/[^/]+\/file\//.test(path)) {
+    return { kind: 'scoped', scopes: [method === 'PUT' ? 'files:write' : 'files:read'] }
+  }
+
+  // Canvas write operations that arrive as POST but mutate state.
+  if (
+    /^\/api\/canvas\/[^/]+\/[^/]+\/(update|export|export-json)$/.test(path) &&
+    method === 'POST'
+  ) {
+    return { kind: 'scoped', scopes: ['canvas:write'] }
+  }
+  if (path === '/api/import-migration-bundle') {
+    return { kind: 'scoped', scopes: ['canvas:write'] }
+  }
+  // Remaining /api/canvas/* routes: honor the write/read split so a mutating
+  // POST (e.g. /viewport) isn't authorized by canvas:read alone. The
+  // specific write routes above still take precedence via ordering.
+  if (path.startsWith('/api/canvas/')) {
+    return { kind: 'scoped', scopes: [isWrite ? 'canvas:write' : 'canvas:read'] }
+  }
+
+  // User library routes: writes mutate workspace-level shared library state.
+  if (path.startsWith('/api/user-libraries')) {
+    return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'canvas:read'] }
+  }
+
+  // Version history, thumbnails, restore, compact — version-control
+  // operations scoped to a single canvas.
+  if (
+    /^\/api\/workspaces\/[^/]+\/canvases\/[^/]+\/(versions|latest-thumbnail|compact)/.test(path)
+  ) {
+    return { kind: 'scoped', scopes: [isWrite ? 'versions:write' : 'versions:read'] }
+  }
+
+  // Branch and checkpoint routes — version-control operations at the
+  // workspace level.
+  if (/^\/api\/workspaces\/[^/]+\/canvases\/[^/]+\/branches/.test(path)) {
+    return { kind: 'scoped', scopes: [isWrite ? 'versions:write' : 'versions:read'] }
+  }
+  if (/^\/api\/workspaces\/[^/]+\/checkpoints$/.test(path)) {
+    return { kind: 'scoped', scopes: ['versions:write'] }
+  }
+  if (/^\/api\/workspaces\/[^/]+\/versions\/prune-sandwiched$/.test(path)) {
+    return { kind: 'scoped', scopes: ['versions:write'] }
+  }
+
+  // Workspace routes (including palette and library sub-resources, which are
+  // workspace-scoped state): default write -> workspace:write, read -> workspace:read.
+  if (path.startsWith('/api/workspaces')) {
+    return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'workspace:read'] }
+  }
+
+  // touch/shutdown/logs-prune all mutate daemon-managed process state
+  // (liveness timer, process lifecycle, on-disk log files) and require the
+  // admin tier even though the HTTP verb for prune is POST like any other
+  // write route.
+  if (
+    path === '/api/runtime/touch' ||
+    path === '/api/runtime/shutdown' ||
+    path === '/api/runtime/logs/prune'
+  ) {
+    return { kind: 'scoped', scopes: ['runtime:admin'] }
+  }
+  if (path.startsWith('/api/runtime/')) {
+    return { kind: 'scoped', scopes: ['runtime:read'] }
+  }
+
+  if (path.startsWith('/api/debug')) {
+    return { kind: 'scoped', scopes: ['runtime:admin'] }
+  }
+
+  // No rule matched: an undeclared /api/* route. Callers must fail closed.
+  return null
+}

--- a/packages/mcp-server/src/server/security/ws-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/ws-scope-registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { clientTextMessageSchema } from '../../shared/ws-messages.js'
+import {
+  hasRequiredScopes,
+  requiredScopesForClientTextMessage,
+  WS_BINARY_UPDATE_REQUIRED_SCOPES,
+  WS_CLIENT_TEXT_MESSAGE_REQUIRED_SCOPES,
+} from './ws-scope-registry.js'
+
+// Discriminated-union options expose their literal `type` value as
+// `.shape.type.value` — the same introspection technique the codebase
+// already uses in tool-registry-descriptions.test.ts style guards.
+function discriminatedUnionLiterals(schema: typeof clientTextMessageSchema): string[] {
+  return schema.options.map((option) => option.shape.type.value)
+}
+
+describe('ws-scope-registry — registry-wide coverage of client→server WS message types', () => {
+  it('every clientTextMessageSchema union member has a registry entry', () => {
+    const literals = discriminatedUnionLiterals(clientTextMessageSchema)
+    expect(literals.length).toBeGreaterThan(0)
+    const missing = literals.filter((type) => !(type in WS_CLIENT_TEXT_MESSAGE_REQUIRED_SCOPES))
+    expect(missing, `no registry entry for WS message type(s): ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('binary Loro updates require canvas:write', () => {
+    expect(WS_BINARY_UPDATE_REQUIRED_SCOPES).toEqual(['canvas:write'])
+  })
+
+  it('every declared client text message type requires only canvas:read (none mutate directly)', () => {
+    for (const [type, scopes] of Object.entries(WS_CLIENT_TEXT_MESSAGE_REQUIRED_SCOPES)) {
+      expect(scopes, `unexpected scopes for ${type}`).toEqual(['canvas:read'])
+    }
+  })
+})
+
+describe('requiredScopesForClientTextMessage', () => {
+  it('returns the registered scopes for a known type', () => {
+    expect(requiredScopesForClientTextMessage('client_ready')).toEqual(['canvas:read'])
+  })
+})
+
+describe('hasRequiredScopes', () => {
+  it('true when every required scope is granted', () => {
+    expect(hasRequiredScopes(['canvas:read', 'canvas:write'], ['canvas:write'])).toBe(true)
+  })
+
+  it('false when a required scope is missing', () => {
+    expect(hasRequiredScopes(['canvas:read'], ['canvas:write'])).toBe(false)
+  })
+
+  it('true for an empty required-scopes list regardless of grants', () => {
+    expect(hasRequiredScopes([], [])).toBe(true)
+  })
+})

--- a/packages/mcp-server/src/server/security/ws-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/ws-scope-registry.ts
@@ -1,0 +1,55 @@
+// Single declarative place for "what scope does this WebSocket operation
+// require" — the WS-side counterpart to route-scope-registry.ts.
+//
+// Before this module, the WebSocket authenticated once at upgrade
+// (`authorizeWsUpgrade`) and then treated every subsequent frame as
+// authorized: a binary Loro update (a canvas mutation) and a `client_ready`
+// control message were dispatched identically once the socket was open.
+// ADR-0005 names this precisely as the likely way scope enforcement ships
+// broken — "the WebSocket authenticates once at upgrade and then accepts
+// every message". This registry gives every client-originated WS operation
+// an explicit required-scope declaration so `routes/ws.ts` can check it per
+// message instead of only at the handshake.
+//
+// `ws-scope-registry.test.ts` walks every literal in
+// `clientTextMessageSchema`'s discriminated union (`shared/ws-messages.ts`)
+// and asserts each one has an entry here — the same "exhaustive Zod union
+// vs registry" guard shape used elsewhere in this codebase.
+
+import type { ClientTextMessage } from '../../shared/ws-messages.js'
+import type { AuthScope } from './auth-strategy.js'
+
+// A binary WS frame is always a Loro CRDT update — a canvas mutation. It has
+// no `type` field to key a registry on, so it gets a fixed requirement
+// rather than a lookup table entry.
+export const WS_BINARY_UPDATE_REQUIRED_SCOPES: readonly AuthScope[] = ['canvas:write']
+
+// Every client→server text message is a read-only control/signal frame
+// today (readiness, tracing metadata, or a response to a request the server
+// itself sent) — none of them mutate the canvas directly, so `canvas:read`
+// is sufficient for all four. Declared as a per-type map (not a single
+// constant) so a future message type must add its own entry rather than
+// silently inheriting this one.
+export const WS_CLIENT_TEXT_MESSAGE_REQUIRED_SCOPES: Record<
+  ClientTextMessage['type'],
+  readonly AuthScope[]
+> = {
+  client_ready: ['canvas:read'],
+  export_response: ['canvas:read'],
+  viewport_response: ['canvas:read'],
+  ws_trace: ['canvas:read'],
+}
+
+export function requiredScopesForClientTextMessage(
+  type: ClientTextMessage['type'],
+): readonly AuthScope[] {
+  return WS_CLIENT_TEXT_MESSAGE_REQUIRED_SCOPES[type]
+}
+
+export function hasRequiredScopes(
+  granted: readonly AuthScope[],
+  required: readonly AuthScope[],
+): boolean {
+  const grantedSet = new Set(granted)
+  return required.every((scope) => grantedSet.has(scope))
+}


### PR DESCRIPTION
## Summary

Prerequisite slice for ADR-0005 (hosted-origin OAuth): makes the *existing*
authorization surface honest and complete before anything is built on top
of it. Does **not** add OAuth.

### Audit (before changing anything, updated post-rebase onto #226)

- **REST `/api/*`, local-daemon mode**: as of #226 (`read-carveout`,
  merged first and now folded into this branch), `createDaemonAuthMiddleware`
  requires the shared bearer token on **every** method — reads included.
  `GET /api/runtime/ping` is the sole pre-auth exception (an availability
  probe apps/web calls before it knows a token even exists). The
  tokenless canvas/asset `GET` carve-out this PR's original audit
  described as "deliberate, left untouched" **no longer exists** — #226
  retired it (ADR-0002's third addendum: the `<img src>` cost it was
  protecting turned out not to exist, every real consumer already
  fetches bytes through the bearer-carrying transport, and a hosted
  origin as a first-class client kills the loopback-only containment
  assumption the carve-out rested on). `AuthScope` exists but
  `createLocalTokenAuthStrategy`'s success path still ignores
  `requiredScopes` — see the coherence note below for whether that's
  still fine.
- **REST `/api/*`, server-mode**: already scope-checked on every method via
  `resolveServerModeApiScopes`, but its final branch was a **silent
  catch-all** (`isWrite ? canvas:write : canvas:read`) — a new route would
  silently inherit a guess instead of a decision.
- **WebSocket**: authenticates once at upgrade against the same shared
  token; there was **no scope concept at all**, and every subsequent frame
  (a binary Loro mutation or a text control message) was treated
  identically once accepted. Narrower than ADR-0005's framing today:
  server-mode never wires up WS at all (`server-mode-http.ts` says so
  explicitly), so the "OAuth REST + WS-accepts-everything" scenario isn't
  live yet — it's the prerequisite gap for when WS gets wired to
  server-mode, not a currently exploitable hole.

Deliberate carve-out that *is* still left untouched here: local-token
ignoring scopes (single-tenant concession, see below). There is no longer
a tokenless-read carve-out to describe — #226 closed it, and this PR's
matrix now reflects that instead of the retired world.

Manually re-verified after the rebase: unauthenticated `GET
/api/workspaces` against a local-daemon app still returns 401, and 200
with the correct bearer — the merge did not silently reopen the hole #226
closed.

### What changed

- `security/route-scope-registry.ts` (+test): single declarative
  `resolveApiRouteScope(method, path)`. Returns `null` — fail closed — for
  any `/api/*` route nobody has declared a scope for (server-mode now
  500s with `auth.route-undeclared` instead of guessing), and `{kind:
  'public'}` only for the one deliberate exception, `GET
  /api/runtime/ping`. The guard test walks the server-mode app's actual
  `app.routes` (careful to include `app.all`-registered endpoints like
  `/api/debug`, not just `app.get/post/...`) and fails if any resolve to
  `null`.
- `security/ws-scope-registry.ts` (+test): declares the required scope
  per WS operation — a binary Loro update (mutation) needs
  `canvas:write`; every client→server control message needs
  `canvas:read`. Guard test walks `clientTextMessageSchema`'s Zod union
  literals and fails if one has no registry entry.
- `routes/ws-auth.ts`: `authorizeWsUpgrade` now returns the granted
  `scopes` explicitly on accept (today always the full set — see the
  coherence note below).
- `routes/ws.ts`: enforces the grant **per message**, not just at
  upgrade — a connection without `canvas:write` cannot import/persist/
  broadcast a binary update; a connection without `canvas:read` can't
  even signal `client_ready`.
- `app.ts` / `http-server.ts`: wired the registry + upgrade grant through.

### Adversarial tests (mutation-checked — verified each fails when the
guard is disabled, then restored)

- a `canvas:read`-only WS connection cannot persist/broadcast a binary
  CRDT mutation; a fully-granted connection still can (no regression); a
  zero-scope connection can't even signal `client_ready`.
- an undeclared `/api/*` route resolves to `null`; removing a real rule
  (`/api/debug`, registered via `app.all`) makes the registry-wide guard
  fail — this also caught that a naive `method !== 'ALL'` filter would
  have silently skipped `app.all`-registered endpoints.

### Is the local-token scope concession still coherent?

Yes, and it's worth saying plainly rather than leaving as an implication.
`createLocalTokenAuthStrategy` ignoring `requiredScopes` was already
documented as a single-tenant concession for REST, and that path is
**untouched** here — local-daemon's real REST auth middleware
(`createDaemonMutationAuthMiddleware`) never consulted the scope registry
before this PR and still doesn't. The registry is consumed by
server-mode's REST middleware (which does issue real per-subject scoped
OAuth tokens) and, new in this PR, by the WS enforcement point.

For WS specifically: the *only* WS credential local-daemon issues today
is the same shared token, and `authorizeWsUpgrade` grants it
`ALL_AUTH_SCOPES` — consistent with, not a new exception to, the
already-accepted single-tenant model. Nothing regresses and nothing is
"pretending" to be scoped, because no consumer holding a narrower
local-daemon credential exists yet. Where this *would* become
incoherent is if a future slice hands out a narrower local-daemon or
hosted-pairing WS credential without actually restricting it — that
credential doesn't exist today, so this PR names it rather than ships it:
**issuing a scoped (non-full-grant) local-daemon/pairing credential is
explicitly the next slice, not this one.**

## Test plan

- [x] `pnpm test --project mcp-node` — 208 files / 3169 tests, all green
      (post-rebase onto #226, re-verified)
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean
- [x] `pnpm --filter @kamiazya/whiteboard-mcp build` clean
- [x] `pnpm lint:noconsole` clean
- [x] Mutation-checked both new guard tests (verified fail before
      restoring)
- [x] Manual check post-rebase: `GET /api/workspaces` without a bearer →
      401; with the correct bearer → 200 (confirms #226's fix and this
      PR's changes don't interact to reopen it)

## Resolved: rebased onto #226 (`read-carveout`)

`read-carveout` merged first and retired ADR-0002's tokenless-GET
carve-out entirely (`requiresDaemonMutationAuth` → `requiresDaemonAuth`,
bearer required on every method except `GET /api/runtime/ping`). This
branch is now rebased onto it — `routes/auth.ts` / `app.ts` reconciled
cleanly (no conflicts; this PR's registry/WS-scope work and #226's
mutation→every-method change touch adjacent, not overlapping, code paths
in those files). The audit prose above is updated to match the
post-rebase world.

## AI review triage (Gemini code-assist)

One comment, medium priority, on `ws-scope-registry.ts`'s
`hasRequiredScopes`: flagged the per-call `new Set(granted)` as
unnecessary allocation on a hot path (runs on every WS message) given
both arrays are tiny (≤11 entries). **Applied** — switched to
`required.every((scope) => granted.includes(scope))`, no behavior
change, covered by the existing test suite.

The same comment also suggested adding `if (!granted || !required) return
false` defensive null-guards. **Rejected**: both parameters are typed
`readonly AuthScope[]` (never optional/nullable) and every call site
passes an actual array — there is no untrusted or process-boundary input
here for the guard to defend, unlike the Zod-validated boundaries
elsewhere in this codebase. Adding a runtime null-check the type system
already rules out would silently swallow a real type violation (returning
`false`/fail-closed) instead of surfacing it as a compile error, which is
the wrong trade for internal, statically-typed call sites.
