### PR TITLE
fix(mcp-server): align distribution smoke expectations with the shipped auth design and fix smoke-harness bugs

### DIFF
--- a/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
@@ -352,23 +352,29 @@ try {
   }
   console.log('[server-mode-smoke] scenario 5c (workspace palette auth): PASS')
 
-  // --- Scenario 5d: GET /api/user-libraries — canvas:read ---
+  // --- Scenario 5d: GET /api/user-libraries — workspace:read ---
+  // route-scope-registry.ts requires workspace:read (not canvas:read) here
+  // deliberately: collapsing this onto canvas:read would let a canvas-only
+  // grant enumerate the user's shared library. The 403 check below is the
+  // positive assertion of that boundary — canvas:read alone must stay
+  // insufficient.
   {
     const appEmpty = makeApp([])
     const res401 = await req(appEmpty, 'GET', '/api/user-libraries')
     if (res401.status !== 401) fail('5d: expected 401 without auth', { status: res401.status })
     assertNoLeak('5d 401', await res401.text())
 
-    const res403 = await req(appEmpty, 'GET', '/api/user-libraries', { bearer: SMOKE_TOKEN })
+    const appCanvasRead = makeApp(['canvas:read'])
+    const res403 = await req(appCanvasRead, 'GET', '/api/user-libraries', { bearer: SMOKE_TOKEN })
     if (res403.status !== 403) {
-      fail('5d: no canvas:read must be 403 on user-libraries', { status: res403.status })
+      fail('5d: canvas:read alone must be 403 on user-libraries', { status: res403.status })
     }
     assertNoLeak('5d 403', await res403.text())
 
-    const appRead = makeApp(['canvas:read'])
+    const appRead = makeApp(['workspace:read'])
     const resPass = await req(appRead, 'GET', '/api/user-libraries', { bearer: SMOKE_TOKEN })
     if (resPass.status === 401 || resPass.status === 403) {
-      fail('5d: canvas:read must pass auth gate on user-libraries', { status: resPass.status })
+      fail('5d: workspace:read must pass auth gate on user-libraries', { status: resPass.status })
     }
   }
   console.log('[server-mode-smoke] scenario 5d (user-libraries auth): PASS')

--- a/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
@@ -14,7 +14,8 @@
 //   5. Data-route auth gates: workspaces, canvas export, workspace palette,
 //      user-libraries — 401 without auth, 403 with wrong scope, pass with
 //      correct scope; error responses pass LEAK_PATTERNS guard
-//   6. Local-daemon unchanged: workspace list open without auth header
+//   6. Local-daemon auth: /api/* requires the daemon token (401 without,
+//      pass with) — only /api/runtime/ping is public
 //   7. WWW-Authenticate contract: 401 carries it, 403 does not
 
 import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
@@ -379,14 +380,18 @@ try {
   }
   console.log('[server-mode-smoke] scenario 5d (user-libraries auth): PASS')
 
-  // --- Scenario 6: local-daemon unchanged ---
+  // --- Scenario 6: local-daemon auth — every /api/* route needs the daemon
+  // token (only /api/runtime/ping is public; see requiresDaemonAuth in
+  // routes/auth.ts). Local-daemon mode never had a truly unauthenticated
+  // /api/* surface once this hardening shipped.
   {
     let threw = false
     let appLocal
+    const LOCAL_TOKEN = 'local-daemon-token'
     try {
       appLocal = createApp({
         authMode: 'local-daemon',
-        token: 'local-daemon-token',
+        token: LOCAL_TOKEN,
         touch: () => {},
         getStatus: makeInternalStatus,
         shutdown: () => Promise.resolve(),
@@ -395,12 +400,25 @@ try {
       threw = true
     }
     if (threw) fail('6: local-daemon createApp must not throw')
-    const res = await appLocal.request('/api/workspaces')
-    if (res.status === 401 || res.status === 403) {
-      fail('6: local-daemon /api/workspaces must not require auth', { status: res.status })
+
+    const resNoAuth = await appLocal.request('/api/workspaces')
+    if (resNoAuth.status !== 401) {
+      fail('6: local-daemon /api/workspaces without a token must be 401', {
+        status: resNoAuth.status,
+      })
+    }
+    assertNoLeak('6 401', await resNoAuth.text())
+
+    const resAuthed = await appLocal.request('/api/workspaces', {
+      headers: { Authorization: `Bearer ${LOCAL_TOKEN}` },
+    })
+    if (resAuthed.status === 401 || resAuthed.status === 403) {
+      fail('6: local-daemon /api/workspaces with the daemon token must pass auth gate', {
+        status: resAuthed.status,
+      })
     }
   }
-  console.log('[server-mode-smoke] scenario 6 (local-daemon unchanged): PASS')
+  console.log('[server-mode-smoke] scenario 6 (local-daemon daemon-token auth): PASS')
 
   // --- Scenario 7: server-mode root serves the static placeholder, not apps/web ---
   // R5 of the MCP-UI retirement (ADR 0001): server-mode has no apps/web-compatible

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -462,7 +462,13 @@ const REQUIRED_FLAGS = [
       fail(`scenario 8: /api/runtime/ping expected 200, got ${pingResp.status}`)
     const pingBody = await pingResp.json()
     if (pingBody.ok !== true) fail('scenario 8: ping.ok must be true')
-    if (typeof pingBody.pid !== 'number') fail('scenario 8: ping.pid must be a number')
+    // daemonPingResponseSchema (shared/api-contracts/runtime.ts) deliberately
+    // carries instanceId, not pid: an OS pid is reused across processes, so a
+    // stale record comparing pid alone could misidentify an unrelated process
+    // as this server. instanceId is unique per start and never reused.
+    if (typeof pingBody.instanceId !== 'string') {
+      fail('scenario 8: ping.instanceId must be a string')
+    }
 
     // Protected route with no auth → 401
     const noAuthResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`)

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -198,6 +198,10 @@ function runCliAsync(args, { env, timeoutMs = 15_000 } = {}) {
         /* already gone */
       }
     }, timeoutMs)
+    child.once('error', (err) => {
+      clearTimeout(timer)
+      resolve({ status: null, stdout, stderr: `${stderr}\nspawn error: ${err?.message ?? err}` })
+    })
     child.once('close', (status) => {
       clearTimeout(timer)
       resolve({ status, stdout, stderr })

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -162,7 +162,11 @@ function runCli(args, { env } = {}) {
   return spawnSync(process.execPath, [CLI, ...args], {
     env: { ...scrubDevEnv(process.env), ...env },
     encoding: 'utf8',
-    timeout: 10_000,
+    // `server stop` can itself wait up to 10s (DEFAULT_STOP_TIMEOUT_MS in
+    // server-stop.ts) for the child process to exit before escalating to
+    // SIGKILL. A CLI timeout equal to that budget races it — bump ours to
+    // leave real headroom over the production-side wait.
+    timeout: 15_000,
   })
 }
 

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -170,6 +170,41 @@ function runCli(args, { env } = {}) {
   })
 }
 
+// Async twin of runCli, for CLI invocations that must fetch a JWKS mock
+// hosted in THIS same process (server doctor's server.jwks check). spawnSync
+// blocks this process's event loop for the child's whole lifetime, so the
+// parent can never service the child's incoming connection to its own mock
+// server — a self-deadlock the child's fetch only escapes by timing out.
+// spawn() keeps the event loop running, so the mock server can actually
+// answer while the child waits. Mirrors runCli's { status, stdout, stderr }
+// shape so call sites need no other changes.
+function runCliAsync(args, { env, timeoutMs = 15_000 } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...scrubDevEnv(process.env), ...env },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already gone */
+      }
+    }, timeoutMs)
+    child.once('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
 const REQUIRED_FLAGS = [
   '--auth-strategy=oauth-jwt',
   '--jwt-issuer=https://auth.example.com',
@@ -677,9 +712,10 @@ const REQUIRED_FLAGS = [
     {
       const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-server-smoke-s14-'))
       try {
-        const r = runCli(['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS], {
-          env: { NODE_EXTRA_CA_CERTS: drCertFile },
-        })
+        const r = await runCliAsync(
+          ['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS],
+          { env: { NODE_EXTRA_CA_CERTS: drCertFile } },
+        )
         if (r.status !== 0)
           fail(`scenario 14: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })
         if (r.stderr.trim() !== '')
@@ -717,7 +753,7 @@ const REQUIRED_FLAGS = [
     {
       const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-server-smoke-s15-'))
       try {
-        const r = runCli(
+        const r = await runCliAsync(
           [
             'server',
             'doctor',
@@ -775,9 +811,10 @@ const REQUIRED_FLAGS = [
         writeFileSync(recordPath, JSON.stringify(staleRecord))
         // chmodSync bypasses umask to reliably set broad permissions.
         chmodSync(recordPath, 0o644)
-        const r = runCli(['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS], {
-          env: { NODE_EXTRA_CA_CERTS: drCertFile },
-        })
+        const r = await runCliAsync(
+          ['server', 'doctor', '--json', `--data-dir=${dataDir}`, ...DOCTOR_FLAGS],
+          { env: { NODE_EXTRA_CA_CERTS: drCertFile } },
+        )
         if (r.status === null) fail('scenario 16: doctor process was killed by signal')
         if (r.status !== 0)
           fail(`scenario 16: expected exit 0, got ${r.status}`, { stderrBytes: r.stderr.length })


### PR DESCRIPTION
## Problem — the v0.0.17 publish failure, and everything behind it

Release run 29591378772 failed at server-mode smoke 5d. Instead of fixing one scenario per release, this PR sweeps ALL remaining stale expectations and harness bugs in the packaged distribution smokes, so the whole gate now passes locally end-to-end (7/7 smokes).

## Changes (each mutation-checked)

1. **app-smoke 5d**: expected `canvas:read` to pass `/api/user-libraries` — stale (#56-era). The shipped scope registry deliberately requires `workspace:read` (a canvas-only grant must not enumerate the shared library, per #231's documented design). Smoke now asserts 403 for canvas-only AND 200 for workspace:read, matching 5a/5c.
2. **app-smoke 6**: expected unauthenticated local-daemon `/api/*` access — stale (#56-era). All `/api/*` except `/api/runtime/ping` require auth since #231/#232. Smoke now asserts 401 unauthenticated (leak-guarded) and 200 with the daemon token.
3. **entrypoint-smoke 8**: expected numeric `pid` in the ping response — stale; `daemonPingResponseSchema` deliberately uses `instanceId` (PIDs get recycled; the schema comment documents this). Now asserts `instanceId` is a string.
4. **entrypoint-smoke 10**: the harness's spawnSync timeout (10s) exactly equaled the production stop timeout (10s), so full-timeout stops lost the race. Raised the harness timeout to 15s; scenarios 11–13 now run for the first time.
5. **entrypoint-smoke 14–16 (last gate blocker)**: self-deadlock — the smoke hosts its HTTPS mock JWKS server in-process, but `spawnSync` blocks the parent's event loop, so the child's JWKS fetch could never be served. New `runCliAsync` (async spawn, same `{status, stdout, stderr}` shape, timeout-kill) used for exactly these three scenarios; every other call keeps `spawnSync`. All 16 scenarios + regression now pass.

## Verification

- All 7 packaged distribution smokes PASS locally (`CI=true`, plain and `WHITEBOARD_DEV=1`; cli-smoke isolated via `WHITEBOARD_DATA_DIR`).
- Each fix individually mutation-checked (reverting reproduces the exact original failure).
- mcp-node suite 231 files green; typecheck clean.

With #239/#240/#241/#245/#247/#249/#251 already on main, this should be the final layer: the next release PR's dry-runs and the v0.0.18 publish gate exercise exactly this suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened local-daemon security by requiring daemon authentication for API routes, except the public runtime health check.
  * Corrected access controls for user libraries to require the appropriate workspace read permission.
  * Updated runtime checks to reliably verify stable instance identity across process lifetimes.
  * Improved server diagnostics reliability when retrieving JWKS data from local services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->