### PR TITLE
feat(mcp-server): derive per-worktree dev daemon ports and guard daemon identity

### DIFF
--- a/.claude/scripts/new-worktree.mjs
+++ b/.claude/scripts/new-worktree.mjs
@@ -12,6 +12,7 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { deriveDevPort } from '../../packages/mcp-server/scripts/dev/dev-port-lib.mjs'
 
 const [, , nameArg, baseArg] = process.argv
 if (!nameArg) {
@@ -32,7 +33,16 @@ const run = (cmd, args) => execFileSync(cmd, args, { stdio: 'inherit' })
 run('git', ['-C', repoRoot, 'worktree', 'add', wtPath, '-b', name, base])
 run('pnpm', ['--dir', wtPath, 'install', '--prefer-offline'])
 
+// A linked worktree always has a `.git` FILE (not a directory) at its root,
+// so it's never the main checkout — deriveDevPort hashes its path instead
+// of returning the 3099 main-checkout default.
+const devPort = deriveDevPort({ repoRoot: wtPath, isMainCheckout: false, env: process.env })
+
 console.log(`\nready worktree: ${wtPath}`)
 console.log(`  branch: ${name} (from ${base})`)
 console.log(`  launch a dev-loop with cwd="${wtPath}" (tests run isolated here).`)
+console.log(`  dev daemon port: ${devPort} (pnpm mcp:http:dev in this worktree binds here)`)
+console.log(
+  '  client wiring for this port is a manual step until the B1/B2 follow-ups land — see docs/contributing/development.md',
+)
 console.log(`  cleanup: git worktree remove --force ${wtPath}`)

--- a/.claude/scripts/new-worktree.test.mjs
+++ b/.claude/scripts/new-worktree.test.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Regression coverage for new-worktree.mjs's cross-package import of
+// dev-port-lib.mjs. That import reaches into packages/mcp-server's internal
+// scripts/dev/ directory via a relative filesystem path rather than a
+// declared package dependency/export, so nothing in the module graph flags
+// a future move/rename of that file — this test is what turns that failure
+// mode from "silently wrong at runtime" into "loud in CI".
+//
+// Run with: pnpm test:scripts (also wired into the CI "check" job).
+
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('the relative path new-worktree.mjs imports dev-port-lib.mjs from resolves and exposes deriveDevPort', async () => {
+  const devPortLibPath = resolve(__dirname, '../../packages/mcp-server/scripts/dev/dev-port-lib.mjs')
+  const { deriveDevPort } = await import(devPortLibPath)
+
+  assert.equal(typeof deriveDevPort, 'function')
+  assert.equal(
+    deriveDevPort({ repoRoot: '/repo', isMainCheckout: true, env: {} }),
+    3099,
+    'sanity-checks the actual imported function still behaves as new-worktree.mjs expects',
+  )
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,14 +98,18 @@ The repo ships HTTP-mode overrides for both clients:
 Both Claude Code (`.claude/settings.json`) and Codex
 (`.codex/config.toml`) wire a `SessionStart` hook to
 `packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`. The hook
-probes port 3099 and, if nothing is listening, spawns `pnpm mcp:http:dev`
-detached so the first MCP request can connect immediately. It is
-idempotent — if our authenticated daemon is already up it exits
-without touching anything; if a foreign service is on the port it
-fails loudly so the developer can investigate. Output goes to
-`tmp/logs/mcp-http-dev.log`. If hooks are disabled or the project is
-not trusted yet, run `pnpm mcp:http:dev` manually in another terminal
-before opening the repo.
+probes this checkout's derived dev port (3099 on the main checkout,
+a deterministic per-worktree port otherwise — see
+`docs/contributing/development.md`'s ".dev-data" section) and, if
+nothing is listening, spawns `pnpm mcp:http:dev` detached so the first
+MCP request can connect immediately. It is idempotent — if our
+authenticated daemon is already up **and its identity marker matches
+this worktree** it exits without touching anything; if a foreign
+service, or a different worktree's daemon that hash-collided on the
+same port, is on the port it fails loudly so the developer can
+investigate. Output goes to `tmp/logs/mcp-http-dev.log`. If hooks are
+disabled or the project is not trusted yet, run `pnpm mcp:http:dev`
+manually in another terminal before opening the repo.
 
 With HTTP transport every client reload connects to the same long-lived
 daemon, picking up source changes immediately and avoiding the stale-daemon

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -68,9 +68,9 @@ For active MCP development, connect Claude Code or Codex to the daemon-hosted `/
 pnpm mcp:http:dev
 ```
 
-The daemon listens on `http://127.0.0.1:3099/mcp`.
+The daemon listens on `http://127.0.0.1:3099/mcp` from the main checkout.
 
-> **Auto-start:** The repo's `SessionStart` hook (`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`) probes port 3099 and spawns the daemon automatically when Claude Code or Codex opens the repo. If the daemon does not start automatically (hooks disabled, project not yet trusted, or port 3099 already in use by another process), run `pnpm mcp:http:dev` manually in a separate terminal before making MCP calls.
+> **Auto-start:** The repo's `SessionStart` hook (`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`) probes this checkout's derived dev port and spawns the daemon automatically when Claude Code or Codex opens the repo. If the daemon does not start automatically (hooks disabled, project not yet trusted, or the port already in use by another process), run `pnpm mcp:http:dev` manually in a separate terminal before making MCP calls.
 
 > **Data lives in `.dev-data/`, not your real `~/.whiteboard`:** `pnpm mcp:http:dev` (and anything that shells out to it — `mcp:debug:http`, the `SessionStart` hook) runs through `packages/mcp-server/scripts/dev/with-dev-data-dir.mjs`, which sets `WHITEBOARD_DATA_DIR` to `<repo root>/.dev-data` unless you already set it yourself. This keeps dev canvases, the SQLite metadata DB, and daemon tokens out of the real `~/.whiteboard` a packaged (npm/Docker/stdio) install uses. Launching from a `git worktree` gets that worktree's own `.dev-data` — intentional, so parallel dev-loop lanes never share (or corrupt) each other's canvas data. If you have existing dev data under `~/.whiteboard` from before this change, move its *contents* into `.dev-data` at the repo root — the `SessionStart` hook typically creates an empty `.dev-data/` before you get to this step, so a plain `mv ~/.whiteboard .dev-data` nests the old directory one level too deep (`.dev-data/.whiteboard/whiteboard.db` instead of `.dev-data/whiteboard.db`) and your canvases will look missing. From the repo root:
 
@@ -79,6 +79,18 @@ mkdir -p .dev-data && mv ~/.whiteboard/* ~/.whiteboard/.[!.]* .dev-data/ 2>/dev/
 ```
 
 Do this only while no dev daemon is running — an already-running old daemon on `:3099` keeps writing to `~/.whiteboard` until you restart it.
+
+> **Per-worktree ports:** every worktree gets its own dev daemon port, not just its own data dir. `packages/mcp-server/scripts/dev/dev-port-lib.mjs` is the single place this is derived, and both `with-dev-data-dir.mjs` (the spawn wrapper) and `ensure-http-dev-daemon.mjs` (the probe/spawn hook) import it — they can never disagree about which port a given worktree belongs on. The rule: the **main checkout always gets 3099** (back-compat with every doc, hook, and packaged script written before per-worktree ports existed); every **linked worktree** gets a deterministic port in `[3100, 3999]` derived by hashing its absolute repo root path. Run `node .claude/scripts/new-worktree.mjs <name>` to see a new worktree's port in its summary output, or compute it directly:
+>
+> ```bash
+> node -e "import('./packages/mcp-server/scripts/dev/dev-port-lib.mjs').then(({deriveDevPort, isMainCheckout}) => { const repoRoot = process.cwd(); console.log(deriveDevPort({ repoRoot, isMainCheckout: isMainCheckout(repoRoot), env: process.env })) })"
+> ```
+>
+> Set `WHITEBOARD_DEV_PORT` in the shell to override the derived port for a checkout (useful if two worktrees happen to hash-collide, or you just want a fixed value).
+>
+> `with-dev-data-dir.mjs` also writes a small identity marker to `<dataDir>/dev-daemon.json` (`{ port, repoRoot, pid, startedAt }`) when it spawns the daemon, and removes it on clean exit. `ensure-http-dev-daemon.mjs` reads this marker back after a healthy authenticated `/mcp` probe: a daemon that answers with the right bearer token but has no marker (or a mismatched port) for this worktree is treated as a **foreign daemon** — most likely a different worktree that happened to hash-collide on the same port, since the default dev token (`whiteboard-dev`) is shared across every checkout. The hook fails loudly in that case rather than silently reusing the wrong worktree's daemon and data; the error message names both the expected port and the expected data dir so you know which `WHITEBOARD_DEV_PORT` override (or `pkill -f mcp:http:dev`) to reach for.
+>
+> This closes the gap left when `.dev-data/` isolation first shipped: before per-worktree ports, every worktree probed the same fixed `:3099`, so opening a second worktree would silently attach to the first worktree's daemon (its code, its data) instead of starting its own. Wiring each worktree's Claude Code / Codex config to its own port automatically is tracked as a follow-up (see the private backlog) — until it lands, point a worktree's client at its derived port manually, e.g. `claude mcp add --transport http whiteboard http://127.0.0.1:<port>/mcp --scope local` or a Codex `-c mcp_servers.whiteboard.url=...` override.
 
 **Codex** — set in `~/.codex/config.toml`:
 

--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -186,6 +186,6 @@ pnpm mcp:http:dev
 ```
 
 The repo-local `SessionStart` hook (`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`)
-probes port 3099 and auto-spawns the daemon when a session opens, so in normal use this
-situation should not arise. If the hook is disabled or the project is not yet trusted, start
-the daemon manually before opening the session.
+probes this checkout's derived dev port (3099 on the main checkout) and auto-spawns the daemon
+when a session opens, so in normal use this situation should not arise. If the hook is disabled
+or the project is not yet trusted, start the daemon manually before opening the session.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -125,7 +125,7 @@
     "mutation:contracts": "stryker run",
     "mcp": "node --import tsx/esm src/server/mcp/index.ts",
     "mcp:http": "node dist/server/index.js --daemon --port=3099 --token=whiteboard-dev",
-    "mcp:http:dev": "node scripts/dev/with-dev-data-dir.mjs --daemon --port=3099 --token=whiteboard-dev",
+    "mcp:http:dev": "node scripts/dev/with-dev-data-dir.mjs --daemon --token=whiteboard-dev",
     "mcp:inspect": "npx @modelcontextprotocol/inspector",
     "mcp:inspect:stdio": "npx @modelcontextprotocol/inspector node --import tsx/esm src/server/mcp/index.ts",
     "mcp:debug:http": "concurrently \"pnpm mcp:http:dev\" \"pnpm mcp:inspect\"",

--- a/packages/mcp-server/scripts/dev/dev-port-lib.mjs
+++ b/packages/mcp-server/scripts/dev/dev-port-lib.mjs
@@ -88,7 +88,11 @@ export function isMainCheckout(repoRoot) {
   try {
     stats = lstatSync(gitPath)
   } catch {
-    throw new Error(`Cannot determine checkout type: no .git found at ${gitPath}`)
+    // No .git at all (npm tarball extraction, some sandboxed checkouts) is
+    // not a linked worktree — fall back to the main-checkout port (3099)
+    // rather than crashing dev startup over a checkout-type check that has
+    // no bearing on whether the server itself can run.
+    return true
   }
   return stats.isDirectory()
 }

--- a/packages/mcp-server/scripts/dev/dev-port-lib.mjs
+++ b/packages/mcp-server/scripts/dev/dev-port-lib.mjs
@@ -1,0 +1,94 @@
+import { lstatSync } from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+
+// Back-compat: the main checkout keeps port 3099, matching every doc,
+// hook, and packaged script written before per-worktree ports existed.
+const MAIN_CHECKOUT_PORT = 3099
+const WORKTREE_PORT_RANGE_START = 3100
+const WORKTREE_PORT_RANGE_SIZE = 900
+
+/**
+ * Normalizes an absolute repo root path before hashing, so two spellings of
+ * the same path (trailing separator, Windows drive-letter case, backslash
+ * vs forward slash) always derive the same port. Posix paths stay
+ * case-sensitive because macOS/Linux filesystems can be too.
+ *
+ * @param {string} repoRootAbsPath
+ * @param {NodeJS.Platform} platform
+ * @returns {string}
+ */
+export function normalizeRepoRootForHash(repoRootAbsPath, platform = process.platform) {
+  const resolved = resolve(repoRootAbsPath)
+  const stripped = resolved.endsWith(sep) ? resolved.slice(0, -sep.length) : resolved
+  if (platform === 'win32') {
+    return stripped.toLowerCase().replaceAll('\\', '/')
+  }
+  return stripped
+}
+
+// FNV-1a: small, dependency-free, stable across Node versions — exactly
+// what a deterministic dev-only port derivation needs (not a security hash).
+function fnv1aHash(input) {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+}
+
+function parseDevPortOverride(value) {
+  if (value === '') {
+    throw new Error('WHITEBOARD_DEV_PORT is set but empty; unset it or provide a port 1-65535')
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(
+      `WHITEBOARD_DEV_PORT must be an integer between 1 and 65535, got ${JSON.stringify(value)}`,
+    )
+  }
+  return parsed
+}
+
+/**
+ * Derives the dev daemon port for a repo checkout. Single source of truth
+ * shared by the with-dev-data-dir spawn wrapper and the ensure-http-dev-daemon
+ * probe/spawn hook, so they can never disagree about which port a given
+ * worktree's daemon should live on.
+ *
+ * Precedence: (1) explicit WHITEBOARD_DEV_PORT env override, (2) main
+ * checkout -> 3099, (3) hash of the normalized repo root -> [3100, 3999].
+ *
+ * @param {{ repoRoot: string, isMainCheckout: boolean, env?: Record<string, string | undefined> }} args
+ * @returns {number}
+ */
+export function deriveDevPort({ repoRoot, isMainCheckout, env = {} }) {
+  if (env.WHITEBOARD_DEV_PORT !== undefined) {
+    return parseDevPortOverride(env.WHITEBOARD_DEV_PORT)
+  }
+  if (isMainCheckout) {
+    return MAIN_CHECKOUT_PORT
+  }
+  const normalized = normalizeRepoRootForHash(repoRoot)
+  const hash = fnv1aHash(normalized)
+  return WORKTREE_PORT_RANGE_START + (hash % WORKTREE_PORT_RANGE_SIZE)
+}
+
+/**
+ * A linked git worktree has a `.git` FILE (`gitdir: <path>`); the main
+ * checkout has a `.git` DIRECTORY. Kept as a thin fs-touching helper so
+ * deriveDevPort itself stays pure and unit-testable without touching disk.
+ *
+ * @param {string} repoRoot
+ * @returns {boolean}
+ */
+export function isMainCheckout(repoRoot) {
+  const gitPath = join(resolve(repoRoot), '.git')
+  let stats
+  try {
+    stats = lstatSync(gitPath)
+  } catch {
+    throw new Error(`Cannot determine checkout type: no .git found at ${gitPath}`)
+  }
+  return stats.isDirectory()
+}

--- a/packages/mcp-server/scripts/dev/dev-port-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/dev-port-lib.test.ts
@@ -132,10 +132,14 @@ describe('isMainCheckout', () => {
     expect(isMainCheckout(tempRoot)).toBe(false)
   })
 
-  it('throws a clear error when .git is missing entirely', () => {
+  it('falls back to true (main-checkout port 3099) when .git is missing entirely, instead of throwing', () => {
+    // A non-git checkout (npm tarball extraction, some sandboxed CI checkouts)
+    // has no .git at all. Throwing here would crash dev startup outright;
+    // falling back to the main-checkout port is the same safe default
+    // deriveDevPort already uses for the ordinary main-checkout case.
     tempRoot = mkdtempSync(join(tmpdir(), 'is-main-checkout-'))
 
-    expect(() => isMainCheckout(tempRoot)).toThrow(/\.git/)
+    expect(isMainCheckout(tempRoot)).toBe(true)
   })
 
   it('resolves relative to the repo root, not the process cwd', () => {

--- a/packages/mcp-server/scripts/dev/dev-port-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/dev-port-lib.test.ts
@@ -1,0 +1,147 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { deriveDevPort, isMainCheckout, normalizeRepoRootForHash } from './dev-port-lib.mjs'
+// This import existing means the repo base includes PR #243 (with-dev-data-dir-lib.mjs).
+// On a pre-#243 base this module doesn't exist and the whole suite fails to load,
+// turning a silent stale-base bug into a loud one.
+import { resolveDevDataDirEnv } from './with-dev-data-dir-lib.mjs'
+
+describe('pre-flight: base includes PR #243 (dev-data-dir)', () => {
+  it('resolveDevDataDirEnv is importable', () => {
+    expect(typeof resolveDevDataDirEnv).toBe('function')
+  })
+})
+
+describe('normalizeRepoRootForHash', () => {
+  it('strips a trailing separator', () => {
+    expect(normalizeRepoRootForHash('/repo/worktree/', 'darwin')).toBe(
+      normalizeRepoRootForHash('/repo/worktree', 'darwin'),
+    )
+  })
+
+  it('lowercases and forward-slashes on win32', () => {
+    expect(normalizeRepoRootForHash('C:\\Repo\\Worktree', 'win32')).toBe(
+      normalizeRepoRootForHash('c:/repo/worktree', 'win32'),
+    )
+  })
+
+  it('is case-sensitive on posix platforms', () => {
+    expect(normalizeRepoRootForHash('/Repo/Worktree', 'darwin')).not.toBe(
+      normalizeRepoRootForHash('/repo/worktree', 'darwin'),
+    )
+  })
+})
+
+describe('deriveDevPort', () => {
+  it('is deterministic: same repoRoot derives the same port on repeated calls', () => {
+    const a = deriveDevPort({ repoRoot: '/repo/worktrees/foo', isMainCheckout: false, env: {} })
+    const b = deriveDevPort({ repoRoot: '/repo/worktrees/foo', isMainCheckout: false, env: {} })
+
+    expect(a).toBe(b)
+  })
+
+  it('always derives a port within [3100, 3999] for non-main checkouts', () => {
+    const fixtures = [
+      '/repo/worktrees/alpha',
+      '/repo/worktrees/beta',
+      '/Users/dev/whiteboard-2',
+      '/home/ci/checkout/pr-1234',
+      '/repo/worktrees/dev-port-split',
+      '/repo/worktrees/apps-web-slice-b',
+      '/repo/worktrees/dev-data-dir',
+      '/repo/worktrees/z',
+    ]
+
+    for (const repoRoot of fixtures) {
+      const port = deriveDevPort({ repoRoot, isMainCheckout: false, env: {} })
+      expect(port).toBeGreaterThanOrEqual(3100)
+      expect(port).toBeLessThanOrEqual(3999)
+    }
+  })
+
+  it('returns 3099 for the main checkout regardless of repoRoot', () => {
+    const port = deriveDevPort({ repoRoot: '/anything', isMainCheckout: true, env: {} })
+
+    expect(port).toBe(3099)
+  })
+
+  it('derives distinct ports for distinct sibling worktree paths', () => {
+    const a = deriveDevPort({ repoRoot: '/repo/worktrees/alpha', isMainCheckout: false, env: {} })
+    const b = deriveDevPort({ repoRoot: '/repo/worktrees/beta', isMainCheckout: false, env: {} })
+
+    expect(a).not.toBe(b)
+  })
+
+  it('WHITEBOARD_DEV_PORT env override wins over derivation, even for the main checkout', () => {
+    const port = deriveDevPort({
+      repoRoot: '/repo',
+      isMainCheckout: true,
+      env: { WHITEBOARD_DEV_PORT: '4242' },
+    })
+
+    expect(port).toBe(4242)
+  })
+
+  it('throws on a non-numeric WHITEBOARD_DEV_PORT override', () => {
+    expect(() =>
+      deriveDevPort({
+        repoRoot: '/repo',
+        isMainCheckout: false,
+        env: { WHITEBOARD_DEV_PORT: 'nope' },
+      }),
+    ).toThrow(/WHITEBOARD_DEV_PORT/)
+  })
+
+  it('throws on an out-of-range WHITEBOARD_DEV_PORT override', () => {
+    expect(() =>
+      deriveDevPort({
+        repoRoot: '/repo',
+        isMainCheckout: false,
+        env: { WHITEBOARD_DEV_PORT: '70000' },
+      }),
+    ).toThrow(/WHITEBOARD_DEV_PORT/)
+  })
+
+  it('throws on an empty-string WHITEBOARD_DEV_PORT override', () => {
+    expect(() =>
+      deriveDevPort({ repoRoot: '/repo', isMainCheckout: false, env: { WHITEBOARD_DEV_PORT: '' } }),
+    ).toThrow(/WHITEBOARD_DEV_PORT/)
+  })
+})
+
+describe('isMainCheckout', () => {
+  let tempRoot: string
+
+  afterEach(() => {
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('returns true when .git is a directory (main checkout)', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'is-main-checkout-'))
+    mkdirSync(join(tempRoot, '.git'))
+
+    expect(isMainCheckout(tempRoot)).toBe(true)
+  })
+
+  it('returns false when .git is a file (linked worktree)', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'is-main-checkout-'))
+    writeFileSync(join(tempRoot, '.git'), 'gitdir: /repo/.git/worktrees/foo\n')
+
+    expect(isMainCheckout(tempRoot)).toBe(false)
+  })
+
+  it('throws a clear error when .git is missing entirely', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'is-main-checkout-'))
+
+    expect(() => isMainCheckout(tempRoot)).toThrow(/\.git/)
+  })
+
+  it('resolves relative to the repo root, not the process cwd', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'is-main-checkout-'))
+    mkdirSync(join(tempRoot, '.git'))
+
+    expect(isMainCheckout(resolve(tempRoot))).toBe(true)
+  })
+})

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
@@ -32,15 +32,40 @@ export function resolveDevBearerToken(env) {
  * Appends `--token=<value>` only when the token differs from the value
  * already baked into the package script (`--token=whiteboard-dev`), so
  * a custom WHITEBOARD_TOKEN is honoured without duplicating the flag on
- * the default path.
+ * the default path. Always appends `--port=<derivedPort>` — the package
+ * script itself no longer bakes in a port, so this is the one place the
+ * spawned daemon's port comes from.
  *
  * @param {string} token
+ * @param {number} derivedPort
  * @returns {string[]}
  */
-export function buildMcpHttpDevSpawnArgs(token) {
+export function buildMcpHttpDevSpawnArgs(token, derivedPort) {
   const base = ['mcp:http:dev']
   if (token !== PACKAGE_SCRIPT_DEFAULT_TOKEN) {
     base.push(`--token=${token}`)
   }
+  base.push(`--port=${derivedPort}`)
   return base
+}
+
+/**
+ * Decides whether a daemon that answered an authenticated MCP probe on this
+ * worktree's derived port actually belongs to this worktree.
+ *
+ * A daemon that never wrote a marker for this data dir, or whose marker
+ * names a different port, is "foreign" — it may be a hash-collision daemon
+ * from another worktree sharing the default bearer token, or a stale
+ * pre-port-split daemon. A marker whose recorded pid is no longer running
+ * is "stale" (its process died without cleaning up); a marker whose port
+ * matches and whose pid is alive is "ours".
+ *
+ * @param {{ marker: { port: number, pid: number } | null, expectedPort: number, isPidAlive: (pid: number) => boolean }} args
+ * @returns {'ours' | 'stale' | 'foreign'}
+ */
+export function verifyDevDaemonIdentity({ marker, expectedPort, isPidAlive }) {
+  if (!marker || marker.port !== expectedPort) {
+    return 'foreign'
+  }
+  return isPidAlive(marker.pid) ? 'ours' : 'stale'
 }

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
@@ -53,18 +53,28 @@ export function buildMcpHttpDevSpawnArgs(token, derivedPort) {
  * Decides whether a daemon that answered an authenticated MCP probe on this
  * worktree's derived port actually belongs to this worktree.
  *
- * A daemon that never wrote a marker for this data dir, or whose marker
- * names a different port, is "foreign" — it may be a hash-collision daemon
- * from another worktree sharing the default bearer token, or a stale
- * pre-port-split daemon. A marker whose recorded pid is no longer running
- * is "stale" (its process died without cleaning up); a marker whose port
- * matches and whose pid is alive is "ours".
+ * A missing marker is "no-marker", not "foreign" — it is indistinguishable
+ * from a daemon started before this feature existed (or before it wrote its
+ * first marker), which is overwhelmingly the common case on a first-adopt
+ * run. Treating that the same as an actual identity mismatch would hard-fail
+ * with no self-healing path. A marker whose port or repoRoot disagrees with
+ * what's expected is "foreign" — either a hash-collision daemon from a
+ * different worktree sharing the default bearer token, or a stale
+ * pre-port-split daemon. The repoRoot check (not just port) is what catches
+ * a startup race between two worktrees that both observed the same derived
+ * port free and raced to bind it — port equality alone can't tell those
+ * apart. A marker whose port and repoRoot both match, but whose recorded pid
+ * is no longer running, is "stale"; matching port, repoRoot, and a live pid
+ * is "ours".
  *
- * @param {{ marker: { port: number, pid: number } | null, expectedPort: number, isPidAlive: (pid: number) => boolean }} args
- * @returns {'ours' | 'stale' | 'foreign'}
+ * @param {{ marker: { port: number, repoRoot: string, pid: number } | null, expectedPort: number, expectedRepoRoot: string, isPidAlive: (pid: number) => boolean }} args
+ * @returns {'ours' | 'stale' | 'foreign' | 'no-marker'}
  */
-export function verifyDevDaemonIdentity({ marker, expectedPort, isPidAlive }) {
-  if (!marker || marker.port !== expectedPort) {
+export function verifyDevDaemonIdentity({ marker, expectedPort, expectedRepoRoot, isPidAlive }) {
+  if (!marker) {
+    return 'no-marker'
+  }
+  if (marker.port !== expectedPort || marker.repoRoot !== expectedRepoRoot) {
     return 'foreign'
   }
   return isPidAlive(marker.pid) ? 'ours' : 'stale'

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
@@ -79,3 +79,25 @@ export function verifyDevDaemonIdentity({ marker, expectedPort, expectedRepoRoot
   }
   return isPidAlive(marker.pid) ? 'ours' : 'stale'
 }
+
+/**
+ * Decides whether a verifyDevDaemonIdentity() verdict should let the caller
+ * self-heal (assume the daemon on the port is this worktree's own) instead
+ * of hard-failing.
+ *
+ * "stale" means the marker's port and repoRoot both matched this worktree —
+ * only the recorded pid is dead. The marker's pid is the with-dev-data-dir
+ * wrapper's own pid, written before it spawns the actual server as a child
+ * and removed on that child's normal exit; a dead wrapper pid with the port
+ * still answering MCP means the wrapper died abnormally (crash, SIGKILL, a
+ * platform-specific pid-liveness quirk) while its child kept running and
+ * bound. That is this worktree's own daemon, not a different worktree's
+ * hash-collision (which "foreign" already catches via port/repoRoot
+ * mismatch) — so treat it the same as "no-marker" rather than hard-failing.
+ *
+ * @param {'ours' | 'stale' | 'foreign' | 'no-marker'} identity
+ * @returns {boolean}
+ */
+export function isSelfHealableIdentity(identity) {
+  return identity === 'no-marker' || identity === 'stale'
+}

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   buildMcpHttpDevSpawnArgs,
+  isSelfHealableIdentity,
   resolveDevBearerToken,
   verifyDevDaemonIdentity,
   waitForAuthenticatedMcp,
@@ -151,5 +152,23 @@ describe('verifyDevDaemonIdentity', () => {
     })
 
     expect(verdict).toBe('ours')
+  })
+})
+
+describe('isSelfHealableIdentity', () => {
+  it('treats "no-marker" as self-healable (daemon predates the marker feature)', () => {
+    expect(isSelfHealableIdentity('no-marker')).toBe(true)
+  })
+
+  it('treats "stale" as self-healable (the daemon on the port matches port+repoRoot; only the recorded pid is dead, most likely because the wrapper that owned that pid crashed or was killed without cleanup while its child kept the port bound)', () => {
+    expect(isSelfHealableIdentity('stale')).toBe(true)
+  })
+
+  it('does NOT treat "foreign" as self-healable (a different worktree really did hash-collide on this port)', () => {
+    expect(isSelfHealableIdentity('foreign')).toBe(false)
+  })
+
+  it('does NOT treat "ours" as self-healable (already a confirmed match, not a self-heal case)', () => {
+    expect(isSelfHealableIdentity('ours')).toBe(false)
   })
 })

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
@@ -93,37 +93,51 @@ describe('buildMcpHttpDevSpawnArgs', () => {
 })
 
 describe('verifyDevDaemonIdentity', () => {
-  it('returns "foreign" when no marker exists for this data dir', () => {
+  it('returns "no-marker" (not "foreign") when no marker exists for this data dir — e.g. a daemon started before this feature existed, or before it wrote its first marker; the caller should self-heal rather than hard-fail', () => {
     const verdict = verifyDevDaemonIdentity({
       marker: null,
       expectedPort: 3123,
+      expectedRepoRoot: '/repo',
       isPidAlive: () => true,
     })
 
-    expect(verdict).toBe('foreign')
+    expect(verdict).toBe('no-marker')
   })
 
   it('returns "foreign" when the marker records a different port (hash collision or stale)', () => {
     const verdict = verifyDevDaemonIdentity({
       marker: { port: 3099, repoRoot: '/other/repo', pid: 1, startedAt: '2026-01-01T00:00:00Z' },
       expectedPort: 3123,
+      expectedRepoRoot: '/repo',
       isPidAlive: () => true,
     })
 
     expect(verdict).toBe('foreign')
   })
 
-  it('returns "stale" when the marker port matches but the recorded pid is dead', () => {
+  it('returns "foreign" when the marker records a different repoRoot even though the port matches (guards a TOCTOU startup race between two worktrees that hash-collided on the same derived port)', () => {
+    const verdict = verifyDevDaemonIdentity({
+      marker: { port: 3123, repoRoot: '/other/repo', pid: 1, startedAt: '2026-01-01T00:00:00Z' },
+      expectedPort: 3123,
+      expectedRepoRoot: '/repo',
+      isPidAlive: () => true,
+    })
+
+    expect(verdict).toBe('foreign')
+  })
+
+  it('returns "stale" when the marker port and repoRoot match but the recorded pid is dead', () => {
     const verdict = verifyDevDaemonIdentity({
       marker: { port: 3123, repoRoot: '/repo', pid: 999999, startedAt: '2026-01-01T00:00:00Z' },
       expectedPort: 3123,
+      expectedRepoRoot: '/repo',
       isPidAlive: () => false,
     })
 
     expect(verdict).toBe('stale')
   })
 
-  it('returns "ours" when the marker port matches and the recorded pid is alive', () => {
+  it('returns "ours" when the marker port and repoRoot match and the recorded pid is alive', () => {
     const verdict = verifyDevDaemonIdentity({
       marker: {
         port: 3123,
@@ -132,6 +146,7 @@ describe('verifyDevDaemonIdentity', () => {
         startedAt: '2026-01-01T00:00:00Z',
       },
       expectedPort: 3123,
+      expectedRepoRoot: '/repo',
       isPidAlive: () => true,
     })
 

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
@@ -2,9 +2,10 @@ import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
-  waitForAuthenticatedMcp,
-  resolveDevBearerToken,
   buildMcpHttpDevSpawnArgs,
+  resolveDevBearerToken,
+  verifyDevDaemonIdentity,
+  waitForAuthenticatedMcp,
 } from './ensure-http-dev-daemon-lib.mjs'
 
 describe('HTTP dev daemon startup', () => {
@@ -75,13 +76,65 @@ describe('resolveDevBearerToken', () => {
 
 describe('buildMcpHttpDevSpawnArgs', () => {
   it('injects --token when token differs from the package-script default', () => {
-    const args = buildMcpHttpDevSpawnArgs('my-custom-token')
+    const args = buildMcpHttpDevSpawnArgs('my-custom-token', 3123)
     expect(args).toContain('--token=my-custom-token')
   })
 
   it('does NOT inject --token when token is the package-script default', () => {
     // pnpm mcp:http:dev already passes --token=whiteboard-dev; no duplication needed
-    const args = buildMcpHttpDevSpawnArgs('whiteboard-dev')
+    const args = buildMcpHttpDevSpawnArgs('whiteboard-dev', 3123)
     expect(args.some((a) => a.startsWith('--token='))).toBe(false)
+  })
+
+  it("appends --port=<derived> so the spawned daemon binds to this worktree's port", () => {
+    const args = buildMcpHttpDevSpawnArgs('whiteboard-dev', 3123)
+    expect(args).toContain('--port=3123')
+  })
+})
+
+describe('verifyDevDaemonIdentity', () => {
+  it('returns "foreign" when no marker exists for this data dir', () => {
+    const verdict = verifyDevDaemonIdentity({
+      marker: null,
+      expectedPort: 3123,
+      isPidAlive: () => true,
+    })
+
+    expect(verdict).toBe('foreign')
+  })
+
+  it('returns "foreign" when the marker records a different port (hash collision or stale)', () => {
+    const verdict = verifyDevDaemonIdentity({
+      marker: { port: 3099, repoRoot: '/other/repo', pid: 1, startedAt: '2026-01-01T00:00:00Z' },
+      expectedPort: 3123,
+      isPidAlive: () => true,
+    })
+
+    expect(verdict).toBe('foreign')
+  })
+
+  it('returns "stale" when the marker port matches but the recorded pid is dead', () => {
+    const verdict = verifyDevDaemonIdentity({
+      marker: { port: 3123, repoRoot: '/repo', pid: 999999, startedAt: '2026-01-01T00:00:00Z' },
+      expectedPort: 3123,
+      isPidAlive: () => false,
+    })
+
+    expect(verdict).toBe('stale')
+  })
+
+  it('returns "ours" when the marker port matches and the recorded pid is alive', () => {
+    const verdict = verifyDevDaemonIdentity({
+      marker: {
+        port: 3123,
+        repoRoot: '/repo',
+        pid: process.pid,
+        startedAt: '2026-01-01T00:00:00Z',
+      },
+      expectedPort: 3123,
+      isPidAlive: () => true,
+    })
+
+    expect(verdict).toBe('ours')
   })
 })

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -141,16 +141,27 @@ if (status === 'in-use') {
     const identity = verifyDevDaemonIdentity({
       marker: readDevDaemonMarker(EXPECTED_DATA_DIR),
       expectedPort: PORT,
+      expectedRepoRoot: REPO_ROOT,
       isPidAlive,
     })
     if (identity === 'ours') {
       info(`[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — verified`)
       process.exit(0)
     }
+    if (identity === 'no-marker') {
+      // A marker-less daemon on our own derived port predates this feature
+      // (or predates its own first marker write) — not evidence of a
+      // foreign daemon. Self-heal instead of hard-failing.
+      info(
+        `[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — no identity marker ` +
+          "found (daemon predates this check); assuming it is this worktree's own daemon",
+      )
+      process.exit(0)
+    }
     console.error(
       `[ensure-http-dev-daemon] http://${HOST}:${PORT} answers MCP but its ` +
         `${EXPECTED_DATA_DIR}/dev-daemon.json marker does not match this worktree ` +
-        `(${identity === 'stale' ? 'recorded pid is no longer running' : 'no marker or a different port recorded'}). ` +
+        `(${identity === 'stale' ? 'recorded pid is no longer running' : 'a different port or repo root is recorded'}). ` +
         "This is very likely a different worktree's daemon that hash-collided on this port. " +
         `Set WHITEBOARD_DEV_PORT to a distinct value for one of the worktrees, or stop the ` +
         'conflicting process (e.g. `pkill -f mcp:http:dev`) and rerun.',
@@ -208,6 +219,30 @@ if (!ready) {
   const detail = exitedEarly ? `; spawned process exited with code ${exitCode}` : ''
   console.error(
     `[ensure-http-dev-daemon] timed out waiting for authenticated MCP at http://${HOST}:${PORT} after ${READY_TIMEOUT_MS}ms${detail} — see ${LOG_PATH}`,
+  )
+  process.exit(1)
+}
+
+// The initial probe() saw the port free, but another worktree's hook can
+// win a startup race and bind the same derived port between that probe and
+// our own spawn becoming ready (TOCTOU). An authenticated MCP response
+// alone doesn't prove it's OUR spawn that answered — cross-check the
+// identity marker before declaring success, exactly as the pre-existing
+// "port already in use" branch does.
+const postSpawnIdentity = verifyDevDaemonIdentity({
+  marker: readDevDaemonMarker(EXPECTED_DATA_DIR),
+  expectedPort: PORT,
+  expectedRepoRoot: REPO_ROOT,
+  isPidAlive,
+})
+if (postSpawnIdentity !== 'ours' && postSpawnIdentity !== 'no-marker') {
+  console.error(
+    `[ensure-http-dev-daemon] http://${HOST}:${PORT} answered MCP right after we spawned our own ` +
+      `daemon, but its ${EXPECTED_DATA_DIR}/dev-daemon.json marker does not match this worktree ` +
+      `(${postSpawnIdentity === 'stale' ? 'recorded pid is no longer running' : 'a different port or repo root is recorded'}). ` +
+      'This is very likely a startup race with another worktree that bound the same derived port ' +
+      'first. Rerun this hook; if it keeps happening, set WHITEBOARD_DEV_PORT to a distinct value ' +
+      'for one of the worktrees.',
   )
   process.exit(1)
 }

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -158,11 +158,10 @@ if (status === 'in-use') {
     process.exit(1)
   }
   const why =
-    verdict === 'wrong-token'
-      ? 'rejected the dev bearer token (likely a stale daemon with a different token)'
-      : verdict === 'not-mcp'
-        ? 'is not speaking MCP'
-        : 'did not respond to a probe'
+    {
+      'wrong-token': 'rejected the dev bearer token (likely a stale daemon with a different token)',
+      'not-mcp': 'is not speaking MCP',
+    }[verdict] ?? 'did not respond to a probe'
   console.error(
     `[ensure-http-dev-daemon] http://${HOST}:${PORT} is in use but ${why}. ` +
       'Stop the conflicting process (e.g. `pkill -f mcp:http:dev`) and rerun.',

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -1,23 +1,35 @@
 #!/usr/bin/env node
-// Idempotent: probe port 3099, and if nothing is listening start
-// `pnpm mcp:http:dev` detached so the next MCP request connects immediately.
+// Idempotent: probe this checkout's derived dev port (3099 on the main
+// checkout, a deterministic per-worktree port otherwise — see
+// dev-port-lib.mjs), and if nothing is listening start `pnpm mcp:http:dev`
+// detached so the next MCP request connects immediately.
 //
 // Wired into client `SessionStart` hooks so opening this repo auto-launches
 // the dev daemon. Re-running this script is safe; if the port is already in
 // use it exits without doing anything.
 
 import { spawn } from 'node:child_process'
-import { createServer } from 'node:net'
 import { mkdir, open } from 'node:fs/promises'
+import { createServer } from 'node:net'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import {
-  waitForAuthenticatedMcp,
-  resolveDevBearerToken,
   buildMcpHttpDevSpawnArgs,
+  resolveDevBearerToken,
+  verifyDevDaemonIdentity,
+  waitForAuthenticatedMcp,
 } from './ensure-http-dev-daemon-lib.mjs'
+import { readDevDaemonMarker, resolveDevDataDirEnv } from './with-dev-data-dir-lib.mjs'
 
-const PORT = 3099
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(SCRIPT_DIR, '..', '..', '..', '..')
+const PORT = deriveDevPort({
+  repoRoot: REPO_ROOT,
+  isMainCheckout: isMainCheckout(REPO_ROOT),
+  env: process.env,
+})
+const EXPECTED_DATA_DIR = resolveDevDataDirEnv(process.env, REPO_ROOT).WHITEBOARD_DATA_DIR
 const HOST = '127.0.0.1'
 // Upper bound on how long we'll wait for `pnpm mcp:http:dev` to bind. tsx
 // + happy-dom + canvas + resvg cold start + node_modules linking can take
@@ -34,14 +46,24 @@ const READY_POLL_INTERVAL_MS = 200
 // is set the spawned daemon receives an explicit --token flag that overrides
 // the default baked into the pnpm script, keeping all three in sync.
 const DEV_BEARER_TOKEN = resolveDevBearerToken(process.env)
-const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
-const REPO_ROOT = resolve(SCRIPT_DIR, '..', '..', '..', '..')
 const LOG_DIR = join(REPO_ROOT, 'tmp', 'logs')
 const LOG_PATH = join(LOG_DIR, 'mcp-http-dev.log')
 const QUIET = process.argv.includes('--quiet')
 
 function info(message) {
   if (!QUIET) console.log(message)
+}
+
+// process.kill(pid, 0) throws (ESRCH) when no process with that pid exists;
+// it does not actually send a signal. This is the standard cross-platform
+// liveness check pattern.
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function probe(port) {
@@ -112,8 +134,28 @@ if (status === 'in-use') {
   // before claiming success.
   const verdict = await probeAuthenticatedMcpDaemon()
   if (verdict === 'ours') {
-    info(`[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — verified`)
-    process.exit(0)
+    // An authenticated MCP daemon answers on our derived port — but with a
+    // shared default bearer token across worktrees, that alone doesn't rule
+    // out a hash-collision daemon from a DIFFERENT worktree. Cross-check
+    // against this worktree's own marker before claiming success.
+    const identity = verifyDevDaemonIdentity({
+      marker: readDevDaemonMarker(EXPECTED_DATA_DIR),
+      expectedPort: PORT,
+      isPidAlive,
+    })
+    if (identity === 'ours') {
+      info(`[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — verified`)
+      process.exit(0)
+    }
+    console.error(
+      `[ensure-http-dev-daemon] http://${HOST}:${PORT} answers MCP but its ` +
+        `${EXPECTED_DATA_DIR}/dev-daemon.json marker does not match this worktree ` +
+        `(${identity === 'stale' ? 'recorded pid is no longer running' : 'no marker or a different port recorded'}). ` +
+        "This is very likely a different worktree's daemon that hash-collided on this port. " +
+        `Set WHITEBOARD_DEV_PORT to a distinct value for one of the worktrees, or stop the ` +
+        'conflicting process (e.g. `pkill -f mcp:http:dev`) and rerun.',
+    )
+    process.exit(1)
   }
   const why =
     verdict === 'wrong-token'
@@ -132,7 +174,7 @@ await mkdir(LOG_DIR, { recursive: true })
 const logFile = await open(LOG_PATH, 'a')
 const pnpmCmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 
-const child = spawn(pnpmCmd, buildMcpHttpDevSpawnArgs(DEV_BEARER_TOKEN), {
+const child = spawn(pnpmCmd, buildMcpHttpDevSpawnArgs(DEV_BEARER_TOKEN, PORT), {
   cwd: REPO_ROOT,
   detached: true,
   stdio: ['ignore', logFile.fd, logFile.fd],

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url'
 import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import {
   buildMcpHttpDevSpawnArgs,
+  isSelfHealableIdentity,
   resolveDevBearerToken,
   verifyDevDaemonIdentity,
   waitForAuthenticatedMcp,
@@ -148,20 +149,28 @@ if (status === 'in-use') {
       info(`[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — verified`)
       process.exit(0)
     }
-    if (identity === 'no-marker') {
+    if (isSelfHealableIdentity(identity)) {
       // A marker-less daemon on our own derived port predates this feature
       // (or predates its own first marker write) — not evidence of a
-      // foreign daemon. Self-heal instead of hard-failing.
+      // foreign daemon. A "stale" marker (port + repoRoot match, recorded
+      // pid dead) means the with-dev-data-dir wrapper that owned that pid
+      // died abnormally while its spawned server child kept the port
+      // bound — also this worktree's own daemon, not a foreign one. Both
+      // self-heal instead of hard-failing.
+      const reason =
+        identity === 'stale'
+          ? 'its recorded pid is no longer running (the dev wrapper likely crashed or was killed without cleanup, but the daemon itself is still up)'
+          : 'no identity marker was found (daemon predates this check)'
       info(
-        `[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — no identity marker ` +
-          "found (daemon predates this check); assuming it is this worktree's own daemon",
+        `[ensure-http-dev-daemon] http://${HOST}:${PORT} already listening — ${reason}; ` +
+          "assuming it is this worktree's own daemon",
       )
       process.exit(0)
     }
     console.error(
       `[ensure-http-dev-daemon] http://${HOST}:${PORT} answers MCP but its ` +
         `${EXPECTED_DATA_DIR}/dev-daemon.json marker does not match this worktree ` +
-        `(${identity === 'stale' ? 'recorded pid is no longer running' : 'a different port or repo root is recorded'}). ` +
+        '(a different port or repo root is recorded). ' +
         "This is very likely a different worktree's daemon that hash-collided on this port. " +
         `Set WHITEBOARD_DEV_PORT to a distinct value for one of the worktrees, or stop the ` +
         'conflicting process (e.g. `pkill -f mcp:http:dev`) and rerun.',
@@ -235,11 +244,11 @@ const postSpawnIdentity = verifyDevDaemonIdentity({
   expectedRepoRoot: REPO_ROOT,
   isPidAlive,
 })
-if (postSpawnIdentity !== 'ours' && postSpawnIdentity !== 'no-marker') {
+if (postSpawnIdentity !== 'ours' && !isSelfHealableIdentity(postSpawnIdentity)) {
   console.error(
     `[ensure-http-dev-daemon] http://${HOST}:${PORT} answered MCP right after we spawned our own ` +
       `daemon, but its ${EXPECTED_DATA_DIR}/dev-daemon.json marker does not match this worktree ` +
-      `(${postSpawnIdentity === 'stale' ? 'recorded pid is no longer running' : 'a different port or repo root is recorded'}). ` +
+      '(a different port or repo root is recorded). ' +
       'This is very likely a startup race with another worktree that bound the same derived port ' +
       'first. Rerun this hook; if it keeps happening, set WHITEBOARD_DEV_PORT to a distinct value ' +
       'for one of the worktrees.',

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -1,5 +1,5 @@
-import { chmodSync, mkdirSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
 // Owner-only, matching shared/data-dir-secure.ts's POSIX_DATA_DIR_MODE. Kept
 // as a separate literal here (rather than importing the TS module) because
@@ -70,6 +70,70 @@ export function reraiseSignalOrExit(
     kill(pid, signal)
   } catch {
     exit(1)
+  }
+}
+
+/**
+ * Appends `--port=<derivedPort>` to argv unless the caller already passed
+ * an explicit `--port`, which always wins. Returns a new array (immutable).
+ *
+ * @param {string[]} argv
+ * @param {number} derivedPort
+ * @returns {string[]}
+ */
+export function injectDerivedPortArg(argv, derivedPort) {
+  if (argv.some((arg) => arg === '--port' || arg.startsWith('--port='))) {
+    return [...argv]
+  }
+  return [...argv, `--port=${derivedPort}`]
+}
+
+const DEV_DAEMON_MARKER_FILENAME = 'dev-daemon.json'
+
+/**
+ * Writes a small identity marker into the dev data dir recording which
+ * worktree/port/pid started this daemon. ensure-http-dev-daemon reads this
+ * back after a healthy probe to confirm the daemon answering on its derived
+ * port actually belongs to this worktree, rather than being a foreign
+ * daemon that happened to land on the same hashed port (or a stale process
+ * from before per-worktree ports existed).
+ *
+ * @param {string} dataDir
+ * @param {{ port: number, repoRoot: string, pid: number }} args
+ */
+export function writeDevDaemonMarker(dataDir, { port, repoRoot, pid }) {
+  const marker = { port, repoRoot, pid, startedAt: new Date().toISOString() }
+  writeFileSync(join(dataDir, DEV_DAEMON_MARKER_FILENAME), JSON.stringify(marker, null, 2))
+}
+
+/**
+ * Reads the marker written by writeDevDaemonMarker. Returns null (never
+ * throws) when the marker is absent or unparseable — both are treated as
+ * "no trustworthy identity" by the caller, not as a crash.
+ *
+ * @param {string} dataDir
+ * @returns {{ port: number, repoRoot: string, pid: number, startedAt: string } | null}
+ */
+export function readDevDaemonMarker(dataDir) {
+  try {
+    return JSON.parse(readFileSync(join(dataDir, DEV_DAEMON_MARKER_FILENAME), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Best-effort removal of the identity marker on clean shutdown, so a
+ * restarted daemon on a different port/pid doesn't leave a stale marker
+ * behind that a probe could misread as still-valid.
+ *
+ * @param {string} dataDir
+ */
+export function removeDevDaemonMarker(dataDir) {
+  try {
+    rmSync(join(dataDir, DEV_DAEMON_MARKER_FILENAME))
+  } catch {
+    /* Absent marker (or unremovable) is fine — nothing to clean up. */
   }
 }
 

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -73,19 +73,54 @@ export function reraiseSignalOrExit(
   }
 }
 
+const PORT_FLAG_PREFIX = '--port='
+
+/**
+ * Finds the effective `--port=<value>` flag in argv, matching exactly what
+ * `parseArg` in server/index.ts recognizes (first match wins). A bare,
+ * space-separated `--port <value>` is NOT a recognized override — parseArg
+ * only ever looks for the `--port=` prefix — so it must not be treated as
+ * one here either, or injection and the server's actual listening port
+ * disagree.
+ *
+ * @param {string[]} argv
+ * @returns {number | undefined}
+ */
+function findPortFlagValue(argv) {
+  const match = argv.find((arg) => arg.startsWith(PORT_FLAG_PREFIX))
+  return match === undefined ? undefined : Number(match.slice(PORT_FLAG_PREFIX.length))
+}
+
 /**
  * Appends `--port=<derivedPort>` to argv unless the caller already passed
- * an explicit `--port`, which always wins. Returns a new array (immutable).
+ * an explicit `--port=value`, which always wins. Returns a new array
+ * (immutable).
  *
  * @param {string[]} argv
  * @param {number} derivedPort
  * @returns {string[]}
  */
 export function injectDerivedPortArg(argv, derivedPort) {
-  if (argv.some((arg) => arg === '--port' || arg.startsWith('--port='))) {
+  if (findPortFlagValue(argv) !== undefined) {
     return [...argv]
   }
-  return [...argv, `--port=${derivedPort}`]
+  return [...argv, `${PORT_FLAG_PREFIX}${derivedPort}`]
+}
+
+/**
+ * Resolves the port the spawned server will actually listen on, given the
+ * argv passed to it after injectDerivedPortArg. Used to persist the true
+ * effective port into the identity marker instead of always recording
+ * derivedPort — a caller-provided `--port=value` override must be reflected
+ * here too, or the marker disagrees with the real listening port and later
+ * collision/identity checks make wrong decisions.
+ *
+ * @param {string[]} argvWithPort
+ * @param {number} derivedPort
+ * @returns {number}
+ */
+export function resolveEffectivePort(argvWithPort, derivedPort) {
+  return findPortFlagValue(argvWithPort) ?? derivedPort
 }
 
 const DEV_DAEMON_MARKER_FILENAME = 'dev-daemon.json'
@@ -98,10 +133,19 @@ const DEV_DAEMON_MARKER_FILENAME = 'dev-daemon.json'
  * daemon that happened to land on the same hashed port (or a stale process
  * from before per-worktree ports existed).
  *
+ * Ensures `dataDir` exists first: resolveDataDir()'s contract only mkdir's
+ * an explicit WHITEBOARD_DATA_DIR override lazily elsewhere (or not at all),
+ * so a caller-provided override that hasn't been created yet would otherwise
+ * make this throw ENOENT before the dev server is even spawned. This mkdir
+ * is unconditional but permission-neutral — it never chmod's, so it does
+ * not widen ensureDevDataDirSecured's hardening contract for the repo-local
+ * default path.
+ *
  * @param {string} dataDir
  * @param {{ port: number, repoRoot: string, pid: number }} args
  */
 export function writeDevDaemonMarker(dataDir, { port, repoRoot, pid }) {
+  mkdirSync(dataDir, { recursive: true })
   const marker = { port, repoRoot, pid, startedAt: new Date().toISOString() }
   writeFileSync(join(dataDir, DEV_DAEMON_MARKER_FILENAME), JSON.stringify(marker, null, 2))
 }

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -17,6 +17,7 @@ import {
   removeDevDaemonMarker,
   reraiseSignalOrExit,
   resolveDevDataDirEnv,
+  resolveEffectivePort,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
   writeDevDaemonMarker,
@@ -139,6 +140,26 @@ describe('injectDerivedPortArg', () => {
     expect(argv).toEqual(['--daemon'])
     expect(result).not.toBe(argv)
   })
+
+  it('still appends --port=<derived> for a bare "--port <value>" (space form), because parseArg in server/index.ts only recognizes the "--port=value" form and would otherwise silently fall back to the default port', () => {
+    const argv = ['--daemon', '--port', '4000']
+
+    expect(injectDerivedPortArg(argv, 3123)).toEqual(['--daemon', '--port', '4000', '--port=3123'])
+  })
+})
+
+describe('resolveEffectivePort', () => {
+  it('returns the derived port when argv has no --port=value flag', () => {
+    expect(resolveEffectivePort(['--daemon'], 3123)).toBe(3123)
+  })
+
+  it('returns the caller-provided --port=value when present, matching what parseArg resolves', () => {
+    expect(resolveEffectivePort(['--daemon', '--port=4000'], 3123)).toBe(4000)
+  })
+
+  it("returns the derived port for a bare '--port <value>' argv, since that form is not a recognized override", () => {
+    expect(resolveEffectivePort(['--daemon', '--port', '4000'], 3123)).toBe(3123)
+  })
 })
 
 describe('dev daemon identity marker', () => {
@@ -156,6 +177,17 @@ describe('dev daemon identity marker', () => {
     const raw = JSON.parse(readFileSync(join(tempRoot, 'dev-daemon.json'), 'utf8'))
     expect(raw).toMatchObject({ port: 3123, repoRoot: '/repo/worktree', pid: 4242 })
     expect(typeof raw.startedAt).toBe('string')
+  })
+
+  it('creates the data dir first when it does not exist yet (e.g. an explicit WHITEBOARD_DATA_DIR override that was never mkdir-ed)', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+    const notYetCreated = join(tempRoot, 'override', 'nested')
+
+    expect(() =>
+      writeDevDaemonMarker(notYetCreated, { port: 3123, repoRoot: '/repo/worktree', pid: 4242 }),
+    ).not.toThrow()
+
+    expect(existsSync(join(notYetCreated, 'dev-daemon.json'))).toBe(true)
   })
 
   it('overwrites a malformed existing marker instead of throwing', () => {

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -1,13 +1,25 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   ensureDevDataDirSecured,
+  injectDerivedPortArg,
+  readDevDaemonMarker,
+  removeDevDaemonMarker,
   reraiseSignalOrExit,
   resolveDevDataDirEnv,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
+  writeDevDaemonMarker,
 } from './with-dev-data-dir-lib.mjs'
 
 describe('resolveDevDataDirEnv', () => {
@@ -103,6 +115,99 @@ describe('reraiseSignalOrExit', () => {
 
     expect(exitCalls).toEqual([1])
   })
+})
+
+describe('injectDerivedPortArg', () => {
+  it('appends --port=<derived> when argv has no --port flag', () => {
+    expect(injectDerivedPortArg(['--daemon', '--token=whiteboard-dev'], 3123)).toEqual([
+      '--daemon',
+      '--token=whiteboard-dev',
+      '--port=3123',
+    ])
+  })
+
+  it('leaves argv untouched (no duplicate) when caller already passed --port', () => {
+    const argv = ['--daemon', '--port=4000']
+
+    expect(injectDerivedPortArg(argv, 3123)).toEqual(['--daemon', '--port=4000'])
+  })
+
+  it('does not mutate the input argv array', () => {
+    const argv = ['--daemon']
+    const result = injectDerivedPortArg(argv, 3123)
+
+    expect(argv).toEqual(['--daemon'])
+    expect(result).not.toBe(argv)
+  })
+})
+
+describe('dev daemon identity marker', () => {
+  let tempRoot: string
+
+  afterEach(() => {
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('writes { port, repoRoot, pid, startedAt } to <dataDir>/dev-daemon.json', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+
+    writeDevDaemonMarker(tempRoot, { port: 3123, repoRoot: '/repo/worktree', pid: 4242 })
+
+    const raw = JSON.parse(readFileSync(join(tempRoot, 'dev-daemon.json'), 'utf8'))
+    expect(raw).toMatchObject({ port: 3123, repoRoot: '/repo/worktree', pid: 4242 })
+    expect(typeof raw.startedAt).toBe('string')
+  })
+
+  it('overwrites a malformed existing marker instead of throwing', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+    writeFileSyncMalformed(tempRoot)
+
+    expect(() =>
+      writeDevDaemonMarker(tempRoot, { port: 3123, repoRoot: '/repo/worktree', pid: 4242 }),
+    ).not.toThrow()
+
+    const raw = JSON.parse(readFileSync(join(tempRoot, 'dev-daemon.json'), 'utf8'))
+    expect(raw.port).toBe(3123)
+  })
+
+  it('readDevDaemonMarker returns null when the marker file is absent', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+
+    expect(readDevDaemonMarker(tempRoot)).toBeNull()
+  })
+
+  it('readDevDaemonMarker returns null (not a throw) when the marker is malformed JSON', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+    writeFileSyncMalformed(tempRoot)
+
+    expect(readDevDaemonMarker(tempRoot)).toBeNull()
+  })
+
+  it('readDevDaemonMarker round-trips a previously written marker', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+    writeDevDaemonMarker(tempRoot, { port: 3123, repoRoot: '/repo/worktree', pid: 4242 })
+
+    expect(readDevDaemonMarker(tempRoot)).toMatchObject({
+      port: 3123,
+      repoRoot: '/repo/worktree',
+      pid: 4242,
+    })
+  })
+
+  it('removeDevDaemonMarker deletes the marker and is a no-op when already absent', () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'dev-daemon-marker-'))
+    writeDevDaemonMarker(tempRoot, { port: 3123, repoRoot: '/repo/worktree', pid: 4242 })
+
+    removeDevDaemonMarker(tempRoot)
+    expect(existsSync(join(tempRoot, 'dev-daemon.json'))).toBe(false)
+
+    expect(() => removeDevDaemonMarker(tempRoot)).not.toThrow()
+  })
+
+  function writeFileSyncMalformed(dataDir: string) {
+    mkdirSync(dataDir, { recursive: true })
+    writeFileSync(join(dataDir, 'dev-daemon.json'), '{ not valid json')
+  }
 })
 
 describe('resolveTsxWatchSpawn', () => {

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -3,12 +3,16 @@
 import { spawn } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import {
   ensureDevDataDirSecured,
+  injectDerivedPortArg,
+  removeDevDaemonMarker,
   reraiseSignalOrExit,
   resolveDevDataDirEnv,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
+  writeDevDaemonMarker,
 } from './with-dev-data-dir-lib.mjs'
 
 // Keeps dev daemons started via `pnpm mcp:http:dev` (and anything that
@@ -37,8 +41,24 @@ if (!hadExplicitDataDirOverride) {
 // dist/cli.mjs rather than node_modules/.bin/tsx: that .bin entry is a POSIX
 // shell shim (with separate .cmd/.ps1 wrappers on Windows), which `shell:
 // false` cannot execute on native Windows.
+// Derived once here so with-dev-data-dir and ensure-http-dev-daemon can
+// never disagree about which port a given worktree's daemon belongs on —
+// both consult this same shared helper rather than a baked-in constant.
+const derivedPort = deriveDevPort({
+  repoRoot,
+  isMainCheckout: isMainCheckout(repoRoot),
+  env: process.env,
+})
+const argvWithPort = injectDerivedPortArg(process.argv.slice(2), derivedPort)
+
 const entryPath = resolve(packageRoot, 'src/server/index.ts')
-const { command, args } = resolveTsxWatchSpawn(packageRoot, entryPath, process.argv.slice(2))
+const { command, args } = resolveTsxWatchSpawn(packageRoot, entryPath, argvWithPort)
+
+writeDevDaemonMarker(env.WHITEBOARD_DATA_DIR, {
+  port: derivedPort,
+  repoRoot,
+  pid: process.pid,
+})
 
 const child = spawn(command, args, {
   cwd: packageRoot,
@@ -52,6 +72,7 @@ child.on('error', (error) => {
 })
 
 child.on('exit', (code, signal) => {
+  removeDevDaemonMarker(env.WHITEBOARD_DATA_DIR)
   if (signal) {
     reraiseSignalOrExit(signal)
     return

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -10,6 +10,7 @@ import {
   removeDevDaemonMarker,
   reraiseSignalOrExit,
   resolveDevDataDirEnv,
+  resolveEffectivePort,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
   writeDevDaemonMarker,
@@ -50,12 +51,17 @@ const derivedPort = deriveDevPort({
   env: process.env,
 })
 const argvWithPort = injectDerivedPortArg(process.argv.slice(2), derivedPort)
+// A caller-provided `--port=value` (recognized by parseArg in
+// server/index.ts) always wins over derivedPort — record that same
+// effective value in the marker so it never disagrees with the port the
+// server actually binds to.
+const effectivePort = resolveEffectivePort(argvWithPort, derivedPort)
 
 const entryPath = resolve(packageRoot, 'src/server/index.ts')
 const { command, args } = resolveTsxWatchSpawn(packageRoot, entryPath, argvWithPort)
 
 writeDevDaemonMarker(env.WHITEBOARD_DATA_DIR, {
-  port: derivedPort,
+  port: effectivePort,
   repoRoot,
   pid: process.pid,
 })

--- a/packages/mcp-server/src/server/index.port-arg.test.ts
+++ b/packages/mcp-server/src/server/index.port-arg.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { parseArg } from './index.js'
+
+describe('parseArg', () => {
+  it('returns the flag value when present once', () => {
+    expect(parseArg(['--port=4000'], 'port')).toBe('4000')
+  })
+
+  it('returns the fallback when the flag is absent', () => {
+    expect(parseArg([], 'port', '3099')).toBe('3099')
+  })
+
+  it('returns undefined when the flag is absent and no fallback is given', () => {
+    expect(parseArg([], 'port')).toBeUndefined()
+  })
+
+  it('duplicate --port flags: the FIRST occurrence wins (Array.find semantics)', () => {
+    // Unlike resolveToken's --token= handling (last-wins, via reverse().find),
+    // readArg/parseArg uses a plain forward find(), so the first flag wins.
+    // with-dev-data-dir.mjs relies on this asymmetry being unchanged: it only
+    // appends its derived --port when argv has none, so a caller-provided
+    // --port is never duplicated in practice — but if that guard ever regressed,
+    // first-wins here would silently keep the caller's original value, not the
+    // newly appended one.
+    expect(parseArg(['--port=4000', '--port=5000'], 'port')).toBe('4000')
+  })
+})

--- a/packages/mcp-server/src/server/index.ts
+++ b/packages/mcp-server/src/server/index.ts
@@ -13,9 +13,24 @@ import {
 import { parseOAuthClientRegistryEnv } from './security/oauth-authz-registry.js'
 import { loadAllowedWebOriginsFromEnv } from './security/web-origin-allowlist.js'
 
-function readArg(name: string, fallback?: string): string | undefined {
+/**
+ * Reads a `--name=value` flag out of an argv list. When the same flag is
+ * passed more than once, `Array.prototype.find` returns the FIRST match —
+ * this is a load-bearing detail for `mcp:http:dev`, which relies on its
+ * caller-provided `--port` winning over any port this process's own
+ * wrapper might append later in the argv list.
+ */
+export function parseArg(
+  argv: readonly string[],
+  name: string,
+  fallback?: string,
+): string | undefined {
   const prefix = `--${name}=`
-  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback
+  return argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback
+}
+
+function readArg(name: string, fallback?: string): string | undefined {
+  return parseArg(process.argv, name, fallback)
 }
 
 function hasFlag(name: string): boolean {


### PR DESCRIPTION
## Problem

PR #243 gave each worktree its own `.dev-data`, but every worktree still connected to whichever daemon owned fixed port 3099 — the SessionStart probe only checks "an authenticated MCP responds", so a second worktree silently reused the first worktree's daemon (its code AND its data), defeating lane isolation. (User decision 2026-07-17: per-worktree port separation.)

## Change (dev scripts only — packaged/npm/docker defaults untouched)

- **`dev-port-lib.mjs`** — single source of port derivation: explicit `WHITEBOARD_DEV_PORT` wins → main checkout keeps 3099 (back-compat, `.git` dir-vs-file detection) → linked worktrees get a deterministic FNV-1a hash of the normalized repo root mapped into [3100, 3999]. Consumed by BOTH the launch wrapper (`with-dev-data-dir.mjs` injects `--port` unless the caller passed one; `mcp:http:dev` no longer bakes `--port=3099`) and the SessionStart hook (`ensure-http-dev-daemon.mjs` probes/spawns the derived port).
- **Daemon identity guard** — the wrapper writes `<dataDir>/dev-daemon.json` ({ effective port, repoRoot, pid, startedAt }); after a healthy authenticated probe the hook verifies the marker belongs to this worktree. Foreign daemon on our port → loud failure with the derived port and a `WHITEBOARD_DEV_PORT` escape hatch; marker-less daemon → self-heal path; startup TOCTOU race guarded.
- Review fix rounds: marker dir creation hardened + records the *effective* CLI port (bare `--port` override respected), marker-less self-heal, TOCTOU guard, nested-ternary cleanup, cross-package import guard test.
- **Docs**: development.md / mcp-debugging.md / AGENTS.md now say "derived dev port (3099 on the main checkout)" and document the marker semantics + one-time `pkill -f mcp:http:dev` migration.

## Known remaining gap (split out by design, tracked)

Checked-in MCP client configs (`.claude/settings.json`, `.codex/config.toml`) still point at 3099, so worktree sessions need the documented manual wiring (`claude mcp add --scope local` / `codex -c`) until the follow-up lanes land: **B1** (Claude Code per-worktree config — starts with an empirical spike; `settings.local.json mcpServers` is rejected by the settings schema so the naive approach is out) and **B2** (Codex equivalent). Both are filed as tmp-issues with spike-first instructions. `new-worktree.mjs` now prints the derived port so manual wiring is one copy-paste.

## Verification

dev-loop gate (plan-review + 6-dimension review + adversarial verify + QA; 1 fix round, 5 commits). Unit suites for port derivation (determinism/range/main→3099/env override), wrapper argv/env assembly, marker read/write/self-heal, readArg duplicate-flag behavior lock. mcp-node suite green; typecheck clean; main-checkout behavior byte-for-byte unchanged.