### PR TITLE
refactor(mcp-server): derive export_svg args type from its Zod shape

### DIFF
--- a/packages/mcp-server/src/server/mcp/tools/export-svg.ts
+++ b/packages/mcp-server/src/server/mcp/tools/export-svg.ts
@@ -21,15 +21,6 @@ function resolveMaxInlineSvgBytes(): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_MAX_INLINE_SVG_BYTES
 }
 
-interface ExportSvgArgs {
-  canvasId: string
-  padding?: number
-  frameId?: string
-  outputPath?: string
-  overwrite?: boolean
-  theme?: 'light' | 'dark'
-}
-
 function buildExportSvgBody(args: ExportSvgArgs): Record<string, number | string | boolean> {
   const body: Record<string, number | string | boolean> = {}
   if (args.padding !== undefined) body.padding = args.padding
@@ -72,12 +63,15 @@ export const exportSvgInputShape = {
     ),
 } satisfies z.ZodRawShape
 
+const exportSvgInputSchema = z.object(exportSvgInputShape)
+type ExportSvgArgs = z.infer<typeof exportSvgInputSchema>
+
 export function exportSvgTool() {
   return {
     name: 'export_svg',
     description:
       'Export the whiteboard canvas as an SVG file, rendered headlessly straight from the persisted document (no browser connection required).',
-    inputSchema: z.toJSONSchema(z.object(exportSvgInputShape)) as {
+    inputSchema: z.toJSONSchema(exportSvgInputSchema) as {
       type: 'object'
       properties: Record<string, unknown>
       required?: string[]


### PR DESCRIPTION
Re-lands a change that was written during the #273 review pass but lost before commit (a shell working-directory mixup committed an unrelated file instead; caught during integrator verification). The hand-written `ExportSvgArgs` interface duplicated `exportSvgInputShape` — the exact drift pattern behind the historical `create_frame` bug — so the args type is now `z.infer` of the same schema the tool registers. Type-level only; no runtime change. `pnpm --filter @kamiazya/whiteboard-mcp typecheck` green.