### PR TITLE
feat(mcp-server): isolate dev daemon data under repo-local .dev-data and make DATA_DIR test-injectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,12 @@ vite.config.ts.timestamp-*
 
 tmp
 
+# Repo-local dev daemon data (WHITEBOARD_DATA_DIR set by
+# packages/mcp-server/scripts/dev/with-dev-data-dir.mjs) — keeps `pnpm
+# mcp:http:dev` from writing into the real ~/.whiteboard. Durable across a
+# dev session (unlike tmp/), scoped per worktree since each has its own.
+.dev-data/
+
 # Generated artifacts (SBOM, dry-run outputs) — not committed, uploaded via CI
 packages/mcp-server/_artifacts/
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -72,7 +72,13 @@ The daemon listens on `http://127.0.0.1:3099/mcp`.
 
 > **Auto-start:** The repo's `SessionStart` hook (`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`) probes port 3099 and spawns the daemon automatically when Claude Code or Codex opens the repo. If the daemon does not start automatically (hooks disabled, project not yet trusted, or port 3099 already in use by another process), run `pnpm mcp:http:dev` manually in a separate terminal before making MCP calls.
 
-> **Data lives in `.dev-data/`, not your real `~/.whiteboard`:** `pnpm mcp:http:dev` (and anything that shells out to it — `mcp:debug:http`, the `SessionStart` hook) runs through `packages/mcp-server/scripts/dev/with-dev-data-dir.mjs`, which sets `WHITEBOARD_DATA_DIR` to `<repo root>/.dev-data` unless you already set it yourself. This keeps dev canvases, the SQLite metadata DB, and daemon tokens out of the real `~/.whiteboard` a packaged (npm/Docker/stdio) install uses. Launching from a `git worktree` gets that worktree's own `.dev-data` — intentional, so parallel dev-loop lanes never share (or corrupt) each other's canvas data. If you have existing dev data under `~/.whiteboard` from before this change, move it in from the repo root with `mv ~/.whiteboard .dev-data` — do this only while no dev daemon is running, and note that an already-running old daemon on `:3099` keeps writing to `~/.whiteboard` until you restart it.
+> **Data lives in `.dev-data/`, not your real `~/.whiteboard`:** `pnpm mcp:http:dev` (and anything that shells out to it — `mcp:debug:http`, the `SessionStart` hook) runs through `packages/mcp-server/scripts/dev/with-dev-data-dir.mjs`, which sets `WHITEBOARD_DATA_DIR` to `<repo root>/.dev-data` unless you already set it yourself. This keeps dev canvases, the SQLite metadata DB, and daemon tokens out of the real `~/.whiteboard` a packaged (npm/Docker/stdio) install uses. Launching from a `git worktree` gets that worktree's own `.dev-data` — intentional, so parallel dev-loop lanes never share (or corrupt) each other's canvas data. If you have existing dev data under `~/.whiteboard` from before this change, move its *contents* into `.dev-data` at the repo root — the `SessionStart` hook typically creates an empty `.dev-data/` before you get to this step, so a plain `mv ~/.whiteboard .dev-data` nests the old directory one level too deep (`.dev-data/.whiteboard/whiteboard.db` instead of `.dev-data/whiteboard.db`) and your canvases will look missing. From the repo root:
+
+```bash
+mkdir -p .dev-data && mv ~/.whiteboard/* ~/.whiteboard/.[!.]* .dev-data/ 2>/dev/null; rmdir ~/.whiteboard
+```
+
+Do this only while no dev daemon is running — an already-running old daemon on `:3099` keeps writing to `~/.whiteboard` until you restart it.
 
 **Codex** — set in `~/.codex/config.toml`:
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -72,6 +72,8 @@ The daemon listens on `http://127.0.0.1:3099/mcp`.
 
 > **Auto-start:** The repo's `SessionStart` hook (`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`) probes port 3099 and spawns the daemon automatically when Claude Code or Codex opens the repo. If the daemon does not start automatically (hooks disabled, project not yet trusted, or port 3099 already in use by another process), run `pnpm mcp:http:dev` manually in a separate terminal before making MCP calls.
 
+> **Data lives in `.dev-data/`, not your real `~/.whiteboard`:** `pnpm mcp:http:dev` (and anything that shells out to it — `mcp:debug:http`, the `SessionStart` hook) runs through `packages/mcp-server/scripts/dev/with-dev-data-dir.mjs`, which sets `WHITEBOARD_DATA_DIR` to `<repo root>/.dev-data` unless you already set it yourself. This keeps dev canvases, the SQLite metadata DB, and daemon tokens out of the real `~/.whiteboard` a packaged (npm/Docker/stdio) install uses. Launching from a `git worktree` gets that worktree's own `.dev-data` — intentional, so parallel dev-loop lanes never share (or corrupt) each other's canvas data. If you have existing dev data under `~/.whiteboard` from before this change, move it in from the repo root with `mv ~/.whiteboard .dev-data` — do this only while no dev daemon is running, and note that an already-running old daemon on `:3099` keeps writing to `~/.whiteboard` until you restart it.
+
 **Codex** — set in `~/.codex/config.toml`:
 
 ```toml

--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -148,15 +148,15 @@ Database migration failed: corrupted migrations: previously executed migration 0
 
 or a similar "corrupted migrations" message, your local database is incompatible with the current codebase.
 
-**Pre-1.0 policy**: `~/.whiteboard` databases are **disposable**. On an incompatible upgrade, re-create the database:
+**Pre-1.0 policy**: the data dir's databases are **disposable**. On an incompatible upgrade, re-create the database. `pnpm mcp:http:dev` defaults to the repo-local `.dev-data/` dir (see [development.md](./development.md)) rather than the packaged install's `~/.whiteboard` — adjust the path below if you set `WHITEBOARD_DATA_DIR` yourself:
 
 ```bash
 # 1. Stop any running daemon first
 # 2. Back up any canvas files you want to keep
-cp -r ~/.whiteboard ~/.whiteboard.bak
+cp -r .dev-data .dev-data.bak
 
 # 3. Remove the database
-rm ~/.whiteboard/whiteboard.db
+rm .dev-data/whiteboard.db
 
 # 4. Restart the daemon — it will create a fresh database
 pnpm mcp:http:dev

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -125,7 +125,7 @@
     "mutation:contracts": "stryker run",
     "mcp": "node --import tsx/esm src/server/mcp/index.ts",
     "mcp:http": "node dist/server/index.js --daemon --port=3099 --token=whiteboard-dev",
-    "mcp:http:dev": "tsx watch src/server/index.ts --daemon --port=3099 --token=whiteboard-dev",
+    "mcp:http:dev": "node scripts/dev/with-dev-data-dir.mjs --daemon --port=3099 --token=whiteboard-dev",
     "mcp:inspect": "npx @modelcontextprotocol/inspector",
     "mcp:inspect:stdio": "npx @modelcontextprotocol/inspector node --import tsx/esm src/server/mcp/index.ts",
     "mcp:debug:http": "concurrently \"pnpm mcp:http:dev\" \"pnpm mcp:inspect\"",

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -56,6 +56,24 @@ export function resolveDevDataDirEnv(env, repoRoot) {
 }
 
 /**
+ * Re-raises a signal the child process died from so the parent's own exit
+ * reflects it (matching shell semantics for a wrapped command). `kill(pid,
+ * signal)` with a POSIX signal name can throw EINVAL on Windows — Windows
+ * has no POSIX signal delivery, so falling through uncaught would crash this
+ * wrapper instead of just exiting non-zero.
+ */
+export function reraiseSignalOrExit(
+  signal,
+  { pid = process.pid, kill = process.kill, exit = process.exit } = {},
+) {
+  try {
+    kill(pid, signal)
+  } catch {
+    exit(1)
+  }
+}
+
+/**
  * Resolves the command + args to launch `tsx watch <entry>` cross-platform.
  *
  * `node_modules/.bin/tsx` is a POSIX shell shim (paired with `.cmd`/`.ps1`

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path'
+
+/**
+ * Resolves the repo root from this script's own directory rather than the
+ * process cwd — `pnpm -F @kamiazya/whiteboard-mcp mcp:http:dev` runs with
+ * cwd=packages/mcp-server, so a cwd-relative guess would be wrong when
+ * launched from the repo root (and wrong again from a worktree).
+ *
+ * dev -> scripts -> mcp-server -> packages -> repoRoot.
+ */
+export function resolveRepoRootFromScriptDir(scriptDir) {
+  return resolve(scriptDir, '../../../..')
+}
+
+/**
+ * Returns a new env object with WHITEBOARD_DATA_DIR pointed at
+ * <repoRoot>/.dev-data, unless the caller already set it — an explicit
+ * env override always wins over the repo-local dev default.
+ *
+ * Running from inside a git worktree resolves to that worktree's own
+ * .dev-data, which is intentional: it keeps parallel dev-loop lanes from
+ * sharing (and corrupting) one another's canvas data.
+ */
+export function resolveDevDataDirEnv(env, repoRoot) {
+  if (env.WHITEBOARD_DATA_DIR) {
+    return { ...env }
+  }
+  return { ...env, WHITEBOARD_DATA_DIR: resolve(repoRoot, '.dev-data') }
+}

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -1,4 +1,31 @@
+import { chmodSync, mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
+
+// Owner-only, matching shared/data-dir-secure.ts's POSIX_DATA_DIR_MODE. Kept
+// as a separate literal here (rather than importing the TS module) because
+// these dev scripts run directly via `node`, before any build step.
+const DEV_DATA_DIR_MODE = 0o700
+
+/**
+ * Creates (if missing) and hardens the dev data dir to owner-only
+ * permissions. resolveDataDir() in shared/data-dir-secure.ts only applies
+ * this hardening on its own home-directory default path — an explicit
+ * WHITEBOARD_DATA_DIR (which is exactly what this wrapper sets) short-circuits
+ * that check and returns immediately. Without this, `.dev-data` can end up
+ * created at 0755 under a common umask, leaving the SQLite DB and daemon
+ * token world/group-readable on shared machines.
+ */
+export function ensureDevDataDirSecured(dir, platformName = process.platform) {
+  mkdirSync(dir, { recursive: true, mode: DEV_DATA_DIR_MODE })
+  if (platformName !== 'win32') {
+    try {
+      // mkdir's mode can still be widened by umask, so tighten it again.
+      chmodSync(dir, DEV_DATA_DIR_MODE)
+    } catch {
+      /* Best-effort only; dev startup should continue even if this fails. */
+    }
+  }
+}
 
 /**
  * Resolves the repo root from this script's own directory rather than the
@@ -26,4 +53,26 @@ export function resolveDevDataDirEnv(env, repoRoot) {
     return { ...env }
   }
   return { ...env, WHITEBOARD_DATA_DIR: resolve(repoRoot, '.dev-data') }
+}
+
+/**
+ * Resolves the command + args to launch `tsx watch <entry>` cross-platform.
+ *
+ * `node_modules/.bin/tsx` is a POSIX shell shim (paired with `.cmd`/`.ps1`
+ * wrappers on Windows); spawning it directly with `shell: false` only works
+ * on POSIX. tsx's package.json `bin` field points at a plain ESM entrypoint
+ * (`dist/cli.mjs`), so spawning `node <that file>` sidesteps the platform
+ * shim entirely and behaves identically on every OS.
+ */
+export function resolveTsxWatchSpawn(
+  packageRoot,
+  entryPath,
+  extraArgs,
+  { execPath = process.execPath } = {},
+) {
+  const tsxCliPath = resolve(packageRoot, 'node_modules/tsx/dist/cli.mjs')
+  return {
+    command: execPath,
+    args: [tsxCliPath, 'watch', entryPath, ...extraArgs],
+  }
 }

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -1,0 +1,38 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveDevDataDirEnv, resolveRepoRootFromScriptDir } from './with-dev-data-dir-lib.mjs'
+
+describe('resolveDevDataDirEnv', () => {
+  const repoRoot = '/repo'
+
+  it('sets WHITEBOARD_DATA_DIR to <repoRoot>/.dev-data when unset', () => {
+    const result = resolveDevDataDirEnv({}, repoRoot)
+
+    expect(result.WHITEBOARD_DATA_DIR).toBe(resolve('/repo/.dev-data'))
+  })
+
+  it('does NOT override an already-set WHITEBOARD_DATA_DIR (explicit env always wins)', () => {
+    const result = resolveDevDataDirEnv({ WHITEBOARD_DATA_DIR: '/custom/data' }, repoRoot)
+
+    expect(result.WHITEBOARD_DATA_DIR).toBe('/custom/data')
+  })
+
+  it('returns a new object and leaves the input env untouched (immutable update)', () => {
+    const input = { FOO: 'bar' }
+    const result = resolveDevDataDirEnv(input, repoRoot)
+
+    expect(result).not.toBe(input)
+    expect(input).not.toHaveProperty('WHITEBOARD_DATA_DIR')
+    expect(result.FOO).toBe('bar')
+  })
+})
+
+describe('resolveRepoRootFromScriptDir', () => {
+  it('resolves the repo root two levels above packages/mcp-server from the dev scripts dir', () => {
+    // This file lives at packages/mcp-server/scripts/dev — repo root is
+    // four levels up (dev -> scripts -> mcp-server -> packages -> repoRoot).
+    const scriptDir = '/repo/packages/mcp-server/scripts/dev'
+
+    expect(resolveRepoRootFromScriptDir(scriptDir)).toBe(resolve('/repo'))
+  })
+})

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   ensureDevDataDirSecured,
+  reraiseSignalOrExit,
   resolveDevDataDirEnv,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
@@ -73,6 +74,34 @@ describe('resolveRepoRootFromScriptDir', () => {
     const scriptDir = '/repo/packages/mcp-server/scripts/dev'
 
     expect(resolveRepoRootFromScriptDir(scriptDir)).toBe(resolve('/repo'))
+  })
+})
+
+describe('reraiseSignalOrExit', () => {
+  it('re-raises the signal against the given pid via kill', () => {
+    const calls = []
+    reraiseSignalOrExit('SIGTERM', {
+      pid: 4242,
+      kill: (pid, signal) => calls.push({ pid, signal }),
+      exit: () => {
+        throw new Error('exit should not be called when kill succeeds')
+      },
+    })
+
+    expect(calls).toEqual([{ pid: 4242, signal: 'SIGTERM' }])
+  })
+
+  it('falls back to exit(1) when kill throws (e.g. Windows EINVAL on POSIX signals)', () => {
+    const exitCalls = []
+    reraiseSignalOrExit('SIGTERM', {
+      pid: 4242,
+      kill: () => {
+        throw new Error('EINVAL: invalid argument, kill')
+      },
+      exit: (code) => exitCalls.push(code),
+    })
+
+    expect(exitCalls).toEqual([1])
   })
 })
 

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -1,6 +1,13 @@
-import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
-import { resolveDevDataDirEnv, resolveRepoRootFromScriptDir } from './with-dev-data-dir-lib.mjs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ensureDevDataDirSecured,
+  resolveDevDataDirEnv,
+  resolveRepoRootFromScriptDir,
+  resolveTsxWatchSpawn,
+} from './with-dev-data-dir-lib.mjs'
 
 describe('resolveDevDataDirEnv', () => {
   const repoRoot = '/repo'
@@ -27,6 +34,38 @@ describe('resolveDevDataDirEnv', () => {
   })
 })
 
+describe('ensureDevDataDirSecured', () => {
+  let tempRoot: string
+
+  afterEach(() => {
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('creates a missing directory and hardens it to owner-only 0700 on posix', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-data-secure-'))
+    const target = join(tempRoot, 'nested', '.dev-data')
+
+    ensureDevDataDirSecured(target)
+
+    expect(existsSync(target)).toBe(true)
+    if (process.platform !== 'win32') {
+      expect(statSync(target).mode & 0o777).toBe(0o700)
+    }
+  })
+
+  it('tightens an existing directory that was created under a looser umask', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-data-secure-'))
+    const target = join(tempRoot, '.dev-data')
+    mkdirSync(target, { mode: 0o755 })
+
+    ensureDevDataDirSecured(target)
+
+    if (process.platform !== 'win32') {
+      expect(statSync(target).mode & 0o777).toBe(0o700)
+    }
+  })
+})
+
 describe('resolveRepoRootFromScriptDir', () => {
   it('resolves the repo root two levels above packages/mcp-server from the dev scripts dir', () => {
     // This file lives at packages/mcp-server/scripts/dev — repo root is
@@ -34,5 +73,33 @@ describe('resolveRepoRootFromScriptDir', () => {
     const scriptDir = '/repo/packages/mcp-server/scripts/dev'
 
     expect(resolveRepoRootFromScriptDir(scriptDir)).toBe(resolve('/repo'))
+  })
+})
+
+describe('resolveTsxWatchSpawn', () => {
+  it('spawns node directly against tsx dist/cli.mjs, not the node_modules/.bin shim', () => {
+    const result = resolveTsxWatchSpawn(
+      '/repo/packages/mcp-server',
+      '/repo/packages/mcp-server/src/server/index.ts',
+      ['--foo'],
+      { execPath: '/usr/local/bin/node' },
+    )
+
+    expect(result).toEqual({
+      command: '/usr/local/bin/node',
+      args: [
+        resolve('/repo/packages/mcp-server/node_modules/tsx/dist/cli.mjs'),
+        'watch',
+        '/repo/packages/mcp-server/src/server/index.ts',
+        '--foo',
+      ],
+    })
+  })
+
+  it('does not reference node_modules/.bin anywhere in the resolved command or args', () => {
+    const result = resolveTsxWatchSpawn('/repo/packages/mcp-server', '/repo/entry.ts', [])
+
+    expect(result.command).not.toContain('.bin')
+    expect(result.args.every((arg) => !arg.includes('.bin'))).toBe(true)
   })
 })

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -3,7 +3,12 @@
 import { spawn } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { resolveDevDataDirEnv, resolveRepoRootFromScriptDir } from './with-dev-data-dir-lib.mjs'
+import {
+  ensureDevDataDirSecured,
+  resolveDevDataDirEnv,
+  resolveRepoRootFromScriptDir,
+  resolveTsxWatchSpawn,
+} from './with-dev-data-dir-lib.mjs'
 
 // Keeps dev daemons started via `pnpm mcp:http:dev` (and anything that
 // shells out to it — mcp:debug:http, the SessionStart ensure-http-dev-daemon
@@ -12,15 +17,29 @@ import { resolveDevDataDirEnv, resolveRepoRootFromScriptDir } from './with-dev-d
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '../..')
 const repoRoot = resolveRepoRootFromScriptDir(scriptDir)
+const hadExplicitDataDirOverride = Boolean(process.env.WHITEBOARD_DATA_DIR)
 const env = resolveDevDataDirEnv(process.env, repoRoot)
+
+// resolveDataDir() (shared/data-dir-secure.ts) only hardens permissions on
+// its own home-directory default; an explicit WHITEBOARD_DATA_DIR — which is
+// exactly what we just set below — short-circuits that and skips it
+// entirely. Harden it ourselves, but only for the repo-local default we
+// injected: a caller-provided override is respected as-is, same contract as
+// resolveDataDir().
+if (!hadExplicitDataDirOverride) {
+  ensureDevDataDirSecured(env.WHITEBOARD_DATA_DIR)
+}
 
 // Shell out to the real tsx CLI (not node's --watch + --import loader) so
 // this matches the exact restart/reload behavior of the pre-existing
-// `tsx watch ...` package script.
-const tsxBin = resolve(packageRoot, 'node_modules/.bin/tsx')
+// `tsx watch ...` package script. Spawns node directly against tsx's
+// dist/cli.mjs rather than node_modules/.bin/tsx: that .bin entry is a POSIX
+// shell shim (with separate .cmd/.ps1 wrappers on Windows), which `shell:
+// false` cannot execute on native Windows.
 const entryPath = resolve(packageRoot, 'src/server/index.ts')
+const { command, args } = resolveTsxWatchSpawn(packageRoot, entryPath, process.argv.slice(2))
 
-const child = spawn(tsxBin, ['watch', entryPath, ...process.argv.slice(2)], {
+const child = spawn(command, args, {
   cwd: packageRoot,
   env,
   stdio: 'inherit',

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resolveDevDataDirEnv, resolveRepoRootFromScriptDir } from './with-dev-data-dir-lib.mjs'
+
+// Keeps dev daemons started via `pnpm mcp:http:dev` (and anything that
+// shells out to it — mcp:debug:http, the SessionStart ensure-http-dev-daemon
+// hook) out of the real ~/.whiteboard by default. A node wrapper (not a
+// shell `VAR=x` prefix in package.json) so this stays correct on Windows.
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '../..')
+const repoRoot = resolveRepoRootFromScriptDir(scriptDir)
+const env = resolveDevDataDirEnv(process.env, repoRoot)
+
+// Shell out to the real tsx CLI (not node's --watch + --import loader) so
+// this matches the exact restart/reload behavior of the pre-existing
+// `tsx watch ...` package script.
+const tsxBin = resolve(packageRoot, 'node_modules/.bin/tsx')
+const entryPath = resolve(packageRoot, 'src/server/index.ts')
+
+const child = spawn(tsxBin, ['watch', entryPath, ...process.argv.slice(2)], {
+  cwd: packageRoot,
+  env,
+  stdio: 'inherit',
+})
+
+child.on('error', (error) => {
+  process.stderr.write(`[with-dev-data-dir] failed to spawn dev server: ${error.message}\n`)
+  process.exit(1)
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 1)
+})

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -5,6 +5,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   ensureDevDataDirSecured,
+  reraiseSignalOrExit,
   resolveDevDataDirEnv,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
@@ -52,7 +53,7 @@ child.on('error', (error) => {
 
 child.on('exit', (code, signal) => {
   if (signal) {
-    process.kill(process.pid, signal)
+    reraiseSignalOrExit(signal)
     return
   }
   process.exit(code ?? 1)

--- a/packages/mcp-server/src/server/config.ts
+++ b/packages/mcp-server/src/server/config.ts
@@ -1,11 +1,25 @@
 import { resolve } from 'node:path'
-import { DATA_DIR, resolveDataDir, WHITEBOARD_ROOT } from '../shared/data-dir-secure.js'
+import {
+  DATA_DIR,
+  getDataDir,
+  resetDataDirForTests,
+  resolveDataDir,
+  setDataDirForTests,
+  WHITEBOARD_ROOT,
+} from '../shared/data-dir-secure.js'
 
 // Re-export the create+secure data-dir resolution from the shared layer so
 // all existing server/store importers keep their '../server/config.js' import
 // paths unchanged. The definitions live in the shared layer so daemon files
 // can depend on them without importing upward into the server layer.
-export { DATA_DIR, resolveDataDir, WHITEBOARD_ROOT }
+export {
+  DATA_DIR,
+  getDataDir,
+  resetDataDirForTests,
+  resolveDataDir,
+  setDataDirForTests,
+  WHITEBOARD_ROOT,
+}
 
 // The compiled web-asset directory is a server-only concept (static-file
 // middleware). It must not live in the shared layer, which daemon and CLI

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -2,19 +2,22 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resetDataDirForTests, setDataDirForTests } from './config.js'
 import { captureLogsForTests } from './log.js'
 
-const { startHttpServerMock } = vi.hoisted(() => ({
+const { startHttpServerMock, saveDaemonRecordMock, deleteDaemonRecordMock } = vi.hoisted(() => ({
   startHttpServerMock: vi.fn(async () => ({
     port: 3099,
     getRuntimeStatus: () => ({ startedAt: '2026-01-01T00:00:00.000Z' }),
   })),
+  saveDaemonRecordMock: vi.fn(async () => undefined),
+  deleteDaemonRecordMock: vi.fn(async () => undefined),
 }))
 
 vi.mock('./http-server.js', () => ({ startHttpServer: startHttpServerMock }))
 vi.mock('../daemon/daemon-registry.js', () => ({
-  saveDaemonRecord: vi.fn(async () => undefined),
-  deleteDaemonRecord: vi.fn(async () => undefined),
+  saveDaemonRecord: saveDaemonRecordMock,
+  deleteDaemonRecord: deleteDaemonRecordMock,
 }))
 vi.mock('./security/mcp-auth.js', () => ({
   createLocalTokenMcpHttpAuthStrategy: vi.fn(() => ({})),
@@ -50,6 +53,50 @@ describe('server/index main() data dir startup log', () => {
       expect((record?.data?.dataDir as string).length).toBeGreaterThan(0)
     } finally {
       capture.restore()
+      stdoutSpy.mockRestore()
+    }
+  })
+})
+
+describe('server/index main() daemon mode data dir threading', () => {
+  const originalArgv = process.argv
+
+  afterEach(() => {
+    process.argv = originalArgv
+    resetDataDirForTests()
+    vi.clearAllMocks()
+    delete process.env.WHITEBOARD_TOKEN
+  })
+
+  it('passes the resolved dataDir (not the frozen DATA_DIR const) to saveDaemonRecord', async () => {
+    const scratchDir = '/tmp/whiteboard-index-daemon-mode-test'
+    setDataDirForTests(scratchDir)
+    process.env.WHITEBOARD_TOKEN = 'test-token'
+    process.argv = [...originalArgv, '--daemon']
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await main()
+      expect(saveDaemonRecordMock).toHaveBeenCalledWith(
+        expect.objectContaining({ pid: process.pid }),
+        scratchDir,
+      )
+    } finally {
+      stdoutSpy.mockRestore()
+    }
+  })
+
+  it('passes the resolved dataDir to deleteDaemonRecord via the close callback', async () => {
+    const scratchDir = '/tmp/whiteboard-index-daemon-mode-test-close'
+    setDataDirForTests(scratchDir)
+    process.env.WHITEBOARD_TOKEN = 'test-token'
+    process.argv = [...originalArgv, '--daemon']
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await main()
+      const onClose = startHttpServerMock.mock.calls[0][0].onClose as () => Promise<void>
+      await onClose()
+      expect(deleteDaemonRecordMock).toHaveBeenCalledWith(scratchDir)
+    } finally {
       stdoutSpy.mockRestore()
     }
   })

--- a/packages/mcp-server/src/server/index.test.ts
+++ b/packages/mcp-server/src/server/index.test.ts
@@ -32,6 +32,29 @@ vi.mock('./export/headless-renderer.js', () => ({
 // call the exported `main` directly instead.
 const { main } = await import('./index.js')
 
+describe('server/index main() data dir startup log', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete process.env.WHITEBOARD_TOKEN
+  })
+
+  it('emits a notice-level record naming the resolved data dir before startHttpServer', async () => {
+    process.env.WHITEBOARD_TOKEN = 'test-token'
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const capture = captureLogsForTests('debug')
+    try {
+      await main()
+      const record = capture.records.find((r) => r.scope === 'server-index' && r.level === 'notice')
+      expect(record).toBeDefined()
+      expect(typeof record?.data?.dataDir).toBe('string')
+      expect((record?.data?.dataDir as string).length).toBeGreaterThan(0)
+    } finally {
+      capture.restore()
+      stdoutSpy.mockRestore()
+    }
+  })
+})
+
 describe('server/index main() WHITEBOARD_ALLOWED_WEB_ORIGINS startup gate', () => {
   afterEach(() => {
     vi.clearAllMocks()

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 import { deleteDaemonRecord, saveDaemonRecord } from '../daemon/daemon-registry.js'
+import { PACKAGE_VERSION } from '../shared/package-version.js'
+import { getDataDir } from './config.js'
+import { applyConfigFileToEnvAndLogLevel, loadConfigFile } from './config-file.js'
+import { isDirectEntryPoint } from './entrypoint.js'
 import { startHttpServer } from './http-server.js'
-import { DATA_DIR } from './config.js'
+import { getLogger } from './log.js'
 import {
   createLocalTokenMcpHttpAuthStrategy,
   resolveMcpProtectedResourceMetadataFromEnv,
 } from './security/mcp-auth.js'
-import { isDirectEntryPoint } from './entrypoint.js'
 import { parseOAuthClientRegistryEnv } from './security/oauth-authz-registry.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
-import { PACKAGE_VERSION } from '../shared/package-version.js'
-import { applyConfigFileToEnvAndLogLevel, loadConfigFile } from './config-file.js'
-import { getLogger } from './log.js'
 
 function readArg(name: string, fallback?: string): string | undefined {
   const prefix = `--${name}=`
@@ -159,7 +159,17 @@ export async function main() {
   // Block startup until the schema is migrated and the v0 importer has run
   // so route handlers never see a half-initialized data directory.
   const { prepareDataDir } = await import('./store/db/prepare.js')
-  await prepareDataDir(DATA_DIR)
+  const dataDir = getDataDir()
+  await prepareDataDir(dataDir)
+
+  // Notice level (not info) because misdirected persistence — e.g. a dev
+  // daemon accidentally writing into the real ~/.whiteboard — is expensive
+  // to notice otherwise; this line is the one place that names where data
+  // actually landed for this process.
+  getLogger('server-index').notice(
+    { dataDir, source: process.env.WHITEBOARD_DATA_DIR ? 'env' : 'default' },
+    'resolved data dir',
+  )
 
   // Best-effort: warm the headless renderer in the background so the first
   // export_canvas call (when no browser is connected) does not pay the
@@ -179,7 +189,7 @@ export async function main() {
     oauthClientRegistry: oauthRegistry.registry,
     onClose: daemonMode
       ? async () => {
-          await deleteDaemonRecord(DATA_DIR)
+          await deleteDaemonRecord(dataDir)
         }
       : undefined,
   })

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -195,13 +195,21 @@ export async function main() {
   })
 
   if (daemonMode && token) {
-    await saveDaemonRecord({
-      pid: process.pid,
-      port: running.port,
-      token,
-      version,
-      startedAt: running.getRuntimeStatus().startedAt,
-    })
+    // Pass the resolved `dataDir` explicitly rather than relying on
+    // saveDaemonRecord's default parameter (the frozen DATA_DIR const) — the
+    // default would silently diverge from where this process actually
+    // prepared/serves data whenever getDataDir() has been redirected (tests,
+    // and any future dev entrypoint that redirects the seam).
+    await saveDaemonRecord(
+      {
+        pid: process.pid,
+        port: running.port,
+        token,
+        version,
+        startedAt: running.getRuntimeStatus().startedAt,
+      },
+      dataDir,
+    )
   }
 
   const shutdown = () => {

--- a/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
@@ -45,6 +45,24 @@ function connectAndWaitForOpen(url: string): Promise<WebSocket> {
   })
 }
 
+// Attaches the message listener at socket-creation time, not after `open`
+// resolves. With two connections opened sequentially, the first one's
+// initial snapshot frame can already have arrived (and be dropped, since
+// `ws`'s 'message' event has no listener-less buffering) by the time the
+// caller gets around to registering a `.once('message', ...)` for it.
+function connectAndCaptureSnapshot(
+  url: string,
+): Promise<{ ws: WebSocket; snapshot: Promise<Buffer> }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url)
+    const snapshot = new Promise<Buffer>((resolveSnapshot) => {
+      ws.once('message', (data: Buffer) => resolveSnapshot(data))
+    })
+    ws.once('open', () => resolve({ ws, snapshot }))
+    ws.once('error', reject)
+  })
+}
+
 describe('handleWsUpgrade over a real WebSocketServer + real ws client', () => {
   const realHomeWhiteboard = join(homedir(), '.whiteboard')
   let realHomeStatBefore: ReturnType<typeof statSync> | undefined
@@ -119,5 +137,74 @@ describe('handleWsUpgrade over a real WebSocketServer + real ws client', () => {
       ? statSync(realHomeWhiteboard)
       : undefined
     expect(realHomeStatAfter?.mtimeMs).toBe(realHomeStatBefore?.mtimeMs)
+  })
+
+  it('closes only the offending socket with 1003 on a malformed binary frame while the daemon and concurrent connections survive', async () => {
+    const server = createServer()
+    const wss = new WebSocketServer({ server })
+    wss.on('connection', (ws, req) => {
+      void handleWsUpgrade(req, ws)
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (address === null || typeof address === 'string') {
+      throw new Error('expected server to bind to a TCP port')
+    }
+    const { port } = address
+
+    const { ws: clientA, snapshot: snapshotA } = await connectAndCaptureSnapshot(
+      `ws://127.0.0.1:${port}/ws/session1/canvas-a`,
+    )
+    const { ws: clientB, snapshot: snapshotB } = await connectAndCaptureSnapshot(
+      `ws://127.0.0.1:${port}/ws/session1/canvas-a`,
+    )
+    try {
+      // Drain each client's initial snapshot frame before sending anything else.
+      await snapshotA
+      const snapshotBytesB = await snapshotB
+
+      const closeEvent = new Promise<{ code: number; reason: string }>((resolve) => {
+        clientA.once('close', (code, reasonBuf) => resolve({ code, reason: reasonBuf.toString() }))
+      })
+
+      // Not a valid Loro update — Loro's decoder should reject this outright.
+      clientA.send(Buffer.from([1, 2, 3]))
+
+      const { code, reason } = await closeEvent
+      expect(code).toBe(1003)
+      expect(reason).toBe('Malformed canvas update')
+
+      // The daemon and the concurrent connection must survive the bad frame.
+      expect(clientB.readyState).toBe(WebSocket.OPEN)
+
+      const clientDoc = new LoroDoc()
+      clientDoc.import(new Uint8Array(snapshotBytesB))
+      const prevVV = clientDoc.version()
+      const list = clientDoc.getMovableList('elements')
+      const map = list.insertContainer(0, new LoroMap())
+      map.set('id', 'survivor-elem')
+      map.set('type', 'rectangle')
+      clientDoc.commit()
+      const update = Buffer.from(clientDoc.export({ mode: 'update', from: prevVV }) as Uint8Array)
+      clientB.send(update)
+
+      await vi.waitFor(async () => {
+        const saved = await loadCanvas('session1', 'canvas-a')
+        const elements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
+        expect(elements.map((entry) => entry.id)).toContain('survivor-elem')
+      })
+
+      // Only B's element made it to disk; A's malformed bytes never
+      // decoded into anything that could be persisted.
+      const saved = await loadCanvas('session1', 'canvas-a')
+      const elements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
+      expect(elements.map((entry) => entry.id)).toEqual(['survivor-elem'])
+    } finally {
+      clientA.close()
+      clientB.close()
+      wss.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
   })
 })

--- a/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
@@ -1,0 +1,123 @@
+// Regression test for tmp/issues/ws-real-socket-e2e-needs-injectable-data-dir.md:
+// exercises a REAL WebSocketServer + real `ws` client (not the FakeWebSocket
+// used elsewhere in ws.test.ts) so a Loro binary update travels over an
+// actual loopback TCP socket into saveCanvas's real filesystem write path.
+// DATA_DIR is redirected via the getDataDir() test-injection seam
+// (setDataDirForTests) instead of a hand-rolled per-file mock, proving the
+// seam is sufficient to keep a real-socket persistence test off the
+// developer's real home directory.
+
+import { existsSync, statSync } from 'node:fs'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LoroDoc, LoroMap } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSocket, WebSocketServer } from 'ws'
+
+let scratchDir: string
+
+vi.mock('../config.js', async () => {
+  const actual = await import('../../shared/data-dir-secure.js')
+  return {
+    get DATA_DIR() {
+      return actual.getDataDir()
+    },
+    getDataDir: actual.getDataDir,
+    setDataDirForTests: actual.setDataDirForTests,
+    resetDataDirForTests: actual.resetDataDirForTests,
+    WHITEBOARD_ROOT: '/tmp/whiteboard',
+    REPO_ROOT: '/tmp',
+  }
+})
+
+const { setDataDirForTests, resetDataDirForTests } = await import('../../shared/data-dir-secure.js')
+const { clearCache } = await import('../store/doc-cache.js')
+const { loadCanvas } = await import('../store/canvas-store.js')
+const { handleWsUpgrade } = await import('./ws.js')
+
+function connectAndWaitForOpen(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url)
+    ws.once('open', () => resolve(ws))
+    ws.once('error', reject)
+  })
+}
+
+describe('handleWsUpgrade over a real WebSocketServer + real ws client', () => {
+  const realHomeWhiteboard = join(homedir(), '.whiteboard')
+  let realHomeStatBefore: ReturnType<typeof statSync> | undefined
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-real-socket-'))
+    await mkdir(join(scratchDir, 'session1'), { recursive: true })
+    setDataDirForTests(scratchDir)
+    clearCache()
+    realHomeStatBefore = existsSync(realHomeWhiteboard) ? statSync(realHomeWhiteboard) : undefined
+  })
+
+  afterEach(async () => {
+    resetDataDirForTests()
+    clearCache()
+    await rm(scratchDir, { recursive: true, force: true })
+  })
+
+  it('persists a binary Loro update under the injected scratch dir and never touches the real home dir', async () => {
+    const server = createServer()
+    const wss = new WebSocketServer({ server })
+    wss.on('connection', (ws, req) => {
+      void handleWsUpgrade(req, ws)
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (address === null || typeof address === 'string') {
+      throw new Error('expected server to bind to a TCP port')
+    }
+    const { port } = address
+
+    const client = await connectAndWaitForOpen(`ws://127.0.0.1:${port}/ws/session1/canvas-a`)
+    try {
+      // First frame off the wire is always the initial snapshot; wait for
+      // it before sending an update so the client doc's version vector is
+      // based on the server's starting state.
+      const snapshotBytes = await new Promise<Buffer>((resolve) => {
+        client.once('message', (data: Buffer) => resolve(data))
+      })
+      const serverDoc = new LoroDoc()
+      serverDoc.import(new Uint8Array(snapshotBytes))
+      const prevVV = serverDoc.version()
+
+      const clientDoc = new LoroDoc()
+      clientDoc.import(new Uint8Array(snapshotBytes))
+      const list = clientDoc.getMovableList('elements')
+      const map = list.insertContainer(0, new LoroMap())
+      map.set('id', 'real-socket-elem')
+      map.set('type', 'rectangle')
+      clientDoc.commit()
+
+      const update = Buffer.from(clientDoc.export({ mode: 'update', from: prevVV }) as Uint8Array)
+      client.send(update)
+
+      // saveCanvas is awaited inside the message handler; poll briefly for
+      // the write to land instead of pinning to a specific timeout value.
+      await vi.waitFor(async () => {
+        const saved = await loadCanvas('session1', 'canvas-a')
+        const elements = saved.getMovableList('elements').toJSON() as Array<{ id: string }>
+        expect(elements.map((entry) => entry.id)).toContain('real-socket-elem')
+      })
+    } finally {
+      client.close()
+      wss.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+
+    // Persistence landed under the injected scratch dir, not the real home.
+    expect(existsSync(join(scratchDir, 'whiteboard.db'))).toBe(true)
+    const realHomeStatAfter = existsSync(realHomeWhiteboard)
+      ? statSync(realHomeWhiteboard)
+      : undefined
+    expect(realHomeStatAfter?.mtimeMs).toBe(realHomeStatBefore?.mtimeMs)
+  })
+})

--- a/packages/mcp-server/src/shared/data-dir-contract.test.ts
+++ b/packages/mcp-server/src/shared/data-dir-contract.test.ts
@@ -16,7 +16,14 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
-import { resolveDataDir, WHITEBOARD_ROOT, DATA_DIR } from './data-dir-secure.js'
+import {
+  DATA_DIR,
+  getDataDir,
+  resetDataDirForTests,
+  resolveDataDir,
+  setDataDirForTests,
+  WHITEBOARD_ROOT,
+} from './data-dir-secure.js'
 
 describe('data-dir contract: probe and create resolvers agree in steady state', () => {
   let tempHome: string
@@ -156,6 +163,33 @@ describe('WHITEBOARD_ROOT depth: shared module resolves to package root', () => 
     // If the re-export chain is broken this import itself would throw.
     expect(typeof DATA_DIR).toBe('string')
     expect(DATA_DIR.length).toBeGreaterThan(0)
+  })
+})
+
+describe('getDataDir test-injection seam', () => {
+  afterEach(() => {
+    resetDataDirForTests()
+  })
+
+  it('returns the same value as the module-load-time DATA_DIR const by default', () => {
+    expect(getDataDir()).toBe(DATA_DIR)
+  })
+
+  it('setDataDirForTests overrides subsequent getDataDir() calls without touching DATA_DIR', () => {
+    const scratchDir = '/tmp/whiteboard-dev-data-dir-injection-test'
+    setDataDirForTests(scratchDir)
+
+    expect(getDataDir()).toBe(scratchDir)
+    // The frozen const must stay untouched — it is a separate, deprecated
+    // export kept only for callers that have not migrated to getDataDir().
+    expect(DATA_DIR).not.toBe(scratchDir)
+  })
+
+  it('resetDataDirForTests restores the default (memoized) resolution', () => {
+    setDataDirForTests('/tmp/whiteboard-dev-data-dir-injection-test-2')
+    resetDataDirForTests()
+
+    expect(getDataDir()).toBe(DATA_DIR)
   })
 })
 

--- a/packages/mcp-server/src/shared/data-dir-contract.test.ts
+++ b/packages/mcp-server/src/shared/data-dir-contract.test.ts
@@ -14,7 +14,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
 import {
   DATA_DIR,
@@ -190,6 +190,22 @@ describe('getDataDir test-injection seam', () => {
     resetDataDirForTests()
 
     expect(getDataDir()).toBe(DATA_DIR)
+  })
+
+  it('resetDataDirForTests clears the memoized default so a later env change is picked up', () => {
+    // Populate the memo with whatever the ambient env resolves to.
+    getDataDir()
+    resetDataDirForTests()
+
+    const overridePath = resolve('/tmp/whiteboard-dev-data-dir-env-after-reset')
+    vi.stubEnv('WHITEBOARD_DATA_DIR', overridePath)
+    try {
+      // If reset left the stale memo in place, this would still return the
+      // pre-reset value instead of picking up the new env override.
+      expect(getDataDir()).toBe(overridePath)
+    } finally {
+      vi.unstubAllEnvs()
+    }
   })
 })
 

--- a/packages/mcp-server/src/shared/data-dir-secure.ts
+++ b/packages/mcp-server/src/shared/data-dir-secure.ts
@@ -86,4 +86,8 @@ export function setDataDirForTests(dir: string): void {
 
 export function resetDataDirForTests(): void {
   dataDirOverride = undefined
+  // Also drop the memoized default: a test that changes WHITEBOARD_DATA_DIR
+  // (or homedir/tmpdir) after reset must see it reflected on the next
+  // getDataDir() call, not a resolution memoized before the reset.
+  memoizedDataDir = undefined
 }

--- a/packages/mcp-server/src/shared/data-dir-secure.ts
+++ b/packages/mcp-server/src/shared/data-dir-secure.ts
@@ -1,8 +1,7 @@
-import { constants as fsConstants } from 'node:fs'
-import { accessSync, chmodSync, mkdirSync } from 'node:fs'
+import { accessSync, chmodSync, constants as fsConstants, mkdirSync } from 'node:fs'
 import { homedir, platform, tmpdir } from 'node:os'
-import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // From src/shared/data-dir-secure.ts, going up two directories reaches the package root.
 // src/shared -> src -> package root. Same depth as src/server, so '../..' is unchanged.
@@ -56,4 +55,35 @@ export function resolveDataDir(
   return resolve(options.tmpDir ?? tmpdir(), '.whiteboard')
 }
 
+// Deprecated: a module-load-time snapshot, frozen before a test (or a
+// future dev entrypoint) can redirect where data lives. Prefer getDataDir()
+// for any new call site — it stays lazily resolved so setDataDirForTests()
+// can retarget it before the first real read.
 export const DATA_DIR = resolveDataDir()
+
+let dataDirOverride: string | undefined
+let memoizedDataDir: string | undefined
+
+/**
+ * Lazily resolved, test-injectable counterpart to DATA_DIR. Memoizes the
+ * first resolveDataDir() call (or the injected override) so repeated reads
+ * stay cheap and consistent within a process, while still letting tests
+ * redirect persistence to a scratch directory before anything touches disk.
+ */
+export function getDataDir(): string {
+  if (dataDirOverride !== undefined) {
+    return dataDirOverride
+  }
+  if (memoizedDataDir === undefined) {
+    memoizedDataDir = resolveDataDir()
+  }
+  return memoizedDataDir
+}
+
+export function setDataDirForTests(dir: string): void {
+  dataDirOverride = dir
+}
+
+export function resetDataDirForTests(): void {
+  dataDirOverride = undefined
+}


### PR DESCRIPTION
## Problem

1. `pnpm mcp:http:dev` (and everything that shells into it — `mcp:debug:http`, the SessionStart hook) started the dev daemon with no data-dir override, so **dev canvases, the SQLite DB, and daemon tokens landed in the developer's real `~/.whiteboard`**, mixed with packaged-install data.
2. `DATA_DIR` was a module-load-time const, so an in-process test running a real WebSocketServer + `saveCanvas` risked writing into the real home dir — which is why PR #238's malformed-frame DoS regression could only be covered with fake sockets.

## Change

- **Repo-local dev data**: new `with-dev-data-dir.mjs` wrapper resolves `<repo root>/.dev-data` (absolute, from the script's own path), sets `WHITEBOARD_DATA_DIR` only when unset (explicit env always wins), enforces owner-only 0700, and spawns tsx via its JS CLI (Windows-safe). `.dev-data/` is gitignored. Packaged distribution behavior (env → `~/.whiteboard` → tmpdir) is untouched.
- **Test-injectable DATA_DIR**: `getDataDir()` (memoized lazy resolve) + `setDataDirForTests()`/`resetDataDirForTests()` in `data-dir-secure.ts`, re-exported from `config.ts`; the daemon startup/persistence path is migrated, the legacy `DATA_DIR` const stays exported (deprecation comment) so existing `vi.mock` / child-process-env tests are untouched. `saveDaemonRecord` now receives the resolved dataDir.
- **Startup visibility**: daemon startup logs one notice-level structured record `{ dataDir, source }` — misdirected persistence is now visible in one line.
- **Real-socket regression suite** (`ws-real-socket.test.ts`, real WebSocketServer + real `ws` client against an injected scratch dir): ① a valid Loro update persists under the scratch dir and never touches the (faked) home dir; ② **the PR #238 DoS scenario at the real socket layer** — malformed binary frame → offending socket closes `1003 "Malformed canvas update"`, daemon survives, a concurrent connection stays open and its subsequent valid update persists, and no malformed bytes are persisted. This resolves both halves of the deferred follow-up from #238.
- **Docs**: `docs/contributing/development.md` (+ mcp-debugging.md) document `.dev-data/`, the worktree-local behavior, and a depth-correct migration command for existing `~/.whiteboard` dev data.

## Known limitation (follow-up decided)

All worktrees still talk to whichever daemon owns port 3099 — the SessionStart probe doesn't verify the daemon's repo root, so a second worktree silently reuses the first one's daemon and `.dev-data`. Per-worktree port separation was chosen as the fix and is tracked as the next lane; this PR's isolation applies to whichever checkout actually starts the daemon.

## Verification

dev-loop gate (plan-review ×2 + multi-dimension review + adversarial verify + QA) with 1 fix round: perms hardening, Windows tsx spawn, dataDir threading into saveDaemonRecord, migration-command depth. mcp-node suite green (incl. new wrapper-lib, data-dir contract, startup-log, and 2 real-socket tests), `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean.