### PR TITLE
feat(canvas-viewer): add widget Refresh bridged through the MCP Apps host session

### DIFF
--- a/docs/how-to/view-canvas-in-chat.md
+++ b/docs/how-to/view-canvas-in-chat.md
@@ -16,19 +16,29 @@ no need to switch to a browser tab to see what the agent drew.
   all Excalidraw assets are inlined), so the client's CSP for the view can stay at its
   strictest default.
 
+## Refreshing the view
+
+On clients whose MCP Apps host advertises the `serverTools` capability, the widget
+shows a small **Refresh** button once the initial `canvas_view` result has loaded. It
+re-invokes `canvas_view` for the same `canvasId` through the host and swaps in the
+latest scene — you do not need to leave the chat or call the tool again by hand. On
+clients that do not advertise `serverTools`, or when the widget cannot confirm a host
+connection at all, the button never appears; call `canvas_view` again to see a fresh
+snapshot instead.
+
 ## What you do not get (yet)
 
 This is **Phase A** of MCP Apps support:
 
-- The view is **read-only**. There is no in-widget editing, annotation, or refresh
-  button yet — call `canvas_view` again to see a fresh snapshot.
+- The view is otherwise **read-only** — Refresh reloads the current scene, but there
+  is no in-widget editing or annotation.
 - Only `canvas_view` renders inline. `canvas_open` (opens the full editor in a real
   browser tab) and `export_canvas` (writes a file) are intentionally **not**
   UI-linked — `canvas_open` would need to pass the daemon's base URL into the widget,
   and `export_canvas` has a file-write side effect that a UI "refresh" action should
   never trigger silently.
-- Live sync (the view updating as the agent keeps drawing, without calling the tool
-  again) is a future phase.
+- Live sync (the view updating as the agent keeps drawing, without you or the widget
+  calling the tool again) is a future phase.
 
 ## Requirements
 

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -161,6 +161,19 @@ async function main() {
     await page.goto(`file://${tmpHtmlPath}`)
     await page.waitForSelector('canvas', { timeout: 10_000 })
 
+    // No embedding host peer (file:// top-level load: window.parent ===
+    // window), so widget-entry's Refresh control must never be created —
+    // asserting this here, rather than only via jsdom mocks, catches the
+    // control leaking into the no-host document under the real bundle.
+    const hasRefreshControl = await page.evaluate(
+      () => document.querySelector('[data-testid="widget-refresh"]') !== null,
+    )
+    if (hasRefreshControl) {
+      fail(
+        'expected no Refresh control without an embedding host (file:// load has no parent frame)',
+      )
+    }
+
     const fontCheck = await page.evaluate(async (text) => {
       await document.fonts.ready
       // window.__whiteboardWidgetFonts__ (see widget-entry.ts) is exactly

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -8,17 +8,26 @@ import { parseViewerScene } from './scene.js'
 interface FakeAppInstance {
   ontoolresult?: (result: unknown) => void
   connect: () => Promise<void>
+  callServerTool: (params: unknown) => Promise<unknown>
 }
 
 const connectMock = vi.fn()
+const callServerToolMock = vi.fn()
 const fakeAppInstances: FakeAppInstance[] = []
 
 vi.mock('@modelcontextprotocol/ext-apps', () => ({
   App: vi.fn(function FakeApp(this: FakeAppInstance) {
     fakeAppInstances.push(this)
     this.connect = connectMock
+    this.callServerTool = callServerToolMock
   }),
 }))
+
+const REFRESH_SELECTOR = '[data-testid="widget-refresh"]'
+
+function queryRefreshButton(): HTMLButtonElement | null {
+  return document.querySelector(REFRESH_SELECTOR)
+}
 
 vi.mock('./mount.js', () => ({
   mountCanvasViewer: vi.fn(() => ({ dispose: vi.fn() })),
@@ -59,6 +68,7 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
     document.body.innerHTML = '<div id="root"></div>'
     fakeAppInstances.length = 0
     connectMock.mockReset()
+    callServerToolMock.mockReset()
     // The mount.js mock module instance persists across vi.resetModules()
     // calls (only the real module graph is reset), so its call history
     // must be cleared explicitly between tests.
@@ -225,5 +235,285 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
     const hostHandle = vi.mocked(mountCanvasViewer).mock.results[0]?.value
     expect(hostHandle.dispose).not.toHaveBeenCalled()
     vi.useRealTimers()
+  })
+
+  it('has no Refresh control when there is no parent frame', async () => {
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(queryRefreshButton()).toBeNull()
+  })
+
+  it('has no Refresh control when host connect() times out', async () => {
+    vi.useFakeTimers()
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(() => new Promise(() => {})) // never resolves
+
+    await importFreshWidgetEntry()
+    await vi.advanceTimersByTimeAsync(2_100)
+
+    expect(queryRefreshButton()).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('reveals Refresh only after connecting AND a valid tool-result commits a canvasId', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Connected, but no tool-result yet: control is either absent or hidden.
+    const beforeResult = queryRefreshButton()
+    if (beforeResult) {
+      expect(beforeResult.style.display).toBe('none')
+    }
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    const button = queryRefreshButton()
+    expect(button).not.toBeNull()
+    expect(button?.style.display).toBe('block')
+  })
+
+  it('keeps Refresh absent when a tool-result mounts before the timeout wins the connect race, even after a late connect resolution or further late results', async () => {
+    vi.useFakeTimers()
+    stubEmbeddedIframeParent()
+    let resolveConnect: (() => void) | undefined
+    connectMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve
+        }),
+    )
+
+    await importFreshWidgetEntry()
+    const scene = { elements: [{ id: 'c' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    await vi.advanceTimersByTimeAsync(2_100)
+    expect(queryRefreshButton()).toBeNull()
+
+    resolveConnect?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(queryRefreshButton()).toBeNull()
+
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+    expect(queryRefreshButton()).toBeNull()
+
+    vi.useRealTimers()
+  })
+
+  it('never commits canvasId or reveals Refresh from a tool-result carrying a malformed scene', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    fakeAppInstances[0].ontoolresult?.({
+      structuredContent: { canvasId: 'wrong', scene: { bogus: true } },
+    })
+    // Connected already, so the control exists but must stay hidden — it is
+    // not absent from the DOM, just never revealed by an unvalidated result.
+    const hiddenButton = queryRefreshButton()
+    if (hiddenButton) {
+      expect(hiddenButton.style.display).toBe('none')
+    }
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/right', scene } })
+    expect(queryRefreshButton()?.style.display).toBe('block')
+  })
+
+  it('clicking Refresh calls callServerTool with the committed canvasId and remounts on a valid result', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene1 = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({
+      structuredContent: { canvasId: 'ws/slug', scene: scene1 },
+    })
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    const initialHandle = vi.mocked(mountCanvasViewer).mock.results[0]?.value
+    vi.mocked(mountCanvasViewer).mockClear()
+
+    const scene2 = { elements: [{ id: 'b' }] }
+    callServerToolMock.mockResolvedValueOnce({
+      structuredContent: { canvasId: 'ws/slug', scene: scene2 },
+    })
+
+    const button = queryRefreshButton()
+    button?.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(callServerToolMock).toHaveBeenCalledTimes(1)
+    expect(callServerToolMock).toHaveBeenCalledWith({
+      name: 'canvas_view',
+      arguments: { canvasId: 'ws/slug' },
+    })
+    expect(initialHandle.dispose).toHaveBeenCalledTimes(1)
+    expect(mountCanvasViewer).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ scene: scene2 }),
+    )
+  })
+
+  it('keeps the current view and resets the in-flight guard when callServerTool rejects', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    vi.mocked(mountCanvasViewer).mockClear()
+
+    callServerToolMock.mockRejectedValueOnce(new Error('boom'))
+    const button = queryRefreshButton() as HTMLButtonElement
+    button.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mountCanvasViewer).not.toHaveBeenCalled()
+    expect(button.disabled).toBe(false)
+
+    const scene2 = { elements: [{ id: 'b' }] }
+    callServerToolMock.mockResolvedValueOnce({
+      structuredContent: { canvasId: 'ws/slug', scene: scene2 },
+    })
+    button.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(callServerToolMock).toHaveBeenCalledTimes(2)
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the current view and resets the guard when callServerTool resolves with a malformed scene', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    vi.mocked(mountCanvasViewer).mockClear()
+
+    callServerToolMock.mockResolvedValueOnce({
+      structuredContent: { canvasId: 'ws/slug', scene: { bogus: true } },
+    })
+    const button = queryRefreshButton() as HTMLButtonElement
+    button.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mountCanvasViewer).not.toHaveBeenCalled()
+    expect(button.disabled).toBe(false)
+
+    const scene2 = { elements: [{ id: 'b' }] }
+    callServerToolMock.mockResolvedValueOnce({
+      structuredContent: { canvasId: 'ws/slug', scene: scene2 },
+    })
+    button.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(callServerToolMock).toHaveBeenCalledTimes(2)
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a re-entrant click while a refresh is already in flight', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    let resolveCall: ((value: unknown) => void) | undefined
+    callServerToolMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCall = resolve
+        }),
+    )
+
+    const button = queryRefreshButton() as HTMLButtonElement
+    button.click()
+    button.click()
+    button.click()
+    await Promise.resolve()
+
+    expect(callServerToolMock).toHaveBeenCalledTimes(1)
+    expect(button.disabled).toBe(true)
+
+    resolveCall?.({ structuredContent: { canvasId: 'ws/slug', scene: { elements: [] } } })
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(button.disabled).toBe(false)
+  })
+
+  it('tolerates a host-echoed ontoolresult duplicate after a successful refresh', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    const { mountCanvasViewer } = await import('./mount.js')
+    vi.mocked(mountCanvasViewer).mockClear()
+
+    const scene2 = { elements: [{ id: 'b' }] }
+    callServerToolMock.mockResolvedValueOnce({
+      structuredContent: { canvasId: 'ws/slug', scene: scene2 },
+    })
+    const button = queryRefreshButton() as HTMLButtonElement
+    button.click()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
+
+    // Host also echoes the refreshed result via its normal notification path.
+    expect(() =>
+      fakeAppInstances[0].ontoolresult?.({
+        structuredContent: { canvasId: 'ws/slug', scene: scene2 },
+      }),
+    ).not.toThrow()
+    expect(mountCanvasViewer).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -215,6 +215,13 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
     // would trade the working view for an empty container.
     fakeAppInstances[0].ontoolresult?.({ structuredContent: { scene: { bogus: true } } })
     fakeAppInstances[0].ontoolresult?.({ structuredContent: {} })
+    // Malformed ENVELOPES (not just malformed scenes): the Zod envelope
+    // parse must degrade to "no scene" for shapes the cast-based extractor
+    // would have crashed on or mis-read — never throw, never remount.
+    fakeAppInstances[0].ontoolresult?.(null)
+    fakeAppInstances[0].ontoolresult?.('not an object')
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: 42 })
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 123, scene } })
 
     expect(mountCanvasViewer).toHaveBeenCalledTimes(1)
     expect(liveHandle.dispose).not.toHaveBeenCalled()

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -9,17 +9,24 @@ interface FakeAppInstance {
   ontoolresult?: (result: unknown) => void
   connect: () => Promise<void>
   callServerTool: (params: unknown) => Promise<unknown>
+  getHostCapabilities: () => { serverTools?: Record<string, unknown> } | undefined
 }
 
 const connectMock = vi.fn()
 const callServerToolMock = vi.fn()
 const fakeAppInstances: FakeAppInstance[] = []
+// Real hosts advertise this via the ext-apps handshake; defaulting to
+// "supported" here keeps the existing Refresh-flow tests focused on the
+// connect()/tool-result behavior they exist to cover. Tests for the
+// capability gate itself override this per-case.
+let getHostCapabilitiesMock: FakeAppInstance['getHostCapabilities'] = () => ({ serverTools: {} })
 
 vi.mock('@modelcontextprotocol/ext-apps', () => ({
   App: vi.fn(function FakeApp(this: FakeAppInstance) {
     fakeAppInstances.push(this)
     this.connect = connectMock
     this.callServerTool = callServerToolMock
+    this.getHostCapabilities = () => getHostCapabilitiesMock()
   }),
 }))
 
@@ -69,6 +76,7 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
     fakeAppInstances.length = 0
     connectMock.mockReset()
     callServerToolMock.mockReset()
+    getHostCapabilitiesMock = () => ({ serverTools: {} })
     // The mount.js mock module instance persists across vi.resetModules()
     // calls (only the real module graph is reset), so its call history
     // must be cleared explicitly between tests.
@@ -255,6 +263,55 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
 
     expect(queryRefreshButton()).toBeNull()
     vi.useRealTimers()
+  })
+
+  it('never reveals Refresh when the host does not advertise the serverTools capability', async () => {
+    stubEmbeddedIframeParent()
+    connectMock.mockImplementation(async () => undefined)
+    getHostCapabilitiesMock = () => ({})
+
+    await importFreshWidgetEntry()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    // A committed canvasId would normally reveal Refresh (see the next
+    // test); the missing serverTools capability must suppress that.
+    expect(queryRefreshButton()).toBeNull()
+  })
+
+  it('reveals Refresh immediately when a tool-result commits a canvasId before the connect() race settles', async () => {
+    stubEmbeddedIframeParent()
+    let resolveConnect: (() => void) | undefined
+    connectMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve
+        }),
+    )
+
+    await importFreshWidgetEntry()
+    // The tool-result fires synchronously right after import, before
+    // connect() has resolved — committedCanvasId is already set when
+    // connect() (and thus the `if (connected)` branch) resolves next.
+    const scene = { elements: [{ id: 'a' }] }
+    fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+    resolveConnect?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // This is the `if (committedCanvasId !== undefined) refreshControl.show()`
+    // branch reflected in widget-entry.ts, not rememberCanvasId's own
+    // `refreshControl?.show()` call (the control did not exist yet when the
+    // tool-result arrived).
+    const button = queryRefreshButton()
+    expect(button).not.toBeNull()
+    expect(button?.style.display).toBe('block')
   })
 
   it('reveals Refresh only after connecting AND a valid tool-result commits a canvasId', async () => {

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -3,6 +3,7 @@
 // from the package's public surface — this file is a build INPUT, loaded
 // only by the widget's own <script type="module"> tag.
 import { App } from '@modelcontextprotocol/ext-apps'
+import { z } from 'zod'
 import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
 import { mountCanvasViewer, type CanvasViewerHandle } from './mount.js'
 import { parseViewerScene } from './scene.js'
@@ -146,14 +147,24 @@ const HOST_CONNECT_TIMEOUT_MS = 2_000
 // validation path for the initial mount and every refresh keeps the
 // malformed-payload defense (parseViewerScene before remount) and the
 // canvasId commit rule (never commit from a result that failed validation)
-// in exactly one place.
+// in exactly one place. The envelope crosses the host↔widget process
+// boundary, so it gets a Zod schema instead of a cast; `scene` stays
+// deliberately unknown here — parseViewerScene is its real validator.
+const toolResultEnvelopeSchema = z.object({
+  structuredContent: z
+    .object({
+      canvasId: z.string().optional(),
+      scene: z.unknown().optional(),
+    })
+    .catchall(z.unknown())
+    .optional(),
+})
+
 function extractCanvasIdAndScene(payload: unknown): { canvasId?: string; scene?: unknown } {
-  const structuredContent = (
-    payload as { structuredContent?: { canvasId?: unknown; scene?: unknown } }
-  )?.structuredContent
-  const canvasId =
-    typeof structuredContent?.canvasId === 'string' ? structuredContent.canvasId : undefined
-  return { canvasId, scene: structuredContent?.scene }
+  const parsed = toolResultEnvelopeSchema.safeParse(payload)
+  if (!parsed.success) return {}
+  const structuredContent = parsed.data.structuredContent
+  return { canvasId: structuredContent?.canvasId, scene: structuredContent?.scene }
 }
 
 // Validates BEFORE remount: remount disposes the live viewer first, so a
@@ -171,7 +182,11 @@ function applyToolResult(
   const { canvasId, scene } = extractCanvasIdAndScene(payload)
   try {
     parseViewerScene(scene)
-  } catch {
+  } catch (err) {
+    // Surfaced for host-integration debugging: the widget deliberately
+    // keeps the current view on malformed payloads, which would otherwise
+    // make a host sending the wrong shape look like a silent no-op.
+    console.error('[whiteboard-widget] ignoring tool-result with invalid scene:', err)
     return
   }
   remount(() => mountCanvasViewer(container, { scene }))
@@ -250,10 +265,12 @@ async function mountFromHost(
         .then((result) => {
           applyToolResult(result, container, remount, rememberCanvasId)
         })
-        .catch(() => {
+        .catch((err) => {
           // Network/host failure: the current view stays mounted (no
           // remount was attempted) — nothing to recover here besides
-          // resetting the in-flight guard below.
+          // resetting the in-flight guard below. Logged so a failing
+          // host transport doesn't present as a dead button.
+          console.error('[whiteboard-widget] refresh via host callServerTool failed:', err)
         })
         .finally(() => {
           refreshInFlight = false

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -75,16 +75,20 @@ function registerFonts(): void {
   window.EXCALIDRAW_ASSET_PATH = resolveInertAssetPrefix()
 }
 
+const INERT_ASSET_PREFIX_FALLBACK = 'https://whiteboard-widget.invalid/'
+
 function resolveInertAssetPrefix(): string {
-  try {
-    return new URL('.', window.location.href).toString()
-  } catch {
+  // document.baseURI (inherited from the embedding document in srcdoc) usually
+  // works when location.href is the non-URL "about:srcdoc"; the fixed inert
+  // prefix is the final fallback if both bases fail to resolve.
+  for (const base of [window.location.href, document.baseURI]) {
     try {
-      return new URL('.', document.baseURI).toString()
+      return new URL('.', base).toString()
     } catch {
-      return 'https://whiteboard-widget.invalid/'
+      // Non-URL base (e.g. "about:srcdoc") throws; try the next candidate.
     }
   }
+  return INERT_ASSET_PREFIX_FALLBACK
 }
 
 // Scoped fallback for the case Excalidraw's lazy font loader still issues a

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -7,6 +7,7 @@ import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
 import { mountCanvasViewer, type CanvasViewerHandle } from './mount.js'
 import { parseViewerScene } from './scene.js'
 import { buildFontFaceDescriptors, resolveFontFetchDataUri } from './widget/font-registration.js'
+import { createRefreshControl } from './widget/refresh-control.js'
 
 declare global {
   interface Window {
@@ -122,10 +123,10 @@ function installFontFetchShim(): void {
 // result via `ui/notifications/tool-result`; `structuredContent` there is
 // the same `{canvasId, scene}` shape returned by canvas_view's Zod
 // outputSchema. This widget never receives daemon credentials — only the
-// scene snapshot — so it cannot call anything back into the daemon
-// directly (the only outbound path, when a host supports it, is
-// re-invoking canvas_view through the host's own MCP session, which this
-// Phase-A bootstrap does not yet do; there is no Refresh action here).
+// scene snapshot plus, once connected, the host's own MCP session — so its
+// only outbound path is re-invoking canvas_view through
+// `app.callServerTool`, which is what the Refresh control below does; there
+// is no direct daemon access from this document.
 //
 // When no ext-apps host is embedding this document (e.g. the widget opened
 // directly in a browser, or the widget-smoke harness), `app.connect()`
@@ -134,6 +135,44 @@ function installFontFetchShim(): void {
 // so bootstrap always falls back to mountCanvasViewer's own embedded-scene
 // slot instead of hanging forever.
 const HOST_CONNECT_TIMEOUT_MS = 2_000
+
+// Both `ui/notifications/tool-result` and the CallToolResult that
+// `app.callServerTool` resolves with wrap canvas_view's payload the same
+// way: `{structuredContent: {canvasId, scene}}`. Sharing one extraction +
+// validation path for the initial mount and every refresh keeps the
+// malformed-payload defense (parseViewerScene before remount) and the
+// canvasId commit rule (never commit from a result that failed validation)
+// in exactly one place.
+function extractCanvasIdAndScene(payload: unknown): { canvasId?: string; scene?: unknown } {
+  const structuredContent = (
+    payload as { structuredContent?: { canvasId?: unknown; scene?: unknown } }
+  )?.structuredContent
+  const canvasId =
+    typeof structuredContent?.canvasId === 'string' ? structuredContent.canvasId : undefined
+  return { canvasId, scene: structuredContent?.scene }
+}
+
+// Validates BEFORE remount: remount disposes the live viewer first, so a
+// malformed payload would otherwise trade a working view for an empty
+// container. `onValidResult` only fires once parseViewerScene has actually
+// accepted the scene, which is what lets the canvasId commit rule ("never
+// remember an ID from an unvalidated result") hold for both the initial
+// tool-result and every subsequent refresh response.
+function applyToolResult(
+  payload: unknown,
+  container: HTMLElement,
+  remount: (mount: () => CanvasViewerHandle) => void,
+  onValidResult: (canvasId: string | undefined) => void,
+): void {
+  const { canvasId, scene } = extractCanvasIdAndScene(payload)
+  try {
+    parseViewerScene(scene)
+  } catch {
+    return
+  }
+  remount(() => mountCanvasViewer(container, { scene }))
+  onValidResult(canvasId)
+}
 
 // `remount` is the single place a mount produced by this bridge happens.
 // `app.connect()` racing HOST_CONNECT_TIMEOUT_MS means a tool-result can
@@ -156,23 +195,20 @@ async function mountFromHost(
 
   const app = new App({ name: 'whiteboard-canvas-view', version: '0.0.0' }, {})
 
+  // Committed only once a tool-result has actually passed parseViewerScene —
+  // an unvalidated canvasId must never enable Refresh (it would call
+  // canvas_view with an ID nobody confirmed is real).
+  let committedCanvasId: string | undefined
+  let refreshControl: ReturnType<typeof createRefreshControl> | undefined
+
+  const rememberCanvasId = (canvasId: string | undefined): void => {
+    if (canvasId === undefined) return
+    committedCanvasId = canvasId
+    refreshControl?.show()
+  }
+
   app.ontoolresult = (result) => {
-    // canvas_view's outputSchema wraps the scene as {canvasId, scene}; only
-    // the `scene` field matches parseViewerScene's strict {elements,
-    // appState?, files?} contract, so the wrapper itself must never reach
-    // mountCanvasViewer.
-    const structuredContent = (result as { structuredContent?: { scene?: unknown } })
-      .structuredContent
-    const scene = structuredContent?.scene
-    // Validate BEFORE remount: remount disposes the live viewer first, so a
-    // malformed tool-result would otherwise trade a working view for an
-    // empty container. On invalid payloads the current view stays up.
-    try {
-      parseViewerScene(scene)
-    } catch {
-      return
-    }
-    remount(() => mountCanvasViewer(container, { scene }))
+    applyToolResult(result, container, remount, rememberCanvasId)
   }
 
   // connect() may reject after the timeout already won the race; a catch on
@@ -184,6 +220,38 @@ async function mountFromHost(
       .catch(() => false),
     new Promise<boolean>((resolve) => setTimeout(() => resolve(false), HOST_CONNECT_TIMEOUT_MS)),
   ])
+
+  // Only ever reveal Refresh when THIS race decided "connected" — a
+  // tool-result can legitimately arrive (and mount) before the timeout wins
+  // the race, but that must not resurrect Refresh once "not connected" has
+  // been decided, even if app.connect() itself resolves later. Deciding
+  // once here, rather than re-checking on every later event, is what keeps
+  // that outcome permanent for the rest of this document's lifetime.
+  if (connected) {
+    let refreshInFlight = false
+    refreshControl = createRefreshControl(() => {
+      if (refreshInFlight || committedCanvasId === undefined) return
+      refreshInFlight = true
+      refreshControl?.setBusy(true)
+      void app
+        .callServerTool({ name: 'canvas_view', arguments: { canvasId: committedCanvasId } })
+        .then((result) => {
+          applyToolResult(result, container, remount, rememberCanvasId)
+        })
+        .catch(() => {
+          // Network/host failure: the current view stays mounted (no
+          // remount was attempted) — nothing to recover here besides
+          // resetting the in-flight guard below.
+        })
+        .finally(() => {
+          refreshInFlight = false
+          refreshControl?.setBusy(false)
+        })
+    })
+    if (committedCanvasId !== undefined) {
+      refreshControl.show()
+    }
+  }
 
   return connected
 }

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -225,13 +225,21 @@ async function mountFromHost(
     new Promise<boolean>((resolve) => setTimeout(() => resolve(false), HOST_CONNECT_TIMEOUT_MS)),
   ])
 
-  // Only ever reveal Refresh when THIS race decided "connected" — a
-  // tool-result can legitimately arrive (and mount) before the timeout wins
-  // the race, but that must not resurrect Refresh once "not connected" has
-  // been decided, even if app.connect() itself resolves later. Deciding
-  // once here, rather than re-checking on every later event, is what keeps
-  // that outcome permanent for the rest of this document's lifetime.
-  if (connected) {
+  // A successful handshake alone does not guarantee the host can proxy tool
+  // calls back to the server — only app.getHostCapabilities()?.serverTools
+  // does (per the ext-apps host-capability negotiation). Creating Refresh
+  // without this check would show a control whose every click silently
+  // fails on hosts that never advertised the capability.
+  const canUseServerTools = app.getHostCapabilities()?.serverTools !== undefined
+
+  // Only ever reveal Refresh when THIS race decided "connected" AND the host
+  // advertised serverTools — a tool-result can legitimately arrive (and
+  // mount) before the timeout wins the race, but that must not resurrect
+  // Refresh once "not connected" has been decided, even if app.connect()
+  // itself resolves later. Deciding once here, rather than re-checking on
+  // every later event, is what keeps that outcome permanent for the rest of
+  // this document's lifetime.
+  if (connected && canUseServerTools) {
     let refreshInFlight = false
     refreshControl = createRefreshControl(() => {
       if (refreshInFlight || committedCanvasId === undefined) return

--- a/packages/canvas-viewer/src/widget/refresh-control.ts
+++ b/packages/canvas-viewer/src/widget/refresh-control.ts
@@ -1,0 +1,53 @@
+// Overlay control for the MCP Apps widget bridge (widget-entry.ts). Rendered
+// as a sibling of #root, never inside it: `remount` clears #root via
+// container.replaceChildren() on every mount, which would delete this
+// element if it lived inside the container.
+export interface RefreshControl {
+  readonly element: HTMLButtonElement
+  show(): void
+  setBusy(busy: boolean): void
+}
+
+// Stable hook for tests and the widget smoke script — deliberately not an
+// `id` (a host document could already use that name) or a class (styling
+// hook, not an identity hook).
+export const REFRESH_CONTROL_TEST_ID = 'widget-refresh'
+
+export function createRefreshControl(onRefresh: () => void): RefreshControl {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.textContent = 'Refresh'
+  button.setAttribute('data-testid', REFRESH_CONTROL_TEST_ID)
+  button.setAttribute('aria-label', 'Refresh canvas from host')
+  // Deliberately minimal inline styling: this widget has no CSS build step
+  // of its own (single-file bundle) and must stay legible over an arbitrary
+  // host-rendered scene without competing with Excalidraw's own UI chrome.
+  button.style.cssText = [
+    'position:fixed',
+    'top:8px',
+    'right:8px',
+    'z-index:2147483647',
+    'padding:4px 10px',
+    'font:12px system-ui,sans-serif',
+    'border-radius:6px',
+    'border:1px solid rgba(0,0,0,0.2)',
+    'background:rgba(255,255,255,0.9)',
+    'color:#1e1e1e',
+    'cursor:pointer',
+    'display:none',
+  ].join(';')
+  button.addEventListener('click', () => {
+    onRefresh()
+  })
+  document.body.appendChild(button)
+
+  return {
+    element: button,
+    show(): void {
+      button.style.display = 'block'
+    },
+    setBusy(busy: boolean): void {
+      button.disabled = busy
+    },
+  }
+}

--- a/packages/canvas-viewer/src/widget/refresh-control.ts
+++ b/packages/canvas-viewer/src/widget/refresh-control.ts
@@ -47,7 +47,13 @@ export function createRefreshControl(onRefresh: () => void): RefreshControl {
       button.style.display = 'block'
     },
     setBusy(busy: boolean): void {
+      // The inline background/color/cursor styles above override the
+      // browser's default disabled rendering, so `disabled` alone would
+      // leave the button looking clickable mid-flight.
       button.disabled = busy
+      button.style.opacity = busy ? '0.5' : ''
+      button.style.cursor = busy ? 'wait' : 'pointer'
+      button.textContent = busy ? 'Refreshing…' : 'Refresh'
     },
   }
 }

--- a/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
@@ -73,4 +73,19 @@ describe('MCP Apps UI-linked tools coverage', () => {
     const linkedNames = entries.filter((e) => /_meta:\s*\{\s*ui:/.test(e)).map((e) => toolNameOf(e))
     expect(linkedNames).toEqual(['viewTool'])
   })
+
+  it('canvas_view leaves `visibility` unset or app-inclusive, so the MCP Apps host can call it back for Refresh', () => {
+    // ext-apps' McpUiToolMeta.visibility defaults to ["model", "app"] when
+    // omitted (spec.types.d.ts), which already permits an app-initiated
+    // callServerTool — this pins that canvas_view never narrows it to
+    // ["model"] only, which would silently break the widget's Refresh
+    // button without touching any test that calls canvas_view as the model.
+    const entries = splitDefineToolEntries(registrationSrc)
+    const viewEntry = entries.find((e) => toolNameOf(e) === 'viewTool')
+    expect(viewEntry).toBeDefined()
+    const visibilityMatch = viewEntry?.match(/visibility:\s*\[([^\]]*)\]/)
+    if (visibilityMatch) {
+      expect(visibilityMatch[1]).toMatch(/["']app["']/)
+    }
+  })
 })

--- a/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
@@ -33,6 +33,29 @@ function toolNameOf(entry: string): string | null {
   return m ? m[1] : null
 }
 
+// Verifies a defineTool entry's `visibility` field, when present, is an
+// inline array literal that includes "app" — anything else (omitted,
+// literal-inclusive) is fine, but a non-literal reference (e.g. a shared
+// `visibility: MODEL_ONLY_VISIBILITY` constant) can't be checked textually,
+// so it must fail loudly rather than let the array-literal regex silently
+// find no match and pass vacuously.
+function assertVisibilityAllowsApp(entry: string): void {
+  const arrayMatch = entry.match(/visibility:\s*\[([^\]]*)\]/)
+  if (arrayMatch) {
+    expect(arrayMatch[1]).toMatch(/["']app["']/)
+    return
+  }
+  const identifierMatch = entry.match(/visibility:\s*([A-Za-z_$][\w$]*)/)
+  if (identifierMatch) {
+    throw new Error(
+      `visibility uses a non-literal reference (${identifierMatch[1]}) this guard cannot verify textually; ` +
+        'inline the array literal, or extend this check, so "app" inclusion stays provable',
+    )
+  }
+  // visibility omitted entirely defaults to ["model", "app"] (see comment
+  // on the caller) — nothing further to assert.
+}
+
 describe('MCP Apps UI-linked tools coverage', () => {
   it('UI_LINKED_TOOLS is a subset of ALL_REGISTERED_TOOLS', () => {
     for (const name of UI_LINKED_TOOLS) {
@@ -83,9 +106,13 @@ describe('MCP Apps UI-linked tools coverage', () => {
     const entries = splitDefineToolEntries(registrationSrc)
     const viewEntry = entries.find((e) => toolNameOf(e) === 'viewTool')
     expect(viewEntry).toBeDefined()
-    const visibilityMatch = viewEntry?.match(/visibility:\s*\[([^\]]*)\]/)
-    if (visibilityMatch) {
-      expect(visibilityMatch[1]).toMatch(/["']app["']/)
-    }
+    assertVisibilityAllowsApp(viewEntry ?? '')
+  })
+
+  it('flags a non-literal `visibility` reference instead of passing vacuously', () => {
+    // Guards the guard: a future edit to `visibility: MODEL_ONLY_VISIBILITY`
+    // (a non-literal reference) must fail this check, not silently pass it
+    // the way a literal-array-only regex would.
+    expect(() => assertVisibilityAllowsApp('visibility: MODEL_ONLY_VISIBILITY,')).toThrow()
   })
 })

--- a/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
@@ -40,21 +40,42 @@ function toolNameOf(entry: string): string | null {
 // so it must fail loudly rather than let the array-literal regex silently
 // find no match and pass vacuously.
 function assertVisibilityAllowsApp(entry: string): void {
+  // Presence is decided FIRST so that any expression form this guard does
+  // not understand (call expression, ternary, spread, member access, …)
+  // fails loudly instead of falling through to the "omitted" default —
+  // only a literally absent field may claim the ["model","app"] default.
+  if (!/\bvisibility\s*:/.test(entry)) {
+    return
+  }
   const arrayMatch = entry.match(/visibility:\s*\[([^\]]*)\]/)
   if (arrayMatch) {
     expect(arrayMatch[1]).toMatch(/["']app["']/)
     return
   }
-  const identifierMatch = entry.match(/visibility:\s*([A-Za-z_$][\w$]*)/)
-  if (identifierMatch) {
-    throw new Error(
-      `visibility uses a non-literal reference (${identifierMatch[1]}) this guard cannot verify textually; ` +
-        'inline the array literal, or extend this check, so "app" inclusion stays provable',
-    )
-  }
-  // visibility omitted entirely defaults to ["model", "app"] (see comment
-  // on the caller) — nothing further to assert.
+  throw new Error(
+    'visibility uses an expression this guard cannot verify textually; ' +
+      'inline the array literal, or extend this check, so "app" inclusion stays provable',
+  )
 }
+
+describe('assertVisibilityAllowsApp guard', () => {
+  it('accepts an omitted field and an app-inclusive array literal', () => {
+    expect(() => assertVisibilityAllowsApp('name: viewTool.name, _meta: { ui: {} }')).not.toThrow()
+    expect(() => assertVisibilityAllowsApp("visibility: ['model', 'app'],")).not.toThrow()
+  })
+
+  it('fails loudly on every non-literal visibility expression, not just bare identifiers', () => {
+    expect(() => assertVisibilityAllowsApp('visibility: SHARED_VISIBILITY,')).toThrow(
+      /cannot verify textually/,
+    )
+    expect(() => assertVisibilityAllowsApp('visibility: getVisibility(),')).toThrow(
+      /cannot verify textually/,
+    )
+    expect(() => assertVisibilityAllowsApp("visibility: (dev ? ['app'] : ['model']),")).toThrow(
+      /cannot verify textually/,
+    )
+  })
+})
 
 describe('MCP Apps UI-linked tools coverage', () => {
   it('UI_LINKED_TOOLS is a subset of ALL_REGISTERED_TOOLS', () => {


### PR DESCRIPTION
## Summary

MCP Apps Phase B, first slice: the `canvas_view` widget gains a **Refresh** control that re-invokes `canvas_view` through the ext-apps host's own MCP session (`App.callServerTool`) — proving the widget→host tool-call bridge that Phase A deferred. The widget still receives zero daemon credentials; the only outbound path is the host session.

- **`applyToolResult` extraction** (`widget-entry.ts`): one shared validate-before-remount path for both the initial `ui/notifications/tool-result` and every Refresh response — Phase A's malformed-payload defense and serialized-remount invariant apply to both.
- **`canvasId` commit rule**: the id is remembered only after `parseViewerScene` succeeds on the same result, so a malformed result can never arm Refresh with an unverified id.
- **Capability gate**: the control is created only when the host advertises `serverTools` in `app.getHostCapabilities()` — hosts that never negotiated app-initiated calls don't get a button that would throw.
- **Overlay placement**: the button lives outside `#root`, so remounts (which clear the container) don't destroy it; an in-flight guard ignores re-entrant clicks and provably re-arms on both rejection and malformed responses.
- **Daemon**: no production change needed — `@modelcontextprotocol/ext-apps` 1.7.4's `visibility` default is `["model","app"]`. `ui-linked-tools.test.ts` now pins that `canvas_view` keeps `visibility` unset-or-app-inclusive (and fails loudly on non-literal metadata) so a future edit can't silently break app-initiated calls.
- **Smoke**: the srcdoc no-host smoke asserts the Refresh control is absent when no host is embedding the widget.
- Docs: `docs/how-to/view-canvas-in-chat.md` documents the Refresh flow and drops the stale "no refresh button yet" claim.

## Real-host verification (MCPJam)

Full bridge round-trip verified against MCPJam as a real ext-apps host:

1. `canvas_view` rendered the seeded scene (blue v1 box) inline — Refresh button visible (capability gate passed).
2. The canvas was then modified out-of-band via MCP `annotate` (green "v2追加 / Refresh後に見える" box).
3. Clicking **Refresh** inside the widget issued a second `canvas_view` call through the host session and the widget remounted with the updated scene — content pixels 1168 → 2031, and the v2 box appeared. The Refresh control survived the remount.

## Visual repro

After clicking Refresh — the green "v2追加" box was added to the canvas *after* the initial render and appears only via the bridged re-fetch:

![mcp-apps-refresh-after.png](https://github.com/user-attachments/assets/18d4a73d-37c3-4d9b-b705-6d2276de7e8a)

## Widget-op ↔ MCP tool mapping (Phase B ledger)

| Widget operation | MCP tool | Arguments | Path |
|---|---|---|---|
| Refresh | `canvas_view` | `{ canvasId }` (committed from last valid result) | host `callServerTool`, visibility default `["model","app"]` |

## Tests

- canvas-viewer: node 43 ✓ / jsdom 30 ✓ (new: capability gate, canvasId commit rule, connect-race orderings, in-flight guard reset on reject+malformed) / widget smoke incl. srcdoc no-Refresh assertion ✓
- mcp-server: typecheck ✓, mcp-node 3705 ✓ (incl. extended `ui-linked-tools.test.ts`)

Follow-up (tracked locally): a connected-host automated harness (fake ext-apps host page speaking PostMessageTransport in the widget smoke) to lock the bridge round-trip into CI; deferred with jsdom coverage + this manual verification as the current net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WyfrPAJrHB3bWZMrRQMry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Refresh** button when viewing a canvas in supported embedded chat hosts.
  * Refresh reloads the latest scene for the currently displayed canvas.
  * The button is hidden when host support or connection status cannot be confirmed.
  * Refresh is temporarily disabled while an update is in progress.

* **Documentation**
  * Updated the canvas viewing guide to describe conditional refresh behavior and current read-only limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->