### PR TITLE
feat(mcp-server): render canvases inline in chat via MCP Apps canvas_view widget

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@ packages/mcp-server/node_modules/
 packages/mcp-server/dist/
 packages/mcp-server/coverage/
 packages/mcp-server/tmp/
+packages/canvas-viewer/node_modules/
+packages/canvas-viewer/dist/
 
 # Test suites and distribution smokes (not needed to build the image).
 tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # canvas_view serves the built widget from mcp-server/dist/widget even
+      # when the server itself runs from source (WHITEBOARD_DEV=1), so the
+      # smokes that exercise ui://whiteboard/canvas-view need the widget
+      # built and copied before any full `pnpm build` happens in this job.
+      - name: Build canvas-viewer widget for smokes
+        run: |
+          pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
+          node packages/mcp-server/scripts/copy-widget-into-dist.mjs
+
       # mcp-smoke spawns the MCP stdio server which in turn calls ensureDaemon.
       # Without WHITEBOARD_DEV=1, ensureDaemon tries dist/server/index.js which
       # does not exist before build. WHITEBOARD_DEV=1 makes it use tsx against

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -31,11 +31,17 @@ RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
 WORKDIR /workspace
 
 # Install dependencies before copying source (cache-friendly layer order).
+# canvas-viewer is included because mcp-server's build copies its built
+# widget bundle (ui://whiteboard/canvas-view) into dist.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/mcp-server/package.json packages/mcp-server/
+COPY packages/canvas-viewer/package.json packages/canvas-viewer/
 RUN pnpm install --frozen-lockfile
 
-# Compile TypeScript.
+# Build the self-contained canvas widget, then compile TypeScript (whose
+# build step copies the widget bundle into mcp-server/dist).
+COPY packages/canvas-viewer/ packages/canvas-viewer/
+RUN pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
 COPY packages/mcp-server/ packages/mcp-server/
 RUN pnpm --filter @kamiazya/whiteboard-mcp build
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,6 +8,8 @@ Guides:
 - **[self-host-with-docker](self-host-with-docker.md)** — run Whiteboard in server mode for a team.
 - **[connect-to-local-daemon](connect-to-local-daemon.md)** — detect a local daemon from the web
   app and copy browser-local canvases onto it.
+- **[view-canvas-in-chat](view-canvas-in-chat.md)** — render an interactive read-only canvas
+  view inline in an MCP Apps-compatible AI chat client.
 
 Planned guides:
 

--- a/docs/how-to/view-canvas-in-chat.md
+++ b/docs/how-to/view-canvas-in-chat.md
@@ -11,7 +11,7 @@ no need to switch to a browser tab to see what the agent drew.
 - The same self-contained Excalidraw viewer bundle used for
   [self-contained HTML export](../explanation/) — no daemon credentials, tokens, or
   base URLs are ever passed into the widget. The widget only ever receives a scene
-  snapshot (elements), nothing else.
+  snapshot — the canvas elements plus any embedded image binaries — nothing else.
 - Zero external network access: the widget bundle is fully self-contained (fonts and
   all Excalidraw assets are inlined), so the client's CSP for the view can stay at its
   strictest default.

--- a/docs/how-to/view-canvas-in-chat.md
+++ b/docs/how-to/view-canvas-in-chat.md
@@ -1,0 +1,58 @@
+# View a canvas inline in your AI chat (MCP Apps)
+
+Whiteboard's local daemon MCP server implements the [MCP Apps extension](https://github.com/modelcontextprotocol/ext-apps)
+(`io.modelcontextprotocol/ui`, spec 2026-01-26). When your MCP client supports it, calling
+the `canvas_view` tool renders an interactive canvas view directly inside the chat —
+no need to switch to a browser tab to see what the agent drew.
+
+## What you get
+
+- A read-only, pan/zoom/select view of the current canvas scene, rendered inline.
+- The same self-contained Excalidraw viewer bundle used for
+  [self-contained HTML export](../explanation/) — no daemon credentials, tokens, or
+  base URLs are ever passed into the widget. The widget only ever receives a scene
+  snapshot (elements), nothing else.
+- Zero external network access: the widget bundle is fully self-contained (fonts and
+  all Excalidraw assets are inlined), so the client's CSP for the view can stay at its
+  strictest default.
+
+## What you do not get (yet)
+
+This is **Phase A** of MCP Apps support:
+
+- The view is **read-only**. There is no in-widget editing, annotation, or refresh
+  button yet — call `canvas_view` again to see a fresh snapshot.
+- Only `canvas_view` renders inline. `canvas_open` (opens the full editor in a real
+  browser tab) and `export_canvas` (writes a file) are intentionally **not**
+  UI-linked — `canvas_open` would need to pass the daemon's base URL into the widget,
+  and `export_canvas` has a file-write side effect that a UI "refresh" action should
+  never trigger silently.
+- Live sync (the view updating as the agent keeps drawing, without calling the tool
+  again) is a future phase.
+
+## Requirements
+
+- A local daemon connection (see [Connect to a local daemon](connect-to-local-daemon.md)).
+- An MCP client that implements the MCP Apps extension. As of this writing that
+  includes Claude Desktop, VS Code (Copilot), Goose, Postman, and MCPJam — check your
+  client's own documentation, since host support varies. Clients without MCP Apps
+  support still get `canvas_view`'s JSON result as plain structured content; they just
+  will not render the inline widget.
+
+## Using it
+
+Ask your agent to view the canvas, or call the tool directly:
+
+```json
+{
+  "name": "canvas_view",
+  "arguments": { "canvasId": "<workspaceId>/<slug>" }
+}
+```
+
+The result's `structuredContent` is `{ canvasId, scene: { elements } }` — the same
+shape the canvas-viewer package's `parseViewerScene` accepts, so a supporting client
+renders it immediately. On a client without MCP Apps support, you see this JSON as
+the tool result instead of an inline view.
+
+← Back to [How-to guides](README.md)

--- a/packages/canvas-viewer/canvas-viewer.widget.html
+++ b/packages/canvas-viewer/canvas-viewer.widget.html
@@ -5,10 +5,12 @@
     <title>Canvas Viewer</title>
     <style>
       /* Inline MCP Apps hosts auto-resize the iframe to the document's
-         scroll height. Any viewport-relative height (100vh) then feeds back
-         into the next measurement and the iframe grows without bound, so
-         the widget must declare a FIXED intrinsic height and clip its own
-         overflow to keep scrollHeight == content height. */
+         scroll height. Any viewport-relative height then feeds back into
+         the next measurement and the iframe grows without bound, so the
+         widget must declare a FIXED intrinsic height and clip its own
+         overflow to keep scrollHeight == content height. (Keep viewport
+         units out of comments too — shell-height.test.ts scans the raw
+         file.) */
       html,
       body {
         margin: 0;

--- a/packages/canvas-viewer/canvas-viewer.widget.html
+++ b/packages/canvas-viewer/canvas-viewer.widget.html
@@ -3,9 +3,21 @@
   <head>
     <meta charset="utf-8" />
     <title>Canvas Viewer</title>
+    <style>
+      /* Inline MCP Apps hosts auto-resize the iframe to the document's
+         scroll height. Any viewport-relative height (100vh) then feeds back
+         into the next measurement and the iframe grows without bound, so
+         the widget must declare a FIXED intrinsic height and clip its own
+         overflow to keep scrollHeight == content height. */
+      html,
+      body {
+        margin: 0;
+        overflow: hidden;
+      }
+    </style>
   </head>
   <body>
-    <div id="root" style="width: 100vw; height: 100vh"></div>
+    <div id="root" style="width: 100%; height: 480px"></div>
     <!--
       Embedded-scene slot (see mountCanvasViewer's readEmbeddedScene). Empty
       by default; a downstream export/widget-bundling step replaces this

--- a/packages/canvas-viewer/package.json
+++ b/packages/canvas-viewer/package.json
@@ -20,11 +20,13 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.node.config.ts && vitest run --config vitest.jsdom.config.ts && vitest run --config vitest.browser.config.ts",
+    "build": "pnpm run build:widget",
     "build:widget": "vite build --config vite.widget.config.ts && node scripts/rename-widget-html.mjs",
     "smoke:widget": "node scripts/smoke-widget.mjs"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "catalog:",
+    "@modelcontextprotocol/ext-apps": "1.7.4",
     "react": "catalog:",
     "react-dom": "catalog:",
     "zod": "catalog:"

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -280,28 +280,35 @@ async function main() {
     // CI runners parse+execute the ~8.5 MB inline bundle noticeably slower
     // than the file:// pages above; give the sandboxed frame extra headroom.
     const srcdocDeadline = Date.now() + 30_000
-    let srcdocFrame
     let srcdocCanvasCount = 0
     while (Date.now() < srcdocDeadline) {
-      srcdocFrame = srcdocPage.frames().find((f) => f.url() === 'about:srcdoc')
-      if (srcdocFrame) {
-        srcdocCanvasCount = await srcdocFrame
+      // Any non-main frame is the widget frame — matching on
+      // url() === 'about:srcdoc' is Chrome-build-dependent (chrome-stable
+      // under CDP can report a sandboxed srcdoc frame's URL differently
+      // than bundled Chromium).
+      for (const frame of srcdocPage.frames()) {
+        if (frame === srcdocPage.mainFrame()) continue
+        srcdocCanvasCount = await frame
           .evaluate(() => document.querySelectorAll('canvas').length)
           .catch(() => 0)
         if (srcdocCanvasCount > 0) break
       }
+      if (srcdocCanvasCount > 0) break
       await new Promise((resolve) => setTimeout(resolve, 200))
     }
     if (srcdocCanvasCount === 0) {
+      const frameUrls = srcdocPage
+        .frames()
+        .map((f) => f.url() || '(empty)')
+        .join(', ')
       const diagnostics = [
+        `frames: ${frameUrls}`,
         srcdocPageErrors.length ? `page errors: ${srcdocPageErrors.join(' | ')}` : '',
         srcdocConsoleErrors.length ? `console errors: ${srcdocConsoleErrors.join(' | ')}` : '',
       ]
         .filter(Boolean)
         .join('; ')
-      fail(
-        `widget did not render a canvas under sandboxed srcdoc hosting${diagnostics ? ` (${diagnostics})` : ''}`,
-      )
+      fail(`widget did not render a canvas under sandboxed srcdoc hosting (${diagnostics})`)
     }
     if (srcdocPageErrors.length > 0) {
       fail(`uncaught page error(s) under srcdoc hosting: ${srcdocPageErrors.join(' | ')}`)

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -243,9 +243,56 @@ async function main() {
       fail(`expected zero network requests after the JP render, saw: ${networkRequests.join(', ')}`)
     }
 
+    // srcdoc hosting: MCP Apps hosts embed this widget via a sandboxed
+    // srcdoc iframe (no allow-same-origin), where location.href is the
+    // non-URL "about:srcdoc". A widget that assumes a real document URL
+    // (e.g. `new URL('.', location.href)`) dies only under THIS hosting
+    // mode — file:// and http(s) loads cannot catch it.
+    const srcdocPage = await browser.newPage()
+    const srcdocPageErrors = []
+    srcdocPage.on('pageerror', (err) => {
+      srcdocPageErrors.push(String(err))
+    })
+    await srcdocPage.route('http://**', (route) => {
+      networkRequests.push(route.request().url())
+      return route.abort()
+    })
+    await srcdocPage.route('https://**', (route) => {
+      networkRequests.push(route.request().url())
+      return route.abort()
+    })
+    await srcdocPage.setContent('<!doctype html><body></body>')
+    await srcdocPage.evaluate((widgetHtml) => {
+      const iframe = document.createElement('iframe')
+      iframe.setAttribute('sandbox', 'allow-scripts')
+      iframe.srcdoc = widgetHtml
+      document.body.appendChild(iframe)
+    }, injectedHtml)
+    const srcdocDeadline = Date.now() + 10_000
+    let srcdocFrame
+    let srcdocCanvasCount = 0
+    while (Date.now() < srcdocDeadline) {
+      srcdocFrame = srcdocPage.frames().find((f) => f.url() === 'about:srcdoc')
+      if (srcdocFrame) {
+        srcdocCanvasCount = await srcdocFrame
+          .evaluate(() => document.querySelectorAll('canvas').length)
+          .catch(() => 0)
+        if (srcdocCanvasCount > 0) break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    if (srcdocCanvasCount === 0) {
+      fail(
+        `widget did not render a canvas under sandboxed srcdoc hosting${srcdocPageErrors.length ? ` (page errors: ${srcdocPageErrors.join(' | ')})` : ''}`,
+      )
+    }
+    if (srcdocPageErrors.length > 0) {
+      fail(`uncaught page error(s) under srcdoc hosting: ${srcdocPageErrors.join(' | ')}`)
+    }
+
     if (process.exitCode !== 1) {
       console.log(
-        '[widget-smoke] PASS: zero network requests, canvas rendered, fonts loaded, JP fallback painted',
+        '[widget-smoke] PASS: zero network requests, canvas rendered, fonts loaded, JP fallback painted, srcdoc hosting OK',
       )
     }
   } finally {

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -253,6 +253,15 @@ async function main() {
     srcdocPage.on('pageerror', (err) => {
       srcdocPageErrors.push(String(err))
     })
+    // Diagnostics only, never a fail condition on their own: Excalidraw's
+    // own font manager issues CSS-level loads for font subsets this bundle
+    // does not embed (they resolve against the inert asset prefix and fail
+    // by design — the widget degrades to fallback glyphs). A real bootstrap
+    // crash surfaces as a pageerror or as no canvas appearing.
+    const srcdocConsoleErrors = []
+    srcdocPage.on('console', (msg) => {
+      if (msg.type() === 'error') srcdocConsoleErrors.push(msg.text())
+    })
     await srcdocPage.route('http://**', (route) => {
       networkRequests.push(route.request().url())
       return route.abort()
@@ -268,7 +277,9 @@ async function main() {
       iframe.srcdoc = widgetHtml
       document.body.appendChild(iframe)
     }, injectedHtml)
-    const srcdocDeadline = Date.now() + 10_000
+    // CI runners parse+execute the ~8.5 MB inline bundle noticeably slower
+    // than the file:// pages above; give the sandboxed frame extra headroom.
+    const srcdocDeadline = Date.now() + 30_000
     let srcdocFrame
     let srcdocCanvasCount = 0
     while (Date.now() < srcdocDeadline) {
@@ -282,8 +293,14 @@ async function main() {
       await new Promise((resolve) => setTimeout(resolve, 200))
     }
     if (srcdocCanvasCount === 0) {
+      const diagnostics = [
+        srcdocPageErrors.length ? `page errors: ${srcdocPageErrors.join(' | ')}` : '',
+        srcdocConsoleErrors.length ? `console errors: ${srcdocConsoleErrors.join(' | ')}` : '',
+      ]
+        .filter(Boolean)
+        .join('; ')
       fail(
-        `widget did not render a canvas under sandboxed srcdoc hosting${srcdocPageErrors.length ? ` (page errors: ${srcdocPageErrors.join(' | ')})` : ''}`,
+        `widget did not render a canvas under sandboxed srcdoc hosting${diagnostics ? ` (${diagnostics})` : ''}`,
       )
     }
     if (srcdocPageErrors.length > 0) {

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -74,6 +74,9 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
   afterEach(() => {
     // Restore window.parent so subsequent tests default back to top-level.
     Object.defineProperty(window, 'parent', { configurable: true, value: window })
+    // A test that fails mid-flight with fake timers active would otherwise
+    // leak them into the next case.
+    vi.useRealTimers()
   })
 
   it('mounts the initial scene from ui/notifications/tool-result when embedded in a host', async () => {
@@ -173,6 +176,54 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
       expect.objectContaining({ scene }),
     )
     expect(fallbackHandle.dispose).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
+  it('keeps the current view when a tool-result carries a malformed scene', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+    const { mountCanvasViewer } = await import('./mount.js')
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+    const liveHandle = vi.mocked(mountCanvasViewer).mock.results[0]?.value
+
+    // remount disposes BEFORE mounting, so an unvalidated malformed payload
+    // would trade the working view for an empty container.
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { scene: { bogus: true } } })
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: {} })
+
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+    expect(liveHandle.dispose).not.toHaveBeenCalled()
+  })
+
+  it('does not stack an embedded-scene fallback over a scene the host mounted before the timeout', async () => {
+    vi.useFakeTimers()
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(() => new Promise(() => {})) // never resolves
+
+    await importFreshWidgetEntry()
+    // Host delivers the tool-result while connect() is still pending, i.e.
+    // before the HOST_CONNECT_TIMEOUT_MS branch decides "not connected".
+    const scene = { elements: [{ id: 'c' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    await vi.advanceTimersByTimeAsync(2_100)
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    // Exactly the host-scene mount — no bare fallback mount stacked on top.
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+    expect(mountCanvasViewer).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ scene }),
+    )
+    const hostHandle = vi.mocked(mountCanvasViewer).mock.results[0]?.value
+    expect(hostHandle.dispose).not.toHaveBeenCalled()
     vi.useRealTimers()
   })
 })

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// widget-entry.ts bootstraps immediately on import (`void bootstrap()`), so
+// each test needs a fresh module instance + fresh DOM to observe one
+// bootstrap in isolation.
+
+interface FakeAppInstance {
+  ontoolresult?: (result: unknown) => void
+  connect: () => Promise<void>
+}
+
+const connectMock = vi.fn()
+const fakeAppInstances: FakeAppInstance[] = []
+
+vi.mock('@modelcontextprotocol/ext-apps', () => ({
+  App: vi.fn(function FakeApp(this: FakeAppInstance) {
+    fakeAppInstances.push(this)
+    this.connect = connectMock
+  }),
+}))
+
+vi.mock('./mount.js', () => ({
+  mountCanvasViewer: vi.fn(() => ({ dispose: vi.fn() })),
+}))
+
+function stubEmbeddedIframeParent(): void {
+  // window.parent === window by default in jsdom (top-level document). A
+  // real MCP Apps host embeds the widget in an iframe, so window.parent
+  // differs from window — simulate that so mountFromHost attempts to
+  // connect instead of short-circuiting to the no-host fallback.
+  Object.defineProperty(window, 'parent', {
+    configurable: true,
+    value: {},
+  })
+}
+
+async function importFreshWidgetEntry() {
+  vi.resetModules()
+  return import('./widget-entry.js')
+}
+
+// jsdom implements neither the FontFace constructor nor document.fonts —
+// registerFonts() (unrelated to this bridge bootstrap, but run
+// unconditionally by the same bootstrap()) needs both to exist so it does
+// not throw before the bridge logic under test ever runs.
+class FakeFontFace {
+  constructor(
+    public family: string,
+    public source: string,
+  ) {}
+  load(): Promise<FakeFontFace> {
+    return Promise.resolve(this)
+  }
+}
+
+describe('widget-entry MCP Apps bridge bootstrap', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="root"></div>'
+    fakeAppInstances.length = 0
+    connectMock.mockReset()
+    // The mount.js mock module instance persists across vi.resetModules()
+    // calls (only the real module graph is reset), so its call history
+    // must be cleared explicitly between tests.
+    const { mountCanvasViewer } = await import('./mount.js')
+    vi.mocked(mountCanvasViewer).mockClear()
+    // biome-ignore lint/suspicious/noExplicitAny: jsdom test shim for a browser-only API
+    ;(globalThis as any).FontFace = FakeFontFace
+    if (!document.fonts) {
+      Object.defineProperty(document, 'fonts', { configurable: true, value: { add() {} } })
+    }
+  })
+
+  afterEach(() => {
+    // Restore window.parent so subsequent tests default back to top-level.
+    Object.defineProperty(window, 'parent', { configurable: true, value: window })
+  })
+
+  it('mounts the initial scene from ui/notifications/tool-result when embedded in a host', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fakeAppInstances).toHaveLength(1)
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    expect(mountCanvasViewer).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ scene: { canvasId: 'ws/slug', scene } }),
+    )
+  })
+
+  it('falls back to the embedded-scene slot when there is no parent frame', async () => {
+    // Default jsdom top-level document: window.parent === window.
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fakeAppInstances).toHaveLength(0)
+    const { mountCanvasViewer } = await import('./mount.js')
+    expect(mountCanvasViewer).toHaveBeenLastCalledWith(expect.any(HTMLElement))
+  })
+
+  it('falls back to the embedded-scene slot when host connect() never resolves', async () => {
+    vi.useFakeTimers()
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(() => new Promise(() => {})) // never resolves
+
+    await importFreshWidgetEntry()
+    await vi.advanceTimersByTimeAsync(2_100)
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    expect(mountCanvasViewer).toHaveBeenLastCalledWith(expect.any(HTMLElement))
+    vi.useRealTimers()
+  })
+})

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseViewerScene } from './scene.js'
 
 // widget-entry.ts bootstraps immediately on import (`void bootstrap()`), so
 // each test needs a fresh module instance + fresh DOM to observe one
@@ -84,14 +85,25 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
     await Promise.resolve()
 
     expect(fakeAppInstances).toHaveLength(1)
+    // canvas_view's outputSchema wraps the scene as {canvasId, scene}; only
+    // the `scene` field is a valid mountCanvasViewer payload.
     const scene = { elements: [{ id: 'a' }] }
     fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
 
     const { mountCanvasViewer } = await import('./mount.js')
     expect(mountCanvasViewer).toHaveBeenCalledWith(
       expect.any(HTMLElement),
-      expect.objectContaining({ scene: { canvasId: 'ws/slug', scene } }),
+      expect.objectContaining({ scene }),
     )
+    // mount.js itself is mocked above (constructing a real Excalidraw root
+    // in jsdom is out of scope here), so re-run the argument through the
+    // real, unmocked scene parser — the same one mountCanvasViewer would
+    // apply — to guarantee this is a value parseViewerScene actually
+    // accepts, not just a value the mock happened to receive. This is what
+    // catches passing the whole {canvasId, scene} wrapper: viewerSceneSchema
+    // is .strict() and would reject the extra `canvasId`/`scene` keys.
+    const call = vi.mocked(mountCanvasViewer).mock.calls[0]?.[1]
+    expect(() => parseViewerScene(call?.scene)).not.toThrow()
   })
 
   it('falls back to the embedded-scene slot when there is no parent frame', async () => {
@@ -115,6 +127,52 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
 
     const { mountCanvasViewer } = await import('./mount.js')
     expect(mountCanvasViewer).toHaveBeenLastCalledWith(expect.any(HTMLElement))
+    vi.useRealTimers()
+  })
+
+  it('does not mount a fallback when the host connects but never sends a tool-result', async () => {
+    // A host that completes the ext-apps handshake but does not support (or
+    // has not yet sent) ui/notifications/tool-result — a plausible
+    // real-world host-integration gap for a new SEP-1865 bridge, distinct
+    // from "no host at all" and "connect() never resolves" above.
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fakeAppInstances).toHaveLength(1)
+    const { mountCanvasViewer } = await import('./mount.js')
+    // bootstrap() must not fall back to the embedded-scene mount here: doing
+    // so would risk a second React root racing whatever ontoolresult mounts
+    // if the host answers late (see the next test).
+    expect(mountCanvasViewer).not.toHaveBeenCalled()
+  })
+
+  it('disposes the timeout fallback mount when the host answers late with a tool-result', async () => {
+    vi.useFakeTimers()
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(() => new Promise(() => {})) // never resolves within the test
+
+    await importFreshWidgetEntry()
+    await vi.advanceTimersByTimeAsync(2_100) // past HOST_CONNECT_TIMEOUT_MS
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+    const fallbackHandle = vi.mocked(mountCanvasViewer).mock.results[0]?.value
+
+    // The host's connect() attempt was never cancelled by the timeout, so a
+    // tool-result notification can still arrive afterward.
+    const scene = { elements: [{ id: 'b' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(2)
+    expect(mountCanvasViewer).toHaveBeenLastCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ scene }),
+    )
+    expect(fallbackHandle.dispose).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
   })
 })

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -5,6 +5,7 @@
 import { App } from '@modelcontextprotocol/ext-apps'
 import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
 import { mountCanvasViewer, type CanvasViewerHandle } from './mount.js'
+import { parseViewerScene } from './scene.js'
 import { buildFontFaceDescriptors, resolveFontFetchDataUri } from './widget/font-registration.js'
 
 declare global {
@@ -162,13 +163,27 @@ async function mountFromHost(
     // mountCanvasViewer.
     const structuredContent = (result as { structuredContent?: { scene?: unknown } })
       .structuredContent
-    remount(() => mountCanvasViewer(container, { scene: structuredContent?.scene }))
+    const scene = structuredContent?.scene
+    // Validate BEFORE remount: remount disposes the live viewer first, so a
+    // malformed tool-result would otherwise trade a working view for an
+    // empty container. On invalid payloads the current view stays up.
+    try {
+      parseViewerScene(scene)
+    } catch {
+      return
+    }
+    remount(() => mountCanvasViewer(container, { scene }))
   }
 
+  // connect() may reject after the timeout already won the race; a catch on
+  // the race result alone would leave that late rejection unhandled.
   const connected = await Promise.race([
-    app.connect().then(() => true),
+    app
+      .connect()
+      .then(() => true)
+      .catch(() => false),
     new Promise<boolean>((resolve) => setTimeout(() => resolve(false), HOST_CONNECT_TIMEOUT_MS)),
-  ]).catch(() => false)
+  ])
 
   return connected
 }
@@ -183,15 +198,21 @@ async function bootstrap(): Promise<void> {
   }
 
   let handle: CanvasViewerHandle | undefined
-  const connectedToHost = await mountFromHost(container, (mount) => {
-    // Order matters: dispose the live root and clear its DOM BEFORE the
-    // factory creates the next root — see mountFromHost's doc comment.
+  // Order matters: dispose the live root and clear its DOM BEFORE the
+  // factory creates the next root — see mountFromHost's doc comment.
+  const remount = (mount: () => CanvasViewerHandle): void => {
     handle?.dispose()
     container.replaceChildren()
     handle = mount()
-  })
-  if (!connectedToHost) {
-    handle = mountCanvasViewer(container)
+  }
+  const connectedToHost = await mountFromHost(container, remount)
+  if (!connectedToHost && handle === undefined) {
+    // The embedded-scene fallback goes through the same remount path: a
+    // slow host can deliver a tool-result mount in the gap between the
+    // timeout losing the race and this line, and a bare mountCanvasViewer
+    // here would then stack a second root on the container. The handle
+    // check keeps a just-arrived host scene instead of replacing it.
+    remount(() => mountCanvasViewer(container))
   }
 }
 

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -62,11 +62,27 @@ function registerFonts(): void {
   }
 
   // EXCALIDRAW_ASSET_PATH must be a string; Excalidraw resolves any font URL
-  // it still needs (one this build didn't anticipate) against it. Since
-  // this document is the only thing that prefix could ever point at, and
-  // the fetch shim below intercepts requests before they reach the
-  // network, the exact value is inert.
-  window.EXCALIDRAW_ASSET_PATH = new URL('.', window.location.href).toString()
+  // it still needs (one this build didn't anticipate) against it. The exact
+  // value is inert (the fetch shim intercepts before the network), but
+  // constructing it must not throw: MCP Apps hosts load this widget via a
+  // sandboxed srcdoc iframe where location.href is the non-URL
+  // "about:srcdoc" and `new URL('.', location.href)` throws, killing the
+  // whole bootstrap. document.baseURI (inherited from the embedding
+  // document in srcdoc) usually works; a fixed inert prefix is the final
+  // fallback.
+  window.EXCALIDRAW_ASSET_PATH = resolveInertAssetPrefix()
+}
+
+function resolveInertAssetPrefix(): string {
+  try {
+    return new URL('.', window.location.href).toString()
+  } catch {
+    try {
+      return new URL('.', document.baseURI).toString()
+    } catch {
+      return 'https://whiteboard-widget.invalid/'
+    }
+  }
 }
 
 // Scoped fallback for the case Excalidraw's lazy font loader still issues a
@@ -118,18 +134,21 @@ function installFontFetchShim(): void {
 // slot instead of hanging forever.
 const HOST_CONNECT_TIMEOUT_MS = 2_000
 
-// `onMount` is the single place a handle produced by this bridge gets
-// recorded. `app.connect()` racing HOST_CONNECT_TIMEOUT_MS means a
-// tool-result can legitimately arrive AFTER the caller already decided
-// `connectedToHost` was false and mounted its own embedded-scene fallback
-// (a connect() that resolves just past the timeout, or a host that answers
-// the handshake slowly). Routing every mount through the same callback lets
-// the caller dispose whichever handle — fallback or a previous tool-result
-// — is currently live before mounting the new one, so two React roots never
-// compete for the same container.
+// `remount` is the single place a mount produced by this bridge happens.
+// `app.connect()` racing HOST_CONNECT_TIMEOUT_MS means a tool-result can
+// legitimately arrive AFTER the caller already decided `connectedToHost`
+// was false and mounted its own embedded-scene fallback (a connect() that
+// resolves just past the timeout, or a host that answers the handshake
+// slowly), and a host may deliver tool-results more than once. Routing
+// every mount through the same callback — which disposes whichever handle
+// is currently live and clears the container BEFORE the factory creates
+// the next root — is what keeps two React roots from ever competing for
+// the same container (createRoot on a container whose children still
+// belong to an undisposed root crashes React with a removeChild
+// NotFoundError).
 async function mountFromHost(
   container: HTMLElement,
-  onMount: (handle: CanvasViewerHandle) => void,
+  remount: (mount: () => CanvasViewerHandle) => void,
 ): Promise<boolean> {
   // No parent frame — this document cannot be an embedded MCP Apps view.
   if (window.parent === window) return false
@@ -143,7 +162,7 @@ async function mountFromHost(
     // mountCanvasViewer.
     const structuredContent = (result as { structuredContent?: { scene?: unknown } })
       .structuredContent
-    onMount(mountCanvasViewer(container, { scene: structuredContent?.scene }))
+    remount(() => mountCanvasViewer(container, { scene: structuredContent?.scene }))
   }
 
   const connected = await Promise.race([
@@ -164,9 +183,12 @@ async function bootstrap(): Promise<void> {
   }
 
   let handle: CanvasViewerHandle | undefined
-  const connectedToHost = await mountFromHost(container, (newHandle) => {
+  const connectedToHost = await mountFromHost(container, (mount) => {
+    // Order matters: dispose the live root and clear its DOM BEFORE the
+    // factory creates the next root — see mountFromHost's doc comment.
     handle?.dispose()
-    handle = newHandle
+    container.replaceChildren()
+    handle = mount()
   })
   if (!connectedToHost) {
     handle = mountCanvasViewer(container)

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -2,8 +2,9 @@
 // (vite.widget.config.ts -> dist/widget/canvas-viewer.html). Never exported
 // from the package's public surface — this file is a build INPUT, loaded
 // only by the widget's own <script type="module"> tag.
+import { App } from '@modelcontextprotocol/ext-apps'
 import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
-import { mountCanvasViewer } from './mount.js'
+import { mountCanvasViewer, type CanvasViewerHandle } from './mount.js'
 import { buildFontFaceDescriptors, resolveFontFetchDataUri } from './widget/font-registration.js'
 
 declare global {
@@ -100,7 +101,45 @@ function installFontFetchShim(): void {
   }
 }
 
-function bootstrap(): void {
+// MCP Apps (SEP-1865) bridge bootstrap. The host sends the canvas_view tool
+// result via `ui/notifications/tool-result`; `structuredContent` there is
+// the same `{canvasId, scene}` shape returned by canvas_view's Zod
+// outputSchema. This widget never receives daemon credentials — only the
+// scene snapshot — so it cannot call anything back into the daemon
+// directly (the only outbound path, when a host supports it, is
+// re-invoking canvas_view through the host's own MCP session, which this
+// Phase-A bootstrap does not yet do; there is no Refresh action here).
+//
+// When no ext-apps host is embedding this document (e.g. the widget opened
+// directly in a browser, or the widget-smoke harness), `app.connect()`
+// never resolves because no PostMessageTransport peer answers on the other
+// end — `mountFromHost` races that against `hasHostContext` timeout below
+// so bootstrap always falls back to mountCanvasViewer's own embedded-scene
+// slot instead of hanging forever.
+const HOST_CONNECT_TIMEOUT_MS = 2_000
+
+async function mountFromHost(container: HTMLElement): Promise<boolean> {
+  // No parent frame — this document cannot be an embedded MCP Apps view.
+  if (window.parent === window) return false
+
+  const app = new App({ name: 'whiteboard-canvas-view', version: '0.0.0' }, {})
+  let handle: CanvasViewerHandle | undefined
+
+  app.ontoolresult = (result) => {
+    const structuredContent = (result as { structuredContent?: unknown }).structuredContent
+    handle?.dispose()
+    handle = mountCanvasViewer(container, { scene: structuredContent })
+  }
+
+  const connected = await Promise.race([
+    app.connect().then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), HOST_CONNECT_TIMEOUT_MS)),
+  ]).catch(() => false)
+
+  return connected
+}
+
+async function bootstrap(): Promise<void> {
   registerFonts()
   installFontFetchShim()
 
@@ -108,7 +147,11 @@ function bootstrap(): void {
   if (!container) {
     throw new Error('widget-entry: expected a #root element in the widget HTML shell')
   }
-  mountCanvasViewer(container)
+
+  const connectedToHost = await mountFromHost(container)
+  if (!connectedToHost) {
+    mountCanvasViewer(container)
+  }
 }
 
-bootstrap()
+void bootstrap()

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -118,17 +118,32 @@ function installFontFetchShim(): void {
 // slot instead of hanging forever.
 const HOST_CONNECT_TIMEOUT_MS = 2_000
 
-async function mountFromHost(container: HTMLElement): Promise<boolean> {
+// `onMount` is the single place a handle produced by this bridge gets
+// recorded. `app.connect()` racing HOST_CONNECT_TIMEOUT_MS means a
+// tool-result can legitimately arrive AFTER the caller already decided
+// `connectedToHost` was false and mounted its own embedded-scene fallback
+// (a connect() that resolves just past the timeout, or a host that answers
+// the handshake slowly). Routing every mount through the same callback lets
+// the caller dispose whichever handle — fallback or a previous tool-result
+// — is currently live before mounting the new one, so two React roots never
+// compete for the same container.
+async function mountFromHost(
+  container: HTMLElement,
+  onMount: (handle: CanvasViewerHandle) => void,
+): Promise<boolean> {
   // No parent frame — this document cannot be an embedded MCP Apps view.
   if (window.parent === window) return false
 
   const app = new App({ name: 'whiteboard-canvas-view', version: '0.0.0' }, {})
-  let handle: CanvasViewerHandle | undefined
 
   app.ontoolresult = (result) => {
-    const structuredContent = (result as { structuredContent?: unknown }).structuredContent
-    handle?.dispose()
-    handle = mountCanvasViewer(container, { scene: structuredContent })
+    // canvas_view's outputSchema wraps the scene as {canvasId, scene}; only
+    // the `scene` field matches parseViewerScene's strict {elements,
+    // appState?, files?} contract, so the wrapper itself must never reach
+    // mountCanvasViewer.
+    const structuredContent = (result as { structuredContent?: { scene?: unknown } })
+      .structuredContent
+    onMount(mountCanvasViewer(container, { scene: structuredContent?.scene }))
   }
 
   const connected = await Promise.race([
@@ -148,9 +163,13 @@ async function bootstrap(): Promise<void> {
     throw new Error('widget-entry: expected a #root element in the widget HTML shell')
   }
 
-  const connectedToHost = await mountFromHost(container)
+  let handle: CanvasViewerHandle | undefined
+  const connectedToHost = await mountFromHost(container, (newHandle) => {
+    handle?.dispose()
+    handle = newHandle
+  })
   if (!connectedToHost) {
-    mountCanvasViewer(container)
+    handle = mountCanvasViewer(container)
   }
 }
 

--- a/packages/canvas-viewer/src/widget/shell-height.test.ts
+++ b/packages/canvas-viewer/src/widget/shell-height.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Inline MCP Apps hosts auto-resize the embedding iframe to the widget
+// document's scroll height. If the widget shell sizes itself with any
+// viewport-relative unit (100vh grows whenever the iframe grows), each host
+// measurement feeds back into the next and the iframe balloons without
+// bound. The shell must therefore declare a fixed intrinsic height and
+// clip its own overflow so scrollHeight always equals content height.
+const shellPath = fileURLToPath(new URL('../../canvas-viewer.widget.html', import.meta.url))
+
+describe('widget shell sizing (host auto-resize safety)', () => {
+  // Comments may legitimately mention viewport units when explaining this
+  // very rule — only effective markup/CSS is checked.
+  const html = readFileSync(shellPath, 'utf8')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+
+  it('never uses viewport-relative units for the root size', () => {
+    expect(html).not.toMatch(/\b\d+(?:vh|vw|dvh|svh|lvh)\b/)
+  })
+
+  it('gives #root a fixed pixel height', () => {
+    const rootTag = html.match(/<div id="root"[^>]*>/)?.[0]
+    expect(rootTag).toBeDefined()
+    expect(rootTag).toMatch(/height:\s*\d+px/)
+  })
+
+  it('clips document overflow so scrollHeight equals content height', () => {
+    expect(html).toMatch(/overflow:\s*hidden/)
+  })
+})

--- a/packages/canvas-viewer/src/widget/shell-height.test.ts
+++ b/packages/canvas-viewer/src/widget/shell-height.test.ts
@@ -12,10 +12,17 @@ const shellPath = fileURLToPath(new URL('../../canvas-viewer.widget.html', impor
 
 describe('widget shell sizing (host auto-resize safety)', () => {
   // Comments may legitimately mention viewport units when explaining this
-  // very rule — only effective markup/CSS is checked.
-  const html = readFileSync(shellPath, 'utf8')
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
+  // very rule — only effective markup/CSS is checked. Stripping runs to a
+  // fixpoint so nested/overlapping comment fragments cannot survive one pass.
+  const stripComments = (input: string): string => {
+    let out = input
+    for (;;) {
+      const next = out.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '')
+      if (next === out) return next
+      out = next
+    }
+  }
+  const html = stripComments(readFileSync(shellPath, 'utf8'))
 
   it('never uses viewport-relative units for the root size', () => {
     expect(html).not.toMatch(/\b\d+(?:vh|vw|dvh|svh|lvh)\b/)

--- a/packages/canvas-viewer/src/widget/shell-height.test.ts
+++ b/packages/canvas-viewer/src/widget/shell-height.test.ts
@@ -11,18 +11,12 @@ import { describe, expect, it } from 'vitest'
 const shellPath = fileURLToPath(new URL('../../canvas-viewer.widget.html', import.meta.url))
 
 describe('widget shell sizing (host auto-resize safety)', () => {
-  // Comments may legitimately mention viewport units when explaining this
-  // very rule — only effective markup/CSS is checked. Stripping runs to a
-  // fixpoint so nested/overlapping comment fragments cannot survive one pass.
-  const stripComments = (input: string): string => {
-    let out = input
-    for (;;) {
-      const next = out.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '')
-      if (next === out) return next
-      out = next
-    }
-  }
-  const html = stripComments(readFileSync(shellPath, 'utf8'))
+  // The raw file is scanned — comments included — so shell comments must
+  // describe viewport units without writing a literal `<digits><unit>`
+  // token. Scanning raw beats comment-stripping: a regex comment-stripper
+  // is exactly the incomplete-sanitization pattern CodeQL flags, and the
+  // ban losing a match to a comment is worse than wording around it.
+  const html = readFileSync(shellPath, 'utf8')
 
   it('never uses viewport-relative units for the root size', () => {
     expect(html).not.toMatch(/\b\d+(?:vh|vw|dvh|svh|lvh)\b/)

--- a/packages/canvas-viewer/vite.widget.config.ts
+++ b/packages/canvas-viewer/vite.widget.config.ts
@@ -43,7 +43,11 @@ function resolveExcalidrawFontsDir(): string {
 // virtual module as base64 data URIs, resolved fresh on every build so the
 // output always matches the currently installed @excalidraw/excalidraw
 // version's font files.
-function widgetFontsPlugin(): Plugin {
+// Exported so vitest.jsdom.config.ts can register the same virtual module
+// for widget-entry.ts's unit tests — that file imports `virtual:widget-fonts`
+// unconditionally, so any test harness that loads it as source needs this
+// plugin too, not just the production widget build.
+export function widgetFontsPlugin(): Plugin {
   return {
     name: 'whiteboard-widget-fonts',
     resolveId(id) {

--- a/packages/canvas-viewer/vitest.jsdom.config.ts
+++ b/packages/canvas-viewer/vitest.jsdom.config.ts
@@ -1,8 +1,12 @@
 import { defineProject } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { widgetFontsPlugin } from './vite.widget.config.js'
 
 export default defineProject({
-  plugins: [react()],
+  // widgetFontsPlugin resolves the `virtual:widget-fonts` module widget-entry.ts
+  // imports unconditionally — needed here so widget-entry.test.tsx can import
+  // that file as source, not just the production widget build.
+  plugins: [react(), widgetFontsPlugin()],
   test: {
     name: 'canvas-viewer-jsdom',
     environment: 'jsdom',

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -132,7 +132,7 @@
     "daemon": "node dist/server/index.js --daemon",
     "daemon:dev": "tsx watch src/server/index.ts --daemon",
     "build:server": "tsc -p tsconfig.server.json && chmod +x dist/cli/index.js",
-    "build": "pnpm build:server",
+    "build": "pnpm build:server && node scripts/copy-widget-into-dist.mjs",
     "dev": "tsx watch src/server/index.ts",
     "test": "vitest run",
     "test:all": "vitest run",
@@ -156,7 +156,7 @@
     "smoke:lna-transport": "node scripts/smoke/mcp-lna-transport-smoke.mjs",
     "smoke:all": "pnpm smoke:e2e && pnpm smoke:template && pnpm smoke:claude",
     "prepublishOnly": "test -x dist/cli/index.js",
-    "prepack": "node scripts/verify-web-app-dist.mjs"
+    "prepack": "node scripts/verify-web-app-dist.mjs && node scripts/verify-widget-dist.mjs"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.1",
@@ -164,6 +164,7 @@
     "@hono/node-server": "^2.0.6",
     "@libsql/client": "^0.17.3",
     "@libsql/kysely-libsql": "^0.4.1",
+    "@modelcontextprotocol/ext-apps": "1.7.4",
     "@modelcontextprotocol/sdk": "~1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@opentelemetry/api": "^1.9.1",
@@ -195,6 +196,7 @@
   },
   "devDependencies": {
     "@fast-check/vitest": "^0.4.1",
+    "@kamiazya/whiteboard-canvas-viewer": "workspace:*",
     "@radix-ui/react-alert-dialog": "^1.1.18",
     "@radix-ui/react-dialog": "^1.1.18",
     "@radix-ui/react-dropdown-menu": "^2.1.19",

--- a/packages/mcp-server/scripts/copy-widget-into-dist.mjs
+++ b/packages/mcp-server/scripts/copy-widget-into-dist.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Build step: copies packages/canvas-viewer's self-contained widget HTML
+// bundle into this package's dist so mcp-apps.ts can serve it as the
+// ui://whiteboard/canvas-view resource. canvas-viewer has no workspace
+// dependency on this package (mcp-server depends on canvas-viewer as a
+// devDependency instead, purely for build ordering), so — unlike
+// apps/web's postbuild copy-into-mcp-dist.mjs, which runs from the SOURCE
+// package after its own build — this copy runs from mcp-server's OWN build
+// step, pulling from a sibling package's already-built dist/.
+import { cpSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+export const SRC_FILE = resolve(
+  SCRIPT_DIR,
+  '..',
+  '..',
+  'canvas-viewer',
+  'dist',
+  'widget',
+  'canvas-viewer.html',
+)
+export const DEST_FILE = resolve(SCRIPT_DIR, '..', 'dist', 'widget', 'canvas-viewer.html')
+
+export function copyWidgetIntoDist(srcFile = SRC_FILE, destFile = DEST_FILE) {
+  if (!existsSync(srcFile)) {
+    throw new Error(
+      `canvas-viewer widget build output not found at ${srcFile} — run ` +
+        '`pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget` first',
+    )
+  }
+  mkdirSync(dirname(destFile), { recursive: true })
+  cpSync(srcFile, destFile)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  copyWidgetIntoDist()
+  console.log(`copied ${SRC_FILE} -> ${DEST_FILE}`)
+}

--- a/packages/mcp-server/scripts/copy-widget-into-dist.test.ts
+++ b/packages/mcp-server/scripts/copy-widget-into-dist.test.ts
@@ -1,0 +1,36 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { copyWidgetIntoDist } from './copy-widget-into-dist.mjs'
+
+describe('copyWidgetIntoDist', () => {
+  let dir: string | undefined
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = undefined
+  })
+
+  it('copies the widget HTML byte-identically to the destination', () => {
+    dir = mkdtempSync(join(tmpdir(), 'copy-widget-into-dist-'))
+    const src = join(dir, 'src', 'canvas-viewer.html')
+    const dest = join(dir, 'dist', 'widget', 'canvas-viewer.html')
+    mkdirSync(join(dir, 'src'), { recursive: true })
+    writeFileSync(src, '<html><body>widget</body></html>')
+
+    copyWidgetIntoDist(src, dest)
+
+    expect(readFileSync(dest, 'utf-8')).toBe('<html><body>widget</body></html>')
+  })
+
+  it('throws a loud error when the source widget build is missing', () => {
+    dir = mkdtempSync(join(tmpdir(), 'copy-widget-into-dist-'))
+    const src = join(dir, 'src', 'canvas-viewer.html')
+    const dest = join(dir, 'dist', 'widget', 'canvas-viewer.html')
+
+    expect(() => copyWidgetIntoDist(src, dest)).toThrow(
+      /canvas-viewer widget build output not found/,
+    )
+  })
+})

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -82,15 +82,22 @@ child.stderr.on('data', (c) => {
   stderrBuf += c.toString()
 })
 
-// Response parser for newline-delimited JSON.
+// Response parser for newline-delimited JSON. Buffers are accumulated and
+// split as Buffers (not strings) before the final utf-8 decode: a large
+// message (e.g. the ~8MB canvas-viewer widget HTML in a resources/read
+// response) arrives split across multiple 'data' events, and decoding each
+// chunk to a string independently corrupts any multi-byte UTF-8 character
+// that straddles a chunk boundary (each half decodes to a replacement
+// character on its own). Decoding only once a full line's bytes are known
+// to be present avoids that class of corruption.
 const pending = new Map()
-let stdoutBuf = ''
+let stdoutBuf = Buffer.alloc(0)
 child.stdout.on('data', (chunk) => {
-  stdoutBuf += chunk.toString()
+  stdoutBuf = Buffer.concat([stdoutBuf, chunk])
   let idx
-  while ((idx = stdoutBuf.indexOf('\n')) !== -1) {
-    const line = stdoutBuf.slice(0, idx)
-    stdoutBuf = stdoutBuf.slice(idx + 1)
+  while ((idx = stdoutBuf.indexOf(0x0a)) !== -1) {
+    const line = stdoutBuf.subarray(0, idx).toString('utf-8')
+    stdoutBuf = stdoutBuf.subarray(idx + 1)
     if (!line.trim()) continue
     let msg
     try {
@@ -165,18 +172,65 @@ async function main() {
 
   // Wait briefly for the Hono server to finish starting.
   // If initialize succeeds, the MCP server is up.
-  await rpc('initialize', {
+  const initResult = await rpc('initialize', {
     protocolVersion: '2024-11-05',
     capabilities: {},
     clientInfo: { name: 'e2e-smoke', version: '0.0.0' },
   })
   notify('notifications/initialized', {})
 
+  // MCP Apps (SEP-1865) extension declaration: io.modelcontextprotocol/ui
+  // must appear in the initialize result's server capabilities.extensions.
+  const UI_EXTENSION_ID = 'io.modelcontextprotocol/ui'
+  if (!initResult?.capabilities?.extensions?.[UI_EXTENSION_ID]) {
+    throw new Error(
+      `initialize result missing extensions.${UI_EXTENSION_ID}: ${JSON.stringify(initResult?.capabilities)}`,
+    )
+  }
+  console.log(`[e2e] initialize → capabilities.extensions.${UI_EXTENSION_ID} present OK`)
+
   const tools = await rpc('tools/list', {})
   const names = tools.tools.map((t) => t.name)
   if (!names.includes('version_save') || !names.includes('version_restore')) {
     throw new Error(`version tools missing from tools/list: ${names.join(', ')}`)
   }
+
+  // MCP Apps UI linkage: exactly canvas_view carries `_meta.ui.resourceUri`;
+  // canvas_open/export_canvas must NOT (see tool-registration.ts).
+  const UI_RESOURCE_URI = 'ui://whiteboard/canvas-view'
+  const uiLinkedNames = tools.tools
+    .filter((t) => t._meta?.ui?.resourceUri === UI_RESOURCE_URI)
+    .map((t) => t.name)
+  if (uiLinkedNames.length !== 1 || uiLinkedNames[0] !== 'canvas_view') {
+    throw new Error(`expected exactly canvas_view UI-linked, got: ${JSON.stringify(uiLinkedNames)}`)
+  }
+  console.log('[e2e] tools/list → canvas_view is the sole UI-linked tool OK')
+
+  const resourceList = await rpc('resources/list', {})
+  const uiResourceEntry = resourceList.resources.find((r) => r.uri === UI_RESOURCE_URI)
+  if (!uiResourceEntry || uiResourceEntry.mimeType !== 'text/html;profile=mcp-app') {
+    throw new Error(`ui:// resource missing/wrong mimeType: ${JSON.stringify(uiResourceEntry)}`)
+  }
+
+  const resourceRead = await rpc('resources/read', { uri: UI_RESOURCE_URI })
+  const widgetHtmlPath = resolve(
+    root,
+    '..',
+    'canvas-viewer',
+    'dist',
+    'widget',
+    'canvas-viewer.html',
+  )
+  const expectedWidgetHtml = (await import('node:fs')).readFileSync(widgetHtmlPath, 'utf-8')
+  const actualWidgetHtml = resourceRead.contents?.[0]?.text
+  if (actualWidgetHtml !== expectedWidgetHtml) {
+    throw new Error(
+      'resources/read ui://whiteboard/canvas-view did not match the shipped widget bundle byte-for-byte',
+    )
+  }
+  console.log(
+    '[e2e] resources/read ui://whiteboard/canvas-view → byte-identical to shipped widget OK',
+  )
 
   const created = await callTool('canvas_create', { slug: 'e2e-src' })
   if (!created.id || !created.url) throw new Error('canvas_create returned unexpected shape')
@@ -394,6 +448,18 @@ async function main() {
     )
   }
   console.log(`[e2e] canvas_inspect → frame name "${inspectedFrame.name}" OK`)
+
+  // canvas_view (MCP Apps UI-linked tool): structuredContent.scene must be a
+  // renderable {elements} shape — parsed inline here rather than importing
+  // the canvas-viewer package's parseViewerScene from a shell script.
+  const viewed = await callTool('canvas_view', { canvasId: created.id })
+  if (viewed.canvasId !== created.id || !Array.isArray(viewed.scene?.elements)) {
+    throw new Error(`canvas_view returned unexpected shape: ${JSON.stringify(viewed)}`)
+  }
+  if (viewed.scene.elements.length < 1) {
+    throw new Error(`canvas_view returned an empty scene: ${JSON.stringify(viewed)}`)
+  }
+  console.log(`[e2e] canvas_view → scene with ${viewed.scene.elements.length} element(s) OK`)
 
   // version_save labels the current state and returns a versionId. The
   // restore-as-new-canvas flow (formerly the checkpoint pair) is now

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -23,7 +23,7 @@
 // execution, use scripts/smoke/mcp-claude-cli-smoke.mjs.
 
 import { spawn } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import http from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -221,7 +221,7 @@ async function main() {
     'widget',
     'canvas-viewer.html',
   )
-  const expectedWidgetHtml = (await import('node:fs')).readFileSync(widgetHtmlPath, 'utf-8')
+  const expectedWidgetHtml = readFileSync(widgetHtmlPath, 'utf-8')
   const actualWidgetHtml = resourceRead.contents?.[0]?.text
   if (actualWidgetHtml !== expectedWidgetHtml) {
     throw new Error(

--- a/packages/mcp-server/scripts/verify-widget-dist.mjs
+++ b/packages/mcp-server/scripts/verify-widget-dist.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// prepack gate: fails the pack/publish when the canvas-viewer widget was
+// never copied in (see copy-widget-into-dist.mjs). Without this, a `pnpm
+// publish` run against a stale or partial `dist/` would ship a tarball
+// whose ui://whiteboard/canvas-view resource 500s at read time with no
+// build-time signal.
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+export function findMissingWidgetHtml(packageRoot = PACKAGE_ROOT) {
+  const htmlPath = resolve(packageRoot, 'dist', 'widget', 'canvas-viewer.html')
+  return existsSync(htmlPath) ? null : htmlPath
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const missing = findMissingWidgetHtml()
+  if (missing) {
+    console.error(
+      `prepack gate: ${missing} not found — run \`pnpm build\` (canvas-viewer's build:widget + copy-widget-into-dist.mjs) before packing.`,
+    )
+    process.exit(1)
+  }
+  // stderr, not stdout — see verify-web-app-dist.mjs for why.
+  console.error('prepack gate: dist/widget/canvas-viewer.html present — OK')
+}

--- a/packages/mcp-server/scripts/verify-widget-dist.test.ts
+++ b/packages/mcp-server/scripts/verify-widget-dist.test.ts
@@ -1,0 +1,29 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findMissingWidgetHtml } from './verify-widget-dist.mjs'
+
+describe('findMissingWidgetHtml', () => {
+  let packageRoot: string | undefined
+
+  afterEach(() => {
+    if (packageRoot) rmSync(packageRoot, { recursive: true, force: true })
+    packageRoot = undefined
+  })
+
+  it('reports nothing missing when dist/widget/canvas-viewer.html exists', () => {
+    packageRoot = mkdtempSync(join(tmpdir(), 'verify-widget-dist-'))
+    mkdirSync(join(packageRoot, 'dist', 'widget'), { recursive: true })
+    writeFileSync(join(packageRoot, 'dist', 'widget', 'canvas-viewer.html'), '<html></html>')
+
+    expect(findMissingWidgetHtml(packageRoot)).toBeNull()
+  })
+
+  it('reports the missing canvas-viewer.html path when the copy step never ran', () => {
+    packageRoot = mkdtempSync(join(tmpdir(), 'verify-widget-dist-'))
+
+    const missing = findMissingWidgetHtml(packageRoot)
+    expect(missing).toBe(join(packageRoot, 'dist', 'widget', 'canvas-viewer.html'))
+  })
+})

--- a/packages/mcp-server/src/server/mcp/index.test.ts
+++ b/packages/mcp-server/src/server/mcp/index.test.ts
@@ -40,6 +40,7 @@ vi.mock('./tool-registration.js', () => ({
 }))
 vi.mock('../config.js', () => ({
   getDataDir: vi.fn(() => '/tmp/whiteboard-index-test'),
+  WHITEBOARD_ROOT: '/tmp/whiteboard-index-test-root',
 }))
 vi.mock('../observability/tracing.js', () => ({
   initTracing: vi.fn(async () => null),
@@ -53,7 +54,7 @@ vi.mock('./stdio-lifecycle.js', () => ({
 }))
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: vi.fn(function FakeMcpServer(this: Record<string, unknown>) {
-    this.server = {}
+    this.server = { registerCapabilities: vi.fn() }
     this.registerResource = vi.fn()
     this.registerPrompt = vi.fn()
     this.connect = vi.fn(async () => undefined)

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -7,6 +7,7 @@ import { PACKAGE_VERSION } from '../../shared/package-version.js'
 import { getDataDir } from '../config.js'
 import { isDirectEntryPoint } from '../entrypoint.js'
 import { createDaemonClient } from './daemon-client.js'
+import { registerMcpAppsExtension } from './mcp-apps.js'
 import { wireMcpLogging } from './logging.js'
 import { ensureWorkspaceId } from './session-resolver.js'
 import { installStdioLifecycle } from './stdio-lifecycle.js'
@@ -162,6 +163,7 @@ export async function createExcalidrawMcpServer() {
   )
 
   registerAllTools(server, workspaceId, withDaemon)
+  registerMcpAppsExtension(server)
 
   return server
 }

--- a/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Widget HTML fixture lives under WHITEBOARD_ROOT/dist/widget in this test
+// run — module-scope caching means each test must reset the cache and
+// remove any file it wrote so runs don't leak into each other.
+const {
+  registerMcpAppsExtension,
+  resetWidgetHtmlCacheForTests,
+  WIDGET_HTML_PATH,
+  CANVAS_VIEW_RESOURCE_URI,
+  RESOURCE_MIME_TYPE,
+  EXTENSION_ID,
+} = await import('./mcp-apps.js')
+
+function fakeServer() {
+  const registerResource = vi.fn()
+  const registerCapabilities = vi.fn()
+  return {
+    registerResource,
+    server: { registerCapabilities },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal structural fake, cast at call sites
+  } as any
+}
+
+describe('registerMcpAppsExtension', () => {
+  beforeEach(() => {
+    resetWidgetHtmlCacheForTests()
+  })
+
+  afterEach(() => {
+    rmSync(WIDGET_HTML_PATH, { force: true })
+    resetWidgetHtmlCacheForTests()
+  })
+
+  it('declares the io.modelcontextprotocol/ui extension capability', () => {
+    expect(EXTENSION_ID).toBe('io.modelcontextprotocol/ui')
+    const server = fakeServer()
+    registerMcpAppsExtension(server)
+    expect(server.server.registerCapabilities).toHaveBeenCalledWith({
+      extensions: { [EXTENSION_ID]: {} },
+    })
+  })
+
+  it('registers the ui://whiteboard/canvas-view resource with the mcp-app mimeType', () => {
+    const server = fakeServer()
+    registerMcpAppsExtension(server)
+    expect(server.registerResource).toHaveBeenCalledWith(
+      'whiteboard-canvas-view',
+      CANVAS_VIEW_RESOURCE_URI,
+      expect.objectContaining({ mimeType: RESOURCE_MIME_TYPE }),
+      expect.any(Function),
+    )
+    expect(RESOURCE_MIME_TYPE).toBe('text/html;profile=mcp-app')
+  })
+
+  it('reads the widget HTML from WIDGET_HTML_PATH on resources/read', async () => {
+    mkdirSync(dirname(WIDGET_HTML_PATH), { recursive: true })
+    writeFileSync(WIDGET_HTML_PATH, '<html><body>widget</body></html>', 'utf-8')
+
+    const server = fakeServer()
+    registerMcpAppsExtension(server)
+    const readCallback = server.registerResource.mock.calls[0][3]
+    const result = await readCallback()
+
+    expect(result.contents[0]).toEqual({
+      uri: CANVAS_VIEW_RESOURCE_URI,
+      mimeType: RESOURCE_MIME_TYPE,
+      text: '<html><body>widget</body></html>',
+    })
+  })
+
+  it('throws and logs loudly when the widget HTML is missing', async () => {
+    const server = fakeServer()
+    registerMcpAppsExtension(server)
+    const readCallback = server.registerResource.mock.calls[0][3]
+
+    await expect(readCallback()).rejects.toThrow()
+  })
+})

--- a/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
@@ -1,14 +1,15 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Widget HTML fixture lives under WHITEBOARD_ROOT/dist/widget in this test
-// run — module-scope caching means each test must reset the cache and
-// remove any file it wrote so runs don't leak into each other.
+// The widget HTML fixture lives in a per-test temp dir, injected via
+// resetWidgetHtmlCacheForTests — never the real WIDGET_HTML_PATH, whose
+// build output a test must not delete out from under a same-machine
+// smoke run.
 const {
   registerMcpAppsExtension,
   resetWidgetHtmlCacheForTests,
-  WIDGET_HTML_PATH,
   CANVAS_VIEW_RESOURCE_URI,
   RESOURCE_MIME_TYPE,
   EXTENSION_ID,
@@ -25,12 +26,17 @@ function fakeServer() {
 }
 
 describe('registerMcpAppsExtension', () => {
+  let fixtureDir: string
+  let fixtureHtmlPath: string
+
   beforeEach(() => {
-    resetWidgetHtmlCacheForTests()
+    fixtureDir = mkdtempSync(join(tmpdir(), 'mcp-apps-widget-'))
+    fixtureHtmlPath = join(fixtureDir, 'canvas-viewer.html')
+    resetWidgetHtmlCacheForTests(fixtureHtmlPath)
   })
 
   afterEach(() => {
-    rmSync(WIDGET_HTML_PATH, { force: true })
+    rmSync(fixtureDir, { recursive: true, force: true })
     resetWidgetHtmlCacheForTests()
   })
 
@@ -55,9 +61,8 @@ describe('registerMcpAppsExtension', () => {
     expect(RESOURCE_MIME_TYPE).toBe('text/html;profile=mcp-app')
   })
 
-  it('reads the widget HTML from WIDGET_HTML_PATH on resources/read', async () => {
-    mkdirSync(dirname(WIDGET_HTML_PATH), { recursive: true })
-    writeFileSync(WIDGET_HTML_PATH, '<html><body>widget</body></html>', 'utf-8')
+  it('reads the widget HTML from the widget path on resources/read', async () => {
+    writeFileSync(fixtureHtmlPath, '<html><body>widget</body></html>', 'utf-8')
 
     const server = fakeServer()
     registerMcpAppsExtension(server)
@@ -79,7 +84,7 @@ describe('registerMcpAppsExtension', () => {
     await expect(readCallback()).rejects.toThrow('widget asset unavailable')
     // The MCP SDK surfaces a rejected resources/read error's message
     // verbatim to the calling client, so the raw fs ENOENT — which embeds
-    // WIDGET_HTML_PATH — must never be the thrown error itself.
-    await expect(readCallback()).rejects.not.toThrow(WIDGET_HTML_PATH)
+    // the widget's absolute path — must never be the thrown error itself.
+    await expect(readCallback()).rejects.not.toThrow(fixtureHtmlPath)
   })
 })

--- a/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.test.ts
@@ -71,11 +71,15 @@ describe('registerMcpAppsExtension', () => {
     })
   })
 
-  it('throws and logs loudly when the widget HTML is missing', async () => {
+  it('throws a generic error (never the absolute install path) when the widget HTML is missing', async () => {
     const server = fakeServer()
     registerMcpAppsExtension(server)
     const readCallback = server.registerResource.mock.calls[0][3]
 
-    await expect(readCallback()).rejects.toThrow()
+    await expect(readCallback()).rejects.toThrow('widget asset unavailable')
+    // The MCP SDK surfaces a rejected resources/read error's message
+    // verbatim to the calling client, so the raw fs ENOENT — which embeds
+    // WIDGET_HTML_PATH — must never be the thrown error itself.
+    await expect(readCallback()).rejects.not.toThrow(WIDGET_HTML_PATH)
   })
 })

--- a/packages/mcp-server/src/server/mcp/mcp-apps.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { EXTENSION_ID, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
@@ -34,11 +34,14 @@ let cachedWidgetHtml: string | undefined
 
 // Reads and caches the widget HTML at module scope. A per-request McpServer
 // (the HTTP /mcp handler constructs one per request) must not re-read this
-// file from disk on every resources/read call.
-function readWidgetHtml(): string {
+// ~8.5 MB file from disk on every resources/read call, and the read is
+// async so the first request never blocks the event loop on it. Only a
+// successful read is cached — a missing file stays retryable (e.g. a build
+// finishing after the daemon started).
+async function readWidgetHtml(): Promise<string> {
   if (cachedWidgetHtml !== undefined) return cachedWidgetHtml
   try {
-    cachedWidgetHtml = readFileSync(activeWidgetHtmlPath, 'utf-8')
+    cachedWidgetHtml = await readFile(activeWidgetHtmlPath, 'utf-8')
   } catch (err) {
     getLogger('mcp-apps').error(
       { path: activeWidgetHtmlPath, err },
@@ -90,7 +93,7 @@ export function registerMcpAppsExtension(server: McpServer): void {
         {
           uri: CANVAS_VIEW_RESOURCE_URI,
           mimeType: RESOURCE_MIME_TYPE,
-          text: readWidgetHtml(),
+          text: await readWidgetHtml(),
         },
       ],
     }),

--- a/packages/mcp-server/src/server/mcp/mcp-apps.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { EXTENSION_ID, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { getLogger } from '../log.js'
+import { WHITEBOARD_ROOT } from '../config.js'
+
+// Re-exported so callers (tool-registration.ts, tests) share one import
+// source for the MCP Apps (SEP-1865, io.modelcontextprotocol/ui) wire
+// constants instead of reaching into the ext-apps package directly.
+export { EXTENSION_ID, RESOURCE_MIME_TYPE }
+
+// _meta key ext-apps' registerAppTool normalizes `_meta.ui.resourceUri`
+// into for backward compatibility with older hosts. Tool registrations in
+// this codebase set `_meta.ui.resourceUri` directly (the preferred,
+// non-deprecated form) rather than this legacy key.
+export const RESOURCE_URI_META_KEY = 'ui/resourceUri'
+
+// Canonical ui:// resource for the Phase-A read-only canvas view widget.
+// Registered once and linked from tool _meta.ui.resourceUri; the widget
+// itself is the self-contained bundle built by
+// packages/canvas-viewer's `build:widget` script and copied into this
+// package's dist by scripts/copy-widget-into-dist.mjs at build time.
+export const CANVAS_VIEW_RESOURCE_URI = 'ui://whiteboard/canvas-view'
+
+// Resolved relative to WHITEBOARD_ROOT (the package root, not this source
+// file) so the same path works from ts-node/tsx (dev, src/) and from the
+// compiled dist/ layout — see DIST_WEB_APP_DIR in config.ts for the same
+// pattern with apps/web's bundle.
+export const WIDGET_HTML_PATH = resolve(WHITEBOARD_ROOT, 'dist/widget/canvas-viewer.html')
+
+let cachedWidgetHtml: string | undefined
+
+// Reads and caches the widget HTML at module scope. A per-request McpServer
+// (the HTTP /mcp handler constructs one per request) must not re-read this
+// file from disk on every resources/read call.
+function readWidgetHtml(): string {
+  if (cachedWidgetHtml !== undefined) return cachedWidgetHtml
+  try {
+    cachedWidgetHtml = readFileSync(WIDGET_HTML_PATH, 'utf-8')
+  } catch (err) {
+    getLogger('mcp-apps').error(
+      { path: WIDGET_HTML_PATH, err },
+      'canvas-viewer widget HTML missing — run `pnpm build` (packages/canvas-viewer build:widget + copy-widget-into-dist.mjs) before serving ui://whiteboard/canvas-view',
+    )
+    throw err
+  }
+  return cachedWidgetHtml
+}
+
+// Test-only hook: clears the module-scope cache so a test can point
+// WIDGET_HTML_PATH-dependent behavior at a fresh fixture between cases.
+export function resetWidgetHtmlCacheForTests(): void {
+  cachedWidgetHtml = undefined
+}
+
+// Declares MCP Apps (SEP-1865) support and registers the ui:// resource
+// referenced by UI-linked tools' `_meta.ui.resourceUri`. Called once per
+// McpServer instance (both stdio and per-request HTTP /mcp transports),
+// mirroring how registerAllTools is invoked in index.ts.
+export function registerMcpAppsExtension(server: McpServer): void {
+  // The extensions capability field exists on ServerCapabilitiesSchema but
+  // is not yet part of the SDK's typed capabilities options accepted by
+  // the McpServer/Server constructor, so it is declared via the
+  // low-level Server's registerCapabilities() instead of the constructor.
+  server.server.registerCapabilities({
+    extensions: { [EXTENSION_ID]: {} },
+  })
+
+  server.registerResource(
+    'whiteboard-canvas-view',
+    CANVAS_VIEW_RESOURCE_URI,
+    {
+      title: 'Whiteboard canvas view',
+      description:
+        'Read-only interactive Excalidraw canvas view rendered inline in the chat. Pan/zoom/select a scene snapshot; no daemon credentials are ever passed into the widget.',
+      mimeType: RESOURCE_MIME_TYPE,
+    },
+    async () => ({
+      contents: [
+        {
+          uri: CANVAS_VIEW_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: readWidgetHtml(),
+        },
+      ],
+    }),
+  )
+}

--- a/packages/mcp-server/src/server/mcp/mcp-apps.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.ts
@@ -43,7 +43,11 @@ function readWidgetHtml(): string {
       { path: WIDGET_HTML_PATH, err },
       'canvas-viewer widget HTML missing — run `pnpm build` (packages/canvas-viewer build:widget + copy-widget-into-dist.mjs) before serving ui://whiteboard/canvas-view',
     )
-    throw err
+    // The raw fs error message embeds WIDGET_HTML_PATH, the server's
+    // absolute install path — the MCP SDK surfaces this error verbatim to
+    // the calling client, so re-throw a generic message instead. The
+    // detailed path already reached the structured log above.
+    throw new Error('widget asset unavailable')
   }
   return cachedWidgetHtml
 }

--- a/packages/mcp-server/src/server/mcp/mcp-apps.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.ts
@@ -29,6 +29,7 @@ export const CANVAS_VIEW_RESOURCE_URI = 'ui://whiteboard/canvas-view'
 // pattern with apps/web's bundle.
 export const WIDGET_HTML_PATH = resolve(WHITEBOARD_ROOT, 'dist/widget/canvas-viewer.html')
 
+let activeWidgetHtmlPath = WIDGET_HTML_PATH
 let cachedWidgetHtml: string | undefined
 
 // Reads and caches the widget HTML at module scope. A per-request McpServer
@@ -37,10 +38,10 @@ let cachedWidgetHtml: string | undefined
 function readWidgetHtml(): string {
   if (cachedWidgetHtml !== undefined) return cachedWidgetHtml
   try {
-    cachedWidgetHtml = readFileSync(WIDGET_HTML_PATH, 'utf-8')
+    cachedWidgetHtml = readFileSync(activeWidgetHtmlPath, 'utf-8')
   } catch (err) {
     getLogger('mcp-apps').error(
-      { path: WIDGET_HTML_PATH, err },
+      { path: activeWidgetHtmlPath, err },
       'canvas-viewer widget HTML missing — run `pnpm build` (packages/canvas-viewer build:widget + copy-widget-into-dist.mjs) before serving ui://whiteboard/canvas-view',
     )
     // The raw fs error message embeds WIDGET_HTML_PATH, the server's
@@ -52,10 +53,14 @@ function readWidgetHtml(): string {
   return cachedWidgetHtml
 }
 
-// Test-only hook: clears the module-scope cache so a test can point
-// WIDGET_HTML_PATH-dependent behavior at a fresh fixture between cases.
-export function resetWidgetHtmlCacheForTests(): void {
+// Test-only hook: clears the module-scope cache and optionally redirects
+// reads at a temp fixture path. Tests must pass an override instead of
+// writing to the real WIDGET_HTML_PATH — deleting the genuine build output
+// in an afterEach breaks any later same-machine smoke run that expects the
+// built widget to still exist.
+export function resetWidgetHtmlCacheForTests(overridePath?: string): void {
   cachedWidgetHtml = undefined
+  activeWidgetHtmlPath = overridePath ?? WIDGET_HTML_PATH
 }
 
 // Declares MCP Apps (SEP-1865) support and registers the ui:// resource

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -36,6 +36,7 @@ export const ALL_REGISTERED_TOOLS = [
   'canvas_inspect',
   'canvas_list',
   'canvas_open',
+  'canvas_view',
   'create_embed',
   'create_frame',
   'create_pairing_link',
@@ -83,6 +84,7 @@ export const COVERED_TOOLS = [
   'create_frame',
   'create_pairing_link',
   'canvas_inspect',
+  'canvas_view',
   'version_save',
   'version_restore',
   'version_list',
@@ -95,6 +97,12 @@ export const COVERED_TOOLS = [
 ] as const
 
 export const ERROR_PATH_ONLY_TOOLS = ['viewport_set'] as const
+
+// MCP Apps (SEP-1865) UI-linked tools: their registered definition carries
+// `_meta.ui.resourceUri` pointing at CANVAS_VIEW_RESOURCE_URI (mcp-apps.ts).
+// canvas_open and export_canvas are deliberately excluded — see the
+// rationale comment at the canvas_view registration in tool-registration.ts.
+export const UI_LINKED_TOOLS = ['canvas_view'] as const
 
 export const UNIT_ONLY_TOOLS = [
   'align_elements',

--- a/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution-impl.ts
@@ -51,6 +51,14 @@ export function assertTarballFileList(entries: readonly string[]): void {
   if (!entries.includes('package/dist/web-app/index.html')) {
     throw new Error('[tarball-smoke] packed tarball is missing dist/web-app/index.html')
   }
+  // The MCP Apps ui://whiteboard/canvas-view resource (mcp-apps.ts) reads
+  // this file at runtime; a tarball missing it would 500 on resources/read
+  // with no build-time signal otherwise (verify-widget-dist.mjs's prepack
+  // gate only catches a LOCAL build that never ran, not a tarball built
+  // correctly but assembled from the wrong `files` list).
+  if (!entries.includes('package/dist/widget/canvas-viewer.html')) {
+    throw new Error('[tarball-smoke] packed tarball is missing dist/widget/canvas-viewer.html')
+  }
 }
 
 // The installed tarball ships only `dist/`, never `src/`. If the ambient

--- a/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
+++ b/packages/mcp-server/src/server/mcp/tarball.distribution.test.ts
@@ -36,9 +36,10 @@ describe('assertTarballFileList', () => {
     'package/package.json',
     'package/dist/server/mcp/index.js',
     'package/dist/web-app/index.html',
+    'package/dist/widget/canvas-viewer.html',
   ]
 
-  it('passes when dist/web-app/index.html is present and no dist/app/ entries exist', () => {
+  it('passes when dist/web-app/index.html and dist/widget/canvas-viewer.html are present and no dist/app/ entries exist', () => {
     expect(() => assertTarballFileList(validEntries)).not.toThrow()
   })
 
@@ -54,6 +55,14 @@ describe('assertTarballFileList', () => {
     const entries = validEntries.filter((e) => e !== 'package/dist/web-app/index.html')
 
     expect(() => assertTarballFileList(entries)).toThrow(/missing dist\/web-app\/index\.html/)
+  })
+
+  it('throws when dist/widget/canvas-viewer.html is missing', () => {
+    const entries = validEntries.filter((e) => e !== 'package/dist/widget/canvas-viewer.html')
+
+    expect(() => assertTarballFileList(entries)).toThrow(
+      /missing dist\/widget\/canvas-viewer\.html/,
+    )
   })
 })
 

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -25,6 +25,7 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   canvas_list: { profile: READ_ONLY, title: 'List canvases' },
   canvas_open: { profile: READ_ONLY, title: 'Open canvas in browser' },
   canvas_inspect: { profile: READ_ONLY, title: 'Inspect canvas elements' },
+  canvas_view: { profile: READ_ONLY, title: 'Render read-only inline canvas view (MCP Apps)' },
   export_svg: { profile: READ_ONLY, title: 'Export canvas as SVG' },
   export_canvas: { profile: READ_ONLY, title: 'Export canvas (png/svg/json)' },
   list_groups: { profile: READ_ONLY, title: 'List element groups' },

--- a/packages/mcp-server/src/server/mcp/tool-registration.ts
+++ b/packages/mcp-server/src/server/mcp/tool-registration.ts
@@ -23,6 +23,12 @@ import {
   canvasInspectTool,
 } from './tools/canvas-inspect.js'
 import {
+  canvasViewInputShape,
+  canvasViewOutputSchema,
+  canvasViewTool,
+} from './tools/canvas-view.js'
+import { CANVAS_VIEW_RESOURCE_URI } from './mcp-apps.js'
+import {
   canvasCreateInputShape,
   canvasCreateOutputSchema,
   canvasListInputShape,
@@ -192,6 +198,8 @@ function defineTool<
   description?: string
   inputSchema?: I
   outputSchema?: O
+  // MCP Apps (SEP-1865) tool-linkage metadata — see registerToolWithAnnotations.
+  _meta?: Record<string, unknown>
   handler: (
     args: { [K in keyof I]: z.infer<I[K]> },
     extra: Parameters<Parameters<McpServer['registerTool']>[2]>[1],
@@ -205,6 +213,7 @@ function defineTool<
         description: entry.description,
         inputSchema: entry.inputSchema,
         outputSchema: entry.outputSchema,
+        _meta: entry._meta,
       },
       entry.handler,
     )
@@ -245,6 +254,7 @@ export function registerAllTools(
   const userLibMetadataSet = userLibraryMetadataSetTool()
   const userLibMetadataDelete = userLibraryMetadataDeleteTool()
   const inspectTool = canvasInspectTool()
+  const viewTool = canvasViewTool()
   const listTemplates = listTemplatesTool()
   const insertTemplate = insertTemplateTool()
   const updateTool = updateElementTool()
@@ -636,6 +646,24 @@ export function registerAllTools(
       outputSchema: canvasInspectOutputSchema,
       handler: async ({ canvasId }) => {
         const result = await withDaemon((client) => inspectTool.execute({ canvasId }, client))
+        return structuredJsonResult(result)
+      },
+    }),
+
+    defineTool({
+      name: viewTool.name,
+      description: viewTool.description,
+      inputSchema: canvasViewInputShape,
+      outputSchema: canvasViewOutputSchema,
+      // MCP Apps (SEP-1865) linkage: renders inline via the ui:// resource
+      // registered in mcp-apps.ts. canvas_open/export_canvas are
+      // intentionally NOT linked (canvas_open would leak the daemon
+      // baseUrl through the bridge; export_canvas writes files on
+      // refresh) — canvas_view exists specifically to be the safe,
+      // read-only, side-effect-free UI-linked tool.
+      _meta: { ui: { resourceUri: CANVAS_VIEW_RESOURCE_URI } },
+      handler: async ({ canvasId }) => {
+        const result = await withDaemon((client) => viewTool.execute({ canvasId }, client))
         return structuredJsonResult(result)
       },
     }),

--- a/packages/mcp-server/src/server/mcp/tool-support.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-support.test.ts
@@ -1,0 +1,46 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { RESOURCE_URI_META_KEY } from './mcp-apps.js'
+import { registerToolWithAnnotations } from './tool-support.js'
+
+function fakeServer() {
+  const registerTool = vi.fn()
+  return { server: { registerTool }, registerTool } as unknown as McpServer
+}
+
+describe('registerToolWithAnnotations', () => {
+  it('mirrors _meta.ui.resourceUri into the deprecated ui/resourceUri key for older hosts', () => {
+    const server = fakeServer()
+    registerToolWithAnnotations(
+      server,
+      'canvas_view',
+      {
+        outputSchema: z.object({ ok: z.boolean() }),
+        _meta: { ui: { resourceUri: 'ui://whiteboard/canvas-view' } },
+      },
+      async () => ({ structuredContent: { ok: true }, content: [] }),
+    )
+
+    const registerToolMock = vi.mocked(server.registerTool)
+    const config = registerToolMock.mock.calls[0]?.[1] as { _meta?: Record<string, unknown> }
+    expect(config._meta).toEqual({
+      ui: { resourceUri: 'ui://whiteboard/canvas-view' },
+      [RESOURCE_URI_META_KEY]: 'ui://whiteboard/canvas-view',
+    })
+  })
+
+  it('leaves _meta untouched for tools without MCP Apps UI linkage', () => {
+    const server = fakeServer()
+    registerToolWithAnnotations(
+      server,
+      'canvas_open',
+      { outputSchema: z.object({ ok: z.boolean() }) },
+      async () => ({ structuredContent: { ok: true }, content: [] }),
+    )
+
+    const registerToolMock = vi.mocked(server.registerTool)
+    const config = registerToolMock.mock.calls[0]?.[1] as { _meta?: Record<string, unknown> }
+    expect(config._meta).toBeUndefined()
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tool-support.ts
+++ b/packages/mcp-server/src/server/mcp/tool-support.ts
@@ -53,6 +53,11 @@ export function registerToolWithAnnotations<
     description?: string
     inputSchema?: I
     outputSchema?: O
+    // MCP Apps (SEP-1865) tool-linkage metadata, e.g.
+    // `{ ui: { resourceUri: 'ui://whiteboard/canvas-view' } }`. Passed
+    // through to server.registerTool untouched — see mcp-apps.ts for the
+    // resource this links against.
+    _meta?: Record<string, unknown>
   },
   handler: (
     args: { [K in keyof I]: z.infer<I[K]> },

--- a/packages/mcp-server/src/server/mcp/tool-support.ts
+++ b/packages/mcp-server/src/server/mcp/tool-support.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { getLogger } from '../log.js'
+import { RESOURCE_URI_META_KEY } from './mcp-apps.js'
 import { getTracer } from '../observability/tracing.js'
 import { MUTATING, TOOL_PROFILES } from './tool-profiles.js'
 
@@ -54,9 +55,10 @@ export function registerToolWithAnnotations<
     inputSchema?: I
     outputSchema?: O
     // MCP Apps (SEP-1865) tool-linkage metadata, e.g.
-    // `{ ui: { resourceUri: 'ui://whiteboard/canvas-view' } }`. Passed
-    // through to server.registerTool untouched — see mcp-apps.ts for the
-    // resource this links against.
+    // `{ ui: { resourceUri: 'ui://whiteboard/canvas-view' } }` — see
+    // mcp-apps.ts for the resource this links against. A `ui.resourceUri`
+    // here is additionally mirrored into the deprecated
+    // `["ui/resourceUri"]` key below before reaching server.registerTool.
     _meta?: Record<string, unknown>
   },
   handler: (
@@ -72,6 +74,19 @@ export function registerToolWithAnnotations<
   const annotations = profile
     ? { ...profile.profile, title: profile.title }
     : { ...MUTATING, title: name }
+  // Mirror the modern `_meta.ui.resourceUri` MCP Apps (SEP-1865) linkage
+  // into the deprecated `_meta["ui/resourceUri"]` key too, matching what
+  // the ext-apps package's own registerAppTool does — a host built before
+  // ui.resourceUri was standardized only reads the legacy key.
+  const uiMeta = config._meta?.ui
+  const resourceUri =
+    uiMeta !== null && typeof uiMeta === 'object' && 'resourceUri' in uiMeta
+      ? (uiMeta as { resourceUri?: unknown }).resourceUri
+      : undefined
+  const meta =
+    typeof resourceUri === 'string'
+      ? { ...config._meta, [RESOURCE_URI_META_KEY]: resourceUri }
+      : config._meta
   // Wrap the handler so thrown errors become isError responses, and so
   // every tool call is observable as a single MCP-semconv span.
   const tracedHandler = async (
@@ -129,5 +144,5 @@ export function registerToolWithAnnotations<
   }
   return (
     server.registerTool as unknown as (n: string, c: object, h: typeof outerHandler) => unknown
-  )(name, { ...config, annotations }, outerHandler)
+  )(name, { ...config, _meta: meta, annotations }, outerHandler)
 }

--- a/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
@@ -1,0 +1,60 @@
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import type { DaemonClient } from '../daemon-client.js'
+import { canvasViewOutputSchema, canvasViewTool } from './canvas-view.js'
+
+function fakeClientWithElements(elements: Array<Record<string, unknown>>): DaemonClient {
+  const doc = new LoroDoc()
+  const list = doc.getMovableList('elements')
+  for (const el of elements) list.push(el)
+  const bytes = doc.export({ mode: 'snapshot' })
+  return {
+    request: async (path: string) => {
+      expect(path).toBe('/api/canvas/ws1/slug1/snapshot')
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      } as unknown as Response
+    },
+  } as unknown as DaemonClient
+}
+
+describe('canvas_view tool', () => {
+  it('returns a scene matching the strict {elements} viewer contract', async () => {
+    const client = fakeClientWithElements([
+      { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
+    ])
+    const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
+    expect(canvasViewOutputSchema.parse(result)).toEqual(result)
+    expect(result.scene.elements).toHaveLength(1)
+    expect(result.scene.elements[0]).toMatchObject({ id: 'a', type: 'rectangle' })
+  })
+
+  it('drops deleted (tombstoned) elements from the rendered scene', async () => {
+    const client = fakeClientWithElements([
+      { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
+      { id: 'b', type: 'rectangle', x: 0, y: 0, width: 10, height: 10, isDeleted: true },
+    ])
+    const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
+    expect(result.scene.elements.map((e) => e.id)).toEqual(['a'])
+  })
+
+  it('never includes daemon credentials or a base URL in its structuredContent', async () => {
+    const client = fakeClientWithElements([
+      { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
+    ])
+    const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toMatch(/token|baseUrl|http:\/\/|https:\/\//i)
+  })
+
+  it('throws a loud error when the snapshot fetch fails', async () => {
+    const client = {
+      request: async () => ({ ok: false, status: 404, statusText: 'Not Found' }) as Response,
+    } as unknown as DaemonClient
+    await expect(canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)).rejects.toThrow()
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { parseViewerScene } from '@kamiazya/whiteboard-canvas-viewer/scene'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonClient } from '../daemon-client.js'
@@ -52,6 +53,11 @@ describe('canvas_view tool', () => {
     ])
     const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
     expect(canvasViewOutputSchema.parse(result)).toEqual(result)
+    // Consumer-side contract: the widget feeds result.scene straight into
+    // the viewer package's parseViewerScene, so producer-schema validity
+    // alone is not enough — the same value must survive the strict viewer
+    // parser or the widget would reject what this tool ships.
+    expect(() => parseViewerScene(result.scene)).not.toThrow()
     expect(result.scene.elements).toHaveLength(1)
     expect(result.scene.elements[0]).toMatchObject({ id: 'a', type: 'rectangle' })
   })

--- a/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-view.test.ts
@@ -1,7 +1,22 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { LoroDoc } from 'loro-crdt'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonClient } from '../daemon-client.js'
-import { canvasViewOutputSchema, canvasViewTool } from './canvas-view.js'
+
+let tempDataDir: string
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tempDataDir
+  },
+  getDataDir: () => tempDataDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { canvasViewOutputSchema, canvasViewTool } = await import('./canvas-view.js')
 
 function fakeClientWithElements(elements: Array<Record<string, unknown>>): DaemonClient {
   const doc = new LoroDoc()
@@ -23,6 +38,14 @@ function fakeClientWithElements(elements: Array<Record<string, unknown>>): Daemo
 }
 
 describe('canvas_view tool', () => {
+  beforeEach(async () => {
+    tempDataDir = await mkdtemp(join(tmpdir(), 'whiteboard-canvas-view-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDataDir, { recursive: true, force: true })
+  })
+
   it('returns a scene matching the strict {elements} viewer contract', async () => {
     const client = fakeClientWithElements([
       { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
@@ -56,5 +79,35 @@ describe('canvas_view tool', () => {
       request: async () => ({ ok: false, status: 404, statusText: 'Not Found' }) as Response,
     } as unknown as DaemonClient
     await expect(canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)).rejects.toThrow()
+  })
+
+  it('embeds the referenced binary as a dataURL for an image element', async () => {
+    // load_image stores image bytes on disk at
+    // getDataDir()/{workspaceId}/files/{fileId}{ext}; the widget has no
+    // daemon access, so canvas_view must inline them into `scene.files`
+    // the same way headless-export's buildExportScene does.
+    await mkdir(join(tempDataDir, 'ws1', 'files'), { recursive: true })
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    await writeFile(join(tempDataDir, 'ws1', 'files', 'file-1.png'), pngBytes)
+
+    const client = fakeClientWithElements([
+      { id: 'img', type: 'image', x: 0, y: 0, width: 10, height: 10, fileId: 'file-1' },
+    ])
+    const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
+
+    expect(canvasViewOutputSchema.parse(result)).toEqual(result)
+    expect(result.scene.files['file-1']).toMatchObject({
+      id: 'file-1',
+      mimeType: 'image/png',
+      dataURL: `data:image/png;base64,${pngBytes.toString('base64')}`,
+    })
+  })
+
+  it('returns an empty files map when no element references a binary file', async () => {
+    const client = fakeClientWithElements([
+      { id: 'a', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 },
+    ])
+    const result = await canvasViewTool().execute({ canvasId: 'ws1/slug1' }, client)
+    expect(result.scene.files).toEqual({})
   })
 })

--- a/packages/mcp-server/src/server/mcp/tools/canvas-view.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-view.ts
@@ -3,18 +3,30 @@ import { z } from 'zod'
 import { resolveParentedElements } from '../../../shared/resolve-parented-elements.js'
 import { loroRawElementSchema, validateLoroRawElements } from '../../../shared/loro-raw-element.js'
 import { getLogger } from '../../log.js'
+import { loadCanvasFiles } from '../../export/load-canvas-files.js'
 import type { DaemonClient } from '../daemon-client.js'
 import { parseCanvasId } from './canvas-id.js'
 
 // Scene shape mirrors packages/canvas-viewer's viewerSceneSchema
 // ({elements, appState?, files?}, .strict()) so the widget's
 // parseViewerScene accepts this structuredContent verbatim — no adapter
-// layer between this tool and the widget. appState/files are omitted here
-// (undefined, not present) because the daemon's Loro document only
-// persists the elements list; the widget falls back to its own defaults.
+// layer between this tool and the widget. appState is omitted (undefined,
+// not present) because the daemon's Loro document only persists the
+// elements list; the widget falls back to its own defaults. `files` IS
+// populated below — an image element only carries a `fileId` (the binary
+// lives on disk, see load_image), so without it the widget would render
+// broken/unresolved images for any canvas containing one.
+const canvasViewFileSchema = z.object({
+  mimeType: z.string(),
+  id: z.string(),
+  dataURL: z.string(),
+  created: z.number(),
+})
+
 const canvasViewSceneSchema = z
   .object({
     elements: z.array(loroRawElementSchema),
+    files: z.record(z.string(), canvasViewFileSchema),
   })
   .strict()
 
@@ -62,7 +74,20 @@ export function canvasViewTool() {
       })
       const resolved = resolveParentedElements(validated)
       const elements = resolved.filter((el) => el.isDeleted !== true)
-      return { canvasId: args.canvasId, scene: { elements } }
+
+      // Mirror headless-export.ts's buildExportScene: image elements only
+      // carry a fileId, so the referenced binaries must be loaded and
+      // embedded as dataURLs — the sandboxed widget has no daemon access
+      // to fetch them itself.
+      const referencedFileIds = new Set<string>()
+      for (const el of elements as Array<Record<string, unknown>>) {
+        if (el.type !== 'image') continue
+        const fileId = el.fileId
+        if (typeof fileId === 'string' && fileId.length > 0) referencedFileIds.add(fileId)
+      }
+      const files = await loadCanvasFiles(workspaceId, referencedFileIds)
+
+      return { canvasId: args.canvasId, scene: { elements, files } }
     },
   }
 }

--- a/packages/mcp-server/src/server/mcp/tools/canvas-view.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-view.ts
@@ -1,0 +1,68 @@
+import { LoroDoc } from 'loro-crdt'
+import { z } from 'zod'
+import { resolveParentedElements } from '../../../shared/resolve-parented-elements.js'
+import { loroRawElementSchema, validateLoroRawElements } from '../../../shared/loro-raw-element.js'
+import { getLogger } from '../../log.js'
+import type { DaemonClient } from '../daemon-client.js'
+import { parseCanvasId } from './canvas-id.js'
+
+// Scene shape mirrors packages/canvas-viewer's viewerSceneSchema
+// ({elements, appState?, files?}, .strict()) so the widget's
+// parseViewerScene accepts this structuredContent verbatim — no adapter
+// layer between this tool and the widget. appState/files are omitted here
+// (undefined, not present) because the daemon's Loro document only
+// persists the elements list; the widget falls back to its own defaults.
+const canvasViewSceneSchema = z
+  .object({
+    elements: z.array(loroRawElementSchema),
+  })
+  .strict()
+
+export const canvasViewOutputSchema = z.object({
+  canvasId: z.string(),
+  scene: canvasViewSceneSchema,
+})
+
+export const canvasViewInputShape = {
+  canvasId: z
+    .string()
+    .describe(
+      'Canvas ID in "{workspaceId}/{slug}" form. Returns a read-only scene snapshot (elements only, no daemon credentials) rendered as an interactive canvas view inline in the chat.',
+    ),
+} satisfies z.ZodRawShape
+
+export function canvasViewTool() {
+  return {
+    name: 'canvas_view',
+    description:
+      'Render a read-only, interactive view of a whiteboard canvas inline in the chat (MCP Apps ui:// widget). Returns the current scene snapshot; the widget can pan/zoom/select but never mutates the canvas or receives daemon credentials.',
+    inputSchema: z.toJSONSchema(z.object(canvasViewInputShape)) as {
+      type: 'object'
+      properties: Record<string, unknown>
+      required?: string[]
+    },
+    execute: async (
+      args: { canvasId: string },
+      client: DaemonClient,
+    ): Promise<z.infer<typeof canvasViewOutputSchema>> => {
+      const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      const res = await client.request(
+        `/api/canvas/${workspaceId}/${encodeURIComponent(slug)}/snapshot`,
+      )
+      if (!res.ok) {
+        throw new Error(`Failed to fetch snapshot: ${res.status} ${res.statusText}`)
+      }
+      const bytes = new Uint8Array(await res.arrayBuffer())
+      const doc = new LoroDoc()
+      doc.import(bytes)
+      const raw = doc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+      const log = getLogger('canvas-view')
+      const validated = validateLoroRawElements(raw, ({ index, error }) => {
+        log.warning({ index, reason: error.issues[0]?.message }, 'dropped corrupt element')
+      })
+      const resolved = resolveParentedElements(validated)
+      const elements = resolved.filter((el) => el.isDeleted !== true)
+      return { canvasId: args.canvasId, scene: { elements } }
+    },
+  }
+}

--- a/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
@@ -1,0 +1,76 @@
+// Regression test that ensures UI_LINKED_TOOLS (mcp-smoke-coverage.ts) stays
+// in sync with the actual `_meta.ui.resourceUri` declarations in
+// tool-registration.ts, and that the security-sensitive exclusions
+// (canvas_open, export_canvas) are never accidentally linked.
+//
+// Verification strategy mirrors tool-annotations.test.ts: read the
+// registration source directly rather than instantiating a real McpServer,
+// so this test does not depend on daemon/transport wiring.
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { ALL_REGISTERED_TOOLS, UI_LINKED_TOOLS } from './mcp-smoke-coverage.js'
+import { RESOURCE_MIME_TYPE } from './mcp-apps.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const registrationSrc = readFileSync(resolve(__dirname, 'tool-registration.ts'), 'utf-8')
+
+// Splits tool-registration.ts's `tools: RegisteredTool[]` array into one
+// chunk per defineTool({...}) entry so each entry's _meta can be checked
+// independently of the others.
+function splitDefineToolEntries(src: string): string[] {
+  const marker = '\n    defineTool({'
+  return src
+    .split(marker)
+    .slice(1)
+    .map((chunk) => marker.slice(1) + chunk)
+}
+
+function toolNameOf(entry: string): string | null {
+  const m = entry.match(/name:\s*([a-zA-Z0-9_]+)\.name,/)
+  return m ? m[1] : null
+}
+
+describe('MCP Apps UI-linked tools coverage', () => {
+  it('UI_LINKED_TOOLS is a subset of ALL_REGISTERED_TOOLS', () => {
+    for (const name of UI_LINKED_TOOLS) {
+      expect(ALL_REGISTERED_TOOLS as readonly string[]).toContain(name)
+    }
+  })
+
+  it('every entry with `_meta: { ui:` in tool-registration.ts references the registered resource URI constant', () => {
+    // tool-registration.ts imports CANVAS_VIEW_RESOURCE_URI from mcp-apps.js
+    // rather than inlining the literal, so this checks the source uses that
+    // identifier — and mcp-apps.test.ts separately locks the constant's
+    // value to the URI actually passed to server.registerResource().
+    expect(registrationSrc).toMatch(
+      /import\s*\{\s*CANVAS_VIEW_RESOURCE_URI\s*\}\s*from\s*'\.\/mcp-apps\.js'/,
+    )
+    const entries = splitDefineToolEntries(registrationSrc)
+    const uiLinkedEntries = entries.filter((e) => /_meta:\s*\{\s*ui:/.test(e))
+    expect(uiLinkedEntries.length).toBeGreaterThan(0)
+    for (const entry of uiLinkedEntries) {
+      expect(entry).toContain('CANVAS_VIEW_RESOURCE_URI')
+    }
+    // Sanity: RESOURCE_MIME_TYPE is what the resource is served with,
+    // confirming this test imports from the same authoritative module.
+    expect(RESOURCE_MIME_TYPE).toBe('text/html;profile=mcp-app')
+  })
+
+  it('canvas_open and export_canvas are explicitly NOT UI-linked', () => {
+    const entries = splitDefineToolEntries(registrationSrc)
+    for (const forbidden of ['openTool', 'exportCanvas']) {
+      const entry = entries.find((e) => new RegExp(`name:\\s*${forbidden}\\.name,`).test(e))
+      expect(entry, `expected a defineTool entry for ${forbidden}`).toBeDefined()
+      expect(entry).not.toMatch(/_meta:\s*\{\s*ui:/)
+    }
+  })
+
+  it('canvas_view is the only tool with a defineTool entry carrying `_meta.ui`', () => {
+    const entries = splitDefineToolEntries(registrationSrc)
+    const linkedNames = entries.filter((e) => /_meta:\s*\{\s*ui:/.test(e)).map((e) => toolNameOf(e))
+    expect(linkedNames).toEqual(['viewTool'])
+  })
+})

--- a/packages/mcp-server/src/server/release/package-shape.test.ts
+++ b/packages/mcp-server/src/server/release/package-shape.test.ts
@@ -23,8 +23,10 @@ describe('packages/mcp-server package shape (legacy build pipeline retired)', ()
     expect(mcpPackage.scripts?.['build:app']).toBeUndefined()
   })
 
-  it('build is build:server only', () => {
-    expect(mcpPackage.scripts?.build).toBe('pnpm build:server')
+  it('build runs build:server plus the MCP Apps widget copy step, nothing else', () => {
+    expect(mcpPackage.scripts?.build).toBe(
+      'pnpm build:server && node scripts/copy-widget-into-dist.mjs',
+    )
   })
 
   it('dev does not spawn vite', () => {

--- a/packages/mcp-server/src/server/release/verify-pack-contents.test.ts
+++ b/packages/mcp-server/src/server/release/verify-pack-contents.test.ts
@@ -44,6 +44,7 @@ const VALID_ENTRY = {
     { path: 'LICENSE' },
     { path: 'package.json' },
     { path: 'dist/server/mcp/index.js' },
+    { path: 'dist/widget/canvas-viewer.html' },
   ],
 }
 
@@ -59,11 +60,17 @@ describe('verifyPackContents (pure core)', () => {
     expect(result.ok).toBe(true)
     expect(result.missing).toEqual([])
     expect(result.forbidden).toEqual([])
-    expect(result.fileCount).toBe(4)
+    expect(result.fileCount).toBe(5)
     expect(result.sizeBytes).toBe(1024)
   })
 
-  for (const required of ['README.md', 'LICENSE', 'package.json', 'dist/server/mcp/index.js']) {
+  for (const required of [
+    'README.md',
+    'LICENSE',
+    'package.json',
+    'dist/server/mcp/index.js',
+    'dist/widget/canvas-viewer.html',
+  ]) {
     it(`flags ${required} as missing when it is absent`, async () => {
       const { verifyPackContents } = await importModule()
       const entry = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@excalidraw/excalidraw':
         specifier: 'catalog:'
         version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@modelcontextprotocol/ext-apps':
+        specifier: 1.7.4
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       react:
         specifier: 'catalog:'
         version: 19.2.5
@@ -273,6 +276,9 @@ importers:
       '@libsql/kysely-libsql':
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.17)
+      '@modelcontextprotocol/ext-apps':
+        specifier: 1.7.4
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ~1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -361,6 +367,9 @@ importers:
       '@fast-check/vitest':
         specifier: ^0.4.1
         version: 0.4.1(vitest@4.1.9)
+      '@kamiazya/whiteboard-canvas-viewer':
+        specifier: workspace:*
+        version: link:../canvas-viewer
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.18
         version: 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1980,6 +1989,20 @@ packages:
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@modelcontextprotocol/ext-apps@1.7.4':
+    resolution: {integrity: sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -6366,10 +6389,6 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
-
   side-channel@1.1.1:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
@@ -8310,7 +8329,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.9)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.3(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -8800,11 +8819,20 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -10785,14 +10813,9 @@ snapshots:
       uri-js: 4.4.1
     optional: true
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
-
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-    optional: true
 
   ajv@8.18.0:
     dependencies:
@@ -13127,7 +13150,7 @@ snapshots:
 
   qs@6.15.2:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -13567,14 +13590,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   side-channel@1.1.1:
     dependencies:

--- a/tools/checks/src/verify-pack-contents.mjs
+++ b/tools/checks/src/verify-pack-contents.mjs
@@ -27,7 +27,16 @@ Options:
   -h, --help   Show this help and exit.
 `
 
-const REQUIRED_FILES = ['README.md', 'LICENSE', 'package.json', 'dist/server/mcp/index.js']
+const REQUIRED_FILES = [
+  'README.md',
+  'LICENSE',
+  'package.json',
+  'dist/server/mcp/index.js',
+  // The MCP Apps ui://whiteboard/canvas-view resource (mcp-apps.ts) reads
+  // this file at runtime; a tarball missing it would 500 on resources/read
+  // with no build-time signal otherwise.
+  'dist/widget/canvas-viewer.html',
+]
 
 // Deliberately does NOT include \.map$ — the packaged tarball legitimately
 // ships hundreds of source maps (dist/**/*.js.map); a promise to exclude


### PR DESCRIPTION
## Summary

Phase A of MCP Apps (SEP-1865, `io.modelcontextprotocol/ui`) support: a read-only `canvas_view` tool that renders a whiteboard canvas inline in the host's chat as a `ui://` HTML widget.

- **`canvas_view` tool** (`packages/mcp-server`): returns `{canvasId, scene}` via Zod `outputSchema` (`z.infer` end to end), declares `_meta.ui.resourceUri` (+ legacy `ui/resourceUri` mirror), and the server declares the `io.modelcontextprotocol/ui` extension capability.
- **`ui://whiteboard/canvas-view` resource**: serves the self-contained single-file widget HTML (`text/html;profile=mcp-app`, ~8.5 MB, zero external requests) with a module-level cache.
- **Widget bridge** (`packages/canvas-viewer`): `@modelcontextprotocol/ext-apps` `App` bootstrap — receives the scene via `ui/notifications/tool-result`, falls back to the embedded-scene slot when no host answers within 2 s. The widget never receives daemon credentials; scene data only.
- **Build/packaging**: widget built by `vite-plugin-singlefile` (base64 woff2 + FontFace + scoped fetch shim), copied into mcp-server `dist/` (`copy-widget-into-dist.mjs` + `verify-widget-dist.mjs`), pack expectations + `smoke:e2e` extended, docs how-to page added.

## Real-client verification (MCPJam)

Verified against MCPJam Inspector as a real ext-apps host (not only the smoke harness). Wire format PASS: extension capability in `initialize`, `_meta` on `tools/list`, resource served with the mcp-app profile. The live run caught **three host-integration bugs** invisible to unit/smoke layers, all fixed here:

1. **srcdoc bootstrap crash** — `new URL('.', location.href)` throws under sandboxed `srcdoc` iframes (`about:srcdoc` is not a URL), killing the whole widget. Now resolved via a fallback chain (`location.href` → `document.baseURI` → fixed inert prefix).
2. **Double React root crash** — a tool-result arriving after the embedded-scene fallback mounted created a second `createRoot` on the same container (`removeChild` NotFoundError). Every bridge mount now routes through one remount callback that disposes the live handle and clears the container first.
3. **Host auto-resize feedback loop** — inline hosts size the iframe to the document scroll height; a `100vh` root grew with each measurement (observed 3400 px → 9650 px, unbounded). The shell now declares a fixed 480 px root with clipped overflow; a node-layer regression test bans viewport-relative units in the shell. Iframe height verified stable at 482 px across repeated measurements.

Remaining console noise in the host is expected: 404s for font subsets this bundle deliberately does not embed (CJK Xiaolai) requested by Excalidraw's own CSS-level loader — the widget degrades to fallback glyphs per design, and JP text still renders (see screenshot).

## Visual repro

`canvas_view` on the seeded demo canvas, rendered inline in MCPJam's chat (Excalifont + JP text, boxes + arrow, stable 482 px inline frame):

![mcp-apps-canvas-view-render.png](https://github.com/user-attachments/assets/cf866c04-5ff5-474d-82c7-4f86521812d9)

## Tests

- `canvas-viewer`: node 43 ✓ (incl. new shell-height regression, mutation-checked red on revert), jsdom 16 ✓, browser 2 ✓, widget smoke ✓ (zero network requests, fonts, JP fallback)
- `mcp-server`: typecheck ✓, mcp-node 3703 ✓
- `smoke:e2e` extended to call `canvas_view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WyfrPAJrHB3bWZMrRQMry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only `canvas_view` tool for displaying interactive canvas snapshots inline in MCP Apps-compatible chat clients.
  * Added MCP Apps integration and packaged the canvas viewer widget with the server.
  * Added documentation explaining setup, requirements, supported functionality, and example usage.

* **Bug Fixes**
  * Improved embedded viewer sizing to prevent uncontrolled iframe growth and overflow issues.

* **Tests**
  * Added coverage for canvas rendering, widget delivery, packaging, tool registration, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->