### PR TITLE
fix(mcp-server): fix backup-restore smoke daemon registration and scrub WHITEBOARD_DEV from packaged smokes

### DIFF
--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -27,7 +27,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
-import { assertNoLeak } from './smoke-helpers.mjs'
+import { assertNoLeak, scrubDevEnv } from './smoke-helpers.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..', '..')
@@ -90,7 +90,7 @@ function startDaemon({ dataDir, port, token, label }) {
     {
       cwd: REPO_ROOT,
       env: {
-        ...process.env,
+        ...scrubDevEnv(process.env),
         WHITEBOARD_DATA_DIR: dataDir,
         // DAEMON_ENTRY is invoked directly (not via `whiteboard daemon run`),
         // so the token is read by resolveToken() in server/index.ts, which
@@ -199,7 +199,10 @@ async function shutdownDaemon(daemon) {
 }
 
 function runCli(args) {
-  return spawnSync(process.execPath, [CLI_ENTRY, ...args], { encoding: 'utf-8' })
+  return spawnSync(process.execPath, [CLI_ENTRY, ...args], {
+    encoding: 'utf-8',
+    env: scrubDevEnv(process.env),
+  })
 }
 
 // assertNoLeak (BASE_LEAK_PATTERNS) is imported from smoke-helpers.mjs.
@@ -287,7 +290,7 @@ try {
     const proc = spawn(
       process.execPath,
       [CLI_ENTRY, 'daemon', 'stop', '--json', `--data-dir=${srcDataDir}`],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      { stdio: ['ignore', 'pipe', 'pipe'], env: scrubDevEnv(process.env) },
     )
     let out = ''
     let err = ''
@@ -457,7 +460,7 @@ try {
     const proc = spawn(
       process.execPath,
       [CLI_ENTRY, 'daemon', 'stop', '--json', `--data-dir=${restoredDataDir}`],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      { stdio: ['ignore', 'pipe', 'pipe'], env: scrubDevEnv(process.env) },
     )
     let out = ''
     let err = ''

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -92,7 +92,15 @@ function startDaemon({ dataDir, port, token, label }) {
       env: {
         ...process.env,
         WHITEBOARD_DATA_DIR: dataDir,
-        WHITEBOARD_DAEMON_TOKEN: token,
+        // DAEMON_ENTRY is invoked directly (not via `whiteboard daemon run`),
+        // so the token is read by resolveToken() in server/index.ts, which
+        // only honours --token= or WHITEBOARD_TOKEN — WHITEBOARD_DAEMON_TOKEN
+        // (the env var the `daemon run` CLI subcommand reads instead) is a
+        // no-op here. Passing the wrong name meant `daemonMode && token` was
+        // always false, so the daemon never wrote its registry record, and
+        // every later `whiteboard daemon stop` for this dir failed with
+        // "record-not-found".
+        WHITEBOARD_TOKEN: token,
         WHITEBOARD_LOG_LEVEL: process.env.WHITEBOARD_LOG_LEVEL ?? 'warning',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -183,10 +191,7 @@ async function shutdownDaemon(daemon) {
     return
   }
   daemon.child.kill('SIGTERM')
-  const winner = await Promise.race([
-    daemon.closed,
-    delay(SHUTDOWN_TIMEOUT_MS, 'timeout'),
-  ])
+  const winner = await Promise.race([daemon.closed, delay(SHUTDOWN_TIMEOUT_MS, 'timeout')])
   if (winner === 'timeout') {
     daemon.child.kill('SIGKILL')
     await daemon.closed
@@ -244,16 +249,11 @@ try {
   }
 
   const seededList = await (
-    await authedFetch(
-      daemonA,
-      `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases`,
-    )
+    await authedFetch(daemonA, `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases`)
   ).json()
   const seededSlugs = (seededList?.canvases ?? []).map((c) => c.slug)
   if (!seededSlugs.includes(SEED_CANVAS_SLUG)) {
-    throw new Error(
-      `seeded canvas not present after POST: ${JSON.stringify(seededSlugs)}`,
-    )
+    throw new Error(`seeded canvas not present after POST: ${JSON.stringify(seededSlugs)}`)
   }
   console.log(`[packaged-daemon-backup-restore-smoke] seeded workspaceId → ${WORKSPACE_ID}`)
 
@@ -368,16 +368,11 @@ try {
     )
   }
   const restoredCanvases = await (
-    await authedFetch(
-      daemonB,
-      `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases`,
-    )
+    await authedFetch(daemonB, `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases`)
   ).json()
   const restoredSlugs = (restoredCanvases?.canvases ?? []).map((c) => c.slug)
   if (!restoredSlugs.includes(SEED_CANVAS_SLUG)) {
-    throw new Error(
-      `restored daemon missing seeded canvas: ${JSON.stringify(restoredSlugs)}`,
-    )
+    throw new Error(`restored daemon missing seeded canvas: ${JSON.stringify(restoredSlugs)}`)
   }
   console.log(
     `[packaged-daemon-backup-restore-smoke] restored data round-tripped (workspace=${WORKSPACE_ID}, canvas=${SEED_CANVAS_SLUG})`,
@@ -422,12 +417,7 @@ try {
   )
 
   // ───────── Phase 4: packaged CLI status against restored dir ─────────
-  const cliRun = runCli([
-    'daemon',
-    'status',
-    '--json',
-    `--data-dir=${restoredDataDir}`,
-  ])
+  const cliRun = runCli(['daemon', 'status', '--json', `--data-dir=${restoredDataDir}`])
   if (cliRun.status !== 0) {
     throw new Error(
       `whiteboard daemon status --json (restored) exited ${cliRun.status}\n` +
@@ -437,13 +427,21 @@ try {
   assertNoLeak('cli status stdout', cliRun.stdout, [TOKEN_B])
   assertNoLeak('cli status stderr', cliRun.stderr, [TOKEN_B])
   const cliResult = JSON.parse(cliRun.stdout.trim())
+  // `whiteboard daemon status --json` (see daemon-status.ts DaemonStatusResult)
+  // has never had a top-level baseUrl field — only record.port/pid. Derive
+  // the expected base URL from record.port instead of asserting a field the
+  // CLI contract does not emit.
   const cliExpectations = [
     ['ok', cliResult.ok, true],
     ['reason', cliResult.reason, null],
     ['recordFresh', cliResult.recordFresh, true],
     ['record.pid', cliResult.record?.pid, daemonB.child.pid],
     ['record.port', cliResult.record?.port, PORT_B],
-    ['baseUrl', cliResult.baseUrl, `http://${HOST}:${PORT_B}`],
+    [
+      'derived baseUrl (host + record.port)',
+      `http://${HOST}:${cliResult.record?.port}`,
+      `http://${HOST}:${PORT_B}`,
+    ],
   ]
   for (const [field, actual, expected] of cliExpectations) {
     if (actual !== expected) {

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -92,14 +92,10 @@ function startDaemon({ dataDir, port, token, label }) {
       env: {
         ...scrubDevEnv(process.env),
         WHITEBOARD_DATA_DIR: dataDir,
-        // DAEMON_ENTRY is invoked directly (not via `whiteboard daemon run`),
-        // so the token is read by resolveToken() in server/index.ts, which
-        // only honours --token= or WHITEBOARD_TOKEN — WHITEBOARD_DAEMON_TOKEN
-        // (the env var the `daemon run` CLI subcommand reads instead) is a
-        // no-op here. Passing the wrong name meant `daemonMode && token` was
-        // always false, so the daemon never wrote its registry record, and
-        // every later `whiteboard daemon stop` for this dir failed with
-        // "record-not-found".
+        // DAEMON_ENTRY is spawned directly (not via `whiteboard daemon run`),
+        // so resolveToken() in server/index.ts only honours --token= or
+        // WHITEBOARD_TOKEN. WHITEBOARD_DAEMON_TOKEN is read by the `daemon
+        // run` CLI subcommand only and has no effect here.
         WHITEBOARD_TOKEN: token,
         WHITEBOARD_LOG_LEVEL: process.env.WHITEBOARD_LOG_LEVEL ?? 'warning',
       },
@@ -300,11 +296,12 @@ try {
     proc.stderr.on('data', (c) => {
       err += c.toString()
     })
-    proc.on('close', (status) => res({ status, stdout: out, stderr: err }))
+    proc.on('close', (status, signal) => res({ status, signal, stdout: out, stderr: err }))
   })
   if (stopA.status !== 0) {
+    const reason = stopA.signal ? `signal ${stopA.signal}` : `code ${stopA.status}`
     throw new Error(
-      `daemon A stop failed: ${stopA.status}\n--- stdout ---\n${stopA.stdout}\n--- stderr ---\n${stopA.stderr}`,
+      `daemon A stop failed: ${reason}\n--- stdout ---\n${stopA.stdout}\n--- stderr ---\n${stopA.stderr}`,
     )
   }
   assertNoLeak('daemon A stop stdout', stopA.stdout, [TOKEN_A])
@@ -472,11 +469,12 @@ try {
     proc.stderr.on('data', (c) => {
       err += c.toString()
     })
-    proc.on('close', (status) => res({ status, stdout: out, stderr: err }))
+    proc.on('close', (status, signal) => res({ status, signal, stdout: out, stderr: err }))
   })
   if (stopB.status !== 0) {
+    const reason = stopB.signal ? `signal ${stopB.signal}` : `code ${stopB.status}`
     throw new Error(
-      `daemon B stop failed: ${stopB.status}\n--- stdout ---\n${stopB.stdout}\n--- stderr ---\n${stopB.stderr}`,
+      `daemon B stop failed: ${reason}\n--- stdout ---\n${stopB.stdout}\n--- stderr ---\n${stopB.stderr}`,
     )
   }
   assertNoLeak('daemon B stop stdout', stopB.stdout, [TOKEN_B])

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -303,7 +303,9 @@ try {
     proc.on('close', (status) => res({ status, stdout: out, stderr: err }))
   })
   if (stopA.status !== 0) {
-    throw new Error(`daemon A stop failed: ${stopA.status} ${stopA.stderr}`)
+    throw new Error(
+      `daemon A stop failed: ${stopA.status}\n--- stdout ---\n${stopA.stdout}\n--- stderr ---\n${stopA.stderr}`,
+    )
   }
   assertNoLeak('daemon A stop stdout', stopA.stdout, [TOKEN_A])
   assertNoLeak('daemon A stop stderr', stopA.stderr, [TOKEN_A])
@@ -473,7 +475,9 @@ try {
     proc.on('close', (status) => res({ status, stdout: out, stderr: err }))
   })
   if (stopB.status !== 0) {
-    throw new Error(`daemon B stop failed: ${stopB.status} ${stopB.stderr}`)
+    throw new Error(
+      `daemon B stop failed: ${stopB.status}\n--- stdout ---\n${stopB.stdout}\n--- stderr ---\n${stopB.stderr}`,
+    )
   }
   assertNoLeak('daemon B stop stdout', stopB.stdout, [TOKEN_B])
   assertNoLeak('daemon B stop stderr', stopB.stderr, [TOKEN_B])

--- a/tests/e2e/distribution/packaged-daemon-token-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-token-smoke.mjs
@@ -23,7 +23,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
-import { assertNoLeak } from './smoke-helpers.mjs'
+import { assertNoLeak, scrubDevEnv } from './smoke-helpers.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..', '..')
@@ -57,6 +57,7 @@ function fail(msg, ctx = {}) {
 
 function runCli(args, opts = {}) {
   return spawnSync(process.execPath, [CLI, ...args], {
+    env: scrubDevEnv(process.env),
     ...opts,
     encoding: 'utf8',
     timeout: 10_000,
@@ -70,7 +71,8 @@ function runCli(args, opts = {}) {
   if (r.stdout.trim() !== '') fail('scenario 1: stdout must be empty', { stdout: r.stdout })
   assertNoLeak('scenario 1 stderr', r.stderr)
   if (r.stderr.includes('smoke-argv-secret-token')) fail('scenario 1: raw token in stderr')
-  if (!r.stderr.includes('--token')) fail('scenario 1: error must mention --token', { stderr: r.stderr })
+  if (!r.stderr.includes('--token'))
+    fail('scenario 1: error must mention --token', { stderr: r.stderr })
   console.log('[token-smoke] scenario 1 PASS: --token=<value> → exit 64, stderr safe')
 }
 
@@ -79,13 +81,10 @@ function runCli(args, opts = {}) {
   const ENV_TOKEN = 'smoke-env-conflict-token-XYZ'
   const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-token-smoke-s2-'))
   try {
-    const r = runCli(
-      ['daemon', 'run', '--json', '--token-stdin', `--data-dir=${dataDir}`],
-      {
-        input: 'stdin-conflict-token\n',
-        env: { ...process.env, WHITEBOARD_DAEMON_TOKEN: ENV_TOKEN },
-      },
-    )
+    const r = runCli(['daemon', 'run', '--json', '--token-stdin', `--data-dir=${dataDir}`], {
+      input: 'stdin-conflict-token\n',
+      env: { ...scrubDevEnv(process.env), WHITEBOARD_DAEMON_TOKEN: ENV_TOKEN },
+    })
     if (r.status !== 1) fail(`scenario 2: expected exit 1, got ${r.status}`, { stderr: r.stderr })
     if (r.stdout.trim() !== '') fail('scenario 2: stdout must be empty', { stdout: r.stdout })
     assertNoLeak('scenario 2 stderr', r.stderr)
@@ -98,16 +97,27 @@ function runCli(args, opts = {}) {
 }
 
 // --- Scenarios 3 & 4: real daemon runs ----------------------------------
-async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.env) {
+async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = scrubDevEnv(process.env)) {
   const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-token-smoke-daemon-'))
   let stdoutBuf = ''
   let stderrBuf = ''
   let firstLineResolve
-  const firstLine = new Promise((r) => { firstLineResolve = r })
+  const firstLine = new Promise((r) => {
+    firstLineResolve = r
+  })
 
   const child = spawn(
     process.execPath,
-    [CLI, 'daemon', 'run', '--json', `--host=${HOST}`, `--port=${PORT}`, `--data-dir=${dataDir}`, ...extraArgs],
+    [
+      CLI,
+      'daemon',
+      'run',
+      '--json',
+      `--host=${HOST}`,
+      `--port=${PORT}`,
+      `--data-dir=${dataDir}`,
+      ...extraArgs,
+    ],
     { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...baseEnv, ...extraEnv } },
   )
   child.stdout.on('data', (chunk) => {
@@ -116,15 +126,25 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.e
     const nl = stdoutBuf.indexOf('\n')
     if (nl !== -1) firstLineResolve(stdoutBuf.slice(0, nl))
   })
-  child.stderr.on('data', (chunk) => { stderrBuf += chunk.toString() })
+  child.stderr.on('data', (chunk) => {
+    stderrBuf += chunk.toString()
+  })
 
   const closed = new Promise((r) => child.once('close', r))
 
   async function shutdown() {
     if (child.exitCode !== null) return
-    try { child.kill('SIGTERM') } catch { /* gone */ }
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      /* gone */
+    }
     await Promise.race([closed, delay(SHUTDOWN_TIMEOUT_MS)])
-    try { child.kill('SIGKILL') } catch { /* gone */ }
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      /* gone */
+    }
     await closed
   }
 
@@ -132,11 +152,15 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.e
     const winner = await Promise.race([firstLine, delay(READINESS_TIMEOUT_MS, 'timeout')])
     if (winner === 'timeout') {
       await shutdown()
-      fail(`${label}: daemon did not emit ready JSON within ${READINESS_TIMEOUT_MS}ms`, { stderr: stderrBuf })
+      fail(`${label}: daemon did not emit ready JSON within ${READINESS_TIMEOUT_MS}ms`, {
+        stderr: stderrBuf,
+      })
     }
 
     let ready
-    try { ready = JSON.parse(winner) } catch {
+    try {
+      ready = JSON.parse(winner)
+    } catch {
       fail(`${label}: first stdout line not valid JSON`, { line: winner })
     }
     if (!ready.ok) fail(`${label}: ready.ok not true`, { ready })
@@ -145,7 +169,8 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.e
     const recordPath = join(dataDir, 'daemon.json')
     if (!existsSync(recordPath)) fail(`${label}: daemon.json not found`)
     const record = JSON.parse(readFileSync(recordPath, 'utf8'))
-    if (!record.token || record.token.length < 8) fail(`${label}: daemon record has no token or token too short`)
+    if (!record.token || record.token.length < 8)
+      fail(`${label}: daemon record has no token or token too short`)
 
     // Non-leak: the token from the record must not appear in stdout or stderr
     if (stdoutBuf.includes(record.token)) fail(`${label}: token leaked to stdout`)
@@ -169,7 +194,9 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.e
     [],
   )
   if (record.token !== ENV_TOKEN)
-    fail(`scenario 3: daemon record token does not match env token (got ${record.token.slice(0, 8)}…)`)
+    fail(
+      `scenario 3: daemon record token does not match env token (got ${record.token.slice(0, 8)}…)`,
+    )
   console.log('[token-smoke] scenario 3 PASS: env token in record, stdout/stderr safe')
 }
 
@@ -178,7 +205,7 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = process.e
 // environment that has the variable set doesn't silently exercise the
 // env-token path instead of the auto-generate path.
 {
-  const baseEnv = { ...process.env }
+  const baseEnv = { ...scrubDevEnv(process.env) }
   delete baseEnv.WHITEBOARD_DAEMON_TOKEN
   const envCanary = process.env.WHITEBOARD_DAEMON_TOKEN
   const { record } = await runDaemonScenario('scenario 4', {}, [], baseEnv)

--- a/tests/e2e/distribution/packaged-daemon-token-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-token-smoke.mjs
@@ -139,13 +139,15 @@ async function runDaemonScenario(label, extraEnv, extraArgs, baseEnv = scrubDevE
     } catch {
       /* gone */
     }
-    await Promise.race([closed, delay(SHUTDOWN_TIMEOUT_MS)])
-    try {
-      child.kill('SIGKILL')
-    } catch {
-      /* gone */
+    const winner = await Promise.race([closed, delay(SHUTDOWN_TIMEOUT_MS, 'timeout')])
+    if (winner === 'timeout') {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* gone */
+      }
+      await closed
     }
-    await closed
   }
 
   try {

--- a/tests/e2e/distribution/packaged-server-mode-cli-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-cli-smoke.mjs
@@ -46,23 +46,23 @@ import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 import { spawn, spawnSync } from 'node:child_process'
-import { assertNoLeak } from './smoke-helpers.mjs'
+import { assertNoLeak, scrubDevEnv } from './smoke-helpers.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '../../..')
-const DIST_CLI  = resolve(REPO_ROOT, 'packages/mcp-server/dist/cli/index.js')
+const DIST_CLI = resolve(REPO_ROOT, 'packages/mcp-server/dist/cli/index.js')
 
-const DAEMON_PORT   = 4292
-const SERVER_PORT   = 4295
-const SEED_TOKEN    = 'smoke-cli-seed-token-x7z9q'
-const SMOKE_ISSUER  = 'https://auth.server-cli-smoke.example'
+const DAEMON_PORT = 4292
+const SERVER_PORT = 4295
+const SEED_TOKEN = 'smoke-cli-seed-token-x7z9q'
+const SMOKE_ISSUER = 'https://auth.server-cli-smoke.example'
 const SMOKE_AUDIENCE = 'https://whiteboard.server-cli-smoke.example'
-const WORKSPACE_ID  = 'sess-cli-smoke'
-const CANVAS_SLUG   = 'canvas-cli-smoke'
+const WORKSPACE_ID = 'sess-cli-smoke'
+const CANVAS_SLUG = 'canvas-cli-smoke'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-const leakTexts = []   // accumulated for the final non-leak pass
+const leakTexts = [] // accumulated for the final non-leak pass
 
 function fail(msg, ctx = {}) {
   console.error(`[server-cli-smoke] FAIL: ${msg}`)
@@ -80,9 +80,13 @@ function cli(args, extraEnv = {}) {
   const r = spawnSync(process.execPath, [DIST_CLI, ...args], {
     encoding: 'utf8',
     timeout: 30_000,
-    env: { ...process.env, ...extraEnv },
+    env: { ...scrubDevEnv(process.env), ...extraEnv },
   })
-  leakTexts.push({ label: `cli ${args.slice(0, 3).join(' ')}`, stdout: r.stdout ?? '', stderr: r.stderr ?? '' })
+  leakTexts.push({
+    label: `cli ${args.slice(0, 3).join(' ')}`,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  })
   return r
 }
 
@@ -103,53 +107,97 @@ async function waitForReadyJson(proc, timeoutMs = 30_000) {
             res(obj)
             return
           }
-        } catch { /* not JSON */ }
+        } catch {
+          /* not JSON */
+        }
       }
     })
-    proc.on('exit', () => { clearTimeout(timer); res(null) })
+    proc.on('exit', () => {
+      clearTimeout(timer)
+      res(null)
+    })
   })
 }
 
 async function waitForHttpReady(url, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    try { const r = await fetch(url); if (r.ok) return true } catch { /* not yet */ }
+    try {
+      const r = await fetch(url)
+      if (r.ok) return true
+    } catch {
+      /* not yet */
+    }
     await delay(300)
   }
   return false
 }
 
 function killProc(proc) {
-  try { proc.kill('SIGTERM') } catch { /* already gone */ }
+  try {
+    proc.kill('SIGTERM')
+  } catch {
+    /* already gone */
+  }
 }
 
 function generateTestTlsCert(dir) {
-  const keyFile  = join(dir, 'server.key')
+  const keyFile = join(dir, 'server.key')
   const certFile = join(dir, 'server.crt')
-  const cnfFile  = join(dir, 'openssl.cnf')
-  writeFileSync(cnfFile, [
-    '[req]', 'distinguished_name = req_dn', 'x509_extensions = san_ext', 'prompt = no',
-    '[req_dn]', 'CN = server-cli-smoke-ca',
-    '[san_ext]', 'subjectAltName = IP:127.0.0.1', 'basicConstraints = critical,CA:true',
-  ].join('\n'))
-  const r = spawnSync('openssl', [
-    'req', '-x509', '-newkey', 'rsa:2048', '-keyout', keyFile, '-out', certFile,
-    '-days', '1', '-nodes', '-config', cnfFile,
-  ], { stdio: 'pipe', encoding: 'utf8' })
+  const cnfFile = join(dir, 'openssl.cnf')
+  writeFileSync(
+    cnfFile,
+    [
+      '[req]',
+      'distinguished_name = req_dn',
+      'x509_extensions = san_ext',
+      'prompt = no',
+      '[req_dn]',
+      'CN = server-cli-smoke-ca',
+      '[san_ext]',
+      'subjectAltName = IP:127.0.0.1',
+      'basicConstraints = critical,CA:true',
+    ].join('\n'),
+  )
+  const r = spawnSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyFile,
+      '-out',
+      certFile,
+      '-days',
+      '1',
+      '-nodes',
+      '-config',
+      cnfFile,
+    ],
+    { stdio: 'pipe', encoding: 'utf8' },
+  )
   if (r.status !== 0) throw new Error(`openssl cert gen failed: ${r.stderr}`)
   return { keyFile, certFile }
 }
 
-function base64url(data) { return Buffer.from(data).toString('base64url') }
+function base64url(data) {
+  return Buffer.from(data).toString('base64url')
+}
 function derToRawEs256(der) {
   let off = 2
-  const rLen = der[off + 1]; let r = der.slice(off + 2, off + 2 + rLen)
+  const rLen = der[off + 1]
+  let r = der.slice(off + 2, off + 2 + rLen)
   if (r[0] === 0x00) r = r.slice(1)
   off += 2 + rLen
-  const sLen = der[off + 1]; let s = der.slice(off + 2, off + 2 + sLen)
+  const sLen = der[off + 1]
+  let s = der.slice(off + 2, off + 2 + sLen)
   if (s[0] === 0x00) s = s.slice(1)
-  const rp = Buffer.alloc(32); r.copy(rp, 32 - r.length)
-  const sp = Buffer.alloc(32); s.copy(sp, 32 - s.length)
+  const rp = Buffer.alloc(32)
+  r.copy(rp, 32 - r.length)
+  const sp = Buffer.alloc(32)
+  s.copy(sp, 32 - s.length)
   return Buffer.concat([rp, sp])
 }
 function signEs256Jwt(priv, header, payload) {
@@ -162,9 +210,17 @@ function signEs256Jwt(priv, header, payload) {
 }
 function makeJwt(priv, scope) {
   const now = Math.floor(Date.now() / 1000)
-  return signEs256Jwt(priv,
+  return signEs256Jwt(
+    priv,
     { alg: 'ES256', kid: 'cli-smoke-key' },
-    { sub: 'cli-smoke-user', scope, iss: SMOKE_ISSUER, aud: SMOKE_AUDIENCE, iat: now, exp: now + 3600 },
+    {
+      sub: 'cli-smoke-user',
+      scope,
+      iss: SMOKE_ISSUER,
+      aud: SMOKE_AUDIENCE,
+      iat: now,
+      exp: now + 3600,
+    },
   )
 }
 
@@ -182,11 +238,11 @@ console.log('[server-cli-smoke] Starting server backup/restore CLI smoke.')
 
 // Canonicalize so paths don't traverse system-level symlinks (e.g. /var →
 // /private/var on macOS) that would trip the ancestor-symlink guard in the CLI.
-const tmpRoot        = realpathSync(mkdtempSync(join(tmpdir(), 'wb-cli-smoke-')))
-const certsDir       = join(tmpRoot, 'certs')
-const srcDataDir     = join(tmpRoot, 'src-data')
-const backupDir      = join(tmpRoot, 'backup')
-const restoredDir    = join(tmpRoot, 'restored')
+const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'wb-cli-smoke-')))
+const certsDir = join(tmpRoot, 'certs')
+const srcDataDir = join(tmpRoot, 'src-data')
+const backupDir = join(tmpRoot, 'backup')
+const restoredDir = join(tmpRoot, 'restored')
 mkdirSync(certsDir)
 mkdirSync(srcDataDir)
 
@@ -198,7 +254,7 @@ const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256
 const jwkPublic = publicKey.export({ format: 'jwk' })
 const jwks = { keys: [{ ...jwkPublic, kid: 'cli-smoke-key', use: 'sig', alg: 'ES256' }] }
 const { certFile: tlsCertFile, keyFile: tlsKeyFile } = generateTestTlsCert(certsDir)
-const tlsKey  = readFileSync(tlsKeyFile)
+const tlsKey = readFileSync(tlsKeyFile)
 const tlsCert = readFileSync(tlsCertFile)
 
 const jwksServer = await new Promise((resolve, reject) => {
@@ -206,13 +262,16 @@ const jwksServer = await new Promise((resolve, reject) => {
     if (req.url === '/.well-known/jwks.json') {
       res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify(jwks))
-    } else { res.writeHead(404); res.end() }
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
   })
   srv.listen(0, '127.0.0.1', () => resolve(srv))
   srv.once('error', reject)
 })
 const jwksPort = jwksServer.address().port
-const jwksUri  = `https://127.0.0.1:${jwksPort}/.well-known/jwks.json`
+const jwksUri = `https://127.0.0.1:${jwksPort}/.well-known/jwks.json`
 SMOKE_LITERALS.push(jwksUri)
 
 let seedDaemon = null
@@ -223,14 +282,23 @@ try {
   // ── Scenario 2: seed data via daemon ───────────────────────────────────────
 
   {
-    seedDaemon = spawn(process.execPath, [
-      DIST_CLI, 'daemon', 'run', '--json',
-      '--host=127.0.0.1', `--port=${DAEMON_PORT}`, `--data-dir=${srcDataDir}`,
-    ], { stdio: 'pipe', env: { ...process.env, WHITEBOARD_DAEMON_TOKEN: SEED_TOKEN } })
+    seedDaemon = spawn(
+      process.execPath,
+      [
+        DIST_CLI,
+        'daemon',
+        'run',
+        '--json',
+        '--host=127.0.0.1',
+        `--port=${DAEMON_PORT}`,
+        `--data-dir=${srcDataDir}`,
+      ],
+      { stdio: 'pipe', env: { ...scrubDevEnv(process.env), WHITEBOARD_DAEMON_TOKEN: SEED_TOKEN } },
+    )
 
     const ready = await waitForReadyJson(seedDaemon)
     if (!ready) fail('scenario 2: daemon did not emit ready JSON')
-    if (!await waitForHttpReady(`http://127.0.0.1:${DAEMON_PORT}/api/runtime/ping`)) {
+    if (!(await waitForHttpReady(`http://127.0.0.1:${DAEMON_PORT}/api/runtime/ping`))) {
       fail('scenario 2: daemon HTTP not ready')
     }
 
@@ -239,7 +307,7 @@ try {
       `http://127.0.0.1:${DAEMON_PORT}/api/workspaces/${WORKSPACE_ID}/canvases`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${SEED_TOKEN}` },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${SEED_TOKEN}` },
         body: JSON.stringify({ slug: CANVAS_SLUG }),
       },
     )
@@ -255,16 +323,24 @@ try {
   // ── Scenario 3: backup via CLI ─────────────────────────────────────────────
 
   {
-    const r = cli(['server', 'backup', '--json', `--data-dir=${srcDataDir}`, `--output-dir=${backupDir}`])
+    const r = cli([
+      'server',
+      'backup',
+      '--json',
+      `--data-dir=${srcDataDir}`,
+      `--output-dir=${backupDir}`,
+    ])
     if (r.status !== 0) {
       fail('scenario 3: backup CLI failed', { stderrBytes: (r.stderr ?? '').length })
     }
     let backupJson
-    try { backupJson = JSON.parse(r.stdout.trim()) } catch {
+    try {
+      backupJson = JSON.parse(r.stdout.trim())
+    } catch {
       fail('scenario 3: backup stdout is not valid JSON')
     }
     if (backupJson.schemaVersion !== 1) fail('scenario 3: schemaVersion mismatch')
-    if (backupJson.ok !== true)         fail('scenario 3: ok not true')
+    if (backupJson.ok !== true) fail('scenario 3: ok not true')
     if (backupJson.operation !== 'backup') fail('scenario 3: operation mismatch')
     assertNoLeak('scenario 3 backup stdout', r.stdout, SMOKE_LITERALS)
     assertNoLeak('scenario 3 backup stderr', r.stderr ?? '')
@@ -274,16 +350,24 @@ try {
   // ── Scenario 4: restore via CLI ────────────────────────────────────────────
 
   {
-    const r = cli(['server', 'restore', '--json', `--backup-dir=${backupDir}`, `--target-dir=${restoredDir}`])
+    const r = cli([
+      'server',
+      'restore',
+      '--json',
+      `--backup-dir=${backupDir}`,
+      `--target-dir=${restoredDir}`,
+    ])
     if (r.status !== 0) {
       fail('scenario 4: restore CLI failed', { stderrBytes: (r.stderr ?? '').length })
     }
     let restoreJson
-    try { restoreJson = JSON.parse(r.stdout.trim()) } catch {
+    try {
+      restoreJson = JSON.parse(r.stdout.trim())
+    } catch {
       fail('scenario 4: restore stdout is not valid JSON')
     }
-    if (restoreJson.schemaVersion !== 1)   fail('scenario 4: schemaVersion mismatch')
-    if (restoreJson.ok !== true)           fail('scenario 4: ok not true')
+    if (restoreJson.schemaVersion !== 1) fail('scenario 4: schemaVersion mismatch')
+    if (restoreJson.ok !== true) fail('scenario 4: ok not true')
     if (restoreJson.operation !== 'restore') fail('scenario 4: operation mismatch')
 
     // server-mode.json must have been removed from restored dir.
@@ -292,33 +376,42 @@ try {
     }
     assertNoLeak('scenario 4 restore stdout', r.stdout, SMOKE_LITERALS)
     assertNoLeak('scenario 4 restore stderr', r.stderr ?? '')
-    console.log('[server-cli-smoke] scenario 4 PASS: restore CLI succeeded, server-mode.json neutralized')
+    console.log(
+      '[server-cli-smoke] scenario 4 PASS: restore CLI succeeded, server-mode.json neutralized',
+    )
   }
 
   // ── Scenario 5: restored server-mode can boot and serve seeded canvas ──────
 
   {
-    serverMode = spawn(process.execPath, [
-      DIST_CLI, 'server', 'run', '--json',
-      `--data-dir=${restoredDir}`,
-      `--external-url=${SMOKE_AUDIENCE}`,
-      '--auth-strategy=oauth-jwt',
-      `--jwt-issuer=${SMOKE_ISSUER}`,
-      `--jwt-audience=${SMOKE_AUDIENCE}`,
-      `--jwks-uri=${jwksUri}`,
-      `--allowed-origins=${SMOKE_AUDIENCE}`,
-    ], {
-      stdio: 'pipe',
-      env: {
-        ...process.env,
-        WHITEBOARD_SERVER_PORT: String(SERVER_PORT),
-        NODE_EXTRA_CA_CERTS: tlsCertFile,
+    serverMode = spawn(
+      process.execPath,
+      [
+        DIST_CLI,
+        'server',
+        'run',
+        '--json',
+        `--data-dir=${restoredDir}`,
+        `--external-url=${SMOKE_AUDIENCE}`,
+        '--auth-strategy=oauth-jwt',
+        `--jwt-issuer=${SMOKE_ISSUER}`,
+        `--jwt-audience=${SMOKE_AUDIENCE}`,
+        `--jwks-uri=${jwksUri}`,
+        `--allowed-origins=${SMOKE_AUDIENCE}`,
+      ],
+      {
+        stdio: 'pipe',
+        env: {
+          ...scrubDevEnv(process.env),
+          WHITEBOARD_SERVER_PORT: String(SERVER_PORT),
+          NODE_EXTRA_CA_CERTS: tlsCertFile,
+        },
       },
-    })
+    )
 
     const ready = await waitForReadyJson(serverMode)
     if (!ready) fail('scenario 5: restored server did not emit ready JSON')
-    if (!await waitForHttpReady(`http://127.0.0.1:${SERVER_PORT}/api/runtime/ping`)) {
+    if (!(await waitForHttpReady(`http://127.0.0.1:${SERVER_PORT}/api/runtime/ping`))) {
       fail('scenario 5: restored server HTTP not ready')
     }
     assertNoLeak('scenario 5 ready JSON', JSON.stringify(ready))
@@ -327,7 +420,7 @@ try {
     const jwt = makeJwt(privateKey, 'workspace:read canvas:read')
     const listRes = await fetch(
       `http://127.0.0.1:${SERVER_PORT}/api/workspaces/${WORKSPACE_ID}/canvases`,
-      { headers: { 'Authorization': `Bearer ${jwt}` } },
+      { headers: { Authorization: `Bearer ${jwt}` } },
     )
     if (!listRes.ok) fail(`scenario 5: canvas list failed with ${listRes.status}`)
     const list = await listRes.json()
@@ -338,13 +431,18 @@ try {
     }
 
     // Auth contract: unauthenticated → 401, wrong scope → 403.
-    const noAuthRes = await fetch(`http://127.0.0.1:${SERVER_PORT}/api/workspaces/${WORKSPACE_ID}/canvases`)
-    if (noAuthRes.status !== 401) fail(`scenario 5: expected 401 for no-auth, got ${noAuthRes.status}`)
+    const noAuthRes = await fetch(
+      `http://127.0.0.1:${SERVER_PORT}/api/workspaces/${WORKSPACE_ID}/canvases`,
+    )
+    if (noAuthRes.status !== 401)
+      fail(`scenario 5: expected 401 for no-auth, got ${noAuthRes.status}`)
     assertNoLeak('scenario 5 no-auth body', await noAuthRes.text(), SMOKE_LITERALS)
 
     killProc(serverMode)
     serverMode = null
-    console.log('[server-cli-smoke] scenario 5 PASS: restored server booted, seeded canvas verified')
+    console.log(
+      '[server-cli-smoke] scenario 5 PASS: restored server booted, seeded canvas verified',
+    )
   }
 
   // ── Scenario 6: non-empty output dir is rejected ──────────────────────────
@@ -354,7 +452,13 @@ try {
     mkdirSync(nonEmptyOut)
     writeFileSync(join(nonEmptyOut, 'canary.txt'), 'content')
 
-    const r = cli(['server', 'backup', '--json', `--data-dir=${srcDataDir}`, `--output-dir=${nonEmptyOut}`])
+    const r = cli([
+      'server',
+      'backup',
+      '--json',
+      `--data-dir=${srcDataDir}`,
+      `--output-dir=${nonEmptyOut}`,
+    ])
     if (r.status === 0) fail('scenario 6: backup into non-empty output dir should have failed')
     if (r.stdout.trim() !== '') fail('scenario 6: stdout not empty on failure')
     assertNoLeak('scenario 6 stderr', r.stderr ?? '', SMOKE_LITERALS)
@@ -368,7 +472,13 @@ try {
     mkdirSync(nonEmptyTarget)
     writeFileSync(join(nonEmptyTarget, 'canary.txt'), 'content')
 
-    const r = cli(['server', 'restore', '--json', `--backup-dir=${backupDir}`, `--target-dir=${nonEmptyTarget}`])
+    const r = cli([
+      'server',
+      'restore',
+      '--json',
+      `--backup-dir=${backupDir}`,
+      `--target-dir=${nonEmptyTarget}`,
+    ])
     if (r.status === 0) fail('scenario 7: restore into non-empty target should have failed')
     if (r.stdout.trim() !== '') fail('scenario 7: stdout not empty on failure')
     assertNoLeak('scenario 7 stderr', r.stderr ?? '', SMOKE_LITERALS)
@@ -378,9 +488,9 @@ try {
   // ── Scenario 8: symlink inside data dir is rejected during backup ─────────
 
   {
-    const symlinkSrc  = join(tmpRoot, 'symlink-src')
+    const symlinkSrc = join(tmpRoot, 'symlink-src')
     const outsideFile = join(tmpRoot, 'outside-secret.txt')
-    const symlinkOut  = join(tmpRoot, 'symlink-out')
+    const symlinkOut = join(tmpRoot, 'symlink-out')
     mkdirSync(symlinkSrc)
     writeFileSync(outsideFile, 'outside-content')
     // Plant a symlink inside the data dir pointing to the outside file.
@@ -388,7 +498,13 @@ try {
     const { symlinkSync } = await import('node:fs')
     symlinkSync(outsideFile, join(symlinkSrc, 'evil-link.png'))
 
-    const r = cli(['server', 'backup', '--json', `--data-dir=${symlinkSrc}`, `--output-dir=${symlinkOut}`])
+    const r = cli([
+      'server',
+      'backup',
+      '--json',
+      `--data-dir=${symlinkSrc}`,
+      `--output-dir=${symlinkOut}`,
+    ])
     if (r.status === 0) fail('scenario 8: backup with symlink in data dir should have failed')
     if (r.stdout.trim() !== '') fail('scenario 8: stdout not empty on failure')
     assertNoLeak('scenario 8 stderr', r.stderr ?? '', SMOKE_LITERALS)
@@ -398,16 +514,23 @@ try {
   // ── Scenario 9: ancestor symlink in --output-dir path is rejected ─────────
 
   {
-    const realOut  = join(tmpRoot, 'anc-real-out')
-    const ancLink  = join(tmpRoot, 'anc-link-out')
+    const realOut = join(tmpRoot, 'anc-real-out')
+    const ancLink = join(tmpRoot, 'anc-link-out')
     const { symlinkSync } = await import('node:fs')
     mkdirSync(realOut)
     symlinkSync(realOut, ancLink)
 
     // Pass a path THROUGH the symlink as --output-dir so the ancestor walk
     // detects the symlink component and rejects the request.
-    const r = cli(['server', 'backup', '--json', `--data-dir=${srcDataDir}`, `--output-dir=${join(ancLink, 'backup')}`])
-    if (r.status === 0) fail('scenario 9: backup with symlinked ancestor in output-dir should have failed')
+    const r = cli([
+      'server',
+      'backup',
+      '--json',
+      `--data-dir=${srcDataDir}`,
+      `--output-dir=${join(ancLink, 'backup')}`,
+    ])
+    if (r.status === 0)
+      fail('scenario 9: backup with symlinked ancestor in output-dir should have failed')
     if (r.stdout.trim() !== '') fail('scenario 9: stdout not empty on failure')
     assertNoLeak('scenario 9 stderr', r.stderr ?? '', SMOKE_LITERALS)
     console.log('[server-cli-smoke] scenario 9 PASS: ancestor symlink in --output-dir rejected')
@@ -417,13 +540,20 @@ try {
 
   {
     const realTarget = join(tmpRoot, 'anc-real-target')
-    const ancLinkT   = join(tmpRoot, 'anc-link-target')
+    const ancLinkT = join(tmpRoot, 'anc-link-target')
     const { symlinkSync } = await import('node:fs')
     mkdirSync(realTarget)
     symlinkSync(realTarget, ancLinkT)
 
-    const r = cli(['server', 'restore', '--json', `--backup-dir=${backupDir}`, `--target-dir=${join(ancLinkT, 'restored')}`])
-    if (r.status === 0) fail('scenario 10: restore with symlinked ancestor in target-dir should have failed')
+    const r = cli([
+      'server',
+      'restore',
+      '--json',
+      `--backup-dir=${backupDir}`,
+      `--target-dir=${join(ancLinkT, 'restored')}`,
+    ])
+    if (r.status === 0)
+      fail('scenario 10: restore with symlinked ancestor in target-dir should have failed')
     if (r.stdout.trim() !== '') fail('scenario 10: stdout not empty on failure')
     assertNoLeak('scenario 10 stderr', r.stderr ?? '', SMOKE_LITERALS)
     console.log('[server-cli-smoke] scenario 10 PASS: ancestor symlink in --target-dir rejected')
@@ -433,20 +563,30 @@ try {
 
   {
     const liveDataDir = join(tmpRoot, 'live-src')
-    const liveOut     = join(tmpRoot, 'live-out')
+    const liveOut = join(tmpRoot, 'live-out')
     mkdirSync(liveDataDir)
     // Write a server-mode.json pointing to the smoke process itself (live PID).
-    writeFileSync(join(liveDataDir, 'server-mode.json'), JSON.stringify({
-      schemaVersion: 1,
-      pid: process.pid,
-      host: '127.0.0.1',
-      port: 3099,
-      publicBaseUrl: SMOKE_AUDIENCE,
-      authStrategy: 'oauth-jwt',
-      startedAt: new Date().toISOString(),
-    }), { mode: 0o600 })
+    writeFileSync(
+      join(liveDataDir, 'server-mode.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        host: '127.0.0.1',
+        port: 3099,
+        publicBaseUrl: SMOKE_AUDIENCE,
+        authStrategy: 'oauth-jwt',
+        startedAt: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    )
 
-    const r = cli(['server', 'backup', '--json', `--data-dir=${liveDataDir}`, `--output-dir=${liveOut}`])
+    const r = cli([
+      'server',
+      'backup',
+      '--json',
+      `--data-dir=${liveDataDir}`,
+      `--output-dir=${liveOut}`,
+    ])
     if (r.status === 0) fail('scenario 11: backup of running server should have been refused')
     if (r.stdout.trim() !== '') fail('scenario 11: stdout not empty on failure')
     if (!r.stderr?.includes('running')) fail('scenario 11: stderr should mention running')
@@ -459,18 +599,29 @@ try {
   {
     const liveTarget = join(tmpRoot, 'live-target')
     mkdirSync(liveTarget)
-    writeFileSync(join(liveTarget, 'server-mode.json'), JSON.stringify({
-      schemaVersion: 1,
-      pid: process.pid,
-      host: '127.0.0.1',
-      port: 3099,
-      publicBaseUrl: SMOKE_AUDIENCE,
-      authStrategy: 'oauth-jwt',
-      startedAt: new Date().toISOString(),
-    }), { mode: 0o600 })
+    writeFileSync(
+      join(liveTarget, 'server-mode.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        host: '127.0.0.1',
+        port: 3099,
+        publicBaseUrl: SMOKE_AUDIENCE,
+        authStrategy: 'oauth-jwt',
+        startedAt: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    )
 
-    const r = cli(['server', 'restore', '--json', `--backup-dir=${backupDir}`, `--target-dir=${liveTarget}`])
-    if (r.status === 0) fail('scenario 12: restore into running server target should have been refused')
+    const r = cli([
+      'server',
+      'restore',
+      '--json',
+      `--backup-dir=${backupDir}`,
+      `--target-dir=${liveTarget}`,
+    ])
+    if (r.status === 0)
+      fail('scenario 12: restore into running server target should have been refused')
     if (r.stdout.trim() !== '') fail('scenario 12: stdout not empty on failure')
     if (!r.stderr?.includes('running')) fail('scenario 12: stderr should mention running')
     assertNoLeak('scenario 12 stderr', r.stderr ?? '', SMOKE_LITERALS)
@@ -495,7 +646,12 @@ try {
     }
     // restore: missing --json
     {
-      const r = cli(['server', 'restore', `--backup-dir=${backupDir}`, `--target-dir=${restoredDir}`])
+      const r = cli([
+        'server',
+        'restore',
+        `--backup-dir=${backupDir}`,
+        `--target-dir=${restoredDir}`,
+      ])
       if (r.status !== 64) fail(`scenario 13c: expected exit 64, got ${r.status}`)
     }
     // restore: missing --target-dir
@@ -513,7 +669,14 @@ try {
     }
     // restore: bare positional must not echo value
     {
-      const r = cli(['server', 'restore', '--json', '--backup-dir=/b', '--target-dir=/t', 'bare-secret'])
+      const r = cli([
+        'server',
+        'restore',
+        '--json',
+        '--backup-dir=/b',
+        '--target-dir=/t',
+        'bare-secret',
+      ])
       if (r.status !== 64) fail(`scenario 13f: expected exit 64, got ${r.status}`)
       if ((r.stderr ?? '').includes('bare-secret')) {
         fail('scenario 13f: bare positional value leaked into stderr')
@@ -527,27 +690,47 @@ try {
   {
     // backup routes correctly (dry-run: --data-dir pointing to valid dir succeeds arg parse)
     {
-      const r = cli(['server', 'backup', '--json', `--output-dir=${join(tmpRoot, 'route-test')}`,
-        `--data-dir=${srcDataDir}`])
+      const r = cli([
+        'server',
+        'backup',
+        '--json',
+        `--output-dir=${join(tmpRoot, 'route-test')}`,
+        `--data-dir=${srcDataDir}`,
+      ])
       // The backup will succeed (srcDataDir exists and outputDir is new).
       // If routing were broken, we'd get exit 64 (usage) or a JSON from a wrong subcommand.
       if (r.status !== 0 && r.status !== 1) {
         fail(`scenario 14a: unexpected exit code ${r.status}`)
       }
       if (r.status === 0) {
-        let j; try { j = JSON.parse(r.stdout.trim()) } catch { fail('scenario 14a: invalid JSON') }
+        let j
+        try {
+          j = JSON.parse(r.stdout.trim())
+        } catch {
+          fail('scenario 14a: invalid JSON')
+        }
         if (j.operation !== 'backup') fail('scenario 14a: operation should be backup')
       }
     }
     // restore routes correctly
     {
-      const r = cli(['server', 'restore', '--json',
-        `--backup-dir=${backupDir}`, `--target-dir=${join(tmpRoot, 'route-restore')}`])
+      const r = cli([
+        'server',
+        'restore',
+        '--json',
+        `--backup-dir=${backupDir}`,
+        `--target-dir=${join(tmpRoot, 'route-restore')}`,
+      ])
       if (r.status !== 0 && r.status !== 1) {
         fail(`scenario 14b: unexpected exit code ${r.status}`)
       }
       if (r.status === 0) {
-        let j; try { j = JSON.parse(r.stdout.trim()) } catch { fail('scenario 14b: invalid JSON') }
+        let j
+        try {
+          j = JSON.parse(r.stdout.trim())
+        } catch {
+          fail('scenario 14b: invalid JSON')
+        }
         if (j.operation !== 'restore') fail('scenario 14b: operation should be restore')
       }
     }
@@ -569,10 +752,12 @@ try {
 
   {
     const bundleDataDir = join(tmpRoot, 'sb-data-missing')
-    const bundleOutDir  = join(tmpRoot, 'sb-out-missing')
+    const bundleOutDir = join(tmpRoot, 'sb-out-missing')
 
     const r = cli([
-      'server', 'support-bundle', '--json',
+      'server',
+      'support-bundle',
+      '--json',
       `--data-dir=${bundleDataDir}`,
       `--output-dir=${bundleOutDir}`,
     ])
@@ -582,28 +767,32 @@ try {
       })
     }
     let sbJson
-    try { sbJson = JSON.parse(r.stdout.trim()) } catch {
+    try {
+      sbJson = JSON.parse(r.stdout.trim())
+    } catch {
       fail('scenario 15: stdout is not valid JSON')
     }
-    if (sbJson.schemaVersion !== 1)          fail('scenario 15: schemaVersion mismatch')
-    if (sbJson.ok !== true)                  fail('scenario 15: ok not true')
+    if (sbJson.schemaVersion !== 1) fail('scenario 15: schemaVersion mismatch')
+    if (sbJson.ok !== true) fail('scenario 15: ok not true')
     if (sbJson.operation !== 'support-bundle') fail('scenario 15: operation mismatch')
-    if (!Array.isArray(sbJson.files))        fail('scenario 15: files not an array')
-    if ('outputDir' in sbJson)               fail('scenario 15: outputDir must not appear in success result')
+    if (!Array.isArray(sbJson.files)) fail('scenario 15: files not an array')
+    if ('outputDir' in sbJson) fail('scenario 15: outputDir must not appear in success result')
 
     for (const f of ['status.json', 'doctor.json', 'record.json', 'manifest.json']) {
       if (!existsSync(join(bundleOutDir, f))) fail(`scenario 15: missing bundle file ${f}`)
     }
     const manifest = JSON.parse(readFileSync(join(bundleOutDir, 'manifest.json'), 'utf-8'))
-    if (manifest.mode !== 'server-mode')    fail('scenario 15: manifest.mode must be server-mode')
-    if (!Array.isArray(manifest.sections))  fail('scenario 15: manifest.sections missing')
-    if (manifest.sections.includes('logs.jsonl')) fail('scenario 15: logs.jsonl must not appear in server-mode manifest')
+    if (manifest.mode !== 'server-mode') fail('scenario 15: manifest.mode must be server-mode')
+    if (!Array.isArray(manifest.sections)) fail('scenario 15: manifest.sections missing')
+    if (manifest.sections.includes('logs.jsonl'))
+      fail('scenario 15: logs.jsonl must not appear in server-mode manifest')
 
     const scenario15Literals = [...SMOKE_LITERALS, bundleDataDir, bundleOutDir]
     assertNoLeak('scenario 15 stdout', r.stdout, scenario15Literals)
     assertNoLeak('scenario 15 stderr', r.stderr ?? '', scenario15Literals)
     const allBundleContent = ['manifest.json', 'status.json', 'doctor.json', 'record.json']
-      .map((f) => readFileSync(join(bundleOutDir, f), 'utf-8')).join('')
+      .map((f) => readFileSync(join(bundleOutDir, f), 'utf-8'))
+      .join('')
     assertNoLeak('scenario 15 bundle files', allBundleContent, scenario15Literals)
     console.log('[server-cli-smoke] scenario 15 PASS: support-bundle with missing record succeeded')
   }
@@ -616,7 +805,9 @@ try {
     writeFileSync(join(bundleOutNonEmpty, 'canary.txt'), 'content')
 
     const r = cli([
-      'server', 'support-bundle', '--json',
+      'server',
+      'support-bundle',
+      '--json',
       `--data-dir=${tmpRoot}`,
       `--output-dir=${bundleOutNonEmpty}`,
     ])
@@ -632,14 +823,16 @@ try {
   // ── Scenario 17: server support-bundle: symlink final output dir → exit 1 ─
 
   {
-    const sbRealOut  = join(tmpRoot, 'sb-real-out')
-    const sbLinkOut  = join(tmpRoot, 'sb-link-out')
+    const sbRealOut = join(tmpRoot, 'sb-real-out')
+    const sbLinkOut = join(tmpRoot, 'sb-link-out')
     const { symlinkSync } = await import('node:fs')
     mkdirSync(sbRealOut)
     symlinkSync(sbRealOut, sbLinkOut)
 
     const r = cli([
-      'server', 'support-bundle', '--json',
+      'server',
+      'support-bundle',
+      '--json',
       `--data-dir=${tmpRoot}`,
       `--output-dir=${sbLinkOut}`,
     ])
@@ -652,18 +845,21 @@ try {
   // ── Scenario 18: server support-bundle: ancestor symlink in output path ───
 
   {
-    const sbAncReal  = join(tmpRoot, 'sb-anc-real')
-    const sbAncLink  = join(tmpRoot, 'sb-anc-link')
+    const sbAncReal = join(tmpRoot, 'sb-anc-real')
+    const sbAncLink = join(tmpRoot, 'sb-anc-link')
     const { symlinkSync } = await import('node:fs')
     mkdirSync(sbAncReal)
     symlinkSync(sbAncReal, sbAncLink)
 
     const r = cli([
-      'server', 'support-bundle', '--json',
+      'server',
+      'support-bundle',
+      '--json',
       `--data-dir=${tmpRoot}`,
       `--output-dir=${join(sbAncLink, 'bundle')}`,
     ])
-    if (r.status === 0) fail('scenario 18: ancestor symlink in output path should have been rejected')
+    if (r.status === 0)
+      fail('scenario 18: ancestor symlink in output path should have been rejected')
     if (r.stdout.trim() !== '') fail('scenario 18: stdout not empty on failure')
     assertNoLeak('scenario 18 stderr', r.stderr ?? '', SMOKE_LITERALS)
     console.log('[server-cli-smoke] scenario 18 PASS: ancestor symlink in output path rejected')
@@ -687,7 +883,13 @@ try {
     }
     // unknown flag must not echo its value
     {
-      const r = cli(['server', 'support-bundle', '--json', '--output-dir=/o', '--unknown-flag=verysecret'])
+      const r = cli([
+        'server',
+        'support-bundle',
+        '--json',
+        '--output-dir=/o',
+        '--unknown-flag=verysecret',
+      ])
       if (r.status !== 64) fail(`scenario 19c: expected exit 64, got ${r.status}`)
       if ((r.stderr ?? '').includes('verysecret')) {
         fail('scenario 19c: unknown flag value leaked into stderr')
@@ -721,35 +923,44 @@ try {
   // and record.json derives kind='ok' from that outcome (not from isPidAlive alone).
   {
     const BUNDLE_SERVER_PORT = 4296
-    const bundleLiveDataDir  = join(tmpRoot, 'sb-live-data')
-    const bundleLiveOutDir   = join(tmpRoot, 'sb-live-out')
+    const bundleLiveDataDir = join(tmpRoot, 'sb-live-data')
+    const bundleLiveOutDir = join(tmpRoot, 'sb-live-out')
 
-    bundleServer2 = spawn(process.execPath, [
-      DIST_CLI, 'server', 'run', '--json',
-      `--data-dir=${bundleLiveDataDir}`,
-      `--external-url=${SMOKE_AUDIENCE}`,
-      '--auth-strategy=oauth-jwt',
-      `--jwt-issuer=${SMOKE_ISSUER}`,
-      `--jwt-audience=${SMOKE_AUDIENCE}`,
-      `--jwks-uri=${jwksUri}`,
-      `--allowed-origins=${SMOKE_AUDIENCE}`,
-    ], {
-      stdio: 'pipe',
-      env: {
-        ...process.env,
-        WHITEBOARD_SERVER_PORT: String(BUNDLE_SERVER_PORT),
-        NODE_EXTRA_CA_CERTS: tlsCertFile,
+    bundleServer2 = spawn(
+      process.execPath,
+      [
+        DIST_CLI,
+        'server',
+        'run',
+        '--json',
+        `--data-dir=${bundleLiveDataDir}`,
+        `--external-url=${SMOKE_AUDIENCE}`,
+        '--auth-strategy=oauth-jwt',
+        `--jwt-issuer=${SMOKE_ISSUER}`,
+        `--jwt-audience=${SMOKE_AUDIENCE}`,
+        `--jwks-uri=${jwksUri}`,
+        `--allowed-origins=${SMOKE_AUDIENCE}`,
+      ],
+      {
+        stdio: 'pipe',
+        env: {
+          ...scrubDevEnv(process.env),
+          WHITEBOARD_SERVER_PORT: String(BUNDLE_SERVER_PORT),
+          NODE_EXTRA_CA_CERTS: tlsCertFile,
+        },
       },
-    })
+    )
 
     const ready21 = await waitForReadyJson(bundleServer2)
     if (!ready21) fail('scenario 21: server did not emit ready JSON')
-    if (!await waitForHttpReady(`http://127.0.0.1:${BUNDLE_SERVER_PORT}/api/runtime/ping`)) {
+    if (!(await waitForHttpReady(`http://127.0.0.1:${BUNDLE_SERVER_PORT}/api/runtime/ping`))) {
       fail('scenario 21: server HTTP not ready')
     }
 
     const r = cli([
-      'server', 'support-bundle', '--json',
+      'server',
+      'support-bundle',
+      '--json',
       `--data-dir=${bundleLiveDataDir}`,
       `--output-dir=${bundleLiveOutDir}`,
     ])
@@ -759,7 +970,9 @@ try {
       })
     }
     let sbJson21
-    try { sbJson21 = JSON.parse(r.stdout.trim()) } catch {
+    try {
+      sbJson21 = JSON.parse(r.stdout.trim())
+    } catch {
       fail('scenario 21: stdout is not valid JSON')
     }
     if (sbJson21.operation !== 'support-bundle') fail('scenario 21: operation mismatch')
@@ -780,16 +993,18 @@ try {
     const scenario21Literals = [...SMOKE_LITERALS, bundleLiveDataDir, bundleLiveOutDir]
     assertNoLeak('scenario 21 stdout', r.stdout, scenario21Literals)
     const allContent21 = ['manifest.json', 'status.json', 'doctor.json', 'record.json']
-      .map((f) => readFileSync(join(bundleLiveOutDir, f), 'utf-8')).join('')
+      .map((f) => readFileSync(join(bundleLiveOutDir, f), 'utf-8'))
+      .join('')
     assertNoLeak('scenario 21 bundle files', allContent21, scenario21Literals)
 
     killProc(bundleServer2)
     bundleServer2 = null
-    console.log('[server-cli-smoke] scenario 21 PASS: running-server bundle has identity-confirmed status/record')
+    console.log(
+      '[server-cli-smoke] scenario 21 PASS: running-server bundle has identity-confirmed status/record',
+    )
   }
 
   console.log('[server-cli-smoke] All scenarios PASSED.')
-
 } finally {
   if (seedDaemon) killProc(seedDaemon)
   if (serverMode) killProc(serverMode)

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -35,7 +35,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
-import { assertNoLeak as assertNoLeakHelper } from './smoke-helpers.mjs'
+import { assertNoLeak as assertNoLeakHelper, scrubDevEnv } from './smoke-helpers.mjs'
 
 // Minimal ES256 JWT helpers using Node.js built-in crypto only.
 // (Distribution smokes run with plain `node`, not in the pnpm workspace.)
@@ -103,24 +103,41 @@ function generateTestTlsCert(dir) {
   const keyFile = join(dir, 'tls-key.pem')
   const certFile = join(dir, 'tls-cert.pem')
   const cnfFile = join(dir, 'openssl.cnf')
-  writeFileSync(cnfFile, [
-    '[req]',
-    'distinguished_name = req_dn',
-    'x509_extensions = san_ext',
-    'prompt = no',
-    '',
-    '[req_dn]',
-    'CN = smoke-test-jwks-ca',
-    '',
-    '[san_ext]',
-    'subjectAltName = IP:127.0.0.1',
-    'basicConstraints = critical,CA:true',
-  ].join('\n'))
-  const r = spawnSync('openssl', [
-    'req', '-x509', '-newkey', 'rsa:2048',
-    '-keyout', keyFile, '-out', certFile,
-    '-days', '1', '-nodes', '-config', cnfFile,
-  ], { stdio: 'pipe', encoding: 'utf8' })
+  writeFileSync(
+    cnfFile,
+    [
+      '[req]',
+      'distinguished_name = req_dn',
+      'x509_extensions = san_ext',
+      'prompt = no',
+      '',
+      '[req_dn]',
+      'CN = smoke-test-jwks-ca',
+      '',
+      '[san_ext]',
+      'subjectAltName = IP:127.0.0.1',
+      'basicConstraints = critical,CA:true',
+    ].join('\n'),
+  )
+  const r = spawnSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyFile,
+      '-out',
+      certFile,
+      '-days',
+      '1',
+      '-nodes',
+      '-config',
+      cnfFile,
+    ],
+    { stdio: 'pipe', encoding: 'utf8' },
+  )
   if (r.status !== 0) throw new Error(`openssl cert gen failed: ${r.stderr}`)
   return { keyFile, certFile }
 }
@@ -143,7 +160,7 @@ function assertNoLeak(label, text) {
 
 function runCli(args, { env } = {}) {
   return spawnSync(process.execPath, [CLI, ...args], {
-    env: { ...process.env, ...env },
+    env: { ...scrubDevEnv(process.env), ...env },
     encoding: 'utf8',
     timeout: 10_000,
   })
@@ -159,12 +176,17 @@ const REQUIRED_FLAGS = [
 // Scenario 1: non-HTTPS externalUrl → plan rejects → exit 1
 {
   const r = runCli([
-    'server', 'run', '--json', '--dry-run',
+    'server',
+    'run',
+    '--json',
+    '--dry-run',
     '--external-url=http://whiteboard.example.com',
     ...REQUIRED_FLAGS,
   ])
-  if (r.status !== 1) fail(`scenario 1: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
-  if (r.stdout.trim() !== '') fail('scenario 1: stdout must be empty', { lineLength: r.stdout.length })
+  if (r.status !== 1)
+    fail(`scenario 1: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
+  if (r.stdout.trim() !== '')
+    fail('scenario 1: stdout must be empty', { lineLength: r.stdout.length })
   assertNoLeak('scenario 1 stderr', r.stderr)
   console.log('[server-run-smoke] scenario 1 PASS: non-HTTPS externalUrl → exit 1, stderr safe')
 }
@@ -172,14 +194,23 @@ const REQUIRED_FLAGS = [
 // Scenario 2: valid dry-run → exit 0, stdout single JSON, fields correct
 {
   const r = runCli([
-    'server', 'run', '--json', '--dry-run',
+    'server',
+    'run',
+    '--json',
+    '--dry-run',
     '--external-url=https://whiteboard.example.com',
     ...REQUIRED_FLAGS,
   ])
-  if (r.status !== 0) fail(`scenario 2: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
-  if (r.stderr.trim() !== '') fail('scenario 2: stderr must be empty', { stderrBytes: r.stderr.length })
+  if (r.status !== 0)
+    fail(`scenario 2: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+  if (r.stderr.trim() !== '')
+    fail('scenario 2: stderr must be empty', { stderrBytes: r.stderr.length })
   let obj
-  try { obj = JSON.parse(r.stdout) } catch { fail('scenario 2: stdout not valid JSON', { lineLength: r.stdout.length }) }
+  try {
+    obj = JSON.parse(r.stdout)
+  } catch {
+    fail('scenario 2: stdout not valid JSON', { lineLength: r.stdout.length })
+  }
   if (obj.schemaVersion !== 1) fail('scenario 2: schemaVersion must be 1')
   if (obj.ok !== true) fail('scenario 2: ok must be true')
   if (obj.dryRun !== true) fail('scenario 2: dryRun must be true')
@@ -196,15 +227,19 @@ const REQUIRED_FLAGS = [
 // Scenario 3: origin normalization https://whiteboard.example.com:443 → https://whiteboard.example.com
 {
   const r = runCli([
-    'server', 'run', '--json', '--dry-run',
+    'server',
+    'run',
+    '--json',
+    '--dry-run',
     '--external-url=https://whiteboard.example.com',
     '--allowed-origins=https://whiteboard.example.com:443',
     ...REQUIRED_FLAGS,
   ])
-  if (r.status !== 0) fail(`scenario 3: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+  if (r.status !== 0)
+    fail(`scenario 3: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
   const obj = JSON.parse(r.stdout)
   if (!Array.isArray(obj.allowedOrigins)) fail('scenario 3: allowedOrigins must be array')
-  if (obj.allowedOrigins.some(o => o.includes(':443')))
+  if (obj.allowedOrigins.some((o) => o.includes(':443')))
     fail(`scenario 3: :443 not stripped from allowedOrigins: ${JSON.stringify(obj.allowedOrigins)}`)
   if (!obj.allowedOrigins.includes('https://whiteboard.example.com'))
     fail(`scenario 3: expected https://whiteboard.example.com in allowedOrigins`)
@@ -214,12 +249,16 @@ const REQUIRED_FLAGS = [
 // Scenario 4: wildcard origin → config-error → exit 1, stderr safe
 {
   const r = runCli([
-    'server', 'run', '--json', '--dry-run',
+    'server',
+    'run',
+    '--json',
+    '--dry-run',
     '--external-url=https://whiteboard.example.com',
     '--allowed-origins=*',
     ...REQUIRED_FLAGS,
   ])
-  if (r.status !== 1) fail(`scenario 4: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
+  if (r.status !== 1)
+    fail(`scenario 4: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
   if (r.stdout.trim() !== '') fail('scenario 4: stdout must be empty')
   assertNoLeak('scenario 4 stderr', r.stderr)
   console.log('[server-run-smoke] scenario 4 PASS: wildcard origin → exit 1, stderr safe')
@@ -238,7 +277,8 @@ const REQUIRED_FLAGS = [
 // Scenario 6: missing --json → exit 64, stdout empty
 {
   const r = runCli([
-    'server', 'run',
+    'server',
+    'run',
     '--dry-run',
     '--external-url=https://whiteboard.example.com',
     ...REQUIRED_FLAGS,
@@ -252,7 +292,10 @@ const REQUIRED_FLAGS = [
 {
   const r = runCli(
     [
-      'server', 'run', '--json', '--dry-run',
+      'server',
+      'run',
+      '--json',
+      '--dry-run',
       '--external-url=https://cli-override.example.com',
       ...REQUIRED_FLAGS,
     ],
@@ -266,7 +309,8 @@ const REQUIRED_FLAGS = [
       },
     },
   )
-  if (r.status !== 0) fail(`scenario 7: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+  if (r.status !== 0)
+    fail(`scenario 7: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
   const obj = JSON.parse(r.stdout)
   if (obj.publicBaseUrl !== 'https://cli-override.example.com')
     fail(`scenario 7: CLI flag did not override env, got ${obj.publicBaseUrl}`)
@@ -312,12 +356,17 @@ const REQUIRED_FLAGS = [
   let stdoutBuf = ''
   let stderrBuf = ''
   let firstLineResolve
-  const firstLine = new Promise((r) => { firstLineResolve = r })
+  const firstLine = new Promise((r) => {
+    firstLineResolve = r
+  })
 
   const child = spawn(
     process.execPath,
     [
-      CLI, 'server', 'run', '--json',
+      CLI,
+      'server',
+      'run',
+      '--json',
       `--external-url=${SMOKE_AUDIENCE}`,
       '--auth-strategy=oauth-jwt',
       `--jwt-issuer=${SMOKE_ISSUER}`,
@@ -330,7 +379,7 @@ const REQUIRED_FLAGS = [
       cwd: REPO_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
-        ...process.env,
+        ...scrubDevEnv(process.env),
         WHITEBOARD_DATA_DIR: dataDir,
         // Trust the self-signed CA so jose's createRemoteJWKSet (undici/fetch)
         // can reach the HTTPS JWKS mock. NODE_EXTRA_CA_CERTS works with undici
@@ -345,14 +394,24 @@ const REQUIRED_FLAGS = [
     const nl = stdoutBuf.indexOf('\n')
     if (nl !== -1) firstLineResolve(stdoutBuf.slice(0, nl))
   })
-  child.stderr.on('data', (chunk) => { stderrBuf += chunk.toString() })
+  child.stderr.on('data', (chunk) => {
+    stderrBuf += chunk.toString()
+  })
   const closed = new Promise((r) => child.once('close', r))
 
   const shutdown = async () => {
     if (child.exitCode !== null) return
-    try { child.kill('SIGTERM') } catch { /* gone */ }
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      /* gone */
+    }
     await Promise.race([closed, delay(SHUTDOWN_TIMEOUT_MS)])
-    try { child.kill('SIGKILL') } catch { /* gone */ }
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      /* gone */
+    }
     await closed
   }
 
@@ -366,7 +425,9 @@ const REQUIRED_FLAGS = [
     }
 
     let ready
-    try { ready = JSON.parse(winner) } catch {
+    try {
+      ready = JSON.parse(winner)
+    } catch {
       fail('scenario 8: first stdout line not valid JSON', {
         lineLength: typeof winner === 'string' ? winner.length : -1,
       })
@@ -415,7 +476,14 @@ const REQUIRED_FLAGS = [
     const validJwt = signEs256Jwt(
       privateKey,
       { alg: 'ES256', kid: 'smoke-key' },
-      { sub: 'smoke-user', scope: 'canvas:read', iss: SMOKE_ISSUER, aud: SMOKE_AUDIENCE, iat: now, exp: now + 3600 },
+      {
+        sub: 'smoke-user',
+        scope: 'canvas:read',
+        iss: SMOKE_ISSUER,
+        aud: SMOKE_AUDIENCE,
+        iat: now,
+        exp: now + 3600,
+      },
     )
     const authResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${validJwt}` },
@@ -430,7 +498,14 @@ const REQUIRED_FLAGS = [
     const wrongScopeJwt = signEs256Jwt(
       privateKey,
       { alg: 'ES256', kid: 'smoke-key' },
-      { sub: 'smoke-user', scope: 'workspace:read', iss: SMOKE_ISSUER, aud: SMOKE_AUDIENCE, iat: now, exp: now + 3600 },
+      {
+        sub: 'smoke-user',
+        scope: 'workspace:read',
+        iss: SMOKE_ISSUER,
+        aud: SMOKE_AUDIENCE,
+        iat: now,
+        exp: now + 3600,
+      },
     )
     const scopeResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${wrongScopeJwt}` },
@@ -438,19 +513,26 @@ const REQUIRED_FLAGS = [
     if (scopeResp.status !== 403)
       fail(`scenario 8: wrong scope expected 403, got ${scopeResp.status}`)
 
-    console.log('[server-run-smoke] scenario 8 PASS: server starts, ready JSON correct, auth contract verified')
+    console.log(
+      '[server-run-smoke] scenario 8 PASS: server starts, ready JSON correct, auth contract verified',
+    )
 
     // Scenario 9: server status while running → ok:true, state:running, fields match ready JSON
     {
       const r = runCli(['server', 'status', '--json', `--data-dir=${dataDir}`])
       if (r.status !== 0) fail('scenario 9: expected exit 0', { stderrBytes: r.stderr.length })
       let obj
-      try { obj = JSON.parse(r.stdout) } catch { fail('scenario 9: stdout not valid JSON', { lineLength: r.stdout.length }) }
+      try {
+        obj = JSON.parse(r.stdout)
+      } catch {
+        fail('scenario 9: stdout not valid JSON', { lineLength: r.stdout.length })
+      }
       if (obj.state !== 'running') fail(`scenario 9: expected state:running, got ${obj.state}`)
       if (obj.ok !== true) fail('scenario 9: ok must be true')
       if (obj.pid !== ready.pid) fail(`scenario 9: pid mismatch: ${obj.pid} vs ${ready.pid}`)
       if (obj.port !== ready.port) fail(`scenario 9: port mismatch: ${obj.port} vs ${ready.port}`)
-      if (obj.publicBaseUrl !== SMOKE_AUDIENCE) fail(`scenario 9: publicBaseUrl wrong: ${obj.publicBaseUrl}`)
+      if (obj.publicBaseUrl !== SMOKE_AUDIENCE)
+        fail(`scenario 9: publicBaseUrl wrong: ${obj.publicBaseUrl}`)
       if (obj.recordFresh !== true) fail('scenario 9: recordFresh must be true')
       assertNoLeak('scenario 9 status stdout', r.stdout)
       console.log('[server-run-smoke] scenario 9 PASS: status while running → correct fields')
@@ -461,7 +543,11 @@ const REQUIRED_FLAGS = [
       const r = runCli(['server', 'stop', '--json', `--data-dir=${dataDir}`])
       if (r.status !== 0) fail('scenario 10: expected exit 0', { stderrBytes: r.stderr.length })
       let obj
-      try { obj = JSON.parse(r.stdout) } catch { fail('scenario 10: stdout not valid JSON', { lineLength: r.stdout.length }) }
+      try {
+        obj = JSON.parse(r.stdout)
+      } catch {
+        fail('scenario 10: stdout not valid JSON', { lineLength: r.stdout.length })
+      }
       if (obj.action !== 'stopped') fail(`scenario 10: expected action:stopped, got ${obj.action}`)
       if (obj.ok !== true) fail('scenario 10: ok must be true')
       if (obj.pid !== ready.pid) fail(`scenario 10: pid mismatch: ${obj.pid} vs ${ready.pid}`)
@@ -478,7 +564,11 @@ const REQUIRED_FLAGS = [
       const r = runCli(['server', 'status', '--json', `--data-dir=${dataDir}`])
       if (r.status !== 1) fail(`scenario 11: expected exit 1, got ${r.status}`)
       let obj
-      try { obj = JSON.parse(r.stdout) } catch { fail('scenario 11: stdout not valid JSON', { lineLength: r.stdout.length }) }
+      try {
+        obj = JSON.parse(r.stdout)
+      } catch {
+        fail('scenario 11: stdout not valid JSON', { lineLength: r.stdout.length })
+      }
       if (obj.state !== 'missing') fail(`scenario 11: expected state:missing, got ${obj.state}`)
       if (obj.ok !== false) fail('scenario 11: ok must be false')
       assertNoLeak('scenario 11 status-after-stop stdout', r.stdout)
@@ -496,10 +586,15 @@ const REQUIRED_FLAGS = [
   const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-server-smoke-s12-'))
   try {
     const r = runCli(['server', 'status', '--json', `--data-dir=${dataDir}`])
-    if (r.status !== 1) fail(`scenario 12: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
+    if (r.status !== 1)
+      fail(`scenario 12: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
     if (r.stdout.trim() === '') fail('scenario 12: stdout must not be empty (expected JSON)')
     let obj
-    try { obj = JSON.parse(r.stdout) } catch { fail('scenario 12: stdout not valid JSON', { lineLength: r.stdout.length }) }
+    try {
+      obj = JSON.parse(r.stdout)
+    } catch {
+      fail('scenario 12: stdout not valid JSON', { lineLength: r.stdout.length })
+    }
     if (obj.state !== 'missing') fail(`scenario 12: expected state:missing, got ${obj.state}`)
     if (obj.ok !== false) fail('scenario 12: ok must be false')
     assertNoLeak('scenario 12 output', r.stdout)
@@ -514,10 +609,16 @@ const REQUIRED_FLAGS = [
   const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-server-smoke-s13-'))
   try {
     const r = runCli(['server', 'stop', '--json', `--data-dir=${dataDir}`])
-    if (r.status !== 0) fail(`scenario 13: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+    if (r.status !== 0)
+      fail(`scenario 13: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
     let obj
-    try { obj = JSON.parse(r.stdout) } catch { fail('scenario 13: stdout not valid JSON', { lineLength: r.stdout.length }) }
-    if (obj.action !== 'not-running') fail(`scenario 13: expected action:not-running, got ${obj.action}`)
+    try {
+      obj = JSON.parse(r.stdout)
+    } catch {
+      fail('scenario 13: stdout not valid JSON', { lineLength: r.stdout.length })
+    }
+    if (obj.action !== 'not-running')
+      fail(`scenario 13: expected action:not-running, got ${obj.action}`)
     if (obj.ok !== true) fail('scenario 13: ok must be true')
     assertNoLeak('scenario 13 output', r.stdout)
     console.log('[server-run-smoke] scenario 13 PASS: stop no record → not-running, exit 0')
@@ -566,25 +667,37 @@ const REQUIRED_FLAGS = [
     {
       const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-server-smoke-s14-'))
       try {
-        const r = runCli(
-          ['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS],
-          { env: { NODE_EXTRA_CA_CERTS: drCertFile } },
-        )
-        if (r.status !== 0) fail(`scenario 14: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
-        if (r.stderr.trim() !== '') fail('scenario 14: stderr must be empty', { stderrBytes: r.stderr.length })
+        const r = runCli(['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS], {
+          env: { NODE_EXTRA_CA_CERTS: drCertFile },
+        })
+        if (r.status !== 0)
+          fail(`scenario 14: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+        if (r.stderr.trim() !== '')
+          fail('scenario 14: stderr must be empty', { stderrBytes: r.stderr.length })
         let obj
-        try { obj = JSON.parse(r.stdout) } catch { fail('scenario 14: stdout not valid JSON', { lineLength: r.stdout.length }) }
+        try {
+          obj = JSON.parse(r.stdout)
+        } catch {
+          fail('scenario 14: stdout not valid JSON', { lineLength: r.stdout.length })
+        }
         if (obj.ok !== true) fail(`scenario 14: ok must be true, got ok:${obj.ok}`)
         if (obj.schemaVersion !== 1) fail('scenario 14: schemaVersion must be 1')
         if (!Array.isArray(obj.checks)) fail('scenario 14: checks must be array')
-        const jwksCheck = obj.checks.find(c => c.id === 'server.jwks')
+        const jwksCheck = obj.checks.find((c) => c.id === 'server.jwks')
         if (!jwksCheck) fail('scenario 14: server.jwks check missing')
-        if (jwksCheck.status !== 'ok') fail(`scenario 14: expected server.jwks ok, got ${jwksCheck.status}`)
-        if (obj.status !== 'ok') fail(`scenario 14: expected status:ok (no warnings), got ${obj.status}`)
-        const badCheck = obj.checks.find(c => c.status !== 'ok' && c.status !== 'skipped')
-        if (badCheck) fail(`scenario 14: all checks must be ok or skipped, got ${badCheck.id}:${badCheck.status}`)
+        if (jwksCheck.status !== 'ok')
+          fail(`scenario 14: expected server.jwks ok, got ${jwksCheck.status}`)
+        if (obj.status !== 'ok')
+          fail(`scenario 14: expected status:ok (no warnings), got ${obj.status}`)
+        const badCheck = obj.checks.find((c) => c.status !== 'ok' && c.status !== 'skipped')
+        if (badCheck)
+          fail(
+            `scenario 14: all checks must be ok or skipped, got ${badCheck.id}:${badCheck.status}`,
+          )
         assertNoLeak('scenario 14 stdout', r.stdout)
-        console.log('[server-run-smoke] scenario 14 PASS: doctor valid config + JWKS → exit 0, ok:true')
+        console.log(
+          '[server-run-smoke] scenario 14 PASS: doctor valid config + JWKS → exit 0, ok:true',
+        )
       } finally {
         rmSync(dataDir, { recursive: true, force: true })
       }
@@ -596,7 +709,10 @@ const REQUIRED_FLAGS = [
       try {
         const r = runCli(
           [
-            'server', 'doctor', '--json', `--data-dir=${dataDir}`,
+            'server',
+            'doctor',
+            '--json',
+            `--data-dir=${dataDir}`,
             '--external-url=http://not-https.example.com',
             '--auth-strategy=oauth-jwt',
             '--jwt-issuer=https://smoke.example.com',
@@ -605,17 +721,27 @@ const REQUIRED_FLAGS = [
           ],
           { env: { NODE_EXTRA_CA_CERTS: drCertFile } },
         )
-        if (r.status !== 1) fail(`scenario 15: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
+        if (r.status !== 1)
+          fail(`scenario 15: expected exit 1, got ${r.status}`, { stderrBytes: r.stderr.length })
         if (r.stdout.trim() === '') fail('scenario 15: stdout must not be empty')
         let obj
-        try { obj = JSON.parse(r.stdout) } catch { fail('scenario 15: stdout not valid JSON', { lineLength: r.stdout.length }) }
+        try {
+          obj = JSON.parse(r.stdout)
+        } catch {
+          fail('scenario 15: stdout not valid JSON', { lineLength: r.stdout.length })
+        }
         if (obj.ok !== false) fail('scenario 15: ok must be false')
-        if (!obj.checks?.some(c => c.status === 'error')) fail('scenario 15: at least one check must have error status')
-        if (r.stdout.includes('not-https.example.com')) fail('scenario 15: stdout must not contain raw externalUrl')
-        if (r.stderr.trim() !== '') fail('scenario 15: stderr must be empty', { stderrBytes: r.stderr.length })
+        if (!obj.checks?.some((c) => c.status === 'error'))
+          fail('scenario 15: at least one check must have error status')
+        if (r.stdout.includes('not-https.example.com'))
+          fail('scenario 15: stdout must not contain raw externalUrl')
+        if (r.stderr.trim() !== '')
+          fail('scenario 15: stderr must be empty', { stderrBytes: r.stderr.length })
         assertNoLeak('scenario 15 stdout', r.stdout)
         assertNoLeak('scenario 15 stderr', r.stderr)
-        console.log('[server-run-smoke] scenario 15 PASS: invalid config → exit 1, ok:false, stderr safe')
+        console.log(
+          '[server-run-smoke] scenario 15 PASS: invalid config → exit 1, ok:false, stderr safe',
+        )
       } finally {
         rmSync(dataDir, { recursive: true, force: true })
       }
@@ -639,35 +765,44 @@ const REQUIRED_FLAGS = [
         writeFileSync(recordPath, JSON.stringify(staleRecord))
         // chmodSync bypasses umask to reliably set broad permissions.
         chmodSync(recordPath, 0o644)
-        const r = runCli(
-          ['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS],
-          { env: { NODE_EXTRA_CA_CERTS: drCertFile } },
-        )
+        const r = runCli(['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS], {
+          env: { NODE_EXTRA_CA_CERTS: drCertFile },
+        })
         if (r.status === null) fail('scenario 16: doctor process was killed by signal')
-        if (r.status !== 0) fail(`scenario 16: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
+        if (r.status !== 0)
+          fail(`scenario 16: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
         if (r.stdout.trim() === '') fail('scenario 16: stdout must not be empty')
         let obj
-        try { obj = JSON.parse(r.stdout) } catch { fail('scenario 16: stdout not valid JSON', { lineLength: r.stdout.length }) }
+        try {
+          obj = JSON.parse(r.stdout)
+        } catch {
+          fail('scenario 16: stdout not valid JSON', { lineLength: r.stdout.length })
+        }
         if (!Array.isArray(obj.checks)) fail('scenario 16: checks must be array')
-        const recordCheck = obj.checks.find(c => c.id === 'server.record')
+        const recordCheck = obj.checks.find((c) => c.id === 'server.record')
         if (!recordCheck) fail('scenario 16: server.record check missing')
-        if (recordCheck.status !== 'ok') fail(`scenario 16: expected server.record ok, got ${recordCheck.status}`)
-        const identityCheck = obj.checks.find(c => c.id === 'server.identity')
+        if (recordCheck.status !== 'ok')
+          fail(`scenario 16: expected server.record ok, got ${recordCheck.status}`)
+        const identityCheck = obj.checks.find((c) => c.id === 'server.identity')
         if (!identityCheck) fail('scenario 16: server.identity check missing')
-        if (identityCheck.status !== 'skipped') fail(`scenario 16: expected server.identity skipped, got ${identityCheck.status}`)
+        if (identityCheck.status !== 'skipped')
+          fail(`scenario 16: expected server.identity skipped, got ${identityCheck.status}`)
         if (process.platform !== 'win32') {
-          const permCheck = obj.checks.find(c => c.id === 'server.record_permissions')
+          const permCheck = obj.checks.find((c) => c.id === 'server.record_permissions')
           if (!permCheck) fail('scenario 16: server.record_permissions check missing')
-          if (permCheck.status !== 'warning') fail(`scenario 16: expected server.record_permissions warning, got ${permCheck.status}`)
+          if (permCheck.status !== 'warning')
+            fail(`scenario 16: expected server.record_permissions warning, got ${permCheck.status}`)
         }
         assertNoLeak('scenario 16 stdout', r.stdout)
-        console.log('[server-run-smoke] scenario 16 PASS: stale record → identity skipped, permissions warning')
+        console.log(
+          '[server-run-smoke] scenario 16 PASS: stale record → identity skipped, permissions warning',
+        )
       } finally {
         rmSync(dataDir, { recursive: true, force: true })
       }
     }
   } finally {
-    await new Promise(resolve => drJwksServer.close(resolve))
+    await new Promise((resolve) => drJwksServer.close(resolve))
     rmSync(drCertsDir, { recursive: true, force: true })
   }
 }
@@ -675,7 +810,8 @@ const REQUIRED_FLAGS = [
 // Regression: local daemon routing unchanged (unknown command still exits 64)
 {
   const r = runCli(['daemon', 'unknown-subcommand', '--json'])
-  if (r.status !== 64) fail(`regression: daemon unknown subcommand should still exit 64, got ${r.status}`)
+  if (r.status !== 64)
+    fail(`regression: daemon unknown subcommand should still exit 64, got ${r.status}`)
   console.log('[server-run-smoke] regression PASS: daemon routing unchanged')
 }
 

--- a/tests/e2e/distribution/smoke-helpers.mjs
+++ b/tests/e2e/distribution/smoke-helpers.mjs
@@ -27,13 +27,7 @@ export const BASE_LEAK_PATTERNS = [
  * Canvas plaintext deny-list. Used by scripts that exercise log/support-bundle
  * formatting where canvas content must be stripped before output.
  */
-export const CANVAS_LEAK_PATTERNS = [
-  /canvasText/,
-  /rawPayload/,
-  /"scene"/,
-  /"elements"/,
-  /"files"/,
-]
+export const CANVAS_LEAK_PATTERNS = [/canvasText/, /rawPayload/, /"scene"/, /"elements"/, /"files"/]
 
 /**
  * Assert that `text` does not match any BASE_LEAK_PATTERNS entry and does not
@@ -53,4 +47,23 @@ export function assertNoLeak(label, text, extraLiterals = []) {
   for (const literal of extraLiterals) {
     if (text.includes(literal)) throw new Error(`[smoke] ${label} leak: literal "${literal}"`)
   }
+}
+
+/**
+ * Strips WHITEBOARD_DEV from an env object before it is spread into a
+ * spawned child. Every distribution smoke here exercises the packaged
+ * `dist/` build, never the `src/` tree, so an ambient WHITEBOARD_DEV=1 (the
+ * publish-gate CI job sets it for its other src-mode e2e checks) must never
+ * leak in — ensureDaemon and the mcp-http child spawner both branch on this
+ * flag to run `node --watch --import tsx/esm <root>/src/...`, which fails
+ * against an installed-only tree that ships no `src/` and no `tsx`
+ * devDependency (see tarball.distribution-impl.ts buildTarballSmokeChildEnv
+ * for the TypeScript-side twin of this same fix).
+ *
+ * @param {NodeJS.ProcessEnv} processEnv
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function scrubDevEnv(processEnv) {
+  const { WHITEBOARD_DEV: _unused, ...rest } = processEnv
+  return rest
 }


### PR DESCRIPTION
## Problem — the v0.0.14 publish failure

The v0.0.14 release run (29582433440) got past the tarball smoke (#240) and the LLM-CLI skips (#241), then died in `packaged-daemon-backup-restore-smoke` with an opaque `daemon A stop failed: 1`.

Root cause (reproduced locally; NOT the WHITEBOARD_DEV propagation initially suspected): the smoke spawns `dist/server/index.js` directly but passed the token as `WHITEBOARD_DAEMON_TOKEN` — the variable the `daemon run` CLI subcommand reads. The direct server entry's `resolveToken()` only reads `--token=` / `WHITEBOARD_TOKEN`, so the daemon ran with no token, never wrote its `daemon.json` registry record, and `whiteboard daemon stop` failed with `{"ok":false,"action":"not-running","reason":"record-not-found"}` — which was invisible because the failure message only printed stderr while the JSON diagnostic goes to stdout.

## Change

1. `fix`: use `WHITEBOARD_TOKEN` for the directly-spawned server entry, and correct an assertion that expected a nonexistent `baseUrl` field in `daemon status --json` (derive it from `record.port`, the actual `DaemonStatusResult` shape). This alone turns the smoke green.
2. `feat`: shared `scrubDevEnv()` helper in `smoke-helpers.mjs` applied to every `...process.env` spread in the packaged distribution smokes (backup-restore / token / server-mode-cli / server-mode-entrypoint) — the plain-JS counterpart of #240's `buildTarballSmokeChildEnv`, so an ambient `WHITEBOARD_DEV=1` from the release gate env can never push a packaged child into dev (tsx/src) mode. (These smokes are plain node scripts that can't import the TS helper; divergence is two lines.)
3. `fix`: stop-failure messages now include stdout as well as stderr (mutation-checked — breaking the token env var again makes the `record-not-found` diagnostic visible), so the next gate failure in this family is diagnosable from the log.

## Verification

- `packaged-daemon-backup-restore-smoke`: ALL OK both plain and with ambient `WHITEBOARD_DEV=1` (the release-gate env shape), repeated runs.
- logs / support-bundle smokes: PASS under `WHITEBOARD_DEV=1`.
- Three pre-existing scenario failures were found in token / server-mode-cli / entrypoint smokes during the sweep — all reproduce identically with and without `WHITEBOARD_DEV` and without this change; they appear related to local `~/.whiteboard` contamination and/or dormant product gaps and are filed separately (see tmp-issues; the PR-gate `dry-run-npm` on this PR will adjudicate whether they affect fresh CI runners).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged daemon, server, backup, restore, token, and support-bundle smoke-test coverage.
  * Prevented development-only environment settings from affecting packaged command behavior.
  * Strengthened validation for JSON responses, authentication failures, token handling, process shutdown, and generated support-bundle files.
  * Updated status checks to validate the reported daemon port and derived server address.
  * Improved failure diagnostics with clearer structured output and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->