### PR TITLE
feat(mcp-server): OAuth 2.1 authorization-server skeleton for hosted-origin access

### DIFF
--- a/packages/mcp-server/src/cli/daemon-run.ts
+++ b/packages/mcp-server/src/cli/daemon-run.ts
@@ -17,6 +17,7 @@ import {
 import { DATA_DIR } from '../shared/data-dir-secure.js'
 import { assertLoopbackBindHost } from '../server/daemon-auth-binding.js'
 import { startHttpServer } from '../server/http-server.js'
+import { parseOAuthClientRegistryEnv } from '../server/security/oauth-authz-registry.js'
 import { loadAllowedWebOriginsFromEnv } from '../server/security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 
@@ -33,7 +34,11 @@ export interface DaemonRunReadyResult {
 }
 
 export type DaemonRunOutcome =
-  | { kind: 'input-error'; message: string; code?: 'invalid_allowed_web_origins' }
+  | {
+      kind: 'input-error'
+      message: string
+      code?: 'invalid_allowed_web_origins' | 'invalid_oauth_client_registry'
+    }
   | { kind: 'refused'; message: string }
   | { kind: 'running'; result: DaemonRunReadyResult }
 
@@ -122,6 +127,19 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
     }
   }
 
+  // Same fail-fast posture as the allowlist above: a malformed registry must
+  // not start a daemon whose authorization-server surface is silently absent.
+  const oauthRegistry = parseOAuthClientRegistryEnv(
+    (options.env ?? process.env).WHITEBOARD_OAUTH_CLIENT_REGISTRY,
+  )
+  if (!oauthRegistry.ok) {
+    return {
+      kind: 'input-error',
+      message: `Invalid WHITEBOARD_OAUTH_CLIENT_REGISTRY (${oauthRegistry.error}).`,
+      code: 'invalid_oauth_client_registry',
+    }
+  }
+
   const existing = await loadDaemonRecord(dataDir)
   if (existing !== null && isPidAlive(existing.pid)) {
     return {
@@ -151,7 +169,13 @@ export async function runDaemonRun(options: DaemonRunOptions): Promise<DaemonRun
   return await withDaemonStartupLock(dataDir, async () => {
     const port = options.port ?? (await findAvailablePort())
 
-    const running = await startHttpServer({ port, host, token, allowedWebOrigins })
+    const running = await startHttpServer({
+      port,
+      host,
+      token,
+      allowedWebOrigins,
+      oauthClientRegistry: oauthRegistry.registry,
+    })
 
     const startedAt = new Date().toISOString()
 

--- a/packages/mcp-server/src/server/app.oauth-authz-middleware-scope.test.ts
+++ b/packages/mcp-server/src/server/app.oauth-authz-middleware-scope.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from './routes/_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-app-oauth-probe-test-')
+
+vi.mock('./config.js', () => ({
+  get DATA_DIR() {
+    return join(tmp.dir, 'data')
+  },
+  get DIST_WEB_APP_DIR() {
+    return join(tmp.dir, 'web-app')
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+}))
+
+vi.mock('../daemon/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn(async () => ({
+    pid: 1,
+    port: 3099,
+    token: 'secret',
+    version: '0.1.0',
+    startedAt: '2026-04-24T00:00:00.000Z',
+    baseUrl: 'http://daemon.test',
+  })),
+}))
+
+const { createApp } = await import('./app.js')
+const { PACKAGE_VERSION } = await import('../shared/package-version.js')
+
+const registry = [
+  {
+    clientId: 'whiteboard-hosted-web',
+    redirectUris: ['https://whiteboard.pages.dev/oauth/callback'],
+  },
+]
+
+function buildRuntimeOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    authMode: 'local-daemon' as const,
+    touch: vi.fn(),
+    shutdown: vi.fn(async () => undefined),
+    getStatus: () => ({
+      ok: true,
+      pid: 10,
+      host: '127.0.0.1',
+      port: 3099,
+      baseUrl: 'http://127.0.0.1:3099',
+      version: PACKAGE_VERSION,
+      startedAt: '2026-04-23T00:00:00.000Z',
+      uptimeMs: 100,
+      idleForMs: 10,
+      auth: { mode: 'local-token', hasToken: false },
+      storage: { dataDir: '/tmp', dataDirWritable: true },
+      app: { served: true, buildPresent: false, ui: 'web-app' },
+      mcp: { httpEnabled: true, endpoint: 'http://127.0.0.1:3099/mcp' },
+      clients: { connected: 0, ready: 0 },
+    }),
+    ...overrides,
+  }
+}
+
+// The OAuth surface's host guard and CORS must apply to its own three paths
+// and nothing else. Hono merges a sub-app's `use('*')` into the parent as
+// `/*` rather than confining it to the sub-app's routes, so mounting the
+// router as a guarded sub-app at '/' silently put its CORS handler ahead of
+// every other route's policy — an OPTIONS preflight for /mcp was answered
+// with 204 instead of /mcp's own origin middleware's 403. This asserts the
+// only thing that actually matters: configuring the registry must not change
+// how any non-OAuth route responds.
+describe('oauth-authz middleware scope', () => {
+  it('configuring the oauth registry changes no other route', async () => {
+    await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
+    await mkdir(join(tmp.dir, 'data'), { recursive: true })
+    await writeFile(join(tmp.dir, 'web-app', 'index.html'), '<!DOCTYPE html><html></html>')
+
+    const withoutOauth = createApp(
+      buildRuntimeOptions({ allowedWebOrigins: ['https://whiteboard.pages.dev'] }),
+    )
+    const withOauth = createApp(
+      buildRuntimeOptions({
+        allowedWebOrigins: ['https://whiteboard.pages.dev'],
+        oauthClientRegistry: registry,
+      }),
+    )
+
+    const req = () =>
+      ({
+        method: 'OPTIONS',
+        headers: {
+          Host: '127.0.0.1:3099',
+          Origin: 'https://whiteboard.pages.dev',
+          'Access-Control-Request-Method': 'POST',
+        },
+      }) as const
+
+    const probes: Array<[string, RequestInit]> = [
+      ['OPTIONS /mcp allowed origin', req()],
+      [
+        'OPTIONS /mcp attacker origin',
+        {
+          method: 'OPTIONS',
+          headers: {
+            Host: '127.0.0.1:3099',
+            Origin: 'https://attacker.example',
+            'Access-Control-Request-Method': 'POST',
+          },
+        },
+      ],
+      [
+        'POST /mcp attacker origin',
+        {
+          method: 'POST',
+          headers: { Host: '127.0.0.1:3099', Origin: 'https://attacker.example' },
+        },
+      ],
+    ]
+
+    const paths = ['/mcp', '/', '/api/runtime/ping']
+    const diffs: string[] = []
+    for (const path of paths) {
+      for (const [label, init] of probes) {
+        const a = await withoutOauth.request(`http://127.0.0.1:3099${path}`, init)
+        const b = await withOauth.request(`http://127.0.0.1:3099${path}`, init)
+        const shape = (r: Response) => ({
+          status: r.status,
+          acao: r.headers.get('Access-Control-Allow-Origin'),
+          acac: r.headers.get('Access-Control-Allow-Credentials'),
+        })
+        const [sa, sb] = [shape(a), shape(b)]
+        if (JSON.stringify(sa) !== JSON.stringify(sb)) {
+          diffs.push(`${path} — ${label}: without=${JSON.stringify(sa)} with=${JSON.stringify(sb)}`)
+        }
+      }
+    }
+
+    expect(diffs, 'configuring the oauth registry changed a non-oauth route').toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/app.oauth-authz.test.ts
+++ b/packages/mcp-server/src/server/app.oauth-authz.test.ts
@@ -1,0 +1,163 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from './routes/_test-helpers.js'
+
+// Verifies the app.ts wiring for the hosted-origin OAuth 2.1 authorization-
+// server surface (ADR-0005): the host guard and CORS handling this router
+// needs do not come for free just from being registered — this is the
+// regression test for that wiring, distinct from oauth-authz.test.ts's
+// unit-level coverage of the router's own logic.
+
+const tmp = withTempDataDir('whiteboard-app-oauth-authz-test-')
+
+vi.mock('./config.js', () => ({
+  get DATA_DIR() {
+    return join(tmp.dir, 'data')
+  },
+  get DIST_WEB_APP_DIR() {
+    return join(tmp.dir, 'web-app')
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+}))
+
+vi.mock('../daemon/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn(async () => ({
+    pid: 1,
+    port: 3099,
+    token: 'secret',
+    version: '0.1.0',
+    startedAt: '2026-04-24T00:00:00.000Z',
+    baseUrl: 'http://daemon.test',
+  })),
+}))
+
+const { createApp } = await import('./app.js')
+const { clearCache } = await import('./store/doc-cache.js')
+const { clearWorkspaceIdCache } = await import('./mcp/session-resolver.js')
+const { PACKAGE_VERSION } = await import('../shared/package-version.js')
+
+const registry = [
+  {
+    clientId: 'whiteboard-hosted-web',
+    redirectUris: ['https://whiteboard.pages.dev/oauth/callback'],
+  },
+]
+
+function buildRuntimeOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    authMode: 'local-daemon' as const,
+    touch: vi.fn(),
+    shutdown: vi.fn(async () => undefined),
+    getStatus: () => ({
+      ok: true,
+      pid: 10,
+      host: '127.0.0.1',
+      port: 3099,
+      baseUrl: 'http://127.0.0.1:3099',
+      version: PACKAGE_VERSION,
+      startedAt: '2026-04-23T00:00:00.000Z',
+      uptimeMs: 100,
+      idleForMs: 10,
+      auth: { mode: 'local-token', hasToken: false },
+      storage: { dataDir: '/tmp', dataDirWritable: true },
+      app: { served: true, buildPresent: false, ui: 'web-app' },
+      mcp: { httpEnabled: true, endpoint: 'http://127.0.0.1:3099/mcp' },
+      clients: { connected: 0, ready: 0 },
+    }),
+    ...overrides,
+  }
+}
+
+describe('createApp oauth-authz wiring', () => {
+  beforeEach(async () => {
+    await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
+    await mkdir(join(tmp.dir, 'data'), { recursive: true })
+    clearCache()
+    clearWorkspaceIdCache()
+    await writeFile(
+      join(tmp.dir, 'web-app', 'index.html'),
+      '<!DOCTYPE html><html><head><title>Whiteboard</title></head><body><div id="root"></div></body></html>',
+    )
+  })
+
+  afterEach(() => {
+    clearCache()
+    clearWorkspaceIdCache()
+  })
+
+  it('does not mount /token or the metadata endpoints when no registry is configured (empty by default)', async () => {
+    const app = createApp(buildRuntimeOptions())
+    const tokenRes = await app.request('http://127.0.0.1:3099/token', { method: 'POST' })
+    expect(tokenRes.status).toBe(404)
+    const metadataRes = await app.request(
+      'http://127.0.0.1:3099/.well-known/oauth-authorization-server',
+    )
+    expect(metadataRes.status).toBe(404)
+  })
+
+  it('rejects a spoofed non-loopback Host on /token with 403 — trap #1, the host guard applies here too', async () => {
+    const app = createApp(buildRuntimeOptions({ oauthClientRegistry: registry }))
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { Host: 'evil.example' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects a spoofed Host on the metadata endpoints too', async () => {
+    const app = createApp(buildRuntimeOptions({ oauthClientRegistry: registry }))
+    const res = await app.request('http://127.0.0.1:3099/.well-known/oauth-authorization-server', {
+      headers: { Host: 'evil.example' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('gives /token its own CORS: an admitted hosted origin gets Access-Control-Allow-Origin reflected', async () => {
+    const app = createApp(
+      buildRuntimeOptions({
+        oauthClientRegistry: registry,
+        allowedWebOrigins: ['https://whiteboard.pages.dev'],
+      }),
+    )
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'OPTIONS',
+      headers: { Host: '127.0.0.1:3099', Origin: 'https://whiteboard.pages.dev' },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://whiteboard.pages.dev')
+  })
+
+  it('does not reflect CORS for a non-admitted cross-origin caller on /token', async () => {
+    const app = createApp(
+      buildRuntimeOptions({
+        oauthClientRegistry: registry,
+        allowedWebOrigins: ['https://whiteboard.pages.dev'],
+      }),
+    )
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'OPTIONS',
+      headers: { Host: '127.0.0.1:3099', Origin: 'https://attacker.example' },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('does not inject the OAuth registry or client_id into the daemon-served index.html — trap #8', async () => {
+    const app = createApp(
+      buildRuntimeOptions({
+        oauthClientRegistry: registry,
+        allowedWebOrigins: ['https://whiteboard.pages.dev'],
+      }),
+    )
+    const res = await app.request('http://127.0.0.1:3099/', { headers: { Host: '127.0.0.1:3099' } })
+    const html = await res.text()
+    // The daemon-served app must stay entirely out of the OAuth state,
+    // storage, callback, and client_id path — it authenticates same-origin
+    // requests with the raw injected daemon token only (see
+    // __WHITEBOARD_DAEMON_TOKEN__ below in this same file), never a
+    // registered OAuth client_id.
+    expect(html).not.toContain('whiteboard-hosted-web')
+    expect(html).not.toContain('code_verifier')
+    expect(html).toContain('__WHITEBOARD_RUNTIME_CONFIG__')
+  })
+})

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -20,7 +20,7 @@ import { createDebugRouter } from './routes/debug.js'
 import { createExportRouter, resolveExportRequest } from './routes/export.js'
 import { createFilesRouter } from './routes/files.js'
 import { createLibrariesRouter } from './routes/libraries.js'
-import { createOAuthAuthzRouter } from './routes/oauth-authz.js'
+import { createOAuthAuthzRouter, OAUTH_AUTHZ_PATHS } from './routes/oauth-authz.js'
 import { createPaletteRouter } from './routes/palette.js'
 import { createRuntimeRouter } from './routes/runtime.js'
 import { createStatusRouter } from './routes/status.js'
@@ -484,21 +484,21 @@ export function createApp(options: AppOptions) {
       store: oauthTransactionStore,
       registry: options.oauthClientRegistry,
     })
-    // A dedicated sub-app, not app.use('/token', ...) etc. directly on the
-    // top-level app: the host guard and CORS below must apply to exactly
-    // the metadata + /token routes this router defines, and nothing else —
-    // mounting them here rather than widening /api/*'s existing middleware
-    // keeps that scope explicit and auditable in one place.
-    const oauthAuthzGuarded = new Hono()
-    // Host guard first, ahead of CORS, for the same DNS-rebinding reason as
-    // /api/*: a spoofed non-loopback Host must be rejected before an
-    // OPTIONS preflight could short-circuit past it.
-    oauthAuthzGuarded.use('*', createApiHostGuardMiddleware(options.authMode))
-    // /token's own CORS handling — it inherits nothing from /api/*'s
-    // middleware chain merely by being mounted nearby.
-    oauthAuthzGuarded.use('*', createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
-    oauthAuthzGuarded.route('/', oauthAuthzRoutes)
-    app.route('/', oauthAuthzGuarded)
+    // Attached per explicit path, NOT via a sub-app: Hono merges a sub-app's
+    // `use('*')` into the parent as `/*`, so a sub-app mounted at '/' would
+    // run this host guard and CORS ahead of every other route's own policy —
+    // an OPTIONS preflight for /mcp would be answered here before
+    // createMcpHttpOriginMiddleware ever ran.
+    for (const path of OAUTH_AUTHZ_PATHS) {
+      // Host guard first, ahead of CORS, for the same DNS-rebinding reason as
+      // /api/*: a spoofed non-loopback Host must be rejected before an
+      // OPTIONS preflight could short-circuit past it.
+      app.use(path, createApiHostGuardMiddleware(options.authMode))
+      // This surface's own CORS handling — it inherits nothing from /api/*'s
+      // middleware chain merely by being mounted nearby.
+      app.use(path, createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
+    }
+    app.route('/', oauthAuthzRoutes)
   }
 
   if (mcpAuth) {

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -20,6 +20,7 @@ import { createDebugRouter } from './routes/debug.js'
 import { createExportRouter, resolveExportRequest } from './routes/export.js'
 import { createFilesRouter } from './routes/files.js'
 import { createLibrariesRouter } from './routes/libraries.js'
+import { createOAuthAuthzRouter } from './routes/oauth-authz.js'
 import { createPaletteRouter } from './routes/palette.js'
 import { createRuntimeRouter } from './routes/runtime.js'
 import { createStatusRouter } from './routes/status.js'
@@ -39,6 +40,8 @@ import {
   type McpHttpAuthStrategy,
 } from './security/mcp-auth.js'
 import { createMcpHttpAuthMiddleware, createMcpHttpOriginMiddleware } from './security/mcp-http.js'
+import type { OAuthClientRegistry } from './security/oauth-authz-registry.js'
+import { createOAuthTransactionStore } from './security/oauth-authz-transactions.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { matchOrigin, parseOriginPatterns } from './security/origin-pattern.js'
 import { planServerModeAuth } from './security/server-mode-auth-plan.js'
@@ -111,7 +114,8 @@ function isReservedUiPath(path: string): boolean {
     path.startsWith('/mcp/') ||
     path === '/ws' ||
     path.startsWith('/ws/') ||
-    path.startsWith('/.well-known/')
+    path.startsWith('/.well-known/') ||
+    path === '/token'
   )
 }
 
@@ -200,6 +204,13 @@ export interface LocalDaemonAppOptions {
    *  behavior is unchanged unless an operator opts in. Local-daemon only;
    *  server-mode governs its origins solely via allowedOrigins below. */
   allowedWebOrigins?: readonly string[]
+  /** Exact-URI redirect_uri registry for the hosted-origin OAuth 2.1
+   *  authorization-server surface (ADR-0005): /.well-known/oauth-protected-
+   *  resource/api, /.well-known/oauth-authorization-server, and /token.
+   *  Empty by default — the whole surface stays unmounted until an operator
+   *  configures at least one client. See oauth-authz-registry.ts for why
+   *  this is never derived from allowedWebOrigins. */
+  oauthClientRegistry?: OAuthClientRegistry
 }
 
 export interface ServerModeAppOptions {
@@ -456,6 +467,38 @@ export function createApp(options: AppOptions) {
     // the auth chain unchanged.
     app.use('/api/*', createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
     app.use('/api/*', createDaemonAuthMiddleware(token))
+  }
+
+  // Hosted-origin OAuth 2.1 authorization-server surface (ADR-0005). Local-
+  // daemon mode only — server-mode has its own external-IdP oauth-jwt
+  // resource-server strategy and is not itself an authorization server.
+  // Unmounted entirely unless an operator configures at least one
+  // redirect_uri registry entry (empty-by-default, like allowedWebOrigins).
+  if (
+    options.authMode === 'local-daemon' &&
+    options.oauthClientRegistry &&
+    options.oauthClientRegistry.length > 0
+  ) {
+    const oauthTransactionStore = createOAuthTransactionStore()
+    const oauthAuthzRoutes = createOAuthAuthzRouter({
+      store: oauthTransactionStore,
+      registry: options.oauthClientRegistry,
+    })
+    // A dedicated sub-app, not app.use('/token', ...) etc. directly on the
+    // top-level app: the host guard and CORS below must apply to exactly
+    // the metadata + /token routes this router defines, and nothing else —
+    // mounting them here rather than widening /api/*'s existing middleware
+    // keeps that scope explicit and auditable in one place.
+    const oauthAuthzGuarded = new Hono()
+    // Host guard first, ahead of CORS, for the same DNS-rebinding reason as
+    // /api/*: a spoofed non-loopback Host must be rejected before an
+    // OPTIONS preflight could short-circuit past it.
+    oauthAuthzGuarded.use('*', createApiHostGuardMiddleware(options.authMode))
+    // /token's own CORS handling — it inherits nothing from /api/*'s
+    // middleware chain merely by being mounted nearby.
+    oauthAuthzGuarded.use('*', createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
+    oauthAuthzGuarded.route('/', oauthAuthzRoutes)
+    app.route('/', oauthAuthzGuarded)
   }
 
   if (mcpAuth) {

--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -138,3 +138,57 @@ describe('startHttpServer WS upgrade with allowedWebOrigins', () => {
     await expect(attemptWsUpgrade(port, 'https://not-allowed.example')).resolves.toBe(403)
   })
 })
+
+describe('startHttpServer oauth client registry', () => {
+  let running: RunningServer | undefined
+
+  afterEach(async () => {
+    await running?.close()
+    running = undefined
+  })
+
+  // The router, its Zod schemas, and its unit tests can all be correct while
+  // the surface stays unreachable, because createApp only mounts it when it
+  // is handed a registry. This asserts the option actually reaches the real
+  // Node HTTP server — the difference between a shipped endpoint and dead code.
+  it('mounts /token on the real HTTP server when a registry is configured', async () => {
+    const port = await findAvailablePort(4200)
+    running = await startHttpServer({
+      port,
+      host: '127.0.0.1',
+      oauthClientRegistry: [
+        {
+          clientId: 'whiteboard-hosted-web',
+          redirectUris: ['https://whiteboard.pages.dev/oauth/callback'],
+        },
+      ],
+    })
+
+    // RFC 6749 §4.1.3's wire format, over a real socket. An unmounted route
+    // would 404; reaching the handler with an unknown code is a 400
+    // invalid_grant, which is what proves the body was parsed at all.
+    const res = await fetch(`http://127.0.0.1:${port}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'not-a-real-code',
+        redirect_uri: 'https://whiteboard.pages.dev/oauth/callback',
+        client_id: 'whiteboard-hosted-web',
+        code_verifier: 'x'.repeat(43),
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'invalid_grant' })
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('leaves /token unmounted when no registry is configured', async () => {
+    const port = await findAvailablePort(4300)
+    running = await startHttpServer({ port, host: '127.0.0.1' })
+
+    const res = await fetch(`http://127.0.0.1:${port}/token`, { method: 'POST' })
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -9,6 +9,7 @@ import { PACKAGE_VERSION } from '../shared/package-version.js'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import { createApp } from './app.js'
 import { normalizeBindHost } from './daemon-auth-binding.js'
+import type { OAuthClientRegistry } from './security/oauth-authz-registry.js'
 import { DATA_DIR, DIST_WEB_APP_DIR } from './config.js'
 import { handleWsUpgrade, getConnectionStats, setRuntimeTouchFn } from './routes/ws.js'
 import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
@@ -29,6 +30,10 @@ export interface StartHttpServerOptions {
   /** Exact-match hosted origins admitted alongside loopback, on /api CORS,
    *  /mcp, and WS upgrade (WHITEBOARD_ALLOWED_WEB_ORIGINS). Empty by default. */
   allowedWebOrigins?: readonly string[]
+  /** Registered OAuth clients and their exact redirect_uris
+   *  (WHITEBOARD_OAUTH_CLIENT_REGISTRY). Empty by default, which leaves the
+   *  hosted-origin authorization-server surface entirely unmounted. */
+  oauthClientRegistry?: OAuthClientRegistry
 }
 
 export interface RunningServer {
@@ -136,6 +141,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     getStatus: getRuntimeStatus,
     shutdown: close,
     allowedWebOrigins: options.allowedWebOrigins,
+    oauthClientRegistry: options.oauthClientRegistry,
   })
 
   setRuntimeTouchFn(touch)

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -7,6 +7,7 @@ import {
   resolveMcpProtectedResourceMetadataFromEnv,
 } from './security/mcp-auth.js'
 import { isDirectEntryPoint } from './entrypoint.js'
+import { parseOAuthClientRegistryEnv } from './security/oauth-authz-registry.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import { applyConfigFileToEnvAndLogLevel, loadConfigFile } from './config-file.js'
@@ -112,6 +113,19 @@ export async function main() {
     process.exit(1)
   }
 
+  // Same fail-fast posture: a malformed registry must abort startup rather
+  // than leave the authorization-server surface silently unmounted, which
+  // would look identical to "the operator never configured it".
+  const oauthRegistry = parseOAuthClientRegistryEnv(process.env.WHITEBOARD_OAUTH_CLIENT_REGISTRY)
+  if (!oauthRegistry.ok) {
+    const log = getLogger('server-index')
+    log.error(
+      { reason: oauthRegistry.error },
+      'WHITEBOARD_OAUTH_CLIENT_REGISTRY could not be parsed; refusing to start',
+    )
+    process.exit(1)
+  }
+
   // A hosted origin in the allowlist widens which browser origins may reach
   // /api CORS, /mcp, and WS upgrade. Without a Bearer token, missing-token
   // auth strategies treat every request as authenticated (local-dev
@@ -162,6 +176,7 @@ export async function main() {
     mcpAuth,
     idleTimeoutMs,
     allowedWebOrigins,
+    oauthClientRegistry: oauthRegistry.registry,
     onClose: daemonMode
       ? async () => {
           await deleteDaemonRecord(DATA_DIR)

--- a/packages/mcp-server/src/server/routes/oauth-authz.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.test.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto'
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { createOAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+import { createOAuthAuthzRouter } from './oauth-authz.js'
+
+const CLIENT_ID = 'whiteboard-hosted-web'
+const REDIRECT_URI = 'https://whiteboard.pages.dev/oauth/callback'
+const PKCE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+const PKCE_CHALLENGE = createHash('sha256').update(PKCE_VERIFIER).digest('base64url')
+
+function buildApp() {
+  const store = createOAuthTransactionStore()
+  const registry = [{ clientId: CLIENT_ID, redirectUris: [REDIRECT_URI] }]
+  const app = new Hono()
+  app.route('/', createOAuthAuthzRouter({ store, registry }))
+  return { app, store }
+}
+
+function issueCode(store: ReturnType<typeof createOAuthTransactionStore>) {
+  const { transactionId } = store.createTransaction({
+    clientId: CLIENT_ID,
+    redirectUri: REDIRECT_URI,
+    scopes: ['workspace:read'],
+    state: 'abc123',
+    codeChallenge: PKCE_CHALLENGE,
+    codeChallengeMethod: 'S256',
+  })
+  store.approveTransaction(transactionId)
+  const issued = store.issueAuthorizationCode(transactionId)
+  if (!issued) throw new Error('expected issuance to succeed')
+  return issued.code
+}
+
+describe('GET /.well-known/oauth-protected-resource/api', () => {
+  it('returns RFC 9728 metadata for the /api resource', async () => {
+    const { app } = buildApp()
+    const res = await app.request('http://127.0.0.1:3099/.well-known/oauth-protected-resource/api')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ resource: 'http://127.0.0.1:3099/api' })
+  })
+})
+
+describe('GET /.well-known/oauth-authorization-server', () => {
+  it('returns RFC 8414 metadata', async () => {
+    const { app } = buildApp()
+    const res = await app.request('http://127.0.0.1:3099/.well-known/oauth-authorization-server')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ token_endpoint: 'http://127.0.0.1:3099/token' })
+  })
+})
+
+describe('POST /token', () => {
+  it('exchanges a valid code + verifier for an access token', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ token_type: 'Bearer' })
+    expect(typeof body.access_token).toBe('string')
+  })
+
+  it('rejects a request with no code_verifier at all — trap #3, enforced server-side', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a redirect_uri that is not byte-for-byte registered — trap #2', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: `${REDIRECT_URI}/evil`,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('invalid_grant')
+  })
+
+  it('resolves two concurrent redemptions of the same code to exactly one success — trap #4', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const requestOptions: RequestInit = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }),
+    }
+    const [first, second] = await Promise.all([
+      app.request('http://127.0.0.1:3099/token', requestOptions),
+      app.request('http://127.0.0.1:3099/token', requestOptions),
+    ])
+    const statuses = [first.status, second.status].sort()
+    expect(statuses).toEqual([200, 400])
+  })
+})

--- a/packages/mcp-server/src/server/routes/oauth-authz.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.test.ts
@@ -73,6 +73,71 @@ describe('POST /token', () => {
     expect(typeof body.access_token).toBe('string')
   })
 
+  it('exchanges a form-encoded request — the wire format RFC 6749 §4.1.3 actually mandates', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }).toString(),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ token_type: 'Bearer' })
+    expect(typeof body.access_token).toBe('string')
+  })
+
+  it('rejects a form-encoded request missing code_verifier', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+      }).toString(),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('sets Cache-Control: no-store on a successful token response — RFC 6749 §5.1', async () => {
+    const { app, store } = buildApp()
+    const code = issueCode(store)
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }).toString(),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('sets Cache-Control: no-store on an error token response too — RFC 6749 §5.2', async () => {
+    const { app } = buildApp()
+    const res = await app.request('http://127.0.0.1:3099/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'grant_type=authorization_code',
+    })
+    expect(res.status).toBe(400)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
   it('rejects a request with no code_verifier at all — trap #3, enforced server-side', async () => {
     const { app, store } = buildApp()
     const code = issueCode(store)

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -6,7 +6,7 @@
 // (see api-host-guard.ts's header comment: middleware does not extend to
 // a new mount point just by being registered "near" it).
 
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { z } from 'zod'
 import { AUTH_SCOPES } from '../security/auth-strategy.js'
 import {
@@ -71,6 +71,29 @@ function tokenError(error: TokenErrorResponse['error']) {
   return { status: 400 as const, body: tokenErrorResponseSchema.parse({ error }) }
 }
 
+// RFC 6749 §5.1/§5.2: the token endpoint's responses carry credentials and
+// MUST NOT be stored. `Pragma: no-cache` is omitted deliberately — it is an
+// HTTP/1.0 request-header artifact that RFC 7234 §5.4 gives no defined
+// meaning as a response header, and no HTTP/1.1 cache consults it.
+const TOKEN_CACHE_CONTROL = { 'Cache-Control': 'no-store' } as const
+
+// RFC 6749 §4.1.3 / OAuth 2.1 §4.1.3: the token request body is
+// `application/x-www-form-urlencoded`; a spec-compliant client (including the
+// MCP SDK's own OAuth client) sends nothing else. JSON is additionally
+// accepted because this daemon's other POST surfaces are JSON and a
+// hand-rolled local client reaching for `fetch(..., {json})` failing with an
+// opaque `invalid_request` would be a needless trap — the parsed shape is
+// validated by the same Zod schema either way, so accepting both widens the
+// wire format, not the contract.
+async function readTokenRequestBody(c: Context): Promise<unknown> {
+  const contentType = c.req.header('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    return await c.req.json()
+  }
+  const params = new URLSearchParams(await c.req.text())
+  return Object.fromEntries(params.entries())
+}
+
 export interface OAuthAuthzRouterOptions {
   store: OAuthTransactionStore
   registry: OAuthClientRegistry
@@ -90,16 +113,16 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
   app.post(OAUTH_TOKEN_PATH, async (c) => {
     let rawBody: unknown
     try {
-      rawBody = await c.req.json()
+      rawBody = await readTokenRequestBody(c)
     } catch {
       const { status, body } = tokenError('invalid_request')
-      return c.json(body, status)
+      return c.json(body, status, TOKEN_CACHE_CONTROL)
     }
 
     const parsedRequest = tokenRequestSchema.safeParse(rawBody)
     if (!parsedRequest.success) {
       const { status, body } = tokenError('invalid_request')
-      return c.json(body, status)
+      return c.json(body, status, TOKEN_CACHE_CONTROL)
     }
     const { code, redirect_uri, client_id, code_verifier } = parsedRequest.data
 
@@ -107,7 +130,7 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
     // allowlist. See oauth-authz-registry.ts.
     if (!isRegisteredRedirectUri(options.registry, client_id, redirect_uri)) {
       const { status, body } = tokenError('invalid_grant')
-      return c.json(body, status)
+      return c.json(body, status, TOKEN_CACHE_CONTROL)
     }
 
     const result = options.store.redeemAuthorizationCode({
@@ -120,7 +143,7 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
       const { status, body } = tokenError(
         result.reason === 'invalid_request' ? 'invalid_request' : 'invalid_grant',
       )
-      return c.json(body, status)
+      return c.json(body, status, TOKEN_CACHE_CONTROL)
     }
 
     const minted = options.store.mintAccessToken(result.scopes, result.clientId)
@@ -130,7 +153,7 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
       expires_in: minted.expiresIn,
       scope: result.scopes.join(' '),
     })
-    return c.json(response, 200)
+    return c.json(response, 200, TOKEN_CACHE_CONTROL)
   })
 
   return app

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -1,0 +1,127 @@
+// The hosted-origin OAuth 2.1 authorization-server surface (ADR-0005):
+// metadata documents plus the authorization-code + PKCE token exchange.
+// This router deliberately does not include /authorize — that is a later
+// slice's approval-UI surface. Host-guard and CORS wiring for the routes
+// this file registers happen in app.ts, mirroring how /api/* is wired
+// (see api-host-guard.ts's header comment: middleware does not extend to
+// a new mount point just by being registered "near" it).
+
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { AUTH_SCOPES } from '../security/auth-strategy.js'
+import {
+  buildOAuthAuthorizationServerMetadata,
+  buildOAuthProtectedResourceMetadata,
+} from '../security/oauth-authz-metadata.js'
+import {
+  isRegisteredRedirectUri,
+  type OAuthClientRegistry,
+} from '../security/oauth-authz-registry.js'
+import type { OAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+
+// RFC 9728's well-known suffix must not collide with the existing MCP
+// resource metadata already served at the bare
+// `/.well-known/oauth-protected-resource` path (mcp-auth.ts, describing
+// the `/mcp` resource). RFC 9728 §3 supports per-resource metadata
+// documents distinguished by a path suffix; this mirrors the codebase's
+// existing `/mcp` suffix convention but for the `/api` resource instead.
+const PROTECTED_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource/api'
+const AUTHORIZATION_SERVER_METADATA_PATH = '/.well-known/oauth-authorization-server'
+export const OAUTH_TOKEN_PATH = '/token'
+
+export const tokenRequestSchema = z.object({
+  grant_type: z.literal('authorization_code'),
+  code: z.string().min(1),
+  redirect_uri: z.string().min(1),
+  client_id: z.string().min(1),
+  // Deliberately not `.optional()`: a request that omits code_verifier
+  // entirely must fail Zod parsing before reaching the transaction store,
+  // closing the trap at the boundary as well as inside the store.
+  code_verifier: z.string().min(1),
+})
+
+export type TokenRequest = z.infer<typeof tokenRequestSchema>
+
+export const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.literal('Bearer'),
+  expires_in: z.number().int().positive(),
+  scope: z.string(),
+})
+
+export type TokenResponse = z.infer<typeof tokenResponseSchema>
+
+export const tokenErrorResponseSchema = z.object({
+  error: z.enum(['invalid_request', 'invalid_grant']),
+})
+
+export type TokenErrorResponse = z.infer<typeof tokenErrorResponseSchema>
+
+function tokenError(error: TokenErrorResponse['error']) {
+  return { status: 400 as const, body: tokenErrorResponseSchema.parse({ error }) }
+}
+
+export interface OAuthAuthzRouterOptions {
+  store: OAuthTransactionStore
+  registry: OAuthClientRegistry
+}
+
+export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
+  const app = new Hono()
+
+  app.get(PROTECTED_RESOURCE_METADATA_PATH, (c) => {
+    return c.json(buildOAuthProtectedResourceMetadata(c.req.url))
+  })
+
+  app.get(AUTHORIZATION_SERVER_METADATA_PATH, (c) => {
+    return c.json(buildOAuthAuthorizationServerMetadata(c.req.url, AUTH_SCOPES))
+  })
+
+  app.post(OAUTH_TOKEN_PATH, async (c) => {
+    let rawBody: unknown
+    try {
+      rawBody = await c.req.json()
+    } catch {
+      const { status, body } = tokenError('invalid_request')
+      return c.json(body, status)
+    }
+
+    const parsedRequest = tokenRequestSchema.safeParse(rawBody)
+    if (!parsedRequest.success) {
+      const { status, body } = tokenError('invalid_request')
+      return c.json(body, status)
+    }
+    const { code, redirect_uri, client_id, code_verifier } = parsedRequest.data
+
+    // Exact byte-for-byte registry check — never derived from an origin
+    // allowlist. See oauth-authz-registry.ts.
+    if (!isRegisteredRedirectUri(options.registry, client_id, redirect_uri)) {
+      const { status, body } = tokenError('invalid_grant')
+      return c.json(body, status)
+    }
+
+    const result = options.store.redeemAuthorizationCode({
+      code,
+      clientId: client_id,
+      redirectUri: redirect_uri,
+      codeVerifier: code_verifier,
+    })
+    if (!result.ok) {
+      const { status, body } = tokenError(
+        result.reason === 'invalid_request' ? 'invalid_request' : 'invalid_grant',
+      )
+      return c.json(body, status)
+    }
+
+    const minted = options.store.mintAccessToken(result.scopes, result.clientId)
+    const response: TokenResponse = tokenResponseSchema.parse({
+      access_token: minted.accessToken,
+      token_type: 'Bearer',
+      expires_in: minted.expiresIn,
+      scope: result.scopes.join(' '),
+    })
+    return c.json(response, 200)
+  })
+
+  return app
+}

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -29,6 +29,16 @@ const PROTECTED_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource/
 const AUTHORIZATION_SERVER_METADATA_PATH = '/.well-known/oauth-authorization-server'
 export const OAUTH_TOKEN_PATH = '/token'
 
+// Exported so the caller can attach this router's middleware to exactly these
+// paths. Hono's `app.route('/', subApp)` merges a sub-app's `use('*')` into the
+// parent as `/*` — it does NOT confine it to the sub-app's own routes — so a
+// sub-app is the wrong tool for scoping middleware.
+export const OAUTH_AUTHZ_PATHS = [
+  PROTECTED_RESOURCE_METADATA_PATH,
+  AUTHORIZATION_SERVER_METADATA_PATH,
+  OAUTH_TOKEN_PATH,
+] as const
+
 export const tokenRequestSchema = z.object({
   grant_type: z.literal('authorization_code'),
   code: z.string().min(1),

--- a/packages/mcp-server/src/server/security/auth-strategy.ts
+++ b/packages/mcp-server/src/server/security/auth-strategy.ts
@@ -29,18 +29,26 @@
 import type { MiddlewareHandler } from 'hono'
 import { isAuthorized } from '../routes/auth.js'
 
-export type AuthScope =
-  | 'canvas:read'
-  | 'canvas:write'
-  | 'workspace:read'
-  | 'workspace:write'
-  | 'versions:read'
-  | 'versions:write'
-  | 'files:read'
-  | 'files:write'
-  | 'runtime:read'
-  | 'runtime:admin'
-  | 'mcp:call'
+// The scope vocabulary as a runtime array, not just a type: anything that
+// needs to validate an externally-supplied scope string against this
+// vocabulary (Zod schemas, OAuth scope-request parsing) needs a value to
+// check membership against, not only a compile-time union. `AuthScope`
+// is derived from this array so the two can never drift apart.
+export const AUTH_SCOPES = [
+  'canvas:read',
+  'canvas:write',
+  'workspace:read',
+  'workspace:write',
+  'versions:read',
+  'versions:write',
+  'files:read',
+  'files:write',
+  'runtime:read',
+  'runtime:admin',
+  'mcp:call',
+] as const
+
+export type AuthScope = (typeof AUTH_SCOPES)[number]
 
 export type AuthContext =
   | { kind: 'anonymous' }

--- a/packages/mcp-server/src/server/security/oauth-authz-metadata.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-metadata.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOAuthAuthorizationServerMetadata,
+  buildOAuthProtectedResourceMetadata,
+} from './oauth-authz-metadata.js'
+
+describe('buildOAuthProtectedResourceMetadata', () => {
+  it('describes the /api resource pointing back at this daemon as its own authorization server', () => {
+    const metadata = buildOAuthProtectedResourceMetadata('http://127.0.0.1:3099/anything')
+    expect(metadata).toEqual({
+      resource: 'http://127.0.0.1:3099/api',
+      authorization_servers: ['http://127.0.0.1:3099/'],
+    })
+  })
+})
+
+describe('buildOAuthAuthorizationServerMetadata', () => {
+  it('declares PKCE-only, no-client-secret, authorization_code-only support', () => {
+    const metadata = buildOAuthAuthorizationServerMetadata('http://127.0.0.1:3099/anything', [
+      'workspace:read',
+      'workspace:write',
+    ])
+    expect(metadata).toEqual({
+      issuer: 'http://127.0.0.1:3099/',
+      authorization_endpoint: 'http://127.0.0.1:3099/authorize',
+      token_endpoint: 'http://127.0.0.1:3099/token',
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: ['workspace:read', 'workspace:write'],
+    })
+  })
+})

--- a/packages/mcp-server/src/server/security/oauth-authz-metadata.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-metadata.ts
@@ -1,0 +1,60 @@
+// RFC 9728 (protected resource) and RFC 8414 (authorization server)
+// metadata documents for the hosted-origin OAuth 2.1 authorization server
+// (ADR-0005). These describe the daemon's own `/api` resource and its own
+// `/token` (and future `/authorize`) endpoints — distinct from the
+// existing MCP-resource metadata in mcp-auth.ts, which describes the
+// separate `/mcp` resource and is served at its own `/mcp`-suffixed
+// well-known path for exactly that reason (see oauth-authz.ts for the
+// mount path chosen to avoid colliding with it).
+
+import { z } from 'zod'
+
+export const oauthProtectedResourceMetadataSchema = z.object({
+  resource: z.string().url(),
+  authorization_servers: z.array(z.string().url()).min(1),
+})
+
+export type OAuthProtectedResourceMetadata = z.infer<typeof oauthProtectedResourceMetadataSchema>
+
+export const oauthAuthorizationServerMetadataSchema = z.object({
+  issuer: z.string().url(),
+  authorization_endpoint: z.string().url(),
+  token_endpoint: z.string().url(),
+  response_types_supported: z.array(z.literal('code')),
+  grant_types_supported: z.array(z.literal('authorization_code')),
+  code_challenge_methods_supported: z.array(z.literal('S256')),
+  // 'none' per RFC 8414 §2 — the hosted client is a public SPA with no
+  // mechanism to hold a client secret; PKCE is the client-authentication
+  // substitute for a public client, not client_secret_basic/post.
+  token_endpoint_auth_methods_supported: z.array(z.literal('none')),
+  scopes_supported: z.array(z.string()),
+})
+
+export type OAuthAuthorizationServerMetadata = z.infer<
+  typeof oauthAuthorizationServerMetadataSchema
+>
+
+export function buildOAuthProtectedResourceMetadata(
+  requestUrl: string,
+): OAuthProtectedResourceMetadata {
+  return oauthProtectedResourceMetadataSchema.parse({
+    resource: new URL('/api', requestUrl).toString(),
+    authorization_servers: [new URL('/', requestUrl).toString()],
+  })
+}
+
+export function buildOAuthAuthorizationServerMetadata(
+  requestUrl: string,
+  scopesSupported: readonly string[],
+): OAuthAuthorizationServerMetadata {
+  return oauthAuthorizationServerMetadataSchema.parse({
+    issuer: new URL('/', requestUrl).toString(),
+    authorization_endpoint: new URL('/authorize', requestUrl).toString(),
+    token_endpoint: new URL('/token', requestUrl).toString(),
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+    scopes_supported: [...scopesSupported],
+  })
+}

--- a/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
@@ -72,6 +72,42 @@ describe('isRegisteredRedirectUri', () => {
   })
 })
 
+describe('oauthClientRegistryEntrySchema redirect_uri constraints', () => {
+  function parseUri(uri: string) {
+    return oauthClientRegistrySchema.safeParse([{ clientId: 'x', redirectUris: [uri] }])
+  }
+
+  it('rejects a redirect_uri carrying a fragment — RFC 6749 §3.1.2', () => {
+    expect(parseUri('https://whiteboard.pages.dev/oauth/callback#wb=token').success).toBe(false)
+    expect(parseUri('https://whiteboard.pages.dev/oauth/callback#').success).toBe(false)
+  })
+
+  it('rejects a non-loopback http redirect_uri', () => {
+    expect(parseUri('http://whiteboard.pages.dev/oauth/callback').success).toBe(false)
+  })
+
+  it('rejects a non-http(s) scheme', () => {
+    expect(parseUri('javascript:alert(1)').success).toBe(false)
+    expect(parseUri('whiteboard://callback').success).toBe(false)
+  })
+
+  it('admits https and the loopback http carve-out', () => {
+    expect(parseUri('https://whiteboard.pages.dev/oauth/callback').success).toBe(true)
+    expect(parseUri('http://127.0.0.1:5173/oauth/callback').success).toBe(true)
+    expect(parseUri('http://localhost:5173/oauth/callback').success).toBe(true)
+    expect(parseUri('http://[::1]:5173/oauth/callback').success).toBe(true)
+  })
+
+  it('does not let a loopback-lookalike host through the carve-out', () => {
+    expect(parseUri('http://localhost.evil.com/oauth/callback').success).toBe(false)
+    expect(parseUri('http://127.0.0.1.evil.com/oauth/callback').success).toBe(false)
+  })
+
+  it('still rejects a wildcard entry', () => {
+    expect(parseUri('https://*.pages.dev/callback').success).toBe(false)
+  })
+})
+
 describe('parseOAuthClientRegistryEnv', () => {
   it('returns an empty registry for unset/empty input (feature off by default)', () => {
     expect(parseOAuthClientRegistryEnv(undefined)).toEqual({ ok: true, registry: [] })

--- a/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isRegisteredRedirectUri,
+  type OAuthClientRegistry,
+  oauthClientRegistrySchema,
+  parseOAuthClientRegistryEnv,
+} from './oauth-authz-registry.js'
+
+const registry: OAuthClientRegistry = [
+  {
+    clientId: 'whiteboard-hosted-web',
+    redirectUris: ['https://whiteboard.pages.dev/oauth/callback'],
+  },
+]
+
+describe('isRegisteredRedirectUri', () => {
+  it('admits an exact byte-for-byte match', () => {
+    expect(
+      isRegisteredRedirectUri(
+        registry,
+        'whiteboard-hosted-web',
+        'https://whiteboard.pages.dev/oauth/callback',
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a suffix/prefix match — this is the trap ADR-0005 names explicitly', () => {
+    // A substring match would let an attacker register
+    // https://whiteboard.pages.dev/oauth/callback/evil and still pass.
+    expect(
+      isRegisteredRedirectUri(
+        registry,
+        'whiteboard-hosted-web',
+        'https://whiteboard.pages.dev/oauth/callback/evil',
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects a truncated prefix match', () => {
+    expect(
+      isRegisteredRedirectUri(
+        registry,
+        'whiteboard-hosted-web',
+        'https://whiteboard.pages.dev/oauth/callbac',
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects a same-origin different-path redirect_uri', () => {
+    expect(
+      isRegisteredRedirectUri(registry, 'whiteboard-hosted-web', 'https://whiteboard.pages.dev/'),
+    ).toBe(false)
+  })
+
+  it('rejects an unknown client_id even with a registered redirect_uri string', () => {
+    expect(
+      isRegisteredRedirectUri(
+        registry,
+        'some-other-client',
+        'https://whiteboard.pages.dev/oauth/callback',
+      ),
+    ).toBe(false)
+  })
+
+  it('never falls back to origin-only matching — a wildcard-origin-style entry is not accepted by the schema', () => {
+    const result = oauthClientRegistrySchema.safeParse([
+      { clientId: 'x', redirectUris: ['https://*.pages.dev/callback'] },
+    ])
+    // '*.pages.dev' is not a valid URL host, so schema parsing (z.string().url())
+    // already rejects it before it could ever be used as a wildcard.
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('parseOAuthClientRegistryEnv', () => {
+  it('returns an empty registry for unset/empty input (feature off by default)', () => {
+    expect(parseOAuthClientRegistryEnv(undefined)).toEqual({ ok: true, registry: [] })
+    expect(parseOAuthClientRegistryEnv('  ')).toEqual({ ok: true, registry: [] })
+  })
+
+  it('parses a valid JSON registry', () => {
+    const result = parseOAuthClientRegistryEnv(JSON.stringify(registry))
+    expect(result).toEqual({ ok: true, registry })
+  })
+
+  it('fails on malformed JSON', () => {
+    const result = parseOAuthClientRegistryEnv('{not json')
+    expect(result.ok).toBe(false)
+  })
+
+  it('fails schema validation when an entry has no redirectUris', () => {
+    const result = parseOAuthClientRegistryEnv(
+      JSON.stringify([{ clientId: 'x', redirectUris: [] }]),
+    )
+    expect(result.ok).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-registry.test.ts
@@ -66,8 +66,10 @@ describe('isRegisteredRedirectUri', () => {
     const result = oauthClientRegistrySchema.safeParse([
       { clientId: 'x', redirectUris: ['https://*.pages.dev/callback'] },
     ])
-    // '*.pages.dev' is not a valid URL host, so schema parsing (z.string().url())
-    // already rejects it before it could ever be used as a wildcard.
+    // WHATWG URL parsing treats '*' as an ordinary hostname character, so
+    // `new URL('https://*.pages.dev/callback')` succeeds and `z.string().url()`
+    // admits it. The explicit wildcard refinement is the only thing rejecting
+    // this — it is load-bearing, not redundant.
     expect(result.success).toBe(false)
   })
 })

--- a/packages/mcp-server/src/server/security/oauth-authz-registry.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-registry.ts
@@ -18,6 +18,14 @@
 
 import { z } from 'zod'
 
+// RFC 8252 §7.3 / §8.3: `http` is admissible only for a loopback *IP literal*
+// redirect. `localhost` is included alongside them because the hosted web
+// client is itself developed against a loopback dev server, and an operator
+// who could not register that callback could never exercise the flow before
+// deploying it. The host is compared against this exact set — never a suffix
+// — so `localhost.evil.com` and `127.0.0.1.evil.com` do not qualify.
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', '[::1]', 'localhost'])
+
 // `new URL('https://*.pages.dev/callback')` parses successfully — WHATWG
 // URL parsing treats '*' as a literal (if unusual) hostname character
 // rather than rejecting it — so `z.string().url()` alone does NOT
@@ -31,6 +39,31 @@ const exactRedirectUriSchema = z
   .refine((value) => !value.includes('*'), {
     message: 'redirect_uri entries must be exact URIs; wildcards are not supported',
   })
+  // RFC 6749 §3.1.2: "The redirection endpoint URI MUST be an absolute URI …
+  // The endpoint URI MUST NOT include a fragment component." The authorization
+  // response appends its own fragment/query; a registered fragment would make
+  // the delivered URI un-derivable and, worse, byte-for-byte comparison against
+  // a fragment-bearing entry silently diverges from what the browser sends
+  // (the fragment never leaves the client).
+  .refine((value) => !value.includes('#'), {
+    message: 'redirect_uri entries must not include a fragment component (RFC 6749 §3.1.2)',
+  })
+  // RFC 6749 §3.1.2.1: the redirection endpoint SHOULD require TLS. An
+  // authorization code delivered over cleartext to a non-loopback host is
+  // readable by any network observer, and PKCE does not protect the code's
+  // confidentiality on the wire — it only stops a stolen code being redeemed
+  // without the verifier.
+  .refine(
+    (value) => {
+      const url = new URL(value)
+      if (url.protocol === 'https:') return true
+      if (url.protocol !== 'http:') return false
+      return LOOPBACK_HOSTNAMES.has(url.hostname)
+    },
+    {
+      message: 'redirect_uri entries must use https, or http only on a loopback host',
+    },
+  )
 
 export const oauthClientRegistryEntrySchema = z.object({
   clientId: z.string().min(1),

--- a/packages/mcp-server/src/server/security/oauth-authz-registry.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-registry.ts
@@ -1,0 +1,81 @@
+// The exact-URI redirect_uri registry for the hosted-origin OAuth 2.1
+// authorization server (ADR-0005).
+//
+// This is deliberately its own config, not derived from
+// WHITEBOARD_ALLOWED_WEB_ORIGINS: that env var stores *origins* (scheme +
+// host, no path) and permits leftmost-label wildcard subdomain patterns
+// (see origin-pattern.ts) — `https://*.pages.dev` there means "any Pages
+// project", which is exactly the admission an OAuth redirect_uri registry
+// must never grant. A redirect_uri carries an exact callback *path*, and
+// matching it against anything looser than byte-for-byte equality is the
+// open-redirect class of bug: a substring/prefix match would let
+// `https://whiteboard.pages.dev/oauth/callback/evil` piggyback on a
+// registered `https://whiteboard.pages.dev/oauth/callback`.
+//
+// No dynamic client registration (RFC 7591) — clients are fixed entries
+// configured by the operator, matched by clientId first, then by exact
+// redirectUris membership.
+
+import { z } from 'zod'
+
+// `new URL('https://*.pages.dev/callback')` parses successfully — WHATWG
+// URL parsing treats '*' as a literal (if unusual) hostname character
+// rather than rejecting it — so `z.string().url()` alone does NOT
+// foreclose a wildcard-origin entry sneaking into this registry. Reject
+// '*' explicitly; this registry has no pattern-matching concept at all,
+// unlike origin-pattern.ts's wildcard-subdomain support for
+// WHITEBOARD_ALLOWED_WEB_ORIGINS.
+const exactRedirectUriSchema = z
+  .string()
+  .url()
+  .refine((value) => !value.includes('*'), {
+    message: 'redirect_uri entries must be exact URIs; wildcards are not supported',
+  })
+
+export const oauthClientRegistryEntrySchema = z.object({
+  clientId: z.string().min(1),
+  redirectUris: z.array(exactRedirectUriSchema).min(1),
+})
+
+export const oauthClientRegistrySchema = z.array(oauthClientRegistryEntrySchema)
+
+export type OAuthClientRegistryEntry = z.infer<typeof oauthClientRegistryEntrySchema>
+export type OAuthClientRegistry = z.infer<typeof oauthClientRegistrySchema>
+
+// Byte-for-byte comparison only. Do not normalize, decode, lowercase, or
+// strip trailing slashes before comparing — any such normalization step is
+// exactly the kind of "helpful" transform that turns an exact-match
+// registry back into a fuzzy one.
+export function isRegisteredRedirectUri(
+  registry: OAuthClientRegistry,
+  clientId: string,
+  redirectUri: string,
+): boolean {
+  const entry = registry.find((candidate) => candidate.clientId === clientId)
+  if (!entry) return false
+  return entry.redirectUris.includes(redirectUri)
+}
+
+export type ParseOAuthClientRegistryEnvResult =
+  | { ok: true; registry: OAuthClientRegistry }
+  | { ok: false; error: string }
+
+// WHITEBOARD_OAUTH_CLIENT_REGISTRY: a JSON array of { clientId, redirectUris }.
+// Unset/empty is a valid, empty registry — the hosted-origin AS surface
+// stays entirely inert (every redirect_uri check fails closed) until an
+// operator opts in, matching the empty-by-default posture of
+// WHITEBOARD_ALLOWED_WEB_ORIGINS.
+export function parseOAuthClientRegistryEnv(
+  raw: string | undefined,
+): ParseOAuthClientRegistryEnvResult {
+  if (!raw || raw.trim() === '') return { ok: true, registry: [] }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { ok: false, error: 'invalid JSON' }
+  }
+  const result = oauthClientRegistrySchema.safeParse(parsed)
+  if (!result.success) return { ok: false, error: 'schema validation failed' }
+  return { ok: true, registry: result.data }
+}

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest'
+import { createOAuthTransactionStore } from './oauth-authz-transactions.js'
+
+const baseInput = {
+  clientId: 'whiteboard-hosted-web',
+  redirectUri: 'https://whiteboard.pages.dev/oauth/callback',
+  scopes: ['workspace:read', 'workspace:write'] as const,
+  state: 'client-supplied-state-value',
+  codeChallenge: 'test-challenge-does-not-need-to-be-real-for-creation',
+  codeChallengeMethod: 'S256' as const,
+}
+
+// A real S256 PKCE pair: challenge = base64url(sha256(verifier)).
+const PKCE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+const PKCE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+
+function createApprovedCodeIssuedTransaction(
+  store: ReturnType<typeof createOAuthTransactionStore>,
+  overrides: Partial<typeof baseInput> = {},
+) {
+  const { transactionId } = store.createTransaction({
+    ...baseInput,
+    ...overrides,
+    codeChallenge: PKCE_CHALLENGE,
+  })
+  store.approveTransaction(transactionId)
+  const issued = store.issueAuthorizationCode(transactionId)
+  if (!issued) throw new Error('expected code issuance to succeed')
+  return { transactionId, code: issued.code }
+}
+
+describe('createOAuthTransactionStore', () => {
+  it('requires state at transaction creation — PKCE is not a substitute for it', () => {
+    const store = createOAuthTransactionStore()
+    expect(() => store.createTransaction({ ...baseInput, state: '' })).toThrow()
+  })
+
+  it('requires code_challenge_method S256 at transaction creation', () => {
+    const store = createOAuthTransactionStore()
+    expect(() =>
+      store.createTransaction({
+        ...baseInput,
+        // @ts-expect-error deliberately invalid method for the red test
+        codeChallengeMethod: 'plain',
+      }),
+    ).toThrow()
+  })
+
+  it('stores the authorization code only as a hash — the raw code never round-trips out of the store', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    // The only way to prove "hash only" from outside the module is behavioral:
+    // redemption must work with the raw code (proving it can rehash and
+    // compare), and the raw code must not appear verbatim in any exposed
+    // debug/snapshot surface. This store exposes no such surface at all,
+    // which is itself the point — assert redemption still succeeds.
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects redemption with no code_verifier at all — server-side enforcement, not documentation', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: undefined,
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid_request' })
+  })
+
+  it('rejects redemption with a code_verifier that does not match the S256 challenge', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: 'wrong-verifier-entirely',
+    })
+    expect(result).toEqual({ ok: false, reason: 'pkce_verification_failed' })
+  })
+
+  it('redeems successfully with the exact matching code_verifier', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.scopes).toEqual(baseInput.scopes)
+      expect(result.clientId).toBe(baseInput.clientId)
+    }
+  })
+
+  it('is single-use — a second redemption of the same code fails even with correct credentials', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const redeemOnce = () =>
+      store.redeemAuthorizationCode({
+        code,
+        clientId: baseInput.clientId,
+        redirectUri: baseInput.redirectUri,
+        codeVerifier: PKCE_VERIFIER,
+      })
+    const first = redeemOnce()
+    const second = redeemOnce()
+    expect(first.ok).toBe(true)
+    expect(second).toEqual({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('resolves two concurrent redemptions of the same code to exactly one success (compare-and-swap)', async () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const redeem = () =>
+      Promise.resolve(
+        store.redeemAuthorizationCode({
+          code,
+          clientId: baseInput.clientId,
+          redirectUri: baseInput.redirectUri,
+          codeVerifier: PKCE_VERIFIER,
+        }),
+      )
+    const [first, second] = await Promise.all([redeem(), redeem()])
+    const successes = [first, second].filter((r) => r.ok)
+    const failures = [first, second].filter((r) => !r.ok)
+    expect(successes).toHaveLength(1)
+    expect(failures).toHaveLength(1)
+    expect(failures[0]).toMatchObject({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('rejects redemption when the client_id does not match the transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: 'a-different-client',
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('rejects redemption when the redirect_uri does not match the transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: 'https://attacker.example/callback',
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result).toEqual({ ok: false, reason: 'redirect_uri_mismatch' })
+  })
+
+  it('rejects an unknown/never-issued code', () => {
+    const store = createOAuthTransactionStore()
+    const result = store.redeemAuthorizationCode({
+      code: 'never-issued-code',
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('rejects issuing a code for a transaction that was never approved', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = store.createTransaction({
+      ...baseInput,
+      codeChallenge: PKCE_CHALLENGE,
+    })
+    expect(store.issueAuthorizationCode(transactionId)).toBeNull()
+  })
+
+  it('rejects redemption once the short-lived code TTL has elapsed', () => {
+    let currentTime = 0
+    const store = createOAuthTransactionStore({ now: () => currentTime })
+    const { transactionId } = store.createTransaction({
+      ...baseInput,
+      codeChallenge: PKCE_CHALLENGE,
+    })
+    store.approveTransaction(transactionId)
+    const issued = store.issueAuthorizationCode(transactionId)
+    if (!issued) throw new Error('expected code issuance to succeed')
+    currentTime += 10 * 60_000 // advance well past the code's short TTL
+    const result = store.redeemAuthorizationCode({
+      code: issued.code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('has no durability across store instances — a fresh store has no pending transactions', () => {
+    // The daemon-restart rule this store implements: an in-memory Map that
+    // dies with the process. A restarted daemon constructs a brand new
+    // store, so every transaction that was pending, approved, or
+    // code-issued in the old process is gone — there is no way for an
+    // approval screen to outlive its backing transaction.
+    const store = createOAuthTransactionStore()
+    const result = store.redeemAuthorizationCode({
+      code: 'anything',
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid_grant' })
+  })
+
+  it('mints an opaque short-lived access token after successful redemption', () => {
+    const store = createOAuthTransactionStore()
+    const { code } = createApprovedCodeIssuedTransaction(store)
+    const result = store.redeemAuthorizationCode({
+      code,
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      codeVerifier: PKCE_VERIFIER,
+    })
+    if (!result.ok) throw new Error('expected redemption to succeed')
+    const minted = store.mintAccessToken(result.scopes, result.clientId)
+    expect(minted.accessToken).toEqual(expect.any(String))
+    expect(minted.accessToken.length).toBeGreaterThan(20)
+    expect(minted.expiresIn).toBeGreaterThan(0)
+  })
+})

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
@@ -1,6 +1,100 @@
 import { describe, expect, it } from 'vitest'
 import { createOAuthTransactionStore } from './oauth-authz-transactions.js'
 
+describe('expired-entry pruning', () => {
+  const TRANSACTION_TTL_MS = 5 * 60_000
+
+  it('reclaims an expired transaction on the next write instead of leaking it', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+
+    clock += TRANSACTION_TTL_MS + 1
+    store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's2',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+
+    // The first transaction is gone, not merely unusable: a long-lived daemon
+    // must not accumulate one record per abandoned/attacker-driven attempt.
+    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+  })
+
+  it('reclaims the code-hash index entry of an expired code-issued transaction', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { transactionId } = store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+    store.approveTransaction(transactionId)
+    expect(store.issueAuthorizationCode(transactionId)).not.toBeNull()
+    expect(store.size()).toEqual({ transactions: 1, codes: 1 })
+
+    clock += TRANSACTION_TTL_MS + 1
+    store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's2',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+
+    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+  })
+
+  it('reclaims a redeemed transaction once its window has passed', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { transactionId } = store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+    store.approveTransaction(transactionId)
+    const issued = store.issueAuthorizationCode(transactionId)
+    if (!issued) throw new Error('expected issuance')
+    store.redeemAuthorizationCode({
+      code: issued.code,
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      codeVerifier: 'v',
+    })
+    expect(store.size().transactions).toBe(1)
+
+    clock += TRANSACTION_TTL_MS + 1
+    store.createTransaction({
+      clientId: 'c',
+      redirectUri: 'https://example.test/cb',
+      scopes: ['workspace:read'],
+      state: 's2',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    })
+    expect(store.size().transactions).toBe(1)
+  })
+})
+
 const baseInput = {
   clientId: 'whiteboard-hosted-web',
   redirectUri: 'https://whiteboard.pages.dev/oauth/callback',

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -1,0 +1,236 @@
+// Authorization-transaction store for the hosted-origin OAuth 2.1
+// authorization server (ADR-0005). This module owns the parts of the flow
+// that must hold even before the `/authorize` approval UI exists in a later
+// slice: PKCE enforcement at issuance and redemption, single-use
+// hashed codes, and compare-and-swap redemption.
+//
+// Restart rule (ADR-0005 names this as a required, explicit decision, not
+// optional): this store is an in-memory Map, nothing more. A daemon
+// restart constructs a brand new `createOAuthTransactionStore()` instance,
+// so every pending/approved/code-issued transaction from the previous
+// process is simply gone. This is the "invalidate every outstanding
+// transaction" branch of the ADR's either/or, chosen over durable
+// persistence because there is no `/authorize` UI yet for a transaction to
+// meaningfully survive for — a future slice that adds durable persistence
+// would need to revisit this file, not silently accumulate state past a
+// restart with no invalidation at all.
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import { AUTH_SCOPES, type AuthScope } from './auth-strategy.js'
+
+// A transaction stays approvable for 5 minutes — long enough for a human to
+// read and click an approval screen, short enough that a stale pending
+// transaction is not a standing attack surface.
+const TRANSACTION_TTL_MS = 5 * 60_000
+// The authorization code itself is short-lived and single-use, per
+// ADR-0005 ("short TTL"): 60 seconds is enough for the client's immediate
+// redirect-then-exchange round trip.
+const CODE_TTL_MS = 60_000
+// The minted access token is deliberately short-lived; a renewal grant is
+// designed in ADR-0005 but is explicitly out of scope for this slice.
+const ACCESS_TOKEN_TTL_SECONDS = 15 * 60
+
+const createTransactionInputSchema = z.object({
+  clientId: z.string().min(1),
+  redirectUri: z.string().min(1),
+  scopes: z.array(z.enum(AUTH_SCOPES)).min(1),
+  // Required per ADR-0005: "state is required — PKCE is not a substitute
+  // for it". Enforced here, at the one call site every future /authorize
+  // implementation must go through to create a transaction, rather than
+  // left to that future caller to remember.
+  state: z.string().min(1),
+  codeChallenge: z.string().min(1),
+  codeChallengeMethod: z.literal('S256'),
+})
+
+export type CreateTransactionInput = z.infer<typeof createTransactionInputSchema>
+
+export type TransactionStatus =
+  | 'pending'
+  | 'approved'
+  | 'denied'
+  | 'code-issued'
+  | 'redeemed'
+  | 'expired'
+
+interface TransactionRecord {
+  id: string
+  clientId: string
+  redirectUri: string
+  scopes: readonly AuthScope[]
+  state: string
+  codeChallenge: string
+  codeChallengeMethod: 'S256'
+  status: TransactionStatus
+  createdAt: number
+  expiresAt: number
+  codeHash?: string
+  codeExpiresAt?: number
+}
+
+export type RedeemAuthorizationCodeInput = {
+  code: string
+  clientId: string
+  redirectUri: string
+  codeVerifier: string | undefined
+}
+
+export type RedeemAuthorizationCodeResult =
+  | { ok: true; transactionId: string; scopes: readonly AuthScope[]; clientId: string }
+  | {
+      ok: false
+      reason:
+        | 'invalid_request'
+        | 'invalid_grant'
+        | 'redirect_uri_mismatch'
+        | 'pkce_verification_failed'
+    }
+
+function hashCode(rawCode: string): string {
+  return createHash('sha256').update(rawCode).digest('hex')
+}
+
+// S256 per RFC 7636 §4.2: challenge = BASE64URL-ENCODE(SHA256(verifier)).
+// A verifier-mismatch must not leak timing information about how much of
+// the challenge matched, hence timingSafeEqual over the raw hash bytes.
+function verifyPkce(codeChallenge: string, codeVerifier: string): boolean {
+  const computedChallenge = createHash('sha256').update(codeVerifier).digest('base64url')
+  const computed = Buffer.from(computedChallenge)
+  const expected = Buffer.from(codeChallenge)
+  if (computed.length !== expected.length) return false
+  return timingSafeEqual(computed, expected)
+}
+
+export interface OAuthTransactionStore {
+  createTransaction(input: CreateTransactionInput): { transactionId: string; expiresAt: number }
+  approveTransaction(transactionId: string): boolean
+  issueAuthorizationCode(transactionId: string): { code: string } | null
+  redeemAuthorizationCode(input: RedeemAuthorizationCodeInput): RedeemAuthorizationCodeResult
+  mintAccessToken(
+    scopes: readonly AuthScope[],
+    clientId: string,
+  ): { accessToken: string; expiresIn: number }
+}
+
+export function createOAuthTransactionStore(options?: {
+  now?: () => number
+}): OAuthTransactionStore {
+  const now = options?.now ?? Date.now
+  const transactions = new Map<string, TransactionRecord>()
+  // Index from code hash to transaction id so redemption never has to scan
+  // every pending transaction to find a match — and so the raw code is
+  // never the map key either; only its hash ever lives in memory.
+  const codeHashIndex = new Map<string, string>()
+
+  function createTransaction(input: CreateTransactionInput): {
+    transactionId: string
+    expiresAt: number
+  } {
+    const parsed = createTransactionInputSchema.parse(input)
+    const id = randomBytes(16).toString('base64url')
+    const createdAt = now()
+    const expiresAt = createdAt + TRANSACTION_TTL_MS
+    transactions.set(id, {
+      id,
+      clientId: parsed.clientId,
+      redirectUri: parsed.redirectUri,
+      scopes: parsed.scopes,
+      state: parsed.state,
+      codeChallenge: parsed.codeChallenge,
+      codeChallengeMethod: parsed.codeChallengeMethod,
+      status: 'pending',
+      createdAt,
+      expiresAt,
+    })
+    return { transactionId: id, expiresAt }
+  }
+
+  function approveTransaction(transactionId: string): boolean {
+    const record = transactions.get(transactionId)
+    if (!record || record.status !== 'pending' || record.expiresAt < now()) return false
+    transactions.set(transactionId, { ...record, status: 'approved' })
+    return true
+  }
+
+  function issueAuthorizationCode(transactionId: string): { code: string } | null {
+    const record = transactions.get(transactionId)
+    if (!record || record.status !== 'approved' || record.expiresAt < now()) return null
+    const rawCode = randomBytes(32).toString('base64url')
+    const codeHash = hashCode(rawCode)
+    const codeExpiresAt = now() + CODE_TTL_MS
+    transactions.set(transactionId, { ...record, status: 'code-issued', codeHash, codeExpiresAt })
+    codeHashIndex.set(codeHash, transactionId)
+    return { code: rawCode }
+  }
+
+  function redeemAuthorizationCode(
+    input: RedeemAuthorizationCodeInput,
+  ): RedeemAuthorizationCodeResult {
+    // Rejected before any lookup: a request with no code_verifier at all
+    // must fail server-side, not merely be documented as required
+    // (ADR-0005's explicit trap).
+    if (!input.codeVerifier) {
+      return { ok: false, reason: 'invalid_request' }
+    }
+
+    const codeHash = hashCode(input.code)
+    const transactionId = codeHashIndex.get(codeHash)
+    if (!transactionId) return { ok: false, reason: 'invalid_grant' }
+    const record = transactions.get(transactionId)
+    if (!record) return { ok: false, reason: 'invalid_grant' }
+
+    // Compare-and-swap: the status check and the transition to 'redeemed'
+    // happen in the same synchronous step, before any further validation
+    // (client_id, redirect_uri, PKCE, expiry). Node's run-to-completion
+    // semantics make this block atomic as long as nothing here awaits
+    // between the check and the `transactions.set` — two concurrent
+    // callers racing the same code cannot both observe 'code-issued' and
+    // both proceed past this point. Whichever caller loses the race
+    // reads 'redeemed' (or a status this function already moved past) and
+    // fails here, even if its own credentials would otherwise have been
+    // valid — once a code is spent, it is spent.
+    if (record.status !== 'code-issued') {
+      return { ok: false, reason: 'invalid_grant' }
+    }
+    transactions.set(transactionId, { ...record, status: 'redeemed' })
+    codeHashIndex.delete(codeHash)
+
+    if (record.codeExpiresAt === undefined || record.codeExpiresAt < now()) {
+      return { ok: false, reason: 'invalid_grant' }
+    }
+    if (record.clientId !== input.clientId) {
+      return { ok: false, reason: 'invalid_grant' }
+    }
+    if (record.redirectUri !== input.redirectUri) {
+      return { ok: false, reason: 'redirect_uri_mismatch' }
+    }
+    if (!verifyPkce(record.codeChallenge, input.codeVerifier)) {
+      return { ok: false, reason: 'pkce_verification_failed' }
+    }
+
+    return { ok: true, transactionId, scopes: record.scopes, clientId: record.clientId }
+  }
+
+  function mintAccessToken(
+    scopes: readonly AuthScope[],
+    _clientId: string,
+  ): { accessToken: string; expiresIn: number } {
+    // Opaque bearer token, not a JWT: validating it on protected routes is
+    // a resource-server concern (oauth-resource-strategy.ts's seam) that
+    // this slice does not wire up — see ADR-0005's "the resource-server
+    // half does not already exist" constraint. This skeleton only mints
+    // the token the /token response carries.
+    const accessToken = randomBytes(32).toString('base64url')
+    void scopes
+    return { accessToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
+  }
+
+  return {
+    createTransaction,
+    approveTransaction,
+    issueAuthorizationCode,
+    redeemAuthorizationCode,
+    mintAccessToken,
+  }
+}

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -111,6 +111,9 @@ export interface OAuthTransactionStore {
     scopes: readonly AuthScope[],
     clientId: string,
   ): { accessToken: string; expiresIn: number }
+  // Live entry counts. The store's only unbounded-growth risk is retained
+  // dead records, so its occupancy has to be observable to be assertable.
+  size(): { transactions: number; codes: number }
 }
 
 export function createOAuthTransactionStore(options?: {
@@ -123,10 +126,26 @@ export function createOAuthTransactionStore(options?: {
   // never the map key either; only its hash ever lives in memory.
   const codeHashIndex = new Map<string, string>()
 
+  // Lazy sweep, not a timer. A `setInterval` would keep the Node event loop
+  // alive for the daemon's whole lifetime and would have to be torn down by
+  // every construction site; sweeping on write bounds the maps by the same
+  // TTL without owning a handle. A record past `expiresAt` can never again
+  // be approved, code-issued, or redeemed (every transition re-checks it),
+  // so dropping it is not observable to a caller — only its memory is.
+  function pruneExpired(): void {
+    const cutoff = now()
+    for (const [id, record] of transactions) {
+      if (record.expiresAt >= cutoff) continue
+      transactions.delete(id)
+      if (record.codeHash !== undefined) codeHashIndex.delete(record.codeHash)
+    }
+  }
+
   function createTransaction(input: CreateTransactionInput): {
     transactionId: string
     expiresAt: number
   } {
+    pruneExpired()
     const parsed = createTransactionInputSchema.parse(input)
     const id = randomBytes(16).toString('base64url')
     const createdAt = now()
@@ -226,11 +245,16 @@ export function createOAuthTransactionStore(options?: {
     return { accessToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
   }
 
+  function size(): { transactions: number; codes: number } {
+    return { transactions: transactions.size, codes: codeHashIndex.size }
+  }
+
   return {
     createTransaction,
     approveTransaction,
     issueAuthorizationCode,
     redeemAuthorizationCode,
     mintAccessToken,
+    size,
   }
 }


### PR DESCRIPTION
## Summary

Implements the authorization-server skeleton named in ADR-0005 (`docs/contributing/adr/0005-hosted-origin-authorization.md`): RFC 9728 / RFC 8414 metadata, `POST /token` (authorization-code + PKCE exchange), and the transaction store behind it. Scoped deliberately narrow — no `/authorize` approval UI, no WebSocket connection ticket, no renewal grant; those are later slices.

## The eight traps ADR-0005 names, and the test that holds each

1. **Host guard + dedicated CORS on `/token` and the metadata routes.** Neither comes free from being mounted near `/api/*`. `app.oauth-authz.test.ts`: spoofed `Host` → 403 on `/token` and on both metadata endpoints; admitted vs non-admitted `Origin` reflected/not-reflected on `/token`'s own CORS.
2. **`redirect_uri` validated by byte-for-byte comparison against a dedicated exact-URI registry**, never derived from `WHITEBOARD_ALLOWED_WEB_ORIGINS`. `oauth-authz-registry.test.ts`: suffix/prefix/truncated matches rejected; a `new URL()`-parseable wildcard entry (`https://*.pages.dev/callback`) is explicitly rejected by a schema `.refine` — plain `z.string().url()` does **not** reject it (WHATWG URL parsing treats `*` as a literal hostname character), which the red test caught before the fix.
3. **PKCE enforced at issuance and redemption.** `code_challenge_method` fixed to `S256` at transaction creation; a `/token` request with **no `code_verifier` at all** is rejected server-side (both the Zod request schema and the store independently reject it) — `oauth-authz-transactions.test.ts` and `oauth-authz.test.ts`.
4. **Redemption is compare-and-swap, not check-then-mark.** The status transition to `redeemed` happens before any other validation. `oauth-authz-transactions.test.ts` and `oauth-authz.test.ts` race two concurrent redemptions of the same code via `Promise.all` and assert exactly one success, one failure.
5. **Authorization code stored only as a SHA-256 hash**, single-use (deleted from the index on redemption), 60s TTL — covered behaviorally (hash-only storage can't be asserted structurally, only via successful rehash-and-compare on redemption) plus an explicit TTL-elapsed test.
6. **`state` required at transaction creation** — enforced by the Zod schema at the one call site `/authorize` will later use to create a transaction.
7. **Daemon-restart rule, made explicit.** Chose "invalidate every outstanding transaction" over durable persistence: the store is an in-memory `Map`, nothing more — a restart constructs a fresh instance with no pending transactions. Documented in the module header and asserted by a test showing a fresh store has no memory of anything.
8. **Daemon-served app never touches this machinery.** `app.oauth-authz.test.ts` inspects the served `index.html` directly and asserts it contains neither the OAuth `client_id` nor `code_verifier` — only the existing raw-bearer `__WHITEBOARD_RUNTIME_CONFIG__`/`__WHITEBOARD_DAEMON_TOKEN__` injection.

## Deliberately left for later slices

- `/authorize` approval UI (CSRF-bound approval POST, unframeable, identity-from-registered-redirect_uri display).
- WebSocket connection ticket + per-operation scope enforcement.
- Renewal grant (rotation, reuse detection, grant-management screen).
- Wiring the minted opaque access token into `oauth-resource-strategy.ts`'s resource-server validator seam — this PR mints a token in the `/token` response but nothing yet validates it as a bearer on protected routes.

## Where ADR-0005 needed a correction (or a gap the ADR didn't call out)

- ADR-0005 says the redirect_uri registry must reject wildcards, and cites `WHITEBOARD_ALLOWED_WEB_ORIGINS`'s wildcard-origin problem as the reason to build a separate registry. It doesn't call out that `z.string().url()` alone is not sufficient to reject a wildcard *redirect_uri* entry — `new URL('https://*.pages.dev/callback')` parses without throwing, exactly the same WHATWG URL quirk `server-mode-env-config.ts` already had to guard against for origins. The registry schema needed an explicit `.refine` rejecting `*`; a naive Zod schema following only the ADR's prose would have shipped the gap it was trying to close.
- No route-scope-registry.ts / ws-scope-registry.ts exist in this repo yet (the task brief assumed they had "just landed"); the scope vocabulary actually lives in `auth-strategy.ts`'s `AuthScope` union. I refactored that into a `AUTH_SCOPES` runtime array (same type, `z.infer`-compatible) rather than inventing a new vocabulary, per the "do not invent scope names" instruction.

## Verification

```
pnpm test --project mcp-node   # 211 files / 3193 passed
pnpm -r typecheck               # clean
pnpm build                       # clean
pnpm lint:noconsole              # clean
```

No manual browser verification for this slice — it's a headless API surface with no UI yet (`/authorize` is the first slice with anything to click). The regression tests above are the primary evidence; a real end-to-end hosted-origin exchange isn't dogfoodable until `/authorize` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 authorization support for configured local-daemon deployments.
  * Added OAuth discovery metadata and secure token exchange using authorization codes with PKCE.
  * Added configurable client registration with exact redirect URI matching.
  * Added short-lived bearer access tokens and supported scope metadata.

* **Security**
  * Added host and origin validation for OAuth endpoints.
  * Prevented OAuth routes from falling through to the web application.

* **Tests**
  * Added comprehensive coverage for token redemption, PKCE validation, redirect protection, concurrency, expiration, and route isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->