### PR TITLE
feat(web): add Settings panel with theme selector and WebMCP toggle

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -81,6 +81,7 @@ interface Props {
   // there is deliberately no PDF option here because no export path (this
   // app's or Excalidraw's own) produces one.
   onExport?: (format: SceneExportFormat) => Promise<Blob | null>
+  onOpenSettings?: () => void
 }
 
 // Give the canvas visual priority and keep the surrounding chrome lightweight.
@@ -110,6 +111,7 @@ export default function WorkspaceTopBar({
   versionRefreshSignal,
   versionPanelExtra,
   onExport,
+  onOpenSettings,
 }: Props) {
   const isLocalMode = dataMode === 'local'
   const versionsEnabled = capabilities?.versions ?? true
@@ -374,6 +376,7 @@ export default function WorkspaceTopBar({
         theme={theme}
         onToggleTheme={onToggleTheme}
         onEnterFullscreen={onEnterFullscreen}
+        onOpenSettings={onOpenSettings}
       />
 
       <NewCanvasDialog

--- a/apps/web/src/components/settings/SettingsPanel.test.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.test.tsx
@@ -20,6 +20,7 @@ describe('SettingsPanel', () => {
         onOpenChange={() => {}}
         theme="system"
         onThemeChange={onThemeChange}
+        webMcpEnabled={true}
       />,
     )
 
@@ -35,14 +36,15 @@ describe('SettingsPanel', () => {
     expect(onThemeChange).toHaveBeenCalledWith('dark')
   })
 
-  test('WebMCP toggle defaults to ON and persists OFF to user-settings', () => {
+  test('WebMCP toggle persists OFF to user-settings and notifies parent', () => {
     const onWebMcpChange = vi.fn()
-    render(
+    const { rerender } = render(
       <SettingsPanel
         open={true}
         onOpenChange={() => {}}
         theme="system"
         onThemeChange={() => {}}
+        webMcpEnabled={true}
         onWebMcpChange={onWebMcpChange}
       />,
     )
@@ -51,26 +53,33 @@ describe('SettingsPanel', () => {
     expect(toggle.getAttribute('aria-checked')).toBe('true')
 
     fireEvent.click(toggle)
-    expect(toggle.getAttribute('aria-checked')).toBe('false')
     expect(onWebMcpChange).toHaveBeenCalledWith(false)
+
+    rerender(
+      <SettingsPanel
+        open={true}
+        onOpenChange={() => {}}
+        theme="system"
+        onThemeChange={() => {}}
+        webMcpEnabled={false}
+        onWebMcpChange={onWebMcpChange}
+      />,
+    )
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
 
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
     expect(stored.capabilities.webMcpEnabled).toBe(false)
   })
 
-  test('WebMCP toggle reads persisted OFF state', () => {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        version: 1,
-        storage: {},
-        migration: {},
-        capabilities: { webMcpEnabled: false },
-      }),
-    )
-
+  test('WebMCP toggle reflects controlled OFF state', () => {
     render(
-      <SettingsPanel open={true} onOpenChange={() => {}} theme="light" onThemeChange={() => {}} />,
+      <SettingsPanel
+        open={true}
+        onOpenChange={() => {}}
+        theme="light"
+        onThemeChange={() => {}}
+        webMcpEnabled={false}
+      />,
     )
 
     const toggle = screen.getByRole('switch')
@@ -84,6 +93,7 @@ describe('SettingsPanel', () => {
         onOpenChange={() => {}}
         theme="system"
         onThemeChange={() => {}}
+        webMcpEnabled={true}
       />,
     )
 

--- a/apps/web/src/components/settings/SettingsPanel.test.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { STORAGE_KEY } from '@/lib/user-settings-store'
+import { SettingsPanel } from './SettingsPanel'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SettingsPanel', () => {
+  test('renders theme options and allows switching', () => {
+    const onThemeChange = vi.fn()
+    render(
+      <SettingsPanel
+        open={true}
+        onOpenChange={() => {}}
+        theme="system"
+        onThemeChange={onThemeChange}
+      />,
+    )
+
+    const lightBtn = screen.getByRole('radio', { name: /light/i })
+    const darkBtn = screen.getByRole('radio', { name: /dark/i })
+    const systemBtn = screen.getByRole('radio', { name: /system/i })
+
+    expect(systemBtn.getAttribute('aria-checked')).toBe('true')
+    expect(lightBtn.getAttribute('aria-checked')).toBe('false')
+    expect(darkBtn.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(darkBtn)
+    expect(onThemeChange).toHaveBeenCalledWith('dark')
+  })
+
+  test('WebMCP toggle defaults to ON and persists OFF to user-settings', () => {
+    const onWebMcpChange = vi.fn()
+    render(
+      <SettingsPanel
+        open={true}
+        onOpenChange={() => {}}
+        theme="system"
+        onThemeChange={() => {}}
+        onWebMcpChange={onWebMcpChange}
+      />,
+    )
+
+    const toggle = screen.getByRole('switch')
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    expect(onWebMcpChange).toHaveBeenCalledWith(false)
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    expect(stored.capabilities.webMcpEnabled).toBe(false)
+  })
+
+  test('WebMCP toggle reads persisted OFF state', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: {},
+        migration: {},
+        capabilities: { webMcpEnabled: false },
+      }),
+    )
+
+    render(
+      <SettingsPanel open={true} onOpenChange={() => {}} theme="light" onThemeChange={() => {}} />,
+    )
+
+    const toggle = screen.getByRole('switch')
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+  })
+
+  test('does not render content when closed', () => {
+    render(
+      <SettingsPanel
+        open={false}
+        onOpenChange={() => {}}
+        theme="system"
+        onThemeChange={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('Settings')).toBeNull()
+  })
+})

--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { Monitor, Moon, Palette, Sun } from 'lucide-react'
-import { useCallback, useId, useState } from 'react'
+import { useCallback, useId } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,7 @@ interface SettingsPanelProps {
   onOpenChange: (open: boolean) => void
   theme: ThemeMode
   onThemeChange: (next: ThemeMode) => void
+  webMcpEnabled: boolean
   onWebMcpChange?: (enabled: boolean) => void
 }
 
@@ -31,26 +32,21 @@ export function SettingsPanel({
   onOpenChange,
   theme,
   onThemeChange,
+  webMcpEnabled,
   onWebMcpChange,
 }: SettingsPanelProps) {
   const themeGroupId = useId()
-
-  const [webMcpEnabled, setWebMcpEnabled] = useState(() => {
-    const settings = settingsStore.load()
-    return settings.capabilities.webMcpEnabled ?? true
-  })
+  const webMcpLabelId = useId()
+  const webMcpDescId = useId()
 
   const handleWebMcpToggle = useCallback(() => {
-    setWebMcpEnabled((prev) => {
-      const next = !prev
-      settingsStore.update((s) => ({
-        ...s,
-        capabilities: { ...s.capabilities, webMcpEnabled: next },
-      }))
-      onWebMcpChange?.(next)
-      return next
-    })
-  }, [onWebMcpChange])
+    const next = !webMcpEnabled
+    settingsStore.update((s) => ({
+      ...s,
+      capabilities: { ...s.capabilities, webMcpEnabled: next },
+    }))
+    onWebMcpChange?.(next)
+  }, [webMcpEnabled, onWebMcpChange])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -94,10 +90,12 @@ export function SettingsPanel({
           {/* Capabilities section */}
           <section>
             <h3 className="mb-3 text-sm font-medium">Capabilities</h3>
-            <label className="flex items-center justify-between gap-3">
+            <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-sm">WebMCP</p>
-                <p className="text-xs text-muted-foreground">
+                <p id={webMcpLabelId} className="text-sm">
+                  WebMCP
+                </p>
+                <p id={webMcpDescId} className="text-xs text-muted-foreground">
                   Expose canvas tools to AI agents via WebMCP
                 </p>
               </div>
@@ -105,6 +103,8 @@ export function SettingsPanel({
                 type="button"
                 role="switch"
                 aria-checked={webMcpEnabled}
+                aria-labelledby={webMcpLabelId}
+                aria-describedby={webMcpDescId}
                 onClick={handleWebMcpToggle}
                 className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors ${
                   webMcpEnabled ? 'bg-primary' : 'bg-input'
@@ -116,7 +116,7 @@ export function SettingsPanel({
                   }`}
                 />
               </button>
-            </label>
+            </div>
           </section>
         </div>
       </DialogContent>

--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -1,0 +1,125 @@
+import { Monitor, Moon, Palette, Sun } from 'lucide-react'
+import { useCallback, useId, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { ThemeMode } from '@/hooks/useThemeMode'
+import { createUserSettingsStore } from '@/lib/user-settings-store'
+
+interface SettingsPanelProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  theme: ThemeMode
+  onThemeChange: (next: ThemeMode) => void
+  onWebMcpChange?: (enabled: boolean) => void
+}
+
+const THEME_OPTIONS: Array<{ value: ThemeMode; label: string; icon: typeof Sun }> = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
+
+const settingsStore = createUserSettingsStore()
+
+export function SettingsPanel({
+  open,
+  onOpenChange,
+  theme,
+  onThemeChange,
+  onWebMcpChange,
+}: SettingsPanelProps) {
+  const themeGroupId = useId()
+
+  const [webMcpEnabled, setWebMcpEnabled] = useState(() => {
+    const settings = settingsStore.load()
+    return settings.capabilities.webMcpEnabled ?? true
+  })
+
+  const handleWebMcpToggle = useCallback(() => {
+    setWebMcpEnabled((prev) => {
+      const next = !prev
+      settingsStore.update((s) => ({
+        ...s,
+        capabilities: { ...s.capabilities, webMcpEnabled: next },
+      }))
+      onWebMcpChange?.(next)
+      return next
+    })
+  }, [onWebMcpChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription className="sr-only">Application settings</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* Appearance section */}
+          <section aria-labelledby={themeGroupId}>
+            <h3 id={themeGroupId} className="mb-3 flex items-center gap-2 text-sm font-medium">
+              <Palette className="size-4" />
+              Appearance
+            </h3>
+            <fieldset>
+              <legend className="sr-only">Theme</legend>
+              <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Theme">
+                {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    role="radio"
+                    aria-checked={theme === value}
+                    onClick={() => onThemeChange(value)}
+                    className={`flex flex-col items-center gap-1.5 rounded-md border px-3 py-2.5 text-xs transition-colors ${
+                      theme === value
+                        ? 'border-primary bg-primary/5 text-primary'
+                        : 'border-border text-muted-foreground hover:border-primary/50 hover:text-foreground'
+                    }`}
+                  >
+                    <Icon className="size-4" />
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+          </section>
+
+          {/* Capabilities section */}
+          <section>
+            <h3 className="mb-3 text-sm font-medium">Capabilities</h3>
+            <label className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm">WebMCP</p>
+                <p className="text-xs text-muted-foreground">
+                  Expose canvas tools to AI agents via WebMCP
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={webMcpEnabled}
+                onClick={handleWebMcpToggle}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors ${
+                  webMcpEnabled ? 'bg-primary' : 'bg-input'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform ${
+                    webMcpEnabled ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </label>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -1,4 +1,4 @@
-import { EllipsisVertical, History, Maximize2 } from 'lucide-react'
+import { EllipsisVertical, History, Maximize2, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -26,6 +26,7 @@ interface TopBarSecondaryActionsProps {
   theme?: ThemeMode
   onToggleTheme?: (next: ThemeMode) => void
   onEnterFullscreen?: () => void
+  onOpenSettings?: () => void
 }
 
 // Right side: version history, theme, and fullscreen — plus the "More
@@ -37,6 +38,7 @@ export function TopBarSecondaryActions({
   theme,
   onToggleTheme,
   onEnterFullscreen,
+  onOpenSettings,
 }: TopBarSecondaryActionsProps) {
   return (
     <>
@@ -78,6 +80,23 @@ export function TopBarSecondaryActions({
             <TooltipContent>Fullscreen (f)</TooltipContent>
           </Tooltip>
         )}
+        {onOpenSettings && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="size-8 p-0"
+                onClick={onOpenSettings}
+                aria-label="Settings"
+                data-testid="settings-trigger"
+              >
+                <Settings className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Settings</TooltipContent>
+          </Tooltip>
+        )}
       </div>
 
       <DropdownMenu>
@@ -111,6 +130,12 @@ export function TopBarSecondaryActions({
             <DropdownMenuItem onSelect={onEnterFullscreen} className="gap-2">
               <Maximize2 className="size-3.5" />
               Fullscreen
+            </DropdownMenuItem>
+          )}
+          {onOpenSettings && (
+            <DropdownMenuItem onSelect={onOpenSettings} className="gap-2">
+              <Settings className="size-3.5" />
+              Settings
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,8 +4,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { App } from './App.js'
+import { applyThemeClass, readPersistedTheme, resolveTheme } from './hooks/useThemeMode.js'
 import './index.css'
 import './pwa/bootstrap.js'
+
+// Apply the persisted theme class before React mounts so the first paint
+// matches the user's saved preference (avoids a light→dark flash on reload).
+applyThemeClass(resolveTheme(readPersistedTheme()))
 
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element #root not found')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,7 +1,7 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
   AlertDialog,
@@ -23,6 +23,7 @@ import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { createSceneExportHandler, useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
+import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { cn } from '../lib/utils.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
@@ -265,16 +266,16 @@ export function BrowserLocalCanvasPage({
 
   const handleExport = createSceneExportHandler(commands, exportScene)
 
-  // Identity key = canvasId — a switch to a different browser-local canvas
-  // re-registers the WebMCP tools against it. Honors the persisted
-  // capabilities.webMcpEnabled setting (see user-settings-store.ts);
-  // unset (the default) is treated as enabled. Read once at mount rather
-  // than on every (per-pointer-move) render.
-  const webMcpEnabled = useMemo(
+  // Reactive: toggling in the SettingsPanel updates this state, which causes
+  // useBrowserToolRegistry to re-run (ON→OFF triggers abort via the hook's
+  // internal AbortController; OFF→ON re-registers without a page reload).
+  const [webMcpEnabled, setWebMcpEnabled] = useState(
     () => settingsStore.load().capabilities.webMcpEnabled !== false,
-    [settingsStore],
   )
   useBrowserToolRegistry(commands, canvasId, webMcpEnabled)
+
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const handleOpenSettings = useCallback(() => setSettingsOpen(true), [])
 
   // The option list refreshes asynchronously (see the effect above) while the
   // selected id changes synchronously on switch/create. Synthesize a
@@ -373,6 +374,7 @@ export function BrowserLocalCanvasPage({
             merge: capabilities.merge,
           }}
           onExport={handleExport}
+          onOpenSettings={handleOpenSettings}
         />
       </Suspense>
       {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain
@@ -452,6 +454,13 @@ export function BrowserLocalCanvasPage({
           theme={resolvedTheme}
         />
       </div>
+      <SettingsPanel
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        theme={theme}
+        onThemeChange={setTheme}
+        onWebMcpChange={setWebMcpEnabled}
+      />
     </main>
   )
 }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -459,6 +459,7 @@ export function BrowserLocalCanvasPage({
         onOpenChange={setSettingsOpen}
         theme={theme}
         onThemeChange={setTheme}
+        webMcpEnabled={webMcpEnabled}
         onWebMcpChange={setWebMcpEnabled}
       />
     </main>

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -478,6 +478,7 @@ export function DaemonCanvasPage({
           onOpenChange={setSettingsOpen}
           theme={theme}
           onThemeChange={setTheme}
+          webMcpEnabled={webMcpEnabled}
           onWebMcpChange={setWebMcpEnabled}
         />
       </main>

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -4,14 +4,16 @@ import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
 import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { MergeToast } from '../components/MergeToast.js'
+import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
+import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { createSceneExportHandler, useWhiteboardCommands } from '../lib/commands/index.js'
@@ -94,6 +96,8 @@ export function DaemonCanvasPage({
   // current capabilities.webMcpEnabled value is needed.
   const [settingsStore] = useState(() => createUserSettingsStore())
 
+  const { theme, resolvedTheme, setTheme } = useThemeMode()
+
   // The selected (workspaceId, slug) pair once both are known, computed once so
   // every downstream guard and child prop shares a single non-null narrowing
   // instead of repeating `workspaceId !== null && slug !== null`.
@@ -167,21 +171,20 @@ export function DaemonCanvasPage({
   const handleExport = createSceneExportHandler(commands, exportScene)
 
   // Identity key = workspaceId+slug, matching this page's own canvas
-  // identity granularity (see useCanvasSync's `identity` above) — a switch
-  // to a different daemon canvas re-registers the WebMCP tools against it.
-  // Honors the persisted capabilities.webMcpEnabled setting (see
-  // user-settings-store.ts); unset (the default) is treated as enabled.
-  // Read once at mount rather than on every (per-pointer-move) render — the
-  // setting only changes via an explicit user action + reload.
-  const webMcpEnabled = useMemo(
+  // Reactive: toggling in the SettingsPanel updates this state, which causes
+  // useBrowserToolRegistry to re-run (ON→OFF triggers abort via the hook's
+  // internal AbortController; OFF→ON re-registers without a page reload).
+  const [webMcpEnabled, setWebMcpEnabled] = useState(
     () => settingsStore.load().capabilities.webMcpEnabled !== false,
-    [settingsStore],
   )
   useBrowserToolRegistry(
     commands,
     canvas !== null ? `${canvas.workspaceId}/${canvas.slug}` : null,
     webMcpEnabled,
   )
+
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const handleOpenSettings = useCallback(() => setSettingsOpen(true), [])
 
   const saveVersion = async (): Promise<void> => {
     if (!capabilities.versions || canvas === null || savingVersion) return
@@ -338,6 +341,7 @@ export function DaemonCanvasPage({
             versionPanelExtra={versionPanelExtra}
             onNavigateBack={onNavigateBack}
             onExport={handleExport}
+            onOpenSettings={handleOpenSettings}
           />
         )}
         {capabilities.branches && canvas && (
@@ -458,6 +462,7 @@ export function DaemonCanvasPage({
                 setExcalidrawAPI(api)
               }}
               onChange={onChange}
+              theme={resolvedTheme}
             />
           </div>
         )}
@@ -468,6 +473,13 @@ export function DaemonCanvasPage({
             onRestored={clearLocalUndo}
           />
         )}
+        <SettingsPanel
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          theme={theme}
+          onThemeChange={setTheme}
+          onWebMcpChange={setWebMcpEnabled}
+        />
       </main>
     </DaemonApiContext.Provider>
   )


### PR DESCRIPTION
## Summary

- Adds a `SettingsPanel` dialog component accessible via a gear icon in the top bar (desktop) and "Settings" item in the kebab menu (mobile ≤400px)
- **Appearance section**: light/dark/system theme radio group, wired through the existing `useThemeMode` hook
- **Capabilities section**: WebMCP toggle that persists to `user-settings-store` and reactively enables/disables tool registration without page reload
- DaemonCanvasPage now passes `theme={resolvedTheme}` to Excalidraw (was previously missing)
- Flash-prevention: `main.tsx` reads persisted theme and applies the `.dark` class before React mounts

## Test plan

- [x] `SettingsPanel.test.tsx` — theme radio state, WebMCP toggle persistence, closed-state
- [x] Full test suite (5111 tests pass, 0 regressions)
- [x] Typecheck clean
- [ ] Manual verification: open settings on browser-local and daemon pages, toggle theme, toggle WebMCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings panel with light, dark, and system theme options.
  * Added a WebMCP capability toggle with saved preferences.
  * Added Settings access from the workspace toolbar and More actions menu.
  * Applied the saved theme immediately when the app loads.

* **Bug Fixes**
  * WebMCP changes now take effect immediately without requiring a page reload.

* **Tests**
  * Added coverage for settings visibility, theme selection, WebMCP toggling, and preference persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->