### PR TITLE
fix(web): stabilize browser-local import panel test on CI

### DIFF
--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -1695,7 +1695,9 @@ describe('DaemonCanvasPage', () => {
       const summary = await screen.findByText('Import from this browser')
       fireEvent.click(summary)
 
-      await waitFor(() => expect(screen.getByText('My local canvas')).toBeTruthy())
+      await waitFor(() => expect(screen.getByText('My local canvas')).toBeTruthy(), {
+        timeout: 5000,
+      })
     })
 
     it('does not touch the browser-local store until the disclosure is opened', async () => {

--- a/packages/mcp-server/src/server/release/legacy-ui-retired.test.ts
+++ b/packages/mcp-server/src/server/release/legacy-ui-retired.test.ts
@@ -83,7 +83,12 @@ function collectFiles(dir: string): string[] {
   }
   const results: string[] = []
   for (const entry of entries) {
-    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.git')) {
+    if (
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === 'tmp' ||
+      entry.name.startsWith('.git')
+    ) {
       continue
     }
     const fullPath = join(dir, entry.name)


### PR DESCRIPTION
## Summary
- Extend `waitFor` timeout to 5000ms for the browser-local import panel test that triggers the first `lazy()` dynamic import resolution — on Linux CI the module compilation + Suspense chain exceeds the default 1000ms, causing a deterministic `TestingLibraryElementError`. Subsequent tests pass because the module is cached.
- Skip `tmp/` directories in the legacy-UI retirement sweep — stale Stryker mutation-testing sandboxes under `packages/mcp-server/tmp/stryker-sandbox/` contain vitest configs referencing `src/app`, tripping the pre-push guard.

## Test plan
- [x] All 902 apps/web tests pass locally
- [x] All 3416 mcp-node tests pass locally (legacy-UI sweep included)
- [ ] CI (verify workflow) passes on this PR
- [ ] Docker publish succeeds on next release (the only blocker was this test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability when loading browser-local canvas entries by allowing additional time for slower rendering.
  - Updated legacy UI checks to ignore temporary build directories while continuing to detect unintended references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->