### PR TITLE
fix(web): explain custom-domain unsupported instead of a cryptic origin error

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -8,6 +8,7 @@ import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
 import {
   BROWSER_LOCAL_CAPABILITIES,
   type ProviderState,
+  resolveHostedProviderStateFromRaw,
   type WhiteboardCapabilities,
 } from './lib/provider.js'
 import { createUserSettingsStore, STORAGE_KEY } from './lib/user-settings-store.js'
@@ -133,6 +134,20 @@ describe('App backend configuration chip', () => {
     )
     expect(screen.queryByText('Browser only')).toBeNull()
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
+  })
+
+  it('renders the custom-domain-unsupported guidance without echoing the rejected origin', () => {
+    const state = resolveHostedProviderStateFromRaw({
+      publicOrigin: 'https://custom.example.com',
+    })
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App providerState={state} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/custom domain/i)).toBeTruthy()
+    expect(screen.queryByText(/custom\.example\.com/)).toBeNull()
+    expect(document.body.textContent).not.toMatch(/https?:\/\//)
   })
 
   it('lets the browser-local escape override invalid-config after a failed pairing', () => {

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -196,6 +196,37 @@ describe('resolveHostedProviderStateFromRaw', () => {
     expect(state.kind).toBe('browser-local')
   })
 
+  it('custom domain publicOrigin surfaces the specific unsupported-custom-domain copy (no browserOrigin)', () => {
+    const state = resolveHostedProviderStateFromRaw({
+      publicOrigin: 'https://custom.example.com',
+    })
+    expect(state.kind).toBe('invalid-config')
+    if (state.kind === 'invalid-config') {
+      expect(state.message).toMatch(/custom domain/i)
+      expect(state.message).not.toBe('Runtime configuration is invalid.')
+    }
+  })
+
+  it('custom domain publicOrigin surfaces the specific copy on the preview-browserOrigin branch too', () => {
+    const state = resolveHostedProviderStateFromRaw(
+      { publicOrigin: 'https://custom.example.com' },
+      'https://abc123.kamiazya-whiteboard.pages.dev',
+    )
+    expect(state.kind).toBe('invalid-config')
+    if (state.kind === 'invalid-config') {
+      expect(state.message).toMatch(/custom domain/i)
+      expect(state.message).not.toBe('Runtime configuration is invalid.')
+    }
+  })
+
+  it('Zod-invalid publicOrigin still yields the generic invalid-config message (no policy-error reflection)', () => {
+    const state = resolveHostedProviderStateFromRaw({ publicOrigin: 'not-a-url' })
+    expect(state.kind).toBe('invalid-config')
+    if (state.kind === 'invalid-config') {
+      expect(state.message).toBe('Runtime configuration is invalid.')
+    }
+  })
+
   it('daemon refusal on a preview browserOrigin does not expose the origin value', () => {
     const state = resolveHostedProviderStateFromRaw(
       { daemonBaseUrl: 'http://127.0.0.1:3099' },

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -1,9 +1,22 @@
 import {
+  type RuntimeConfig,
+  RuntimeConfigPolicyError,
   resolveHostedRuntimeConfig,
   resolveRuntimeConfig,
-  type RuntimeConfig,
 } from '../runtime-config.js'
 import { classifyPagesOrigin } from './pages-origin-policy.js'
+
+const GENERIC_INVALID_CONFIG_MESSAGE = 'Runtime configuration is invalid.'
+
+// Only a RuntimeConfigPolicyError carries authored, known-safe, user-facing
+// copy. Zod/unknown errors keep the generic message so raw input (query,
+// path, credential fragments) is never reflected back to the user.
+function toInvalidConfigState(err: unknown): Extract<ProviderState, { kind: 'invalid-config' }> {
+  if (err instanceof RuntimeConfigPolicyError) {
+    return { kind: 'invalid-config', message: err.message }
+  }
+  return { kind: 'invalid-config', message: GENERIC_INVALID_CONFIG_MESSAGE }
+}
 
 export type ProviderKind = 'browser-local' | 'local-daemon'
 
@@ -69,7 +82,7 @@ export function resolveProviderStateFromRaw(raw: unknown): ProviderState {
   } catch {
     // Return a safe message without reflecting the raw input to avoid leaking
     // credential, query, or path fragments in user-facing error output.
-    return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
+    return { kind: 'invalid-config', message: GENERIC_INVALID_CONFIG_MESSAGE }
   }
 }
 
@@ -82,20 +95,15 @@ export function resolveHostedProviderStateFromRaw(
   raw: unknown,
   browserOrigin?: string,
 ): ProviderState {
-  if (browserOrigin !== undefined && classifyPagesOrigin(browserOrigin) === 'preview') {
-    try {
-      const state = resolveProviderState(resolveHostedRuntimeConfig(raw))
-      if (state.kind === 'local-daemon') {
-        return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
-      }
-      return state
-    } catch {
-      return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
-    }
-  }
+  const isPreviewOrigin =
+    browserOrigin !== undefined && classifyPagesOrigin(browserOrigin) === 'preview'
   try {
-    return resolveProviderState(resolveHostedRuntimeConfig(raw))
-  } catch {
-    return { kind: 'invalid-config', message: 'Runtime configuration is invalid.' }
+    const state = resolveProviderState(resolveHostedRuntimeConfig(raw))
+    if (isPreviewOrigin && state.kind === 'local-daemon') {
+      return { kind: 'invalid-config', message: GENERIC_INVALID_CONFIG_MESSAGE }
+    }
+    return state
+  } catch (err) {
+    return toInvalidConfigState(err)
   }
 }

--- a/apps/web/src/runtime-config.test.ts
+++ b/apps/web/src/runtime-config.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import { isProductionPagesOrigin } from './lib/pages-origin-policy.js'
 import {
   EMPTY_RUNTIME_CONFIG,
+  RuntimeConfigPolicyError,
   resolveHostedRuntimeConfig,
   resolveRuntimeConfig,
   runtimeConfigSchema,
 } from './runtime-config.js'
-import { isProductionPagesOrigin } from './lib/pages-origin-policy.js'
 
 describe('runtimeConfigSchema', () => {
   it('parses an empty object as a valid config', () => {
@@ -114,6 +115,32 @@ describe('resolveHostedRuntimeConfig', () => {
     expect(() =>
       resolveHostedRuntimeConfig({ publicOrigin: 'https://custom.example.com' }),
     ).toThrow()
+  })
+
+  it('rejects custom domain publicOrigin with a RuntimeConfigPolicyError explaining it is unsupported', () => {
+    expect(() =>
+      resolveHostedRuntimeConfig({ publicOrigin: 'https://custom.example.com' }),
+    ).toThrow(RuntimeConfigPolicyError)
+    try {
+      resolveHostedRuntimeConfig({ publicOrigin: 'https://custom.example.com' })
+      expect.unreachable('expected resolveHostedRuntimeConfig to throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(RuntimeConfigPolicyError)
+      const message = e instanceof Error ? e.message : String(e)
+      expect(message).toMatch(/custom domain/i)
+      expect(message).toMatch(/not (yet )?supported/i)
+    }
+  })
+
+  it('custom domain rejection message does not expose the raw origin value', () => {
+    let message = ''
+    try {
+      resolveHostedRuntimeConfig({ publicOrigin: 'https://secret.example.com' })
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e)
+    }
+    expect(message).not.toContain('secret')
+    expect(message).not.toMatch(/https?:\/\//)
   })
 
   it('error message is a safe generic copy — does not expose raw publicOrigin value', () => {

--- a/apps/web/src/runtime-config.ts
+++ b/apps/web/src/runtime-config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { isProductionPagesOrigin } from './lib/pages-origin-policy.js'
+import { classifyPagesOrigin } from './lib/pages-origin-policy.js'
 
 // Validates that a URL string is a bare origin: scheme + host + optional port, no path/query/hash/credentials.
 // Downstream CORS, OAuth, and Cloudflare config all require a strict origin, not an arbitrary URL.
@@ -42,13 +42,34 @@ export function resolveRuntimeConfig(raw: unknown): RuntimeConfig {
 
 export const EMPTY_RUNTIME_CONFIG: RuntimeConfig = {}
 
+// Thrown only for known-safe, hand-authored, user-facing copy — never built by
+// interpolating the rejected origin. resolveProviderStateFromRaw callers rely
+// on this type to distinguish trusted policy copy from Zod/unknown errors,
+// which must keep their generic non-reflective message instead.
+export class RuntimeConfigPolicyError extends Error {}
+
+const GENERIC_HOSTED_ORIGIN_REJECTION =
+  'This deployment origin is not supported. Use the production pages.dev origin for hosted deployments.'
+
 // Stricter variant for hosted (Cloudflare Pages) deployments.
 // Rejects non-production publicOrigin values so preview deploys and localhost
 // cannot accidentally masquerade as the production origin.
 export function resolveHostedRuntimeConfig(raw: unknown): RuntimeConfig {
   const config = runtimeConfigSchema.parse(raw)
-  if (config.publicOrigin !== undefined && !isProductionPagesOrigin(config.publicOrigin)) {
-    throw new Error('publicOrigin must be the production pages.dev origin for hosted deployments.')
+  if (config.publicOrigin === undefined) {
+    return config
   }
-  return config
+  switch (classifyPagesOrigin(config.publicOrigin)) {
+    case 'production':
+      return config
+    case 'custom-domain-deferred':
+      // Future support seam: once a canonical custom domain is confirmed
+      // (see pages-origin-policy.ts), this branch is where it would move to
+      // the 'production' path above instead of throwing.
+      throw new RuntimeConfigPolicyError(
+        'Custom domains and other Pages projects are not yet supported for hosted deployments. Deploy the hosted app on the production pages.dev origin.',
+      )
+    default:
+      throw new RuntimeConfigPolicyError(GENERIC_HOSTED_ORIGIN_REJECTION)
+  }
 }


### PR DESCRIPTION
## Summary

`resolveHostedRuntimeConfig` rejected custom-domain deployments with `publicOrigin must be the production pages.dev origin` — accurate to the implementation but useless to someone who just deployed to their own domain.

- Branch on `classifyPagesOrigin`'s class (accept-only-on-`production`, never default-accept) and throw a typed `RuntimeConfigPolicyError` whose authored copy states that custom domains and other Pages projects are not yet supported. The wording covers the whole `custom-domain-deferred` class (true custom domains AND unrecognized pages.dev projects).
- `provider.ts` passes only that typed error's message through to the invalid-config page; Zod/unknown failures keep the generic non-reflective copy — preserving the existing no-input-echo guarantee (no URL literal, no origin echoed).

## Test plan

- [x] Red-first (runtime-config): custom-domain origin throws `RuntimeConfigPolicyError` matching /custom domain/i and /not (yet )?supported/i; safety test asserts no origin echo / no `https?://` literal
- [x] Red-first (provider): custom-domain input surfaces the specific copy in `state.message` for both call-site branches; Zod-invalid/unknown still yields the generic message
- [x] App-level test: injected custom-domain config renders the new guidance without leaking the origin
- [x] Existing runtime-config/provider tests unmodified and green (94 tests); `apps/web` typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)