### PR TITLE
fix(release): use un-prefixed root outputs so advance-stable actually runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,12 @@ jobs:
     outputs:
       mcp_release_created: ${{ steps.release.outputs['packages/mcp-server--release_created'] }}
       mcp_tag_name: ${{ steps.release.outputs['packages/mcp-server--tag_name'] }}
-      root_release_created: ${{ steps.release.outputs['--release_created'] }}
-      root_tag_name: ${{ steps.release.outputs['--tag_name'] }}
+      # Root-path (".") outputs are NOT path-prefixed: release-please-action
+      # emits plain `release_created` / `tag_name` for the root component.
+      # The previous `['--release_created']` keys never existed, so
+      # advance-stable was silently skipped on every release.
+      root_release_created: ${{ steps.release.outputs.release_created }}
+      root_tag_name: ${{ steps.release.outputs.tag_name }}
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
## Problem

The `stable` branch (git-based plugin distribution ref) has been stuck at the v0.0.10-era commit (`1b06448`, merged 2026-07-05) while release tags advanced to `whiteboard-plugin-v0.0.12`.

Cause: `release.yml` maps job outputs from `steps.release.outputs['--release_created']` / `['--tag_name']`. Per the release-please-action docs, only non-root paths get the `<path>--` prefix — the root component (path `.`) emits plain `release_created` / `tag_name`. The bracketed keys never exist, so `root_release_created` was always empty and `advance-stable`'s `if:` never fired. Evidence: run 29100853711 (v0.0.12 release) logs show only `mcp_release_created` / `mcp_tag_name` / `releases_created` being set, and `advance-stable: skipped`.

## Change

Two-line mapping fix + a comment documenting the root-vs-path output naming so it doesn't regress.

## Verification

Static only (the mapping is exercised exclusively by a real release-PR merge). Cross-checked against the release-please-action README output tables (root component outputs vs path outputs). Next release-PR merge should show `advance-stable` running and fast-forwarding `stable` to the new root tag; noted in the merge summary to watch for it.

## Follow-up (separate)

The npm publish failure itself (`smoke:tarball` "Daemon startup timeout" in the release-candidate gate — npm stuck at 0.0.6) is under separate investigation.