### PR TITLE
fix(mcp-server): reject mutating tools on unknown canvasId instead of implicit-creating

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -67,6 +67,14 @@ The MCP server exposes a small, opinionated set of tools that match the canvas l
 | `version_save` / `version_restore` / `version_list` | Save and restore labeled canvas versions. `version_restore` accepts an optional `targetSlug` to fork the past state into a new canvas instead of reconciling in place. |
 | `load_image` | Import an external image into the canvas. |
 
+`canvas_create` is the only tool that lazily creates a canvas on first
+touch. `annotate`, `annotate_batch`, `load_image`, `create_frame`,
+`create_embed`, and library-insert calls all check that `canvasId`
+resolves to an existing canvas first and fail with an explicit error
+(pointing at `canvas_create`) instead of silently creating a new, empty
+canvas — this catches a mistyped or hallucinated `canvasId` immediately
+rather than writing into the wrong place.
+
 `viewport_set` and `export_canvas({ format: "png" })` send instructions to the browser over WebSocket and settle on ACK, which is why they need a connected canvas tab. `export_canvas({ format: "svg" | "json" })` always renders headless from the persisted document instead. See [wire-protocol](../contributing/architecture/wire-protocol.md) for the full WebSocket message shapes.
 
 ## Why Loro

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -308,6 +308,22 @@ async function main() {
   }
   console.log(`[e2e] annotate → rect`)
 
+  // annotate against an unregistered canvasId must fail loudly instead of
+  // silently creating the workspace/canvas on write — a hallucinated or
+  // mistyped canvasId should never succeed.
+  await expectRejected(
+    callTool('annotate', {
+      canvasId: `${created.id.split('/')[0]}/no-such-canvas`,
+      type: 'rectangle',
+      target: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    }),
+    /canvas_create/i,
+    'annotate against unregistered canvas',
+  )
+  console.log('[e2e] annotate → canvas_create hint OK for unregistered canvas')
+
   // Exercises the exact argument shape the canvas-viewer widget's
   // sticky-note affordance sends (widget-entry.ts): box_with_label with
   // width but no height/color. canvas-viewer cannot z.infer this from

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -413,6 +413,9 @@ describe('createApp daemon mutation auth', () => {
       if (url === 'http://daemon.test/api/workspaces/M7lgM0WguBnkfP_1iOFtY/palette') {
         return new Response(JSON.stringify({ palette: {} }), { status: 200 })
       }
+      if (url === 'http://daemon.test/api/canvas/M7lgM0WguBnkfP_1iOFtY/via-mcp/exists') {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (url === 'http://daemon.test/api/canvas/M7lgM0WguBnkfP_1iOFtY/via-mcp/snapshot') {
         return new Response(snapshot, { status: 200 })
       }

--- a/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
@@ -23,6 +23,9 @@ describe('annotate_batch', () => {
 
     fetchMock = vi.fn(async (url: string | URL, init?: { body?: unknown }) => {
       const u = url.toString()
+      if (u.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (u.endsWith('/palette')) {
         return new Response(JSON.stringify({ palette: {} }), { status: 200 })
       }
@@ -59,8 +62,8 @@ describe('annotate_batch', () => {
     )
 
     expect(res.elementIds).toHaveLength(3)
-    // 1 palette GET + 1 snapshot GET + 1 update POST
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    // 1 canvases GET (existence check) + 1 palette GET + 1 snapshot GET + 1 update POST
+    expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(postedUpdate).not.toBeNull()
     expect(postedUpdate!.byteLength).toBeGreaterThan(0)
   })
@@ -742,6 +745,9 @@ describe('annotate_batch', () => {
     it('omits unknownPaletteKeys when all tokens resolve', async () => {
       fetchMock.mockImplementation(async (url: string | URL, init?: { body?: unknown }) => {
         const u = url.toString()
+        if (u.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: true }), { status: 200 })
+        }
         if (u.endsWith('/palette')) {
           return new Response(JSON.stringify({ palette: { 'role.client': '#ff0000' } }), {
             status: 200,

--- a/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate-batch.test.ts
@@ -74,6 +74,34 @@ describe('annotate_batch', () => {
     const res = await tool.execute({ canvasId: 'sid/slug', annotations: [] }, client)
     expect(res.elementIds).toEqual([])
   })
+
+  it('rejects an unknown canvasId before touching palette/snapshot/update endpoints', async () => {
+    const { annotateBatchTool } = await import('./annotate-batch.js')
+    const tool = annotateBatchTool()
+    let touchedWriteEndpoint = false
+    const fakeClient = {
+      port: 3099,
+      baseUrl: 'http://localhost:3099',
+      request: async (path: string) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: false }), { status: 200 })
+        }
+        touchedWriteEndpoint = true
+        throw new Error(`Unexpected request: ${path}`)
+      },
+      touch: async () => undefined,
+    }
+    await expect(
+      tool.execute(
+        {
+          canvasId: 'unknown-ws/sticky-demo',
+          annotations: [{ type: 'rectangle', target: { x: 0, y: 0 }, coords: 'absolute' }],
+        },
+        fakeClient,
+      ),
+    ).rejects.toThrow(/canvas_create/)
+    expect(touchedWriteEndpoint).toBe(false)
+  })
   describe('warnings (box_with_label overflow)', () => {
     it('case 317', async () => {
       const { annotateBatchTool } = await import('./annotate-batch.js')

--- a/packages/mcp-server/src/server/mcp/tools/annotate-batch.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate-batch.ts
@@ -11,6 +11,7 @@ import {
   flattenAnnotationResult,
 } from './annotate.js'
 import { decomposeBoxWithLabel } from './box-with-label.js'
+import { assertCanvasExists } from './canvas-existence.js'
 import { parseCanvasId } from './canvas-id.js'
 import { applyAssignToGroup } from './element-ops.js'
 import { resolvePaletteColor } from './color-palette.js'
@@ -380,6 +381,7 @@ export function annotateBatchTool() {
       client: DaemonClient,
     ): Promise<z.infer<typeof annotateBatchOutputSchema>> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const sessionPalette = await apiGetPalette(client, workspaceId)
       const unknownPaletteKeySet = new Set<string>()
       for (const item of args.annotations) {

--- a/packages/mcp-server/src/server/mcp/tools/annotate.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.test.ts
@@ -54,6 +54,38 @@ describe('annotateInputSchema — target conditionally required', () => {
   })
 })
 
+describe('annotate execute — unknown canvasId', () => {
+  it('returns an error mentioning canvas_create and never touches the snapshot/update endpoints', async () => {
+    const { annotateTool } = await import('./annotate.js')
+    const tool = annotateTool()
+    let touchedWriteEndpoint = false
+    const fakeClient = {
+      port: 3099,
+      baseUrl: 'http://localhost:3099',
+      request: async (path: string) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: false }), { status: 200 })
+        }
+        touchedWriteEndpoint = true
+        throw new Error(`Unexpected request: ${path}`)
+      },
+      touch: async () => undefined,
+    }
+    await expect(
+      tool.execute(
+        {
+          canvasId: 'unknown-ws/sticky-demo',
+          type: 'text',
+          target: { x: 0, y: 0 },
+          text: 'hi',
+        },
+        fakeClient,
+      ),
+    ).rejects.toThrow(/canvas_create/)
+    expect(touchedWriteEndpoint).toBe(false)
+  })
+})
+
 describe('annotate (single) execute — targetless box-snapped arrow parity', () => {
   function seedTwoRectsSnapshot(): Uint8Array {
     const doc = new LoroDoc()
@@ -84,6 +116,9 @@ describe('annotate (single) execute — targetless box-snapped arrow parity', ()
       port: 3099,
       baseUrl: 'http://localhost:3099',
       request: async (path: string, init?: RequestInit) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: true }), { status: 200 })
+        }
         if (path.endsWith('/palette')) {
           return new Response(JSON.stringify({ palette: {} }), { status: 200 })
         }
@@ -160,6 +195,9 @@ describe('annotate (single) warnings', () => {
 
     fetchMock = vi.fn(async (url: string | URL) => {
       const u = url.toString()
+      if (u.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (u.endsWith('/palette')) {
         return new Response(JSON.stringify({ palette: {} }), { status: 200 })
       }
@@ -256,6 +294,9 @@ describe('annotate (single) warnings', () => {
   it('omits unknownPaletteKeys when all color tokens resolve', async () => {
     fetchMock.mockImplementation(async (url: string | URL) => {
       const u = url.toString()
+      if (u.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (u.endsWith('/palette')) {
         return new Response(JSON.stringify({ palette: { 'role.client': '#ff0000' } }), {
           status: 200,
@@ -373,6 +414,8 @@ describe('annotate (single) structured result shape', () => {
     const snapshot = emptyDoc.export({ mode: 'snapshot' })
     fetchMock = vi.fn(async (url: string | URL) => {
       const u = url.toString()
+      if (u.endsWith('/exists'))
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
       if (u.endsWith('/palette'))
         return new Response(JSON.stringify({ palette: {} }), { status: 200 })
       if (u.endsWith('/snapshot')) return new Response(snapshot, { status: 200 })

--- a/packages/mcp-server/src/server/mcp/tools/annotate.ts
+++ b/packages/mcp-server/src/server/mcp/tools/annotate.ts
@@ -8,6 +8,7 @@ import {
   buildAnnotationFields,
 } from './annotation-fields.js'
 import { decomposeBoxWithLabel, type SubTextPosition } from './box-with-label.js'
+import { assertCanvasExists } from './canvas-existence.js'
 import { parseCanvasId } from './canvas-id.js'
 import {
   contrastRatio,
@@ -825,6 +826,7 @@ export function annotateTool() {
         throw new Error(validation.error.issues[0]?.message ?? 'Invalid annotate arguments')
       }
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const sessionPalette = await apiGetPalette(client, workspaceId)
       const unknownPaletteKeySet = new Set<string>()
       for (const colorArg of [args.color, args.backgroundColor]) {

--- a/packages/mcp-server/src/server/mcp/tools/canvas-auto-layout.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-auto-layout.test.ts
@@ -78,13 +78,23 @@ function installFetchMock(state: HarnessState) {
     const parts = url.pathname.split('/').filter(Boolean)
     const method = init?.method ?? 'GET'
 
+    if (parts[0] === 'api' && parts[1] === 'canvas' && parts[4] === 'exists') {
+      // This harness treats every referenced canvasId as already created
+      // (ensureCanvas lazily seeds it), so the existence check always passes.
+      return new Response(JSON.stringify({ exists: true }), { status: 200 })
+    }
+
     if (parts[0] === 'api' && parts[1] === 'canvas' && parts[4] === 'snapshot') {
       const canvasId = `${parts[2]}/${decodeURIComponent(parts[3])}`
       const doc = ensureCanvas(state, canvasId)
       return new Response(doc.export({ mode: 'snapshot' }), { status: 200 })
     }
 
-    if (parts[0] === 'api' && ['sessions', 'workspaces'].includes(parts[1] ?? '') && parts[3] === 'palette') {
+    if (
+      parts[0] === 'api' &&
+      ['sessions', 'workspaces'].includes(parts[1] ?? '') &&
+      parts[3] === 'palette'
+    ) {
       return new Response(JSON.stringify({ palette: {} }), { status: 200 })
     }
 
@@ -146,12 +156,7 @@ function toRect(element: CanvasElement): Rect {
 }
 
 function rectsOverlap(a: Rect, b: Rect): boolean {
-  return (
-    a.x < b.x + b.width &&
-    a.x + a.width > b.x &&
-    a.y < b.y + b.height &&
-    a.y + a.height > b.y
-  )
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
 }
 
 function arrowAbsolutePoints(arrow: CanvasElement): Point[] {
@@ -350,7 +355,9 @@ describe('canvas_auto_layout', () => {
     const nextLabel = readElement(state, canvasId, labelId!)
     const nextObstacle = readElement(state, canvasId, obstacle.elementId)
     const nextNearbyText = readElement(state, canvasId, nearbyText.elementId)
-    expect(distanceRectToPolyline(toRect(nextLabel), arrowAbsolutePoints(nextArrow))).toBeLessThan(50)
+    expect(distanceRectToPolyline(toRect(nextLabel), arrowAbsolutePoints(nextArrow))).toBeLessThan(
+      50,
+    )
     expect(rectsOverlap(toRect(nextLabel), toRect(nextObstacle))).toBe(false)
     expect(Math.hypot(nextLabel.x - oldLabel.x, nextLabel.y - oldLabel.y)).toBeGreaterThan(80)
     expect(nextNearbyText.x).toBe(oldNearbyText.x)
@@ -424,7 +431,9 @@ describe('canvas_auto_layout', () => {
     const nextLabel = readElement(state, canvasId, labelId!)
     const nextDecoy = readElement(state, canvasId, decoy.elementId)
 
-    expect(distanceRectToPolyline(toRect(nextLabel), arrowAbsolutePoints(nextArrow))).toBeLessThan(50)
+    expect(distanceRectToPolyline(toRect(nextLabel), arrowAbsolutePoints(nextArrow))).toBeLessThan(
+      50,
+    )
     expect(Math.hypot(nextLabel.x - oldLabel.x, nextLabel.y - oldLabel.y)).toBeGreaterThan(80)
     expect(nextDecoy.x).toBe(oldDecoy.x)
     expect(nextDecoy.y).toBe(oldDecoy.y)
@@ -574,8 +583,20 @@ describe('layout regression cases', () => {
       {
         canvasId,
         annotations: [
-          { type: 'rectangle', coords: 'absolute', target: { x: 40, y: 40 }, width: 120, height: 60 },
-          { type: 'rectangle', coords: 'absolute', target: { x: 200, y: 40 }, width: 120, height: 60 },
+          {
+            type: 'rectangle',
+            coords: 'absolute',
+            target: { x: 40, y: 40 },
+            width: 120,
+            height: 60,
+          },
+          {
+            type: 'rectangle',
+            coords: 'absolute',
+            target: { x: 200, y: 40 },
+            width: 120,
+            height: 60,
+          },
         ],
       },
       client,
@@ -643,9 +664,11 @@ describe('layout regression cases', () => {
     expect(nextFrame.y + nextFrame.height).toBeGreaterThanOrEqual(
       Math.max(primaryRect.y + primaryRect.height, secondaryRect.y + secondaryRect.height),
     )
-    expect(elements.filter((el) => el.frameId === frame.elementId && el.isDeleted !== true).map((el) => el.id).sort()).toEqual(
-      [primaryRectId!, secondaryRectId!].sort(),
-    )
+    expect(
+      elements
+        .filter((el) => el.frameId === frame.elementId && el.isDeleted !== true)
+        .map((el) => el.id)
+        .sort(),
+    ).toEqual([primaryRectId!, secondaryRectId!].sort())
   })
-
 })

--- a/packages/mcp-server/src/server/mcp/tools/canvas-existence.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-existence.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import type { DaemonClient } from '../daemon-client.js'
+import { assertCanvasExists } from './canvas-existence.js'
+
+function makeClient(request: DaemonClient['request']): DaemonClient {
+  return {
+    port: 3099,
+    baseUrl: 'http://localhost:3099',
+    request,
+    touch: async () => undefined,
+  }
+}
+
+describe('assertCanvasExists', () => {
+  it('resolves without throwing when the canvas exists', async () => {
+    const client = makeClient(
+      async () => new Response(JSON.stringify({ exists: true }), { status: 200 }),
+    )
+    await expect(assertCanvasExists(client, 'ws', 'slug')).resolves.toBeUndefined()
+  })
+
+  it('throws an actionable canvas_create hint when the canvas does not exist', async () => {
+    const client = makeClient(
+      async () => new Response(JSON.stringify({ exists: false }), { status: 200 }),
+    )
+    await expect(assertCanvasExists(client, 'ws', 'slug')).rejects.toThrow(
+      /Canvas "ws\/slug" does not exist.*canvas_create.*slug "slug"/s,
+    )
+  })
+
+  it('throws with the HTTP status when the daemon responds with a non-ok status', async () => {
+    const client = makeClient(async () => new Response('boom', { status: 500 }))
+    await expect(assertCanvasExists(client, 'ws', 'slug')).rejects.toThrow(
+      'Failed to check canvas "ws/slug" existence: 500',
+    )
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/canvas-existence.ts
+++ b/packages/mcp-server/src/server/mcp/tools/canvas-existence.ts
@@ -1,0 +1,27 @@
+import { canvasExistsResponseSchema } from '../../../shared/api-contracts/canvas.js'
+import type { DaemonClient } from '../daemon-client.js'
+
+// The daemon's snapshot GET / update POST routes (getDoc -> loadCanvas)
+// silently create an empty workspace+canvas on first touch instead of
+// erroring on an unknown id. That is the right default for canvas_create
+// (an explicit "make this" request), but wrong for tools that only mean to
+// mutate an *existing* canvas: a hallucinated or mistyped canvasId would
+// otherwise write into a brand-new, empty canvas instead of failing loudly.
+// Call this before any write so annotate / annotate_batch / load_image fail
+// fast on an unregistered canvasId.
+export async function assertCanvasExists(
+  client: DaemonClient,
+  workspaceId: string,
+  slug: string,
+): Promise<void> {
+  const res = await client.request(`/api/canvas/${workspaceId}/${encodeURIComponent(slug)}/exists`)
+  if (!res.ok) {
+    throw new Error(`Failed to check canvas "${workspaceId}/${slug}" existence: ${res.status}`)
+  }
+  const parsed = canvasExistsResponseSchema.parse(await res.json())
+  if (!parsed.exists) {
+    throw new Error(
+      `Canvas "${workspaceId}/${slug}" does not exist. Call canvas_create with slug "${slug}" first, or check canvasId for a typo.`,
+    )
+  }
+}

--- a/packages/mcp-server/src/server/mcp/tools/frame-embed.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/frame-embed.test.ts
@@ -208,6 +208,14 @@ describe('update_frame_members', () => {
   })
   afterEach(() => restore())
 
+  it('rejects a canvasId that does not exist instead of silently registering it', async () => {
+    state.exists = false
+    const tool = updateFrameMembersTool()
+    await expect(
+      tool.execute({ canvasId: 'sess/ghost', frameId: 'F', add: ['a'] }, client),
+    ).rejects.toThrow(/does not exist/)
+  })
+
   it('case 5', async () => {
     seedFrame('F', 0, 0, 100, 100)
     seedEl('a', 200, 100, 50, 50)

--- a/packages/mcp-server/src/server/mcp/tools/frame-embed.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/frame-embed.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { LoroDoc, LoroMap } from 'loro-crdt'
-import {
-  createEmbedTool,
-  createFrameTool,
-  updateFrameMembersTool,
-} from './frame-embed.js'
+import { createEmbedTool, createFrameTool, updateFrameMembersTool } from './frame-embed.js'
 
 const client = {
   port: 9999,
@@ -16,12 +12,16 @@ const client = {
 
 interface SnapshotState {
   doc: LoroDoc
+  exists?: boolean
 }
 
 function installFetchMock(state: SnapshotState) {
   const originalFetch = globalThis.fetch
   const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
     const u = url.toString()
+    if (u.endsWith('/exists')) {
+      return new Response(JSON.stringify({ exists: state.exists ?? true }), { status: 200 })
+    }
     if (u.endsWith('/palette')) {
       return new Response(JSON.stringify({ palette: {} }), { status: 200 })
     }
@@ -68,18 +68,34 @@ describe('create_frame', () => {
     expect(elements[0].id).toBe(res.elementId)
   })
 
+  it('rejects a canvasId that does not exist instead of silently registering it', async () => {
+    state.exists = false
+    const tool = createFrameTool()
+    await expect(
+      tool.execute({ canvasId: 'sid/ghost', x: 10, y: 20, width: 300, height: 200 }, client),
+    ).rejects.toThrow(/does not exist/)
+  })
+
   it('case 2', async () => {
     const list = state.doc.getMovableList('elements')
     const a = list.insertContainer(0, new LoroMap())
     a.set('id', 'el-a')
     a.set('type', 'rectangle')
-    a.set('x', 100); a.set('y', 100); a.set('width', 100); a.set('height', 50)
-    a.set('frameId', null); a.set('isDeleted', false)
+    a.set('x', 100)
+    a.set('y', 100)
+    a.set('width', 100)
+    a.set('height', 50)
+    a.set('frameId', null)
+    a.set('isDeleted', false)
     const b = list.insertContainer(1, new LoroMap())
     b.set('id', 'el-b')
     b.set('type', 'rectangle')
-    b.set('x', 300); b.set('y', 200); b.set('width', 80); b.set('height', 40)
-    b.set('frameId', null); b.set('isDeleted', false)
+    b.set('x', 300)
+    b.set('y', 200)
+    b.set('width', 80)
+    b.set('height', 40)
+    b.set('frameId', null)
+    b.set('isDeleted', false)
     state.doc.commit()
 
     const tool = createFrameTool()
@@ -137,6 +153,14 @@ describe('create_embed', () => {
     expect(elements[0].width).toBe(640)
     expect(elements[0].height).toBe(400)
   })
+
+  it('rejects a canvasId that does not exist instead of silently registering it', async () => {
+    state.exists = false
+    const tool = createEmbedTool()
+    await expect(
+      tool.execute({ canvasId: 'sid/ghost', url: 'https://youtu.be/dQw4w9WgXcQ' }, client),
+    ).rejects.toThrow(/does not exist/)
+  })
 })
 
 describe('update_frame_members', () => {
@@ -147,15 +171,28 @@ describe('update_frame_members', () => {
     const m = list.insertContainer(list.length, new LoroMap())
     m.set('id', id)
     m.set('type', 'frame')
-    m.set('x', x); m.set('y', y); m.set('width', w); m.set('height', h)
+    m.set('x', x)
+    m.set('y', y)
+    m.set('width', w)
+    m.set('height', h)
     m.set('isDeleted', false)
   }
-  const seedEl = (id: string, x: number, y: number, w: number, h: number, frameId: string | null = null): void => {
+  const seedEl = (
+    id: string,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    frameId: string | null = null,
+  ): void => {
     const list = state.doc.getMovableList('elements')
     const m = list.insertContainer(list.length, new LoroMap())
     m.set('id', id)
     m.set('type', 'rectangle')
-    m.set('x', x); m.set('y', y); m.set('width', w); m.set('height', h)
+    m.set('x', x)
+    m.set('y', y)
+    m.set('width', w)
+    m.set('height', h)
     m.set('isDeleted', false)
     m.set('frameId', frameId)
   }
@@ -178,10 +215,7 @@ describe('update_frame_members', () => {
     state.doc.commit()
 
     const tool = updateFrameMembersTool()
-    await tool.execute(
-      { canvasId: 'sess/canvas', frameId: 'F', add: ['a', 'b'] },
-      client,
-    )
+    await tool.execute({ canvasId: 'sess/canvas', frameId: 'F', add: ['a', 'b'] }, client)
 
     expect(readEl('a')?.frameId).toBe('F')
     expect(readEl('b')?.frameId).toBe('F')
@@ -190,14 +224,11 @@ describe('update_frame_members', () => {
   it('case 6', async () => {
     seedFrame('F', 0, 0, 100, 100)
     seedEl('a', 200, 100, 50, 50, 'F') // Already belongs to F
-    seedEl('b', 260, 200, 40, 30)      // Will be added now
+    seedEl('b', 260, 200, 40, 30) // Will be added now
     state.doc.commit()
 
     const tool = updateFrameMembersTool()
-    await tool.execute(
-      { canvasId: 'sess/canvas', frameId: 'F', add: ['b'], padding: 10 },
-      client,
-    )
+    await tool.execute({ canvasId: 'sess/canvas', frameId: 'F', add: ['b'], padding: 10 }, client)
 
     const f = readEl('F')
     expect(f?.x).toBe(200 - 10)
@@ -213,10 +244,7 @@ describe('update_frame_members', () => {
     state.doc.commit()
 
     const tool = updateFrameMembersTool()
-    await tool.execute(
-      { canvasId: 'sess/canvas', frameId: 'F', remove: ['a'] },
-      client,
-    )
+    await tool.execute({ canvasId: 'sess/canvas', frameId: 'F', remove: ['a'] }, client)
 
     expect(readEl('a')?.frameId).toBeNull()
     expect(readEl('b')?.frameId).toBe('F')
@@ -229,10 +257,7 @@ describe('update_frame_members', () => {
     state.doc.commit()
 
     const tool = updateFrameMembersTool()
-    await tool.execute(
-      { canvasId: 'sess/canvas', frameId: 'F', add: ['b'], remove: ['a'] },
-      client,
-    )
+    await tool.execute({ canvasId: 'sess/canvas', frameId: 'F', add: ['b'], remove: ['a'] }, client)
 
     expect(readEl('a')?.frameId).toBeNull()
     expect(readEl('b')?.frameId).toBe('F')
@@ -265,10 +290,7 @@ describe('update_frame_members', () => {
     state.doc.commit()
     const tool = updateFrameMembersTool()
     await expect(
-      tool.execute(
-        { canvasId: 'sess/canvas', frameId: 'F', add: ['a', 'ghost'] },
-        client,
-      ),
+      tool.execute({ canvasId: 'sess/canvas', frameId: 'F', add: ['a', 'ghost'] }, client),
     ).rejects.toThrow(/not found/i)
     expect(readEl('a')?.frameId).toBeNull()
   })
@@ -299,10 +321,7 @@ describe('update_frame_members', () => {
     seedEl('a', 100, 100, 50, 50, 'F')
     state.doc.commit()
     const tool = updateFrameMembersTool()
-    const result = await tool.execute(
-      { canvasId: 'sess/canvas', frameId: 'F' },
-      client,
-    )
+    const result = await tool.execute({ canvasId: 'sess/canvas', frameId: 'F' }, client)
     expect(result.addedMembers).toEqual([])
     expect(result.removedMembers).toEqual([])
     expect(readEl('a')?.frameId).toBe('F')

--- a/packages/mcp-server/src/server/mcp/tools/frame-embed.ts
+++ b/packages/mcp-server/src/server/mcp/tools/frame-embed.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { z } from 'zod'
 import type { DaemonClient } from '../daemon-client.js'
 import { apiGetSnapshot, apiPostLoroUpdate } from './annotate.js'
+import { assertCanvasExists } from './canvas-existence.js'
 import { parseCanvasId } from './canvas-id.js'
 import { boundsSchema } from './shared-schemas.js'
 
@@ -189,6 +190,7 @@ export function createFrameTool() {
     },
     execute: async (args: CreateFrameArgs, client: DaemonClient): Promise<CreateFrameResult> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const memberIds = (args.memberIds ?? []).slice(0, MAX_MEMBER_IDS)
       const padding = args.padding ?? 24
 
@@ -297,6 +299,7 @@ export function createEmbedTool() {
         throw new Error(`Invalid url "${args.url}": must start with http:// or https://`)
       }
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const doc = await apiGetSnapshot(client, workspaceId, slug)
       const prevVV = doc.version()
 

--- a/packages/mcp-server/src/server/mcp/tools/frame-embed.ts
+++ b/packages/mcp-server/src/server/mcp/tools/frame-embed.ts
@@ -383,6 +383,7 @@ export function updateFrameMembersTool() {
       client: DaemonClient,
     ): Promise<UpdateFrameMembersResult> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const padding = args.padding ?? 24
       const add = args.add ?? []
       const remove = args.remove ?? []

--- a/packages/mcp-server/src/server/mcp/tools/library.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/library.test.ts
@@ -89,9 +89,7 @@ describe('libraryPayloadV1Schema / libraryPayloadV2Schema', () => {
     const payload = {
       type: 'excalidrawlib',
       version: 1,
-      library: [
-        [{ id: 'el-1', type: 'rectangle', x: 0, y: 0, width: 100, height: 50 }],
-      ],
+      library: [[{ id: 'el-1', type: 'rectangle', x: 0, y: 0, width: 100, height: 50 }]],
     }
     const result = libraryPayloadV1Schema.safeParse(payload)
     expect(result.success).toBe(true)
@@ -313,7 +311,11 @@ describe('session library tools', () => {
       },
     )
     globalThis.fetch = vi.fn(async (input: string | URL) => {
-      expect(input.toString()).toBe('http://localhost:3099/api/user-libraries/icons')
+      const url = input.toString()
+      if (url.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
+      expect(url).toBe('http://localhost:3099/api/user-libraries/icons')
       return new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })
     }) as typeof globalThis.fetch
 
@@ -330,7 +332,7 @@ describe('session library tools', () => {
       client,
     )
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
     expect(apiGetSnapshotMock).toHaveBeenCalledTimes(1)
     expect(apiPostLoroUpdateMock).toHaveBeenCalledTimes(1)
     expect(res).toEqual({
@@ -358,6 +360,9 @@ describe('session library tools', () => {
         postedUpdate = update
       },
     )
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ exists: true }), { status: 200 }),
+    ) as typeof globalThis.fetch
 
     await tool.execute(
       {
@@ -390,6 +395,9 @@ describe('session library tools', () => {
     )
     globalThis.fetch = vi.fn(async (input: string | URL) => {
       const url = input.toString()
+      if (url.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (url === 'http://localhost:3099/api/user-libraries/icons') {
         return new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })
       }
@@ -419,7 +427,7 @@ describe('session library tools', () => {
 
     const [element] = readUpdateElements(postedUpdate!)
     expect(element).toMatchObject({ x: 10, y: 20, width: 20, height: 20 })
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
   })
 
   it('library_insert_batch lets explicit item scale override metadata scale', async () => {
@@ -433,6 +441,9 @@ describe('session library tools', () => {
     )
     globalThis.fetch = vi.fn(async (input: string | URL) => {
       const url = input.toString()
+      if (url.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (url === 'http://localhost:3099/api/user-libraries/icons') {
         return new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })
       }
@@ -467,7 +478,13 @@ describe('session library tools', () => {
   it('library_insert_batch fails on invalid itemIndex without partial insert', async () => {
     const tool = libraryInsertBatchTool()
     apiGetSnapshotMock.mockResolvedValue(new LoroDoc())
-    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })) as typeof globalThis.fetch
+    globalThis.fetch = vi.fn(async (input: string | URL) => {
+      const url = input.toString()
+      if (url.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
+      return new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })
+    }) as typeof globalThis.fetch
 
     await expect(
       tool.execute(
@@ -497,7 +514,13 @@ describe('session library tools', () => {
         postedUpdate = update
       },
     )
-    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })) as typeof globalThis.fetch
+    globalThis.fetch = vi.fn(async (input: string | URL) => {
+      const url = input.toString()
+      if (url.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
+      return new Response(JSON.stringify(INSERT_LIBRARY), { status: 200 })
+    }) as typeof globalThis.fetch
 
     const res = await tool.execute(
       {
@@ -513,10 +536,42 @@ describe('session library tools', () => {
     )
 
     const elements = readUpdateElements(postedUpdate!)
-    const grouped = new Map(elements.map((element) => [element.id as string, element.groupIds as string[]]))
+    const grouped = new Map(
+      elements.map((element) => [element.id as string, element.groupIds as string[]]),
+    )
     expect(grouped.get(res.items[0].elementIds[0])).toEqual(['trial-sheet', 'selected-icon'])
     expect(grouped.get(res.items[0].elementIds[1])).toEqual(['trial-sheet', 'selected-icon'])
     expect(grouped.get(res.items[1].elementIds[0])).toEqual(['trial-sheet'])
+  })
+
+  it('library_insert_batch rejects an unknown canvasId before touching the library source', async () => {
+    const tool = libraryInsertBatchTool()
+    let touchedLibraryOrSnapshot = false
+    const fakeClient = {
+      port: 3099,
+      baseUrl: 'http://localhost:3099',
+      request: async (path: string) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: false }), { status: 200 })
+        }
+        touchedLibraryOrSnapshot = true
+        throw new Error(`Unexpected request: ${path}`)
+      },
+      touch: async () => undefined,
+    }
+
+    await expect(
+      tool.execute(
+        {
+          canvasId: 'unknown-ws/sticky-demo',
+          libraryPath: join(tempDir, 'icons.excalidrawlib'),
+          items: [{ itemIndex: 0, target: { x: 0, y: 0 } }],
+        },
+        fakeClient,
+      ),
+    ).rejects.toThrow(/canvas_create/)
+    expect(touchedLibraryOrSnapshot).toBe(false)
+    expect(apiGetSnapshotMock).not.toHaveBeenCalled()
   })
 
   it('library_insert_item keeps the existing single-item response shape', async () => {
@@ -525,6 +580,9 @@ describe('session library tools', () => {
     await writeFile(libraryPath, JSON.stringify(INSERT_LIBRARY))
     apiGetSnapshotMock.mockResolvedValue(new LoroDoc())
     apiPostLoroUpdateMock.mockResolvedValue(undefined)
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ exists: true }), { status: 200 }),
+    ) as typeof globalThis.fetch
 
     const res = await tool.execute(
       {
@@ -570,10 +628,12 @@ describe('user library tools', () => {
       return new Response(JSON.stringify({ name: 'icons', itemCount: 1 }), { status: 200 })
     }) as typeof globalThis.fetch
 
-    await expect(tool.execute({ name: 'icons', content: SAMPLE_LIBRARY }, client)).resolves.toEqual({
-      name: 'icons',
-      itemCount: 1,
-    })
+    await expect(tool.execute({ name: 'icons', content: SAMPLE_LIBRARY }, client)).resolves.toEqual(
+      {
+        name: 'icons',
+        itemCount: 1,
+      },
+    )
   })
 
   it('user_library_list reads via the daemon route', async () => {
@@ -581,7 +641,9 @@ describe('user library tools', () => {
     globalThis.fetch = vi.fn(async (input: string | URL) => {
       expect(input.toString()).toBe('http://localhost:3099/api/user-libraries')
       return new Response(
-        JSON.stringify({ libraries: [{ name: 'icons', path: '/tmp/icons.excalidrawlib', itemCount: 1 }] }),
+        JSON.stringify({
+          libraries: [{ name: 'icons', path: '/tmp/icons.excalidrawlib', itemCount: 1 }],
+        }),
         { status: 200 },
       )
     }) as typeof globalThis.fetch
@@ -740,8 +802,11 @@ describe('user library tools', () => {
 
   it('user_library_metadata_set surfaces daemon conflict responses', async () => {
     const tool = userLibraryMetadataSetTool()
-    globalThis.fetch = vi.fn(async () =>
-      new Response(JSON.stringify({ error: 'conflict', message: 'revision mismatch' }), { status: 409 }),
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: 'conflict', message: 'revision mismatch' }), {
+          status: 409,
+        }),
     ) as typeof globalThis.fetch
 
     await expect(

--- a/packages/mcp-server/src/server/mcp/tools/library.ts
+++ b/packages/mcp-server/src/server/mcp/tools/library.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../shared/api-contracts/libraries.js'
 import { validateExternalUrl } from '../../validators.js'
 import { apiGetSnapshot, apiPostLoroUpdate } from './annotate.js'
+import { assertCanvasExists } from './canvas-existence.js'
 import { parseCanvasId } from './canvas-id.js'
 import { resolveLibraryItem, type LibraryElement } from './resolve-library-item.js'
 import { boundsSchema } from './shared-schemas.js'
@@ -291,6 +292,7 @@ async function insertLibraryBatch(
   items: Array<{ itemIndex: number; insertedCount: number; elementIds: string[] }>
 }> {
   const { workspaceId, slug } = parseCanvasId(args.canvasId)
+  await assertCanvasExists(client, workspaceId, slug)
   const items = await loadLibrarySource(args, client)
   let metadata: UserLibraryMetadataManifest | undefined
   const needsMetadata =

--- a/packages/mcp-server/src/server/mcp/tools/load.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/load.test.ts
@@ -59,6 +59,7 @@ describe('load_image execute', () => {
     const emptyDoc = new LoroDoc()
     const snapshot = emptyDoc.export({ mode: 'snapshot' })
     let uploadedBody: unknown
+    let uploadedFileId: string | undefined
     let postedUpdate: Uint8Array | null = null
 
     const fakeClient: DaemonClient = {
@@ -73,6 +74,7 @@ describe('load_image execute', () => {
         }
         if (path.includes('/file/')) {
           uploadedBody = init?.body
+          uploadedFileId = path.split('/file/')[1]
           return new Response(null, { status: 204 })
         }
         if (path.endsWith('/update')) {
@@ -88,5 +90,15 @@ describe('load_image execute', () => {
     expect(res.elementId).toBeDefined()
     expect(uploadedBody).toBeDefined()
     expect(postedUpdate).not.toBeNull()
+
+    const resultDoc = new LoroDoc()
+    resultDoc.import(postedUpdate!)
+    const elements = resultDoc.getMovableList('elements').toJSON() as Array<Record<string, unknown>>
+    expect(elements).toHaveLength(1)
+    expect(elements[0]).toMatchObject({
+      id: res.elementId,
+      type: 'image',
+      fileId: uploadedFileId,
+    })
   })
 })

--- a/packages/mcp-server/src/server/mcp/tools/load.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/load.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, afterEach } from 'vitest'
+import { LoroDoc } from 'loro-crdt'
+import type { DaemonClient } from '../daemon-client.js'
+
+// Tiny solid-color PNG so tests don't depend on a real asset file.
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAGUlEQVR4nGP8z8DAwIQDMOEUobiUgQEkAQATDQMR/HpTEgAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+describe('load_image execute', () => {
+  let tmpDir: string | undefined
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true })
+      tmpDir = undefined
+    }
+  })
+
+  async function writeTinyPng(): Promise<string> {
+    tmpDir = await mkdtemp(join(tmpdir(), 'load-image-test-'))
+    const imagePath = join(tmpDir, 'tiny.png')
+    await writeFile(imagePath, TINY_PNG)
+    return imagePath
+  }
+
+  it('rejects an unknown canvasId before touching the snapshot/update/file endpoints', async () => {
+    const imagePath = await writeTinyPng()
+    const { loadImageTool } = await import('./load.js')
+    const tool = loadImageTool()
+    let touchedWriteEndpoint = false
+    const fakeClient: DaemonClient = {
+      port: 3099,
+      baseUrl: 'http://localhost:3099',
+      request: async (path: string) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: false }), { status: 200 })
+        }
+        touchedWriteEndpoint = true
+        throw new Error(`Unexpected request: ${path}`)
+      },
+      touch: async () => undefined,
+    }
+    await expect(
+      tool.execute({ canvasId: 'unknown-ws/sticky-demo', imagePath }, fakeClient),
+    ).rejects.toThrow(/canvas_create/)
+    expect(touchedWriteEndpoint).toBe(false)
+  })
+
+  it('uploads the image and appends it to the doc when the canvas exists', async () => {
+    const imagePath = await writeTinyPng()
+    const { loadImageTool } = await import('./load.js')
+    const tool = loadImageTool()
+
+    const emptyDoc = new LoroDoc()
+    const snapshot = emptyDoc.export({ mode: 'snapshot' })
+    let uploadedBody: unknown
+    let postedUpdate: Uint8Array | null = null
+
+    const fakeClient: DaemonClient = {
+      port: 3099,
+      baseUrl: 'http://localhost:3099',
+      request: async (path: string, init?: RequestInit) => {
+        if (path.endsWith('/exists')) {
+          return new Response(JSON.stringify({ exists: true }), { status: 200 })
+        }
+        if (path.endsWith('/snapshot')) {
+          return new Response(snapshot, { status: 200 })
+        }
+        if (path.includes('/file/')) {
+          uploadedBody = init?.body
+          return new Response(null, { status: 204 })
+        }
+        if (path.endsWith('/update')) {
+          postedUpdate = init?.body as Uint8Array
+          return new Response(null, { status: 204 })
+        }
+        throw new Error(`Unexpected request: ${path}`)
+      },
+      touch: async () => undefined,
+    }
+
+    const res = await tool.execute({ canvasId: 'sid/slug', imagePath }, fakeClient)
+    expect(res.elementId).toBeDefined()
+    expect(uploadedBody).toBeDefined()
+    expect(postedUpdate).not.toBeNull()
+  })
+})

--- a/packages/mcp-server/src/server/mcp/tools/load.ts
+++ b/packages/mcp-server/src/server/mcp/tools/load.ts
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 import { imageSize } from 'image-size'
 import { z } from 'zod'
 import type { DaemonClient } from '../daemon-client.js'
+import { assertCanvasExists } from './canvas-existence.js'
 import { parseCanvasId } from './canvas-id.js'
 
 export const loadImageOutputSchema = z.object({ elementId: z.string() })
@@ -85,6 +86,7 @@ export function loadImageTool() {
       client: DaemonClient,
     ): Promise<z.infer<typeof loadImageOutputSchema>> => {
       const { workspaceId, slug } = parseCanvasId(args.canvasId)
+      await assertCanvasExists(client, workspaceId, slug)
       const position = args.position ?? 'center'
 
       // 1. Read the image file.

--- a/packages/mcp-server/src/server/mcp/tools/template.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/tools/template.smoke-impl.ts
@@ -40,8 +40,17 @@ export async function runTemplateSmokeChecks(): Promise<void> {
 
   try {
     const posted: number[] = []
-    globalThis.fetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    globalThis.fetch = async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
       const u = url.toString()
+      if (u.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
       if (u.endsWith('/palette')) {
         return new Response(JSON.stringify({ palette: {} }), {
           status: 200,
@@ -53,9 +62,7 @@ export async function runTemplateSmokeChecks(): Promise<void> {
       }
       if (u.endsWith('/update')) {
         posted.push(
-          init?.body instanceof Uint8Array
-            ? init.body.byteLength
-            : String(init?.body ?? '').length,
+          init?.body instanceof Uint8Array ? init.body.byteLength : String(init?.body ?? '').length,
         )
         return new Response(null, { status: 200 })
       }
@@ -73,7 +80,10 @@ export async function runTemplateSmokeChecks(): Promise<void> {
     const list = await listTemplatesTool().execute()
     check('list.templates is array', Array.isArray(list.templates))
     check('list has 3 built-ins', list.templates.length === 3, `got ${list.templates.length}`)
-    check('list contains client-api-db', list.templates.some((t) => t.id === 'client-api-db'))
+    check(
+      'list contains client-api-db',
+      list.templates.some((t) => t.id === 'client-api-db'),
+    )
     const cad = list.templates.find((t) => t.id === 'client-api-db')!
     check('client-api-db exposes variables', cad.variables.length === 5)
     check('variable has default', cad.variables[0].default === 'Client')
@@ -87,10 +97,7 @@ export async function runTemplateSmokeChecks(): Promise<void> {
     check('insert returns templateId', r1.templateId === 'client-api-db')
     check('insert source=builtin', r1.source === 'builtin')
     check('insert annotations=5', (r1.annotations as unknown[])?.length === 5)
-    check(
-      'insert produced elementIds',
-      Array.isArray(r1.elementIds) && r1.elementIds.length >= 5,
-    )
+    check('insert produced elementIds', Array.isArray(r1.elementIds) && r1.elementIds.length >= 5)
     check('posted 1 update', posted.length === 1)
     check('default client=Client', r1.variables.client === 'Client')
 

--- a/packages/mcp-server/src/server/mcp/tools/template.test.ts
+++ b/packages/mcp-server/src/server/mcp/tools/template.test.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LoroDoc } from 'loro-crdt'
 
-import { instantiateTemplate, insertTemplateTool, listTemplatesTool, resolveTemplateSource } from './template.js'
+import {
+  instantiateTemplate,
+  insertTemplateTool,
+  listTemplatesTool,
+  resolveTemplateSource,
+} from './template.js'
 import { getBuiltinTemplate } from './template-library.js'
 
 function makeEmptySnapshot(): Uint8Array {
@@ -261,6 +266,9 @@ describe('template tools', () => {
     const updateBodies: Uint8Array[] = []
     globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
       const textUrl = url.toString()
+      if (textUrl.endsWith('/exists')) {
+        return new Response(JSON.stringify({ exists: true }), { status: 200 })
+      }
       if (textUrl.endsWith('/palette')) {
         return new Response(JSON.stringify({ palette: {} }), { status: 200 })
       }

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -258,6 +258,44 @@ describe('GET /api/canvas/:workspaceId/:slug/snapshot', () => {
   })
 })
 
+describe('GET /api/canvas/:workspaceId/:slug/exists', () => {
+  beforeEach(async () => {
+    await mkdir(join(tmp.dir, 'session1'), { recursive: true })
+    clearCache()
+  })
+  afterEach(() => {
+    clearCache()
+  })
+
+  it('returns exists:true for a canvas that was actually saved', async () => {
+    const doc = new LoroDoc()
+    await saveCanvas('session1', 'canvas-a', doc)
+
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/canvas-a/exists')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ exists: true })
+  })
+
+  it('returns exists:false for an unregistered canvas without creating it', async () => {
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/never-created/exists')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ exists: false })
+
+    // GET /exists must never have the getDoc/loadCanvas side effect that
+    // /snapshot has: the canvas should still be absent afterward.
+    const followUp = await app.request('/api/canvas/session1/never-created/exists')
+    expect(await followUp.json()).toEqual({ exists: false })
+  })
+
+  it('returns 400 for an invalid slug', async () => {
+    const app = createCanvasRouter()
+    const res = await app.request('/api/canvas/session1/bad.slug/exists')
+    expect(res.status).toBe(400)
+  })
+})
+
 describe('POST /api/workspaces/:workspaceId/canvases/:slug/compact', () => {
   function createVersionStoreMock() {
     return {

--- a/packages/mcp-server/src/server/routes/canvas/live-doc.ts
+++ b/packages/mcp-server/src/server/routes/canvas/live-doc.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { LoroDoc } from 'loro-crdt'
 import type {
@@ -26,6 +26,22 @@ export interface LiveDocRouterOptions {
   ) => Promise<VersionEntry | null>
 }
 
+// Validate the shared :workspaceId/:slug path params. Returns a 400 JSON
+// Response to short-circuit the handler on invalid input, or the parsed
+// params on success. Rethrows non-validation errors unchanged.
+function validatePathParams(c: Context): { workspaceId: string; slug: string } | Response {
+  const { workspaceId, slug } = c.req.param()
+  try {
+    validateWorkspaceId(workspaceId)
+    validateSlug(slug)
+  } catch (err) {
+    const body = validationErrorBody(err)
+    if (body) return c.json(body, 400)
+    throw err
+  }
+  return { workspaceId, slug }
+}
+
 // GET /api/canvas/:workspaceId/:slug/snapshot
 // GET /api/canvas/:workspaceId/:slug/exists
 // POST /api/canvas/:workspaceId/:slug/update
@@ -33,29 +49,17 @@ export function createLiveDocRouter(options: LiveDocRouterOptions) {
   const app = new Hono()
 
   app.get('/api/canvas/:workspaceId/:slug/exists', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+    const params = validatePathParams(c)
+    if (params instanceof Response) return params
+    const { workspaceId, slug } = params
     const response: CanvasExistsResponse = { exists: await canvasExists(workspaceId, slug) }
     return c.json(response)
   })
 
   app.get('/api/canvas/:workspaceId/:slug/snapshot', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+    const params = validatePathParams(c)
+    if (params instanceof Response) return params
+    const { workspaceId, slug } = params
     const doc = await getDoc(workspaceId, slug)
     const snapshot = doc.export({ mode: 'snapshot' }) as Uint8Array<ArrayBuffer>
     return c.body(snapshot, 200, {
@@ -77,15 +81,9 @@ export function createLiveDocRouter(options: LiveDocRouterOptions) {
         ),
     }),
     async (c) => {
-      const { workspaceId, slug } = c.req.param()
-      try {
-        validateWorkspaceId(workspaceId)
-        validateSlug(slug)
-      } catch (err) {
-        const body = validationErrorBody(err)
-        if (body) return c.json(body, 400)
-        throw err
-      }
+      const params = validatePathParams(c)
+      if (params instanceof Response) return params
+      const { workspaceId, slug } = params
       const bytes = new Uint8Array(await c.req.arrayBuffer())
 
       const doc = await getDoc(workspaceId, slug)

--- a/packages/mcp-server/src/server/routes/canvas/live-doc.ts
+++ b/packages/mcp-server/src/server/routes/canvas/live-doc.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { LoroDoc } from 'loro-crdt'
-import type { UpdateCanvasResponse } from '../../../shared/api-contracts/canvas.js'
+import type {
+  CanvasExistsResponse,
+  UpdateCanvasResponse,
+} from '../../../shared/api-contracts/canvas.js'
 import { getLogger } from '../../log.js'
-import { saveCanvas } from '../../store/canvas-store.js'
+import { canvasExists, saveCanvas } from '../../store/canvas-store.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionEntry } from '../../store/version-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
@@ -24,9 +27,24 @@ export interface LiveDocRouterOptions {
 }
 
 // GET /api/canvas/:workspaceId/:slug/snapshot
+// GET /api/canvas/:workspaceId/:slug/exists
 // POST /api/canvas/:workspaceId/:slug/update
 export function createLiveDocRouter(options: LiveDocRouterOptions) {
   const app = new Hono()
+
+  app.get('/api/canvas/:workspaceId/:slug/exists', async (c) => {
+    const { workspaceId, slug } = c.req.param()
+    try {
+      validateWorkspaceId(workspaceId)
+      validateSlug(slug)
+    } catch (err) {
+      const body = validationErrorBody(err)
+      if (body) return c.json(body, 400)
+      throw err
+    }
+    const response: CanvasExistsResponse = { exists: await canvasExists(workspaceId, slug) }
+    return c.json(response)
+  })
 
   app.get('/api/canvas/:workspaceId/:slug/snapshot', async (c) => {
     const { workspaceId, slug } = c.req.param()

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -99,6 +99,13 @@ export const updateCanvasResponseSchema = z.object({
   ok: z.literal(true),
 })
 
+// GET /api/canvas/:workspaceId/:slug/exists — success body. Read-only lookup
+// so callers can distinguish "canvas not yet created" from a live doc,
+// without the snapshot/update routes' silent lazy-create side effect.
+export const canvasExistsResponseSchema = z.object({
+  exists: z.boolean(),
+})
+
 // Workspace + canvas listings consumed by IndexPage to render the
 // "open workspaces" grid.
 export const workspaceSummarySchema = z.object({
@@ -135,6 +142,7 @@ export type ListCanvasesResponse = z.infer<typeof listCanvasesResponseSchema>
 export type ProblemDetailsError = z.infer<typeof problemDetailsErrorSchema>
 export type CreateCanvasResponse = z.infer<typeof createCanvasResponseSchema>
 export type UpdateCanvasResponse = z.infer<typeof updateCanvasResponseSchema>
+export type CanvasExistsResponse = z.infer<typeof canvasExistsResponseSchema>
 export type WorkspaceNames = z.infer<typeof workspaceNamesSchema>
 
 // GET /api/runtime/storage — response body.


### PR DESCRIPTION
## Summary

Resolves `annotate-typo-creates-workspace`. Calling a mutating MCP tool (`annotate`, `annotate_batch`, `load_image`, `library_insert_item`/`_batch`, `create_frame`, `create_embed`) with an unknown canvasId — a hallucinated or mistyped workspace prefix — silently created a brand-new workspace+canvas and succeeded, instead of erroring. One typo wrote data to the wrong place; an LLM hallucinating a canvasId got no error signal.

**Root cause:** `GET .../snapshot` → `loadCanvas` resolves a cache miss to a fresh empty `LoroDoc`, and the follow-up `POST /update` persists it with `overwrite: true`, so any canvasId "worked" on first write.

**Fix:**
- New read-only `GET /api/canvas/:workspaceId/:slug/exists` route backed by the existing `canvasExists()` store helper (no lazy-create side effect), with a `z.infer`'d `canvasExistsResponseSchema`
- New shared `assertCanvasExists()` helper that throws an MCP `isError` response pointing the caller at `canvas_create`
- Wired into every snapshot/update-based mutator: annotate, annotate_batch, load, library_insert_item/_batch, create_frame, create_embed
- `canvas_create` (the explicit creation API) is unchanged

The guard is applied to **all** mutating tools that write through snapshot/update, not selectively — a review pass caught `create_frame`/`create_embed` as an initial gap and the fix loop closed it.

## Test plan

- [x] RED-first unit test (mcp-node): unknown canvasId → isError mentioning `canvas_create`, no snapshot/update side effect
- [x] Route test for `GET /exists`: registered vs unregistered, no lazy-create on repeated calls, 400 on invalid slug
- [x] Real e2e smoke (`mcp-e2e-smoke.mjs`): annotate on unregistered canvasId rejects; full create→annotate→…→export flow still green
- [x] Mutation-checked (disabled guard → smoke fails → restored)
- [x] Full mcp-server suite (261 files) + typecheck + knip + lint:noconsole clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canvas-editing tools now verify that the requested canvas exists before making changes.
  * Invalid or mistyped canvas IDs fail clearly with guidance to create the canvas first.
  * Prevented unintended empty canvas creation during annotations, image loading, frame/embed creation, and library insertions.

* **Documentation**
  * Updated architecture guidance to clarify canvas creation and validation behavior.

* **Tests**
  * Added coverage for missing canvases, existence checks, and related error handling across supported tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->