### PR TITLE
feat(canvas-viewer): append sticky notes from the MCP Apps widget via the host session

### DIFF
--- a/docs/how-to/view-canvas-in-chat.md
+++ b/docs/how-to/view-canvas-in-chat.md
@@ -26,12 +26,26 @@ clients that do not advertise `serverTools`, or when the widget cannot confirm a
 connection at all, the button never appears; call `canvas_view` again to see a fresh
 snapshot instead.
 
+## Adding a sticky note from the widget
+
+On the same clients that show Refresh (host connected and `serverTools`
+advertised), the widget also shows a small text field with an **Add** button
+in the top-left corner. Typing a note and submitting it calls the `annotate`
+tool through the host to add a `box_with_label` sticky note to the canvas,
+placed automatically so it does not overlap existing elements, then
+refreshes the view so the new note appears. This is **append-only** — there
+is no in-widget way to edit or remove an existing note or any other element;
+use the full editor or the `annotate` / other canvas tools directly for that.
+The field is disabled while a note is being added and re-enabled once the
+follow-up refresh completes.
+
 ## What you do not get (yet)
 
 This is **Phase A** of MCP Apps support:
 
-- The view is otherwise **read-only** — Refresh reloads the current scene, but there
-  is no in-widget editing or annotation.
+- Beyond adding a new sticky note as described above, the view is
+  **read-only** — Refresh reloads the current scene, but there is no
+  in-widget editing, moving, or deleting of existing elements.
 - Only `canvas_view` renders inline. `canvas_open` (opens the full editor in a real
   browser tab) and `export_canvas` (writes a file) are intentionally **not**
   UI-linked — `canvas_open` would need to pass the daemon's base URL into the widget,

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -174,6 +174,17 @@ async function main() {
       )
     }
 
+    // Same gate as Refresh: the sticky-note affordance must never appear
+    // without an embedding host peer.
+    const hasStickyNoteControl = await page.evaluate(
+      () => document.querySelector('[data-testid="widget-sticky-note"]') !== null,
+    )
+    if (hasStickyNoteControl) {
+      fail(
+        'expected no sticky-note control without an embedding host (file:// load has no parent frame)',
+      )
+    }
+
     const fontCheck = await page.evaluate(async (text) => {
       await document.fonts.ready
       // window.__whiteboardWidgetFonts__ (see widget-entry.ts) is exactly
@@ -325,6 +336,26 @@ async function main() {
     }
     if (srcdocPageErrors.length > 0) {
       fail(`uncaught page error(s) under srcdoc hosting: ${srcdocPageErrors.join(' | ')}`)
+    }
+
+    // No real MCP Apps host answers the postMessage handshake in this
+    // harness, so app.connect() loses the HOST_CONNECT_TIMEOUT_MS race —
+    // Refresh and the sticky-note affordance must both stay absent here too,
+    // the same as the file:// no-parent-frame load above.
+    if (srcdocCanvasCount > 0) {
+      const widgetFrame = srcdocPage.frames().find((frame) => frame !== srcdocPage.mainFrame())
+      const controlPresence = await widgetFrame
+        ?.evaluate(() => ({
+          refresh: document.querySelector('[data-testid="widget-refresh"]') !== null,
+          stickyNote: document.querySelector('[data-testid="widget-sticky-note"]') !== null,
+        }))
+        .catch(() => undefined)
+      if (controlPresence?.refresh) {
+        fail('expected no Refresh control under sandboxed srcdoc hosting with no real host')
+      }
+      if (controlPresence?.stickyNote) {
+        fail('expected no sticky-note control under sandboxed srcdoc hosting with no real host')
+      }
     }
 
     if (process.exitCode !== 1) {

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -723,6 +723,9 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
         expect.any(HTMLElement),
         expect.objectContaining({ scene: refreshedScene }),
       )
+      // Submitted text is cleared only on full success — the user can add a
+      // second note without deleting the first one's text.
+      expect(queryStickyInput()?.value).toBe('')
     })
 
     it('keeps the current view and never refreshes when the annotate call rejects', async () => {
@@ -741,6 +744,8 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
       expect(callServerToolMock).toHaveBeenCalledTimes(1)
       expect(mountCanvasViewer).not.toHaveBeenCalled()
       expect(queryStickyInput()?.disabled).toBe(false)
+      // Failure keeps the typed text so the user can retry without retyping.
+      expect(queryStickyInput()?.value).toBe('note text')
     })
 
     it('treats a resolved {isError:true} annotate result as failure — no follow-up refresh', async () => {

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -31,9 +31,27 @@ vi.mock('@modelcontextprotocol/ext-apps', () => ({
 }))
 
 const REFRESH_SELECTOR = '[data-testid="widget-refresh"]'
+const STICKY_FORM_SELECTOR = '[data-testid="widget-sticky-note"]'
+const STICKY_INPUT_SELECTOR = '[data-testid="widget-sticky-note-input"]'
 
 function queryRefreshButton(): HTMLButtonElement | null {
   return document.querySelector(REFRESH_SELECTOR)
+}
+
+function queryStickyForm(): HTMLFormElement | null {
+  return document.querySelector(STICKY_FORM_SELECTOR)
+}
+
+function queryStickyInput(): HTMLInputElement | null {
+  return document.querySelector(STICKY_INPUT_SELECTOR)
+}
+
+function submitSticky(text: string): void {
+  const input = queryStickyInput() as HTMLInputElement
+  input.value = text
+  ;(queryStickyForm() as HTMLFormElement).dispatchEvent(
+    new Event('submit', { bubbles: true, cancelable: true }),
+  )
 }
 
 vi.mock('./mount.js', () => ({
@@ -579,5 +597,298 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
       }),
     ).not.toThrow()
     expect(mountCanvasViewer).toHaveBeenCalledTimes(2)
+  })
+
+  describe('sticky-note affordance', () => {
+    it('is absent when there is no parent frame', async () => {
+      await importFreshWidgetEntry()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(queryStickyForm()).toBeNull()
+    })
+
+    it('is absent when the host does not advertise the serverTools capability', async () => {
+      stubEmbeddedIframeParent()
+      connectMock.mockImplementation(async () => undefined)
+      getHostCapabilitiesMock = () => ({})
+
+      await importFreshWidgetEntry()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      const scene = { elements: [{ id: 'a' }] }
+      fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+      expect(queryStickyForm()).toBeNull()
+    })
+
+    it('stays hidden until a valid tool-result commits a canvasId', async () => {
+      stubEmbeddedIframeParent()
+      connectMock.mockImplementation(async () => undefined)
+
+      await importFreshWidgetEntry()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      const beforeResult = queryStickyForm()
+      if (beforeResult) {
+        expect(beforeResult.style.display).toBe('none')
+      }
+
+      const scene = { elements: [{ id: 'a' }] }
+      fakeAppInstances[0].ontoolresult?.({ structuredContent: { canvasId: 'ws/slug', scene } })
+
+      const form = queryStickyForm()
+      expect(form).not.toBeNull()
+      expect(form?.style.display).not.toBe('none')
+    })
+
+    async function mountConnectedWithScene(elements: unknown[]): Promise<void> {
+      stubEmbeddedIframeParent()
+      connectMock.mockImplementation(async () => undefined)
+
+      await importFreshWidgetEntry()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      fakeAppInstances[0].ontoolresult?.({
+        structuredContent: { canvasId: 'ws/slug', scene: { elements } },
+      })
+    }
+
+    it('submitting text calls callServerTool with the exact annotate sticky shape and no height/color keys', async () => {
+      await mountConnectedWithScene([{ id: 'a', x: 0, y: 0, width: 100, height: 50 }])
+
+      callServerToolMock.mockResolvedValueOnce({
+        structuredContent: { canvasId: 'ws/slug', scene: { elements: [] } },
+      })
+
+      submitSticky('hello sticky')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(callServerToolMock).toHaveBeenCalledWith({
+        name: 'annotate',
+        arguments: {
+          canvasId: 'ws/slug',
+          type: 'box_with_label',
+          target: { x: 124, y: 0 },
+          text: 'hello sticky',
+          width: 260,
+          backgroundColor: '#ffec99',
+        },
+      })
+      const callArgs = callServerToolMock.mock.calls.find(
+        (call) => (call[0] as { name: string }).name === 'annotate',
+      )?.[0] as { arguments: Record<string, unknown> }
+      expect(callArgs.arguments).not.toHaveProperty('height')
+      expect(callArgs.arguments).not.toHaveProperty('color')
+    })
+
+    it('empty or whitespace-only text is a no-op — no callServerTool call', async () => {
+      await mountConnectedWithScene([])
+
+      submitSticky('   ')
+      await Promise.resolve()
+
+      expect(callServerToolMock).not.toHaveBeenCalled()
+    })
+
+    it('on success, re-invokes canvas_view and remounts the appended scene', async () => {
+      await mountConnectedWithScene([])
+
+      const { mountCanvasViewer } = await import('./mount.js')
+      vi.mocked(mountCanvasViewer).mockClear()
+
+      const annotateResult = { structuredContent: { annotation: { type: 'box_with_label' } } }
+      const refreshedScene = { elements: [{ id: 'sticky-1' }] }
+      callServerToolMock.mockResolvedValueOnce(annotateResult).mockResolvedValueOnce({
+        structuredContent: { canvasId: 'ws/slug', scene: refreshedScene },
+      })
+
+      submitSticky('note text')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(callServerToolMock).toHaveBeenCalledTimes(2)
+      expect(callServerToolMock).toHaveBeenNthCalledWith(2, {
+        name: 'canvas_view',
+        arguments: { canvasId: 'ws/slug' },
+      })
+      expect(mountCanvasViewer).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ scene: refreshedScene }),
+      )
+    })
+
+    it('keeps the current view and never refreshes when the annotate call rejects', async () => {
+      await mountConnectedWithScene([])
+
+      const { mountCanvasViewer } = await import('./mount.js')
+      vi.mocked(mountCanvasViewer).mockClear()
+
+      callServerToolMock.mockRejectedValueOnce(new Error('boom'))
+
+      submitSticky('note text')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(callServerToolMock).toHaveBeenCalledTimes(1)
+      expect(mountCanvasViewer).not.toHaveBeenCalled()
+      expect(queryStickyInput()?.disabled).toBe(false)
+    })
+
+    it('treats a resolved {isError:true} annotate result as failure — no follow-up refresh', async () => {
+      await mountConnectedWithScene([])
+
+      const { mountCanvasViewer } = await import('./mount.js')
+      vi.mocked(mountCanvasViewer).mockClear()
+
+      callServerToolMock.mockResolvedValueOnce({ isError: true, content: [] })
+
+      submitSticky('note text')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(callServerToolMock).toHaveBeenCalledTimes(1)
+      expect(mountCanvasViewer).not.toHaveBeenCalled()
+      expect(queryStickyInput()?.disabled).toBe(false)
+    })
+
+    it('keeps the current view when the follow-up canvas_view resolves with a malformed scene', async () => {
+      await mountConnectedWithScene([])
+
+      const { mountCanvasViewer } = await import('./mount.js')
+      vi.mocked(mountCanvasViewer).mockClear()
+
+      callServerToolMock
+        .mockResolvedValueOnce({ structuredContent: { annotation: {} } })
+        .mockResolvedValueOnce({
+          structuredContent: { canvasId: 'ws/slug', scene: { bogus: true } },
+        })
+
+      submitSticky('note text')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(mountCanvasViewer).not.toHaveBeenCalled()
+      expect(queryStickyInput()?.disabled).toBe(false)
+    })
+
+    it('ignores a re-entrant submit while an annotate call is already in flight', async () => {
+      await mountConnectedWithScene([])
+
+      let resolveCall: ((value: unknown) => void) | undefined
+      callServerToolMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve
+          }),
+      )
+
+      submitSticky('first')
+      submitSticky('second')
+      await Promise.resolve()
+
+      expect(callServerToolMock).toHaveBeenCalledTimes(1)
+      expect(queryStickyInput()?.disabled).toBe(true)
+
+      resolveCall?.({ structuredContent: { annotation: {} } })
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    it('coalesces a required post-annotation refresh with an in-flight manual Refresh instead of skipping it', async () => {
+      await mountConnectedWithScene([])
+
+      const { mountCanvasViewer } = await import('./mount.js')
+      vi.mocked(mountCanvasViewer).mockClear()
+
+      let resolveManualRefresh: ((value: unknown) => void) | undefined
+      let resolveAnnotate: ((value: unknown) => void) | undefined
+
+      callServerToolMock.mockImplementation((params: unknown) => {
+        const name = (params as { name: string }).name
+        if (name === 'canvas_view') {
+          return new Promise((resolve) => {
+            resolveManualRefresh = resolve
+          })
+        }
+        return new Promise((resolve) => {
+          resolveAnnotate = resolve
+        })
+      })
+
+      // Manual Refresh starts first and stays pending.
+      const refreshButton = queryRefreshButton() as HTMLButtonElement
+      refreshButton.click()
+      await Promise.resolve()
+      expect(callServerToolMock).toHaveBeenCalledTimes(1)
+
+      // Annotate succeeds while the manual refresh is still in flight; its
+      // required follow-up refresh must be coalesced, not dropped.
+      submitSticky('note text')
+      await Promise.resolve()
+      resolveAnnotate?.({ structuredContent: { annotation: {} } })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // The in-flight manual refresh has not resolved yet, so no second
+      // canvas_view call has fired — but one is now pending.
+      expect(callServerToolMock).toHaveBeenCalledTimes(2)
+
+      resolveManualRefresh?.({
+        structuredContent: { canvasId: 'ws/slug', scene: { elements: [] } },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // The coalesced follow-up refresh now fires exactly once more.
+      expect(callServerToolMock).toHaveBeenCalledTimes(3)
+      expect(callServerToolMock).toHaveBeenNthCalledWith(3, {
+        name: 'canvas_view',
+        arguments: { canvasId: 'ws/slug' },
+      })
+      resolveManualRefresh = undefined
+
+      await Promise.resolve()
+    })
+  })
+})
+
+describe('widget-entry append-only invariant', () => {
+  it('only calls callServerTool with tool names from the append-only allowlist', async () => {
+    const { readFileSync, readdirSync } = await import('node:fs')
+    const { dirname, resolve: resolvePath } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+
+    const here = dirname(fileURLToPath(import.meta.url))
+    const widgetDir = resolvePath(here, 'widget')
+    const sources = [
+      readFileSync(resolvePath(here, 'widget-entry.ts'), 'utf-8'),
+      ...readdirSync(widgetDir)
+        .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts') && !f.endsWith('.test.tsx'))
+        .map((f) => readFileSync(resolvePath(widgetDir, f), 'utf-8')),
+    ].join('\n')
+
+    const allowlist = new Set(['canvas_view', 'annotate'])
+    const callSiteNames = [...sources.matchAll(/callServerTool\(\s*\{\s*name:\s*'([^']+)'/g)].map(
+      (m) => m[1],
+    )
+
+    expect(callSiteNames.length).toBeGreaterThan(0)
+    for (const name of callSiteNames) {
+      expect(allowlist.has(name as string), `unexpected callServerTool name: ${name}`).toBe(true)
+    }
   })
 })

--- a/packages/canvas-viewer/src/widget-entry.test.tsx
+++ b/packages/canvas-viewer/src/widget-entry.test.tsx
@@ -807,6 +807,42 @@ describe('widget-entry MCP Apps bridge bootstrap', () => {
       await Promise.resolve()
     })
 
+    it('keeps the sticky control disabled until the required post-annotation refresh resolves', async () => {
+      await mountConnectedWithScene([{ id: 'a', x: 0, y: 0, width: 100, height: 50 }])
+
+      let resolveRefresh: ((value: unknown) => void) | undefined
+      callServerToolMock.mockImplementation((params: unknown) => {
+        const name = (params as { name: string }).name
+        if (name === 'annotate') {
+          return Promise.resolve({ structuredContent: { annotation: {} } })
+        }
+        return new Promise((resolve) => {
+          resolveRefresh = resolve
+        })
+      })
+
+      submitSticky('first')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // annotate already resolved, but the required follow-up canvas_view is
+      // still pending — the control (and the stale lastValidScene it would
+      // otherwise let a re-entrant submit compute placement from) must stay
+      // disabled until that refresh actually lands.
+      expect(callServerToolMock).toHaveBeenCalledTimes(2)
+      expect(queryStickyInput()?.disabled).toBe(true)
+
+      resolveRefresh?.({
+        structuredContent: { canvasId: 'ws/slug', scene: { elements: [] } },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(queryStickyInput()?.disabled).toBe(false)
+    })
+
     it('coalesces a required post-annotation refresh with an in-flight manual Refresh instead of skipping it', async () => {
       await mountConnectedWithScene([])
 

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -377,6 +377,9 @@ async function mountFromHost(
         // compute its target from the stale pre-annotation scene and land on
         // the same coordinates as the first note.
         await performRefresh()
+        // Only after full success — a failed annotate keeps the text so the
+        // user can retry without retyping.
+        stickyControl?.clear()
       } catch (err) {
         console.error('[whiteboard-widget] annotate via host callServerTool failed:', err)
       } finally {

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -369,10 +369,14 @@ async function mountFromHost(
         // Required, not optional: append-only means the new note is only
         // visible once canvas_view re-fetches. Routed through the same
         // coalescing performRefresh a concurrent manual Refresh uses, so
-        // neither call can silently skip the other's refresh. Fire-and-forget
-        // (not awaited) so the sticky control frees up as soon as annotate
-        // resolves, independent of the follow-up refresh completing.
-        void performRefresh()
+        // neither call can silently skip the other's refresh. Awaited
+        // (rather than fire-and-forget) so the sticky control — and the
+        // placement math a rapid next submission would read from
+        // lastValidScene — only re-enable once this refresh has actually
+        // updated lastValidScene; otherwise a second quick submission could
+        // compute its target from the stale pre-annotation scene and land on
+        // the same coordinates as the first note.
+        await performRefresh()
       } catch (err) {
         console.error('[whiteboard-widget] annotate via host callServerTool failed:', err)
       } finally {

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -341,21 +341,14 @@ async function mountFromHost(
       }
     }
 
-    refreshControl = createRefreshControl(() => {
-      void performRefresh()
-    })
-    if (committedCanvasId !== undefined) {
-      refreshControl.show()
-    }
-
     let annotateInFlight = false
-    stickyControl = createStickyNoteControl((text) => {
+    const performAnnotate = async (text: string): Promise<void> => {
       if (annotateInFlight || committedCanvasId === undefined) return
       annotateInFlight = true
       stickyControl?.setBusy(true)
       const target = computeStickyPlacement(lastValidScene?.elements ?? [])
-      void app
-        .callServerTool({
+      try {
+        const result = await app.callServerTool({
           name: 'annotate',
           arguments: {
             canvasId: committedCanvasId,
@@ -366,29 +359,39 @@ async function mountFromHost(
             backgroundColor: STICKY_BACKGROUND_COLOR,
           },
         })
-        .then((result) => {
-          if (isErrorResult(result)) {
-            console.error(
-              '[whiteboard-widget] annotate via host callServerTool returned an error result:',
-              result,
-            )
-            return
-          }
-          // Required, not optional: append-only means the new note is only
-          // visible once canvas_view re-fetches. Routed through the same
-          // coalescing performRefresh a concurrent manual Refresh uses, so
-          // neither call can silently skip the other's refresh.
-          void performRefresh()
-        })
-        .catch((err) => {
-          console.error('[whiteboard-widget] annotate via host callServerTool failed:', err)
-        })
-        .finally(() => {
-          annotateInFlight = false
-          stickyControl?.setBusy(false)
-        })
+        if (isErrorResult(result)) {
+          console.error(
+            '[whiteboard-widget] annotate via host callServerTool returned an error result:',
+            result,
+          )
+          return
+        }
+        // Required, not optional: append-only means the new note is only
+        // visible once canvas_view re-fetches. Routed through the same
+        // coalescing performRefresh a concurrent manual Refresh uses, so
+        // neither call can silently skip the other's refresh. Fire-and-forget
+        // (not awaited) so the sticky control frees up as soon as annotate
+        // resolves, independent of the follow-up refresh completing.
+        void performRefresh()
+      } catch (err) {
+        console.error('[whiteboard-widget] annotate via host callServerTool failed:', err)
+      } finally {
+        annotateInFlight = false
+        stickyControl?.setBusy(false)
+      }
+    }
+
+    refreshControl = createRefreshControl(() => {
+      void performRefresh()
     })
+    stickyControl = createStickyNoteControl((text) => {
+      void performAnnotate(text)
+    })
+
+    // A tool-result can commit an ID during connect() above, before either
+    // control existed to be shown — reveal both if that already happened.
     if (committedCanvasId !== undefined) {
+      refreshControl.show()
       stickyControl.show()
     }
   }

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -2,13 +2,16 @@
 // (vite.widget.config.ts -> dist/widget/canvas-viewer.html). Never exported
 // from the package's public surface — this file is a build INPUT, loaded
 // only by the widget's own <script type="module"> tag.
+
+import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
 import { App } from '@modelcontextprotocol/ext-apps'
 import { z } from 'zod'
-import { FONT_FILENAME_MAP, WIDGET_FONTS } from 'virtual:widget-fonts'
-import { mountCanvasViewer, type CanvasViewerHandle } from './mount.js'
-import { parseViewerScene } from './scene.js'
+import { type CanvasViewerHandle, mountCanvasViewer } from './mount.js'
+import { parseViewerScene, type ViewerScene } from './scene.js'
 import { buildFontFaceDescriptors, resolveFontFetchDataUri } from './widget/font-registration.js'
 import { createRefreshControl } from './widget/refresh-control.js'
+import { createStickyNoteControl } from './widget/sticky-note-control.js'
+import { computeStickyPlacement } from './widget/sticky-placement.js'
 
 declare global {
   interface Window {
@@ -141,6 +144,18 @@ function installFontFetchShim(): void {
 // slot instead of hanging forever.
 const HOST_CONNECT_TIMEOUT_MS = 2_000
 
+// annotate's execute() (mcp-server tools/annotate.ts) throws for
+// type:'box_with_label' when spec.width is undefined — a fixed width keeps
+// this append-only affordance from depending on any DOM measurement the
+// widget has no reliable way to take inside a sandboxed iframe. `height` is
+// deliberately omitted: autoFit defaults to true, so annotate auto-grows the
+// box instead of requiring an explicit height.
+const STICKY_WIDTH = 260
+// Fixed sticky-note fill; `color` (text ink) is deliberately left unset so
+// annotate's own readable-ink contrast logic picks a legible ink against
+// this fill instead of the widget hardcoding one.
+const STICKY_BACKGROUND_COLOR = '#ffec99'
+
 // Both `ui/notifications/tool-result` and the CallToolResult that
 // `app.callServerTool` resolves with wrap canvas_view's payload the same
 // way: `{structuredContent: {canvasId, scene}}`. Sharing one extraction +
@@ -173,15 +188,33 @@ function extractCanvasIdAndScene(payload: unknown): { canvasId?: string; scene?:
 // accepted the scene, which is what lets the canvasId commit rule ("never
 // remember an ID from an unvalidated result") hold for both the initial
 // tool-result and every subsequent refresh response.
+// Also whether a result is an application-level failure rather than a
+// transport-level rejection: the ext-apps host resolves (never rejects) a
+// server-side tool handler exception as `{isError: true}` — treating that as
+// success would remount on annotate's own error payload or skip the
+// required post-annotation refresh.
+function isErrorResult(payload: unknown): boolean {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as { isError?: unknown }).isError === true
+  )
+}
+
 function applyToolResult(
   payload: unknown,
   container: HTMLElement,
   remount: (mount: () => CanvasViewerHandle) => void,
-  onValidResult: (canvasId: string | undefined) => void,
+  onValidResult: (canvasId: string | undefined, scene: ViewerScene) => void,
 ): void {
+  if (isErrorResult(payload)) {
+    console.error('[whiteboard-widget] ignoring tool-result carrying an error result:', payload)
+    return
+  }
   const { canvasId, scene } = extractCanvasIdAndScene(payload)
+  let parsedScene: ViewerScene
   try {
-    parseViewerScene(scene)
+    parsedScene = parseViewerScene(scene)
   } catch (err) {
     // Surfaced for host-integration debugging: the widget deliberately
     // keeps the current view on malformed payloads, which would otherwise
@@ -190,7 +223,7 @@ function applyToolResult(
     return
   }
   remount(() => mountCanvasViewer(container, { scene }))
-  onValidResult(canvasId)
+  onValidResult(canvasId, parsedScene)
 }
 
 // `remount` is the single place a mount produced by this bridge happens.
@@ -215,19 +248,27 @@ async function mountFromHost(
   const app = new App({ name: 'whiteboard-canvas-view', version: '0.0.0' }, {})
 
   // Committed only once a tool-result has actually passed parseViewerScene —
-  // an unvalidated canvasId must never enable Refresh (it would call
-  // canvas_view with an ID nobody confirmed is real).
+  // an unvalidated canvasId must never enable Refresh or the sticky-note
+  // affordance (either would call back into the daemon with an ID nobody
+  // confirmed is real).
   let committedCanvasId: string | undefined
+  // Retained so the sticky-note affordance can place a new note relative to
+  // the last scene this widget actually rendered, without ever reaching
+  // into Excalidraw's own viewport internals (mount.ts stays read-only).
+  let lastValidScene: ViewerScene | undefined
   let refreshControl: ReturnType<typeof createRefreshControl> | undefined
+  let stickyControl: ReturnType<typeof createStickyNoteControl> | undefined
 
-  const rememberCanvasId = (canvasId: string | undefined): void => {
+  const commitResult = (canvasId: string | undefined, scene: ViewerScene): void => {
+    lastValidScene = scene
     if (canvasId === undefined) return
     committedCanvasId = canvasId
     refreshControl?.show()
+    stickyControl?.show()
   }
 
   app.ontoolresult = (result) => {
-    applyToolResult(result, container, remount, rememberCanvasId)
+    applyToolResult(result, container, remount, commitResult)
   }
 
   // connect() may reject after the timeout already won the race; a catch on
@@ -256,29 +297,99 @@ async function mountFromHost(
   // this document's lifetime.
   if (connected && canUseServerTools) {
     let refreshInFlight = false
-    refreshControl = createRefreshControl(() => {
-      if (refreshInFlight || committedCanvasId === undefined) return
+    // Set whenever a refresh is REQUIRED while one is already in flight (a
+    // manual Refresh click racing a just-succeeded annotate, or vice versa)
+    // — the in-flight run loops once more instead of the caller's request
+    // being silently dropped. A single boolean (rather than a queue) is
+    // enough because every refresh call targets the same committedCanvasId
+    // and asks for the same thing: "the latest scene".
+    let pendingRefresh = false
+
+    const runRefreshOnce = async (): Promise<void> => {
+      if (committedCanvasId === undefined) return
+      try {
+        const result = await app.callServerTool({
+          name: 'canvas_view',
+          arguments: { canvasId: committedCanvasId },
+        })
+        applyToolResult(result, container, remount, commitResult)
+      } catch (err) {
+        // Network/host failure: the current view stays mounted (no remount
+        // was attempted) — nothing to recover here besides resetting the
+        // in-flight guard below. Logged so a failing host transport doesn't
+        // present as a dead button.
+        console.error('[whiteboard-widget] refresh via host callServerTool failed:', err)
+      }
+    }
+
+    const performRefresh = async (): Promise<void> => {
+      if (committedCanvasId === undefined) return
+      if (refreshInFlight) {
+        pendingRefresh = true
+        return
+      }
       refreshInFlight = true
       refreshControl?.setBusy(true)
-      void app
-        .callServerTool({ name: 'canvas_view', arguments: { canvasId: committedCanvasId } })
-        .then((result) => {
-          applyToolResult(result, container, remount, rememberCanvasId)
-        })
-        .catch((err) => {
-          // Network/host failure: the current view stays mounted (no
-          // remount was attempted) — nothing to recover here besides
-          // resetting the in-flight guard below. Logged so a failing
-          // host transport doesn't present as a dead button.
-          console.error('[whiteboard-widget] refresh via host callServerTool failed:', err)
-        })
-        .finally(() => {
-          refreshInFlight = false
-          refreshControl?.setBusy(false)
-        })
+      try {
+        do {
+          pendingRefresh = false
+          await runRefreshOnce()
+        } while (pendingRefresh)
+      } finally {
+        refreshInFlight = false
+        refreshControl?.setBusy(false)
+      }
+    }
+
+    refreshControl = createRefreshControl(() => {
+      void performRefresh()
     })
     if (committedCanvasId !== undefined) {
       refreshControl.show()
+    }
+
+    let annotateInFlight = false
+    stickyControl = createStickyNoteControl((text) => {
+      if (annotateInFlight || committedCanvasId === undefined) return
+      annotateInFlight = true
+      stickyControl?.setBusy(true)
+      const target = computeStickyPlacement(lastValidScene?.elements ?? [])
+      void app
+        .callServerTool({
+          name: 'annotate',
+          arguments: {
+            canvasId: committedCanvasId,
+            type: 'box_with_label',
+            target,
+            text,
+            width: STICKY_WIDTH,
+            backgroundColor: STICKY_BACKGROUND_COLOR,
+          },
+        })
+        .then((result) => {
+          if (isErrorResult(result)) {
+            console.error(
+              '[whiteboard-widget] annotate via host callServerTool returned an error result:',
+              result,
+            )
+            return
+          }
+          // Required, not optional: append-only means the new note is only
+          // visible once canvas_view re-fetches. Routed through the same
+          // coalescing performRefresh a concurrent manual Refresh uses, so
+          // neither call can silently skip the other's refresh.
+          void performRefresh()
+        })
+        .catch((err) => {
+          console.error('[whiteboard-widget] annotate via host callServerTool failed:', err)
+        })
+        .finally(() => {
+          annotateInFlight = false
+          stickyControl?.setBusy(false)
+        })
+    })
+    if (committedCanvasId !== undefined) {
+      stickyControl.show()
     }
   }
 

--- a/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createStickyNoteControl,
+  STICKY_NOTE_CONTROL_TEST_ID,
+  STICKY_NOTE_INPUT_TEST_ID,
+  STICKY_NOTE_SUBMIT_TEST_ID,
+} from './sticky-note-control.js'
+
+function queryControl(): HTMLElement | null {
+  return document.querySelector(`[data-testid="${STICKY_NOTE_CONTROL_TEST_ID}"]`)
+}
+
+function queryInput(): HTMLInputElement | null {
+  return document.querySelector(`[data-testid="${STICKY_NOTE_INPUT_TEST_ID}"]`)
+}
+
+function querySubmit(): HTMLButtonElement | null {
+  return document.querySelector(`[data-testid="${STICKY_NOTE_SUBMIT_TEST_ID}"]`)
+}
+
+describe('createStickyNoteControl', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>'
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders hidden as a sibling of #root, not inside it', () => {
+    createStickyNoteControl(() => {})
+    const control = queryControl()
+    expect(control).not.toBeNull()
+    expect(control?.parentElement).toBe(document.body)
+    expect(document.getElementById('root')?.contains(control ?? null)).toBe(false)
+    expect(control?.style.display).toBe('none')
+  })
+
+  it('show() reveals the control', () => {
+    const control = createStickyNoteControl(() => {})
+    control.show()
+    expect(queryControl()?.style.display).not.toBe('none')
+  })
+
+  it('submitting non-empty text calls onSubmit with the trimmed text exactly once', () => {
+    const onSubmit = vi.fn()
+    const control = createStickyNoteControl(onSubmit)
+    control.show()
+
+    const input = queryInput() as HTMLInputElement
+    input.value = '  hello sticky  '
+    ;(queryControl() as HTMLFormElement).dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true }),
+    )
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('hello sticky')
+  })
+
+  it('submitting empty or whitespace-only text is a no-op', () => {
+    const onSubmit = vi.fn()
+    const control = createStickyNoteControl(onSubmit)
+    control.show()
+
+    const input = queryInput() as HTMLInputElement
+    input.value = '   '
+    ;(queryControl() as HTMLFormElement).dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true }),
+    )
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('setBusy(true) disables the input and submit button; setBusy(false) re-enables them', () => {
+    const control = createStickyNoteControl(() => {})
+    control.setBusy(true)
+    expect(queryInput()?.disabled).toBe(true)
+    expect(querySubmit()?.disabled).toBe(true)
+
+    control.setBusy(false)
+    expect(queryInput()?.disabled).toBe(false)
+    expect(querySubmit()?.disabled).toBe(false)
+  })
+
+  it('survives a container replaceChildren() remount because it lives outside #root', () => {
+    createStickyNoteControl(() => {})
+    const root = document.getElementById('root') as HTMLElement
+    root.replaceChildren(document.createElement('span'))
+    expect(queryControl()).not.toBeNull()
+  })
+})

--- a/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
@@ -36,6 +36,22 @@ describe('createStickyNoteControl', () => {
     expect(control?.style.display).toBe('none')
   })
 
+  it('bounds the form width so a narrow frame cannot clip the input off-screen', () => {
+    createStickyNoteControl(() => {})
+    const control = queryControl() as HTMLFormElement
+    const input = queryInput() as HTMLInputElement
+
+    // Pinning only `right` (with no `left`/`max-width`) lets a shrink-to-fit
+    // form grow past the left viewport edge in a narrow frame; pinning both
+    // edges and bounding the form's max-width is what keeps it on-screen.
+    expect(control.style.left).not.toBe('')
+    expect(control.style.maxWidth).not.toBe('')
+    // The input must be able to shrink with the form instead of holding the
+    // form open at its own intrinsic width.
+    expect(input.style.flex).not.toBe('')
+    expect(input.style.minWidth).toBe('0px')
+  })
+
   it('show() reveals the control', () => {
     const control = createStickyNoteControl(() => {})
     control.show()

--- a/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.test.tsx
@@ -104,4 +104,12 @@ describe('createStickyNoteControl', () => {
     root.replaceChildren(document.createElement('span'))
     expect(queryControl()).not.toBeNull()
   })
+
+  it('clear() empties the input value', () => {
+    const control = createStickyNoteControl(() => {})
+    const input = queryInput() as HTMLInputElement
+    input.value = 'some text'
+    control.clear()
+    expect(input.value).toBe('')
+  })
 })

--- a/packages/canvas-viewer/src/widget/sticky-note-control.ts
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.ts
@@ -1,0 +1,89 @@
+// Overlay control for the append-only sticky-note affordance (widget-entry.ts).
+// Rendered as a sibling of #root, never inside it — see refresh-control.ts's
+// doc comment: `remount` clears #root via container.replaceChildren() on
+// every mount, which would delete this element if it lived inside the
+// container.
+export interface StickyNoteControl {
+  readonly element: HTMLFormElement
+  show(): void
+  setBusy(busy: boolean): void
+}
+
+// Stable hooks for tests and the widget smoke script — deliberately not an
+// `id` (a host document could already use that name) or a class (styling
+// hook, not an identity hook).
+export const STICKY_NOTE_CONTROL_TEST_ID = 'widget-sticky-note'
+export const STICKY_NOTE_INPUT_TEST_ID = 'widget-sticky-note-input'
+export const STICKY_NOTE_SUBMIT_TEST_ID = 'widget-sticky-note-submit'
+
+export function createStickyNoteControl(onSubmit: (text: string) => void): StickyNoteControl {
+  const form = document.createElement('form')
+  form.setAttribute('data-testid', STICKY_NOTE_CONTROL_TEST_ID)
+  // Deliberately minimal inline styling: this widget has no CSS build step
+  // of its own (single-file bundle) and must stay legible over an arbitrary
+  // host-rendered scene without competing with Excalidraw's own UI chrome.
+  form.style.cssText = [
+    'position:fixed',
+    'top:8px',
+    'right:96px',
+    'z-index:2147483647',
+    'display:none',
+    'gap:4px',
+    'padding:4px',
+    'border-radius:6px',
+    'border:1px solid rgba(0,0,0,0.2)',
+    'background:rgba(255,255,255,0.9)',
+  ].join(';')
+
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.placeholder = 'Add sticky note…'
+  input.setAttribute('data-testid', STICKY_NOTE_INPUT_TEST_ID)
+  input.setAttribute('aria-label', 'Sticky note text')
+  input.style.cssText = [
+    'font:12px system-ui,sans-serif',
+    'padding:4px 6px',
+    'border-radius:4px',
+    'border:1px solid rgba(0,0,0,0.2)',
+  ].join(';')
+
+  const submit = document.createElement('button')
+  submit.type = 'submit'
+  submit.textContent = 'Add'
+  submit.setAttribute('data-testid', STICKY_NOTE_SUBMIT_TEST_ID)
+  submit.setAttribute('aria-label', 'Add sticky note to canvas')
+  submit.style.cssText = [
+    'padding:4px 10px',
+    'font:12px system-ui,sans-serif',
+    'border-radius:6px',
+    'border:1px solid rgba(0,0,0,0.2)',
+    'background:rgba(255,255,255,0.9)',
+    'color:#1e1e1e',
+    'cursor:pointer',
+  ].join(';')
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault()
+    const text = input.value.trim()
+    if (text.length === 0) return
+    onSubmit(text)
+  })
+
+  form.appendChild(input)
+  form.appendChild(submit)
+  document.body.appendChild(form)
+
+  return {
+    element: form,
+    show(): void {
+      form.style.display = 'flex'
+    },
+    setBusy(busy: boolean): void {
+      input.disabled = busy
+      submit.disabled = busy
+      submit.style.opacity = busy ? '0.5' : ''
+      submit.style.cursor = busy ? 'wait' : 'pointer'
+      submit.textContent = busy ? 'Adding…' : 'Add'
+    },
+  }
+}

--- a/packages/canvas-viewer/src/widget/sticky-note-control.ts
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.ts
@@ -7,6 +7,7 @@ export interface StickyNoteControl {
   readonly element: HTMLFormElement
   show(): void
   setBusy(busy: boolean): void
+  clear(): void
 }
 
 // Stable hooks for tests and the widget smoke script — deliberately not an
@@ -100,6 +101,9 @@ export function createStickyNoteControl(onSubmit: (text: string) => void): Stick
       submit.style.opacity = busy ? '0.5' : ''
       submit.style.cursor = busy ? 'wait' : 'pointer'
       submit.textContent = busy ? 'Adding…' : 'Add'
+    },
+    clear(): void {
+      input.value = ''
     },
   }
 }

--- a/packages/canvas-viewer/src/widget/sticky-note-control.ts
+++ b/packages/canvas-viewer/src/widget/sticky-note-control.ts
@@ -22,10 +22,19 @@ export function createStickyNoteControl(onSubmit: (text: string) => void): Stick
   // Deliberately minimal inline styling: this widget has no CSS build step
   // of its own (single-file bundle) and must stay legible over an arbitrary
   // host-rendered scene without competing with Excalidraw's own UI chrome.
+  // `left` (not just `right`) pins the other edge, and `max-width` bounds the
+  // form to whatever room remains between the two — without both, a form
+  // with no explicit width shrinks-to-fit its content and, in a narrow
+  // inline/mobile MCP App frame, that content can be wider than the space
+  // between `right:96px` and the left viewport edge, pushing the form (and
+  // its input) off-screen to the left.
   form.style.cssText = [
     'position:fixed',
     'top:8px',
+    'left:8px',
     'right:96px',
+    'max-width:calc(100% - 104px)',
+    'box-sizing:border-box',
     'z-index:2147483647',
     'display:none',
     'gap:4px',
@@ -40,7 +49,13 @@ export function createStickyNoteControl(onSubmit: (text: string) => void): Stick
   input.placeholder = 'Add sticky note…'
   input.setAttribute('data-testid', STICKY_NOTE_INPUT_TEST_ID)
   input.setAttribute('aria-label', 'Sticky note text')
+  // `flex:1 1 auto` plus `min-width:0` (the flexbox default is `min-width:auto`,
+  // which floors the input at its intrinsic content width and defeats
+  // shrinking) lets the input shrink to whatever room the form's `max-width`
+  // above leaves, instead of forcing the form wider than that bound.
   input.style.cssText = [
+    'flex:1 1 auto',
+    'min-width:0',
     'font:12px system-ui,sans-serif',
     'padding:4px 6px',
     'border-radius:4px',
@@ -53,6 +68,7 @@ export function createStickyNoteControl(onSubmit: (text: string) => void): Stick
   submit.setAttribute('data-testid', STICKY_NOTE_SUBMIT_TEST_ID)
   submit.setAttribute('aria-label', 'Add sticky note to canvas')
   submit.style.cssText = [
+    'flex:0 0 auto',
     'padding:4px 10px',
     'font:12px system-ui,sans-serif',
     'border-radius:6px',

--- a/packages/canvas-viewer/src/widget/sticky-placement.test.ts
+++ b/packages/canvas-viewer/src/widget/sticky-placement.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { computeStickyPlacement, STICKY_PLACEMENT_MARGIN } from './sticky-placement.js'
+
+describe('computeStickyPlacement', () => {
+  it('falls back to the origin when the scene has no elements', () => {
+    expect(computeStickyPlacement([])).toEqual({ x: 0, y: 0 })
+  })
+
+  it('falls back to the origin when no element has finite numeric geometry', () => {
+    const elements = [
+      { id: 'no-geometry' },
+      { id: 'string-coords', x: '10', y: '10', width: 20, height: 20 },
+      { id: 'nan', x: Number.NaN, y: 0, width: 20, height: 20 },
+      { id: 'infinite', x: Number.POSITIVE_INFINITY, y: 0, width: 20, height: 20 },
+      { id: 'partial', x: 0, y: 0, width: 20 },
+    ]
+    expect(computeStickyPlacement(elements)).toEqual({ x: 0, y: 0 })
+  })
+
+  it('excludes isDeleted elements from the bounds computation', () => {
+    const elements = [
+      { id: 'live', x: 0, y: 0, width: 100, height: 50 },
+      { id: 'deleted', x: 1000, y: 1000, width: 10, height: 10, isDeleted: true },
+    ]
+    expect(computeStickyPlacement(elements)).toEqual({
+      x: 100 + STICKY_PLACEMENT_MARGIN,
+      y: 0,
+    })
+  })
+
+  it('places to the right of the eligible content bounding box, top-aligned to minY', () => {
+    const elements = [
+      { id: 'a', x: 0, y: 30, width: 100, height: 50 },
+      { id: 'b', x: 50, y: 0, width: 40, height: 20 },
+    ]
+    // maxX across elements = max(0+100, 50+40) = 100; minY = min(30, 0) = 0.
+    expect(computeStickyPlacement(elements)).toEqual({
+      x: 100 + STICKY_PLACEMENT_MARGIN,
+      y: 0,
+    })
+  })
+})

--- a/packages/canvas-viewer/src/widget/sticky-placement.test.ts
+++ b/packages/canvas-viewer/src/widget/sticky-placement.test.ts
@@ -39,4 +39,30 @@ describe('computeStickyPlacement', () => {
       y: 0,
     })
   })
+
+  it('accounts for a rotated element by using its rotated AABB, not its unrotated x+width', () => {
+    // A tall, narrow element (20 wide, 100 tall) rotated 90 degrees around its
+    // own center: its visible footprint becomes 100 wide, 20 tall, centered
+    // on the same point as the unrotated rect. Using the raw x+width here
+    // would place the sticky note well inside the element's actual (rotated)
+    // right edge instead of clear of it.
+    const elements = [{ id: 'rotated', x: 0, y: 0, width: 20, height: 100, angle: Math.PI / 2 }]
+    // Center = (10, 50). Rotated AABB: x in [10-50, 10+50] = [-40, 60],
+    // y in [50-10, 50+10] = [40, 60]. So maxX = 60, minY = 40.
+    expect(computeStickyPlacement(elements)).toEqual({
+      x: 60 + STICKY_PLACEMENT_MARGIN,
+      y: 40,
+    })
+  })
+
+  it('treats a missing or non-numeric angle as unrotated (angle 0)', () => {
+    const elements = [
+      { id: 'no-angle', x: 0, y: 0, width: 100, height: 50 },
+      { id: 'nan-angle', x: 200, y: 0, width: 10, height: 10, angle: Number.NaN },
+    ]
+    expect(computeStickyPlacement(elements)).toEqual({
+      x: 210 + STICKY_PLACEMENT_MARGIN,
+      y: 0,
+    })
+  })
 })

--- a/packages/canvas-viewer/src/widget/sticky-placement.ts
+++ b/packages/canvas-viewer/src/widget/sticky-placement.ts
@@ -1,0 +1,66 @@
+// Deliberately reads the retained parseViewerScene output, never Excalidraw
+// viewport internals (mount.ts stays untouched) — the widget only knows the
+// scene it last rendered, not the host's current pan/zoom.
+export const STICKY_PLACEMENT_MARGIN = 24
+
+interface EligibleElement {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+// parseViewerScene (scene.ts) validates elements only as loose records, so
+// geometry here can be missing, non-numeric, NaN, or Infinity — any of those
+// disqualifies the element from the bounds computation rather than
+// corrupting it.
+function isEligibleElement(element: unknown): element is EligibleElement {
+  if (typeof element !== 'object' || element === null) return false
+  const record = element as Record<string, unknown>
+  if (record.isDeleted === true) return false
+  return (
+    isFiniteNumber(record.x) &&
+    isFiniteNumber(record.y) &&
+    isFiniteNumber(record.width) &&
+    isFiniteNumber(record.height)
+  )
+}
+
+interface Bounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export interface StickyPlacement {
+  x: number
+  y: number
+}
+
+// Right of the last-valid-scene content, top-aligned to its topmost element.
+// An empty scene, or one with no geometrically-eligible element, falls back
+// to the origin deterministically rather than guessing a viewport center
+// this widget has no way to observe.
+export function computeStickyPlacement(elements: readonly unknown[]): StickyPlacement {
+  let bounds: Bounds | undefined
+  for (const element of elements) {
+    if (!isEligibleElement(element)) continue
+    const maxX = element.x + element.width
+    const maxY = element.y + element.height
+    bounds = bounds
+      ? {
+          minX: Math.min(bounds.minX, element.x),
+          minY: Math.min(bounds.minY, element.y),
+          maxX: Math.max(bounds.maxX, maxX),
+          maxY: Math.max(bounds.maxY, maxY),
+        }
+      : { minX: element.x, minY: element.y, maxX, maxY }
+  }
+  if (!bounds) return { x: 0, y: 0 }
+  return { x: bounds.maxX + STICKY_PLACEMENT_MARGIN, y: bounds.minY }
+}

--- a/packages/canvas-viewer/src/widget/sticky-placement.ts
+++ b/packages/canvas-viewer/src/widget/sticky-placement.ts
@@ -8,6 +8,11 @@ interface EligibleElement {
   y: number
   width: number
   height: number
+  // Excalidraw's rotation, in radians, around the element's own center.
+  // Missing or non-numeric input is treated as unrotated (0) rather than
+  // disqualifying the element — angle is optional in Excalidraw's element
+  // schema, so a well-formed unrotated element must stay eligible.
+  angle: number
 }
 
 function isFiniteNumber(value: unknown): value is number {
@@ -18,16 +23,59 @@ function isFiniteNumber(value: unknown): value is number {
 // geometry here can be missing, non-numeric, NaN, or Infinity — any of those
 // disqualifies the element from the bounds computation rather than
 // corrupting it.
-function isEligibleElement(element: unknown): element is EligibleElement {
-  if (typeof element !== 'object' || element === null) return false
+function toEligibleElement(element: unknown): EligibleElement | undefined {
+  if (typeof element !== 'object' || element === null) return undefined
   const record = element as Record<string, unknown>
-  if (record.isDeleted === true) return false
-  return (
-    isFiniteNumber(record.x) &&
-    isFiniteNumber(record.y) &&
-    isFiniteNumber(record.width) &&
-    isFiniteNumber(record.height)
-  )
+  if (record.isDeleted === true) return undefined
+  if (
+    !isFiniteNumber(record.x) ||
+    !isFiniteNumber(record.y) ||
+    !isFiniteNumber(record.width) ||
+    !isFiniteNumber(record.height)
+  ) {
+    return undefined
+  }
+  return {
+    x: record.x,
+    y: record.y,
+    width: record.width,
+    height: record.height,
+    angle: isFiniteNumber(record.angle) ? record.angle : 0,
+  }
+}
+
+// Excalidraw rotates an element around its own center, so its visible
+// footprint's axis-aligned bounding box is generally larger than (and offset
+// from) the unrotated x/y/width/height rect — using the raw rect for a
+// rotated element (especially a tall, narrow one close to 90 degrees) can
+// place a target that reads as "clear of the content" well inside its actual
+// rendered bounds.
+function rotatedAabb(element: EligibleElement): Bounds {
+  const { x, y, width, height, angle } = element
+  if (angle === 0) {
+    return { minX: x, minY: y, maxX: x + width, maxY: y + height }
+  }
+  const centerX = x + width / 2
+  const centerY = y + height / 2
+  const cos = Math.cos(angle)
+  const sin = Math.sin(angle)
+  const halfWidth = width / 2
+  const halfHeight = height / 2
+  const corners = [
+    [-halfWidth, -halfHeight],
+    [halfWidth, -halfHeight],
+    [halfWidth, halfHeight],
+    [-halfWidth, halfHeight],
+  ].map(([dx, dy]) => ({
+    x: centerX + dx * cos - dy * sin,
+    y: centerY + dx * sin + dy * cos,
+  }))
+  return {
+    minX: Math.min(...corners.map((corner) => corner.x)),
+    minY: Math.min(...corners.map((corner) => corner.y)),
+    maxX: Math.max(...corners.map((corner) => corner.x)),
+    maxY: Math.max(...corners.map((corner) => corner.y)),
+  }
 }
 
 interface Bounds {
@@ -49,17 +97,17 @@ export interface StickyPlacement {
 export function computeStickyPlacement(elements: readonly unknown[]): StickyPlacement {
   let bounds: Bounds | undefined
   for (const element of elements) {
-    if (!isEligibleElement(element)) continue
-    const maxX = element.x + element.width
-    const maxY = element.y + element.height
+    const eligible = toEligibleElement(element)
+    if (!eligible) continue
+    const elementAabb = rotatedAabb(eligible)
     bounds = bounds
       ? {
-          minX: Math.min(bounds.minX, element.x),
-          minY: Math.min(bounds.minY, element.y),
-          maxX: Math.max(bounds.maxX, maxX),
-          maxY: Math.max(bounds.maxY, maxY),
+          minX: Math.min(bounds.minX, elementAabb.minX),
+          minY: Math.min(bounds.minY, elementAabb.minY),
+          maxX: Math.max(bounds.maxX, elementAabb.maxX),
+          maxY: Math.max(bounds.maxY, elementAabb.maxY),
         }
-      : { minX: element.x, minY: element.y, maxX, maxY }
+      : elementAabb
   }
   if (!bounds) return { x: 0, y: 0 }
   return { x: bounds.maxX + STICKY_PLACEMENT_MARGIN, y: bounds.minY }

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -308,6 +308,27 @@ async function main() {
   }
   console.log(`[e2e] annotate → rect`)
 
+  // Exercises the exact argument shape the canvas-viewer widget's
+  // sticky-note affordance sends (widget-entry.ts): box_with_label with
+  // width but no height/color. canvas-viewer cannot z.infer this from
+  // mcp-server (no cross-package dependency), so this call is the runtime
+  // guard against that literal drifting from annotate's real input contract.
+  const sticky = await callTool('annotate', {
+    canvasId: created.id,
+    type: 'box_with_label',
+    target: { x: 200, y: 20 },
+    coords: 'absolute',
+    text: 'smoke sticky note',
+    width: 260,
+    backgroundColor: '#ffec99',
+  })
+  if (!sticky.elementId && !sticky.elementIds) {
+    throw new Error(
+      `annotate (sticky-note shape) returned unexpected shape: ${JSON.stringify(sticky)}`,
+    )
+  }
+  console.log('[e2e] annotate → sticky-note shape (box_with_label, width, no height/color)')
+
   // Exercise annotate_batch with an arrow that uses text as a label alias.
   // The SDK validates structuredContent against outputSchema at runtime, so
   // any drift between the Zod schema and the actual payload surfaces here.

--- a/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/ui-linked-tools.test.ts
@@ -130,6 +130,18 @@ describe('MCP Apps UI-linked tools coverage', () => {
     assertVisibilityAllowsApp(viewEntry ?? '')
   })
 
+  it('annotate has no `_meta.ui` and leaves `visibility` unset or app-inclusive, so the canvas-viewer widget can call it back for the sticky-note affordance', () => {
+    // annotate is deliberately NOT UI-linked (no _meta.ui — rendering stays
+    // exclusive to canvas_view), but the widget's sticky-note affordance
+    // still needs to CALL it via app.callServerTool, which requires the
+    // same app-inclusive visibility default as canvas_view's Refresh.
+    const entries = splitDefineToolEntries(registrationSrc)
+    const annotateEntry = entries.find((e) => toolNameOf(e) === 'annotateToolDef')
+    expect(annotateEntry).toBeDefined()
+    expect(annotateEntry).not.toMatch(/_meta:\s*\{\s*ui:/)
+    assertVisibilityAllowsApp(annotateEntry ?? '')
+  })
+
   it('flags a non-literal `visibility` reference instead of passing vacuously', () => {
     // Guards the guard: a future edit to `visibility: MODEL_ONLY_VISIBILITY`
     // (a non-literal reference) must fail this check, not silently pass it


### PR DESCRIPTION
## Summary

MCP Apps Phase B, second slice: the `canvas_view` widget gains its **first write operation** — an append-only sticky-note affordance bridged through the host session to the existing `annotate` tool. The widget still holds zero daemon credentials; both tool calls (annotate, follow-up canvas_view) go through `App.callServerTool`.

- **`sticky-note-control.ts`**: overlay text form beside the Refresh control (sibling of `#root`, survives remounts), shown only under the same gate as Refresh (connect race won + host advertises `serverTools` + a validated `canvasId` committed).
- **`sticky-placement.ts`**: deterministic placement right of the last-valid-scene content bounds — computed from retained `parseViewerScene` output with a finite-geometry filter (skips non-numeric/NaN/deleted elements, accounts for element rotation), origin fallback for empty scenes. Never touches Excalidraw viewport internals.
- **Argument shape**: `{canvasId, type:'box_with_label', target, text, width: 260, backgroundColor:'#ffec99'}` — `height` omitted (annotate's autoFit) and `color` omitted (annotate's readable-ink contrast). `pnpm smoke:e2e` now calls annotate with this exact shape as the runtime drift guard (canvas-viewer cannot `z.infer` across the package boundary).
- **Refresh coalescing**: `performRefresh()` with a pending-refresh flag replaces the bare in-flight boolean — the post-annotation refresh can never be silently skipped by a concurrent manual Refresh; the sticky control stays busy until the follow-up refresh resolves (no duplicate placement at the same coordinates).
- **Failure handling** covers both channels: rejected promises AND resolved `{isError:true}` results — view stays mounted, `console.error`, guards re-arm.
- **Append-only invariant is machine-checked**: a source-scan test asserts every `callServerTool` site names only `canvas_view` or `annotate` — introducing an edit/delete call fails the suite.
- Daemon: zero production change (`annotate` is app-callable by default); `ui-linked-tools.test.ts` pins that annotate stays non-UI-linked and app-callable.
- Docs: how-to updated; the view is no longer *fully* read-only — only editing/moving/deleting existing elements remains out of scope.

## Real-host verification (MCPJam)

Full write round-trip verified against MCPJam as a real ext-apps host:

1. `canvas_view` rendered the seeded scene; sticky-note form + Refresh visible (capability gate).
2. Typed 「付箋テスト: widgetから追加」 and submitted → widget issued `annotate` through the host session, then auto-refreshed via the coalesced path — content pixels 1093 → 7597, the yellow note rendered right of the existing content with auto-fit line wrapping.
3. **Cross-client persistence**: a separate direct MCP client read of `canvas_view` shows the appended elements (`#ffec99` rectangle + bound text) on the daemon canvas — the note exists in the persistent, versioned whiteboard, not just the widget.

Dogfood side-finding (filed locally, out of scope here): `annotate` with a mistyped `workspaceId/slug` silently creates a brand-new workspace instead of erroring.

## Visual repro

After submitting the sticky note from the widget (input form top-left, appended yellow note placed right of existing content):

![mcp-apps-sticky-note.png](https://github.com/user-attachments/assets/6306648b-5812-496f-a796-249c04ce2b3d)

## Widget-op ↔ MCP tool mapping (Phase B ledger)

| Widget operation | MCP tool | Arguments | Path |
|---|---|---|---|
| Refresh | `canvas_view` | `{canvasId}` | host `callServerTool` |
| Add sticky note | `annotate` | `{canvasId, type:'box_with_label', target, text, width, backgroundColor}` | host `callServerTool` (visibility default `["model","app"]`) |

## Tests

- canvas-viewer: node 49 ✓ / jsdom 50 ✓ (isError channel, refresh-race, placement geometry filter + rotation, append-only source scan) / widget smoke incl. sticky-absence in both no-host paths ✓
- mcp-server: typecheck ✓, ui-linked-tools 9 ✓; `smoke:e2e` extended with the widget's exact annotate payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WyfrPAJrHB3bWZMrRQMry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-widget sticky-note form for supported hosts.
  * Sticky notes are added beside existing canvas content and appear after the view refreshes.
  * The control indicates when an addition is in progress and prevents duplicate submissions.

* **Bug Fixes**
  * Improved handling of invalid or failed canvas updates without replacing the current view.
  * Prevented overlapping refreshes and annotation requests.

* **Documentation**
  * Clarified Phase A read-only limitations and documented sticky-note behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->