### PR TITLE
fix(mcp-server): harden scope enforcement (file-route write verbs, WS close on scope violation)

### DIFF
--- a/packages/mcp-server/src/server/routes/ws.test.ts
+++ b/packages/mcp-server/src/server/routes/ws.test.ts
@@ -22,6 +22,7 @@ const { handleWsUpgrade, setAutoVersionTrigger, sendViewportRequest } = await im
 
 class FakeWebSocket {
   sent: Array<string | Uint8Array> = []
+  closes: Array<{ code?: number; reason?: string }> = []
   private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
 
   send(data: string | Uint8Array | ArrayBuffer): void {
@@ -42,7 +43,9 @@ class FakeWebSocket {
     this.listeners.set(event, handlers)
   }
 
-  close(): void {}
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason })
+  }
 
   async emitMessage(data: Buffer, isBinary: boolean): Promise<void> {
     for (const handler of this.listeners.get('message') ?? []) {
@@ -466,6 +469,9 @@ describe('handleWsUpgrade per-message scope enforcement (ADR-0005)', () => {
     const savedElements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
     expect(savedElements).toEqual([])
 
+    // And the socket is closed rather than silently swallowing further frames.
+    expect(ws.closes).toEqual([{ code: 1008, reason: 'Insufficient scope' }])
+
     ws.emitClose()
   })
 
@@ -513,6 +519,11 @@ describe('handleWsUpgrade per-message scope enforcement (ADR-0005)', () => {
     await new Promise((resolve) => setTimeout(resolve, 10))
 
     expect(getReadyClientCount('session1', 'canvas-noscope')).toBe(0)
+
+    // Scopes are fixed at upgrade, so a client that lacks the scope for a
+    // message can never succeed by retrying. Leaving the socket open would
+    // let it keep pushing rejected frames indefinitely; close it out.
+    expect(ws.closes).toEqual([{ code: 1008, reason: 'Insufficient scope' }])
     ws.emitClose()
   })
 })

--- a/packages/mcp-server/src/server/routes/ws.test.ts
+++ b/packages/mcp-server/src/server/routes/ws.test.ts
@@ -526,4 +526,33 @@ describe('handleWsUpgrade per-message scope enforcement (ADR-0005)', () => {
     expect(ws.closes).toEqual([{ code: 1008, reason: 'Insufficient scope' }])
     ws.emitClose()
   })
+
+  it('a frame already in flight when the socket was closed for scope takes no effect', async () => {
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      { url: '/ws/session1/canvas-inflight', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+      ['canvas:read'],
+    )
+
+    const clientDoc = new LoroDoc()
+    const prevVV = clientDoc.version()
+    clientDoc.getMovableList('elements').insertContainer(0, new LoroMap())
+    clientDoc.commit()
+
+    // The mutation trips the scope gate and starts the closing handshake...
+    await ws.emitMessage(
+      Buffer.from(clientDoc.export({ mode: 'update', from: prevVV }) as Uint8Array),
+      true,
+    )
+    // ...but `close()` only *starts* it, so a frame the client had already put
+    // on the wire still arrives. Even though canvas:read alone would normally
+    // authorize client_ready, it must not register a socket that is closing.
+    const { getReadyClientCount } = await import('./ws.js')
+    await ws.emitMessage(Buffer.from(JSON.stringify({ type: 'client_ready' })), false)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(getReadyClientCount('session1', 'canvas-inflight')).toBe(0)
+    ws.emitClose()
+  })
 })

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -241,6 +241,15 @@ export async function handleWsUpgrade(
   // in closure scope keeps the per-canvas connection map untouched.
   let pendingTraceContext: ReturnType<typeof extractContextFromHeaders> | null = null
 
+  // The connection's scopes are fixed at upgrade and cannot widen mid-session,
+  // so a client that sends a message it lacks the scope for can never succeed
+  // by retrying. Dropping the frame while leaving the socket open would let it
+  // keep pushing rejected traffic; RFC 6455 1008 (Policy Violation) is the
+  // close code for a message the peer is not permitted to send.
+  function closeForInsufficientScope(): void {
+    ws.close(1008, 'Insufficient scope')
+  }
+
   ws.on('message', async (data: RawData, isBinary: boolean) => {
     runtimeTouch()
     if (!isBinary) {
@@ -253,6 +262,7 @@ export async function handleWsUpgrade(
           { workspaceId, slug, messageType: msg.type },
           'ws message rejected: insufficient scope',
         )
+        closeForInsufficientScope()
         return
       }
       if (msg.type === 'client_ready') {
@@ -296,6 +306,7 @@ export async function handleWsUpgrade(
         { workspaceId, slug },
         'ws binary update rejected: insufficient scope',
       )
+      closeForInsufficientScope()
       return
     }
 

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -246,11 +246,19 @@ export async function handleWsUpgrade(
   // by retrying. Dropping the frame while leaving the socket open would let it
   // keep pushing rejected traffic; RFC 6455 1008 (Policy Violation) is the
   // close code for a message the peer is not permitted to send.
+  // `ws.close()` only starts the closing handshake: frames the client already
+  // put on the wire still reach this handler before the socket is torn down.
+  // Without this flag a connection that just lost the socket for one message
+  // could still have an in-scope follow-up frame (e.g. `client_ready`) take
+  // effect on a socket that is on its way out.
+  let isClosing = false
   function closeForInsufficientScope(): void {
+    isClosing = true
     ws.close(1008, 'Insufficient scope')
   }
 
   ws.on('message', async (data: RawData, isBinary: boolean) => {
+    if (isClosing) return
     runtimeTouch()
     if (!isBinary) {
       // text frame = JSON（export_response / viewport_response / ws_trace）

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -92,4 +92,22 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
     expect(resolveApiRouteScope('GET', '/mcp')).toBeNull()
     expect(resolveApiRouteScope('GET', '/')).toBeNull()
   })
+
+  // The file-route rule must key off the write/read split, not off the one
+  // write verb that happens to be mounted today — otherwise adding a DELETE
+  // (or POST) file route later silently authorizes a mutation with a
+  // read-only credential.
+  it('any write verb on a file route requires files:write, not just PUT', () => {
+    const filePath = '/api/canvas/ws1/main/file/abc'
+    expect(resolveApiRouteScope('GET', filePath)).toEqual({
+      kind: 'scoped',
+      scopes: ['files:read'],
+    })
+    for (const method of ['PUT', 'POST', 'PATCH', 'DELETE']) {
+      expect(resolveApiRouteScope(method, filePath), `${method} on a file route`).toEqual({
+        kind: 'scoped',
+        scopes: ['files:write'],
+      })
+    }
+  })
 })

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -47,7 +47,7 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
 
   // File routes: reading/writing a canvas's attached binary file.
   if (/^\/api\/canvas\/[^/]+\/[^/]+\/file\//.test(path)) {
-    return { kind: 'scoped', scopes: [method === 'PUT' ? 'files:write' : 'files:read'] }
+    return { kind: 'scoped', scopes: [isWrite ? 'files:write' : 'files:read'] }
   }
 
   // Canvas write operations that arrive as POST but mutate state.


### PR DESCRIPTION
Follow-up to #227 (scope registry): three Gemini findings arrived after the merge. All three were valid; this applies them, each with a red-first test.

## 1. `files:write` was only required for `PUT` (security)

`resolveApiRouteScope` already computed `isWrite`, but the file-route branch keyed off `method === 'PUT'`. Every other rule in the registry uses the write/read split. The moment a `DELETE` or `POST` file route is mounted, the mutation would be authorized by a read-only `files:read` credential — a latent scope bypass, not a live one (only `GET`/`PUT` file routes exist today).

Red test: `any write verb on a file route requires files:write, not just PUT` — asserts `GET → files:read` and `PUT/POST/PATCH/DELETE → files:write`. Fails on `POST` before the fix.

## 2/3. Insufficient-scope WS messages were dropped, not closed

Both scope gates in `ws.ts` (client text messages and binary CRDT updates) logged a warning and `return`ed, leaving the socket open. A connection's scopes are fixed at upgrade and cannot widen mid-session, so such a client can never succeed by retrying — it can only keep pushing rejected traffic at the server indefinitely. Both sites now `ws.close(1008, 'Insufficient scope')` (RFC 6455 Policy Violation).

The two existing adversarial tests (`canvas:read`-only cannot emit a CRDT mutation; a no-scope connection cannot signal `client_ready`) were extended to assert the close code, so they now cover *rejection* as well as *no state change*.

## Verification

- Red-first: all 3 assertions fail on `origin/main`, for the right reason.
- `pnpm test --project mcp-node` → 3170 passed, 2 skipped (208 files).
- `pnpm -r typecheck` → clean.

Backend-only; no user-visible surface, so no screenshot.
