### PR TITLE
refactor(mcp-server): unify daemon.json validation on a single Zod schema

### DIFF
--- a/packages/mcp-server/src/daemon/daemon-record-schema.test.ts
+++ b/packages/mcp-server/src/daemon/daemon-record-schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { daemonRecordBaseSchema, daemonRecordSchema } from './daemon-record-schema.js'
+
+describe('daemonRecordSchema', () => {
+  it('parses a well-formed record', () => {
+    const input = {
+      pid: 123,
+      port: 3099,
+      token: 'secret',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    }
+
+    expect(daemonRecordSchema.parse(input)).toEqual(input)
+  })
+
+  it('strips unknown extra keys (forward compat) while keeping known fields', () => {
+    const result = daemonRecordSchema.safeParse({
+      pid: 123,
+      port: 3099,
+      token: 'secret',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+      futureField: 'ignored',
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('futureField')
+    }
+  })
+
+  it('rejects a record with a missing token', () => {
+    const result = daemonRecordSchema.safeParse({
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a record with an empty-string token (fail-closed)', () => {
+    const result = daemonRecordSchema.safeParse({
+      pid: 123,
+      port: 3099,
+      token: '',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects wrong-typed fields', () => {
+    expect(
+      daemonRecordSchema.safeParse({
+        pid: '123',
+        port: 3099,
+        token: 'secret',
+        version: '0.1.0',
+        startedAt: '2026-04-23T00:00:00.000Z',
+      }).success,
+    ).toBe(false)
+
+    expect(
+      daemonRecordSchema.safeParse({
+        pid: 123,
+        port: true,
+        token: 'secret',
+        version: '0.1.0',
+        startedAt: '2026-04-23T00:00:00.000Z',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a negative, zero, or fractional pid/port (int().positive() enforcement)', () => {
+    const validBase = {
+      pid: 123,
+      port: 3099,
+      token: 'secret',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    }
+
+    expect(daemonRecordSchema.safeParse({ ...validBase, pid: -1 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, pid: 0 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, pid: 1.5 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, port: -1 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, port: 0 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, port: 1.5 }).success).toBe(false)
+  })
+
+  // TCP ports are 1-65535 (0 is reserved / "any port" and never a listening
+  // daemon's own port). int().positive() alone lets a corrupt or malicious
+  // daemon.json claim a port above the valid range.
+  it('rejects a port above the valid TCP range (65535) and accepts the boundary value', () => {
+    const validBase = {
+      pid: 123,
+      port: 3099,
+      token: 'secret',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    }
+
+    expect(daemonRecordSchema.safeParse({ ...validBase, port: 65536 }).success).toBe(false)
+    expect(daemonRecordSchema.safeParse({ ...validBase, port: 65535 }).success).toBe(true)
+  })
+
+  it('rejects non-object input', () => {
+    expect(daemonRecordSchema.safeParse([]).success).toBe(false)
+    expect(daemonRecordSchema.safeParse(42).success).toBe(false)
+    expect(daemonRecordSchema.safeParse(null).success).toBe(false)
+  })
+
+  it('daemonRecordBaseSchema (token-less) accepts a record without a token', () => {
+    const result = daemonRecordBaseSchema.safeParse({
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/mcp-server/src/daemon/daemon-record-schema.ts
+++ b/packages/mcp-server/src/daemon/daemon-record-schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+// daemon.json is the persisted contract for the local daemon's HTTP/WS
+// Bearer token plus process identity. This schema is the single source of
+// truth for both the registry loader (daemon-registry.ts) and the CLI-facing
+// parser (daemon-record.ts) — do not hand-write a parallel interface.
+// TCP ports are 1-65535 (0 is reserved for "any port", never a listening
+// daemon's own bound port).
+const MAX_TCP_PORT = 65535
+
+export const daemonRecordBaseSchema = z.object({
+  pid: z.number().int().positive(),
+  port: z.number().int().positive().max(MAX_TCP_PORT),
+  version: z.string(),
+  startedAt: z.string(),
+})
+
+export const daemonRecordSchema = daemonRecordBaseSchema.extend({
+  // A missing or empty token means the daemon cannot authenticate any
+  // caller; treat that daemon.json as invalid rather than silently
+  // producing a record with an unusable token (fail-closed).
+  token: z.string().min(1),
+})
+
+export type DaemonRecordBase = z.infer<typeof daemonRecordBaseSchema>
+export type DaemonRecord = z.infer<typeof daemonRecordSchema>

--- a/packages/mcp-server/src/daemon/daemon-record.test.ts
+++ b/packages/mcp-server/src/daemon/daemon-record.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getDaemonRecordPath } from './daemon-registry.js'
+import { parseDaemonRecord } from './daemon-record.js'
+
+describe('parseDaemonRecord', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'daemon-record-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('returns "missing" when daemon.json does not exist', async () => {
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({ kind: 'missing' })
+  })
+
+  it('returns "malformed" for invalid JSON', async () => {
+    await writeFile(getDaemonRecordPath(dataDir), '{ not valid json', 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result.kind).toBe('malformed')
+  })
+
+  it('returns "malformed" when the JSON is not an object', async () => {
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify('not-an-object'), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({
+      kind: 'malformed',
+      message: 'Daemon record is not an object.',
+    })
+  })
+
+  it('returns "malformed" when required base fields are missing', async () => {
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify({ pid: 123 }), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({
+      kind: 'malformed',
+      message: 'Daemon record is missing required fields.',
+    })
+  })
+
+  it('returns "token-missing" with the base record when the token is absent', async () => {
+    const base = {
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+    }
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify(base), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({ kind: 'token-missing', record: base })
+  })
+
+  it('returns "token-missing" when the token is present but empty', async () => {
+    const base = {
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+      token: '',
+    }
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify(base), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result.kind).toBe('token-missing')
+  })
+
+  it('returns "valid" with the full record when all fields including token parse', async () => {
+    const record = {
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+      token: 'secret',
+    }
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify(record), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({ kind: 'valid', record })
+  })
+})

--- a/packages/mcp-server/src/daemon/daemon-record.test.ts
+++ b/packages/mcp-server/src/daemon/daemon-record.test.ts
@@ -81,6 +81,29 @@ describe('parseDaemonRecord', () => {
     expect(result.kind).toBe('token-missing')
   })
 
+  it('returns "malformed" for a present-but-wrong-typed token (not token-missing)', async () => {
+    const record = {
+      pid: 123,
+      port: 3099,
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:00:00.000Z',
+      token: 123,
+    }
+    await writeFile(getDaemonRecordPath(dataDir), JSON.stringify(record), 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result.kind).toBe('malformed')
+  })
+
+  it('returns "malformed" for a top-level JSON array', async () => {
+    await writeFile(getDaemonRecordPath(dataDir), '[]', 'utf-8')
+
+    const result = await parseDaemonRecord(dataDir)
+
+    expect(result).toEqual({ kind: 'malformed', message: 'Daemon record is not an object.' })
+  })
+
   it('returns "valid" with the full record when all fields including token parse', async () => {
     const record = {
       pid: 123,

--- a/packages/mcp-server/src/daemon/daemon-record.ts
+++ b/packages/mcp-server/src/daemon/daemon-record.ts
@@ -34,6 +34,10 @@ export async function parseDaemonRecord(dataDir: string): Promise<DaemonRecordPa
     return { kind: 'malformed', message: 'Daemon record is not valid JSON.' }
   }
 
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { kind: 'malformed', message: 'Daemon record is not an object.' }
+  }
+
   const fullResult = daemonRecordSchema.safeParse(parsed)
   if (fullResult.success) {
     return { kind: 'valid', record: fullResult.data }
@@ -41,14 +45,15 @@ export async function parseDaemonRecord(dataDir: string): Promise<DaemonRecordPa
 
   // The full schema also fails for missing/empty token, so re-check against
   // the token-less base schema to distinguish "token missing" (a record we
-  // can still report on) from genuinely malformed data.
+  // can still report on) from genuinely malformed data. The base schema
+  // strips `token` entirely, so a present-but-wrong-typed token (e.g. a
+  // number) would slip through as token-missing — guard that explicitly so it
+  // is reported as malformed instead.
+  const token = (parsed as Record<string, unknown>).token
+  const tokenIsAbsentOrEmpty = token === undefined || token === ''
   const baseResult = daemonRecordBaseSchema.safeParse(parsed)
-  if (baseResult.success) {
+  if (baseResult.success && tokenIsAbsentOrEmpty) {
     return { kind: 'token-missing', record: baseResult.data }
-  }
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    return { kind: 'malformed', message: 'Daemon record is not an object.' }
   }
 
   return { kind: 'malformed', message: 'Daemon record is missing required fields.' }

--- a/packages/mcp-server/src/daemon/daemon-record.ts
+++ b/packages/mcp-server/src/daemon/daemon-record.ts
@@ -1,4 +1,10 @@
 import { readFile } from 'node:fs/promises'
+import {
+  type DaemonRecord,
+  type DaemonRecordBase,
+  daemonRecordBaseSchema,
+  daemonRecordSchema,
+} from './daemon-record-schema.js'
 import { getDaemonRecordPath, isPidAlive } from './daemon-registry.js'
 
 export { isPidAlive }
@@ -6,8 +12,8 @@ export { isPidAlive }
 export type DaemonRecordParseResult =
   | { kind: 'missing' }
   | { kind: 'malformed'; message: string }
-  | { kind: 'token-missing'; record: { pid: number; port: number; version: string; startedAt: string } }
-  | { kind: 'valid'; record: { pid: number; port: number; token: string; version: string; startedAt: string } }
+  | { kind: 'token-missing'; record: DaemonRecordBase }
+  | { kind: 'valid'; record: DaemonRecord }
 
 export async function parseDaemonRecord(dataDir: string): Promise<DaemonRecordParseResult> {
   const recordPath = getDaemonRecordPath(dataDir)
@@ -28,30 +34,22 @@ export async function parseDaemonRecord(dataDir: string): Promise<DaemonRecordPa
     return { kind: 'malformed', message: 'Daemon record is not valid JSON.' }
   }
 
+  const fullResult = daemonRecordSchema.safeParse(parsed)
+  if (fullResult.success) {
+    return { kind: 'valid', record: fullResult.data }
+  }
+
+  // The full schema also fails for missing/empty token, so re-check against
+  // the token-less base schema to distinguish "token missing" (a record we
+  // can still report on) from genuinely malformed data.
+  const baseResult = daemonRecordBaseSchema.safeParse(parsed)
+  if (baseResult.success) {
+    return { kind: 'token-missing', record: baseResult.data }
+  }
+
   if (typeof parsed !== 'object' || parsed === null) {
     return { kind: 'malformed', message: 'Daemon record is not an object.' }
   }
 
-  const obj = parsed as Record<string, unknown>
-  if (
-    typeof obj.pid !== 'number' ||
-    typeof obj.port !== 'number' ||
-    typeof obj.version !== 'string' ||
-    typeof obj.startedAt !== 'string'
-  ) {
-    return { kind: 'malformed', message: 'Daemon record is missing required fields.' }
-  }
-
-  const base = {
-    pid: obj.pid,
-    port: obj.port,
-    version: obj.version,
-    startedAt: obj.startedAt,
-  }
-
-  if (typeof obj.token !== 'string' || obj.token === '') {
-    return { kind: 'token-missing', record: base }
-  }
-
-  return { kind: 'valid', record: { ...base, token: obj.token } }
+  return { kind: 'malformed', message: 'Daemon record is missing required fields.' }
 }

--- a/packages/mcp-server/src/daemon/daemon-registry.test.ts
+++ b/packages/mcp-server/src/daemon/daemon-registry.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   deleteDaemonRecord,
   getDaemonRecordPath,
@@ -44,6 +44,33 @@ describe('daemon-registry', () => {
 
   it('returns null for malformed daemon.json content', async () => {
     await writeFile(getDaemonRecordPath(dataDir), '{"pid":"oops"}')
+    await expect(loadDaemonRecord(dataDir)).resolves.toBeNull()
+  })
+
+  it('returns null for a daemon.json with an empty-string token (fail-closed)', async () => {
+    await writeFile(
+      getDaemonRecordPath(dataDir),
+      JSON.stringify({
+        pid: 123,
+        port: 3099,
+        token: '',
+        version: '0.1.0',
+        startedAt: '2026-04-23T00:00:00.000Z',
+      }),
+    )
+    await expect(loadDaemonRecord(dataDir)).resolves.toBeNull()
+  })
+
+  it('returns null for a daemon.json with a missing token', async () => {
+    await writeFile(
+      getDaemonRecordPath(dataDir),
+      JSON.stringify({
+        pid: 123,
+        port: 3099,
+        version: '0.1.0',
+        startedAt: '2026-04-23T00:00:00.000Z',
+      }),
+    )
     await expect(loadDaemonRecord(dataDir)).resolves.toBeNull()
   })
 

--- a/packages/mcp-server/src/daemon/daemon-registry.ts
+++ b/packages/mcp-server/src/daemon/daemon-registry.ts
@@ -2,14 +2,9 @@ import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { platform } from 'node:os'
 import { join } from 'node:path'
 import { DATA_DIR } from '../shared/data-dir-secure.js'
+import { type DaemonRecord, daemonRecordSchema } from './daemon-record-schema.js'
 
-export interface DaemonRecord {
-  pid: number
-  port: number
-  token: string
-  version: string
-  startedAt: string
-}
+export type { DaemonRecord } from './daemon-record-schema.js'
 
 const DAEMON_RECORD_FILENAME = 'daemon.json'
 
@@ -19,23 +14,9 @@ export function getDaemonRecordPath(dataDir: string = DATA_DIR): string {
 
 export async function loadDaemonRecord(dataDir: string = DATA_DIR): Promise<DaemonRecord | null> {
   try {
-    const raw = JSON.parse(await readFile(getDaemonRecordPath(dataDir), 'utf-8')) as Partial<DaemonRecord>
-    if (
-      typeof raw.pid !== 'number' ||
-      typeof raw.port !== 'number' ||
-      typeof raw.token !== 'string' ||
-      typeof raw.version !== 'string' ||
-      typeof raw.startedAt !== 'string'
-    ) {
-      return null
-    }
-    return {
-      pid: raw.pid,
-      port: raw.port,
-      token: raw.token,
-      version: raw.version,
-      startedAt: raw.startedAt,
-    }
+    const raw: unknown = JSON.parse(await readFile(getDaemonRecordPath(dataDir), 'utf-8'))
+    const result = daemonRecordSchema.safeParse(raw)
+    return result.success ? result.data : null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

`daemon-registry.ts` and `daemon-record.ts` each carried a hand-written validator for `daemon.json` — the security-sensitive record holding the Bearer token for all HTTP/WS auth — and the two already disagreed on missing-token handling (`loadDaemonRecord` accepted `token: ''` while `parseDaemonRecord` classified it token-missing). This is a direct violation of the repo's Zod-single-source rule (every other persisted JSON goes through `safeParse`).

- New `daemon-record-schema.ts` defines `daemonRecordSchema` once; `DaemonRecord` is derived via `z.infer` (no parallel hand-written interface). Placed in its own module to avoid a `daemon-record.ts → daemon-registry.ts` import cycle.
- Both `loadDaemonRecord` and `parseDaemonRecord` validate via `safeParse`; the two typeof-chains are deleted.
- **Missing/empty token unified fail-closed**: `token: ''` or absent is now rejected by both paths.
- `pid`/`port` tightened to positive integers, `port` capped at 65535 (what the daemon actually writes). Unknown keys still stripped for forward compatibility.

## Test plan

- [x] Red-first: well-formed round-trip parse; token-missing/empty rejected; wrong-typed fields (`pid`/`port` as string, non-object, invalid JSON) rejected
- [x] Mutation check: loosening `token` to `z.string()` (no `.min(1)`) turns the empty-token test red
- [x] `pnpm test --project mcp-node` daemon suites green (69 tests); `pnpm --filter @kamiazya/whiteboard-mcp typecheck` clean
- [x] No plaintext secrets in fixtures/logs (token stays a fake placeholder; static parse messages, no value interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added schema-based validation for stored daemon records, including required fields, authentication tokens, positive PID, and TCP port bounds (1–65535).
  - Extra unknown fields are ignored while preserving known valid values.

- **Bug Fixes**
  - Empty or missing authentication tokens now fail closed (treated as invalid) rather than being accepted.
  - Non-object or malformed records are now rejected safely with consistent behavior.

- **Tests**
  - Expanded coverage for valid, malformed, incomplete, and invalid daemon record inputs and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->