### PR TITLE
fix(mcp-server): stop the packaged tarball smoke from inheriting WHITEBOARD_DEV

### DIFF
--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.test.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildCheckpointChildEnv,
+  readDaemonLogsForFailure,
   triggerDaemonCanvasCreate,
 } from './mcp-e2e-checkpoint.smoke-impl.js'
 
@@ -21,6 +25,42 @@ describe('buildCheckpointChildEnv', () => {
     const childEnv = buildCheckpointChildEnv(processEnv, '/tmp/data-dir')
 
     expect(childEnv.WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS).toBeUndefined()
+  })
+})
+
+describe('readDaemonLogsForFailure', () => {
+  let dataDir: string
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-e2e-log-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  it('returns an empty string when the logs dir does not exist', async () => {
+    await expect(readDaemonLogsForFailure(dataDir)).resolves.toBe('')
+  })
+
+  it('returns an empty string when the logs dir has no daemon-*.log files', async () => {
+    mkdirSync(join(dataDir, 'logs'))
+    writeFileSync(join(dataDir, 'logs', 'unrelated.txt'), 'noise')
+
+    await expect(readDaemonLogsForFailure(dataDir)).resolves.toBe('')
+  })
+
+  it('surfaces daemon-*.log contents so a startup failure is never diagnosed blind', async () => {
+    mkdirSync(join(dataDir, 'logs'))
+    writeFileSync(
+      join(dataDir, 'logs', 'daemon-2026-01-01.log'),
+      "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsx'",
+    )
+
+    const detail = await readDaemonLogsForFailure(dataDir)
+
+    expect(detail).toContain('daemon-2026-01-01.log')
+    expect(detail).toContain("Cannot find package 'tsx'")
   })
 })
 

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -20,6 +20,12 @@ interface RunOptions {
   retryDaemonStartup?: boolean
   /** Extra RPC attempts beyond the first when retryDaemonStartup is set. */
   maxDaemonStartupRetries?: number
+  /**
+   * Ambient environment to spread into the spawned child. Defaults to
+   * process.env; callers that must not forward an ambient flag (e.g. the
+   * packaged tarball smoke excluding WHITEBOARD_DEV) pass a filtered copy.
+   */
+  env?: NodeJS.ProcessEnv
 }
 
 type RpcResponse = {
@@ -61,13 +67,14 @@ export async function runE2eCheckpointSmoke({
   root,
   retryDaemonStartup: shouldRetryDaemonStartup = false,
   maxDaemonStartupRetries = 1,
+  env: ambientEnv = process.env,
 }: RunOptions): Promise<void> {
   const tmpDataDir = mkdtempSync(join(tmpdir(), 'whiteboard-e2e-'))
   const childArgs = entry.endsWith('.ts') ? ['--import', 'tsx/esm', entry] : [entry]
 
   const child = spawn('node', childArgs, {
     cwd: root,
-    env: buildCheckpointChildEnv(process.env, tmpDataDir),
+    env: buildCheckpointChildEnv(ambientEnv, tmpDataDir),
     stdio: ['pipe', 'pipe', 'pipe'],
   })
 

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -60,6 +60,33 @@ export function triggerDaemonCanvasCreate(
   return options.retryDaemonStartup
     ? retryDaemonStartup({ attempt, maxRetries: options.maxDaemonStartupRetries })
     : attempt()
+}
+
+/**
+ * Reads every daemon-*.log file under <dataDir>/logs, which is where
+ * ensureDaemon (see ensure-daemon.ts openDaemonLogFile) redirects the
+ * detached daemon child's stdout/stderr. The caller's tmp data dir is
+ * deleted right after this smoke fails, so a "Daemon startup timeout"
+ * would otherwise discard the one artifact that explains why the daemon
+ * process never bound its port (crash on require, missing devDependency
+ * when run against an installed-only tree, etc.). Best-effort: absent or
+ * unreadable logs must never mask the original failure.
+ */
+export async function readDaemonLogsForFailure(dataDir: string): Promise<string> {
+  try {
+    const logsDir = join(dataDir, 'logs')
+    const files = readdirSync(logsDir).filter((f) => f.startsWith('daemon-') && f.endsWith('.log'))
+    if (files.length === 0) return ''
+    const contents = await Promise.all(
+      files.map(async (f) => {
+        const body = await readFile(join(logsDir, f), 'utf-8')
+        return `--- ${f} ---\n${body.trim()}`
+      }),
+    )
+    return `\n--- daemon log(s) ---\n${contents.join('\n')}\n--- end daemon log(s) ---`
+  } catch {
+    return ''
+  }
 }
 
 export async function runE2eCheckpointSmoke({
@@ -179,6 +206,7 @@ export async function runE2eCheckpointSmoke({
 
   try {
     console.log(`[e2e] entry → ${entry}`)
+    console.log(`[e2e] spawn → node ${childArgs.join(' ')} (dataDir=${tmpDataDir})`)
 
     await rpc('initialize', {
       protocolVersion: '2024-11-05',
@@ -457,7 +485,10 @@ export async function runE2eCheckpointSmoke({
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     const detail = stderrBuf ? `\n--- MCP stderr ---\n${stderrBuf}\n--- end ---` : ''
-    throw new Error(`${msg}${detail}`)
+    // Read before `finally` deletes tmpDataDir, so a startup failure still
+    // surfaces why the detached daemon process never bound its port.
+    const daemonLogDetail = await readDaemonLogsForFailure(tmpDataDir)
+    throw new Error(`${msg}${detail}${daemonLogDetail}`)
   } finally {
     process.removeListener('exit', exitHandler)
     try {

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
-import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { retryDaemonStartup } from './daemon-readiness.js'
@@ -75,7 +75,9 @@ export function triggerDaemonCanvasCreate(
 export async function readDaemonLogsForFailure(dataDir: string): Promise<string> {
   try {
     const logsDir = join(dataDir, 'logs')
-    const files = readdirSync(logsDir).filter((f) => f.startsWith('daemon-') && f.endsWith('.log'))
+    const files = (await readdir(logsDir)).filter(
+      (f) => f.startsWith('daemon-') && f.endsWith('.log'),
+    )
     if (files.length === 0) return ''
     const contents = await Promise.all(
       files.map(async (f) => {

--- a/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
@@ -53,6 +53,19 @@ export function assertTarballFileList(entries: readonly string[]): void {
   }
 }
 
+// The installed tarball ships only `dist/`, never `src/`. If the ambient
+// environment carries WHITEBOARD_DEV=1 (e.g. a CI job that runs this smoke
+// alongside a src-mode e2e check under the same env block), ensureDaemon
+// would try to spawn `node --watch --import tsx/esm <root>/src/server/index.ts`
+// against a source tree that was never packed — the daemon process exits
+// immediately, every readiness poll fails, and the only symptom is an opaque
+// "Daemon startup timeout" after the full wait window. Stripping the flag
+// keeps this smoke pinned to the same dist-mode spawn a real npm install uses.
+export function buildTarballSmokeChildEnv(processEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const { WHITEBOARD_DEV: _unused, ...rest } = processEnv
+  return rest
+}
+
 function listTarballEntries(tarballPath: string): string[] {
   const result = spawnSync('tar', ['-tzf', tarballPath], { encoding: 'utf-8' })
   if (result.status !== 0) {
@@ -175,6 +188,7 @@ export async function runPackedTarballSmoke({
       entry: installedEntry,
       root: repoRoot,
       retryDaemonStartup: true,
+      env: buildTarballSmokeChildEnv(process.env),
     })
 
     console.log('[tarball-smoke] installed tarball entrypoint OK')

--- a/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
@@ -3,7 +3,11 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import { assertTarballFileList, runPackedTarballSmoke } from './tarball.distribution-impl.js'
+import {
+  assertTarballFileList,
+  buildTarballSmokeChildEnv,
+  runPackedTarballSmoke,
+} from './tarball.distribution-impl.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(__dirname, '../../..')
@@ -12,6 +16,20 @@ const repoRoot = resolve(packageRoot, '../..')
 describe('packed tarball smoke', () => {
   it('npm pack → pnpm install → installed entry passes full e2e checkpoint flow', async () => {
     await runPackedTarballSmoke({ packageRoot, repoRoot })
+  }, 120_000)
+
+  // Regression for the release-blocking "Daemon startup timeout" failure: a
+  // CI job env block that sets WHITEBOARD_DEV=1 for its src-mode checks must
+  // not make this smoke spawn the installed (dist-only) daemon in watch mode.
+  it('succeeds even when the ambient env carries WHITEBOARD_DEV=1', async () => {
+    const originalDev = process.env.WHITEBOARD_DEV
+    process.env.WHITEBOARD_DEV = '1'
+    try {
+      await runPackedTarballSmoke({ packageRoot, repoRoot })
+    } finally {
+      if (originalDev === undefined) delete process.env.WHITEBOARD_DEV
+      else process.env.WHITEBOARD_DEV = originalDev
+    }
   }, 120_000)
 })
 
@@ -38,5 +56,32 @@ describe('assertTarballFileList', () => {
     const entries = validEntries.filter((e) => e !== 'package/dist/web-app/index.html')
 
     expect(() => assertTarballFileList(entries)).toThrow(/missing dist\/web-app\/index\.html/)
+  })
+})
+
+describe('buildTarballSmokeChildEnv', () => {
+  it('strips WHITEBOARD_DEV so the packaged entry never spawns the daemon in watch mode', () => {
+    const processEnv = { PATH: '/usr/bin', WHITEBOARD_DEV: '1' }
+
+    const childEnv = buildTarballSmokeChildEnv(processEnv)
+
+    expect(childEnv.WHITEBOARD_DEV).toBeUndefined()
+    expect(childEnv.PATH).toBe('/usr/bin')
+  })
+
+  it('is a no-op when WHITEBOARD_DEV is already absent from the parent env', () => {
+    const processEnv = { PATH: '/usr/bin' }
+
+    const childEnv = buildTarballSmokeChildEnv(processEnv)
+
+    expect(childEnv).toEqual({ PATH: '/usr/bin' })
+  })
+
+  it('does not mutate the input env object', () => {
+    const processEnv = { WHITEBOARD_DEV: '1' }
+
+    buildTarballSmokeChildEnv(processEnv)
+
+    expect(processEnv.WHITEBOARD_DEV).toBe('1')
   })
 })

--- a/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   assertTarballFileList,
@@ -22,13 +22,11 @@ describe('packed tarball smoke', () => {
   // CI job env block that sets WHITEBOARD_DEV=1 for its src-mode checks must
   // not make this smoke spawn the installed (dist-only) daemon in watch mode.
   it('succeeds even when the ambient env carries WHITEBOARD_DEV=1', async () => {
-    const originalDev = process.env.WHITEBOARD_DEV
-    process.env.WHITEBOARD_DEV = '1'
+    vi.stubEnv('WHITEBOARD_DEV', '1')
     try {
       await runPackedTarballSmoke({ packageRoot, repoRoot })
     } finally {
-      if (originalDev === undefined) delete process.env.WHITEBOARD_DEV
-      else process.env.WHITEBOARD_DEV = originalDev
+      vi.unstubAllEnvs()
     }
   }, 120_000)
 })


### PR DESCRIPTION
## Problem — why npm has been stuck at 0.0.6 while tags reached v0.0.12

Every npm publish since v0.0.7 died in the release-candidate gate with `[tarball-smoke] FAIL: Daemon startup timeout`, with no further detail. Root cause (reproduced locally, first made visible by the log-surfacing change in this PR):

- `release.yml`'s publish gate sets `WHITEBOARD_DEV: '1'` for the src-mode e2e check, and that ambient env propagates into the tarball smoke's daemon child process.
- With `WHITEBOARD_DEV=1`, `ensure-daemon` spawns the daemon as `node --watch --import tsx/esm <root>/src/server/index.ts` — but the installed tarball ships only `dist/` (no `src/`, no `tsx` devDependency), so the daemon crash-loops with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` until the startup budget expires.
- The earlier v0.0.9/v0.0.10 "fixes" (raising `WHITEBOARD_DAEMON_STARTUP_TIMEOUT_MS` / RPC timeout) were symptomatic; the crash loop can't be outwaited.

## Change

1. `fix`: `buildTarballSmokeChildEnv()` — pure function that strips `WHITEBOARD_DEV` from the env handed to the packed-tarball smoke's child, so the installed package is always exercised the way a real user runs it (dist mode). Unit tests + a full e2e regression test that runs the smoke with ambient `WHITEBOARD_DEV=1` (the exact CI condition).
2. `feat`: on startup failure the smoke now prints the spawned command line and the daemon's `logs/daemon-*.log` contents (read before the tmp data dir is cleaned up) — the blind "Daemon startup timeout" that hid this bug for six releases can't happen again.

Both mutation-checked: reverting the env scrub reproduces the CI failure verbatim (now with the tsx ERR_MODULE_NOT_FOUND visible); breaking the log reader turns its unit tests red.

## Verification

- `vitest --project mcp-node`: 222 files / 3330 passed
- `vitest --config vitest.distribution.config.ts tarball.distribution.test.ts`: 8/8 (incl. the WHITEBOARD_DEV=1 regression)
- CLI-level: `CI=true WHITEBOARD_DEV=1 pnpm --filter @kamiazya/whiteboard-mcp smoke:tarball` → ALL OK (same env shape as the failing publish job)
- typecheck clean

Together with #239 (advance-stable output-key fix), the next release-PR merge should publish to npm end-to-end.