### PR TITLE
test(web): wait out blocked IDB deletion instead of failing the run

### DIFF
--- a/apps/web/src/lib/canvas-file-store.browser.test.tsx
+++ b/apps/web/src/lib/canvas-file-store.browser.test.tsx
@@ -19,6 +19,11 @@ async function clearDb(): Promise<void> {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
+    req.onblocked = () => {
+      console.warn(
+        'clearDb: whiteboard database deletion blocked — waiting for open connections to close',
+      )
+    }
   })
 }
 

--- a/apps/web/src/lib/canvas-file-store.browser.test.tsx
+++ b/apps/web/src/lib/canvas-file-store.browser.test.tsx
@@ -9,12 +9,16 @@ import { CanvasFileStore, canvasFileRecordSchema } from './canvas-file-store.js'
 
 // Rejects on failure: silently keeping stale fixed-key records would let
 // these persistence tests pass without exercising the current write.
+// 'blocked' is NOT a failure — store operations close their connections in
+// tx.oncomplete, which can land after the op's promise resolves, so the
+// deletion is briefly blocked and then proceeds (onsuccess still fires).
+// Waiting keeps that benign race quiet; a genuinely stuck connection still
+// surfaces as a loud test timeout.
 async function clearDb(): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
-    req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
@@ -65,12 +65,15 @@ const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
 
 // Rejects on failure: silently keeping stale image-persistence records
 // would let both halves of this regression test pass on stale data.
+// 'blocked' is NOT a failure — connections close asynchronously
+// (tx.oncomplete), so deletion can be briefly blocked and then proceed;
+// waiting keeps that benign race quiet while a stuck connection still
+// surfaces as a loud test timeout.
 async function clearDb(): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
-    req.onblocked = () => reject(new Error('whiteboard database deletion was blocked'))
   })
 }
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.image-persistence.browser.test.tsx
@@ -74,6 +74,11 @@ async function clearDb(): Promise<void> {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
+    req.onblocked = () => {
+      console.warn(
+        'clearDb: whiteboard database deletion blocked — waiting for open connections to close',
+      )
+    }
   })
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #260: rejecting `clearDb` on `onblocked` turned a benign race into a CI flake (seen on PR #262's `test-browser`: the previous test's store connection closes in `tx.oncomplete`, which can land after the op's promise resolves, so `deleteDatabase` reports 'blocked' briefly and then completes). `onblocked` now waits for the deletion to finish instead of failing; `onerror` still rejects, and a genuinely stuck connection still fails loudly via the test timeout.

## Test plan
- [x] Both touched browser test files pass locally (4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)