### PR TITLE
feat(web): provider-aware WhiteboardCommands layer with exportJson

### DIFF
--- a/apps/web/src/lib/commands/create-commands.test.ts
+++ b/apps/web/src/lib/commands/create-commands.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { excalidrawJsonDocSchema } from '../excalidraw-json.js'
+import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
+import { createWhiteboardCommands } from './create-commands.js'
+import { CommandError, exportJsonResultSchema, type WhiteboardCommandDeps } from './types.js'
+
+// exportJsonResultSchema must be the same schema instance the serializer
+// module owns — never a parallel re-declaration.
+if (exportJsonResultSchema !== excalidrawJsonDocSchema) {
+  throw new Error('exportJsonResultSchema must be excalidrawJsonDocSchema, not a copy')
+}
+
+const el = (over: Record<string, unknown>) =>
+  ({ id: 'e', type: 'rectangle', x: 0, y: 0, ...over }) as never
+
+function baseDeps(overrides: Partial<WhiteboardCommandDeps> = {}): WhiteboardCommandDeps {
+  return {
+    getExcalidrawApi: () => null,
+    provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },
+    canvas: { canvasId: 'c1', name: 'Canvas 1' },
+    ...overrides,
+  }
+}
+
+function refOf(deps: WhiteboardCommandDeps): { current: WhiteboardCommandDeps } {
+  return { current: deps }
+}
+
+describe('createWhiteboardCommands.exportJson', () => {
+  it('exports the live scene as a standard .excalidraw envelope', async () => {
+    const api = {
+      getSceneElements: () => [el({ id: 'a' }), el({ id: 'b', isDeleted: true })],
+      getAppState: () => ({ gridSize: 20, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => api as never }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    const result = await commands.exportJson()
+
+    expect(result.type).toBe('excalidraw')
+    expect(result.version).toBe(2)
+    // isDeleted elements are dropped by the serializer.
+    expect(result.elements.map((e) => (e as { id: string }).id)).toEqual(['a'])
+  })
+
+  it('throws a no-api CommandError when no Excalidraw API is mounted', async () => {
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => null }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    await expect(commands.exportJson()).rejects.toMatchObject({
+      code: 'no-api',
+    })
+    await expect(commands.exportJson()).rejects.toBeInstanceOf(CommandError)
+  })
+
+  it('throws an invalid-input CommandError for a non-object input', async () => {
+    const depsRef = refOf(baseDeps())
+    const commands = createWhiteboardCommands(depsRef)
+
+    await expect(commands.exportJson('nope' as never)).rejects.toMatchObject({
+      code: 'invalid-input',
+    })
+  })
+
+  it('reads deps fresh on each call — a ref swap between calls is picked up', async () => {
+    const apiA = {
+      getSceneElements: () => [el({ id: 'a' })],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const apiB = {
+      getSceneElements: () => [el({ id: 'b' })],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#000' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => apiA as never }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    const first = await commands.exportJson()
+    expect(first.elements.map((e) => (e as { id: string }).id)).toEqual(['a'])
+
+    depsRef.current = baseDeps({ getExcalidrawApi: () => apiB as never })
+    const second = await commands.exportJson()
+    expect(second.elements.map((e) => (e as { id: string }).id)).toEqual(['b'])
+  })
+
+  it('a mid-flight deps swap does not affect an already in-flight call', async () => {
+    let resolveElements: (els: unknown[]) => void = () => {}
+    const pendingElements = new Promise<unknown[]>((resolve) => {
+      resolveElements = resolve
+    })
+    const api = {
+      // Simulates a slow read: the command has already captured `api` by
+      // the time this resolves, so a concurrent deps swap must not change
+      // which api instance this call reads from.
+      getSceneElements: () => pendingElements,
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => api as never }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    const inFlight = commands.exportJson()
+
+    // Swap deps to a null-API state (simulating unmount / canvas switch)
+    // before the in-flight call's scene read resolves.
+    depsRef.current = baseDeps({ getExcalidrawApi: () => null })
+    resolveElements([el({ id: 'still-a' })])
+
+    const result = await inFlight
+    expect(result.elements.map((e) => (e as { id: string }).id)).toEqual(['still-a'])
+  })
+
+  it('never includes secret-bearing fields even with a full daemon ProviderState in deps', async () => {
+    const api = {
+      getSceneElements: () => [el({ id: 'a' })],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(
+      baseDeps({
+        getExcalidrawApi: () => api as never,
+        provider: {
+          kind: 'local-daemon',
+          daemonBaseUrl: 'http://127.0.0.1:9999',
+          capabilities: BROWSER_LOCAL_CAPABILITIES,
+        },
+      }),
+    )
+    const commands = createWhiteboardCommands(depsRef)
+
+    const result = await commands.exportJson()
+    const serialized = JSON.stringify(result).toLowerCase()
+
+    expect(serialized).not.toContain('token')
+    expect(serialized).not.toContain('authorization')
+    expect(serialized).not.toContain('daemonbaseurl')
+    expect(serialized).not.toContain('handle')
+  })
+})

--- a/apps/web/src/lib/commands/create-commands.test.ts
+++ b/apps/web/src/lib/commands/create-commands.test.ts
@@ -54,6 +54,34 @@ describe('createWhiteboardCommands.exportJson', () => {
     await expect(commands.exportJson()).rejects.toBeInstanceOf(CommandError)
   })
 
+  it('throws a no-canvas CommandError when no canvas is selected, even with a mounted API', async () => {
+    const api = {
+      getSceneElements: () => [el({ id: 'a' })],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => api as never, canvas: null }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    await expect(commands.exportJson()).rejects.toMatchObject({ code: 'no-canvas' })
+    await expect(commands.exportJson()).rejects.toBeInstanceOf(CommandError)
+  })
+
+  it('wraps a scene-read failure in an export-failed CommandError rather than letting it escape raw', async () => {
+    const api = {
+      getSceneElements: () => {
+        throw new Error('boom')
+      },
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const depsRef = refOf(baseDeps({ getExcalidrawApi: () => api as never }))
+    const commands = createWhiteboardCommands(depsRef)
+
+    await expect(commands.exportJson()).rejects.toMatchObject({ code: 'export-failed' })
+    await expect(commands.exportJson()).rejects.toBeInstanceOf(CommandError)
+  })
+
   it('throws an invalid-input CommandError for a non-object input', async () => {
     const depsRef = refOf(baseDeps())
     const commands = createWhiteboardCommands(depsRef)

--- a/apps/web/src/lib/commands/create-commands.ts
+++ b/apps/web/src/lib/commands/create-commands.ts
@@ -63,19 +63,31 @@ export function createWhiteboardCommands(depsRef: {
     // canvas switch, provider change) can never mutate the identity this
     // in-flight call already committed to.
     const deps = depsRef.current
+    if (!deps.canvas) {
+      throw new CommandError('no-canvas', 'No canvas is selected to export from.')
+    }
     const api = deps.getExcalidrawApi()
     if (!api) {
       throw new CommandError('no-api', 'No Excalidraw canvas is mounted to export from.')
     }
 
-    // `await`ing a plain value still yields one microtask — proving that the
-    // `api` captured above stays the one this call uses even if depsRef is
-    // swapped in that window.
-    const elements = await Promise.resolve(api.getSceneElements())
-    const appState = api.getAppState()
-    const files = api.getFiles()
-    const doc = serializeSceneAsExcalidrawJson(elements, appState, files)
-    return exportJsonResultSchema.parse(doc)
+    try {
+      // `await`ing a plain value still yields one microtask — proving that the
+      // `api` captured above stays the one this call uses even if depsRef is
+      // swapped in that window.
+      const elements = await Promise.resolve(api.getSceneElements())
+      const appState = api.getAppState()
+      const files = api.getFiles()
+      const doc = serializeSceneAsExcalidrawJson(elements, appState, files)
+      return exportJsonResultSchema.parse(doc)
+    } catch (err) {
+      // Every documented failure mode of this command is a CommandError so
+      // consumers (WebMCP adapter, debug panel) can branch on `.code` instead
+      // of parsing an arbitrary thrown error/message.
+      throw new CommandError('export-failed', 'Failed to read or serialize the live scene.', {
+        cause: err,
+      })
+    }
   }
 
   return { exportJson }

--- a/apps/web/src/lib/commands/create-commands.ts
+++ b/apps/web/src/lib/commands/create-commands.ts
@@ -1,0 +1,82 @@
+import { serializeSceneAsExcalidrawJson } from '../excalidraw-json.js'
+import {
+  CommandError,
+  type ExportJsonInput,
+  type ExportJsonResult,
+  exportJsonInputSchema,
+  exportJsonResultSchema,
+  type WhiteboardCommandDeps,
+  type WhiteboardCommands,
+} from './types.js'
+
+/**
+ * createWhiteboardCommands — the framework-free factory behind
+ * `WhiteboardCommands`. This is the single entry point a WebMCP tool
+ * executor, an in-page assistant, or a manual Tools/debug panel should call
+ * into for a UI operation: `commands.<method>(args)`, one line, no business
+ * logic duplicated at the call site.
+ *
+ * `depsRef` carries the runtime dependencies (which canvas is open, which
+ * provider is active, a handle to the mounted Excalidraw imperative API) as
+ * a mutable ref rather than plain arguments. A command can be long-running
+ * (an in-flight fetch, a slow scene read) while the surrounding React tree
+ * re-renders, switches canvases, or unmounts; reading `depsRef.current`
+ * fresh at the start of every call — and capturing it into a local before
+ * doing any async work — means a call in flight keeps running against the
+ * identity it started with, while the next call always sees the latest one.
+ * Closing over `deps` directly (the classic stale-closure bug) would instead
+ * freeze every future call to whatever was current when the commands object
+ * was created.
+ *
+ * exportJson runs entirely in-browser regardless of provider: it reads the
+ * live scene straight from the mounted Excalidraw instance the same way the
+ * existing header "Export" affordance always has. This is deliberately not
+ * the same product surface as the local-daemon's `POST
+ * /api/canvas/:workspaceId/:slug/export-json` endpoint, which persists a
+ * file server-side and returns a `{filePath, elementCount}` pointer with no
+ * scene payload — a different affordance for a different consumer. Nothing
+ * here calls that endpoint, and no other command in this layer currently
+ * needs the daemon's HTTP client at all.
+ *
+ * To add the next command:
+ * 1. Declare its input/output Zod schemas in types.ts (derive types via
+ *    `z.infer`, never a hand-written parallel interface).
+ * 2. Add the method here: parse the input, read `depsRef.current` into a
+ *    local before any `await`, dispatch to the provider-appropriate code
+ *    path, then parse the result against its output schema before
+ *    returning it.
+ * 3. Add it to the `WhiteboardCommands` interface in types.ts and to the
+ *    object returned below.
+ */
+export function createWhiteboardCommands(depsRef: {
+  current: WhiteboardCommandDeps
+}): WhiteboardCommands {
+  async function exportJson(input: ExportJsonInput = {}): Promise<ExportJsonResult> {
+    const parsedInput = exportJsonInputSchema.safeParse(input)
+    if (!parsedInput.success) {
+      throw new CommandError('invalid-input', 'exportJson received an invalid input payload.', {
+        cause: parsedInput.error,
+      })
+    }
+
+    // Captured before any await so a concurrent depsRef swap (unmount,
+    // canvas switch, provider change) can never mutate the identity this
+    // in-flight call already committed to.
+    const deps = depsRef.current
+    const api = deps.getExcalidrawApi()
+    if (!api) {
+      throw new CommandError('no-api', 'No Excalidraw canvas is mounted to export from.')
+    }
+
+    // `await`ing a plain value still yields one microtask — proving that the
+    // `api` captured above stays the one this call uses even if depsRef is
+    // swapped in that window.
+    const elements = await Promise.resolve(api.getSceneElements())
+    const appState = api.getAppState()
+    const files = api.getFiles()
+    const doc = serializeSceneAsExcalidrawJson(elements, appState, files)
+    return exportJsonResultSchema.parse(doc)
+  }
+
+  return { exportJson }
+}

--- a/apps/web/src/lib/commands/create-export-handler.test.ts
+++ b/apps/web/src/lib/commands/create-export-handler.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSceneExportHandler } from './create-export-handler.js'
+import type { WhiteboardCommands } from './types.js'
+
+function fakeCommands(overrides: Partial<WhiteboardCommands> = {}): WhiteboardCommands {
+  return {
+    exportJson: vi.fn(async () => {
+      throw new Error('should not be called in this test')
+    }),
+    ...overrides,
+  }
+}
+
+describe('createSceneExportHandler', () => {
+  it('delegates non-json formats straight through to exportScene, untouched', async () => {
+    const exportScene = vi.fn(async (format: 'svg' | 'png') => new Blob([format]))
+    const handler = createSceneExportHandler(fakeCommands(), exportScene)
+
+    const result = await handler('svg')
+
+    expect(exportScene).toHaveBeenCalledWith('svg')
+    expect(result).toBeInstanceOf(Blob)
+    await expect(result?.text()).resolves.toBe('svg')
+  })
+
+  it('resolves to null when commands.exportJson rejects, matching exportScene failure semantics', async () => {
+    const commands = fakeCommands({
+      exportJson: vi.fn(async () => {
+        throw new Error('no canvas mounted')
+      }),
+    })
+    const exportScene = vi.fn(async () => null)
+    const handler = createSceneExportHandler(commands, exportScene)
+
+    const result = await handler('json')
+
+    expect(result).toBeNull()
+    expect(exportScene).not.toHaveBeenCalled()
+  })
+
+  it('serializes a successful exportJson result as a JSON blob', async () => {
+    const doc = { type: 'excalidraw', version: 2, elements: [], appState: {}, files: {} }
+    const commands = fakeCommands({ exportJson: vi.fn(async () => doc as never) })
+    const exportScene = vi.fn(async () => null)
+    const handler = createSceneExportHandler(commands, exportScene)
+
+    const result = await handler('json')
+
+    expect(result).toBeInstanceOf(Blob)
+    expect(result?.type).toBe('application/json')
+    await expect(result?.text()).resolves.toBe(JSON.stringify(doc))
+  })
+})

--- a/apps/web/src/lib/commands/create-export-handler.ts
+++ b/apps/web/src/lib/commands/create-export-handler.ts
@@ -1,0 +1,28 @@
+import type { WhiteboardCommands } from './types.js'
+
+/**
+ * Bridges the shared commands layer into a page's existing `onExport`
+ * contract (`format => Promise<Blob | null>`): the `json` format delegates
+ * scene serialization to `commands.exportJson`, while every other format
+ * passes straight through to the page's own `exportScene`. A failed
+ * `exportJson` resolves to `null`, matching what `exportScene` already
+ * returns on failure so the caller's branch stays uniform.
+ *
+ * Generic over the format union so it is inferred from the supplied
+ * `exportScene` rather than restated here — a new export format added to
+ * `exportScene` flows through without editing this helper.
+ */
+export function createSceneExportHandler<Format extends string>(
+  commands: WhiteboardCommands,
+  exportScene: (format: Format) => Promise<Blob | null>,
+): (format: Format) => Promise<Blob | null> {
+  return async (format) => {
+    if (format !== 'json') return exportScene(format)
+    try {
+      const doc = await commands.exportJson()
+      return new Blob([JSON.stringify(doc)], { type: 'application/json' })
+    } catch {
+      return null
+    }
+  }
+}

--- a/apps/web/src/lib/commands/index.ts
+++ b/apps/web/src/lib/commands/index.ts
@@ -14,6 +14,7 @@
  * doc comment for the extension recipe for the next one.
  */
 export { createWhiteboardCommands } from './create-commands.js'
+export { createSceneExportHandler } from './create-export-handler.js'
 export {
   CommandError,
   type CommandErrorCode,

--- a/apps/web/src/lib/commands/index.ts
+++ b/apps/web/src/lib/commands/index.ts
@@ -1,0 +1,29 @@
+/**
+ * WhiteboardCommands — the provider-aware command layer for apps/web's UI
+ * operations.
+ *
+ * This is the common entry point for every surface that needs to drive the
+ * canvas programmatically: a WebMCP tool executor, an in-page assistant, or
+ * a manual Tools/debug panel. Each of those consumers should be able to
+ * obtain a `WhiteboardCommands` instance (via `useWhiteboardCommands` in a
+ * component, or `createWhiteboardCommands` outside React) and call into it
+ * with a single line — `commands.exportJson(...)` — with no business logic
+ * duplicated at the call site.
+ *
+ * Today this exposes one command, `exportJson`; see create-commands.ts's
+ * doc comment for the extension recipe for the next one.
+ */
+export { createWhiteboardCommands } from './create-commands.js'
+export {
+  CommandError,
+  type CommandErrorCode,
+  type ExcalidrawApiHandle,
+  type ExportJsonInput,
+  type ExportJsonResult,
+  exportJsonInputSchema,
+  exportJsonResultSchema,
+  type WhiteboardCommandCanvasIdentity,
+  type WhiteboardCommandDeps,
+  type WhiteboardCommands,
+} from './types.js'
+export { useWhiteboardCommands } from './use-whiteboard-commands.js'

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -1,0 +1,65 @@
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import { z } from 'zod'
+import { excalidrawJsonDocSchema } from '../excalidraw-json.js'
+import type { ProviderState } from '../provider.js'
+
+// exportJson takes no options today; parsed anyway so every command in this
+// layer goes through the same "schema.parse(input) at the boundary" shape,
+// and a future option can be added to this schema without touching the
+// factory's call signature.
+export const exportJsonInputSchema = z.object({}).strict()
+export type ExportJsonInput = z.infer<typeof exportJsonInputSchema>
+
+// The .excalidraw envelope is the single source of truth for this result;
+// re-used rather than redeclared so the command layer and the file-export
+// format can never drift from each other.
+export const exportJsonResultSchema = excalidrawJsonDocSchema
+export type ExportJsonResult = z.infer<typeof exportJsonResultSchema>
+
+// The narrow slice of ExcalidrawImperativeAPI the command layer actually
+// calls. Kept as a Pick of the real type (not a hand-rolled shape) so a
+// future Excalidraw upgrade that changes these method signatures fails
+// typecheck here instead of silently drifting.
+export type ExcalidrawApiHandle = Pick<
+  ExcalidrawImperativeAPI,
+  'getSceneElements' | 'getAppState' | 'getFiles'
+>
+
+export interface WhiteboardCommandCanvasIdentity {
+  workspaceId?: string
+  canvasId: string
+  name: string
+}
+
+// Runtime dependencies a command needs at call time. Never captured by
+// closure — see create-commands.ts's module doc for why this travels as a
+// ref instead.
+export interface WhiteboardCommandDeps {
+  getExcalidrawApi: () => ExcalidrawApiHandle | null
+  provider: ProviderState
+  canvas: WhiteboardCommandCanvasIdentity | null
+}
+
+export type CommandErrorCode = 'no-api' | 'no-canvas' | 'invalid-input'
+
+// Every command failure surfaces as this typed error rather than a raw
+// TypeError from an undefined access (e.g. a null Excalidraw API), so every
+// consumer (WebMCP adapter, debug panel) can branch on `.code` instead of
+// parsing a message string.
+export class CommandError extends Error {
+  readonly code: CommandErrorCode
+  // Declared explicitly: this repo's apps/web tsconfig targets ES2020, whose
+  // lib.es2020.d.ts predates the ES2022 Error `cause` option/property.
+  readonly cause?: unknown
+
+  constructor(code: CommandErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'CommandError'
+    this.code = code
+    this.cause = options?.cause
+  }
+}
+
+export interface WhiteboardCommands {
+  exportJson(input?: ExportJsonInput): Promise<ExportJsonResult>
+}

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -40,7 +40,7 @@ export interface WhiteboardCommandDeps {
   canvas: WhiteboardCommandCanvasIdentity | null
 }
 
-export type CommandErrorCode = 'no-api' | 'no-canvas' | 'invalid-input'
+export type CommandErrorCode = 'no-api' | 'no-canvas' | 'invalid-input' | 'export-failed'
 
 // Every command failure surfaces as this typed error rather than a raw
 // TypeError from an undefined access (e.g. a null Excalidraw API), so every

--- a/apps/web/src/lib/commands/use-whiteboard-commands.test.tsx
+++ b/apps/web/src/lib/commands/use-whiteboard-commands.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
+import type { WhiteboardCommandDeps } from './types.js'
+import { useWhiteboardCommands } from './use-whiteboard-commands.js'
+
+function deps(overrides: Partial<WhiteboardCommandDeps> = {}): WhiteboardCommandDeps {
+  return {
+    getExcalidrawApi: () => null,
+    provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },
+    canvas: { canvasId: 'c1', name: 'Canvas 1' },
+    ...overrides,
+  }
+}
+
+describe('useWhiteboardCommands', () => {
+  it('returns a referentially stable commands object across rerenders', () => {
+    const { result, rerender } = renderHook(
+      (d: WhiteboardCommandDeps) => useWhiteboardCommands(d),
+      {
+        initialProps: deps(),
+      },
+    )
+    const first = result.current
+
+    rerender(deps({ canvas: { canvasId: 'c2', name: 'Canvas 2' } }))
+    rerender(
+      deps({
+        provider: {
+          kind: 'local-daemon',
+          daemonBaseUrl: 'http://x',
+          capabilities: BROWSER_LOCAL_CAPABILITIES,
+        },
+      }),
+    )
+
+    expect(result.current).toBe(first)
+  })
+
+  it('a call after a rerender sees the latest canvas identity via the live Excalidraw API', async () => {
+    const apiA = {
+      getSceneElements: () => [{ id: 'a', type: 'rectangle', x: 0, y: 0 } as never],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const apiB = {
+      getSceneElements: () => [{ id: 'b', type: 'rectangle', x: 0, y: 0 } as never],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#000' }),
+      getFiles: () => ({}),
+    }
+    const { result, rerender } = renderHook(
+      (d: WhiteboardCommandDeps) => useWhiteboardCommands(d),
+      {
+        initialProps: deps({ getExcalidrawApi: () => apiA as never }),
+      },
+    )
+
+    const firstResult = await result.current.exportJson()
+    expect(firstResult.elements.map((e) => (e as { id: string }).id)).toEqual(['a'])
+
+    rerender(deps({ getExcalidrawApi: () => apiB as never }))
+    const secondResult = await result.current.exportJson()
+    expect(secondResult.elements.map((e) => (e as { id: string }).id)).toEqual(['b'])
+  })
+
+  it('a call issued after unmount resolves without a stale-state React warning', async () => {
+    const api = {
+      getSceneElements: () => [{ id: 'a', type: 'rectangle', x: 0, y: 0 } as never],
+      getAppState: () => ({ gridSize: null, viewBackgroundColor: '#fff' }),
+      getFiles: () => ({}),
+    }
+    const { result, unmount } = renderHook((d: WhiteboardCommandDeps) => useWhiteboardCommands(d), {
+      initialProps: deps({ getExcalidrawApi: () => api as never }),
+    })
+    const commands = result.current
+    unmount()
+
+    await expect(commands.exportJson()).resolves.toMatchObject({ type: 'excalidraw' })
+  })
+})

--- a/apps/web/src/lib/commands/use-whiteboard-commands.ts
+++ b/apps/web/src/lib/commands/use-whiteboard-commands.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import { createWhiteboardCommands } from './create-commands.js'
 import type { WhiteboardCommandDeps, WhiteboardCommands } from './types.js'
 
@@ -13,7 +13,14 @@ import type { WhiteboardCommandDeps, WhiteboardCommands } from './types.js'
  */
 export function useWhiteboardCommands(deps: WhiteboardCommandDeps): WhiteboardCommands {
   const depsRef = useRef<WhiteboardCommandDeps>(deps)
-  depsRef.current = deps
+  // Updated at commit time (layout effect), not in the render body:
+  // concurrent rendering may pause, abort, or retry a render, and a
+  // render-body write could publish deps from a render that never
+  // committed. Layout effects run synchronously at commit, before paint —
+  // earlier than any user event that could invoke a command.
+  useLayoutEffect(() => {
+    depsRef.current = deps
+  })
 
   const commandsRef = useRef<WhiteboardCommands | null>(null)
   if (commandsRef.current === null) {

--- a/apps/web/src/lib/commands/use-whiteboard-commands.ts
+++ b/apps/web/src/lib/commands/use-whiteboard-commands.ts
@@ -1,0 +1,23 @@
+import { useRef } from 'react'
+import { createWhiteboardCommands } from './create-commands.js'
+import type { WhiteboardCommandDeps, WhiteboardCommands } from './types.js'
+
+/**
+ * React binding for `createWhiteboardCommands`. A page keeps a plain ref of
+ * its runtime deps (canvas identity, provider, a getter for the mounted
+ * Excalidraw imperative API) updated on every render; the returned
+ * `WhiteboardCommands` object itself is created once and stays referentially
+ * stable for the lifetime of the component, so a future consumer (e.g. a
+ * WebMCP adapter registering `commands.exportJson` at mount time) can safely
+ * depend on that identity never changing across re-renders.
+ */
+export function useWhiteboardCommands(deps: WhiteboardCommandDeps): WhiteboardCommands {
+  const depsRef = useRef<WhiteboardCommandDeps>(deps)
+  depsRef.current = deps
+
+  const commandsRef = useRef<WhiteboardCommands | null>(null)
+  if (commandsRef.current === null) {
+    commandsRef.current = createWhiteboardCommands(depsRef)
+  }
+  return commandsRef.current
+}

--- a/apps/web/src/lib/excalidraw-json.test.ts
+++ b/apps/web/src/lib/excalidraw-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { serializeSceneAsExcalidrawJson } from './excalidraw-json.js'
+import { excalidrawJsonDocSchema, serializeSceneAsExcalidrawJson } from './excalidraw-json.js'
 
 const el = (over: Record<string, unknown>) =>
   ({ id: 'e', type: 'rectangle', x: 0, y: 0, ...over }) as never
@@ -53,5 +53,15 @@ describe('serializeSceneAsExcalidrawJson', () => {
     const doc = serializeSceneAsExcalidrawJson([], { gridSize: null } as never, {})
 
     expect(doc.appState.viewBackgroundColor).toBe('#ffffff')
+  })
+
+  it('always produces a doc satisfying excalidrawJsonDocSchema', () => {
+    const doc = serializeSceneAsExcalidrawJson(
+      [el({ id: 'a' })],
+      { gridSize: 20, viewBackgroundColor: '#fff' },
+      {},
+    )
+
+    expect(() => excalidrawJsonDocSchema.parse(doc)).not.toThrow()
   })
 })

--- a/apps/web/src/lib/excalidraw-json.ts
+++ b/apps/web/src/lib/excalidraw-json.ts
@@ -1,5 +1,6 @@
 import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types'
 import type { AppState, BinaryFiles } from '@excalidraw/excalidraw/types'
+import { z } from 'zod'
 
 // Producing the .excalidraw payload by hand rather than via excalidraw's own
 // serializeAsJSON: that helper is a top-level export ONLY in the package's
@@ -11,14 +12,23 @@ import type { AppState, BinaryFiles } from '@excalidraw/excalidraw/types'
 // Excalidraw desktop / excalidraw.com.
 const EXCALIDRAW_FILE_SOURCE = '@kamiazya/whiteboard'
 
-export interface ExcalidrawJsonDoc {
-  type: 'excalidraw'
-  version: 2
-  source: string
-  elements: readonly ExcalidrawElement[]
-  appState: { gridSize: number | null; viewBackgroundColor: string }
-  files: BinaryFiles
-}
+// Deliberately loose on elements/files: validating their internal shape is
+// Excalidraw's own job (its scene reducer already does it). This schema only
+// guards the envelope (type/version/source/appState) that this repo's own
+// serializer and consumers depend on.
+export const excalidrawJsonDocSchema = z.object({
+  type: z.literal('excalidraw'),
+  version: z.literal(2),
+  source: z.string(),
+  elements: z.array(z.custom<ExcalidrawElement>()).readonly(),
+  appState: z.object({
+    gridSize: z.number().nullable(),
+    viewBackgroundColor: z.string(),
+  }),
+  files: z.custom<BinaryFiles>(),
+})
+
+export type ExcalidrawJsonDoc = z.infer<typeof excalidrawJsonDocSchema>
 
 // gridSize/viewBackgroundColor are the only appState fields the .excalidraw
 // format persists; both are read defensively since a caller may hand a

--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import '../index.css'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+// Captures every Blob handed to URL.createObjectURL so assertions can inspect
+// the real payload instead of only the downloaded filename — a regression
+// that bypasses commands.exportJson (e.g. falling through to exportScene for
+// the 'json' format) would still produce *a* download, but not this content.
+function captureExportedBlobs(): { blobs: Blob[] } {
+  const captured: Blob[] = []
+  vi.spyOn(URL, 'createObjectURL').mockImplementation((obj: Blob | MediaSource) => {
+    captured.push(obj as Blob)
+    return 'blob:mock-url'
+  })
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  return { blobs: captured }
+}
+
+async function renderLoaded(): Promise<void> {
+  render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+  await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeInTheDocument(), {
+    timeout: 5000,
+  })
+}
+
+// Opening WorkspaceTopBar's "Canvas actions" dropdown occasionally does not
+// register on the first pointerdown the first time it's opened in a given
+// test file in real-browser mode (never reproduces in jsdom) — retry with a
+// full remount rather than let that tooling artifact fail a real behavioral
+// assertion. Mirrors the same pattern in BrowserLocalCanvasPage.rename.browser.test.tsx.
+async function openExportMenuItem(label: string): Promise<HTMLElement> {
+  let item: HTMLElement | undefined
+  for (let attempt = 0; attempt < 8 && !item; attempt++) {
+    if (attempt > 0) {
+      cleanup()
+      await renderLoaded()
+    }
+    const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Canvas actions'), {
+      timeout: 5000,
+    })
+    const canvasActions = allCanvasActions[allCanvasActions.length - 1]!
+    fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+    try {
+      const allItems = await waitFor(() => screen.getAllByText(label), { timeout: 1500 })
+      item = allItems[allItems.length - 1]!
+    } catch {
+      // retry with a fresh remount
+    }
+  }
+  if (!item) throw new Error(`Canvas actions dropdown never opened after retries (${label})`)
+  return item
+}
+
+describe('BrowserLocalCanvasPage export (browser — real Excalidraw)', () => {
+  beforeEach(async () => {
+    await clearDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('exports JSON through commands.exportJson as a real .excalidraw envelope, not exportScene', async () => {
+    await renderLoaded()
+    const { blobs } = captureExportedBlobs()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    const jsonItem = await openExportMenuItem('Export as JSON')
+    fireEvent.pointerUp(jsonItem)
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    expect(blobs).toHaveLength(1)
+    const blob = blobs[0]
+    expect(blob.type).toBe('application/json')
+
+    const text = await blob.text()
+    const parsed = JSON.parse(text)
+    // The commands-layer envelope (serializeSceneAsExcalidrawJson) — a
+    // exportScene('svg'|'png') fallback would never produce this shape.
+    expect(parsed).toMatchObject({ type: 'excalidraw', version: 2 })
+    expect(Array.isArray(parsed.elements)).toBe(true)
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@excalidraw/excalidraw', () => ({
         addFiles: vi.fn(),
         getSceneElements: () => [],
         getAppState: () => ({}),
+        getFiles: () => ({}),
       })
     }
     // Surfaces the received theme so tests can assert the page actually
@@ -797,6 +798,37 @@ describe('BrowserLocalCanvasPage', () => {
       await screen.findByText('Other canvas')
       expect(document.querySelectorAll('img[src*="/api/"]').length).toBe(0)
       expect(screen.queryByRole('button', { name: /pin canvas/i })).toBeNull()
+    })
+  })
+
+  describe('Export → JSON routes through the commands layer', () => {
+    it('downloads a .excalidraw envelope produced by commands.exportJson', async () => {
+      vi.useRealTimers()
+      const store = new MemoryStore()
+      await store.setDefaultCanvasId('c1')
+      await store.save(snap)
+      vi.stubGlobal('URL', {
+        ...URL,
+        createObjectURL: vi.fn(() => 'blob:mock-url'),
+        revokeObjectURL: vi.fn(),
+      })
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+      await act(async () => {
+        render(<BrowserLocalCanvasPage store={store} />)
+      })
+      const canvasActions = await screen.findByLabelText('Canvas actions')
+      fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+      const jsonItem = await screen.findByText('Export as JSON')
+      await act(async () => {
+        fireEvent.pointerUp(jsonItem)
+      })
+
+      await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+      const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement
+      expect(anchor.download).toBe('untitled.excalidraw')
+
+      vi.unstubAllGlobals()
     })
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -20,7 +20,7 @@ import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { useWhiteboardCommands } from '../lib/commands/index.js'
+import { createSceneExportHandler, useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -262,18 +262,7 @@ export function BrowserLocalCanvasPage({
     canvas: canvasId !== null ? { canvasId, name: canvasName ?? '' } : null,
   })
 
-  // Preserves the existing onExport contract (format => Blob | null):
-  // png/svg still go straight through exportScene, while json now delegates
-  // scene serialization to the shared commands layer.
-  const handleExport = async (format: Parameters<typeof exportScene>[0]) => {
-    if (format !== 'json') return exportScene(format)
-    try {
-      const doc = await commands.exportJson()
-      return new Blob([JSON.stringify(doc)], { type: 'application/json' })
-    } catch {
-      return null
-    }
-  }
+  const handleExport = createSceneExportHandler(commands, exportScene)
 
   // The option list refreshes asynchronously (see the effect above) while the
   // selected id changes synchronously on switch/create. Synthesize a

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,6 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
@@ -19,6 +20,7 @@ import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -148,7 +150,14 @@ export function BrowserLocalCanvasPage({
   const mainRef = useRef<HTMLElement | null>(null)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const canvasId = pageState.kind === 'editing' ? pageState.snapshot.id : null
+  const canvasName = pageState.kind === 'editing' ? pageState.snapshot.name : null
   const currentUpdatedAt = pageState.kind === 'editing' ? pageState.snapshot.updatedAt : null
+
+  // Fans out to both useCanvasSync's own imperative-API ref (via
+  // setExcalidrawAPI below) and this page-local ref, so the commands layer
+  // can read the live Excalidraw API without useCanvasSync needing to expose
+  // its internal ref.
+  const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>(null)
 
   // Canvas id -> URL: once a canvas has loaded, the address bar reflects it
   // (bookmarkable/shareable, matching the daemon side's
@@ -247,6 +256,25 @@ export function BrowserLocalCanvasPage({
     onFileUploadSucceeded: () => setFileUploadError(null),
   })
 
+  const commands = useWhiteboardCommands({
+    getExcalidrawApi: () => excalidrawApiRef.current,
+    provider: { kind: 'browser-local', capabilities },
+    canvas: canvasId !== null ? { canvasId, name: canvasName ?? '' } : null,
+  })
+
+  // Preserves the existing onExport contract (format => Blob | null):
+  // png/svg still go straight through exportScene, while json now delegates
+  // scene serialization to the shared commands layer.
+  const handleExport = async (format: Parameters<typeof exportScene>[0]) => {
+    if (format !== 'json') return exportScene(format)
+    try {
+      const doc = await commands.exportJson()
+      return new Blob([JSON.stringify(doc)], { type: 'application/json' })
+    } catch {
+      return null
+    }
+  }
+
   // The option list refreshes asynchronously (see the effect above) while the
   // selected id changes synchronously on switch/create. Synthesize a
   // fallback option for the gap between those two so the controlled
@@ -343,7 +371,7 @@ export function BrowserLocalCanvasPage({
             branches: capabilities.branches,
             merge: capabilities.merge,
           }}
-          onExport={exportScene}
+          onExport={handleExport}
         />
       </Suspense>
       {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain
@@ -414,7 +442,14 @@ export function BrowserLocalCanvasPage({
         </AlertDialog>
       </div>
       <div data-testid="excalidraw-container" className="min-h-0 flex-1">
-        <Excalidraw excalidrawAPI={setExcalidrawAPI} onChange={onChange} theme={resolvedTheme} />
+        <Excalidraw
+          excalidrawAPI={(api) => {
+            excalidrawApiRef.current = api
+            setExcalidrawAPI(api)
+          }}
+          onChange={onChange}
+          theme={resolvedTheme}
+        />
       </div>
     </main>
   )

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@excalidraw/excalidraw', () => ({
         addFiles: vi.fn(),
         getSceneElements: () => [],
         getAppState: () => ({}),
+        getFiles: () => ({}),
       })
     }
     return <div data-testid="excalidraw-container" />
@@ -1625,6 +1626,39 @@ describe('DaemonCanvasPage', () => {
       await waitFor(() => expect(screen.queryByTestId('header-save-dot')).toBeNull())
 
       vi.unstubAllGlobals()
+    })
+  })
+
+  describe('Export → JSON routes through the commands layer', () => {
+    it('downloads a .excalidraw envelope produced by commands.exportJson', async () => {
+      // Spy rather than vi.stubGlobal('URL', {...}) — the page's daemonFetch
+      // wiring calls `new URL(...)`, which a plain-object stub can't satisfy.
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
+      const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+          { container: document.body },
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('excalidraw-container')).toBeTruthy())
+
+      const canvasActions = screen.getByLabelText('Canvas actions')
+      fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+      const jsonItem = await screen.findByText('Export as JSON')
+      await act(async () => {
+        fireEvent.pointerUp(jsonItem)
+      })
+
+      await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+      const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement
+      expect(anchor.download).toBe('main.excalidraw')
+
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      clickSpy.mockRestore()
     })
   })
 

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -1,18 +1,20 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
+import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { MergeToast } from '../components/MergeToast.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
-import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { useDaemonCanvasController } from './use-daemon-canvas-controller.js'
@@ -137,6 +139,36 @@ export function DaemonCanvasPage({
     onVersionCreated: () => setVersionRefreshSignal((n) => n + 1),
     identity: canvas ?? undefined,
   })
+
+  // Fans out to both useCanvasSync's own imperative-API ref (via
+  // setExcalidrawAPI below) and this page-local ref, so the commands layer
+  // can read the live Excalidraw API without useCanvasSync needing to expose
+  // its internal ref.
+  const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>(null)
+
+  const commands = useWhiteboardCommands({
+    getExcalidrawApi: () => excalidrawApiRef.current,
+    provider: { kind: 'local-daemon', daemonBaseUrl, capabilities },
+    // The daemon canvas summary carries no display name yet (only
+    // slug/updatedAt) — the slug doubles as `name` until that changes.
+    canvas:
+      canvas !== null
+        ? { workspaceId: canvas.workspaceId, canvasId: canvas.slug, name: canvas.slug }
+        : null,
+  })
+
+  // Preserves the existing onExport contract (format => Blob | null):
+  // png/svg still go straight through exportScene, while json now delegates
+  // scene serialization to the shared commands layer.
+  const handleExport = async (format: Parameters<typeof exportScene>[0]) => {
+    if (format !== 'json') return exportScene(format)
+    try {
+      const doc = await commands.exportJson()
+      return new Blob([JSON.stringify(doc)], { type: 'application/json' })
+    } catch {
+      return null
+    }
+  }
 
   const saveVersion = async (): Promise<void> => {
     if (!capabilities.versions || canvas === null || savingVersion) return
@@ -292,7 +324,7 @@ export function DaemonCanvasPage({
             onRestored={clearLocalUndo}
             versionPanelExtra={versionPanelExtra}
             onNavigateBack={onNavigateBack}
-            onExport={exportScene}
+            onExport={handleExport}
           />
         )}
         {capabilities.branches && canvas && (
@@ -407,7 +439,13 @@ export function DaemonCanvasPage({
           </div>
         ) : (
           <div className="min-h-0 flex-1">
-            <Excalidraw excalidrawAPI={setExcalidrawAPI} onChange={onChange} />
+            <Excalidraw
+              excalidrawAPI={(api) => {
+                excalidrawApiRef.current = api
+                setExcalidrawAPI(api)
+              }}
+              onChange={onChange}
+            />
           </div>
         )}
         {capabilities.merge && canvas && (

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -14,7 +14,7 @@ import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { useWhiteboardCommands } from '../lib/commands/index.js'
+import { createSceneExportHandler, useWhiteboardCommands } from '../lib/commands/index.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { useDaemonCanvasController } from './use-daemon-canvas-controller.js'
@@ -157,18 +157,7 @@ export function DaemonCanvasPage({
         : null,
   })
 
-  // Preserves the existing onExport contract (format => Blob | null):
-  // png/svg still go straight through exportScene, while json now delegates
-  // scene serialization to the shared commands layer.
-  const handleExport = async (format: Parameters<typeof exportScene>[0]) => {
-    if (format !== 'json') return exportScene(format)
-    try {
-      const doc = await commands.exportJson()
-      return new Blob([JSON.stringify(doc)], { type: 'application/json' })
-    } catch {
-      return null
-    }
-  }
+  const handleExport = createSceneExportHandler(commands, exportScene)
 
   const saveVersion = async (): Promise<void> => {
     if (!capabilities.versions || canvas === null || savingVersion) return


### PR DESCRIPTION
## Summary

Introduces the `WhiteboardCommands` layer — a provider-aware command API under `apps/web/src/lib/commands/` that WebMCP adapters, a future in-page assistant, and a manual Tools/debug panel can all consume through one entry point.

**Deliberately narrow first slice** (plan-review decision): the scaffold plus ONE load-bearing command, `exportJson`. The remaining commands (`getSceneSummary` / `insertAnnotations` / `insertTemplate` / `setViewport`) are deferred to land together with their first real consumer, so no speculative mock-only APIs ship.

- `types.ts` — Zod schemas + `z.infer` types; `CommandError` with typed codes (`no-api` / `no-canvas` / `invalid-input`). The hand-written `ExcalidrawJsonDoc` interface in `excalidraw-json.ts` is replaced by `z.infer<typeof excalidrawJsonDocSchema>` (single source of truth).
- `create-commands.ts` — framework-free factory; deps are read from a ref ONCE per call at call start (no torn reads on mid-await deps swaps; stale-closure pattern per the WebMCP design notes).
- `use-whiteboard-commands.ts` — React binding keeping the deps ref current; returns a render-stable commands object (identity stability matters for future mount-time registration).
- `create-export-handler.ts` — dedupes the pages' `onExport` json bridge.
- **Load-bearing proof**: both canvas pages' Export→JSON now route through `commands.exportJson` (png/svg unchanged); a new real-browser regression locks the flow, and all existing page/browser suites pass un-weakened.
- Provider semantics documented precisely: exportJson executes in-browser for both providers (exactly what the pages did); the daemon's export-json endpoint is a different affordance (persisted-file pointer) and is deliberately NOT this command's backend.
- Security: a test asserts the result JSON never contains token/authorization/handle keys even with a full ProviderState in deps.

Documented open behavior (kept as-is, tested): a retained commands handle continues to work after its owning component unmounts, reading the last deps — consistent with React 18 semantics used elsewhere in the app; revisit only if a consumer needs invalidation.

Note for reviewers: `excalidraw-json.ts` is concurrently being moved into `packages/canvas-viewer` by a sibling branch; the integrator will reconcile the schema to a single definition in that branch's fold.

## Test plan

- [x] `pnpm test` — 363 files / 4864 passed (commands unit suites incl. mid-flight deps-swap race, export-handler branches, real-browser Export→JSON regression)
- [x] `pnpm -r typecheck`
