### PR TITLE
fix(web): persist browser-local image uploads to IndexedDB instead of silently discarding them

### DIFF
--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -4,9 +4,10 @@
  * ('loroCanvases'), so a legacy 'scene' field on a v2 'canvases' row must be
  * stripped on upgrade without ever touching 'loroCanvases'.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
 import { Loro } from 'loro-crdt'
-import { openWhiteboardDb, DB_VERSION } from './browser-idb.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DB_VERSION, openWhiteboardDb } from './browser-idb.js'
 import { IndexedDBStore } from './browser-local-store.js'
 import { LoroStore } from './loro-store.js'
 
@@ -77,6 +78,74 @@ async function readRawCanvasesRow(canvasId: string): Promise<unknown> {
     req.onerror = () => reject(req.error)
   })
 }
+
+/** Seed a pre-v4 ("v3 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
+async function seedV3Fixture(canvasId: string, loroSnapshot: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard', 3)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
+      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction(['meta', 'canvases', 'loroCanvases'], 'readwrite')
+      tx.objectStore('meta').put(canvasId, 'defaultCanvasId')
+      tx.objectStore('canvases').put(
+        { id: canvasId, name: 'Pre-v4 canvas', updatedAt: '2026-01-01T00:00:00.000Z' },
+        canvasId,
+      )
+      tx.objectStore('loroCanvases').put(
+        { v: 1, snapshot: loroSnapshot, updatedAt: '2026-01-01T00:00:00.000Z' },
+        canvasId,
+      )
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('current DB_VERSION is 4 or higher (guards against reverting the bump alone)', () => {
+    expect(DB_VERSION).toBeGreaterThanOrEqual(4)
+  })
+
+  it('opening a v3 database at v4 creates canvasFiles and preserves existing loroCanvases/canvases/meta contents', async () => {
+    const canvasId = 'canvas-migrate-v4'
+    const doc = new Loro()
+    doc.getList('elements').push({ id: 'canonical-el' })
+    const loroSnapshot = doc.export({ mode: 'snapshot' })
+    await seedV3Fixture(canvasId, loroSnapshot)
+
+    const db = await openWhiteboardDb()
+    expect(db.objectStoreNames.contains('canvasFiles')).toBe(true)
+    db.close()
+
+    const loroStore = new LoroStore()
+    const loroResult = await loroStore.load(canvasId)
+    expect(loroResult.kind).toBe('ok')
+
+    const metaStore = new IndexedDBStore()
+    expect(await metaStore.getDefaultCanvasId()).toBe(canvasId)
+    const loadResult = await metaStore.load(canvasId)
+    expect(loadResult.kind).toBe('ok')
+    if (loadResult.kind === 'ok') {
+      expect(loadResult.snapshot.name).toBe('Pre-v4 canvas')
+    }
+  })
+})
 
 describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
   beforeEach(clearDb)

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -14,8 +14,18 @@ export const DB_NAME = 'whiteboard'
  * 'canvases' row is demoted to metadata only (id/name/updatedAt). Any legacy
  * 'scene' field left over from a pre-v3 row is stripped during upgrade so no
  * old-schema shape survives to fail canvasSnapshotSchema.parse.
+ *
+ * v3 -> v4: additive — adds the 'canvasFiles' object store (uploaded image
+ * Blobs, see canvas-file-store.ts). Existing 'meta'/'canvases'/'loroCanvases'
+ * data is untouched.
+ *
+ * Known limitation (accepted, not handled): if another tab holds a
+ * connection open at the previous version, this open blocks
+ * (onblocked/onversionchange) until that tab closes or upgrades — the same
+ * behavior every prior DB_VERSION bump in this file has had. No new handling
+ * is added for it here.
  */
-export const DB_VERSION = 3
+export const DB_VERSION = 4
 
 function stripLegacySceneField(tx: IDBTransaction): void {
   const store = tx.objectStore('canvases')
@@ -42,6 +52,7 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
       if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
       if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+      if (!db.objectStoreNames.contains('canvasFiles')) db.createObjectStore('canvasFiles')
 
       // oldVersion === 0 is a fresh install (empty 'canvases' store), so the
       // scene-strip is a pure no-op there — only run it for a real v1/v2 upgrade.

--- a/apps/web/src/lib/browser-local-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-local-backend.browser.test.tsx
@@ -3,11 +3,15 @@
  *
  * Real browser context required for IndexedDB + loro-crdt WASM.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  BinaryFileDataLike,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
 import { Loro } from 'loro-crdt'
-import { BrowserLocalBackend } from './browser-local-backend.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DB_VERSION } from './browser-idb.js'
-import type { CanvasBackendHandlers } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { BrowserLocalBackend } from './browser-local-backend.js'
 
 // Generous timeout: async IDB reads under CI load can take well over the
 // 200ms fixed sleeps this file used to rely on. Waiting on the concrete
@@ -166,14 +170,123 @@ describe('BrowserLocalBackend', () => {
     expect(handlers.onSnapshot).not.toHaveBeenCalled()
   })
 
-  it('getFile returns null (deferred OPFS — not implemented in 3-C)', async () => {
+  it('getFile returns null for an unknown fileId', async () => {
     const backend = new BrowserLocalBackend('canvas-1')
     const result = await backend.getFile('any-file-id')
     expect(result).toBeNull()
   })
 
-  it('putFile resolves without calling onFileSuccess (deferred OPFS)', async () => {
+  it('putFile stores two entries, calls onFileSuccess exactly once per fileId, and getFile on a NEW instance returns each Blob', async () => {
     const backend = new BrowserLocalBackend('canvas-1')
+    const onFileSuccess = vi.fn()
+    const entries: [string, BinaryFileDataLike][] = [
+      [
+        'file-1',
+        {
+          mimeType: 'image/png',
+          id: 'file-1',
+          dataURL: 'data:image/png;base64,QQ==',
+          created: Date.now(),
+        },
+      ],
+      [
+        'file-2',
+        {
+          mimeType: 'image/jpeg',
+          id: 'file-2',
+          dataURL: 'data:image/jpeg;base64,QkI=',
+          created: Date.now(),
+        },
+      ],
+    ]
+
+    await backend.putFile(entries, onFileSuccess)
+
+    expect(onFileSuccess).toHaveBeenCalledTimes(2)
+    expect(onFileSuccess).toHaveBeenCalledWith('file-1')
+    expect(onFileSuccess).toHaveBeenCalledWith('file-2')
+
+    // Simulated reload: fresh instance, same canvasId.
+    const reloaded = new BrowserLocalBackend('canvas-1')
+    const blob1 = await reloaded.getFile('file-1')
+    const blob2 = await reloaded.getFile('file-2')
+    expect(blob1).not.toBeNull()
+    expect(blob1?.type).toBe('image/png')
+    expect(blob2).not.toBeNull()
+    expect(blob2?.type).toBe('image/jpeg')
+  })
+
+  it('putFile keys by the tuple fileId, never BinaryFileDataLike.id', async () => {
+    const backend = new BrowserLocalBackend('canvas-1')
+    const onFileSuccess = vi.fn()
+    const tupleKey = 'tuple-key'
+    const disagreeingDataId = 'data-id-disagrees'
+
+    await backend.putFile(
+      [
+        [
+          tupleKey,
+          {
+            mimeType: 'image/png',
+            id: disagreeingDataId,
+            dataURL: 'data:image/png;base64,QQ==',
+            created: Date.now(),
+          },
+        ],
+      ],
+      onFileSuccess,
+    )
+
+    expect(onFileSuccess).toHaveBeenCalledWith(tupleKey)
+    expect(onFileSuccess).not.toHaveBeenCalledWith(disagreeingDataId)
+    expect(await backend.getFile(tupleKey)).not.toBeNull()
+    expect(await backend.getFile(disagreeingDataId)).toBeNull()
+  })
+
+  it('putFile with an empty newEntries array resolves immediately with no IDB writes and zero onFileSuccess calls', async () => {
+    const backend = new BrowserLocalBackend('canvas-1')
+    const onFileSuccess = vi.fn()
+    await expect(backend.putFile([], onFileSuccess)).resolves.toBeUndefined()
+    expect(onFileSuccess).not.toHaveBeenCalled()
+  })
+
+  it('getFile returns null for a corrupt stored record and NEVER calls onError (repeated calls produce zero onError invocations)', async () => {
+    await forceCorruptFileRecord('canvas-1', 'corrupt-file')
+    const handlers = makeHandlers()
+    const backend = new BrowserLocalBackend('canvas-1')
+    backend.connect(handlers)
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
+
+    expect(await backend.getFile('corrupt-file')).toBeNull()
+    expect(await backend.getFile('corrupt-file')).toBeNull()
+    expect(handlers.onError).not.toHaveBeenCalled()
+    backend.disconnect()
+  })
+
+  it('putFile rejects and calls onError("storage-failure") without calling onFileSuccess when the underlying store put fails', async () => {
+    const handlers = makeHandlers()
+    const faultyStore = {
+      put: vi.fn().mockRejectedValue(new Error('simulated IDB failure')),
+      get: vi.fn().mockResolvedValue(null),
+    }
+    const backend = new BrowserLocalBackend(
+      'canvas-1',
+      undefined,
+      faultyStore as unknown as import('./canvas-file-store.js').CanvasFileStore,
+    )
+    backend.connect(handlers)
+    await vi.waitFor(
+      () => {
+        expect(handlers.onSnapshot).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
+
     const onFileSuccess = vi.fn()
     await expect(
       backend.putFile(
@@ -183,15 +296,18 @@ describe('BrowserLocalBackend', () => {
             {
               mimeType: 'image/png',
               id: 'file-1',
-              dataURL: 'data:image/png;base64,abc',
+              dataURL: 'data:image/png;base64,QQ==',
               created: Date.now(),
             },
           ],
         ],
         onFileSuccess,
       ),
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow()
+
     expect(onFileSuccess).not.toHaveBeenCalled()
+    expect(handlers.onError).toHaveBeenCalledWith('storage-failure')
+    backend.disconnect()
   })
 
   it('sendClientReady and sendExportResponse are no-ops (no WebSocket)', () => {
@@ -398,6 +514,34 @@ async function forceRecordWithBadDelta(canvasId: string, snapshot: Uint8Array): 
         },
         canvasId,
       )
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function forceCorruptFileRecord(_canvasId: string, fileId: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard', DB_VERSION)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+      if (!db.objectStoreNames.contains('canvases')) db.createObjectStore('canvases')
+      if (!db.objectStoreNames.contains('loroCanvases')) db.createObjectStore('loroCanvases')
+      if (!db.objectStoreNames.contains('canvasFiles')) db.createObjectStore('canvasFiles')
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction('canvasFiles', 'readwrite')
+      // Missing required fields — fails canvasFileRecordSchema.safeParse.
+      tx.objectStore('canvasFiles').put({ v: 1, garbage: true }, fileId)
       tx.oncomplete = () => {
         db.close()
         resolve()

--- a/apps/web/src/lib/browser-local-backend.ts
+++ b/apps/web/src/lib/browser-local-backend.ts
@@ -1,15 +1,27 @@
+import type {
+  BinaryFileDataLike,
+  CanvasBackend,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
 import { Loro } from 'loro-crdt'
-import type { CanvasBackend, CanvasBackendHandlers, BinaryFileDataLike } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { CanvasFileStore, dataUrlToBlob } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
 
 /**
  * BrowserLocalBackend: CanvasBackend implementation for fully offline,
  * browser-local use. Persists Loro CRDT snapshots and incremental deltas
- * in IndexedDB via LoroStore (DB v2 'loroCanvases' store).
+ * in IndexedDB via LoroStore (DB v2 'loroCanvases' store), and uploaded
+ * image files via CanvasFileStore (DB v4 'canvasFiles' store).
  *
- * getFile/putFile: OPFS file storage is deferred to a later slice. Both
- * methods are present to satisfy the CanvasBackend interface; getFile
- * returns null and putFile resolves without calling onFileSuccess.
+ * getFile/putFile: images are persisted to IndexedDB (not OPFS — see the
+ * class-level design note in canvas-file-store.ts for the rationale).
+ * putFile stores each entry keyed by its tuple fileId (never
+ * BinaryFileDataLike.id, which callers must not rely on for keying) and
+ * calls onFileSuccess once per successfully stored entry; it rejects on a
+ * storage failure so the caller never observes a false "success". getFile
+ * returns null (without signaling onError) for both unknown ids and
+ * corrupt/unknown-version records, so a damaged store degrades to a missing
+ * image instead of spamming onError on every render.
  *
  * sendClientReady/sendExportResponse: no WebSocket in browser-local mode;
  * both are no-ops.
@@ -26,14 +38,16 @@ import { LoroStore } from './loro-store.js'
 export class BrowserLocalBackend implements CanvasBackend {
   private readonly canvasId: string
   private readonly store: LoroStore
+  private readonly fileStore: CanvasFileStore
   private handlers: CanvasBackendHandlers | null = null
   private disconnected = false
   /** Serializes all write operations (pushLocalUpdate) to prevent TOCTOU races. */
   private _writeQueue: Promise<void> = Promise.resolve()
 
-  constructor(canvasId: string, store?: LoroStore) {
+  constructor(canvasId: string, store?: LoroStore, fileStore?: CanvasFileStore) {
     this.canvasId = canvasId
     this.store = store ?? new LoroStore()
+    this.fileStore = fileStore ?? new CanvasFileStore()
   }
 
   connect(handlers: CanvasBackendHandlers): void {
@@ -86,27 +100,53 @@ export class BrowserLocalBackend implements CanvasBackend {
   }
 
   /**
-   * OPFS file storage is deferred. Returns null for every fileId.
+   * Returns the persisted Blob for fileId, or null for an unknown id and for
+   * a corrupt/unknown-version record — never calls onError, since a read-path
+   * miss is not a storage failure (see CanvasFileStore.get).
    */
-  async getFile(_fileId: string): Promise<Blob | null> {
-    return null
+  async getFile(fileId: string): Promise<Blob | null> {
+    return this.fileStore.get(fileId)
   }
 
   /**
-   * OPFS file storage is deferred. Resolves without calling onFileSuccess.
+   * Persists each entry keyed by its tuple fileId (the dedupe key
+   * useCanvasSync already uses — never `data.id`, which a caller's
+   * BinaryFileDataLike is not guaranteed to agree with). Calls
+   * onFileSuccess once per successfully stored entry. Rejects and routes
+   * handlers.onError?.('storage-failure') on any store failure so a failed
+   * upload is never observed as a silent success.
    */
   async putFile(
-    _newEntries: [string, BinaryFileDataLike][],
-    _onFileSuccess: (fileId: string) => void,
+    newEntries: [string, BinaryFileDataLike][],
+    onFileSuccess: (fileId: string) => void,
   ): Promise<void> {
-    // Intentionally a no-op: OPFS upload is not implemented in 3-C.
+    if (newEntries.length === 0) return
+
+    try {
+      for (const [fileId, data] of newEntries) {
+        const blob = dataUrlToBlob(data.dataURL, data.mimeType)
+        await this.fileStore.put(fileId, {
+          mimeType: blob.type,
+          blob,
+          created: data.created,
+        })
+        onFileSuccess(fileId)
+      }
+    } catch (err) {
+      this.handlers?.onError?.('storage-failure')
+      throw err
+    }
   }
 
   /** No WebSocket in browser-local mode. */
-  sendClientReady(): void { /* no-op */ }
+  sendClientReady(): void {
+    /* no-op */
+  }
 
   /** No WebSocket in browser-local mode. */
-  sendExportResponse(_requestId: string, _data: string): void { /* no-op */ }
+  sendExportResponse(_requestId: string, _data: string): void {
+    /* no-op */
+  }
 
   // ── Private ──────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -1,5 +1,6 @@
 import { IDBFactory } from 'fake-indexeddb'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { DB_VERSION } from './browser-idb.js'
 import { IndexedDBStore, MemoryStore } from './browser-local-store.js'
 import type { CanvasSnapshot } from './whiteboard-client.js'
 
@@ -201,7 +202,7 @@ describe('IndexedDBStore', () => {
     await store.save(a)
     // Write a malformed row directly via raw IDB (bypasses canvasSnapshotSchema).
     await new Promise<void>((resolve, reject) => {
-      const req = indexedDB.open('whiteboard', 3)
+      const req = indexedDB.open('whiteboard', DB_VERSION)
       req.onsuccess = () => {
         const db = req.result
         const tx = db.transaction('canvases', 'readwrite')

--- a/apps/web/src/lib/canvas-file-store.browser.test.tsx
+++ b/apps/web/src/lib/canvas-file-store.browser.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * CanvasFileStore — real IndexedDB round-trip tests.
+ *
+ * Real browser context required for IndexedDB.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { openWhiteboardDb } from './browser-idb.js'
+import { CanvasFileStore, canvasFileRecordSchema } from './canvas-file-store.js'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+describe('CanvasFileStore', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('put then get round-trips a Blob with identical bytes and mimeType', async () => {
+    const store = new CanvasFileStore()
+    const bytes = new Uint8Array([1, 2, 3, 4, 5])
+    const blob = new Blob([bytes], { type: 'image/png' })
+
+    await store.put('file-1', { mimeType: 'image/png', blob, created: 123 })
+    const result = await store.get('file-1')
+
+    expect(result).not.toBeNull()
+    expect(result?.type).toBe('image/png')
+    const resultBytes = new Uint8Array(await (result as Blob).arrayBuffer())
+    expect(Array.from(resultBytes)).toEqual(Array.from(bytes))
+  })
+
+  it('stored record carries v:1', async () => {
+    const store = new CanvasFileStore()
+    const blob = new Blob([new Uint8Array([1])], { type: 'image/png' })
+    await store.put('file-1', { mimeType: 'image/png', blob, created: 123 })
+
+    const db = await openWhiteboardDb()
+    const raw = await new Promise<unknown>((resolve, reject) => {
+      const tx = db.transaction('canvasFiles', 'readonly')
+      const req = tx.objectStore('canvasFiles').get('file-1')
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+      tx.oncomplete = () => db.close()
+    })
+    const parsed = canvasFileRecordSchema.safeParse(raw)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.v).toBe(1)
+    }
+  })
+
+  it('get returns null for an unknown fileId', async () => {
+    const store = new CanvasFileStore()
+    expect(await store.get('does-not-exist')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/canvas-file-store.test.ts
+++ b/apps/web/src/lib/canvas-file-store.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { canvasFileRecordSchema, dataUrlToBlob } from './canvas-file-store.js'
+import { describe, expect, it, vi } from 'vitest'
+
+const openWhiteboardDbMock = vi.hoisted(() => vi.fn())
+vi.mock('./browser-idb.js', () => ({ openWhiteboardDb: openWhiteboardDbMock }))
+
+const { CanvasFileStore, canvasFileRecordSchema, dataUrlToBlob } = await import(
+  './canvas-file-store.js'
+)
 
 describe('dataUrlToBlob', () => {
   it('decodes a valid PNG dataURL into a Blob with the correct mimeType and byte length', async () => {
@@ -63,5 +69,14 @@ describe('canvasFileRecordSchema', () => {
     expect(
       canvasFileRecordSchema.safeParse({ v: 2, mimeType: 'image/png', created: 123, blob }).success,
     ).toBe(false)
+  })
+})
+
+describe('CanvasFileStore.get', () => {
+  it('resolves null instead of rejecting when opening the database fails', async () => {
+    openWhiteboardDbMock.mockRejectedValueOnce(new Error('VersionError: boom'))
+    const store = new CanvasFileStore()
+
+    await expect(store.get('file-1')).resolves.toBeNull()
   })
 })

--- a/apps/web/src/lib/canvas-file-store.test.ts
+++ b/apps/web/src/lib/canvas-file-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { canvasFileRecordSchema, dataUrlToBlob } from './canvas-file-store.js'
+
+describe('dataUrlToBlob', () => {
+  it('decodes a valid PNG dataURL into a Blob with the correct mimeType and byte length', async () => {
+    // 1x1 transparent PNG.
+    const base64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+    const dataURL = `data:image/png;base64,${base64}`
+
+    const blob = dataUrlToBlob(dataURL, 'image/png')
+
+    expect(blob.type).toBe('image/png')
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    expect(bytes.length).toBe(atob(base64).length)
+  })
+
+  it('prefers the dataURL prefix mimeType and falls back to the provided field when the prefix is absent/malformed', () => {
+    const validDataUrl = 'data:image/jpeg;base64,QQ=='
+    expect(dataUrlToBlob(validDataUrl, 'image/png').type).toBe('image/jpeg')
+
+    // Malformed prefix (missing the `data:` scheme) — fall back to the field.
+    const noPrefixDataUrl = 'base64,QQ=='
+    expect(dataUrlToBlob(noPrefixDataUrl, 'image/png').type).toBe('image/png')
+  })
+
+  it('rejects a malformed dataURL (no comma) rather than producing an empty Blob', () => {
+    expect(() => dataUrlToBlob('not-a-data-url', 'image/png')).toThrow()
+  })
+
+  it('rejects a dataURL with invalid base64 payload', () => {
+    expect(() => dataUrlToBlob('data:image/png;base64,not valid base64!!!', 'image/png')).toThrow()
+  })
+})
+
+describe('canvasFileRecordSchema', () => {
+  const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+
+  it('accepts a valid v:1 record', () => {
+    const result = canvasFileRecordSchema.safeParse({
+      v: 1,
+      mimeType: 'image/png',
+      created: 123,
+      blob,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects records missing mimeType/blob/created', () => {
+    expect(canvasFileRecordSchema.safeParse({ v: 1, created: 123, blob }).success).toBe(false)
+    expect(canvasFileRecordSchema.safeParse({ v: 1, mimeType: 'image/png', blob }).success).toBe(
+      false,
+    )
+    expect(
+      canvasFileRecordSchema.safeParse({ v: 1, mimeType: 'image/png', created: 123 }).success,
+    ).toBe(false)
+  })
+
+  it('rejects records with a wrong/absent v field', () => {
+    expect(
+      canvasFileRecordSchema.safeParse({ mimeType: 'image/png', created: 123, blob }).success,
+    ).toBe(false)
+    expect(
+      canvasFileRecordSchema.safeParse({ v: 2, mimeType: 'image/png', created: 123, blob }).success,
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/lib/canvas-file-store.ts
+++ b/apps/web/src/lib/canvas-file-store.ts
@@ -62,8 +62,8 @@ export function dataUrlToBlob(dataURL: string, fallbackMimeType: string): Blob {
  *
  * Keying is global (not scoped per-canvas): Excalidraw fileIds are
  * content-hashes, so cross-canvas reuse of the same fileId is an acceptable,
- * intentional trade-off — see tmp/issues/canvas-files-gc-refcounting.md for
- * the follow-up on unbounded growth / GC.
+ * intentional trade-off. Records are never deleted here, so the store grows
+ * unbounded — GC / refcounting is a deliberate follow-up, not an oversight.
  */
 export class CanvasFileStore {
   async put(

--- a/apps/web/src/lib/canvas-file-store.ts
+++ b/apps/web/src/lib/canvas-file-store.ts
@@ -96,12 +96,19 @@ export class CanvasFileStore {
   }
 
   /**
-   * Returns the stored Blob for fileId, or null for an unknown id AND for a
-   * corrupt/unknown-version record. Never throws — a damaged record degrades
-   * to a missing image rather than crashing the read path.
+   * Returns the stored Blob for fileId, or null for an unknown id, a
+   * corrupt/unknown-version record, AND a failure to open the database
+   * (VersionError, denied access, etc). Never throws — a damaged record or an
+   * unreachable store degrades to a missing image rather than crashing the
+   * read path.
    */
   async get(fileId: string): Promise<Blob | null> {
-    const db = await openWhiteboardDb()
+    let db: IDBDatabase
+    try {
+      db = await openWhiteboardDb()
+    } catch {
+      return null
+    }
     return new Promise((resolve) => {
       const tx = db.transaction('canvasFiles', 'readonly')
       const req = tx.objectStore('canvasFiles').get(fileId)

--- a/apps/web/src/lib/canvas-file-store.ts
+++ b/apps/web/src/lib/canvas-file-store.ts
@@ -78,7 +78,17 @@ export class CanvasFileStore {
         created: entry.created,
         blob: entry.blob,
       }
-      const tx = db.transaction('canvasFiles', 'readwrite')
+      // transaction() throws synchronously when the store is missing — e.g.
+      // the v3->v4 upgrade was blocked by a stale tab — so the connection
+      // must be closed here too, not only in the async lifecycle callbacks.
+      let tx: IDBTransaction
+      try {
+        tx = db.transaction('canvasFiles', 'readwrite')
+      } catch (err) {
+        db.close()
+        reject(err)
+        return
+      }
       tx.objectStore('canvasFiles').put(record, fileId)
       tx.oncomplete = () => {
         db.close()
@@ -110,7 +120,17 @@ export class CanvasFileStore {
       return null
     }
     return new Promise((resolve) => {
-      const tx = db.transaction('canvasFiles', 'readonly')
+      // Same synchronous-throw hazard as put(): a missing store must close
+      // the connection and degrade to null, per this method's never-throws
+      // contract.
+      let tx: IDBTransaction
+      try {
+        tx = db.transaction('canvasFiles', 'readonly')
+      } catch {
+        db.close()
+        resolve(null)
+        return
+      }
       const req = tx.objectStore('canvasFiles').get(fileId)
       req.onsuccess = () => {
         if (req.result === undefined) {

--- a/apps/web/src/lib/canvas-file-store.ts
+++ b/apps/web/src/lib/canvas-file-store.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod'
+import { openWhiteboardDb } from './browser-idb.js'
+
+/**
+ * Versioned envelope for image file records persisted in the 'canvasFiles'
+ * IndexedDB object store. Single parse boundary — every IDB read for
+ * canvasFiles goes through this. Type is derived via z.infer; no parallel
+ * hand-written interface (mirrors loro-store.ts's loroRecordEnvelopeSchema).
+ *
+ * v: envelope format version (literal 1). Bump this when the envelope shape
+ *    changes in a backward-incompatible way; old/unknown-version records are
+ *    treated as a cache miss (get() resolves null) rather than crashing.
+ */
+export const canvasFileRecordSchema = z.object({
+  v: z.literal(1),
+  mimeType: z.string(),
+  created: z.number(),
+  blob: z.instanceof(Blob),
+})
+
+export type CanvasFileRecord = z.infer<typeof canvasFileRecordSchema>
+
+/**
+ * Decode a data: URL into a Blob. Prefers the MIME type embedded in the
+ * dataURL prefix (the authoritative source for what was actually encoded)
+ * and falls back to `fallbackMimeType` only when the prefix itself is
+ * missing/malformed.
+ *
+ * Throws on a structurally invalid dataURL (no comma separator) or invalid
+ * base64 payload — callers must not swallow this into a silently-empty Blob.
+ */
+export function dataUrlToBlob(dataURL: string, fallbackMimeType: string): Blob {
+  const commaIndex = dataURL.indexOf(',')
+  if (commaIndex === -1) {
+    throw new Error('dataUrlToBlob: malformed dataURL (no comma separator)')
+  }
+  const header = dataURL.slice(0, commaIndex)
+  const base64 = dataURL.slice(commaIndex + 1)
+
+  const prefixMatch = /^data:([^;,]+)/.exec(header)
+  const mimeType = prefixMatch?.[1] ?? fallbackMimeType
+
+  let binary: string
+  try {
+    binary = atob(base64)
+  } catch {
+    throw new Error('dataUrlToBlob: invalid base64 payload')
+  }
+
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new Blob([bytes], { type: mimeType })
+}
+
+/**
+ * CanvasFileStore: persists uploaded image Blobs in the 'canvasFiles'
+ * IndexedDB object store, keyed by the caller-supplied fileId. Isolated from
+ * 'loroCanvases'/'canvases' so a schema issue in one store never corrupts
+ * reads of the others.
+ *
+ * Keying is global (not scoped per-canvas): Excalidraw fileIds are
+ * content-hashes, so cross-canvas reuse of the same fileId is an acceptable,
+ * intentional trade-off — see tmp/issues/canvas-files-gc-refcounting.md for
+ * the follow-up on unbounded growth / GC.
+ */
+export class CanvasFileStore {
+  async put(
+    fileId: string,
+    entry: { mimeType: string; blob: Blob; created: number },
+  ): Promise<void> {
+    const db = await openWhiteboardDb()
+    return new Promise((resolve, reject) => {
+      const record: CanvasFileRecord = {
+        v: 1,
+        mimeType: entry.mimeType,
+        created: entry.created,
+        blob: entry.blob,
+      }
+      const tx = db.transaction('canvasFiles', 'readwrite')
+      tx.objectStore('canvasFiles').put(record, fileId)
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+      tx.onabort = () => {
+        db.close()
+        reject(tx.error ?? new Error('transaction aborted'))
+      }
+    })
+  }
+
+  /**
+   * Returns the stored Blob for fileId, or null for an unknown id AND for a
+   * corrupt/unknown-version record. Never throws — a damaged record degrades
+   * to a missing image rather than crashing the read path.
+   */
+  async get(fileId: string): Promise<Blob | null> {
+    const db = await openWhiteboardDb()
+    return new Promise((resolve) => {
+      const tx = db.transaction('canvasFiles', 'readonly')
+      const req = tx.objectStore('canvasFiles').get(fileId)
+      req.onsuccess = () => {
+        if (req.result === undefined) {
+          resolve(null)
+          return
+        }
+        const parsed = canvasFileRecordSchema.safeParse(req.result)
+        resolve(parsed.success ? parsed.data.blob : null)
+      }
+      req.onerror = (e) => {
+        e.preventDefault()
+        db.close()
+        resolve(null)
+      }
+      tx.onerror = () => {
+        db.close()
+        resolve(null)
+      }
+      tx.onabort = () => {
+        db.close()
+        resolve(null)
+      }
+      tx.oncomplete = () => db.close()
+    })
+  }
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.file-upload-notification.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.file-upload-notification.test.tsx
@@ -1,13 +1,30 @@
 import { act, cleanup, render as rtlRender, screen } from '@testing-library/react'
 import type { ReactElement } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { browserLocalCanvasPath } from '../lib/app-routes.js'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 
+// Exposes react-router's navigate() to the test so it can drive the page's
+// URL -> canvas id effect (the same path a Back/Forward navigation or the
+// switcher's push takes) without needing to click through the real
+// WorkspaceTopBar switcher UI.
+let capturedNavigate: ((path: string) => void) | null = null
+function NavigateCapture() {
+  const navigate = useNavigate()
+  capturedNavigate = (path: string) => navigate(path)
+  return null
+}
+
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    <MemoryRouter initialEntries={['/']}>
+      <NavigateCapture />
+      {ui}
+    </MemoryRouter>,
+  )
 }
 
 // Excalidraw requires a real browser (roughjs native bindings). Mock it in jsdom.
@@ -51,10 +68,17 @@ const snap: CanvasSnapshot = {
   updatedAt: '2026-05-24T00:00:00.000Z',
 }
 
+const snap2: CanvasSnapshot = {
+  id: 'c2',
+  name: 'second',
+  updatedAt: '2026-05-24T00:00:00.000Z',
+}
+
 describe('BrowserLocalCanvasPage file upload notification', () => {
   afterEach(() => {
     cleanup()
     capturedOptions = {}
+    capturedNavigate = null
   })
 
   it('wires onFileUploadFailed into useCanvasSync and shows a visible notification when it fires', async () => {
@@ -73,5 +97,46 @@ describe('BrowserLocalCanvasPage file upload notification', () => {
     })
 
     expect(screen.getByRole('alert')).toBeTruthy()
+  })
+
+  it('clears the failure notification once onFileUploadSucceeded fires', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+
+    await act(async () => {
+      capturedOptions.onFileUploadFailed?.()
+    })
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    await act(async () => {
+      capturedOptions.onFileUploadSucceeded?.()
+    })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('clears a stale upload-failure banner when the user switches to a different canvas', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await store.save(snap2)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+
+    await act(async () => {
+      capturedOptions.onFileUploadFailed?.()
+    })
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    await act(async () => {
+      capturedNavigate?.(browserLocalCanvasPath('c2'))
+    })
+
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.file-upload-notification.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.file-upload-notification.test.tsx
@@ -1,0 +1,77 @@
+import { act, cleanup, render as rtlRender, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MemoryStore } from '../lib/browser-local-store.js'
+import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+// Excalidraw requires a real browser (roughjs native bindings). Mock it in jsdom.
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: () => <div data-testid="excalidraw-mock" />,
+  restoreElements: (els: unknown[]) => els,
+  CaptureUpdateAction: { NEVER: 'NEVER' },
+  exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+}))
+
+// Captures the options object BrowserLocalCanvasPage passes to useCanvasSync
+// so the test can invoke onFileUploadFailed/onFileUploadSucceeded directly —
+// isolating the page's notification-wiring from the full backend/doc flow
+// already covered by useCanvasSync.test.ts and the browser-mode backend tests.
+let capturedOptions: { onFileUploadFailed?: () => void; onFileUploadSucceeded?: () => void } = {}
+vi.mock('../hooks/useCanvasSync.js', () => ({
+  useCanvasSync: (
+    _backend: unknown,
+    options?: { onFileUploadFailed?: () => void; onFileUploadSucceeded?: () => void },
+  ) => {
+    capturedOptions = options ?? {}
+    return {
+      syncStatus: 'connected',
+      setExcalidrawAPI: vi.fn(),
+      onChange: vi.fn(),
+      restoreInProgress: false,
+      restoreLabel: null,
+      clearLocalUndo: vi.fn(),
+      exportScene: vi.fn(async () => null),
+    }
+  },
+}))
+
+vi.mock('../lib/browser-local-backend.js', () => ({
+  BrowserLocalBackend: class {},
+}))
+
+const snap: CanvasSnapshot = {
+  id: 'c1',
+  name: 'untitled',
+  updatedAt: '2026-05-24T00:00:00.000Z',
+}
+
+describe('BrowserLocalCanvasPage file upload notification', () => {
+  afterEach(() => {
+    cleanup()
+    capturedOptions = {}
+  })
+
+  it('wires onFileUploadFailed into useCanvasSync and shows a visible notification when it fires', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+
+    expect(capturedOptions.onFileUploadFailed).toBeInstanceOf(Function)
+    expect(screen.queryByText(/could not save|failed to save|upload failed/i)).toBeNull()
+
+    await act(async () => {
+      capturedOptions.onFileUploadFailed?.()
+    })
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Image-persists-across-reload regression (real IndexedDB, real
+ * BrowserLocalBackend/CanvasFileStore — only Excalidraw itself is mocked,
+ * since it requires native roughjs bindings jsdom/CI cannot provide).
+ *
+ * This exercises the actual wiring an image paste goes through in
+ * production: onChange with a new image element + its file data URL ->
+ * BrowserLocalBackend.putFile -> CanvasFileStore (IndexedDB) -> remount ->
+ * BrowserLocalBackend.getFile -> useCanvasSync's applyLoroToExcalidraw ->
+ * ExcalidrawImperativeAPI.addFiles. A wiring or lifecycle regression that
+ * silently drops the getFile round trip (the bug this file's sibling unit
+ * tests target individually) would still show up here because nothing
+ * between the page and IndexedDB is mocked.
+ */
+
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import '../index.css'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+type ExcalidrawOnChange = (
+  elements: unknown[],
+  appState: unknown,
+  files: Record<string, unknown>,
+) => void
+
+interface CapturedFile {
+  id: string
+  mimeType: string
+  dataURL: string
+}
+
+let latestOnChange: ExcalidrawOnChange | null = null
+let addFilesCalls: CapturedFile[][] = []
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: (props: {
+    excalidrawAPI?: (api: unknown) => void
+    onChange?: ExcalidrawOnChange
+  }) => {
+    latestOnChange = props.onChange ?? null
+    props.excalidrawAPI?.({
+      updateScene: () => {},
+      addFiles: (files: CapturedFile[]) => {
+        addFilesCalls.push(files)
+      },
+      getSceneElements: () => [],
+      getAppState: () => ({}),
+    })
+    return null
+  },
+  restoreElements: (els: unknown[]) => els,
+  CaptureUpdateAction: { NEVER: 'never' },
+  exportToBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+  exportToSvg: vi.fn(async () => document.createElementNS('http://www.w3.org/2000/svg', 'svg')),
+}))
+
+const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+    req.onblocked = () => resolve()
+  })
+}
+
+// 1x1 transparent PNG, matching canvas-file-store.test.ts's fixture.
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+const PNG_DATA_URL = `data:image/png;base64,${PNG_BASE64}`
+
+describe('BrowserLocalCanvasPage image persistence (browser — real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+    latestOnChange = null
+    addFilesCalls = []
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('restores a pasted image after remount via the real backend/IndexedDB round trip', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const imageElement = {
+      id: 'image-persistence-el',
+      type: 'image',
+      fileId: 'image-persistence-file',
+      x: 10,
+      y: 10,
+      width: 40,
+      height: 40,
+    }
+    const files = {
+      'image-persistence-file': {
+        id: 'image-persistence-file',
+        mimeType: 'image/png',
+        dataURL: PNG_DATA_URL,
+        created: Date.now(),
+      },
+    }
+
+    // The backend connects asynchronously; re-fire (idempotent) until the
+    // putFile write actually lands, then wait for the debounce to flush —
+    // matching BrowserLocalCanvasPage.reload-elements.browser.test.tsx's
+    // pattern for the same async-connect race.
+    await waitFor(
+      async () => {
+        act(() => {
+          latestOnChange!([imageElement], {}, files)
+        })
+        const db = await new Promise<IDBDatabase>((resolve, reject) => {
+          const req = indexedDB.open('whiteboard')
+          req.onsuccess = () => resolve(req.result)
+          req.onerror = () => reject(req.error)
+        })
+        const stored = await new Promise<unknown>((resolve, reject) => {
+          const tx = db.transaction('canvasFiles', 'readonly')
+          const getReq = tx.objectStore('canvasFiles').get('image-persistence-file')
+          getReq.onsuccess = () => resolve(getReq.result)
+          getReq.onerror = () => reject(getReq.error)
+          tx.oncomplete = () => db.close()
+        })
+        expect(stored).not.toBeUndefined()
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    cleanup()
+    addFilesCalls = []
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+
+    // The restored file must reach Excalidraw's addFiles with matching bytes
+    // — proving the whole getFile -> blobToBase64 -> addFiles chain survived
+    // a real remount, not just that IndexedDB holds a row.
+    await waitFor(
+      () => {
+        const restored = addFilesCalls.flat().find((f) => f.id === 'image-persistence-file')
+        expect(restored).toBeDefined()
+        expect(restored?.mimeType).toBe('image/png')
+        expect(restored?.dataURL).toBe(PNG_DATA_URL)
+      },
+      { timeout: 5000 },
+    )
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -228,6 +228,15 @@ export function BrowserLocalCanvasPage({
   // upload so a transient failure doesn't stick around forever.
   const [fileUploadError, setFileUploadError] = useState<string | null>(null)
 
+  // This banner is page-level state, not scoped per backend connection, so a
+  // failure seen on canvas A would otherwise keep showing after switching to
+  // canvas B (which never fired the failure). Reset whenever the loaded
+  // canvas identity changes so a stale error never follows the user across
+  // canvases.
+  useEffect(() => {
+    setFileUploadError(null)
+  }, [canvasId])
+
   // useCanvasSync tolerates a null backend (idle, no writes) and reconnects
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -222,10 +222,21 @@ export function BrowserLocalCanvasPage({
     [canvasId],
   )
 
+  // Surfaced when the backend's putFile rejects (IDB write/quota failure),
+  // so a failed image upload is never silent — see useCanvasSync's own
+  // no-silent-success contract for putFile. Cleared on the next successful
+  // upload so a transient failure doesn't stick around forever.
+  const [fileUploadError, setFileUploadError] = useState<string | null>(null)
+
   // useCanvasSync tolerates a null backend (idle, no writes) and reconnects
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.
-  const { setExcalidrawAPI, onChange, exportScene } = useCanvasSync(backend)
+  const { setExcalidrawAPI, onChange, exportScene } = useCanvasSync(backend, {
+    onFileUploadFailed: () => {
+      setFileUploadError('Could not save an image to this browser. It may not survive a reload.')
+    },
+    onFileUploadSucceeded: () => setFileUploadError(null),
+  })
 
   // The option list refreshes asynchronously (see the effect above) while the
   // selected id changes synchronously on switch/create. Synthesize a
@@ -343,6 +354,11 @@ export function BrowserLocalCanvasPage({
         {duplicateError && (
           <div role="alert" aria-live="assertive" className="text-destructive">
             {duplicateError}
+          </div>
+        )}
+        {fileUploadError && (
+          <div role="alert" aria-live="assertive" className="text-destructive">
+            {fileUploadError}
           </div>
         )}
         <span className="ml-auto text-muted-foreground">

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -18,7 +18,8 @@ The page mounts a full Excalidraw canvas. Pick the rectangle tool from the
 toolbar (or press `r`) and draw a shape, then reload the tab — the shape is
 still there. That's your canvas persisting to IndexedDB in your own browser,
 with no server and no account. Draw, close the tab, and come back later: the
-same canvas is right where you left it.
+same canvas is right where you left it. Pasted or uploaded images persist the
+same way — reload the tab and they're still on the canvas.
 
 **Where to go next:** want your AI agent (Claude Code, Codex, Gemini) to draw with
 you, or durable canvases as files on disk? That's the **Local daemon** — see


### PR DESCRIPTION
## Summary

Browser-local mode (`/local/:canvasId`) silently discarded every pasted/imported image: `putFile` resolved as if it succeeded but persisted nothing, and `getFile` always returned `null`, so images vanished on reload (user-visible data loss with no signal).

- **Persist uploads for real**: new `CanvasFileStore` (`apps/web/src/lib/canvas-file-store.ts`) stores decoded image blobs in a new `canvasFiles` IndexedDB object store (`DB_VERSION` 3→4, additive migration). Records use a versioned Zod envelope (`{v: 1, mimeType, blob, created}`) with the TS type derived via `z.infer`, mirroring the `loroRecordEnvelopeSchema` convention.
- **No silent failure paths left**: `putFile` now rejects on storage failure and routes `onError('storage-failure')`; `BrowserLocalCanvasPage` surfaces upload failures as a visible notification (cleared on canvas switch / next success). `getFile` returns `null` for unknown/corrupt records without notification spam, and never throws on DB-open failure.
- **Design choice** (ratified at PlanReview): IndexedDB-primary instead of OPFS — browser-local mode already hard-requires IDB via LoroStore, IDB stores Blobs natively, and OPFS would add a capability/test matrix with no user-visible gain.

Follow-up filed: `canvasFiles` GC/refcounting (unbounded growth) tracked as a local backlog item.

## Test evidence

Real-browser (`web-browser` project) regression coverage, red-first:

- paste-image-then-reload round-trip survives a fresh `BrowserLocalBackend` instance (simulated reload)
- storage key is the upload tuple key, locked against `BinaryFileDataLike.id` disagreement
- empty `newEntries` no-op, corrupt-record silent `null`, DB-open failure returns `null` without throwing
- v3→v4 IDB migration preserves existing meta/canvases/loro data
- upload-failure banner: shown on failure, cleared on canvas switch and on next success

`pnpm test` (incl. web-browser project) and `pnpm -r typecheck` green in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pasted and uploaded canvas images now persist across browser reloads and remounts.
  * Browser-local mode now stores image files offline and restores them reliably.
  * Image upload failures display a clear alert, while successful uploads dismiss it.
  * Added support for upgrading existing local data to the latest storage format.

* **Bug Fixes**
  * Improved handling of missing, corrupt, or failed image records without silent success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->