### PR TITLE
feat(mcp-server): add the /authorize consent screen and approval flow

### DIFF
--- a/packages/mcp-server/src/cli/daemon-run.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run.test.ts
@@ -158,3 +158,49 @@ describe('runDaemonRun WHITEBOARD_ALLOWED_WEB_ORIGINS wiring', () => {
     )
   })
 })
+
+describe('runDaemonRun WHITEBOARD_OAUTH_CLIENT_REGISTRY wiring', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('fails fast with a structured outcome on an invalid env value and never calls startHttpServer', async () => {
+    const outcome = await runDaemonRun({
+      host: '127.0.0.1',
+      tokenStdin: false,
+      dataDir: '/tmp/whiteboard-test',
+      env: { WHITEBOARD_OAUTH_CLIENT_REGISTRY: 'not json' },
+    })
+    expect(outcome).toEqual({
+      kind: 'input-error',
+      message: expect.stringContaining('WHITEBOARD_OAUTH_CLIENT_REGISTRY'),
+      code: 'invalid_oauth_client_registry',
+    })
+    expect(startHttpServerMock).not.toHaveBeenCalled()
+  })
+
+  it('threads a valid registry through to startHttpServer', async () => {
+    const registry = [{ clientId: 'test-client', redirectUris: ['https://example.com/callback'] }]
+    const outcome = await runDaemonRun({
+      host: '127.0.0.1',
+      tokenStdin: false,
+      dataDir: '/tmp/whiteboard-test',
+      env: { WHITEBOARD_OAUTH_CLIENT_REGISTRY: JSON.stringify(registry) },
+    })
+    expect(outcome.kind).toBe('running')
+    expect(startHttpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ oauthClientRegistry: registry }),
+    )
+  })
+
+  it('defaults to an empty registry when the env var is unset', async () => {
+    const outcome = await runDaemonRun({
+      host: '127.0.0.1',
+      tokenStdin: false,
+      dataDir: '/tmp/whiteboard-test',
+      env: {},
+    })
+    expect(outcome.kind).toBe('running')
+    expect(startHttpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ oauthClientRegistry: [] }),
+    )
+  })
+})

--- a/packages/mcp-server/src/server/app.oauth-authorize-cors.test.ts
+++ b/packages/mcp-server/src/server/app.oauth-authorize-cors.test.ts
@@ -1,0 +1,138 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from './routes/_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-app-oauth-authorize-cors-test-')
+
+vi.mock('./config.js', () => ({
+  get DATA_DIR() {
+    return join(tmp.dir, 'data')
+  },
+  get DIST_WEB_APP_DIR() {
+    return join(tmp.dir, 'web-app')
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+}))
+
+vi.mock('../daemon/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn(async () => ({
+    pid: 1,
+    port: 3099,
+    token: 'secret',
+    version: '0.1.0',
+    startedAt: '2026-04-24T00:00:00.000Z',
+    baseUrl: 'http://daemon.test',
+  })),
+}))
+
+const { createApp } = await import('./app.js')
+const { PACKAGE_VERSION } = await import('../shared/package-version.js')
+
+const HOSTED_ORIGIN = 'https://whiteboard.pages.dev'
+const registry = [
+  { clientId: 'whiteboard-hosted-web', redirectUris: [`${HOSTED_ORIGIN}/oauth/callback`] },
+]
+
+function buildApp() {
+  return createApp({
+    authMode: 'local-daemon' as const,
+    allowedWebOrigins: [HOSTED_ORIGIN],
+    oauthClientRegistry: registry,
+    touch: vi.fn(),
+    shutdown: vi.fn(async () => undefined),
+    getStatus: () => ({
+      ok: true,
+      pid: 10,
+      host: '127.0.0.1',
+      port: 3099,
+      baseUrl: 'http://127.0.0.1:3099',
+      version: PACKAGE_VERSION,
+      startedAt: '2026-04-23T00:00:00.000Z',
+      uptimeMs: 100,
+      idleForMs: 10,
+      auth: { mode: 'local-token' as const, hasToken: false },
+      storage: { dataDir: '/tmp', dataDirWritable: true },
+      app: { served: true, buildPresent: false, ui: 'web-app' as const },
+      mcp: { httpEnabled: true, endpoint: 'http://127.0.0.1:3099/mcp' },
+      clients: { connected: 0, ready: 0 },
+    }),
+  })
+}
+
+// The approval surface is a top-level *navigation* target, never an XHR one.
+// Reflecting an allowed web origin back on /authorize would let a page on that
+// origin read the approval screen — and script the approval POST — cross-site,
+// which is precisely the attack the double-submit CSRF binding and the
+// SameSite=Strict cookie exist to prevent. The loopback CORS middleware
+// therefore must cover only the metadata documents and /token.
+describe('oauth /authorize CORS scope', () => {
+  it('never reflects an allowed web origin on the approval endpoints', async () => {
+    await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
+    await mkdir(join(tmp.dir, 'data'), { recursive: true })
+    await writeFile(join(tmp.dir, 'web-app', 'index.html'), '<!DOCTYPE html><html></html>')
+    const app = buildApp()
+
+    for (const path of ['/authorize', '/authorize/decision']) {
+      const preflight = await app.request(`http://127.0.0.1:3099${path}`, {
+        method: 'OPTIONS',
+        headers: {
+          Host: '127.0.0.1:3099',
+          Origin: HOSTED_ORIGIN,
+          'Access-Control-Request-Method': 'POST',
+        },
+      })
+      expect(
+        preflight.headers.get('Access-Control-Allow-Origin'),
+        `${path} preflight reflected an origin`,
+      ).toBeNull()
+
+      const get = await app.request(`http://127.0.0.1:3099${path}`, {
+        headers: { Host: '127.0.0.1:3099', Origin: HOSTED_ORIGIN },
+      })
+      expect(
+        get.headers.get('Access-Control-Allow-Origin'),
+        `${path} response reflected an origin`,
+      ).toBeNull()
+    }
+  })
+
+  it('still reflects the allowed web origin on /token', async () => {
+    const app = buildApp()
+    const preflight = await app.request('http://127.0.0.1:3099/token', {
+      method: 'OPTIONS',
+      headers: {
+        Host: '127.0.0.1:3099',
+        Origin: HOSTED_ORIGIN,
+        'Access-Control-Request-Method': 'POST',
+      },
+    })
+    expect(preflight.headers.get('Access-Control-Allow-Origin')).toBe(HOSTED_ORIGIN)
+  })
+
+  // The app-wide baseline security headers run AFTER the route and must not
+  // *downgrade* a policy the route deliberately made stricter. The approval
+  // page loads nothing and runs no script, so it ships `default-src 'none'`;
+  // an isolated router test cannot see this, because the clobbering
+  // middleware only exists in the composed app.
+  it('does not downgrade the approval page CSP to the app-wide baseline', async () => {
+    const app = buildApp()
+    const res = await app.request('http://127.0.0.1:3099/authorize', {
+      headers: { Host: '127.0.0.1:3099' },
+    })
+    const csp = res.headers.get('content-security-policy') ?? ''
+    expect(csp).toContain("default-src 'none'")
+    expect(csp).toContain("frame-ancestors 'none'")
+  })
+
+  // The host guard is orthogonal to CORS and must NOT be dropped along with it:
+  // a spoofed non-loopback Host is a DNS-rebinding vector on the approval
+  // surface exactly as it is on /api/*.
+  it('keeps the host guard on the approval endpoints', async () => {
+    const app = buildApp()
+    const res = await app.request('http://127.0.0.1:3099/authorize', {
+      headers: { Host: 'evil.example.com' },
+    })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -20,7 +20,11 @@ import { createDebugRouter } from './routes/debug.js'
 import { createExportRouter, resolveExportRequest } from './routes/export.js'
 import { createFilesRouter } from './routes/files.js'
 import { createLibrariesRouter } from './routes/libraries.js'
-import { createOAuthAuthzRouter, OAUTH_AUTHZ_PATHS } from './routes/oauth-authz.js'
+import {
+  createOAuthAuthzRouter,
+  OAUTH_AUTHZ_CORS_PATHS,
+  OAUTH_AUTHZ_PATHS,
+} from './routes/oauth-authz.js'
 import { createPaletteRouter } from './routes/palette.js'
 import { createRuntimeRouter } from './routes/runtime.js'
 import { createStatusRouter } from './routes/status.js'
@@ -86,8 +90,15 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+// A floor, not a ceiling. This runs after every route, so `set`ting a header a
+// route already chose would silently *downgrade* it — the OAuth approval page
+// ships a `default-src 'none'` CSP that this baseline would otherwise replace
+// with the far weaker frame-ancestors-only policy. Every header below is
+// applied unconditionally except CSP, whose value is route-specific by nature.
 function setBaselineSecurityHeaders(headers: Headers): void {
-  headers.set('Content-Security-Policy', "frame-ancestors 'none'")
+  if (!headers.has('Content-Security-Policy')) {
+    headers.set('Content-Security-Policy', "frame-ancestors 'none'")
+  }
   headers.set('X-Frame-Options', 'DENY')
   headers.set('X-Content-Type-Options', 'nosniff')
   headers.set('Referrer-Policy', 'no-referrer')
@@ -441,12 +452,18 @@ export function createApp(options: AppOptions) {
     // an OPTIONS preflight for /mcp would be answered here before
     // createMcpHttpOriginMiddleware ever ran.
     for (const path of OAUTH_AUTHZ_PATHS) {
-      // Host guard first, ahead of CORS, for the same DNS-rebinding reason as
-      // /api/*: a spoofed non-loopback Host must be rejected before an
-      // OPTIONS preflight could short-circuit past it.
+      // Host guard on EVERY path of the surface, including /authorize: a
+      // spoofed non-loopback Host is a DNS-rebinding vector here exactly as
+      // on /api/*, and it must be rejected before an OPTIONS preflight could
+      // short-circuit past it.
       app.use(path, createApiHostGuardMiddleware(options.authMode))
-      // This surface's own CORS handling — it inherits nothing from /api/*'s
-      // middleware chain merely by being mounted nearby.
+    }
+    // CORS covers only OAUTH_AUTHZ_CORS_PATHS — the metadata documents and
+    // /token — never the /authorize pair. Reflecting an allowed web origin on
+    // the approval endpoints would let the requesting page read the approval
+    // screen and script its POST cross-site, which is the whole thing the
+    // approval step exists to prevent. See oauth-authz.ts.
+    for (const path of OAUTH_AUTHZ_CORS_PATHS) {
       app.use(path, createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
     }
     app.route('/', oauthAuthzRoutes)

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -102,6 +102,53 @@ describe('server/index main() WHITEBOARD_ALLOWED_WEB_ORIGINS startup gate', () =
   })
 })
 
+describe('server/index main() WHITEBOARD_OAUTH_CLIENT_REGISTRY startup gate', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    delete process.env.WHITEBOARD_OAUTH_CLIENT_REGISTRY
+    delete process.env.WHITEBOARD_TOKEN
+  })
+
+  it('aborts before startHttpServer and logs a structured record on an invalid env value', async () => {
+    process.env.WHITEBOARD_OAUTH_CLIENT_REGISTRY = 'not json'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const capture = captureLogsForTests('debug')
+    try {
+      await expect(main()).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(startHttpServerMock).not.toHaveBeenCalled()
+      const record = capture.records.find((r) => r.scope === 'server-index' && r.level === 'error')
+      expect(record).toBeDefined()
+    } finally {
+      capture.restore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('threads a valid registry through to startHttpServer and never exits', async () => {
+    const registry = [{ clientId: 'test-client', redirectUris: ['https://example.com/callback'] }]
+    process.env.WHITEBOARD_OAUTH_CLIENT_REGISTRY = JSON.stringify(registry)
+    process.env.WHITEBOARD_TOKEN = 'test-token'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await main()
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(startHttpServerMock).toHaveBeenCalledWith(
+        expect.objectContaining({ oauthClientRegistry: registry }),
+      )
+    } finally {
+      exitSpy.mockRestore()
+      stdoutSpy.mockRestore()
+    }
+  })
+})
+
 describe('server/index main() config-file wiring', () => {
   let dir: string
   let originalCwd: string

--- a/packages/mcp-server/src/server/routes/oauth-approval-page.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-approval-page.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalView } from '../security/oauth-authz-transactions.js'
+import { renderApprovalPage, renderAuthorizeErrorPage } from './oauth-approval-page.js'
+
+function baseView(overrides: Partial<ApprovalView> = {}): ApprovalView {
+  return {
+    clientId: 'demo-client',
+    redirectUri: 'https://app.example.test/callback?next=/dashboard',
+    scopes: ['canvas:read', 'workspace:write'],
+    status: 'pending',
+    expiresAt: 1_700_000_000_000,
+    ...overrides,
+  }
+}
+
+describe('renderApprovalPage', () => {
+  it('derives the relying-party identity from the registered redirect URI origin only', () => {
+    const html = renderApprovalPage({
+      transactionId: 'txn-1',
+      csrfToken: 'csrf-1',
+      view: baseView({
+        redirectUri: 'https://app.example.test/callback?evil=https://attacker.test',
+      }),
+    })
+
+    expect(html).toContain('https://app.example.test')
+    expect(html).not.toContain('attacker.test')
+  })
+
+  it('HTML-escapes every interpolated value', () => {
+    const html = renderApprovalPage({
+      transactionId: '"><script>alert(1)</script>',
+      csrfToken: 'csrf-1',
+      view: baseView({ clientId: '<b>evil</b>' }),
+    })
+
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).not.toContain('<b>evil</b>')
+    expect(html).toContain('&lt;b&gt;evil&lt;/b&gt;')
+  })
+
+  it('emits no <script> tag and no inline event handler, per CSP script-src none', () => {
+    const html = renderApprovalPage({
+      transactionId: 'txn-1',
+      csrfToken: 'csrf-1',
+      view: baseView(),
+    })
+
+    expect(html).not.toMatch(/<script/i)
+    expect(html).not.toMatch(/\son\w+\s*=/i)
+  })
+
+  it('lists every requested scope with human-readable copy', () => {
+    const html = renderApprovalPage({
+      transactionId: 'txn-1',
+      csrfToken: 'csrf-1',
+      view: baseView({ scopes: ['canvas:read', 'files:write'] }),
+    })
+
+    expect(html).toContain('Read canvas content')
+    expect(html).toContain('Write files')
+  })
+
+  it('renders Deny before Approve and autofocused, with nothing pre-checked', () => {
+    const html = renderApprovalPage({
+      transactionId: 'txn-1',
+      csrfToken: 'csrf-1',
+      view: baseView(),
+    })
+
+    const denyIndex = html.indexOf('value="deny"')
+    const approveIndex = html.indexOf('value="approve"')
+    expect(denyIndex).toBeGreaterThan(-1)
+    expect(approveIndex).toBeGreaterThan(-1)
+    expect(denyIndex).toBeLessThan(approveIndex)
+    expect(html).toMatch(/name="decision" value="deny"[^>]*autofocus/)
+    expect(html).not.toContain('checked')
+  })
+
+  it('carries the transaction id and CSRF token as hidden form fields', () => {
+    const html = renderApprovalPage({
+      transactionId: 'txn-42',
+      csrfToken: 'csrf-secret',
+      view: baseView(),
+    })
+
+    expect(html).toContain('name="transaction_id" value="txn-42"')
+    expect(html).toContain('name="csrf_token" value="csrf-secret"')
+  })
+})
+
+describe('renderAuthorizeErrorPage', () => {
+  it('renders a local error page without any redirect affordance', () => {
+    const html = renderAuthorizeErrorPage('unknown_client')
+
+    expect(html).not.toMatch(/<meta[^>]+refresh/i)
+    expect(html).not.toMatch(/<script/i)
+    expect(html.toLowerCase()).toContain('not registered')
+  })
+
+  it('renders a distinct message for a restarted daemon', () => {
+    const html = renderAuthorizeErrorPage('transaction_not_found')
+
+    expect(html.toLowerCase()).toContain('restart')
+  })
+
+  it('renders a distinct message for a rate-limited client', () => {
+    const html = renderAuthorizeErrorPage('rate_limited')
+
+    expect(html.toLowerCase()).toContain('too many')
+  })
+})

--- a/packages/mcp-server/src/server/routes/oauth-approval-page.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-approval-page.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { ApprovalView } from '../security/oauth-authz-transactions.js'
 import { renderApprovalPage, renderAuthorizeErrorPage } from './oauth-approval-page.js'
 
+const TEST_NONCE = 'test-nonce'
+
 function baseView(overrides: Partial<ApprovalView> = {}): ApprovalView {
   return {
     clientId: 'demo-client',
@@ -16,6 +18,7 @@ function baseView(overrides: Partial<ApprovalView> = {}): ApprovalView {
 describe('renderApprovalPage', () => {
   it('derives the relying-party identity from the registered redirect URI origin only', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: 'txn-1',
       csrfToken: 'csrf-1',
       view: baseView({
@@ -29,18 +32,36 @@ describe('renderApprovalPage', () => {
 
   it('HTML-escapes every interpolated value', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: '"><script>alert(1)</script>',
-      csrfToken: 'csrf-1',
-      view: baseView({ clientId: '<b>evil</b>' }),
+      csrfToken: '"><b>csrf</b>',
+      view: baseView(),
     })
 
     expect(html).not.toContain('<script>alert(1)</script>')
-    expect(html).not.toContain('<b>evil</b>')
-    expect(html).toContain('&lt;b&gt;evil&lt;/b&gt;')
+    expect(html).not.toContain('<b>csrf</b>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('&lt;b&gt;csrf&lt;/b&gt;')
+  })
+
+  // The user is asked to trust an *origin*, and the only trustworthy name for
+  // one is the registered redirect_uri it was matched against. client_id is an
+  // internal identifier that means nothing to the person deciding, so showing
+  // it would add a second, weaker-provenance identity to the same screen.
+  it('never shows the raw client_id — identity on screen is the redirect origin alone', () => {
+    const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
+      transactionId: 'txn-1',
+      csrfToken: 'csrf-1',
+      view: baseView({ clientId: 'internal-client-identifier' }),
+    })
+
+    expect(html).not.toContain('internal-client-identifier')
   })
 
   it('emits no <script> tag and no inline event handler, per CSP script-src none', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: 'txn-1',
       csrfToken: 'csrf-1',
       view: baseView(),
@@ -52,6 +73,7 @@ describe('renderApprovalPage', () => {
 
   it('lists every requested scope with human-readable copy', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: 'txn-1',
       csrfToken: 'csrf-1',
       view: baseView({ scopes: ['canvas:read', 'files:write'] }),
@@ -63,6 +85,7 @@ describe('renderApprovalPage', () => {
 
   it('renders Deny before Approve and autofocused, with nothing pre-checked', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: 'txn-1',
       csrfToken: 'csrf-1',
       view: baseView(),
@@ -79,6 +102,7 @@ describe('renderApprovalPage', () => {
 
   it('carries the transaction id and CSRF token as hidden form fields', () => {
     const html = renderApprovalPage({
+      styleNonce: TEST_NONCE,
       transactionId: 'txn-42',
       csrfToken: 'csrf-secret',
       view: baseView(),
@@ -91,7 +115,7 @@ describe('renderApprovalPage', () => {
 
 describe('renderAuthorizeErrorPage', () => {
   it('renders a local error page without any redirect affordance', () => {
-    const html = renderAuthorizeErrorPage('unknown_client')
+    const html = renderAuthorizeErrorPage('unknown_client', TEST_NONCE)
 
     expect(html).not.toMatch(/<meta[^>]+refresh/i)
     expect(html).not.toMatch(/<script/i)
@@ -99,13 +123,13 @@ describe('renderAuthorizeErrorPage', () => {
   })
 
   it('renders a distinct message for a restarted daemon', () => {
-    const html = renderAuthorizeErrorPage('transaction_not_found')
+    const html = renderAuthorizeErrorPage('transaction_not_found', TEST_NONCE)
 
     expect(html.toLowerCase()).toContain('restart')
   })
 
   it('renders a distinct message for a rate-limited client', () => {
-    const html = renderAuthorizeErrorPage('rate_limited')
+    const html = renderAuthorizeErrorPage('rate_limited', TEST_NONCE)
 
     expect(html.toLowerCase()).toContain('too many')
   })

--- a/packages/mcp-server/src/server/routes/oauth-approval-page.ts
+++ b/packages/mcp-server/src/server/routes/oauth-approval-page.ts
@@ -17,6 +17,12 @@ export interface ApprovalPageInput {
   transactionId: string
   csrfToken: string
   view: ApprovalView
+  // Per-response nonce for the single <style> block. The page ships
+  // `default-src 'none'`, so a stylesheet needs an explicit grant; a nonce
+  // keeps that grant to this one response instead of blanket
+  // `style-src 'unsafe-inline'`. The caller must put the same value in the
+  // CSP header, or the page renders unstyled rather than insecurely.
+  styleNonce: string
 }
 
 // Every reason the /authorize route can refuse to redirect at all —
@@ -68,38 +74,97 @@ function relyingPartyOrigin(redirectUri: string): string {
   return new URL(redirectUri).origin
 }
 
-function pageShell(title: string, body: string): string {
+// One stylesheet, sent inline under a per-response nonce. A local consent
+// screen must render correctly with no network access of any kind — an
+// external stylesheet would need `style-src` to admit an origin, and a page
+// whose job is to explain a trust decision must not depend on a fetch that
+// can fail or be tampered with.
+const STYLES = `
+:root { color-scheme: light dark; --fg:#111; --muted:#5b6169; --bg:#f4f5f7;
+  --card:#fff; --line:#dfe2e6; --danger:#8a2b2b; --danger-bg:#fdf1f1; }
+@media (prefers-color-scheme: dark) {
+  :root { --fg:#e9eaec; --muted:#a2a8b0; --bg:#16181c; --card:#1e2126;
+    --line:#31353c; --danger:#f0a8a8; --danger-bg:#2a1c1c; }
+}
+* { box-sizing: border-box; }
+body { margin:0; min-height:100vh; display:grid; place-items:center; padding:2rem 1rem;
+  background:var(--bg); color:var(--fg);
+  font:16px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+main { width:100%; max-width:30rem; background:var(--card); border:1px solid var(--line);
+  border-radius:14px; padding:1.75rem; box-shadow:0 1px 2px rgba(0,0,0,.05), 0 12px 32px rgba(0,0,0,.06); }
+.eyebrow { margin:0 0 .35rem; font-size:.75rem; letter-spacing:.08em; text-transform:uppercase;
+  color:var(--muted); }
+h1 { margin:0 0 .5rem; font-size:1.4rem; line-height:1.25; overflow-wrap:anywhere; }
+.origin { font-family:ui-monospace, SFMono-Regular, Menlo, monospace; }
+.lede { margin:0 0 1.25rem; color:var(--muted); font-size:.9rem; }
+ul { margin:0 0 1.25rem; padding:0; list-style:none; border-top:1px solid var(--line); }
+li { padding:.6rem .1rem; border-bottom:1px solid var(--line); font-size:.95rem; }
+li.write::after { content:"can change your data"; float:right; font-size:.72rem; color:var(--danger);
+  background:var(--danger-bg); border-radius:999px; padding:.1rem .5rem; }
+.consequence { margin:0 0 1.5rem; font-size:.85rem; color:var(--muted); }
+form { display:flex; gap:.6rem; }
+button { flex:1; padding:.65rem 1rem; font:inherit; font-weight:600; font-size:.95rem;
+  border-radius:9px; border:1px solid var(--line); background:transparent; color:var(--fg);
+  cursor:pointer; transition:background .12s ease, border-color .12s ease; }
+button:hover { background:var(--bg); }
+button.primary { background:var(--fg); color:var(--card); border-color:var(--fg); }
+button.primary:hover { opacity:.88; }
+button:focus-visible { outline:2px solid currentColor; outline-offset:2px; }
+`
+
+function pageShell(title: string, body: string, styleNonce: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(title)}</title>
+<style nonce="${escapeHtml(styleNonce)}">${STYLES}</style>
 </head>
 <body>
+<main>
 ${body}
+</main>
 </body>
 </html>`
 }
 
+// Scopes that let the grantee change something, as opposed to only read it.
+// The consent screen calls these out visually: "read my canvases" and "rewrite
+// my canvases" are not the same decision and must not look the same.
+const WRITE_SCOPES: ReadonlySet<AuthScope> = new Set<AuthScope>([
+  'canvas:write',
+  'workspace:write',
+  'versions:write',
+  'files:write',
+  'runtime:admin',
+  'mcp:call',
+])
+
 export function renderApprovalPage(input: ApprovalPageInput): string {
-  const { transactionId, csrfToken, view } = input
+  const { transactionId, csrfToken, view, styleNonce } = input
   const origin = relyingPartyOrigin(view.redirectUri)
   const scopeItems = view.scopes
-    .map((scope) => `<li>${escapeHtml(SCOPE_COPY[scope])}</li>`)
+    .map(
+      (scope) =>
+        `<li${WRITE_SCOPES.has(scope) ? ' class="write"' : ''}>${escapeHtml(SCOPE_COPY[scope])}</li>`,
+    )
     .join('')
 
   const body = `
-<h1>Grant access to ${escapeHtml(origin)}?</h1>
-<p><strong>${escapeHtml(view.clientId)}</strong> is requesting the following:</p>
+<p class="eyebrow">Authorization request</p>
+<h1>Allow <span class="origin">${escapeHtml(origin)}</span> to use this whiteboard?</h1>
+<p class="lede">It is asking for:</p>
 <ul>${scopeItems}</ul>
+<p class="consequence">Approving lets that site act on the data stored on this computer until you revoke it. Only approve if you opened it yourself, just now.</p>
 <form method="post" action="/authorize/decision">
 <input type="hidden" name="transaction_id" value="${escapeHtml(transactionId)}">
 <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
 <button type="submit" name="decision" value="deny" autofocus>Deny</button>
-<button type="submit" name="decision" value="approve">Approve</button>
+<button type="submit" name="decision" value="approve" class="primary">Approve</button>
 </form>`
 
-  return pageShell(`Authorize ${origin}`, body)
+  return pageShell(`Authorize ${origin}`, body, styleNonce)
 }
 
 const ERROR_COPY: Record<AuthorizeErrorReason, string> = {
@@ -112,10 +177,11 @@ const ERROR_COPY: Record<AuthorizeErrorReason, string> = {
     'This approval could not be verified as coming from this page. Start the authorization request again.',
 }
 
-export function renderAuthorizeErrorPage(reason: AuthorizeErrorReason): string {
+export function renderAuthorizeErrorPage(reason: AuthorizeErrorReason, styleNonce: string): string {
   const body = `
-<h1>Authorization request failed</h1>
-<p>${escapeHtml(ERROR_COPY[reason])}</p>`
+<p class="eyebrow">Authorization request</p>
+<h1>This request was not granted</h1>
+<p class="lede">${escapeHtml(ERROR_COPY[reason])}</p>`
 
-  return pageShell('Authorization request failed', body)
+  return pageShell('Authorization request failed', body, styleNonce)
 }

--- a/packages/mcp-server/src/server/routes/oauth-approval-page.ts
+++ b/packages/mcp-server/src/server/routes/oauth-approval-page.ts
@@ -1,0 +1,114 @@
+// Pure HTML renderers for the /authorize approval surface (ADR-0005).
+//
+// These functions take no request/response objects and perform no I/O —
+// the route module (a later slice) owns cookies, status codes, and
+// headers. Keeping the render pure makes the security-sensitive
+// properties below (escaping, CSP-safe markup, default-deny ordering)
+// assertable without spinning up an HTTP server.
+//
+// No inline JavaScript, no <script> tag: the route sends
+// `script-src 'none'` and this page has to work under that policy, not
+// merely avoid tripping it in a test.
+
+import type { AuthScope } from '../security/auth-strategy.js'
+import type { ApprovalView } from '../security/oauth-authz-transactions.js'
+
+export interface ApprovalPageInput {
+  transactionId: string
+  csrfToken: string
+  view: ApprovalView
+}
+
+// Every reason the /authorize route can refuse to redirect at all —
+// an unregistered client or redirect_uri must never receive a
+// Location header pointing anywhere, so those refusals render locally
+// instead of bouncing through the (unverified) party's own callback.
+export type AuthorizeErrorReason =
+  | 'unknown_client'
+  | 'redirect_uri_mismatch'
+  | 'transaction_not_found'
+  | 'rate_limited'
+
+// Human copy for every scope in the vocabulary. `Record<AuthScope, string>`
+// makes omitting a scope here a compile error rather than a silent gap in
+// what the consent screen discloses to the user.
+const SCOPE_COPY: Record<AuthScope, string> = {
+  'canvas:read': 'Read canvas content',
+  'canvas:write': 'Modify canvas content',
+  'workspace:read': 'Read workspace metadata',
+  'workspace:write': 'Modify workspace metadata',
+  'versions:read': 'Read version history',
+  'versions:write': 'Create versions',
+  'files:read': 'Read attached files',
+  'files:write': 'Write files',
+  'runtime:read': 'Read daemon runtime status',
+  'runtime:admin': 'Administer the daemon runtime',
+  'mcp:call': 'Call MCP tools',
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// The relying-party identity shown to the user is derived ONLY from the
+// registered redirect_uri's origin — never from Origin, Referer, or any
+// query parameter on the request, all of which are attacker-controlled
+// inputs that must not influence what the user is told they're trusting.
+function relyingPartyOrigin(redirectUri: string): string {
+  return new URL(redirectUri).origin
+}
+
+function pageShell(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+</head>
+<body>
+${body}
+</body>
+</html>`
+}
+
+export function renderApprovalPage(input: ApprovalPageInput): string {
+  const { transactionId, csrfToken, view } = input
+  const origin = relyingPartyOrigin(view.redirectUri)
+  const scopeItems = view.scopes
+    .map((scope) => `<li>${escapeHtml(SCOPE_COPY[scope])}</li>`)
+    .join('')
+
+  const body = `
+<h1>Grant access to ${escapeHtml(origin)}?</h1>
+<p><strong>${escapeHtml(view.clientId)}</strong> is requesting the following:</p>
+<ul>${scopeItems}</ul>
+<form method="post" action="/authorize/decision">
+<input type="hidden" name="transaction_id" value="${escapeHtml(transactionId)}">
+<input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}">
+<button type="submit" name="decision" value="deny" autofocus>Deny</button>
+<button type="submit" name="decision" value="approve">Approve</button>
+</form>`
+
+  return pageShell(`Authorize ${origin}`, body)
+}
+
+const ERROR_COPY: Record<AuthorizeErrorReason, string> = {
+  unknown_client: 'This application is not registered with this daemon.',
+  redirect_uri_mismatch: 'The requested redirect address is not registered for this application.',
+  transaction_not_found:
+    'This approval request no longer exists, most likely because the daemon restarted. Start the authorization request again.',
+  rate_limited: 'Too many authorization attempts. Please wait a minute and try again.',
+}
+
+export function renderAuthorizeErrorPage(reason: AuthorizeErrorReason): string {
+  const body = `
+<h1>Authorization request failed</h1>
+<p>${escapeHtml(ERROR_COPY[reason])}</p>`
+
+  return pageShell('Authorization request failed', body)
+}

--- a/packages/mcp-server/src/server/routes/oauth-approval-page.ts
+++ b/packages/mcp-server/src/server/routes/oauth-approval-page.ts
@@ -28,6 +28,11 @@ export type AuthorizeErrorReason =
   | 'redirect_uri_mismatch'
   | 'transaction_not_found'
   | 'rate_limited'
+  // The approval POST failed its cross-site / double-submit checks. Rendered
+  // rather than returned as a bare 403 so a user who hit it by navigating
+  // oddly (stale tab, cleared cookies) is told what to do, not shown what
+  // reads like a server bug.
+  | 'csrf_check_failed'
 
 // Human copy for every scope in the vocabulary. `Record<AuthScope, string>`
 // makes omitting a scope here a compile error rather than a silent gap in
@@ -103,6 +108,8 @@ const ERROR_COPY: Record<AuthorizeErrorReason, string> = {
   transaction_not_found:
     'This approval request no longer exists, most likely because the daemon restarted. Start the authorization request again.',
   rate_limited: 'Too many authorization attempts. Please wait a minute and try again.',
+  csrf_check_failed:
+    'This approval could not be verified as coming from this page. Start the authorization request again.',
 }
 
 export function renderAuthorizeErrorPage(reason: AuthorizeErrorReason): string {

--- a/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
@@ -1,0 +1,286 @@
+import { createHash } from 'node:crypto'
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { createOAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+import { createOAuthAuthzRouter } from './oauth-authz.js'
+
+const CLIENT_ID = 'whiteboard-hosted-web'
+const REDIRECT_URI = 'https://whiteboard.pages.dev/oauth/callback'
+const PKCE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+const PKCE_CHALLENGE = createHash('sha256').update(PKCE_VERIFIER).digest('base64url')
+const ORIGIN = 'http://127.0.0.1:3099'
+
+function buildApp() {
+  const store = createOAuthTransactionStore()
+  const registry = [{ clientId: CLIENT_ID, redirectUris: [REDIRECT_URI] }]
+  const app = new Hono()
+  app.route('/', createOAuthAuthzRouter({ store, registry }))
+  return { app, store }
+}
+
+function authorizeUrl(overrides: Record<string, string | undefined> = {}): string {
+  const base: Record<string, string | undefined> = {
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    state: 'state-abc',
+    code_challenge: PKCE_CHALLENGE,
+    code_challenge_method: 'S256',
+    scope: 'workspace:read canvas:read',
+    ...overrides,
+  }
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(base)) {
+    if (value !== undefined) params.set(key, value)
+  }
+  return `${ORIGIN}/authorize?${params.toString()}`
+}
+
+function readSessionCookie(res: Response): string {
+  const raw = res.headers.get('set-cookie')
+  if (!raw) throw new Error('expected an approval-session cookie')
+  const value = /(?:^|,\s*)([^=;,\s]+)=([^;]+)/.exec(raw)
+  if (!value) throw new Error(`unparseable Set-Cookie: ${raw}`)
+  return `${value[1]}=${value[2]}`
+}
+
+function readHiddenField(html: string, name: string): string {
+  const match = new RegExp(`name="${name}" value="([^"]+)"`).exec(html)
+  if (!match?.[1]) throw new Error(`missing hidden field ${name}`)
+  return match[1]
+}
+
+async function startApproval(app: Hono) {
+  const res = await app.request(authorizeUrl())
+  const html = await res.text()
+  return {
+    res,
+    html,
+    cookie: readSessionCookie(res),
+    transactionId: readHiddenField(html, 'transaction_id'),
+    csrfToken: readHiddenField(html, 'csrf_token'),
+  }
+}
+
+function decisionRequest(
+  body: Record<string, string>,
+  init: { cookie?: string; origin?: string | null } = {},
+): [string, RequestInit] {
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+    'sec-fetch-site': 'same-origin',
+  }
+  if (init.cookie) headers.cookie = init.cookie
+  if (init.origin !== null) headers.origin = init.origin ?? ORIGIN
+  return [
+    `${ORIGIN}/authorize/decision`,
+    { method: 'POST', headers, body: new URLSearchParams(body).toString() },
+  ]
+}
+
+describe('GET /authorize — client/redirect validation must never redirect', () => {
+  it('renders a local error page for an unregistered client_id', async () => {
+    const { app } = buildApp()
+    const res = await app.request(authorizeUrl({ client_id: 'evil-client' }))
+    expect(res.status).toBe(400)
+    expect(res.headers.get('location')).toBeNull()
+    expect(await res.text()).toContain('not registered')
+  })
+
+  it('renders a local error page for a redirect_uri that is not byte-for-byte registered', async () => {
+    const { app } = buildApp()
+    const res = await app.request(authorizeUrl({ redirect_uri: `${REDIRECT_URI}/evil` }))
+    expect(res.status).toBe(400)
+    expect(res.headers.get('location')).toBeNull()
+  })
+})
+
+describe('GET /authorize — parameter errors redirect per RFC 6749 §4.1.2.1', () => {
+  it('refuses a request with no code_challenge', async () => {
+    const { app } = buildApp()
+    const res = await app.request(authorizeUrl({ code_challenge: undefined }))
+    expect(res.status).toBe(302)
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.searchParams.get('error')).toBe('invalid_request')
+    expect(location.searchParams.get('state')).toBe('state-abc')
+  })
+
+  it('refuses a downgrade to code_challenge_method=plain', async () => {
+    const { app } = buildApp()
+    const res = await app.request(
+      authorizeUrl({ code_challenge: PKCE_VERIFIER, code_challenge_method: 'plain' }),
+    )
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.searchParams.get('error')).toBe('invalid_request')
+  })
+
+  it('treats an omitted scope as invalid_scope, never a silent full grant', async () => {
+    const { app } = buildApp()
+    const res = await app.request(authorizeUrl({ scope: undefined }))
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.searchParams.get('error')).toBe('invalid_scope')
+  })
+
+  it('rejects a scope outside the vocabulary', async () => {
+    const { app } = buildApp()
+    const res = await app.request(authorizeUrl({ scope: 'workspace:read admin:everything' }))
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.searchParams.get('error')).toBe('invalid_scope')
+  })
+})
+
+describe('GET /authorize — approval screen', () => {
+  it('renders the approval form and binds a CSRF cookie without putting it in the URL', async () => {
+    const { app } = buildApp()
+    const { res, html, transactionId, csrfToken } = await startApproval(app)
+
+    expect(res.status).toBe(200)
+    expect(html).toContain('whiteboard.pages.dev')
+    expect(transactionId).not.toHaveLength(0)
+    expect(csrfToken).not.toHaveLength(0)
+
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('SameSite=Strict')
+    // Plain http request: marking the cookie Secure would make it undeliverable.
+    expect(setCookie).not.toContain('Secure')
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('sends no-store, no-referrer, DENY and a frame-ancestors CSP', async () => {
+    const { app } = buildApp()
+    const { res } = await startApproval(app)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer')
+    expect(res.headers.get('x-frame-options')).toBe('DENY')
+    expect(res.headers.get('content-security-policy')).toContain("frame-ancestors 'none'")
+  })
+
+  it('rate-limits a client hammering the endpoint', async () => {
+    const { app } = buildApp()
+    let lastStatus = 0
+    for (let i = 0; i < 12; i += 1) {
+      const res = await app.request(authorizeUrl())
+      lastStatus = res.status
+    }
+    expect(lastStatus).toBe(429)
+  })
+})
+
+describe('POST /authorize/decision', () => {
+  it('approves: issues a code bound to the state and the registered redirect_uri', async () => {
+    const { app } = buildApp()
+    const { cookie, transactionId, csrfToken } = await startApproval(app)
+
+    const res = await app.request(
+      ...decisionRequest(
+        { transaction_id: transactionId, csrf_token: csrfToken, decision: 'approve' },
+        { cookie },
+      ),
+    )
+    expect(res.status).toBe(303)
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.origin + location.pathname).toBe(REDIRECT_URI)
+    expect(location.searchParams.get('state')).toBe('state-abc')
+    const code = location.searchParams.get('code')
+    expect(code).toBeTruthy()
+    expect(res.headers.get('cache-control')).toBe('no-store')
+
+    const tokenRes = await app.request(`${ORIGIN}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code ?? '',
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: PKCE_VERIFIER,
+      }).toString(),
+    })
+    expect(tokenRes.status).toBe(200)
+    const token = (await tokenRes.json()) as { scope: string }
+    expect(token.scope).toBe('workspace:read canvas:read')
+  })
+
+  it('denies: redirects with access_denied and never a code', async () => {
+    const { app } = buildApp()
+    const { cookie, transactionId, csrfToken } = await startApproval(app)
+
+    const res = await app.request(
+      ...decisionRequest(
+        { transaction_id: transactionId, csrf_token: csrfToken, decision: 'deny' },
+        { cookie },
+      ),
+    )
+    expect(res.status).toBe(303)
+    const location = new URL(res.headers.get('location') ?? '')
+    expect(location.searchParams.get('error')).toBe('access_denied')
+    expect(location.searchParams.get('state')).toBe('state-abc')
+    expect(location.searchParams.get('code')).toBeNull()
+  })
+
+  it('rejects a POST with the form field but no cookie', async () => {
+    const { app } = buildApp()
+    const { transactionId, csrfToken } = await startApproval(app)
+    const res = await app.request(
+      ...decisionRequest({
+        transaction_id: transactionId,
+        csrf_token: csrfToken,
+        decision: 'approve',
+      }),
+    )
+    expect(res.status).toBe(403)
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('rejects a POST whose form field is not bound to the transaction', async () => {
+    const { app } = buildApp()
+    const { cookie, transactionId } = await startApproval(app)
+    const res = await app.request(
+      ...decisionRequest(
+        { transaction_id: transactionId, csrf_token: 'forged-token', decision: 'approve' },
+        { cookie },
+      ),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects a cross-site POST even when the cookie rides along', async () => {
+    const { app } = buildApp()
+    const { cookie, transactionId, csrfToken } = await startApproval(app)
+    const [url, init] = decisionRequest(
+      { transaction_id: transactionId, csrf_token: csrfToken, decision: 'approve' },
+      { cookie, origin: 'https://attacker.example' },
+    )
+    const res = await app.request(url, {
+      ...init,
+      headers: { ...(init.headers as Record<string, string>), 'sec-fetch-site': 'cross-site' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('renders a start-again page when the transaction is gone (daemon restart)', async () => {
+    const { app } = buildApp()
+    const { cookie, csrfToken } = await startApproval(app)
+    const res = await app.request(
+      ...decisionRequest(
+        { transaction_id: 'no-such-transaction', csrf_token: csrfToken, decision: 'approve' },
+        { cookie },
+      ),
+    )
+    expect(res.status).toBe(400)
+    expect(res.headers.get('location')).toBeNull()
+    expect(await res.text()).toContain('Start the authorization request again')
+  })
+
+  it('refuses to issue a second code for an already-decided transaction', async () => {
+    const { app } = buildApp()
+    const { cookie, transactionId, csrfToken } = await startApproval(app)
+    const form = { transaction_id: transactionId, csrf_token: csrfToken, decision: 'approve' }
+    const first = await app.request(...decisionRequest(form, { cookie }))
+    expect(first.status).toBe(303)
+    const second = await app.request(...decisionRequest(form, { cookie }))
+    expect(second.status).toBe(400)
+    expect(second.headers.get('location')).toBeNull()
+  })
+})

--- a/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
@@ -156,6 +156,31 @@ describe('GET /authorize — approval screen', () => {
     expect(res.headers.get('content-security-policy')).toContain("frame-ancestors 'none'")
   })
 
+  // The page's one stylesheet is admitted by a nonce, not by
+  // `style-src 'unsafe-inline'`. If the header's nonce and the <style> tag's
+  // ever drift apart the consent screen silently renders unstyled — legible,
+  // but not the deliberate surface a trust decision deserves — and nothing
+  // else would catch it.
+  it('admits its stylesheet by a per-response nonce that matches the CSP header', async () => {
+    const { app } = buildApp()
+    const { res, html } = await startApproval(app)
+
+    const csp = res.headers.get('content-security-policy') ?? ''
+    const headerNonce = /style-src 'nonce-([^']+)'/.exec(csp)?.[1]
+    const tagNonce = /<style nonce="([^"]+)">/.exec(html)?.[1]
+
+    expect(headerNonce).toBeDefined()
+    expect(tagNonce).toBe(headerNonce)
+    expect(csp).not.toContain('unsafe-inline')
+
+    // And it is per-response, not a constant baked into the module.
+    const second = await startApproval(app)
+    const secondNonce = /style-src 'nonce-([^']+)'/.exec(
+      second.res.headers.get('content-security-policy') ?? '',
+    )?.[1]
+    expect(secondNonce).not.toBe(headerNonce)
+  })
+
   it('rate-limits a client hammering the endpoint', async () => {
     const { app } = buildApp()
     let lastStatus = 0

--- a/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authorize.test.ts
@@ -192,6 +192,24 @@ describe('GET /authorize — approval screen', () => {
   })
 })
 
+// Both POST surfaces read the whole body before any validation can reject it,
+// so an unbounded body is an OOM lever on a daemon holding the user's data —
+// and these are the only two routes reachable before any credential exists.
+describe('OAuth POST bodies are bounded', () => {
+  it.each([
+    ['/token', 'application/x-www-form-urlencoded'],
+    ['/authorize/decision', 'application/x-www-form-urlencoded'],
+  ])('rejects an oversized body on %s with 413', async (path, contentType) => {
+    const { app } = buildApp()
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': contentType, Origin: ORIGIN },
+      body: `x=${'a'.repeat(64 * 1024)}`,
+    })
+    expect(res.status).toBe(413)
+  })
+})
+
 describe('POST /authorize/decision', () => {
   it('approves: issues a code bound to the state and the registered redirect_uri', async () => {
     const { app } = buildApp()

--- a/packages/mcp-server/src/server/routes/oauth-authz.test.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.test.ts
@@ -25,6 +25,7 @@ function issueCode(store: ReturnType<typeof createOAuthTransactionStore>) {
     state: 'abc123',
     codeChallenge: PKCE_CHALLENGE,
     codeChallengeMethod: 'S256',
+    csrfToken: 'test-csrf-token',
   })
   store.approveTransaction(transactionId)
   const issued = store.issueAuthorizationCode(transactionId)

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -7,6 +7,7 @@
 
 import { randomBytes } from 'node:crypto'
 import { type Context, Hono } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { z } from 'zod'
 import { AUTH_SCOPES, type AuthScope } from '../security/auth-strategy.js'
@@ -102,6 +103,17 @@ function tokenError(error: TokenErrorResponse['error']) {
 // HTTP/1.0 request-header artifact that RFC 7234 §5.4 gives no defined
 // meaning as a response header, and no HTTP/1.1 cache consults it.
 const TOKEN_CACHE_CONTROL = { 'Cache-Control': 'no-store' } as const
+
+// Both OAuth POST bodies are read in full before anything can reject them, and
+// both are reachable with no credential at all — so an unbounded body is a
+// straight OOM lever on a daemon holding the user's data. Every legitimate
+// request here is a handful of short fields (a code, a verifier, a URI), so
+// the cap can sit far below any real payload.
+const OAUTH_BODY_LIMIT_BYTES = 8 * 1024
+const oauthBodyLimit = bodyLimit({
+  maxSize: OAUTH_BODY_LIMIT_BYTES,
+  onError: (c) => c.text('Payload too large', 413),
+})
 
 // RFC 6749 §4.1.3 / OAuth 2.1 §4.1.3: the token request body is
 // `application/x-www-form-urlencoded`; a spec-compliant client (including the
@@ -343,7 +355,7 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
     )
   })
 
-  app.post(OAUTH_AUTHORIZE_DECISION_PATH, async (c) => {
+  app.post(OAUTH_AUTHORIZE_DECISION_PATH, oauthBodyLimit, async (c) => {
     if (isCrossSiteRequest(c)) return errorPage(c, 'csrf_check_failed', 403)
 
     const form = decisionFormSchema.safeParse(
@@ -413,7 +425,7 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
     return response
   })
 
-  app.post(OAUTH_TOKEN_PATH, async (c) => {
+  app.post(OAUTH_TOKEN_PATH, oauthBodyLimit, async (c) => {
     let rawBody: unknown
     try {
       rawBody = await readTokenRequestBody(c)

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -1,14 +1,15 @@
 // The hosted-origin OAuth 2.1 authorization-server surface (ADR-0005):
-// metadata documents plus the authorization-code + PKCE token exchange.
-// This router deliberately does not include /authorize — that is a later
-// slice's approval-UI surface. Host-guard and CORS wiring for the routes
-// this file registers happen in app.ts, mirroring how /api/* is wired
-// (see api-host-guard.ts's header comment: middleware does not extend to
-// a new mount point just by being registered "near" it).
+// metadata documents, the /authorize approval flow, and the
+// authorization-code + PKCE token exchange. Host-guard and CORS wiring for
+// the routes this file registers happen in app.ts, mirroring how /api/* is
+// wired (see api-host-guard.ts's header comment: middleware does not extend
+// to a new mount point just by being registered "near" it).
 
+import { randomBytes } from 'node:crypto'
 import { type Context, Hono } from 'hono'
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { z } from 'zod'
-import { AUTH_SCOPES } from '../security/auth-strategy.js'
+import { AUTH_SCOPES, type AuthScope } from '../security/auth-strategy.js'
 import {
   buildOAuthAuthorizationServerMetadata,
   buildOAuthProtectedResourceMetadata,
@@ -18,6 +19,11 @@ import {
   type OAuthClientRegistry,
 } from '../security/oauth-authz-registry.js'
 import type { OAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+import {
+  type AuthorizeErrorReason,
+  renderApprovalPage,
+  renderAuthorizeErrorPage,
+} from './oauth-approval-page.js'
 
 // RFC 9728's well-known suffix must not collide with the existing MCP
 // resource metadata already served at the bare
@@ -28,12 +34,32 @@ import type { OAuthTransactionStore } from '../security/oauth-authz-transactions
 const PROTECTED_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource/api'
 const AUTHORIZATION_SERVER_METADATA_PATH = '/.well-known/oauth-authorization-server'
 export const OAUTH_TOKEN_PATH = '/token'
+export const OAUTH_AUTHORIZE_PATH = '/authorize'
+export const OAUTH_AUTHORIZE_DECISION_PATH = '/authorize/decision'
 
 // Exported so the caller can attach this router's middleware to exactly these
 // paths. Hono's `app.route('/', subApp)` merges a sub-app's `use('*')` into the
 // parent as `/*` — it does NOT confine it to the sub-app's own routes — so a
 // sub-app is the wrong tool for scoping middleware.
 export const OAUTH_AUTHZ_PATHS = [
+  PROTECTED_RESOURCE_METADATA_PATH,
+  AUTHORIZATION_SERVER_METADATA_PATH,
+  OAUTH_TOKEN_PATH,
+  OAUTH_AUTHORIZE_PATH,
+  OAUTH_AUTHORIZE_DECISION_PATH,
+] as const
+
+// The strict subset of the surface that a browser page on an allowed web
+// origin is *supposed* to reach with a scripted, credentialed request: the
+// two public metadata documents and the token exchange. The /authorize pair
+// is deliberately absent. Those are top-level navigation targets; answering
+// them with a reflected `Access-Control-Allow-Origin` would let the very
+// hosted page that is asking for authorization read the approval screen and
+// script the approval POST from its own context — handing itself the consent
+// that the SameSite=Strict cookie and the double-submit CSRF binding exist to
+// require a human to give. Absence of CORS headers is what makes the browser
+// refuse to hand that response body to the requesting script.
+export const OAUTH_AUTHZ_CORS_PATHS = [
   PROTECTED_RESOURCE_METADATA_PATH,
   AUTHORIZATION_SERVER_METADATA_PATH,
   OAUTH_TOKEN_PATH,
@@ -94,6 +120,120 @@ async function readTokenRequestBody(c: Context): Promise<unknown> {
   return Object.fromEntries(params.entries())
 }
 
+// The /authorize query string, declared once. Note what is NOT here:
+// client_id and redirect_uri are read and checked against the registry
+// *before* this schema runs, because a failure of any rule below is
+// reported by redirecting to the redirect_uri (RFC 6749 §4.1.2.1) — which
+// is only a safe thing to do once that redirect_uri is known to be
+// registered. Validating them together would mean a request with a bogus
+// redirect_uri and a bogus scope could take the redirecting branch.
+const authorizeQuerySchema = z.object({
+  response_type: z.literal('code'),
+  state: z.string().min(1),
+  // RFC 7636: PKCE is mandatory in OAuth 2.1. `S256` only — `plain` offers
+  // no protection against an attacker who can observe the authorization
+  // request, and permitting it as a fallback is the same as not requiring
+  // PKCE at all.
+  code_challenge: z.string().min(1),
+  code_challenge_method: z.literal('S256'),
+  // Space-delimited per RFC 6749 §3.3, and REQUIRED here even though the RFC
+  // permits omission: this server has no default scope, so "no scope" can
+  // only mean an under-specified request, never a full grant.
+  scope: z.string().min(1),
+})
+
+const authorizeScopesSchema = z.array(z.enum(AUTH_SCOPES)).min(1)
+
+// RFC 6749 §4.1.2.1 error codes this endpoint can deliver to a *validated*
+// redirect_uri. Codes about the client's or redirect_uri's own validity are
+// absent by construction — those never redirect.
+type AuthorizeRedirectError = 'invalid_request' | 'unsupported_response_type' | 'invalid_scope'
+
+// RFC 6749 §3.3: scope is a space-delimited list. Splitting on general
+// whitespace (rather than a single space) tolerates a client that
+// double-encodes or joins with a tab without widening what is *accepted* —
+// every token is still checked against the vocabulary.
+function parseScopes(rawScope: string): readonly AuthScope[] | null {
+  const tokens = rawScope.split(/\s+/).filter((token) => token.length > 0)
+  const parsed = authorizeScopesSchema.safeParse(tokens)
+  return parsed.success ? parsed.data : null
+}
+
+// The /authorize URL carries `state` and `code_challenge`, and the approval
+// page is a security decision surface:
+// - `no-store` keeps the approval screen and the redirect response (which
+//   carries the authorization code in its Location) out of shared caches.
+// - `no-referrer` stops the query string — state, code_challenge — from
+//   leaking to any origin the page might reach.
+// - DENY + `frame-ancestors 'none'` stop a clickjacked approval: the user
+//   must see this page to click Approve on it.
+// - `default-src 'none'` matches a page that loads nothing at all and has no
+//   inline script; `form-action` is deliberately omitted, since the approval
+//   POST's response is a cross-origin redirect to the client's callback.
+const AUTHORIZE_SECURITY_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Referrer-Policy': 'no-referrer',
+  'X-Frame-Options': 'DENY',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+} as const
+
+// Scoped to /authorize so it is never attached to any other request. The
+// value is the transaction's csrfToken; the approval form echoes the same
+// value in a hidden field, and both must match what the store bound at
+// creation (double submit). SameSite=Strict keeps it off any cross-site
+// navigation, so a POST driven from another origin arrives with no cookie
+// at all and fails the check even before the form field is inspected.
+const APPROVAL_COOKIE_NAME = 'whiteboard_oauth_approval'
+const APPROVAL_COOKIE_PATH = OAUTH_AUTHORIZE_PATH
+
+function isSecureRequest(c: Context): boolean {
+  return new URL(c.req.url).protocol === 'https:'
+}
+
+function htmlResponse(c: Context, body: string, status: 200 | 400 | 403 | 429) {
+  return c.html(body, status, AUTHORIZE_SECURITY_HEADERS)
+}
+
+function errorPage(c: Context, reason: AuthorizeErrorReason, status: 400 | 403 | 429) {
+  return htmlResponse(c, renderAuthorizeErrorPage(reason), status)
+}
+
+// RFC 6749 §4.1.2 / §4.1.2.1: the authorization response — success or error —
+// is delivered as query parameters appended to the (registered) redirect_uri,
+// and `state` is echoed back verbatim so the client can match the response to
+// its own request.
+function redirectToClient(
+  c: Context,
+  redirectUri: string,
+  params: Record<string, string>,
+  status: 302 | 303,
+) {
+  const target = new URL(redirectUri)
+  for (const [key, value] of Object.entries(params)) {
+    target.searchParams.set(key, value)
+  }
+  return c.redirect(target.toString(), status)
+}
+
+// A form POST from the approval page is same-origin. Both signals are checked
+// because neither alone is universally present: `Sec-Fetch-Site` is absent on
+// older browsers, and `Origin` is what remains. Absence of both is treated as
+// same-site — the double-submit CSRF binding, not this check, is the load
+// bearing defense; this is defense in depth over it.
+function isCrossSiteRequest(c: Context): boolean {
+  const fetchSite = c.req.header('sec-fetch-site')
+  if (fetchSite !== undefined && fetchSite !== 'same-origin' && fetchSite !== 'none') return true
+  const origin = c.req.header('origin')
+  if (origin !== undefined && origin !== new URL(c.req.url).origin) return true
+  return false
+}
+
+const decisionFormSchema = z.object({
+  transaction_id: z.string().min(1),
+  csrf_token: z.string().min(1),
+  decision: z.enum(['approve', 'deny']),
+})
+
 export interface OAuthAuthzRouterOptions {
   store: OAuthTransactionStore
   registry: OAuthClientRegistry
@@ -108,6 +248,149 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
 
   app.get(AUTHORIZATION_SERVER_METADATA_PATH, (c) => {
     return c.json(buildOAuthAuthorizationServerMetadata(c.req.url, AUTH_SCOPES))
+  })
+
+  app.get(OAUTH_AUTHORIZE_PATH, (c) => {
+    const query = c.req.query()
+    const clientId = query.client_id ?? ''
+    const redirectUri = query.redirect_uri ?? ''
+
+    // Registry check FIRST, and locally rendered on failure. An unregistered
+    // client_id or a redirect_uri that is not a byte-for-byte match of a
+    // registered one must never produce a Location header: sending an OAuth
+    // error to an unverified redirect_uri *is* an open redirect, and the
+    // error parameters would be attacker-chosen bait on top of it.
+    const knownClient = options.registry.some((entry) => entry.clientId === clientId)
+    if (!knownClient) return errorPage(c, 'unknown_client', 400)
+    if (!isRegisteredRedirectUri(options.registry, clientId, redirectUri)) {
+      return errorPage(c, 'redirect_uri_mismatch', 400)
+    }
+
+    // Past this line the redirect_uri is trusted, so RFC 6749 §4.1.2.1
+    // error redirects are safe.
+    const parsed = authorizeQuerySchema.safeParse(query)
+    if (!parsed.success) {
+      const failedKeys = new Set(parsed.error.issues.map((issue) => issue.path[0]))
+      const error: AuthorizeRedirectError = failedKeys.has('response_type')
+        ? 'unsupported_response_type'
+        : failedKeys.has('scope')
+          ? 'invalid_scope'
+          : 'invalid_request'
+      // `state` may itself be the missing parameter; echo it only when the
+      // client actually sent one.
+      const state = query.state
+      return redirectToClient(c, redirectUri, state ? { error, state } : { error }, 302)
+    }
+
+    const scopes = parseScopes(parsed.data.scope)
+    if (!scopes) {
+      return redirectToClient(
+        c,
+        redirectUri,
+        { error: 'invalid_scope', state: parsed.data.state },
+        302,
+      )
+    }
+
+    if (!options.store.recordAuthorizeAttempt(clientId)) {
+      return errorPage(c, 'rate_limited', 429)
+    }
+
+    // Minted here, never accepted from the request and never placed in a URL:
+    // a CSRF token that travels in the query string is readable from the
+    // Referer, browser history, and any logging proxy, which would make the
+    // double-submit check a formality.
+    const csrfToken = randomBytes(32).toString('base64url')
+    const { transactionId } = options.store.createTransaction({
+      clientId,
+      redirectUri,
+      scopes: [...scopes],
+      state: parsed.data.state,
+      codeChallenge: parsed.data.code_challenge,
+      codeChallengeMethod: parsed.data.code_challenge_method,
+      csrfToken,
+    })
+
+    const view = options.store.getTransactionForApproval(transactionId)
+    if (!view) return errorPage(c, 'transaction_not_found', 400)
+
+    setCookie(c, APPROVAL_COOKIE_NAME, csrfToken, {
+      httpOnly: true,
+      sameSite: 'Strict',
+      path: APPROVAL_COOKIE_PATH,
+      // Only over TLS: a Secure cookie on a plain-http loopback daemon would
+      // never be sent back, breaking the flow the operator is running.
+      secure: isSecureRequest(c),
+    })
+    return htmlResponse(c, renderApprovalPage({ transactionId, csrfToken, view }), 200)
+  })
+
+  app.post(OAUTH_AUTHORIZE_DECISION_PATH, async (c) => {
+    if (isCrossSiteRequest(c)) return errorPage(c, 'csrf_check_failed', 403)
+
+    const form = decisionFormSchema.safeParse(
+      Object.fromEntries(new URLSearchParams(await c.req.text()).entries()),
+    )
+    if (!form.success) return errorPage(c, 'csrf_check_failed', 403)
+    const { transaction_id: transactionId, csrf_token: formCsrfToken, decision } = form.data
+
+    const cookieCsrfToken = getCookie(c, APPROVAL_COOKIE_NAME)
+    if (!cookieCsrfToken) return errorPage(c, 'csrf_check_failed', 403)
+
+    // Read the redirect target while the transaction is still pending — after
+    // approve/deny it is no longer readable, and a missing one here is also
+    // how a restarted daemon (in-memory store) surfaces to the user.
+    const target = options.store.getTransactionRedirect(transactionId)
+    if (!target) return errorPage(c, 'transaction_not_found', 400)
+
+    // Double submit: the cookie AND the form field must each be the value the
+    // store bound to this transaction. Possession of a transaction id alone
+    // authorizes nothing.
+    const bound =
+      options.store.verifyApprovalBinding(transactionId, cookieCsrfToken) &&
+      options.store.verifyApprovalBinding(transactionId, formCsrfToken)
+    if (!bound) return errorPage(c, 'csrf_check_failed', 403)
+
+    // Re-check the stored redirect_uri against the registry rather than
+    // trusting that the GET validated it: an operator can remove a client
+    // between the two requests, and this is the last point before a Location
+    // header is emitted.
+    if (!isRegisteredRedirectUri(options.registry, target.clientId, target.redirectUri)) {
+      return errorPage(c, 'redirect_uri_mismatch', 400)
+    }
+
+    // The approval session is spent either way — a decided transaction can
+    // never be decided again, so leaving its cookie on the browser only keeps
+    // a live secret around.
+    deleteCookie(c, APPROVAL_COOKIE_NAME, { path: APPROVAL_COOKIE_PATH })
+
+    if (decision === 'deny') {
+      options.store.denyTransaction(transactionId)
+      return redirectToClient(
+        c,
+        target.redirectUri,
+        { error: 'access_denied', state: target.state },
+        303,
+      )
+    }
+
+    if (!options.store.approveTransaction(transactionId)) {
+      return errorPage(c, 'transaction_not_found', 400)
+    }
+    const issued = options.store.issueAuthorizationCode(transactionId)
+    if (!issued) return errorPage(c, 'transaction_not_found', 400)
+
+    const response = redirectToClient(
+      c,
+      target.redirectUri,
+      { code: issued.code, state: target.state },
+      303,
+    )
+    // The Location header of this response carries the authorization code.
+    for (const [header, value] of Object.entries(AUTHORIZE_SECURITY_HEADERS)) {
+      response.headers.set(header, value)
+    }
+    return response
   })
 
   app.post(OAUTH_TOKEN_PATH, async (c) => {

--- a/packages/mcp-server/src/server/routes/oauth-authz.ts
+++ b/packages/mcp-server/src/server/routes/oauth-authz.ts
@@ -170,12 +170,17 @@ function parseScopes(rawScope: string): readonly AuthScope[] | null {
 // - `default-src 'none'` matches a page that loads nothing at all and has no
 //   inline script; `form-action` is deliberately omitted, since the approval
 //   POST's response is a cross-origin redirect to the client's callback.
-const AUTHORIZE_SECURITY_HEADERS = {
-  'Cache-Control': 'no-store',
-  'Referrer-Policy': 'no-referrer',
-  'X-Frame-Options': 'DENY',
-  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
-} as const
+// The single inline <style> is admitted by a per-response nonce rather than
+// `style-src 'unsafe-inline'`: the grant then covers exactly the stylesheet
+// this response carries, and nothing an injection could add to it.
+function authorizeSecurityHeaders(styleNonce: string) {
+  return {
+    'Cache-Control': 'no-store',
+    'Referrer-Policy': 'no-referrer',
+    'X-Frame-Options': 'DENY',
+    'Content-Security-Policy': `default-src 'none'; style-src 'nonce-${styleNonce}'; frame-ancestors 'none'; base-uri 'none'`,
+  }
+}
 
 // Scoped to /authorize so it is never attached to any other request. The
 // value is the transaction's csrfToken; the approval form echoes the same
@@ -190,12 +195,21 @@ function isSecureRequest(c: Context): boolean {
   return new URL(c.req.url).protocol === 'https:'
 }
 
-function htmlResponse(c: Context, body: string, status: 200 | 400 | 403 | 429) {
-  return c.html(body, status, AUTHORIZE_SECURITY_HEADERS)
+function newStyleNonce(): string {
+  return randomBytes(16).toString('base64')
+}
+
+function htmlResponse(
+  c: Context,
+  render: (styleNonce: string) => string,
+  status: 200 | 400 | 403 | 429,
+) {
+  const styleNonce = newStyleNonce()
+  return c.html(render(styleNonce), status, authorizeSecurityHeaders(styleNonce))
 }
 
 function errorPage(c: Context, reason: AuthorizeErrorReason, status: 400 | 403 | 429) {
-  return htmlResponse(c, renderAuthorizeErrorPage(reason), status)
+  return htmlResponse(c, (styleNonce) => renderAuthorizeErrorPage(reason, styleNonce), status)
 }
 
 // RFC 6749 §4.1.2 / §4.1.2.1: the authorization response — success or error —
@@ -322,7 +336,11 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
       // never be sent back, breaking the flow the operator is running.
       secure: isSecureRequest(c),
     })
-    return htmlResponse(c, renderApprovalPage({ transactionId, csrfToken, view }), 200)
+    return htmlResponse(
+      c,
+      (styleNonce) => renderApprovalPage({ transactionId, csrfToken, view, styleNonce }),
+      200,
+    )
   })
 
   app.post(OAUTH_AUTHORIZE_DECISION_PATH, async (c) => {
@@ -386,10 +404,12 @@ export function createOAuthAuthzRouter(options: OAuthAuthzRouterOptions) {
       { code: issued.code, state: target.state },
       303,
     )
-    // The Location header of this response carries the authorization code.
-    for (const [header, value] of Object.entries(AUTHORIZE_SECURITY_HEADERS)) {
-      response.headers.set(header, value)
-    }
+    // The Location header of this response carries the authorization code, so
+    // it must not be cached, and no-referrer keeps the /authorize URL (with
+    // its state and code_challenge) out of the callback's Referer. A CSP is
+    // meaningless on a redirect with no body, so none is set here.
+    response.headers.set('Cache-Control', 'no-store')
+    response.headers.set('Referrer-Policy', 'no-referrer')
     return response
   })
 

--- a/packages/mcp-server/src/server/security/auth-strategy.test.ts
+++ b/packages/mcp-server/src/server/security/auth-strategy.test.ts
@@ -1,12 +1,24 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import {
+  ALL_AUTH_SCOPES,
+  AUTH_SCOPES,
   type AuthAuthorizeInput,
   type AuthDecision,
   type AuthStrategy,
   createAuthStrategyMiddleware,
   createLocalTokenAuthStrategy,
 } from './auth-strategy.js'
+
+describe('ALL_AUTH_SCOPES', () => {
+  // ALL_AUTH_SCOPES is handed out wholesale on every accepted WS upgrade.
+  // It must always cover exactly the AUTH_SCOPES vocabulary — not a
+  // hand-copied literal that can silently drift (under- or over-grant)
+  // when a scope is added to one list and forgotten in the other.
+  it('contains exactly the same scopes as AUTH_SCOPES, no more and no less', () => {
+    expect(new Set(ALL_AUTH_SCOPES)).toEqual(new Set(AUTH_SCOPES))
+  })
+})
 
 describe('createLocalTokenAuthStrategy', () => {
   // Behavior parity with the legacy `isAuthorized()` rule in

--- a/packages/mcp-server/src/server/security/auth-strategy.ts
+++ b/packages/mcp-server/src/server/security/auth-strategy.ts
@@ -52,23 +52,11 @@ export type AuthScope = (typeof AUTH_SCOPES)[number]
 
 // The full grant set a single-tenant local-token session holds today (see
 // `createLocalTokenAuthStrategy` below: the success path ignores
-// `requiredScopes` entirely). Kept as one literal array so every call site
-// that needs to express "this credential can do anything" — the WS upgrade
-// grant included — derives it from the same list instead of re-typing the
-// scope vocabulary and silently drifting from it.
-export const ALL_AUTH_SCOPES: readonly AuthScope[] = [
-  'canvas:read',
-  'canvas:write',
-  'workspace:read',
-  'workspace:write',
-  'versions:read',
-  'versions:write',
-  'files:read',
-  'files:write',
-  'runtime:read',
-  'runtime:admin',
-  'mcp:call',
-]
+// `requiredScopes` entirely). Derived directly from `AUTH_SCOPES` — the WS
+// upgrade "full grant" set that every call site expressing "this credential
+// can do anything" reads from — so adding a scope to the vocabulary can
+// never leave this grant set silently under-provisioned.
+export const ALL_AUTH_SCOPES: readonly AuthScope[] = AUTH_SCOPES
 
 export type AuthContext =
   | { kind: 'anonymous' }

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
@@ -14,8 +14,9 @@ describe('expired-entry pruning', () => {
       state: 's',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
-    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
 
     clock += TRANSACTION_TTL_MS + 1
     store.createTransaction({
@@ -25,11 +26,12 @@ describe('expired-entry pruning', () => {
       state: 's2',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
 
     // The first transaction is gone, not merely unusable: a long-lived daemon
     // must not accumulate one record per abandoned/attacker-driven attempt.
-    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
   })
 
   it('reclaims the code-hash index entry of an expired code-issued transaction', () => {
@@ -42,10 +44,11 @@ describe('expired-entry pruning', () => {
       state: 's',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
     store.approveTransaction(transactionId)
     expect(store.issueAuthorizationCode(transactionId)).not.toBeNull()
-    expect(store.size()).toEqual({ transactions: 1, codes: 1 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 1, attempts: 0 })
 
     clock += TRANSACTION_TTL_MS + 1
     store.createTransaction({
@@ -55,9 +58,10 @@ describe('expired-entry pruning', () => {
       state: 's2',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
 
-    expect(store.size()).toEqual({ transactions: 1, codes: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
   })
 
   it('reclaims a redeemed transaction once its window has passed', () => {
@@ -70,6 +74,7 @@ describe('expired-entry pruning', () => {
       state: 's',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
     store.approveTransaction(transactionId)
     const issued = store.issueAuthorizationCode(transactionId)
@@ -90,6 +95,7 @@ describe('expired-entry pruning', () => {
       state: 's2',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      csrfToken: 'csrf-token',
     })
     expect(store.size().transactions).toBe(1)
   })
@@ -102,6 +108,7 @@ const baseInput = {
   state: 'client-supplied-state-value',
   codeChallenge: 'test-challenge-does-not-need-to-be-real-for-creation',
   codeChallengeMethod: 'S256' as const,
+  csrfToken: 'csrf-token-for-approval-binding',
 }
 
 // A real S256 PKCE pair: challenge = base64url(sha256(verifier)).
@@ -327,5 +334,135 @@ describe('createOAuthTransactionStore', () => {
     expect(minted.accessToken).toEqual(expect.any(String))
     expect(minted.accessToken.length).toBeGreaterThan(20)
     expect(minted.expiresIn).toBeGreaterThan(0)
+  })
+
+  it('rejects creation with a missing or empty csrfToken at the Zod boundary', () => {
+    const store = createOAuthTransactionStore()
+    expect(() => store.createTransaction({ ...baseInput, csrfToken: '' })).toThrow()
+    const { csrfToken, ...withoutCsrfToken } = baseInput
+    expect(() =>
+      store.createTransaction(
+        withoutCsrfToken as unknown as Parameters<typeof store.createTransaction>[0],
+      ),
+    ).toThrow()
+  })
+})
+
+describe('verifyApprovalBinding', () => {
+  it('returns true only for the exact csrfToken bound to the transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = store.createTransaction(baseInput)
+    expect(store.verifyApprovalBinding(transactionId, baseInput.csrfToken)).toBe(true)
+    expect(store.verifyApprovalBinding(transactionId, 'wrong-token')).toBe(false)
+  })
+
+  it('returns false for an unknown transaction id', () => {
+    const store = createOAuthTransactionStore()
+    expect(store.verifyApprovalBinding('never-created', 'anything')).toBe(false)
+  })
+})
+
+describe('denyTransaction', () => {
+  it('moves a pending transaction to denied, closing off approval and code issuance', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = store.createTransaction(baseInput)
+    expect(store.denyTransaction(transactionId)).toBe(true)
+    expect(store.approveTransaction(transactionId)).toBe(false)
+    expect(store.issueAuthorizationCode(transactionId)).toBeNull()
+  })
+
+  it('returns false for an unknown transaction id', () => {
+    const store = createOAuthTransactionStore()
+    expect(store.denyTransaction('never-created')).toBe(false)
+  })
+})
+
+describe('issueAuthorizationCode single-issuance', () => {
+  it('returns null for a second issuance attempt on an already code-issued transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = store.createTransaction(baseInput)
+    store.approveTransaction(transactionId)
+    expect(store.issueAuthorizationCode(transactionId)).not.toBeNull()
+    expect(store.issueAuthorizationCode(transactionId)).toBeNull()
+  })
+})
+
+describe('getTransactionForApproval', () => {
+  it('returns an approval view for a pending, unexpired transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId, expiresAt } = store.createTransaction(baseInput)
+    expect(store.getTransactionForApproval(transactionId)).toEqual({
+      clientId: baseInput.clientId,
+      redirectUri: baseInput.redirectUri,
+      scopes: baseInput.scopes,
+      status: 'pending',
+      expiresAt,
+    })
+  })
+
+  it('returns null once the transaction has been denied', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = store.createTransaction(baseInput)
+    store.denyTransaction(transactionId)
+    expect(store.getTransactionForApproval(transactionId)).toBeNull()
+  })
+
+  it('returns null once a code has been issued for the transaction', () => {
+    const store = createOAuthTransactionStore()
+    const { transactionId } = createApprovedCodeIssuedTransaction(store)
+    expect(store.getTransactionForApproval(transactionId)).toBeNull()
+  })
+
+  it('returns null once the transaction has expired', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { transactionId } = store.createTransaction(baseInput)
+    clock += 5 * 60_000 + 1
+    expect(store.getTransactionForApproval(transactionId)).toBeNull()
+  })
+
+  it('returns null for an unknown transaction id', () => {
+    const store = createOAuthTransactionStore()
+    expect(store.getTransactionForApproval('never-created')).toBeNull()
+  })
+})
+
+describe('authorize attempt rate limiting', () => {
+  const RATE_LIMIT_MAX_ATTEMPTS = 10
+  const RATE_LIMIT_WINDOW_MS = 60_000
+
+  it('blocks the Nth+1 attempt in-window for the same client and recovers after the window passes', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    for (let i = 0; i < RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      expect(store.recordAuthorizeAttempt('client-a')).toBe(true)
+    }
+    expect(store.recordAuthorizeAttempt('client-a')).toBe(false)
+
+    clock += RATE_LIMIT_WINDOW_MS + 1
+    expect(store.recordAuthorizeAttempt('client-a')).toBe(true)
+  })
+
+  it('tracks each client independently', () => {
+    const store = createOAuthTransactionStore()
+    for (let i = 0; i < RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      expect(store.recordAuthorizeAttempt('client-a')).toBe(true)
+    }
+    expect(store.recordAuthorizeAttempt('client-a')).toBe(false)
+    expect(store.recordAuthorizeAttempt('client-b')).toBe(true)
+  })
+
+  it('keeps the attempt-tracking map bounded once a client-window has fully elapsed', () => {
+    let clock = 1_000_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    store.recordAuthorizeAttempt('client-a')
+    expect(store.size().attempts).toBe(1)
+
+    clock += RATE_LIMIT_WINDOW_MS + 1
+    // A prune only ever runs on a write for this client (or another one) — a
+    // fresh attempt from a different client must not resurrect client-a's
+    // stale entry.
+    store.recordAuthorizeAttempt('client-b')
+    expect(store.size().attempts).toBe(1)
   })
 })

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -31,6 +31,13 @@ const CODE_TTL_MS = 60_000
 // designed in ADR-0005 but is explicitly out of scope for this slice.
 const ACCESS_TOKEN_TTL_SECONDS = 15 * 60
 
+// Bounds for the per-client /authorize attempt counter (slice B's rate
+// limit on the GET before a transaction even exists). Values are
+// deliberately generous for a human clicking through a consent screen,
+// not tuned against a specific attacker model.
+const RATE_LIMIT_MAX_ATTEMPTS = 10
+const RATE_LIMIT_WINDOW_MS = 60_000
+
 const createTransactionInputSchema = z.object({
   clientId: z.string().min(1),
   redirectUri: z.string().min(1),
@@ -42,6 +49,11 @@ const createTransactionInputSchema = z.object({
   state: z.string().min(1),
   codeChallenge: z.string().min(1),
   codeChallengeMethod: z.literal('S256'),
+  // Double-submit CSRF binding for the approval POST (ADR-0005: "possession
+  // of a transaction id must not authorize a cross-site POST"). The route
+  // generates this value and never places it in a URL; the approval form
+  // must echo it back alongside a matching cookie.
+  csrfToken: z.string().min(1),
 })
 
 export type CreateTransactionInput = z.infer<typeof createTransactionInputSchema>
@@ -62,12 +74,23 @@ interface TransactionRecord {
   state: string
   codeChallenge: string
   codeChallengeMethod: 'S256'
+  csrfToken: string
   status: TransactionStatus
   createdAt: number
   expiresAt: number
   codeHash?: string
   codeExpiresAt?: number
 }
+
+const approvalViewSchema = z.object({
+  clientId: z.string().min(1),
+  redirectUri: z.string().min(1),
+  scopes: z.array(z.enum(AUTH_SCOPES)),
+  status: z.literal('pending'),
+  expiresAt: z.number(),
+})
+
+export type ApprovalView = z.infer<typeof approvalViewSchema>
 
 export type RedeemAuthorizationCodeInput = {
   code: string
@@ -105,15 +128,28 @@ function verifyPkce(codeChallenge: string, codeVerifier: string): boolean {
 export interface OAuthTransactionStore {
   createTransaction(input: CreateTransactionInput): { transactionId: string; expiresAt: number }
   approveTransaction(transactionId: string): boolean
+  denyTransaction(transactionId: string): boolean
   issueAuthorizationCode(transactionId: string): { code: string } | null
   redeemAuthorizationCode(input: RedeemAuthorizationCodeInput): RedeemAuthorizationCodeResult
   mintAccessToken(
     scopes: readonly AuthScope[],
     clientId: string,
   ): { accessToken: string; expiresIn: number }
+  // Constant-time check that a submitted csrfToken is the one bound to the
+  // transaction at creation. Mirrors verifyPkce's approach below.
+  verifyApprovalBinding(transactionId: string, csrfToken: string): boolean
+  // Read accessor for the approval screen. Deliberately narrower than
+  // TransactionRecord: no state/codeChallenge/csrfToken/codeHash leak into
+  // rendered HTML, and only a 'pending', unexpired transaction is
+  // renderable at all — a screen cannot outlive its transaction.
+  getTransactionForApproval(transactionId: string): ApprovalView | null
+  // Per-client sliding-window limiter for GET /authorize, gating attempts
+  // before a transaction exists at all. Returns true when the attempt is
+  // allowed (and is recorded), false when the client is over the limit.
+  recordAuthorizeAttempt(clientId: string): boolean
   // Live entry counts. The store's only unbounded-growth risk is retained
   // dead records, so its occupancy has to be observable to be assertable.
-  size(): { transactions: number; codes: number }
+  size(): { transactions: number; codes: number; attempts: number }
 }
 
 export function createOAuthTransactionStore(options?: {
@@ -125,6 +161,10 @@ export function createOAuthTransactionStore(options?: {
   // every pending transaction to find a match — and so the raw code is
   // never the map key either; only its hash ever lives in memory.
   const codeHashIndex = new Map<string, string>()
+  // Per-client sliding window of attempt timestamps for the /authorize
+  // rate limit. Pruned lazily on every write, same posture as
+  // pruneExpired, so it never needs a timer handle.
+  const authorizeAttempts = new Map<string, number[]>()
 
   // Lazy sweep, not a timer. A `setInterval` would keep the Node event loop
   // alive for the daemon's whole lifetime and would have to be torn down by
@@ -158,6 +198,7 @@ export function createOAuthTransactionStore(options?: {
       state: parsed.state,
       codeChallenge: parsed.codeChallenge,
       codeChallengeMethod: parsed.codeChallengeMethod,
+      csrfToken: parsed.csrfToken,
       status: 'pending',
       createdAt,
       expiresAt,
@@ -169,6 +210,54 @@ export function createOAuthTransactionStore(options?: {
     const record = transactions.get(transactionId)
     if (!record || record.status !== 'pending' || record.expiresAt < now()) return false
     transactions.set(transactionId, { ...record, status: 'approved' })
+    return true
+  }
+
+  function denyTransaction(transactionId: string): boolean {
+    const record = transactions.get(transactionId)
+    if (!record || record.status !== 'pending' || record.expiresAt < now()) return false
+    transactions.set(transactionId, { ...record, status: 'denied' })
+    return true
+  }
+
+  function verifyApprovalBinding(transactionId: string, csrfToken: string): boolean {
+    const record = transactions.get(transactionId)
+    if (!record) return false
+    const computed = Buffer.from(csrfToken)
+    const expected = Buffer.from(record.csrfToken)
+    if (computed.length !== expected.length) return false
+    return timingSafeEqual(computed, expected)
+  }
+
+  function getTransactionForApproval(transactionId: string): ApprovalView | null {
+    const record = transactions.get(transactionId)
+    if (!record || record.status !== 'pending' || record.expiresAt < now()) return null
+    return {
+      clientId: record.clientId,
+      redirectUri: record.redirectUri,
+      scopes: [...record.scopes],
+      status: 'pending',
+      expiresAt: record.expiresAt,
+    }
+  }
+
+  function recordAuthorizeAttempt(clientId: string): boolean {
+    const cutoff = now() - RATE_LIMIT_WINDOW_MS
+    // Prune every client's window on each call, not just the current
+    // client's, so an abandoned client's entry does not linger forever
+    // just because nobody ever calls this again with its id.
+    for (const [id, timestamps] of authorizeAttempts) {
+      const live = timestamps.filter((t) => t > cutoff)
+      if (live.length === 0) {
+        authorizeAttempts.delete(id)
+      } else if (live.length !== timestamps.length) {
+        authorizeAttempts.set(id, live)
+      }
+    }
+
+    const existing = authorizeAttempts.get(clientId) ?? []
+    if (existing.length >= RATE_LIMIT_MAX_ATTEMPTS) return false
+    authorizeAttempts.set(clientId, [...existing, now()])
     return true
   }
 
@@ -245,16 +334,24 @@ export function createOAuthTransactionStore(options?: {
     return { accessToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
   }
 
-  function size(): { transactions: number; codes: number } {
-    return { transactions: transactions.size, codes: codeHashIndex.size }
+  function size(): { transactions: number; codes: number; attempts: number } {
+    return {
+      transactions: transactions.size,
+      codes: codeHashIndex.size,
+      attempts: authorizeAttempts.size,
+    }
   }
 
   return {
     createTransaction,
     approveTransaction,
+    denyTransaction,
     issueAuthorizationCode,
     redeemAuthorizationCode,
     mintAccessToken,
+    verifyApprovalBinding,
+    getTransactionForApproval,
+    recordAuthorizeAttempt,
     size,
   }
 }

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -92,6 +92,14 @@ const approvalViewSchema = z.object({
 
 export type ApprovalView = z.infer<typeof approvalViewSchema>
 
+const redirectTargetSchema = z.object({
+  clientId: z.string().min(1),
+  redirectUri: z.string().min(1),
+  state: z.string().min(1),
+})
+
+export type RedirectTarget = z.infer<typeof redirectTargetSchema>
+
 export type RedeemAuthorizationCodeInput = {
   code: string
   clientId: string
@@ -148,6 +156,14 @@ export interface OAuthTransactionStore {
   // rendered HTML, and only a 'pending', unexpired transaction is
   // renderable at all — a screen cannot outlive its transaction.
   getTransactionForApproval(transactionId: string): ApprovalView | null
+  // Where an authorization response for this transaction may be delivered,
+  // and the `state` RFC 6749 §4.1.2 requires it to echo. Separate from
+  // ApprovalView because that view feeds the rendered HTML and must not
+  // carry `state`; this one feeds only a Location header. Pending-only, so
+  // the decision route must read it *before* it approves or denies — a
+  // transaction that has already been decided has no further response to
+  // deliver.
+  getTransactionRedirect(transactionId: string): RedirectTarget | null
   // Per-client sliding-window limiter for GET /authorize, gating attempts
   // before a transaction exists at all. Returns true when the attempt is
   // allowed (and is recorded), false when the client is over the limit.
@@ -251,6 +267,12 @@ export function createOAuthTransactionStore(options?: {
       status: 'pending',
       expiresAt: record.expiresAt,
     }
+  }
+
+  function getTransactionRedirect(transactionId: string): RedirectTarget | null {
+    const record = getPendingTransaction(transactionId)
+    if (!record) return null
+    return { clientId: record.clientId, redirectUri: record.redirectUri, state: record.state }
   }
 
   function recordAuthorizeAttempt(clientId: string): boolean {
@@ -364,6 +386,7 @@ export function createOAuthTransactionStore(options?: {
     mintAccessToken,
     verifyApprovalBinding,
     getTransactionForApproval,
+    getTransactionRedirect,
     recordAuthorizeAttempt,
     size,
   }

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -114,15 +114,20 @@ function hashCode(rawCode: string): string {
   return createHash('sha256').update(rawCode).digest('hex')
 }
 
+// Compare two secrets without leaking, through timing, how much of the
+// value matched. timingSafeEqual throws on a length mismatch, so unequal
+// lengths are rejected up front — a length difference is not itself secret.
+function secretsMatch(actual: string, expected: string): boolean {
+  const actualBytes = Buffer.from(actual)
+  const expectedBytes = Buffer.from(expected)
+  if (actualBytes.length !== expectedBytes.length) return false
+  return timingSafeEqual(actualBytes, expectedBytes)
+}
+
 // S256 per RFC 7636 §4.2: challenge = BASE64URL-ENCODE(SHA256(verifier)).
-// A verifier-mismatch must not leak timing information about how much of
-// the challenge matched, hence timingSafeEqual over the raw hash bytes.
 function verifyPkce(codeChallenge: string, codeVerifier: string): boolean {
   const computedChallenge = createHash('sha256').update(codeVerifier).digest('base64url')
-  const computed = Buffer.from(computedChallenge)
-  const expected = Buffer.from(codeChallenge)
-  if (computed.length !== expected.length) return false
-  return timingSafeEqual(computed, expected)
+  return secretsMatch(computedChallenge, codeChallenge)
 }
 
 export interface OAuthTransactionStore {
@@ -136,7 +141,7 @@ export interface OAuthTransactionStore {
     clientId: string,
   ): { accessToken: string; expiresIn: number }
   // Constant-time check that a submitted csrfToken is the one bound to the
-  // transaction at creation. Mirrors verifyPkce's approach below.
+  // transaction at creation.
   verifyApprovalBinding(transactionId: string, csrfToken: string): boolean
   // Read accessor for the approval screen. Deliberately narrower than
   // TransactionRecord: no state/codeChallenge/csrfToken/codeHash leak into
@@ -206,32 +211,39 @@ export function createOAuthTransactionStore(options?: {
     return { transactionId: id, expiresAt }
   }
 
-  function approveTransaction(transactionId: string): boolean {
+  // The only state a transaction can still be approved, denied, or rendered
+  // from. Every caller below re-checks expiry here rather than trusting
+  // pruneExpired to have run.
+  function getPendingTransaction(transactionId: string): TransactionRecord | null {
     const record = transactions.get(transactionId)
-    if (!record || record.status !== 'pending' || record.expiresAt < now()) return false
-    transactions.set(transactionId, { ...record, status: 'approved' })
+    if (!record || record.status !== 'pending' || record.expiresAt < now()) return null
+    return record
+  }
+
+  function decidePendingTransaction(transactionId: string, status: 'approved' | 'denied'): boolean {
+    const record = getPendingTransaction(transactionId)
+    if (!record) return false
+    transactions.set(transactionId, { ...record, status })
     return true
   }
 
+  function approveTransaction(transactionId: string): boolean {
+    return decidePendingTransaction(transactionId, 'approved')
+  }
+
   function denyTransaction(transactionId: string): boolean {
-    const record = transactions.get(transactionId)
-    if (!record || record.status !== 'pending' || record.expiresAt < now()) return false
-    transactions.set(transactionId, { ...record, status: 'denied' })
-    return true
+    return decidePendingTransaction(transactionId, 'denied')
   }
 
   function verifyApprovalBinding(transactionId: string, csrfToken: string): boolean {
     const record = transactions.get(transactionId)
     if (!record) return false
-    const computed = Buffer.from(csrfToken)
-    const expected = Buffer.from(record.csrfToken)
-    if (computed.length !== expected.length) return false
-    return timingSafeEqual(computed, expected)
+    return secretsMatch(csrfToken, record.csrfToken)
   }
 
   function getTransactionForApproval(transactionId: string): ApprovalView | null {
-    const record = transactions.get(transactionId)
-    if (!record || record.status !== 'pending' || record.expiresAt < now()) return null
+    const record = getPendingTransaction(transactionId)
+    if (!record) return null
     return {
       clientId: record.clientId,
       redirectUri: record.redirectUri,
@@ -242,7 +254,8 @@ export function createOAuthTransactionStore(options?: {
   }
 
   function recordAuthorizeAttempt(clientId: string): boolean {
-    const cutoff = now() - RATE_LIMIT_WINDOW_MS
+    const attemptedAt = now()
+    const cutoff = attemptedAt - RATE_LIMIT_WINDOW_MS
     // Prune every client's window on each call, not just the current
     // client's, so an abandoned client's entry does not linger forever
     // just because nobody ever calls this again with its id.
@@ -257,7 +270,7 @@ export function createOAuthTransactionStore(options?: {
 
     const existing = authorizeAttempts.get(clientId) ?? []
     if (existing.length >= RATE_LIMIT_MAX_ATTEMPTS) return false
-    authorizeAttempts.set(clientId, [...existing, now()])
+    authorizeAttempts.set(clientId, [...existing, attemptedAt])
     return true
   }
 


### PR DESCRIPTION
Closes the last hole in the ADR-0005 authorization server: the metadata document already advertised `authorization_endpoint: /authorize`, but that path 404'd. This builds it, so path 2 of the ADR (hosted origin → local consent → code → token) works end to end.

## What ships

**`GET /authorize`** — validates against the client registry *before* rendering anything. An unregistered `client_id`, or a `redirect_uri` that is not a byte-for-byte match of a registered raw string, renders a local error page and **never emits a `Location` header** (that is how an open redirect is born). PKCE is mandatory: a missing `code_challenge` or a method other than `S256` is refused. Scope is space-delimited and validated against the scope vocabulary; an omitted scope is `invalid_scope`, never a silent full grant. Errors that are safe to hand back to an *already-validated* redirect_uri follow RFC 6749 §4.1.2.1. On success: per-client rate limit, transaction created, CSRF token bound to that transaction (generated server-side, never in a URL), approval-session cookie (HttpOnly, SameSite=Strict, Secure only on https).

**`POST /authorize/decision`** — double-submit CSRF (the cookie *and* the hidden field, both checked against what the store bound at creation, constant-time), plus a cross-site `Origin` / `Sec-Fetch-Site` rejection. Approve issues a single-use code and 303s to the registered redirect_uri with `code`+`state`; deny 303s with `error=access_denied`. A transaction that is missing (the store is in-memory — the daemon may have restarted), already decided, or expired renders an explicit "start again" page: never a code, and never a bare 403 that a user would read as a server bug.

**The consent screen** is treated as a real decision surface, not a debug page. Identity on screen derives **solely** from the registered redirect_uri's origin — never a client-supplied name, never `Origin`/`Referer`. Write-granting scopes are visually distinguished from read-only ones (`read my canvases` and `rewrite my canvases` are not the same decision). Deny holds focus. No client JS. The one stylesheet is admitted by a **per-response nonce**, not `style-src 'unsafe-inline'`, and a test pins the header nonce to the `<style>` nonce — drift would silently render the page unstyled.

## Two real bugs the tests caught

1. **Reflecting CORS would have reached `/authorize`.** The existing `for (const path of OAUTH_AUTHZ_PATHS)` loop attaches `createApiLoopbackCorsMiddleware` to every path in it. Naively appending the two new paths would have reflected `Access-Control-Allow-Origin: <hosted origin>` onto the approval POST — handing the requesting page exactly the cross-site approval this design exists to prevent — **while every existing test still passed**. CORS is now scoped to the metadata docs + `/token` only; mutation-checked (put it back, the regression test goes red).
2. **The baseline security-header pass downgraded the page's CSP.** `setBaselineSecurityHeaders` runs after every route and overwrote the approval page's `default-src 'none'` with the weaker frame-ancestors-only baseline. It is now a floor, not a ceiling.

## Verification

- `pnpm test --project mcp-node` → 217 files, 3277 passed. `pnpm -r typecheck` clean. `pnpm lint:noconsole` clean.
- **Against a real daemon process** (`WHITEBOARD_OAUTH_CLIENT_REGISTRY` set), not just in-process:
  - approve → `303 … /oauth/callback?code=…&state=st1` → form-encoded `/token` → `{"access_token":"…","token_type":"Bearer"}`
  - replayed code → `{"error":"invalid_grant"}`
  - wrong PKCE verifier → `{"error":"invalid_grant"}`
  - unregistered redirect_uri → `400`, **no `Location` header**
  - cross-site decision POST (cookie riding along) → `403`

## Consent screen

![oauth-approval-screen.png](https://github.com/user-attachments/assets/16438464-3c11-4954-9b68-1d1253e0323d)

## Deliberately out of scope

The minted access token still **authorizes nothing**: no resource server validates it yet. `/api/*` and the WebSocket continue to accept only the daemon bearer token. Wiring the token into `oauth-resource-strategy.ts` (and the WS connection ticket) is the next slice — this PR is the human gate, not the enforcement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OAuth authorization approval flow with scope review, approve/deny actions, and secure redirects.
  * Added support for configuring OAuth client registries through an environment setting.
* **Security**
  * Strengthened authorization-page protections, including CSRF validation, secure cookies, rate limiting, clickjacking protection, and stricter content security policies.
  * Improved handling of invalid clients, redirect URIs, scopes, and authorization errors without exposing sensitive information.
* **Bug Fixes**
  * Prevented OAuth approval endpoints from incorrectly enabling cross-origin access or weakening existing security headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->