### PR TITLE
fix(mcp-server): exempt the legitimate storage.dataDir value from the backup-restore smoke leak check

### DIFF
--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -351,12 +351,15 @@ try {
   // storage.dataDir is a documented field of GET /api/runtime/status (asserted
   // below), not a leaked path — under /tmp on Linux CI it otherwise trips
   // BASE_LEAK_PATTERNS' blanket /tmp/ check. Redact only that known-good
-  // value before the leak scan so any other /tmp/ path (e.g. a stray stack
-  // frame) still fails the check.
-  const statusBTextForLeakCheck = statusB.storage?.dataDir
-    ? statusBText.split(statusB.storage.dataDir).join('<dataDir>')
-    : statusBText
-  assertNoLeak('runtime status B', statusBTextForLeakCheck, [TOKEN_B])
+  // field (via a parsed-object copy, not a raw-text replace, so a payload
+  // that happens to contain the same substring elsewhere or JSON-escaped
+  // characters in the path can't dodge or over-match the leak scan) before
+  // running it, so any other /tmp/ path (e.g. a stray stack frame) still
+  // fails the check.
+  const statusBForLeakCheck = statusB.storage
+    ? { ...statusB, storage: { ...statusB.storage, dataDir: '<dataDir>' } }
+    : statusB
+  assertNoLeak('runtime status B', JSON.stringify(statusBForLeakCheck), [TOKEN_B])
   if (statusB.storage?.dataDir !== restoredDataDir) {
     throw new Error(
       `daemon B storage.dataDir expected ${restoredDataDir}, got ${statusB.storage?.dataDir}`,

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -347,8 +347,16 @@ try {
   const statusBRes = await authedFetch(daemonB, '/api/runtime/status')
   if (!statusBRes.ok) throw new Error(`daemon B /status: ${statusBRes.status}`)
   const statusBText = await statusBRes.text()
-  assertNoLeak('runtime status B', statusBText, [TOKEN_B])
   const statusB = JSON.parse(statusBText)
+  // storage.dataDir is a documented field of GET /api/runtime/status (asserted
+  // below), not a leaked path — under /tmp on Linux CI it otherwise trips
+  // BASE_LEAK_PATTERNS' blanket /tmp/ check. Redact only that known-good
+  // value before the leak scan so any other /tmp/ path (e.g. a stray stack
+  // frame) still fails the check.
+  const statusBTextForLeakCheck = statusB.storage?.dataDir
+    ? statusBText.split(statusB.storage.dataDir).join('<dataDir>')
+    : statusBText
+  assertNoLeak('runtime status B', statusBTextForLeakCheck, [TOKEN_B])
   if (statusB.storage?.dataDir !== restoredDataDir) {
     throw new Error(
       `daemon B storage.dataDir expected ${restoredDataDir}, got ${statusB.storage?.dataDir}`,


### PR DESCRIPTION
## Problem — the v0.0.15 publish failure

Release run 29586847806 failed at `[packaged-daemon-backup-restore-smoke] FAIL: [smoke] runtime status B leak: /(^|[^a-zA-Z])\/tmp\//`.

Root cause (reproduced with `TMPDIR=/tmp/` — invisible on macOS where `os.tmpdir()` is `/var/folders/...`, deterministic on Linux CI where it is literally `/tmp`): `GET /api/runtime/status` intentionally returns `storage.dataDir` — a long-standing contract field that this very smoke asserts a few lines later (`statusB.storage?.dataDir === restoredDataDir`). On CI the restored data dir lives under `/tmp`, so the legitimate field value tripped the generic `/tmp/` pattern in the leak check. Not a #243 regression (verified: #243 didn't touch the status contract, and its startup notice log is filtered by the smoke's `WHITEBOARD_LOG_LEVEL=warning`).

## Change

The leak check's intent is catching secrets and stack traces, not a documented status field the smoke itself validates. Before running the leak patterns, the smoke now replaces the known `statusB.storage.dataDir` value with a `<dataDir>` placeholder — any OTHER `/tmp/` path in the payload still fails, and the exact-value assertion against `restoredDataDir` is unchanged.

## Verification

- Red: reverting the fix reproduces the CI failure verbatim under `CI=true TMPDIR=/tmp/`.
- Green: ALL OK under `TMPDIR=/tmp/` (CI shape), `TMPDIR=/tmp/ WHITEBOARD_DEV=1`, and default macOS tmpdir; typecheck clean.

Fifth and hopefully final layer of the publish-gate excavation (#239 advance-stable → #240 tarball WHITEBOARD_DEV → #241 LLM-CLI skip → #245 daemon-token env var → this). The PR-gate `dry-run-npm`/`dry-run-docker` on the next release PR run on Linux and will exercise this exact path before merge.