### PR TITLE
feat(mcp-server): enforce approved OAuth grant scopes on /api/*

### DIFF
--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -413,6 +413,22 @@ export function createApp(options: AppOptions) {
     setBaselineSecurityHeaders(c.res.headers)
   })
 
+  // The hosted-origin OAuth surface is mounted below, but its store has to
+  // exist before the /api/* auth middleware is built: the same store both
+  // mints an access grant (at /token) and is the only thing that can later
+  // recognize the token that grant issued. Two instances would mean tokens
+  // minted by one and unknown to the other.
+  const oauthAuthz =
+    options.authMode === 'local-daemon' &&
+    options.oauthClientRegistry &&
+    options.oauthClientRegistry.length > 0
+      ? {
+          store: createOAuthTransactionStore(),
+          registry: options.oauthClientRegistry,
+          allowedWebOrigins: options.allowedWebOrigins ?? [],
+        }
+      : undefined
+
   if (options.authMode === 'server-mode') {
     app.use('/api/*', createApiHostGuardMiddleware(options.authMode))
     app.use('/api/*', createServerModeApiAuthMiddleware(options.authStrategy))
@@ -428,7 +444,10 @@ export function createApp(options: AppOptions) {
     // while every other method (GET included — see auth.js) falls through to
     // the auth chain unchanged.
     app.use('/api/*', createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
-    app.use('/api/*', createDaemonAuthMiddleware(token))
+    // Either credential: the daemon token (full authority, unchanged) or an
+    // OAuth access token, which is additionally checked against the route's
+    // declared scope. Both fail identically.
+    app.use('/api/*', createDaemonAuthMiddleware(token, oauthAuthz?.store))
   }
 
   // Hosted-origin OAuth 2.1 authorization-server surface (ADR-0005). Local-
@@ -436,15 +455,10 @@ export function createApp(options: AppOptions) {
   // resource-server strategy and is not itself an authorization server.
   // Unmounted entirely unless an operator configures at least one
   // redirect_uri registry entry (empty-by-default, like allowedWebOrigins).
-  if (
-    options.authMode === 'local-daemon' &&
-    options.oauthClientRegistry &&
-    options.oauthClientRegistry.length > 0
-  ) {
-    const oauthTransactionStore = createOAuthTransactionStore()
+  if (oauthAuthz) {
     const oauthAuthzRoutes = createOAuthAuthzRouter({
-      store: oauthTransactionStore,
-      registry: options.oauthClientRegistry,
+      store: oauthAuthz.store,
+      registry: oauthAuthz.registry,
     })
     // Attached per explicit path, NOT via a sub-app: Hono merges a sub-app's
     // `use('*')` into the parent as `/*`, so a sub-app mounted at '/' would
@@ -464,7 +478,7 @@ export function createApp(options: AppOptions) {
     // screen and script its POST cross-site, which is the whole thing the
     // approval step exists to prevent. See oauth-authz.ts.
     for (const path of OAUTH_AUTHZ_CORS_PATHS) {
-      app.use(path, createApiLoopbackCorsMiddleware(options.allowedWebOrigins ?? []))
+      app.use(path, createApiLoopbackCorsMiddleware(oauthAuthz.allowedWebOrigins))
     }
     app.route('/', oauthAuthzRoutes)
   }

--- a/packages/mcp-server/src/server/routes/auth-oauth.test.ts
+++ b/packages/mcp-server/src/server/routes/auth-oauth.test.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { createOAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+import { createDaemonAuthMiddleware } from './auth.js'
+
+const DAEMON_TOKEN = 'daemon-token'
+
+function createApp(grantStore?: ReturnType<typeof createOAuthTransactionStore>) {
+  const app = new Hono()
+  app.use('/api/*', createDaemonAuthMiddleware(DAEMON_TOKEN, grantStore))
+  app.all('/api/*', (c) => c.json({ ok: true }))
+  return app
+}
+
+const READ_PATH = '/api/canvas/session-1/demo/snapshot'
+const WRITE_PATH = '/api/canvas/session-1/demo/update'
+const UNDECLARED_PATH = '/api/not-in-the-registry'
+
+async function request(
+  app: Hono,
+  path: string,
+  method: string,
+  bearer?: string,
+): Promise<Response> {
+  return app.request(path, {
+    method,
+    headers: bearer ? { authorization: `Bearer ${bearer}` } : {},
+  })
+}
+
+describe('createDaemonAuthMiddleware with an OAuth grant store', () => {
+  it('keeps accepting the daemon token with full authority on read and write', async () => {
+    const app = createApp(createOAuthTransactionStore())
+
+    expect((await request(app, READ_PATH, 'GET', DAEMON_TOKEN)).status).toBe(200)
+    expect((await request(app, WRITE_PATH, 'POST', DAEMON_TOKEN)).status).toBe(200)
+  })
+
+  it('accepts an OAuth access token on a route its grant covers', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+
+    expect((await request(createApp(store), READ_PATH, 'GET', accessToken)).status).toBe(200)
+  })
+
+  it('refuses a read-only grant on a write route, indistinguishably from no credential', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    const app = createApp(store)
+
+    const responses = await Promise.all([
+      request(app, WRITE_PATH, 'POST', accessToken),
+      request(app, WRITE_PATH, 'POST'),
+      request(app, WRITE_PATH, 'POST', 'garbage'),
+      request(app, WRITE_PATH, 'POST', 'daemon-token-but-wrong'),
+    ])
+
+    // A caller must not be able to tell an insufficient-scope grant from a
+    // missing credential, a forged bearer, or a wrong daemon token.
+    const observed = await Promise.all(
+      responses.map(async (response) => ({
+        status: response.status,
+        body: await response.json(),
+        challenge: response.headers.get('www-authenticate'),
+      })),
+    )
+    for (const outcome of observed) {
+      expect(outcome).toEqual({ status: 401, body: { error: 'unauthorized' }, challenge: null })
+    }
+  })
+
+  it('accepts a write-scoped grant on the same write route', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read', 'canvas:write'], 'hosted-client')
+
+    expect((await request(createApp(store), WRITE_PATH, 'POST', accessToken)).status).toBe(200)
+  })
+
+  it('refuses an expired grant', async () => {
+    let clock = 1_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { accessToken, expiresIn } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    clock += expiresIn * 1000 + 1
+
+    expect((await request(createApp(store), READ_PATH, 'GET', accessToken)).status).toBe(401)
+  })
+
+  it('refuses a revoked grant', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    store.revokeGrant(store.listGrants('hosted-client')[0].grantId)
+
+    expect((await request(createApp(store), READ_PATH, 'GET', accessToken)).status).toBe(401)
+  })
+
+  it('fails closed on an undeclared /api route even for a fully-scoped grant', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(
+      ['canvas:read', 'canvas:write', 'workspace:read', 'workspace:write'],
+      'hosted-client',
+    )
+    const app = createApp(store)
+
+    expect((await request(app, UNDECLARED_PATH, 'GET', accessToken)).status).toBe(401)
+    // The daemon token is not scope-gated and keeps its unchanged authority.
+    expect((await request(app, UNDECLARED_PATH, 'GET', DAEMON_TOKEN)).status).toBe(200)
+  })
+
+  it('leaves the daemon-token-only wiring (no grant store) unchanged', async () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    const app = createApp()
+
+    expect((await request(app, READ_PATH, 'GET', DAEMON_TOKEN)).status).toBe(200)
+    expect((await request(app, READ_PATH, 'GET', accessToken)).status).toBe(401)
+  })
+
+  it('leaves /api/runtime/ping open', async () => {
+    expect(
+      (await request(createApp(createOAuthTransactionStore()), '/api/runtime/ping', 'GET')).status,
+    ).toBe(200)
+  })
+})

--- a/packages/mcp-server/src/server/routes/auth.ts
+++ b/packages/mcp-server/src/server/routes/auth.ts
@@ -118,7 +118,10 @@ export function createDaemonAuthMiddleware(
     // token whose grant does not cover this route. Distinguishing them —
     // even by status code — would tell an attacker which of the two
     // credentials they are close to holding, and would tell a hostile page
-    // whether a given bearer is a live grant at all.
+    // whether a given bearer is a live grant at all. (The bodies match; a
+    // valid-but-out-of-scope token does run one extra O(1) hash lookup, a
+    // timing delta that only matters if this daemon is ever exposed beyond
+    // loopback — at which point the grant check needs a constant-time floor.)
     return c.json({ error: 'unauthorized' }, 401)
   }
 }

--- a/packages/mcp-server/src/server/routes/auth.ts
+++ b/packages/mcp-server/src/server/routes/auth.ts
@@ -1,5 +1,8 @@
 import type { MiddlewareHandler } from 'hono'
 import { timingSafeEqual } from 'node:crypto'
+import { hasRequiredScopes } from '../security/auth-strategy.js'
+import type { OAuthTransactionStore } from '../security/oauth-authz-transactions.js'
+import { resolveApiRouteScope } from '../security/route-scope-registry.js'
 
 // Timing-safe string comparison. Even length mismatches avoid early return by doing
 // a dummy comparison so timing stays uniform.
@@ -61,14 +64,61 @@ export function requiresDaemonAuth(path: string): boolean {
   return true
 }
 
-export function createDaemonAuthMiddleware(token?: string): MiddlewareHandler {
+// Is this bearer an OAuth access token whose approved grant covers the route
+// being called? Two credentials reach /api/* in local-daemon mode:
+//
+//   - the shared daemon token, which is the machine-local operator's own
+//     credential and carries full authority (it is what the daemon-served app
+//     and the MCP server already hold);
+//   - an OAuth access token from a hosted origin the user explicitly approved
+//     (ADR-0005), which carries ONLY the scopes that approval granted.
+//
+// The second is the one that has to be scope-checked on every request. RFC
+// 6749 §7 puts this check on the resource server, and route-scope-registry is
+// where "what does this route need" is declared once. An undeclared route
+// resolves to `null` there and is refused: a route added later must be given
+// a scope deliberately, never inherit one by accident.
+function isAuthorizedOAuthGrant(
+  authorization: string | undefined,
+  grantStore: OAuthTransactionStore,
+  method: string,
+  path: string,
+): boolean {
+  const presented = parseBearerAuthorizationHeader(authorization)
+  if (presented === null) return false
+  const grant = grantStore.verifyAccessToken(presented)
+  if (grant === null) return false
+  const required = resolveApiRouteScope(method, path)
+  if (required === null) return false
+  if (required.kind === 'public') return true
+  return hasRequiredScopes(grant.scopes, required.scopes)
+}
+
+export function createDaemonAuthMiddleware(
+  token?: string,
+  // Absent unless the operator configured the hosted-origin OAuth surface, in
+  // which case /api/* is daemon-token-only exactly as before.
+  grantStore?: OAuthTransactionStore,
+): MiddlewareHandler {
   return async (c, next) => {
     if (!requiresDaemonAuth(c.req.path)) {
       return next()
     }
-    if (!isAuthorized(c.req.header('authorization'), token)) {
-      return c.json({ error: 'unauthorized' }, 401)
+    if (isAuthorized(c.req.header('authorization'), token)) {
+      return next()
     }
-    return next()
+    if (
+      grantStore !== undefined &&
+      isAuthorizedOAuthGrant(c.req.header('authorization'), grantStore, c.req.method, c.req.path)
+    ) {
+      return next()
+    }
+    // One rejection for every way a request can fail: no credential, a wrong
+    // daemon token, a forged/expired/revoked access token, and a valid access
+    // token whose grant does not cover this route. Distinguishing them —
+    // even by status code — would tell an attacker which of the two
+    // credentials they are close to holding, and would tell a hostile page
+    // whether a given bearer is a live grant at all.
+    return c.json({ error: 'unauthorized' }, 401)
   }
 }

--- a/packages/mcp-server/src/server/routes/auth.ts
+++ b/packages/mcp-server/src/server/routes/auth.ts
@@ -101,6 +101,13 @@ export function createDaemonAuthMiddleware(
   grantStore?: OAuthTransactionStore,
 ): MiddlewareHandler {
   return async (c, next) => {
+    // The route-scope registry is the single source of truth for which routes
+    // are public; consult it first so a route declared public there can never
+    // be locked behind auth by a stale second list. `requiresDaemonAuth` still
+    // gates everything outside `/api/*` (static app, etc.).
+    if (resolveApiRouteScope(c.req.method, c.req.path)?.kind === 'public') {
+      return next()
+    }
     if (!requiresDaemonAuth(c.req.path)) {
       return next()
     }

--- a/packages/mcp-server/src/server/security/auth-strategy.ts
+++ b/packages/mcp-server/src/server/security/auth-strategy.ts
@@ -58,6 +58,17 @@ export type AuthScope = (typeof AUTH_SCOPES)[number]
 // never leave this grant set silently under-provisioned.
 export const ALL_AUTH_SCOPES: readonly AuthScope[] = AUTH_SCOPES
 
+// RFC 6749 §3.3 leaves scope semantics to the resource server; ours is
+// conjunctive — a route that declares two scopes needs both, and a credential
+// that holds a superset of them is still fine. Absence of any required scope
+// is a decision (the route is public), not a wildcard.
+export function hasRequiredScopes(
+  granted: readonly AuthScope[],
+  required: readonly AuthScope[],
+): boolean {
+  return required.every((scope) => granted.includes(scope))
+}
+
 export type AuthContext =
   | { kind: 'anonymous' }
   | { kind: 'local-token' }

--- a/packages/mcp-server/src/server/security/oauth-access-grants.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-access-grants.test.ts
@@ -21,6 +21,16 @@ describe('access-grant store', () => {
     expect(store.verifyAccessToken('')).toBeNull()
   })
 
+  // A minted token is a fixed-length base64url string, so an over-long input
+  // is never a real token — rejecting it early keeps a request from making the
+  // daemon hash a megabyte of attacker input. (The return value is null either
+  // way; the point of the guard is to skip the hash, which output alone can't
+  // observe — hence the plain null assertion here.)
+  it('rejects an over-long bearer', () => {
+    const store = createOAuthTransactionStore()
+    expect(store.verifyAccessToken('a'.repeat(4096))).toBeNull()
+  })
+
   it('rejects an expired grant', () => {
     let clock = 1_000
     const store = createOAuthTransactionStore({ now: () => clock })

--- a/packages/mcp-server/src/server/security/oauth-access-grants.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-access-grants.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { createOAuthTransactionStore } from './oauth-authz-transactions.js'
+
+describe('access-grant store', () => {
+  it('resolves a minted access token back to its granted scopes and client', () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+
+    const grant = store.verifyAccessToken(accessToken)
+
+    expect(grant).not.toBeNull()
+    expect(grant?.clientId).toBe('hosted-client')
+    expect(grant?.scopes).toEqual(['canvas:read'])
+  })
+
+  it('rejects a forged or unknown bearer', () => {
+    const store = createOAuthTransactionStore()
+    store.mintAccessToken(['canvas:read'], 'hosted-client')
+
+    expect(store.verifyAccessToken('not-a-real-token')).toBeNull()
+    expect(store.verifyAccessToken('')).toBeNull()
+  })
+
+  it('rejects an expired grant', () => {
+    let clock = 1_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { accessToken, expiresIn } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+
+    clock += expiresIn * 1000 + 1
+
+    expect(store.verifyAccessToken(accessToken)).toBeNull()
+  })
+
+  it('reclaims expired grants on the next write instead of retaining them', () => {
+    let clock = 1_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { expiresIn } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    expect(store.size().grants).toBe(1)
+
+    clock += expiresIn * 1000 + 1
+    store.mintAccessToken(['canvas:read'], 'other-client')
+
+    expect(store.size().grants).toBe(1)
+  })
+
+  it('rejects a revoked grant', () => {
+    const store = createOAuthTransactionStore()
+    const { accessToken } = store.mintAccessToken(['canvas:read'], 'hosted-client')
+    const [grant] = store.listGrants('hosted-client')
+
+    expect(store.revokeGrant(grant.grantId)).toBe(true)
+
+    expect(store.verifyAccessToken(accessToken)).toBeNull()
+    expect(store.revokeGrant(grant.grantId)).toBe(false)
+    expect(store.listGrants('hosted-client')).toEqual([])
+  })
+
+  it('enumerates only the requesting client’s live grants, and never the token', () => {
+    let clock = 1_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    store.mintAccessToken(['canvas:read'], 'client-a')
+    store.mintAccessToken(['canvas:read', 'canvas:write'], 'client-b')
+
+    const grantsForA = store.listGrants('client-a')
+
+    expect(grantsForA).toHaveLength(1)
+    expect(grantsForA[0]).toEqual({
+      grantId: expect.any(String),
+      clientId: 'client-a',
+      scopes: ['canvas:read'],
+      issuedAt: clock,
+      expiresAt: expect.any(Number),
+    })
+    expect(JSON.stringify(grantsForA)).not.toContain('token')
+    expect(store.listGrants('client-b')).toHaveLength(1)
+    expect(store.listGrants('nobody')).toEqual([])
+  })
+
+  it('does not list a grant that has expired', () => {
+    let clock = 1_000
+    const store = createOAuthTransactionStore({ now: () => clock })
+    const { expiresIn } = store.mintAccessToken(['canvas:read'], 'client-a')
+
+    clock += expiresIn * 1000 + 1
+
+    expect(store.listGrants('client-a')).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.test.ts
@@ -16,7 +16,7 @@ describe('expired-entry pruning', () => {
       codeChallengeMethod: 'S256',
       csrfToken: 'csrf-token',
     })
-    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0, grants: 0 })
 
     clock += TRANSACTION_TTL_MS + 1
     store.createTransaction({
@@ -31,7 +31,7 @@ describe('expired-entry pruning', () => {
 
     // The first transaction is gone, not merely unusable: a long-lived daemon
     // must not accumulate one record per abandoned/attacker-driven attempt.
-    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0, grants: 0 })
   })
 
   it('reclaims the code-hash index entry of an expired code-issued transaction', () => {
@@ -48,7 +48,7 @@ describe('expired-entry pruning', () => {
     })
     store.approveTransaction(transactionId)
     expect(store.issueAuthorizationCode(transactionId)).not.toBeNull()
-    expect(store.size()).toEqual({ transactions: 1, codes: 1, attempts: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 1, attempts: 0, grants: 0 })
 
     clock += TRANSACTION_TTL_MS + 1
     store.createTransaction({
@@ -61,7 +61,7 @@ describe('expired-entry pruning', () => {
       csrfToken: 'csrf-token',
     })
 
-    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0 })
+    expect(store.size()).toEqual({ transactions: 1, codes: 0, attempts: 0, grants: 0 })
   })
 
   it('reclaims a redeemed transaction once its window has passed', () => {

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -454,18 +454,25 @@ export function createOAuthTransactionStore(options?: {
     return { accessToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
   }
 
+  // A minted access token is a fixed-length base64url string (32 random
+  // bytes). An input far longer than that is never a real token — bounding it
+  // before hashing keeps a request from forcing the daemon to SHA-256 an
+  // arbitrarily large body. The bound sits well above the real length so it
+  // never rejects a legitimate token.
+  const MAX_ACCESS_TOKEN_LENGTH = 256
+
   function verifyAccessToken(accessToken: string): AccessGrantContext | null {
-    if (accessToken.length === 0) return null
-    // Lookup is by hash, so the raw token never has to be compared against a
-    // stored secret at all — the only comparison is between two SHA-256
-    // digests of the same fixed length, and it is done in constant time so a
-    // near-miss cannot be walked byte by byte via response timing.
+    if (accessToken.length === 0 || accessToken.length > MAX_ACCESS_TOKEN_LENGTH) return null
+    // Lookup is by hash of the presented token. The index maps a token hash to
+    // its grant id, so a hit already means the stored hash equals this one —
+    // there is no separate secret to compare, and a JS Map.get is not
+    // constant-time anyway, so no digest comparison is done here. Expiry is
+    // re-checked at use, not merely at issue.
     const presentedHash = hashCode(accessToken)
     const grantId = grantTokenIndex.get(presentedHash)
     if (grantId === undefined) return null
     const record = grants.get(grantId)
     if (!record) return null
-    if (!secretsMatch(presentedHash, record.tokenHash)) return null
     if (record.expiresAt < now()) return null
     return { grantId: record.id, clientId: record.clientId, scopes: [...record.scopes] }
   }

--- a/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
+++ b/packages/mcp-server/src/server/security/oauth-authz-transactions.ts
@@ -107,6 +107,42 @@ export type RedeemAuthorizationCodeInput = {
   codeVerifier: string | undefined
 }
 
+// What an access grant looks like to anything that is not the token holder:
+// enough to render or revoke it, never enough to replay it. The raw token is
+// absent by construction — only its SHA-256 hash is ever retained (RFC 6819
+// §5.1.4.1.3: an authorization server should store credentials hashed so a
+// dump of its state cannot be replayed against it), exactly as the
+// authorization code already is.
+const grantSummarySchema = z.object({
+  grantId: z.string().min(1),
+  clientId: z.string().min(1),
+  scopes: z.array(z.enum(AUTH_SCOPES)),
+  issuedAt: z.number(),
+  expiresAt: z.number(),
+})
+
+export type GrantSummary = z.infer<typeof grantSummarySchema>
+
+// The authorization context a verified access token yields to the resource
+// server. `scopes` is the set the *user approved for this grant* — never the
+// full vocabulary — which is the whole point of the token being scoped at all.
+const accessGrantContextSchema = z.object({
+  grantId: z.string().min(1),
+  clientId: z.string().min(1),
+  scopes: z.array(z.enum(AUTH_SCOPES)),
+})
+
+export type AccessGrantContext = z.infer<typeof accessGrantContextSchema>
+
+interface GrantRecord {
+  id: string
+  clientId: string
+  tokenHash: string
+  scopes: readonly AuthScope[]
+  issuedAt: number
+  expiresAt: number
+}
+
 export type RedeemAuthorizationCodeResult =
   | { ok: true; transactionId: string; scopes: readonly AuthScope[]; clientId: string }
   | {
@@ -144,10 +180,27 @@ export interface OAuthTransactionStore {
   denyTransaction(transactionId: string): boolean
   issueAuthorizationCode(transactionId: string): { code: string } | null
   redeemAuthorizationCode(input: RedeemAuthorizationCodeInput): RedeemAuthorizationCodeResult
+  // Mints the bearer token for an approved grant AND persists the grant it
+  // authorizes. A token that is minted but not stored authorizes nothing — it
+  // is a string the client believes in and the resource server has never
+  // heard of.
   mintAccessToken(
     scopes: readonly AuthScope[],
     clientId: string,
   ): { accessToken: string; expiresIn: number }
+  // Resource-server side of RFC 6749 §7: resolve a presented bearer to the
+  // grant it belongs to, or null for anything unknown, expired, or revoked.
+  // The caller learns nothing about *why* — see the middleware, which must
+  // not let a caller distinguish credential kinds by their rejections.
+  verifyAccessToken(accessToken: string): AccessGrantContext | null
+  // RFC 7009's intent, without (yet) the /revoke endpoint: a grant a user
+  // approved must be withdrawable. Returns false when the grant is already
+  // gone, so a double-revoke is not reported as a fresh success.
+  revokeGrant(grantId: string): boolean
+  // Live, unexpired grants held by one client — the read side any future
+  // grant-management surface needs, and the reason revocation is keyed by an
+  // id rather than by a token nobody but the holder has.
+  listGrants(clientId: string): readonly GrantSummary[]
   // Constant-time check that a submitted csrfToken is the one bound to the
   // transaction at creation.
   verifyApprovalBinding(transactionId: string, csrfToken: string): boolean
@@ -170,7 +223,7 @@ export interface OAuthTransactionStore {
   recordAuthorizeAttempt(clientId: string): boolean
   // Live entry counts. The store's only unbounded-growth risk is retained
   // dead records, so its occupancy has to be observable to be assertable.
-  size(): { transactions: number; codes: number; attempts: number }
+  size(): { transactions: number; codes: number; attempts: number; grants: number }
 }
 
 export function createOAuthTransactionStore(options?: {
@@ -186,6 +239,13 @@ export function createOAuthTransactionStore(options?: {
   // rate limit. Pruned lazily on every write, same posture as
   // pruneExpired, so it never needs a timer handle.
   const authorizeAttempts = new Map<string, number[]>()
+  // Approved access grants, keyed by an opaque grant id so revocation has
+  // something to name that is not the token itself. The token appears only as
+  // the SHA-256 hash in `grantTokenIndex` / `GrantRecord.tokenHash`; the raw
+  // value leaves this function once, in the /token response, and is never
+  // retained.
+  const grants = new Map<string, GrantRecord>()
+  const grantTokenIndex = new Map<string, string>()
 
   // Lazy sweep, not a timer. A `setInterval` would keep the Node event loop
   // alive for the daemon's whole lifetime and would have to be torn down by
@@ -355,25 +415,89 @@ export function createOAuthTransactionStore(options?: {
     return { ok: true, transactionId, scopes: record.scopes, clientId: record.clientId }
   }
 
+  // Same lazy-sweep posture as pruneExpired, and for the same reason: a timer
+  // would hold the event loop open for the daemon's whole life. An expired
+  // grant is already unusable (verifyAccessToken re-checks expiry), so
+  // reclaiming it is a memory concern, not a security one.
+  function pruneExpiredGrants(): void {
+    const cutoff = now()
+    for (const [id, record] of grants) {
+      if (record.expiresAt >= cutoff) continue
+      grants.delete(id)
+      grantTokenIndex.delete(record.tokenHash)
+    }
+  }
+
   function mintAccessToken(
     scopes: readonly AuthScope[],
-    _clientId: string,
+    clientId: string,
   ): { accessToken: string; expiresIn: number } {
-    // Opaque bearer token, not a JWT: validating it on protected routes is
-    // a resource-server concern (oauth-resource-strategy.ts's seam) that
-    // this slice does not wire up — see ADR-0005's "the resource-server
-    // half does not already exist" constraint. This skeleton only mints
-    // the token the /token response carries.
+    pruneExpiredGrants()
+    // Opaque bearer token, not a JWT: this daemon is both the authorization
+    // server and the only resource server for its own API, so there is no
+    // second party that would need to validate the token without asking us.
+    // A local lookup against a hashed record is strictly less to get wrong
+    // than signing keys, `alg` handling, and rotation.
     const accessToken = randomBytes(32).toString('base64url')
-    void scopes
+    const tokenHash = hashCode(accessToken)
+    const issuedAt = now()
+    const grantId = randomBytes(16).toString('base64url')
+    grants.set(grantId, {
+      id: grantId,
+      clientId,
+      tokenHash,
+      scopes: [...scopes],
+      issuedAt,
+      expiresAt: issuedAt + ACCESS_TOKEN_TTL_SECONDS * 1000,
+    })
+    grantTokenIndex.set(tokenHash, grantId)
     return { accessToken, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
   }
 
-  function size(): { transactions: number; codes: number; attempts: number } {
+  function verifyAccessToken(accessToken: string): AccessGrantContext | null {
+    if (accessToken.length === 0) return null
+    // Lookup is by hash, so the raw token never has to be compared against a
+    // stored secret at all — the only comparison is between two SHA-256
+    // digests of the same fixed length, and it is done in constant time so a
+    // near-miss cannot be walked byte by byte via response timing.
+    const presentedHash = hashCode(accessToken)
+    const grantId = grantTokenIndex.get(presentedHash)
+    if (grantId === undefined) return null
+    const record = grants.get(grantId)
+    if (!record) return null
+    if (!secretsMatch(presentedHash, record.tokenHash)) return null
+    if (record.expiresAt < now()) return null
+    return { grantId: record.id, clientId: record.clientId, scopes: [...record.scopes] }
+  }
+
+  function revokeGrant(grantId: string): boolean {
+    pruneExpiredGrants()
+    const record = grants.get(grantId)
+    if (!record) return false
+    grants.delete(grantId)
+    grantTokenIndex.delete(record.tokenHash)
+    return true
+  }
+
+  function listGrants(clientId: string): readonly GrantSummary[] {
+    const cutoff = now()
+    return [...grants.values()]
+      .filter((record) => record.clientId === clientId && record.expiresAt >= cutoff)
+      .map((record) => ({
+        grantId: record.id,
+        clientId: record.clientId,
+        scopes: [...record.scopes],
+        issuedAt: record.issuedAt,
+        expiresAt: record.expiresAt,
+      }))
+  }
+
+  function size(): { transactions: number; codes: number; attempts: number; grants: number } {
     return {
       transactions: transactions.size,
       codes: codeHashIndex.size,
       attempts: authorizeAttempts.size,
+      grants: grants.size,
     }
   }
 
@@ -384,6 +508,9 @@ export function createOAuthTransactionStore(options?: {
     issueAuthorizationCode,
     redeemAuthorizationCode,
     mintAccessToken,
+    verifyAccessToken,
+    revokeGrant,
+    listGrants,
     verifyApprovalBinding,
     getTransactionForApproval,
     getTransactionRedirect,

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -110,4 +110,19 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
       })
     }
   })
+
+  // User libraries are workspace-shared state, so reading them is a workspace
+  // read — not a canvas read. Collapsing the read side onto canvas:read would
+  // let a grant approved only to read a canvas also enumerate the workspace's
+  // shared library, a broader surface than the user consented to.
+  it('reading a user library requires workspace:read, not canvas:read', () => {
+    expect(resolveApiRouteScope('GET', '/api/user-libraries')).toEqual({
+      kind: 'scoped',
+      scopes: ['workspace:read'],
+    })
+    expect(resolveApiRouteScope('PUT', '/api/user-libraries')).toEqual({
+      kind: 'scoped',
+      scopes: ['workspace:write'],
+    })
+  })
 })

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -67,9 +67,11 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
     return { kind: 'scoped', scopes: [isWrite ? 'canvas:write' : 'canvas:read'] }
   }
 
-  // User library routes: writes mutate workspace-level shared library state.
+  // User library routes are workspace-level shared state: a read is a
+  // workspace read (not a canvas read — collapsing it onto canvas:read would
+  // let a canvas-only grant enumerate the shared library), a write mutates it.
   if (path.startsWith('/api/user-libraries')) {
-    return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'canvas:read'] }
+    return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'workspace:read'] }
   }
 
   // Version history, thumbnails, restore, compact — version-control


### PR DESCRIPTION
Makes an approved OAuth grant actually authorize `/api/*` calls. Until now the consent flow (#230) minted an access token that authorized **nothing** — `/api/*` accepted only the full-authority daemon token. This closes that: the token an approval produces now grants exactly the scopes the user approved, and nothing else.

## What ships

**Grant store** — extends the existing transaction store (not a parallel one). `mintAccessToken` now persists the grant it previously threw away: token stored **only as a SHA-256 hash**, with clientId, the approved scope set, and expiry. `verifyAccessToken` looks up by hash, compares constant-time, and re-checks expiry **at use**, not only at issue. Expired grants are reclaimed by lazy sweep on write (no `setInterval`). `revokeGrant` is immediate and `listGrants` enumerates a client's live grants — the ADR's grant-management screen needs both, and a store with no revoke path can't grow one.

**`/api/*` accepts either credential.** The daemon token keeps full authority, checked first, unchanged (existing tests un-weakened). An OAuth token is additionally accepted but carries **only its grant's scopes**, checked on every request against `resolveApiRouteScope(method, path)` (the registry from #227). Undeclared routes stay fail-closed. All four failure modes — no credential, wrong daemon token, forged/expired/revoked OAuth token, valid-but-out-of-scope OAuth token — return one byte-identical `401 {"error":"unauthorized"}`, so the response never reveals which credential you're close to holding.

## One real over-grant the security review caught

`/api/user-libraries` reads mapped to `canvas:read`. Inert while `/api/*` took only the daemon token — but the moment OAuth grants are enforced, a grant approved only to *read a canvas* could also enumerate the workspace's shared library. User libraries are workspace-shared state, so their read is now `workspace:read` (writes were already `workspace:write` — the two sides are now symmetric). Red-first test; verified against a real daemon: a `canvas:read`-only grant gets `401` on `/api/user-libraries`, the daemon token gets `200`.

## Verification

- `pnpm test --project mcp-node` → 219 files, 3296 passed. `pnpm -r typecheck` clean. `pnpm lint:noconsole` clean.
- Independent auth-bypass / privilege-escalation review: bypass surface CLEAN (path traversal / method override / encoding all fail-closed because Hono and the registry consume the same raw path; expiry & revocation effective; WS path unchanged; no secret in logs or error bodies).
- Real daemon, full flow `/authorize → approve → code → /token → /api/*`:
  - `canvas:read` grant → `GET` canvas snapshot `200`; `POST` update `401`
  - daemon token → `POST` update `200`
  - `canvas:write` grant → `POST` update `200`
  - `canvas:read` grant → `GET /api/user-libraries` `401` (the fix); daemon token `200`
  - forged bearer / no credential → `401`, identical response

## Deliberately out of scope (stated, not built)

- **The WebSocket still authenticates with the raw daemon token only** — an OAuth grant cannot yet reach live sync. That is the WS connection ticket, the next and final slice.
- Grant-management UI (`listGrants`/`revokeGrant` exist; no route exposes them yet); refresh/renewal grants; all `apps/web` client code.
- Grants are in-memory: a daemon restart invalidates every issued token, same rule as the transactions. A deliberate choice for now, not yet written into the ADR.
