### PR TITLE
fix(mcp-server): guard box_with_label text ink contrast on solid fills

### DIFF
--- a/packages/mcp-server/src/server/mcp/tools/annotate.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.ts
@@ -9,7 +9,12 @@ import {
 } from './annotation-fields.js'
 import { decomposeBoxWithLabel, type SubTextPosition } from './box-with-label.js'
 import { parseCanvasId } from './canvas-id.js'
-import { resolvePaletteColor } from './color-palette.js'
+import {
+  contrastRatio,
+  isExplicitHexColor,
+  readableInkForFill,
+  resolvePaletteColor,
+} from './color-palette.js'
 import { decomposeGroup } from './group.js'
 import { apiGetPalette } from './palette.js'
 import { resolveAnnotationPosition, type CoordsMode } from './resolve-annotation-position.js'
@@ -106,7 +111,7 @@ export const annotateInputShape = {
     .string()
     .optional()
     .describe(
-      'Stroke / text color. Accepts semantic keys ("primary","success","danger","warning","neutral","info") or palette key (declared via palette_set) or hex (#RRGGBB).',
+      'Stroke / text color. Accepts semantic keys ("primary","success","danger","warning","neutral","info") or palette key (declared via palette_set) or hex (#RRGGBB). For box_with_label on a solid fill, a semantic/palette text ink that would be unreadable against the fill is auto-adjusted for contrast; pass an explicit hex to opt out.',
     ),
   backgroundColor: z
     .string()
@@ -655,6 +660,32 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
     { coords: spec.coords, imageId: spec.imageId, target: spec.target },
     elements,
   )
+  // Text-ink contrast guard: when the caller delegated the color choice
+  // (semantic key / palette key / omitted — anything but an explicit hex)
+  // and the box has a solid fill, an ink below WCAG's large-text 3:1 against
+  // that fill is swapped for a readable one picked by the fill's luminance.
+  // The rectangle stroke keeps the requested color: the outline borders the
+  // canvas background, not the fill, and recoloring it would change the
+  // box's semantic identity.
+  const MIN_TEXT_FILL_CONTRAST = 3
+  const effectiveFillStyle = spec.fillStyle ?? (spec.backgroundColor ? 'solid' : undefined)
+  let readableTextInk: string | undefined
+  if (
+    spec.backgroundColor !== undefined &&
+    effectiveFillStyle === 'solid' &&
+    (spec.color === undefined || !isExplicitHexColor(spec.color))
+  ) {
+    const fill = resolvePaletteColor(spec.backgroundColor, spec.sessionPalette ?? {}).color
+    const ink = spec.color
+      ? resolvePaletteColor(spec.color, spec.sessionPalette ?? {}).color
+      : DEFAULT_COLORS.text
+    const ratio = contrastRatio(ink, fill)
+    if (ratio !== null && ratio < MIN_TEXT_FILL_CONTRAST) {
+      readableTextInk = readableInkForFill(fill) ?? undefined
+    }
+  }
+  const textInkOverride = readableTextInk !== undefined ? { color: readableTextInk } : {}
+
   const [rectSpec, textSpec, , subTextSpec, titleSpec] = decomposeBoxWithLabel({
     target: absoluteTarget,
     width: spec.width,
@@ -681,6 +712,7 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
   const titleId = titleSpec
     ? appendSingleAnnotation(doc, {
         ...titleSpec,
+        ...textInkOverride,
         coords: 'absolute',
         sessionPalette: spec.sessionPalette,
       }).elementId
@@ -688,6 +720,7 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
   const textId = textSpec
     ? appendSingleAnnotation(doc, {
         ...textSpec,
+        ...textInkOverride,
         coords: 'absolute',
         sessionPalette: spec.sessionPalette,
       }).elementId
@@ -695,6 +728,7 @@ export function appendAnnotationToDoc(doc: LoroDoc, spec: AnnotationSpec): Annot
   const subTextId = subTextSpec
     ? appendSingleAnnotation(doc, {
         ...subTextSpec,
+        ...textInkOverride,
         coords: 'absolute',
         sessionPalette: spec.sessionPalette,
       }).elementId

--- a/packages/mcp-server/src/server/mcp/tools/box-with-label-ink.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/box-with-label-ink.test.ts
@@ -1,0 +1,89 @@
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { appendAnnotationToDoc } from './annotate.js'
+import { contrastRatio } from './color-palette.js'
+
+function appendBox(doc: LoroDoc, over: Record<string, unknown> = {}) {
+  return appendAnnotationToDoc(doc, {
+    type: 'box_with_label',
+    coords: 'absolute',
+    target: { x: 0, y: 0 },
+    width: 240,
+    height: 140,
+    title: 'Title',
+    text: 'Body',
+    subText: 'Sub',
+    ...over,
+  } as never)
+}
+
+function textStrokeColors(doc: LoroDoc): string[] {
+  return (doc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>)
+    .filter((e) => e.type === 'text')
+    .map((e) => e.strokeColor as string)
+}
+
+function rectStrokeColor(doc: LoroDoc): string {
+  return (doc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>).find(
+    (e) => e.type === 'rectangle',
+  )?.strokeColor as string
+}
+
+describe('box_with_label readable-ink guard on solid fills', () => {
+  it('replaces a low-contrast semantic ink with a readable one for title, body, and subText', () => {
+    const doc = new LoroDoc()
+    // neutral (#6c757d) on success (#2f9e44) is ~1.2:1 — illegible.
+    appendBox(doc, { color: 'neutral', backgroundColor: 'success', fillStyle: 'solid' })
+
+    const inks = textStrokeColors(doc)
+    expect(inks).toHaveLength(3)
+    for (const ink of inks) {
+      expect(contrastRatio(ink, '#2f9e44')).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('keeps the requested color on the rectangle stroke (guard applies to text ink only)', () => {
+    const doc = new LoroDoc()
+    appendBox(doc, { color: 'neutral', backgroundColor: 'success', fillStyle: 'solid' })
+
+    expect(rectStrokeColor(doc)).toBe('#6c757d')
+  })
+
+  it('honors an explicit hex ink even when its contrast against the fill is poor', () => {
+    const doc = new LoroDoc()
+    appendBox(doc, { color: '#6c757d', backgroundColor: 'success', fillStyle: 'solid' })
+
+    for (const ink of textStrokeColors(doc)) {
+      expect(ink).toBe('#6c757d')
+    }
+  })
+
+  it('leaves a semantic ink alone when its contrast against the fill is already sufficient', () => {
+    const doc = new LoroDoc()
+    // danger (#e03131) on a very light fill reads fine; contrast >= 3.
+    appendBox(doc, { color: 'danger', backgroundColor: '#f8f9fa', fillStyle: 'solid' })
+
+    for (const ink of textStrokeColors(doc)) {
+      expect(ink).toBe('#e03131')
+    }
+  })
+
+  it('does not adjust ink when the box has no backgroundColor', () => {
+    const doc = new LoroDoc()
+    appendBox(doc, { color: 'neutral' })
+
+    for (const ink of textStrokeColors(doc)) {
+      expect(ink).toBe('#6c757d')
+    }
+  })
+
+  it('guards the default ink too when the fill is dark and color is omitted', () => {
+    const doc = new LoroDoc()
+    // Default text ink #1e1e2e on a near-black fill would vanish.
+    appendBox(doc, { backgroundColor: '#212529', fillStyle: 'solid' })
+
+    for (const ink of textStrokeColors(doc)) {
+      expect(contrastRatio(ink, '#212529')).toBeGreaterThanOrEqual(3)
+    }
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/color-palette.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/color-palette.test.ts
@@ -1,10 +1,38 @@
 import { describe, it, expect } from 'vitest'
 import {
+  contrastRatio,
   DEFAULT_PALETTE_FALLBACK,
   normalizeColor,
+  relativeLuminance,
   resolvePaletteColor,
   SEMANTIC_PALETTE,
 } from './color-palette.js'
+
+describe('relativeLuminance hex-digit handling', () => {
+  it('parses 3- and 6-digit hex to the same luminance', () => {
+    expect(relativeLuminance('#fff')).toBeCloseTo(relativeLuminance('#ffffff')!, 10)
+    expect(relativeLuminance('#000')).toBe(relativeLuminance('#000000'))
+  })
+
+  it('drops the alpha channel of 4- and 8-digit hex (treated as opaque)', () => {
+    // #2f9e44 with any alpha suffix must equal the opaque luminance.
+    expect(relativeLuminance('#2f9e4480')).toBeCloseTo(relativeLuminance('#2f9e44')!, 10)
+    // 4-digit #rgba: rgb nibbles are 2/9/4 -> #229944 doubled.
+    expect(relativeLuminance('#2948')).toBeCloseTo(relativeLuminance('#229944')!, 10)
+  })
+
+  it('returns null for non-hex input', () => {
+    expect(relativeLuminance('rebeccapurple')).toBeNull()
+    expect(relativeLuminance('#12345')).toBeNull()
+  })
+
+  it('lets contrastRatio work against an 8-digit fill instead of returning null', () => {
+    expect(contrastRatio('#1e1e2e', '#2f9e4480')).toBeCloseTo(
+      contrastRatio('#1e1e2e', '#2f9e44')!,
+      10,
+    )
+  })
+})
 
 describe('normalizeColor', () => {
   it('case 116', () => {

--- a/packages/mcp-server/src/server/mcp/tools/color-palette.ts
+++ b/packages/mcp-server/src/server/mcp/tools/color-palette.ts
@@ -33,6 +33,50 @@ export interface PaletteResolution {
   warningKey?: string
 }
 
+export function isExplicitHexColor(input: string): boolean {
+  return HEX_COLOR_RE.test(input)
+}
+
+// WCAG 2.x relative luminance (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance).
+// Returns null for anything that isn't a 3/6-digit hex color — CSS named
+// colors pass through this module unresolved, and the contrast guard simply
+// skips them rather than guessing.
+export function relativeLuminance(hex: string): number | null {
+  const m = /^#(?:([0-9a-f]{3})|([0-9a-f]{6}))$/i.exec(hex)
+  if (!m) return null
+  const digits = m[1] ? [...m[1]].map((c) => c + c).join('') : m[2]!
+  const channel = (i: number) => {
+    const v = Number.parseInt(digits.slice(i * 2, i * 2 + 2), 16) / 255
+    return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2)
+}
+
+// WCAG contrast ratio, 1 (identical) .. 21 (black on white). Null when either
+// side isn't parseable hex.
+export function contrastRatio(hexA: string, hexB: string): number | null {
+  const la = relativeLuminance(hexA)
+  const lb = relativeLuminance(hexB)
+  if (la === null || lb === null) return null
+  const [dark, light] = la < lb ? [la, lb] : [lb, la]
+  return (light + 0.05) / (dark + 0.05)
+}
+
+// Inks used when the guard replaces an unreadable one. The dark ink matches
+// DEFAULT_COLORS.text in annotate.ts; the light one is plain white — both
+// clear WCAG large-text contrast (3:1) against any fill the other doesn't.
+export const READABLE_DARK_INK = '#1e1e2e'
+export const READABLE_LIGHT_INK = '#ffffff'
+
+export function readableInkForFill(fillHex: string): string | null {
+  const lum = relativeLuminance(fillHex)
+  if (lum === null) return null
+  const darkContrast = contrastRatio(READABLE_DARK_INK, fillHex)
+  const lightContrast = contrastRatio(READABLE_LIGHT_INK, fillHex)
+  if (darkContrast === null || lightContrast === null) return null
+  return darkContrast >= lightContrast ? READABLE_DARK_INK : READABLE_LIGHT_INK
+}
+
 export function resolvePaletteColor(
   input: string,
   sessionPalette: Record<string, string>,

--- a/packages/mcp-server/src/server/mcp/tools/color-palette.ts
+++ b/packages/mcp-server/src/server/mcp/tools/color-palette.ts
@@ -42,9 +42,17 @@ export function isExplicitHexColor(input: string): boolean {
 // colors pass through this module unresolved, and the contrast guard simply
 // skips them rather than guessing.
 export function relativeLuminance(hex: string): number | null {
-  const m = /^#(?:([0-9a-f]{3})|([0-9a-f]{6}))$/i.exec(hex)
+  // Accepts 3/4/6/8-digit hex. An alpha channel (4th/8th) is dropped: the
+  // effective luminance of a translucent fill depends on the canvas behind
+  // it, which is unknown here, so the guard treats the color as opaque.
+  const m = /^#(?:([0-9a-f]{3,4})|([0-9a-f]{6})|([0-9a-f]{8}))$/i.exec(hex)
   if (!m) return null
-  const digits = m[1] ? [...m[1]].map((c) => c + c).join('') : m[2]!
+  let digits: string
+  if (m[1]) {
+    digits = [...m[1].slice(0, 3)].map((c) => c + c).join('')
+  } else {
+    digits = (m[2] ?? m[3]!).slice(0, 6)
+  }
   const channel = (i: number) => {
     const v = Number.parseInt(digits.slice(i * 2, i * 2 + 2), 16) / 255
     return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4


### PR DESCRIPTION
## Summary

`annotate {type:"box_with_label", color:"neutral", backgroundColor:"success", fillStyle:"solid"}` rendered its text at ~1.2:1 contrast (#6c757d gray on #2f9e44 green) — effectively invisible in exported PNGs. Any semantic-ink + saturated-semantic-fill combination had the same failure.

- **New guard in `appendBoxWithLabel`**: when the caller delegated the color choice (semantic key, palette key, or omitted) and the fill is solid, a text ink below WCAG's large-text 3:1 threshold against the fill is replaced with a readable ink picked by the fill's relative luminance (dark `#1e1e2e` on light fills, white on dark fills).
- **Explicit hex ink is honored unchanged** (opt-out by being explicit), and the **rectangle stroke keeps the requested color** — it borders the canvas background, not the fill.
- New pure helpers in `color-palette.ts`: WCAG `relativeLuminance` / `contrastRatio` / `readableInkForFill`.
- The `color` tool description documents the auto-adjustment for LLM callers.

Triage note: the backlog item reported a title-vs-body asymmetry ("title faint, body dark"). That does not reproduce — title, body, and subText all resolve the same ink through the same path (now locked by tests); the real defect was the delegated-color combination itself.

## Test plan

- [x] Red-first: `box-with-label-ink.test.ts` (6 cases — guard replaces low-contrast semantic ink on all three text elements; rect stroke unchanged; explicit hex honored; sufficient-contrast semantic ink untouched; no-fill untouched; omitted ink on dark fill guarded)
- [x] Mutation check: guard disabled → 2 tests red; restored → green
- [x] Full `src/server/mcp` suite: 50 files / 765 tests green; `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean

The asserted `strokeColor` on the Loro elements is exactly what the PNG/SVG exporters draw, so the element-level tests verify the user-visible behavior directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)