### PR TITLE
chore: make property-based specs a first-class design artifact

### DIFF
--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -25,8 +25,9 @@ Notes:
 
 ## Property-Based / Model-Based Testing (PBT)
 
-fast-check is already wired in via shared wrappers — `packages/mcp-server/src/shared/test-utils/fast-check.ts`
-and `apps/web/src/test-utils/fast-check.ts`. Reach for a property (or model-based) test instead of,
+fast-check is already wired in via shared wrappers — `packages/mcp-server/src/shared/test-utils/fast-check.ts`,
+`apps/web/src/test-utils/fast-check.ts`, and `packages/canvas-viewer/src/test-utils/fast-check.ts`. Reach for
+a property (or model-based) test instead of,
 or in addition to, an example test when the change is one of:
 
 - **Parser / serializer**: assert a round-trip (`parse(serialize(x))` equals `x`, or an explicitly

--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-layer-selection
-description: How to pick the nearest test layer in the whiteboard repo (mcp-node / mcp-jsdom / mcp-browser / web-browser / E2E) and the commands to run each. Use when writing the red test for a change, or deciding where a regression belongs.
+description: How to pick the nearest test layer in the whiteboard repo (mcp-node / canvas-viewer-node / canvas-viewer-jsdom / canvas-viewer-browser / apps/web jsdom / web-browser / E2E), when to reach for a property or model-based test instead of an example, and the commands to run each. Use when writing the red test for a change, or deciding where a regression belongs.
 ---
 
 # Test Layer Selection
@@ -9,15 +9,52 @@ Start with the smallest failing test at the **nearest** layer. Do not jump to br
 
 | Layer | Use for | Command |
 |---|---|---|
-| `mcp-node` | pure functions, stores, routes, server behavior, persistence logic | `pnpm test --project mcp-node` |
-| `mcp-jsdom` | React components/hooks when browser layout & pointer behavior are NOT the core risk | `pnpm test --project mcp-jsdom` |
-| `mcp-browser` | popovers, dialogs, scroll, focus, keyboard, pointer, restore flows (real browser) in `packages/mcp-server` | `pnpm test --project mcp-browser` |
+| `mcp-node` | pure functions, stores, routes, server behavior, persistence logic in `packages/mcp-server` | `pnpm test --project mcp-node` |
+| `canvas-viewer-node` | pure parsing/serialization logic in `packages/canvas-viewer` with no DOM dependency | `pnpm test --project canvas-viewer-node` |
+| `canvas-viewer-jsdom` | `packages/canvas-viewer` components/hooks when browser layout & pointer behavior are NOT the core risk | `pnpm test --project canvas-viewer-jsdom` |
+| `canvas-viewer-browser` | `packages/canvas-viewer` popovers, dialogs, scroll, focus, keyboard, pointer, restore flows (real browser) | `pnpm test --project canvas-viewer-browser` |
+| `apps/web` jsdom project | React components/hooks in `apps/web` when browser layout & pointer behavior are NOT the core risk | `pnpm --filter @kamiazya/whiteboard-web test` |
 | `web-browser` | `apps/web` tests needing real browser APIs jsdom lacks: IndexedDB, OPFS, `window.showOpenFilePicker`. File suffix `.browser.test.tsx` | part of `pnpm test:browser` |
 | E2E | real routes, server composition, websocket timing, persistence order, multi-step page flows | promote only when needed |
 
 Notes:
-- `apps/web` unit/jsdom: `pnpm --filter @kamiazya/whiteboard-web test`.
-- Browser suites together: `pnpm run test:browser` (mcp-browser + web-browser); `pnpm run test:browser:trace` for trace artifacts on failure (under `<package>/tmp/vitest-traces`).
+- Browser suites together: `pnpm run test:browser` (`canvas-viewer-browser` + `web-browser`); `pnpm run test:browser:trace` for trace artifacts on failure (under `<package>/tmp/vitest-traces`).
 - After the targeted test passes, run the broader suite covering the touched area, then `pnpm test`.
 - Runtime is the source of truth: if behavior disagrees with a test, fix the test or implementation to match real behavior.
 - Passing tests alone are not sufficient — manually verify the real behavior (Playwright/Chrome MCP) before locking the scenario into regression coverage.
+
+## Property-Based / Model-Based Testing (PBT)
+
+fast-check is already wired in via shared wrappers — `packages/mcp-server/src/shared/test-utils/fast-check.ts`
+and `apps/web/src/test-utils/fast-check.ts`. Reach for a property (or model-based) test instead of,
+or in addition to, an example test when the change is one of:
+
+- **Parser / serializer**: assert a round-trip (`parse(serialize(x))` equals `x`, or an explicitly
+  computed normalization of `x` when the serializer is not injective) plus a totality property
+  (parse either throws or returns a schema-valid value — no silent coercion).
+- **State machine with time/TTL/revocation** (auth/session/challenge stores, sliding-window caches):
+  model the entity as `fc.commands`-style random sequences of operations (mint/enroll/verify/revoke/
+  advance-clock) driven by an injected `now()`, and assert invariants hold after every step — this
+  catches ordering bugs an example test's fixed script cannot.
+- **Concurrent store**: N concurrent writers converge to one agreed result (e.g. two tabs racing to
+  create the same keypair land on the same key).
+- **CRDT / mergeable structure**: idempotence (merge twice = merge once), commutativity/convergence
+  (independent edits merged either order reach the same state).
+- **Rounding / normalization**: the transform's algebraic invariant (e.g. `normalize(normalize(x)) ===
+  normalize(x)`).
+
+Prefer example/browser tests for UI wiring and one-off integrations with no clean invariant to state.
+
+**Runtime budget by layer**: node-layer properties (`mcp-node`, `canvas-viewer-node`) can afford the
+library's default `numRuns`; jsdom-layer properties should stay modest; `web-browser`/`canvas-viewer-browser`
+properties are the most expensive per run (real browser + IndexedDB/etc.) — keep `numRuns` small
+(single digits to ~20) and prefer the shared wrapper's `withDefaults()`-style override over inlining
+`{ numRuns }` ad hoc.
+
+**Discipline** (matches the fast-check wrappers already in the repo):
+- Never pin a fast-check seed to force a flaky property green — a flake under load is a resource
+  signal (lower `numRuns`), not an RNG problem to hide.
+- When a property finds a real bug: pin the shrunk counterexample as an example test **before**
+  fixing production code, fix the implementation, then mutation-check (revert the fix, confirm the
+  pinned example — and ideally the property — goes red, then restore).
+- Shared arbitraries belong in the owning package's `test-utils`, not copy-pasted per test file.

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -145,20 +145,31 @@ const FIX_SCHEMA = {
 // for why this is duplicated instead of imported).
 const propertiesItemPattern = new RegExp(DESIGN_SCHEMA.properties.properties.items.pattern)
 
+// Kept in lockstep with DESIGN_SCHEMA's `additionalProperties: false` at both the top level and
+// inside `testScenarios` — isValidDesignShape below must reject any key outside these lists.
+const ALLOWED_TOP_LEVEL_KEYS = ['completionCriteria', 'scope', 'contractChanges', 'testScenarios', 'risks', 'properties']
+const ALLOWED_TEST_SCENARIO_KEYS = ['unit', 'browser', 'e2e']
+
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string')
+}
+
 // Guards a caller-provided `designDoc` against the same shape DESIGN_SCHEMA enforces on a
 // generated design, so a malformed/incomplete args.designDoc can't skip PlanReview's invariant
-// check by never passing through the schema-constrained agent() call in the first place.
+// check by never passing through the schema-constrained agent() call in the first place. Checks
+// every field DESIGN_SCHEMA constrains, not just the four required ones.
 function isValidDesignShape(d) {
   if (!d || typeof d !== 'object') return false
+  if (!Object.keys(d).every((k) => ALLOWED_TOP_LEVEL_KEYS.includes(k))) return false
   if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
   if (typeof d.scope !== 'string') return false
-  if (
-    !d.testScenarios ||
-    !Array.isArray(d.testScenarios.unit) ||
-    !d.testScenarios.unit.every((u) => typeof u === 'string')
-  ) {
-    return false
-  }
+  if (d.contractChanges !== undefined && typeof d.contractChanges !== 'string') return false
+  if (!d.testScenarios || typeof d.testScenarios !== 'object') return false
+  if (!Object.keys(d.testScenarios).every((k) => ALLOWED_TEST_SCENARIO_KEYS.includes(k))) return false
+  if (!isStringArray(d.testScenarios.unit)) return false
+  if (d.testScenarios.browser !== undefined && !isStringArray(d.testScenarios.browser)) return false
+  if (d.testScenarios.e2e !== undefined && !isStringArray(d.testScenarios.e2e)) return false
+  if (d.risks !== undefined && !isStringArray(d.risks)) return false
   if (!Array.isArray(d.properties) || d.properties.length < 1) return false
   if (!d.properties.every((p) => typeof p === 'string' && propertiesItemPattern.test(p))) return false
   return true
@@ -171,6 +182,13 @@ function isValidDesignShape(d) {
 function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedDesign }) {
   if (hasDesign) return false
   return !skipDesign || !!discardedInvalidProvidedDesign
+}
+
+// Gates the Implement phase on the PlanReview gate's final verdict. Mirrors
+// .claude/workflows/lib/design-schema.mjs's shouldBlockOnFailedPlanReview (see the sync test for
+// why this is duplicated instead of imported).
+function shouldBlockOnFailedPlanReview({ hasDesign, pass }) {
+  return !!hasDesign && !pass
 }
 
 // --- Phase 1: design ---
@@ -225,6 +243,20 @@ if (design) {
       { label: `design-revise:${planRev}`, phase: 'Design', schema: DESIGN_SCHEMA },
     )
     planVerdict = await runGate()
+  }
+}
+
+if (shouldBlockOnFailedPlanReview({ hasDesign: !!design, pass: planVerdict.pass })) {
+  return {
+    taskTitle: TASK,
+    design,
+    planVerdict,
+    codexPlanVerdict,
+    implReport: null,
+    review: null,
+    openFollowups: [],
+    needsHumanGate: true,
+    note: `PlanReview did not pass after ${MAX_PLAN_REV} revision(s); returning to the integrator instead of implementing a rejected design. mustFix: ${(planVerdict.mustFix || []).join('; ')}`,
   }
 }
 

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -139,26 +139,49 @@ const FIX_SCHEMA = {
   required: ['fixed', 'committed'],
 }
 
+// Reuses the schema's own item pattern (rather than a second hand-picked regex) so a caller-
+// provided designDoc is held to the exact same non-blank-entry invariant as an agent-generated
+// design. Mirrors .claude/workflows/lib/design-schema.mjs's isValidDesignShape (see the sync test
+// for why this is duplicated instead of imported).
+const propertiesItemPattern = new RegExp(DESIGN_SCHEMA.properties.properties.items.pattern)
+
 // Guards a caller-provided `designDoc` against the same shape DESIGN_SCHEMA enforces on a
 // generated design, so a malformed/incomplete args.designDoc can't skip PlanReview's invariant
 // check by never passing through the schema-constrained agent() call in the first place.
 function isValidDesignShape(d) {
   if (!d || typeof d !== 'object') return false
-  if (!Array.isArray(d.completionCriteria)) return false
+  if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
   if (typeof d.scope !== 'string') return false
-  if (!d.testScenarios || !Array.isArray(d.testScenarios.unit)) return false
+  if (
+    !d.testScenarios ||
+    !Array.isArray(d.testScenarios.unit) ||
+    !d.testScenarios.unit.every((u) => typeof u === 'string')
+  ) {
+    return false
+  }
   if (!Array.isArray(d.properties) || d.properties.length < 1) return false
-  if (!d.properties.every((p) => typeof p === 'string')) return false
+  if (!d.properties.every((p) => typeof p === 'string' && propertiesItemPattern.test(p))) return false
   return true
+}
+
+// Gates the design-generation phase. `skipDesign` means "skip generation because a valid design
+// was already provided" — NOT "skip generation even after we just discarded that provided design
+// as invalid". Mirrors .claude/workflows/lib/design-schema.mjs's shouldGenerateDesign (see the
+// sync test for why this is duplicated instead of imported).
+function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedDesign }) {
+  if (hasDesign) return false
+  return !skipDesign || !!discardedInvalidProvidedDesign
 }
 
 // --- Phase 1: design ---
 let design = PROVIDED_DESIGN
+let discardedInvalidProvidedDesign = false
 if (design && !isValidDesignShape(design)) {
   log('provided designDoc does not match DESIGN_SCHEMA (missing/invalid completionCriteria, scope, testScenarios.unit, or properties) — discarding it and generating a fresh design instead.')
   design = null
+  discardedInvalidProvidedDesign = true
 }
-if (!SKIP_DESIGN && !design) {
+if (shouldGenerateDesign({ hasDesign: !!design, skipDesign: SKIP_DESIGN, discardedInvalidProvidedDesign })) {
   phase('Design')
   design = await agent(
     `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), risks, and \`properties\` — the invariants, round-trips, or metamorphic relations this change must preserve (e.g. parser/serializer round-trip, state-machine invariant, CRDT idempotence/convergence, concurrent-store convergence). \`properties\` must never be empty: for a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry \`"none: <reason>"\` instead. Do NOT write code yet.`,

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -53,6 +53,8 @@ const disciplineNote =
   'Follow AGENTS.md: Zod as the single source of truth for cross-boundary contracts (annotate execute returns with z.infer), never call console.* in server code (use getLogger), keep changes immutable, and keep at least one nearest-layer test for the root cause.'
 
 // --- schemas ---
+// Mirrors .claude/workflows/lib/design-schema.mjs (unit-tested via node:test — the workflow
+// sandbox has no import/fs, so the schema is duplicated rather than imported; keep both in sync).
 const DESIGN_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -71,8 +73,20 @@ const DESIGN_SCHEMA = {
       required: ['unit'],
     },
     risks: { type: 'array', items: { type: 'string' } },
+    // Never empty: pins the invariants/round-trips/metamorphic relations this change must hold.
+    // A stateless/pure-UI design supplies exactly one sentinel entry `"none: <reason>"` so the
+    // justification lives inside this same field instead of contradicting a `minItems: 1` empty
+    // array. PlanReview fails the gate when a design that touches state/parser/store logic
+    // supplies only that sentinel.
+    properties: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      description:
+        'Invariants, round-trip, and metamorphic relations this change must preserve (e.g. "parse(serialize(x)) === x", "reconcile is idempotent"). Never empty. For a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry of the form "none: <reason>".',
+    },
   },
-  required: ['completionCriteria', 'scope', 'testScenarios'],
+  required: ['completionCriteria', 'scope', 'testScenarios', 'properties'],
 }
 
 const PLAN_VERDICT_SCHEMA = {
@@ -128,7 +142,7 @@ let design = PROVIDED_DESIGN
 if (!SKIP_DESIGN && !PROVIDED_DESIGN) {
   phase('Design')
   design = await agent(
-    `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), and risks. Do NOT write code yet.`,
+    `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), risks, and \`properties\` — the invariants, round-trips, or metamorphic relations this change must preserve (e.g. parser/serializer round-trip, state-machine invariant, CRDT idempotence/convergence, concurrent-store convergence). \`properties\` must never be empty: for a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry \`"none: <reason>"\` instead. Do NOT write code yet.`,
     { label: 'design', phase: 'Design', schema: DESIGN_SCHEMA },
   )
 }
@@ -140,12 +154,12 @@ if (design) {
   phase('PlanReview')
   const reviewDesign = () =>
     agent(
-      `Review this design for completeness before implementation. Task: ${TASK}\nDesign: ${JSON.stringify(design)}\n\nCheck: do the test scenarios cover every completion criterion? Are high-risk angles (negative path, contract/Zod drift, migration/fallback, race/unmount) present? Is scope a single coherent change? Return pass=false with mustFix[] if not.`,
+      `Review this design for completeness before implementation. Task: ${TASK}\nDesign: ${JSON.stringify(design)}\n\nCheck: do the test scenarios cover every completion criterion? Are high-risk angles (negative path, contract/Zod drift, migration/fallback, race/unmount) present? Is scope a single coherent change? FAIL the gate if the design touches state, a parser/serializer, or a store (in-memory, persisted, or CRDT) and \`properties\` contains only the \`"none: <reason>"\` sentinel with no real invariant/round-trip/metamorphic property — that combination means an untested state-shape risk. Return pass=false with mustFix[] if not.`,
       { label: 'plan-review', phase: 'PlanReview', agentType: 'plan-reviewer', schema: PLAN_VERDICT_SCHEMA },
     )
   const codexReviewDesign = () =>
     agent(
-      `Independently review this implementation design as a gate BEFORE coding starts. Task: ${TASK}\nDesign: ${JSON.stringify(design)}\n\nFlag missing test coverage, contract/Zod-vs-runtime drift risk, hidden edge cases, scope creep, or wrong assumptions about the codebase. Return pass=false with concrete mustFix[] if implementation should not start as-is.`,
+      `Independently review this implementation design as a gate BEFORE coding starts. Task: ${TASK}\nDesign: ${JSON.stringify(design)}\n\nFlag missing test coverage, contract/Zod-vs-runtime drift risk, hidden edge cases, scope creep, or wrong assumptions about the codebase. FAIL the gate if the design touches state, a parser/serializer, or a store (in-memory, persisted, or CRDT) and \`properties\` contains only the \`"none: <reason>"\` sentinel with no real invariant/round-trip/metamorphic property. Return pass=false with concrete mustFix[] if implementation should not start as-is.`,
       { label: 'plan-review:codex', phase: 'PlanReview', agentType: 'codex:codex-rescue', schema: PLAN_VERDICT_SCHEMA },
     )
   // Both reviewers run; the gate fails if EITHER fails. Codex unavailable (null) never blocks.

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -80,7 +80,9 @@ const DESIGN_SCHEMA = {
     // supplies only that sentinel.
     properties: {
       type: 'array',
-      items: { type: 'string' },
+      // `pattern: '\\S'` rejects "", "   ", and other whitespace-only entries — minItems alone
+      // only guards array length, not per-entry content.
+      items: { type: 'string', pattern: '\\S' },
       minItems: 1,
       description:
         'Invariants, round-trip, and metamorphic relations this change must preserve (e.g. "parse(serialize(x)) === x", "reconcile is idempotent"). Never empty. For a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry of the form "none: <reason>".',
@@ -137,9 +139,26 @@ const FIX_SCHEMA = {
   required: ['fixed', 'committed'],
 }
 
+// Guards a caller-provided `designDoc` against the same shape DESIGN_SCHEMA enforces on a
+// generated design, so a malformed/incomplete args.designDoc can't skip PlanReview's invariant
+// check by never passing through the schema-constrained agent() call in the first place.
+function isValidDesignShape(d) {
+  if (!d || typeof d !== 'object') return false
+  if (!Array.isArray(d.completionCriteria)) return false
+  if (typeof d.scope !== 'string') return false
+  if (!d.testScenarios || !Array.isArray(d.testScenarios.unit)) return false
+  if (!Array.isArray(d.properties) || d.properties.length < 1) return false
+  if (!d.properties.every((p) => typeof p === 'string')) return false
+  return true
+}
+
 // --- Phase 1: design ---
 let design = PROVIDED_DESIGN
-if (!SKIP_DESIGN && !PROVIDED_DESIGN) {
+if (design && !isValidDesignShape(design)) {
+  log('provided designDoc does not match DESIGN_SCHEMA (missing/invalid completionCriteria, scope, testScenarios.unit, or properties) — discarding it and generating a fresh design instead.')
+  design = null
+}
+if (!SKIP_DESIGN && !design) {
   phase('Design')
   design = await agent(
     `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), risks, and \`properties\` — the invariants, round-trips, or metamorphic relations this change must preserve (e.g. parser/serializer round-trip, state-machine invariant, CRDT idempotence/convergence, concurrent-store convergence). \`properties\` must never be empty: for a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry \`"none: <reason>"\` instead. Do NOT write code yet.`,

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -159,7 +159,7 @@ function isStringArray(v) {
 // check by never passing through the schema-constrained agent() call in the first place. Checks
 // every field DESIGN_SCHEMA constrains, not just the four required ones.
 function isValidDesignShape(d) {
-  if (!d || typeof d !== 'object') return false
+  if (!d || typeof d !== 'object' || Array.isArray(d)) return false
   if (!Object.keys(d).every((k) => ALLOWED_TOP_LEVEL_KEYS.includes(k))) return false
   if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
   if (typeof d.scope !== 'string') return false

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -1,0 +1,36 @@
+// Extracted so it can be unit-tested with node:test (see design-schema.test.mjs) without pulling
+// in the workflow-runtime globals (`args`, `agent`, `workflow`, ...) that dev-loop.workflow.mjs
+// only has when actually run inside a workflow.
+export const DESIGN_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    completionCriteria: { type: 'array', items: { type: 'string' } },
+    scope: { type: 'string' },
+    contractChanges: { type: 'string', description: 'Zod/contract/type impact, or "none"' },
+    testScenarios: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        unit: { type: 'array', items: { type: 'string' } },
+        browser: { type: 'array', items: { type: 'string' } },
+        e2e: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['unit'],
+    },
+    risks: { type: 'array', items: { type: 'string' } },
+    // Never empty: pins the invariants/round-trips/metamorphic relations this change must hold.
+    // A stateless/pure-UI design supplies exactly one sentinel entry `"none: <reason>"` so the
+    // justification lives inside this same field instead of contradicting a `minItems: 1` empty
+    // array. PlanReview fails the gate when a design that touches state/parser/store logic
+    // supplies only that sentinel.
+    properties: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      description:
+        'Invariants, round-trip, and metamorphic relations this change must preserve (e.g. "parse(serialize(x)) === x", "reconcile is idempotent"). Never empty. For a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry of the form "none: <reason>".',
+    },
+  },
+  required: ['completionCriteria', 'scope', 'testScenarios', 'properties'],
+}

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -42,20 +42,35 @@ export const DESIGN_SCHEMA = {
 // same non-blank-entry invariant as an agent-generated design.
 const propertiesItemPattern = new RegExp(DESIGN_SCHEMA.properties.properties.items.pattern)
 
+// Kept in lockstep with DESIGN_SCHEMA's `additionalProperties: false` at both the top level and
+// inside `testScenarios` — isValidDesignShape below must reject any key outside these lists or a
+// caller-provided designDoc could carry fields the schema-constrained agent() path can never
+// produce.
+const ALLOWED_TOP_LEVEL_KEYS = ['completionCriteria', 'scope', 'contractChanges', 'testScenarios', 'risks', 'properties']
+const ALLOWED_TEST_SCENARIO_KEYS = ['unit', 'browser', 'e2e']
+
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string')
+}
+
 // Guards a caller-provided `designDoc` against the same shape DESIGN_SCHEMA enforces on a
 // generated design, so a malformed/incomplete args.designDoc can't skip PlanReview's invariant
-// check by never passing through the schema-constrained agent() call in the first place.
+// check by never passing through the schema-constrained agent() call in the first place. Checks
+// every field DESIGN_SCHEMA constrains (types, additionalProperties:false at both levels), not
+// just the four required ones, otherwise a caller-supplied document can carry schema-violating
+// values (wrong-typed optional fields, unknown keys) straight into PlanReview and implementation.
 export function isValidDesignShape(d) {
   if (!d || typeof d !== 'object') return false
+  if (!Object.keys(d).every((k) => ALLOWED_TOP_LEVEL_KEYS.includes(k))) return false
   if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
   if (typeof d.scope !== 'string') return false
-  if (
-    !d.testScenarios ||
-    !Array.isArray(d.testScenarios.unit) ||
-    !d.testScenarios.unit.every((u) => typeof u === 'string')
-  ) {
-    return false
-  }
+  if (d.contractChanges !== undefined && typeof d.contractChanges !== 'string') return false
+  if (!d.testScenarios || typeof d.testScenarios !== 'object') return false
+  if (!Object.keys(d.testScenarios).every((k) => ALLOWED_TEST_SCENARIO_KEYS.includes(k))) return false
+  if (!isStringArray(d.testScenarios.unit)) return false
+  if (d.testScenarios.browser !== undefined && !isStringArray(d.testScenarios.browser)) return false
+  if (d.testScenarios.e2e !== undefined && !isStringArray(d.testScenarios.e2e)) return false
+  if (d.risks !== undefined && !isStringArray(d.risks)) return false
   if (!Array.isArray(d.properties) || d.properties.length < 1) return false
   if (!d.properties.every((p) => typeof p === 'string' && propertiesItemPattern.test(p))) return false
   return true
@@ -69,4 +84,13 @@ export function isValidDesignShape(d) {
 export function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedDesign }) {
   if (hasDesign) return false
   return !skipDesign || !!discardedInvalidProvidedDesign
+}
+
+// Gates dev-loop's Implement phase on the PlanReview gate's final verdict. Without this, a design
+// that keeps failing PlanReview past the revision cap (e.g. a state/store design carrying only the
+// `none:` properties sentinel) still proceeds into Implement labeled "Approved design," making the
+// gate advisory instead of blocking. `hasDesign` is false when design/PlanReview was skipped
+// entirely (skipDesign with a pre-approved designDoc) — that case must not block.
+export function shouldBlockOnFailedPlanReview({ hasDesign, pass }) {
+  return !!hasDesign && !pass
 }

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -26,7 +26,9 @@ export const DESIGN_SCHEMA = {
     // supplies only that sentinel.
     properties: {
       type: 'array',
-      items: { type: 'string' },
+      // `pattern: '\\S'` rejects "", "   ", and other whitespace-only entries — minItems alone
+      // only guards array length, not per-entry content.
+      items: { type: 'string', pattern: '\\S' },
       minItems: 1,
       description:
         'Invariants, round-trip, and metamorphic relations this change must preserve (e.g. "parse(serialize(x)) === x", "reconcile is idempotent"). Never empty. For a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry of the form "none: <reason>".',

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -36,3 +36,37 @@ export const DESIGN_SCHEMA = {
   },
   required: ['completionCriteria', 'scope', 'testScenarios', 'properties'],
 }
+
+// Reuses the schema's own item pattern (rather than a second hand-picked regex) so a caller-
+// provided designDoc that bypasses the schema-constrained `agent()` call is held to the exact
+// same non-blank-entry invariant as an agent-generated design.
+const propertiesItemPattern = new RegExp(DESIGN_SCHEMA.properties.properties.items.pattern)
+
+// Guards a caller-provided `designDoc` against the same shape DESIGN_SCHEMA enforces on a
+// generated design, so a malformed/incomplete args.designDoc can't skip PlanReview's invariant
+// check by never passing through the schema-constrained agent() call in the first place.
+export function isValidDesignShape(d) {
+  if (!d || typeof d !== 'object') return false
+  if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
+  if (typeof d.scope !== 'string') return false
+  if (
+    !d.testScenarios ||
+    !Array.isArray(d.testScenarios.unit) ||
+    !d.testScenarios.unit.every((u) => typeof u === 'string')
+  ) {
+    return false
+  }
+  if (!Array.isArray(d.properties) || d.properties.length < 1) return false
+  if (!d.properties.every((p) => typeof p === 'string' && propertiesItemPattern.test(p))) return false
+  return true
+}
+
+// Gates dev-loop's design-generation phase. `skipDesign` means "skip generation because a valid
+// design was already provided" — NOT "skip generation even after we just discarded that provided
+// design as invalid". Without `discardedInvalidProvidedDesign` in the OR, an invalid designDoc
+// passed alongside skipDesign:true would leave `design` null forever, silently skipping both
+// design and PlanReview instead of falling back to a freshly generated design.
+export function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedDesign }) {
+  if (hasDesign) return false
+  return !skipDesign || !!discardedInvalidProvidedDesign
+}

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -60,7 +60,7 @@ function isStringArray(v) {
 // just the four required ones, otherwise a caller-supplied document can carry schema-violating
 // values (wrong-typed optional fields, unknown keys) straight into PlanReview and implementation.
 export function isValidDesignShape(d) {
-  if (!d || typeof d !== 'object') return false
+  if (!d || typeof d !== 'object' || Array.isArray(d)) return false
   if (!Object.keys(d).every((k) => ALLOWED_TOP_LEVEL_KEYS.includes(k))) return false
   if (!Array.isArray(d.completionCriteria) || !d.completionCriteria.every((c) => typeof c === 'string')) return false
   if (typeof d.scope !== 'string') return false

--- a/.claude/workflows/lib/design-schema.test.mjs
+++ b/.claude/workflows/lib/design-schema.test.mjs
@@ -13,6 +13,14 @@ test('requires a non-empty `properties` field pinning invariants/round-trips/met
   assert.ok(DESIGN_SCHEMA.required.includes('properties'))
 })
 
+test('rejects blank/whitespace-only `properties` entries via the item pattern', () => {
+  const itemPattern = new RegExp(DESIGN_SCHEMA.properties.properties.items.pattern)
+  assert.equal(itemPattern.test(''), false)
+  assert.equal(itemPattern.test('   '), false)
+  assert.equal(itemPattern.test('parse(serialize(x)) === x'), true)
+  assert.equal(itemPattern.test('none: pure UI wiring'), true)
+})
+
 test('describes the invariant intent and the none:<reason> escape hatch for stateless changes', () => {
   const description = DESIGN_SCHEMA.properties.properties.description || ''
   assert.match(description, /invariant/i)

--- a/.claude/workflows/lib/design-schema.test.mjs
+++ b/.claude/workflows/lib/design-schema.test.mjs
@@ -1,0 +1,26 @@
+// Run with: node --test .claude/workflows/lib/design-schema.test.mjs
+// No vitest project covers .claude/workflows (it orchestrates AI agents, not app code), so this
+// uses node:test directly, mirroring normalize-dimensions.test.mjs.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { DESIGN_SCHEMA } from './design-schema.mjs'
+
+test('requires a non-empty `properties` field pinning invariants/round-trips/metamorphic relations', () => {
+  const properties = DESIGN_SCHEMA.properties.properties
+  assert.equal(properties.type, 'array')
+  assert.equal(properties.items.type, 'string')
+  assert.equal(properties.minItems, 1)
+  assert.ok(DESIGN_SCHEMA.required.includes('properties'))
+})
+
+test('describes the invariant intent and the none:<reason> escape hatch for stateless changes', () => {
+  const description = DESIGN_SCHEMA.properties.properties.description || ''
+  assert.match(description, /invariant/i)
+  assert.match(description, /none:/)
+})
+
+test('keeps the existing required fields intact', () => {
+  assert.ok(DESIGN_SCHEMA.required.includes('completionCriteria'))
+  assert.ok(DESIGN_SCHEMA.required.includes('scope'))
+  assert.ok(DESIGN_SCHEMA.required.includes('testScenarios'))
+})

--- a/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+++ b/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
@@ -13,6 +13,7 @@ import path from 'node:path'
 import {
   DESIGN_SCHEMA,
   isValidDesignShape as sharedIsValidDesignShape,
+  shouldBlockOnFailedPlanReview as sharedShouldBlockOnFailedPlanReview,
   shouldGenerateDesign as sharedShouldGenerateDesign,
 } from './design-schema.mjs'
 
@@ -44,6 +45,16 @@ function extractShouldGenerateDesign() {
   assert.ok(match, 'could not locate `function shouldGenerateDesign({...}) {...}` in dev-loop.workflow.mjs')
   // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
   return new Function(`${match[0]}\nreturn shouldGenerateDesign`)()
+}
+
+function extractShouldBlockOnFailedPlanReview() {
+  const match = source.match(/\nfunction shouldBlockOnFailedPlanReview\(\{[\s\S]*?\n\}\n/)
+  assert.ok(
+    match,
+    'could not locate `function shouldBlockOnFailedPlanReview({...}) {...}` in dev-loop.workflow.mjs',
+  )
+  // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
+  return new Function(`${match[0]}\nreturn shouldBlockOnFailedPlanReview`)()
 }
 
 test('inline DESIGN_SCHEMA in dev-loop.workflow.mjs matches the exported design-schema.mjs module', () => {
@@ -145,6 +156,47 @@ test('the duplicated inline isValidDesignShape agrees with the single-sourced de
   for (const design of cases) {
     assert.equal(isValidDesignShape(design), sharedIsValidDesignShape(design), `mismatch for ${JSON.stringify(design)}`)
   }
+})
+
+test('isValidDesignShape rejects values forbidden by DESIGN_SCHEMA even when the required fields are present', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  const base = {
+    completionCriteria: ['does the thing'],
+    scope: 'small',
+    testScenarios: { unit: ['covers the thing'] },
+    properties: ['none: pure UI wiring, no state/parser/store surface'],
+  }
+  const cases = [
+    { ...base, contractChanges: 42 },
+    { ...base, testScenarios: { ...base.testScenarios, browser: 42 } },
+    { ...base, unknownTopLevel: 'nope' },
+    { ...base, testScenarios: { ...base.testScenarios, unknownNested: 'nope' } },
+  ]
+  for (const design of cases) {
+    assert.equal(isValidDesignShape(design), false, `expected inline validator to reject ${JSON.stringify(design)}`)
+    assert.equal(sharedIsValidDesignShape(design), false, `expected shared validator to reject ${JSON.stringify(design)}`)
+  }
+})
+
+test('shouldBlockOnFailedPlanReview blocks implementation when a design was reviewed and the gate never passed', () => {
+  const shouldBlockOnFailedPlanReview = extractShouldBlockOnFailedPlanReview()
+  const input = { hasDesign: true, pass: false }
+  assert.equal(shouldBlockOnFailedPlanReview(input), true)
+  assert.equal(sharedShouldBlockOnFailedPlanReview(input), true)
+})
+
+test('shouldBlockOnFailedPlanReview does not block when the plan-review gate passed', () => {
+  const shouldBlockOnFailedPlanReview = extractShouldBlockOnFailedPlanReview()
+  const input = { hasDesign: true, pass: true }
+  assert.equal(shouldBlockOnFailedPlanReview(input), false)
+  assert.equal(sharedShouldBlockOnFailedPlanReview(input), false)
+})
+
+test('shouldBlockOnFailedPlanReview does not block when design/PlanReview was skipped entirely', () => {
+  const shouldBlockOnFailedPlanReview = extractShouldBlockOnFailedPlanReview()
+  const input = { hasDesign: false, pass: false }
+  assert.equal(shouldBlockOnFailedPlanReview(input), false)
+  assert.equal(sharedShouldBlockOnFailedPlanReview(input), false)
 })
 
 test('shouldGenerateDesign regenerates when skipDesign is set but the provided designDoc was just discarded as invalid', () => {

--- a/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+++ b/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
@@ -10,7 +10,11 @@ import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
-import { DESIGN_SCHEMA } from './design-schema.mjs'
+import {
+  DESIGN_SCHEMA,
+  isValidDesignShape as sharedIsValidDesignShape,
+  shouldGenerateDesign as sharedShouldGenerateDesign,
+} from './design-schema.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const workflowPath = path.join(__dirname, '..', 'dev-loop.workflow.mjs')
@@ -24,10 +28,22 @@ function extractInlineDesignSchema() {
 }
 
 function extractIsValidDesignShape() {
-  const match = source.match(/\nfunction isValidDesignShape\(d\) \{[\s\S]*?\n\}\n/)
-  assert.ok(match, 'could not locate `function isValidDesignShape(d) {...}` in dev-loop.workflow.mjs')
+  const match = source.match(
+    /\nconst propertiesItemPattern = new RegExp\(DESIGN_SCHEMA[\s\S]*?\nfunction isValidDesignShape\(d\) \{[\s\S]*?\n\}\n/,
+  )
+  assert.ok(
+    match,
+    'could not locate `propertiesItemPattern` + `function isValidDesignShape(d) {...}` in dev-loop.workflow.mjs',
+  )
+  // eslint-disable-next-line no-new-func -- evaluating our own source (DESIGN_SCHEMA + a plain function declaration), not untrusted input
+  return new Function('DESIGN_SCHEMA', `${match[0]}\nreturn isValidDesignShape`)(DESIGN_SCHEMA)
+}
+
+function extractShouldGenerateDesign() {
+  const match = source.match(/\nfunction shouldGenerateDesign\(\{[\s\S]*?\n\}\n/)
+  assert.ok(match, 'could not locate `function shouldGenerateDesign({...}) {...}` in dev-loop.workflow.mjs')
   // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
-  return new Function(`${match[0]}\nreturn isValidDesignShape`)()
+  return new Function(`${match[0]}\nreturn shouldGenerateDesign`)()
 }
 
 test('inline DESIGN_SCHEMA in dev-loop.workflow.mjs matches the exported design-schema.mjs module', () => {
@@ -77,4 +93,84 @@ test('isValidDesignShape rejects a non-object and a null designDoc', () => {
   const isValidDesignShape = extractIsValidDesignShape()
   assert.equal(isValidDesignShape(null), false)
   assert.equal(isValidDesignShape('not an object'), false)
+})
+
+test('isValidDesignShape rejects a whitespace-only `properties` entry, matching DESIGN_SCHEMA\'s `\\S` pattern', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  const designWithBlankProperty = {
+    completionCriteria: ['does the thing'],
+    scope: 'small',
+    testScenarios: { unit: ['covers the thing'] },
+    properties: ['   '],
+  }
+  assert.equal(isValidDesignShape(designWithBlankProperty), false)
+  assert.equal(sharedIsValidDesignShape(designWithBlankProperty), false)
+})
+
+test('isValidDesignShape rejects non-string elements in completionCriteria and testScenarios.unit', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  const designWithNonStringCompletionCriteria = {
+    completionCriteria: [42],
+    scope: 'small',
+    testScenarios: { unit: ['covers the thing'] },
+    properties: ['none: pure UI wiring, no state/parser/store surface'],
+  }
+  const designWithNonStringTestScenario = {
+    completionCriteria: ['does the thing'],
+    scope: 'small',
+    testScenarios: { unit: [42] },
+    properties: ['none: pure UI wiring, no state/parser/store surface'],
+  }
+  assert.equal(isValidDesignShape(designWithNonStringCompletionCriteria), false)
+  assert.equal(sharedIsValidDesignShape(designWithNonStringCompletionCriteria), false)
+  assert.equal(isValidDesignShape(designWithNonStringTestScenario), false)
+  assert.equal(sharedIsValidDesignShape(designWithNonStringTestScenario), false)
+})
+
+test('the duplicated inline isValidDesignShape agrees with the single-sourced design-schema.mjs export across a table of designs', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  const cases = [
+    {
+      completionCriteria: ['does the thing'],
+      scope: 'small',
+      testScenarios: { unit: ['covers the thing'] },
+      properties: ['none: pure UI wiring, no state/parser/store surface'],
+    },
+    { completionCriteria: ['x'], scope: 's', testScenarios: { unit: ['u'] }, properties: ['   '] },
+    { completionCriteria: [42], scope: 's', testScenarios: { unit: ['u'] }, properties: ['x'] },
+    { completionCriteria: ['x'], scope: 's', testScenarios: { unit: [42] }, properties: ['x'] },
+    { completionCriteria: ['x'], scope: 's', testScenarios: { unit: ['u'] }, properties: [] },
+    null,
+  ]
+  for (const design of cases) {
+    assert.equal(isValidDesignShape(design), sharedIsValidDesignShape(design), `mismatch for ${JSON.stringify(design)}`)
+  }
+})
+
+test('shouldGenerateDesign regenerates when skipDesign is set but the provided designDoc was just discarded as invalid', () => {
+  const shouldGenerateDesign = extractShouldGenerateDesign()
+  const input = { hasDesign: false, skipDesign: true, discardedInvalidProvidedDesign: true }
+  assert.equal(shouldGenerateDesign(input), true)
+  assert.equal(sharedShouldGenerateDesign(input), true)
+})
+
+test('shouldGenerateDesign does not regenerate when skipDesign is set and no design was ever provided', () => {
+  const shouldGenerateDesign = extractShouldGenerateDesign()
+  const input = { hasDesign: false, skipDesign: true, discardedInvalidProvidedDesign: false }
+  assert.equal(shouldGenerateDesign(input), false)
+  assert.equal(sharedShouldGenerateDesign(input), false)
+})
+
+test('shouldGenerateDesign never regenerates once a valid design is already present', () => {
+  const shouldGenerateDesign = extractShouldGenerateDesign()
+  const input = { hasDesign: true, skipDesign: false, discardedInvalidProvidedDesign: false }
+  assert.equal(shouldGenerateDesign(input), false)
+  assert.equal(sharedShouldGenerateDesign(input), false)
+})
+
+test('shouldGenerateDesign generates when design was never skipped and none is present', () => {
+  const shouldGenerateDesign = extractShouldGenerateDesign()
+  const input = { hasDesign: false, skipDesign: false, discardedInvalidProvidedDesign: false }
+  assert.equal(shouldGenerateDesign(input), true)
+  assert.equal(sharedShouldGenerateDesign(input), true)
 })

--- a/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+++ b/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
@@ -1,0 +1,80 @@
+// Run with: node --test .claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+// dev-loop.workflow.mjs runs inside a sandbox with no import/fs, so it keeps its own duplicated
+// copy of DESIGN_SCHEMA (and an isValidDesignShape guard) instead of importing design-schema.mjs.
+// This test extracts both inline literals straight from the workflow source and diffs them
+// against the single-sourced module/behavior, so an edit to one copy that forgets the other
+// fails here instead of drifting silently (the same class of bug AGENTS.md's Zod-discipline
+// section calls out for schema/runtime drift elsewhere in the repo).
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { DESIGN_SCHEMA } from './design-schema.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workflowPath = path.join(__dirname, '..', 'dev-loop.workflow.mjs')
+const source = readFileSync(workflowPath, 'utf8')
+
+function extractInlineDesignSchema() {
+  const match = source.match(/\nconst DESIGN_SCHEMA = (\{[\s\S]*?\n\})\n\nconst PLAN_VERDICT_SCHEMA/)
+  assert.ok(match, 'could not locate the inline `const DESIGN_SCHEMA = {...}` literal in dev-loop.workflow.mjs')
+  // eslint-disable-next-line no-new-func -- evaluating a plain object literal extracted from our own source, not untrusted input
+  return new Function(`return (${match[1]})`)()
+}
+
+function extractIsValidDesignShape() {
+  const match = source.match(/\nfunction isValidDesignShape\(d\) \{[\s\S]*?\n\}\n/)
+  assert.ok(match, 'could not locate `function isValidDesignShape(d) {...}` in dev-loop.workflow.mjs')
+  // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
+  return new Function(`${match[0]}\nreturn isValidDesignShape`)()
+}
+
+test('inline DESIGN_SCHEMA in dev-loop.workflow.mjs matches the exported design-schema.mjs module', () => {
+  const inline = extractInlineDesignSchema()
+  assert.deepEqual(inline, DESIGN_SCHEMA)
+})
+
+test('isValidDesignShape accepts a well-formed caller-provided designDoc', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  assert.equal(
+    isValidDesignShape({
+      completionCriteria: ['does the thing'],
+      scope: 'small',
+      testScenarios: { unit: ['covers the thing'] },
+      properties: ['none: pure UI wiring, no state/parser/store surface'],
+    }),
+    true,
+  )
+})
+
+test('isValidDesignShape rejects a designDoc missing the required `properties` invariant field', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  assert.equal(
+    isValidDesignShape({
+      completionCriteria: ['does the thing'],
+      scope: 'small',
+      testScenarios: { unit: ['covers the thing'] },
+    }),
+    false,
+  )
+})
+
+test('isValidDesignShape rejects a designDoc with an empty `properties` array', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  assert.equal(
+    isValidDesignShape({
+      completionCriteria: ['does the thing'],
+      scope: 'small',
+      testScenarios: { unit: ['covers the thing'] },
+      properties: [],
+    }),
+    false,
+  )
+})
+
+test('isValidDesignShape rejects a non-object and a null designDoc', () => {
+  const isValidDesignShape = extractIsValidDesignShape()
+  assert.equal(isValidDesignShape(null), false)
+  assert.equal(isValidDesignShape('not an object'), false)
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,33 @@ Use this repo's standard development loop for every feature, bug fix, or refacto
 
 ## Test Layer Selection
 
-- Use `mcp-node` for pure functions, stores, routes, server behavior, and persistence logic.
-- Use `mcp-jsdom` for React components and hooks when browser layout and pointer behavior are not the core risk.
-- Use `mcp-browser` for popovers, dialogs, scroll, focus, keyboard, pointer behavior, restore flows, and other real browser interactions.
+- Use `mcp-node` for pure functions, stores, routes, server behavior, and persistence logic in `packages/mcp-server`.
+- Use `canvas-viewer-node` / `canvas-viewer-jsdom` for `packages/canvas-viewer` parsing, hooks, and components where browser layout and pointer behavior are not the core risk; use `canvas-viewer-browser` when they are.
+- Use the `apps/web` jsdom project (`apps/web/vitest.config.ts`) for React components and hooks when browser layout and pointer behavior are not the core risk.
 - Use `web-browser` for `apps/web` tests that require real browser APIs not available in jsdom: IndexedDB, OPFS, `window.showOpenFilePicker`. File suffix: `.browser.test.tsx`.
 - Promote to E2E when the bug depends on real routes, server composition, websocket timing, persistence order, or multi-step page flows.
 
 Do not jump to broad E2E first if a smaller failing test can isolate the bug.
+
+### Property-Based / Model-Based Testing (PBT)
+
+Prefer a property or model-based test (fast-check; shared wrappers in
+`packages/mcp-server/src/shared/test-utils/fast-check.ts` and
+`apps/web/src/test-utils/fast-check.ts`) over an example-only test when the change touches:
+
+- a parser/serializer (round-trip: `parse(serialize(x))` equals `x` or a well-defined normalization of `x`)
+- a state machine or store with time/TTL/revocation semantics (model-based: generate a random
+  command sequence, check invariants after each step)
+- a concurrent store (convergence: N concurrent operations settle on one agreed-upon result)
+- a CRDT or other mergeable structure (idempotence, commutativity, convergence under any merge order)
+- rounding, normalization, or other value transforms with an algebraic invariant
+
+Prefer example/browser tests for UI wiring, one-off integrations, and anything without a clean
+invariant to state. When a property finds a real bug, pin the shrunk counterexample as an example
+test before fixing the implementation — the example is the regression guard, the property is the
+generator that found it. Never pin a fast-check seed to make a flaky property pass; treat repeat
+failures under load as a signal to reduce `numRuns`, not to fix the RNG. Put arbitraries shared
+across test files in the owning package's `test-utils`, not duplicated per file.
 
 ## Required Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Use this repo's standard development loop for every feature, bug fix, or refacto
 1. Start with the smallest failing test at the nearest layer.
 2. Make the smallest patch that turns it green.
 3. Manually verify the real behavior in a running app or browser.
-4. Lock the verified user flow into `mcp-browser` or a broader E2E test when browser-mode is not enough.
+4. Lock the verified user flow into `canvas-viewer-browser`/`web-browser` or a broader E2E test when browser-mode is not enough.
 
 ## Test Layer Selection
 
@@ -50,8 +50,8 @@ Run the narrowest project first:
 
 ```bash
 pnpm test --project mcp-node
-pnpm test --project mcp-jsdom
-pnpm test --project mcp-browser
+pnpm test --project canvas-viewer-jsdom
+pnpm test --project canvas-viewer-browser
 ```
 
 After the targeted test passes, run the broader suite that covers the touched area.
@@ -71,19 +71,19 @@ Passing tests alone are not sufficient.
 
 After manual verification, preserve the exact user flow:
 
-- Add or extend an `mcp-browser` test if component mount plus mocked fetches are enough.
+- Add or extend a `canvas-viewer-browser` or `web-browser` test if component mount plus mocked fetches are enough.
 - Add or extend E2E coverage if the scenario depends on real routing, websockets, persistence, daemon behavior, or page composition.
 
 Do not stop at manual verification without preserving the scenario in automation.
 
 ## Browser Mode And Trace
 
-`mcp-browser` is the default place for real browser regression tests in `packages/mcp-server`. Use `web-browser` for `apps/web` browser tests (IndexedDB, OPFS, etc.). `pnpm test:browser` runs both.
+`canvas-viewer-browser` is the default place for real browser regression tests in `packages/canvas-viewer`. Use `web-browser` for `apps/web` browser tests (IndexedDB, OPFS, etc.). `pnpm test:browser` runs both.
 
 Use:
 
 ```bash
-pnpm run test:browser        # mcp-browser + web-browser
+pnpm run test:browser        # canvas-viewer-browser + web-browser
 pnpm run test:browser:trace  # same, with trace artifacts on failure
 ```
 
@@ -283,7 +283,7 @@ Before closing a change:
 
 - Keep at least one nearest-layer automated test for the root cause.
 - Complete manual verification of the real behavior.
-- Preserve the verified user scenario in `mcp-browser` or E2E coverage.
+- Preserve the verified user scenario in `canvas-viewer-browser`/`web-browser` or E2E coverage.
 - Run `pnpm test`.
 - Resolve any `pnpm knip` finding one of three ways before closing: delete the dead code, drop the unused `export`, or register it in `knip.jsonc` as an intentional public surface with a reason comment.
 - If the change can affect typing or packaging, also run:
@@ -317,7 +317,7 @@ Workflow:
 3. Paste the markdown into the PR body under a `## Visual repro` (or similarly named) section. Show before/after when the change is a fix; show one annotated capture when adding a new affordance.
 4. Keep the actual screenshot file in `tmp/screenshots/` until the PR merges; remove it afterward to keep the dir lean (the GitHub upload is the durable copy).
 
-Skip this rule for changes that are invisible to humans — purely backend, schema, internal helper, etc. — but lean toward attaching when in doubt; even a `pnpm test` output paste counts as visual evidence for `mcp-browser` regressions.
+Skip this rule for changes that are invisible to humans — purely backend, schema, internal helper, etc. — but lean toward attaching when in doubt; even a `pnpm test` output paste counts as visual evidence for `canvas-viewer-browser`/`web-browser` regressions.
 
 ## Source Comment Discipline
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lint:noconsole": "biome lint --only=lint/suspicious/noConsole --diagnostic-level=error packages/mcp-server/src/server apps/web/src",
     "knip": "knip",
     "secretlint": "secretlint --secretlintignore .secretlintignore \"**/*\"",
-    "test:scripts": "node --test .claude/scripts/*.test.mjs",
+    "test:scripts": "node --test .claude/scripts/*.test.mjs .claude/workflows/lib/*.test.mjs",
     "prepare": "lefthook install || true"
   },
   "devDependencies": {

--- a/packages/canvas-viewer/package.json
+++ b/packages/canvas-viewer/package.json
@@ -32,11 +32,13 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@fast-check/vitest": "^0.4.1",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/browser-playwright": "catalog:",
+    "fast-check": "^4.7.0",
     "playwright": "1.61.1",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/canvas-viewer/src/test-utils/fast-check.test.ts
+++ b/packages/canvas-viewer/src/test-utils/fast-check.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from './fast-check.js'
+
+describe('fast-check test-utils wrapper', () => {
+  fcTest.prop([fc.integer()], withDefaults())(
+    'round-trips an integer through String/Number',
+    (n) => {
+      expect(Number(String(n))).toBe(n)
+    },
+  )
+
+  it('withDefaults sets numRuns to 200 and lets callers override it', () => {
+    expect(withDefaults()).toEqual({ numRuns: 200 })
+    expect(withDefaults({ numRuns: 10 })).toEqual({ numRuns: 10 })
+  })
+})

--- a/packages/canvas-viewer/src/test-utils/fast-check.ts
+++ b/packages/canvas-viewer/src/test-utils/fast-check.ts
@@ -1,0 +1,8 @@
+import { test as fcTest } from '@fast-check/vitest'
+import * as fc from 'fast-check'
+
+export { fc, fcTest }
+
+export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
+  return { numRuns: 200, ...override }
+}

--- a/packages/canvas-viewer/src/test-utils/fast-check.ts
+++ b/packages/canvas-viewer/src/test-utils/fast-check.ts
@@ -3,6 +3,9 @@ import * as fc from 'fast-check'
 
 export { fc, fcTest }
 
-export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
+// T defaults to `never` (not `unknown`): fc.Parameters<never> is assignable to
+// every fc.Parameters<[...]> at zero-config call sites, while callers passing
+// type-bearing options like `examples` name T explicitly.
+export function withDefaults<T = never>(override?: fc.Parameters<T>): fc.Parameters<T> {
   return { numRuns: 200, ...override }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.1.9)
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -240,6 +243,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))(vitest@4.1.9)
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.8.0
       playwright:
         specifier: 1.61.1
         version: 1.61.1
@@ -11078,9 +11084,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:


### PR DESCRIPTION
## Summary

Makes property-based specification a first-class artifact of the dev flow (slice A of the PBT-systematization program; the package-level property-test pilots land as separate PRs).

- **`properties` in the design gate**: dev-loop's design schema gains a required, never-empty `properties` field — every design must state the invariants / round-trips / metamorphic relations it preserves, with an explicit `"none: <reason>"` sentinel for genuinely stateless changes. The plan-review gate (in-house + Codex lanes) fails a design that touches state/parser/store logic but supplies only the sentinel.
- **Schema as a tested module**: the schema lives in `.claude/workflows/lib/design-schema.mjs` (node:test-covered, mirroring `normalize-dimensions.mjs`), with the workflow's inline copy drift-checked by test.
- **Hardening found by its own review loop**: closed `isValidDesignShape` gaps, a `skipDesign` bypass, and a rejected-plan-still-implements path in dev-loop.
- **PBT selection rubric** in AGENTS.md + the `test-layer-selection` skill: parser/serializer/state-machine/concurrent-store/CRDT/normalization → prefer property or model-based (fc command sequences with injected `now()`); UI wiring → example/browser tests; counterexamples get pinned as example tests before the fix; fast-check seeds are never pinned; shared arbitraries live in the owning package's test-utils. Stale `mcp-jsdom`/`mcp-browser` project names fixed en route.
- canvas-viewer gets the shared fast-check wrapper wiring (prep for the scene round-trip pilot).

## Verification

- `node --test` on the new schema tests green; the workflow body syntax-checked and dry-run through the documented AsyncFunction harness (a stateless design's sentinel flows Design → PlanReview → report).
- `pnpm -r typecheck` / `pnpm test` / `pnpm knip` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added property- and model-based testing support, including reusable Fast-Check utilities and configurable test runs.
  - Added stronger design validation to ensure required invariants and test scenarios are provided.
  - Failed design reviews now stop implementation and provide a clear human-review status.

- **Bug Fixes**
  - Prevented invalid pre-supplied designs from bypassing validation and review checks.

- **Documentation**
  - Updated development guidance with expanded test-layer options and recommendations for property-based testing.

- **Tests**
  - Expanded automated coverage for design validation, workflow decisions, and property-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->