### PR TITLE
fix(mcp-server): skip LLM-CLI smokes when the CLI is absent so release gates pass on CI

### DIFF
--- a/packages/mcp-server/scripts/smoke/lib/cli-available.mjs
+++ b/packages/mcp-server/scripts/smoke/lib/cli-available.mjs
@@ -1,0 +1,18 @@
+// Shared guard for the LLM-CLI smokes (mcp-claude-cli-smoke.mjs,
+// mcp-codex-cli-smoke.mjs). Those smokes spawn a real `claude` / `codex`
+// binary and burn API quota, so CI images intentionally ship without either
+// CLI installed. Without this guard the smokes fail with `spawn ... ENOENT`
+// on every CI runner instead of skipping cleanly.
+
+/**
+ * @param {string} command
+ * @param {(cmd: string, args: string[], opts: import('node:child_process').SpawnSyncOptions) => import('node:child_process').SpawnSyncReturns<Buffer>} spawnSyncImpl
+ * @returns {boolean}
+ */
+export function isCliAvailable(command, spawnSyncImpl) {
+  const result = spawnSyncImpl(command, ['--version'], { stdio: 'ignore' })
+  if (result.error) {
+    return false
+  }
+  return typeof result.status === 'number' && result.status === 0
+}

--- a/packages/mcp-server/scripts/smoke/lib/cli-available.mjs
+++ b/packages/mcp-server/scripts/smoke/lib/cli-available.mjs
@@ -4,13 +4,22 @@
 // CLI installed. Without this guard the smokes fail with `spawn ... ENOENT`
 // on every CI runner instead of skipping cleanly.
 
+import { spawnSync } from 'node:child_process'
+
 /**
  * @param {string} command
  * @param {(cmd: string, args: string[], opts: import('node:child_process').SpawnSyncOptions) => import('node:child_process').SpawnSyncReturns<Buffer>} spawnSyncImpl
  * @returns {boolean}
  */
-export function isCliAvailable(command, spawnSyncImpl) {
-  const result = spawnSyncImpl(command, ['--version'], { stdio: 'ignore' })
+export function isCliAvailable(command, spawnSyncImpl = spawnSync) {
+  // Windows installs npm-global CLIs as .cmd/.bat shims, which execvp cannot
+  // launch directly — they need a shell to resolve. shell:true is safe here
+  // because `command` is always one of our own fixed literals ('claude',
+  // 'codex'), never attacker- or user-controlled input.
+  const result = spawnSyncImpl(command, ['--version'], {
+    stdio: 'ignore',
+    shell: process.platform === 'win32',
+  })
   if (result.error) {
     return false
   }

--- a/packages/mcp-server/scripts/smoke/lib/cli-available.test.ts
+++ b/packages/mcp-server/scripts/smoke/lib/cli-available.test.ts
@@ -9,7 +9,10 @@ describe('isCliAvailable', () => {
     })
 
     expect(isCliAvailable('claude', spawnSyncImpl)).toBe(false)
-    expect(spawnSyncImpl).toHaveBeenCalledWith('claude', ['--version'], { stdio: 'ignore' })
+    expect(spawnSyncImpl).toHaveBeenCalledWith('claude', ['--version'], {
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    })
   })
 
   it('returns false when the CLI exits with a non-zero status', () => {

--- a/packages/mcp-server/scripts/smoke/lib/cli-available.test.ts
+++ b/packages/mcp-server/scripts/smoke/lib/cli-available.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isCliAvailable } from './cli-available.mjs'
+
+describe('isCliAvailable', () => {
+  it('returns false when spawnSync reports an ENOENT error', () => {
+    const spawnSyncImpl = vi.fn().mockReturnValue({
+      error: Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }),
+      status: null,
+    })
+
+    expect(isCliAvailable('claude', spawnSyncImpl)).toBe(false)
+    expect(spawnSyncImpl).toHaveBeenCalledWith('claude', ['--version'], { stdio: 'ignore' })
+  })
+
+  it('returns false when the CLI exits with a non-zero status', () => {
+    const spawnSyncImpl = vi.fn().mockReturnValue({ error: undefined, status: 1 })
+
+    expect(isCliAvailable('codex', spawnSyncImpl)).toBe(false)
+  })
+
+  it('returns true when the CLI exits successfully', () => {
+    const spawnSyncImpl = vi.fn().mockReturnValue({ error: undefined, status: 0 })
+
+    expect(isCliAvailable('claude', spawnSyncImpl)).toBe(true)
+  })
+})

--- a/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.mjs
@@ -15,15 +15,28 @@
 //   node scripts/smoke/mcp-claude-cli-smoke.mjs
 // For a lightweight version that does not consume quota and talks directly to
 // JSON-RPC stdio, use scripts/smoke/mcp-e2e-smoke.mjs.
+// CI images ship without the claude CLI installed (by design — this smoke
+// needs a local install and live API quota), so the release-gate scripts
+// that chain into this one (smoke:distribution:packaged, test:e2e:distribution)
+// would otherwise always fail with `spawn claude ENOENT`. Skip cleanly instead.
 
-import { spawn } from 'node:child_process'
+import { spawnSync, spawn } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isCliAvailable } from './lib/cli-available.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
+
+if (!isCliAvailable('claude', spawnSync)) {
+  console.log(
+    '[claude-smoke] SKIP: claude CLI not found on PATH — this smoke needs a local claude install and API quota (manual/dev-machine check)',
+  )
+  process.exit(0)
+}
+
 const tmpDataDir = mkdtempSync(join(tmpdir(), 'whiteboard-claude-smoke-'))
 const mcpConfigPath = join(tmpDataDir, 'mcp.json')
 
@@ -49,20 +62,29 @@ const prompt = [
 ].join('\n')
 
 const args = [
-  '-p', prompt,
-  '--mcp-config', mcpConfigPath,
+  '-p',
+  prompt,
+  '--mcp-config',
+  mcpConfigPath,
   '--strict-mcp-config',
-  '--allowedTools', 'mcp__excalidraw__canvas_create mcp__excalidraw__annotate mcp__excalidraw__version_save',
-  '--max-turns', '6',
-  '--output-format', 'text',
+  '--allowedTools',
+  'mcp__excalidraw__canvas_create mcp__excalidraw__annotate mcp__excalidraw__version_save',
+  '--max-turns',
+  '6',
+  '--output-format',
+  'text',
 ]
 
 const child = spawn('claude', args, { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] })
 
 let stdout = ''
 let stderr = ''
-child.stdout.on('data', (c) => { stdout += c.toString() })
-child.stderr.on('data', (c) => { stderr += c.toString() })
+child.stdout.on('data', (c) => {
+  stdout += c.toString()
+})
+child.stderr.on('data', (c) => {
+  stderr += c.toString()
+})
 
 const killTimer = setTimeout(() => {
   child.kill('SIGTERM')

--- a/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.mjs
@@ -20,7 +20,7 @@
 // that chain into this one (smoke:distribution:packaged, test:e2e:distribution)
 // would otherwise always fail with `spawn claude ENOENT`. Skip cleanly instead.
 
-import { spawnSync, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
@@ -30,7 +30,7 @@ import { isCliAvailable } from './lib/cli-available.mjs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
 
-if (!isCliAvailable('claude', spawnSync)) {
+if (!isCliAvailable('claude')) {
   console.log(
     '[claude-smoke] SKIP: claude CLI not found on PATH — this smoke needs a local claude install and API quota (manual/dev-machine check)',
   )

--- a/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.test.ts
+++ b/packages/mcp-server/scripts/smoke/mcp-claude-cli-smoke.test.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('mcp-claude-cli-smoke.mjs', () => {
+  it('exits 0 with a SKIP message when the claude CLI is absent from PATH', () => {
+    const scriptPath = resolve(import.meta.dirname, 'mcp-claude-cli-smoke.mjs')
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, PATH: '' },
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('[claude-smoke] SKIP')
+  })
+})

--- a/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
@@ -18,16 +18,29 @@
 // - When run inside the Codex sandbox it may fail because it cannot write to
 //   ~/.codex/sessions. If that happens, run it outside the sandbox.
 // - Set KEEP_SMOKE_TMP=1 to keep the temp directory instead of deleting it.
+// - CI images ship without the codex CLI installed (by design — this smoke
+//   needs a local install and live API quota), so the release-gate scripts
+//   that chain into this one (smoke:distribution:packaged, test:e2e:distribution)
+//   would otherwise always fail with `spawn codex ENOENT`. Skip cleanly instead.
 
-import { spawn } from 'node:child_process'
+import { spawnSync, spawn } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isCliAvailable } from './lib/cli-available.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
 const repoRoot = resolve(root, '../..')
+
+if (!isCliAvailable('codex', spawnSync)) {
+  console.log(
+    '[codex-smoke] SKIP: codex CLI not found on PATH — this smoke needs a local codex install and API quota (manual/dev-machine check)',
+  )
+  process.exit(0)
+}
+
 const keepTmp = process.env.KEEP_SMOKE_TMP === '1'
 const tmpRoot = mkdtempSync(join(tmpdir(), 'whiteboard-codex-smoke-'))
 const tmpDataDir = join(tmpRoot, 'data')
@@ -73,11 +86,16 @@ const args = [
   'exec',
   '--ephemeral',
   '--skip-git-repo-check',
-  '-C', repoRoot,
-  '-s', 'read-only',
-  '--output-schema', schemaPath,
-  '-o', outputPath,
-  '-c', configOverride,
+  '-C',
+  repoRoot,
+  '-s',
+  'read-only',
+  '--output-schema',
+  schemaPath,
+  '-o',
+  outputPath,
+  '-c',
+  configOverride,
   prompt,
 ]
 

--- a/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
@@ -23,7 +23,7 @@
 //   that chain into this one (smoke:distribution:packaged, test:e2e:distribution)
 //   would otherwise always fail with `spawn codex ENOENT`. Skip cleanly instead.
 
-import { spawnSync, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -34,7 +34,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '../..')
 const repoRoot = resolve(root, '../..')
 
-if (!isCliAvailable('codex', spawnSync)) {
+if (!isCliAvailable('codex')) {
   console.log(
     '[codex-smoke] SKIP: codex CLI not found on PATH — this smoke needs a local codex install and API quota (manual/dev-machine check)',
   )

--- a/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.test.ts
+++ b/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.test.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('mcp-codex-cli-smoke.mjs', () => {
+  it('exits 0 with a SKIP message when the codex CLI is absent from PATH', () => {
+    const scriptPath = resolve(import.meta.dirname, 'mcp-codex-cli-smoke.mjs')
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, PATH: '' },
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('[codex-smoke] SKIP')
+  })
+})


### PR DESCRIPTION
## Problem

The v0.0.13 release run failed in BOTH publish jobs with `spawn claude ENOENT`:

- `publish-mcp` → publish gate → `smoke:distribution:packaged` starts with `pnpm smoke:claude && pnpm smoke:codex`
- `docker-publish-sign` → `check:release-candidate` → `test:e2e:distribution` includes the same two smokes

`mcp-claude-cli-smoke.mjs` / `mcp-codex-cli-smoke.mjs` are self-documented as manual dev-machine checks ("consumes API quota, does not run in CI"), but both release-gate paths invoke them — and GitHub runners have neither CLI. This was the last blocker after #239 (advance-stable — succeeded this run) and #240 (tarball smoke — passed this run).

## Change

`isCliAvailable(command)` helper (spawnSync `--version`, injectable for tests) + a guard at the top of both smokes: CLI absent → loud `[claude-smoke] SKIP: …` / `[codex-smoke] SKIP: …` and exit 0; CLI present → unchanged full run. Comments updated to state the CI-skip behavior as the enduring contract.

## Verification

- Unit: `cli-available.test.ts` (ENOENT / non-zero / success paths, mocked spawnSync)
- Integration: both smokes executed with `PATH=''` exit 0 and print SKIP (deterministic, in vitest)
- Full `pnpm test --project mcp-node`: 225 files / 3332 passed; typecheck clean
- Manual: with the real claude CLI on PATH the guard passes through to the real spawn (killed before consuming quota)

After this merges, the next release-please PR (v0.0.14) should publish npm/docker end-to-end — v0.0.13's tag predates this fix and publish checks out the tag, so v0.0.13 is intentionally left unpublished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smoke tests now skip gracefully when the Claude or Codex command-line tools are unavailable, instead of failing with a missing-command error.
  * Skipped checks exit successfully and clearly report that they were skipped.

* **Tests**
  * Added coverage for unavailable, failed, and successful CLI checks.
  * Added end-to-end validation for graceful skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->