### PR TITLE
fix(release): keep npm pack --json parseable when prepack prints its gate message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,11 @@ jobs:
           OUT=$(npm pack --dry-run --json)
           echo "$OUT" | node -e '
             let d=""; process.stdin.on("data",c=>d+=c); process.stdin.on("end",()=>{
-              const j=JSON.parse(d)[0];
+              // Lifecycle scripts (prepack etc.) may interleave their stdout with
+              // npm'"'"'s JSON payload; parse from the first JSON-array bracket.
+              const start = d.indexOf("[");
+              if (start === -1) { console.error("No JSON array found in npm pack output"); process.exit(1); }
+              const j=JSON.parse(d.slice(start))[0];
               const files = j.files.map(f=>f.path);
               const must = ["README.md", "LICENSE", "package.json", "dist/server/mcp/index.js"];
               const forbidden = [/\.test\.(js|d\.ts)$/, /\/_artifacts\//, /\.tsbuildinfo$/, /\.DS_Store$/];

--- a/packages/mcp-server/scripts/verify-web-app-dist.mjs
+++ b/packages/mcp-server/scripts/verify-web-app-dist.mjs
@@ -23,5 +23,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     )
     process.exit(1)
   }
-  console.log('prepack gate: dist/web-app/index.html present — OK')
+  // stderr, not stdout: npm interleaves lifecycle-script stdout with the
+  // `npm pack --json` payload, so anything printed here on stdout corrupts
+  // JSON consumers of the pack output (e.g. the release pack-contents check).
+  console.error('prepack gate: dist/web-app/index.html present — OK')
 }


### PR DESCRIPTION
## Problem — the v0.0.18 publish failure (gate layer 8, and the first one AFTER the publish gate itself passed)

Release run 29596189046: `[publish-gate] all steps passed` for the first time ever — then the workflow's **Verify pack contents** step crashed with `SyntaxError: Unexpected token 'p', "prepack ga"... is not valid JSON`. The `prepack` gate (`verify-web-app-dist.mjs`) prints `prepack gate: dist/web-app/index.html present — OK` to stdout, and npm interleaves lifecycle-script stdout with the `npm pack --dry-run --json` payload, so the captured output was not pure JSON.

## Change

1. `verify-web-app-dist.mjs`: gate message → stderr (stdout is npm's JSON channel during pack), with the constraint documented.
2. `release.yml` pack-contents parser: parse from the first `[` so any future lifecycle stdout cannot break it (fails loudly if no JSON array is present).

## Verification

- Local repro of the CI failure shape, then after the fix: `npm pack --dry-run --json` output parses cleanly (1130 files, 16.7 MB) with the prepack gate still exercised (fails the pack when `dist/web-app` is absent — confirmed both directions).
- Note: the docker job in the same run failed separately on `apps/web DaemonCanvasPage.test.tsx` (jsdom), which passes 3/3 locally and passed the pre-merge `verify` on the same commit — treated as a CI flake and tracked; not addressed here.