### PR TITLE
docs(web): clarify WebMCP toggle scope in settings copy

### DIFF
--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -96,7 +96,8 @@ export function SettingsPanel({
                   WebMCP
                 </p>
                 <p id={webMcpDescId} className="text-xs text-muted-foreground">
-                  Expose canvas tools to AI agents via WebMCP
+                  Lets in-page scripts in supporting browsers read a canvas summary (identifier,
+                  selection count, viewport). Never exposes secrets, tokens, or full scene content.
                 </p>
               </div>
               <button


### PR DESCRIPTION
## Summary

Follow-up to #289. Updates the WebMCP toggle description in the Settings panel to explicitly state what the capability exposes:

> Lets in-page scripts in supporting browsers read a canvas summary (identifier, selection count, viewport). Never exposes secrets, tokens, or full scene content.

This satisfies the copy requirement tracked in the WebMCP opt-out UI follow-up (now resolved — the toggle itself shipped in #289).

## Test plan

- [x] `SettingsPanel.test.tsx` passes (4/4)
- [x] Copy-only change; no behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the WebMCP setting description to clarify what in-page scripts can access.
  * Added reassurance that secrets, tokens, and full scene content are not exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->