### PR TITLE
test(web): fail image-persistence tests when IDB cleanup is blocked or errors

### DIFF
--- a/apps/web/src/lib/canvas-file-store.browser.test.tsx
+++ b/apps/web/src/lib/canvas-file-store.browser.test.tsx
@@ -7,11 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { openWhiteboardDb } from './browser-idb.js'
 import { CanvasFileStore, canvasFileRecordSchema } from './canvas-file-store.js'
 
+// Rejects on failure: silently keeping stale fixed-key records would let
+// these persistence tests pass without exercising the current write.
 async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }
 

--- a/apps/web/src/lib/canvas-file-store.browser.test.tsx
+++ b/apps/web/src/lib/canvas-file-store.browser.test.tsx
@@ -13,7 +13,7 @@ async function clearDb(): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
+    req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
     req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
@@ -63,12 +63,14 @@ vi.mock('@excalidraw/excalidraw', () => ({
 
 const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
 
+// Rejects on failure: silently keeping stale image-persistence records
+// would let both halves of this regression test pass on stale data.
 async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-    req.onblocked = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
@@ -69,7 +69,7 @@ async function clearDb(): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
+    req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
     req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }


### PR DESCRIPTION
## Summary

Follow-up to #259, applying CodeRabbit's two post-merge findings (both valid): the `clearDb` helpers in `canvas-file-store.browser.test.tsx` and `BrowserLocalCanvasPage.image-persistence.browser.test.tsx` resolved on `onerror`/`onblocked`, so a failed database deletion could leave stale fixed-key records that satisfy the persistence assertions without exercising the current write. Both helpers now reject on failure.

## Test plan

- [x] `pnpm vitest run --project web-browser` for both touched files: 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)