### PR TITLE
fix(web): drain flush-triggered push before disconnect in canvas-sync dispose

### DIFF
--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -391,6 +391,46 @@ describe('createCanvasSyncSession', () => {
     expect(callOrder).toEqual(['push-called', 'disconnect'])
   })
 
+  it('dispose() falls through to disconnect via the drain timeout when the commit chain is stuck behind a hung putFile', async () => {
+    // Regression for DISPOSE_DRAIN_TIMEOUT_MS itself: a putFile that never
+    // settles blocks the commit chain for up to PUT_FILE_TIMEOUT_MS (15s),
+    // far longer than the 2s drain bound. dispose() must still disconnect
+    // once the drain timeout elapses, without waiting for the stuck chain.
+    const backend: CanvasBackend & { _ctrl: FakeBackendControl } = {
+      ...makeFakeBackend(),
+      putFile: () => new Promise(() => {}), // never resolves — simulates a hung upload
+    }
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeEmptySnapshot())
+
+    session.onChange([{ id: 'el-1', type: 'rectangle' } as never], {
+      'file-1': { id: 'file-1', dataURL: 'data:,' } as never,
+    })
+    session.dispose()
+
+    // Only the drain timeout (2s) elapses here, well short of the putFile
+    // race's own 15s deadline, so the chain is still stuck on putFile.
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(0)
+    expect(backend._ctrl.disconnectCalled).toBe(true)
+  })
+
+  it('dispose() disconnects synchronously when nothing is pending (fast path, no drain)', () => {
+    // Regression for the pendingCommitCount === 0 branch: with no onChange
+    // ever fired, dispose() must call backend.disconnect() synchronously —
+    // not behind any await — preserving the "callers do not await dispose()"
+    // contract for the common no-edit teardown path.
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+
+    session.dispose()
+
+    expect(backend._ctrl.disconnectCalled).toBe(true)
+  })
+
   it('onAuthError sets error status and invokes options.onAuthError via getOptions', () => {
     const backend = makeFakeBackend()
     const onStatusChange = vi.fn()

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -125,7 +125,7 @@ describe('createCanvasSyncSession', () => {
     expect(sendReadySpy).toHaveBeenCalledTimes(1)
   })
 
-  it('dispose() flushes a pending debounced edit into this session before disconnecting', () => {
+  it('dispose() flushes a pending debounced edit into this session before disconnecting', async () => {
     const backend = makeFakeBackend()
     const session = createCanvasSyncSession(backend, makeDeps())
     session.connect()
@@ -139,12 +139,15 @@ describe('createCanvasSyncSession', () => {
     session.dispose()
 
     // flush() runs the commit synchronously; the resulting
-    // subscribeLocalUpdates push fires on a microtask, which fake timers do
-    // not control — flushing microtasks with a real await is required.
-    return Promise.resolve().then(() => {
-      expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(0)
-      expect(backend._ctrl.disconnectCalled).toBe(true)
-    })
+    // subscribeLocalUpdates push fires on a microtask, and dispose()'s drain
+    // phase defers backend.disconnect() a few more microtask turns behind
+    // that push — draining several turns with real awaits (fake timers do
+    // not control microtasks) covers both.
+    for (let i = 0; i < 30; i++) {
+      await Promise.resolve()
+    }
+    expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(0)
+    expect(backend._ctrl.disconnectCalled).toBe(true)
   })
 
   it('mutation check: an isStale() guard on the subscribeLocalUpdates callback would drop the post-dispose flush push', async () => {
@@ -346,6 +349,41 @@ describe('createCanvasSyncSession', () => {
 
     expect(api.addFiles).not.toHaveBeenCalled()
     expect(api.updateScene).not.toHaveBeenCalled()
+  })
+
+  it('dispose() invokes backend.pushLocalUpdate for the flush-triggered commit before calling backend.disconnect()', async () => {
+    // Regression for the drain phase: disconnect() must never be called
+    // before the flush-triggered commit's subscribeLocalUpdates callback has
+    // invoked pushLocalUpdate, or the last edit made just before teardown
+    // never reaches the transport. Tracking call ORDER (not settle order) is
+    // the right assertion — a real transport's pushLocalUpdate may take an
+    // arbitrarily long time to settle (network ack), but the *call* itself
+    // is what puts bytes on a still-open connection.
+    const callOrder: string[] = []
+    const backend: CanvasBackend & { _ctrl: FakeBackendControl } = {
+      ...makeFakeBackend(),
+      pushLocalUpdate(_bytes) {
+        callOrder.push('push-called')
+        return new Promise(() => {}) // never settles — disconnect must not wait for this
+      },
+      disconnect() {
+        callOrder.push('disconnect')
+      },
+    }
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeEmptySnapshot())
+
+    session.onChange([{ id: 'el-1', type: 'rectangle' } as never], {})
+    session.dispose()
+
+    // Drain a generous number of microtask turns without advancing fake
+    // timers (real transport call scheduling is not timer-driven).
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve()
+    }
+
+    expect(callOrder).toEqual(['push-called', 'disconnect'])
   })
 
   it('onAuthError sets error status and invokes options.onAuthError via getOptions', () => {

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -39,6 +39,16 @@ function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void }
   return { promise, resolve }
 }
 
+// Drains several microtask turns with real awaits. dispose()'s drain phase
+// schedules the flush-triggered push and the deferred disconnect across a few
+// microtask turns; fake timers do not control microtasks, so a generous number
+// of turns is the reliable way to let that chain settle.
+async function flushMicrotasks(turns = 30): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve()
+  }
+}
+
 // Builds a snapshot containing a single image element referencing fileId, so
 // onSnapshot triggers a backend.getFile(fileId) fetch inside applyLoroToExcalidraw.
 function makeSnapshotWithImage(fileId: string): Uint8Array {
@@ -141,11 +151,8 @@ describe('createCanvasSyncSession', () => {
     // flush() runs the commit synchronously; the resulting
     // subscribeLocalUpdates push fires on a microtask, and dispose()'s drain
     // phase defers backend.disconnect() a few more microtask turns behind
-    // that push — draining several turns with real awaits (fake timers do
-    // not control microtasks) covers both.
-    for (let i = 0; i < 30; i++) {
-      await Promise.resolve()
-    }
+    // that push — draining several turns covers both.
+    await flushMicrotasks()
     expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(0)
     expect(backend._ctrl.disconnectCalled).toBe(true)
   })
@@ -377,11 +384,9 @@ describe('createCanvasSyncSession', () => {
     session.onChange([{ id: 'el-1', type: 'rectangle' } as never], {})
     session.dispose()
 
-    // Drain a generous number of microtask turns without advancing fake
-    // timers (real transport call scheduling is not timer-driven).
-    for (let i = 0; i < 20; i++) {
-      await Promise.resolve()
-    }
+    // Drain microtask turns without advancing fake timers (real transport
+    // call scheduling is not timer-driven).
+    await flushMicrotasks()
 
     expect(callOrder).toEqual(['push-called', 'disconnect'])
   })

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -559,14 +559,24 @@ export function createCanvasSyncSession(
   // cannot leave disconnect() pending forever.
   async function drainBeforePushHasFired(): Promise<void> {
     const chainAtDispose = commitChain
-    await Promise.race([
-      // Awaiting the commit chain lets any still-queued firing's
-      // doc.commit() run; one more microtask turn after that gives Loro's
-      // subscribeLocalUpdates callback (scheduled internally on commit,
-      // not synchronously) room to fire and call backend.pushLocalUpdate.
-      chainAtDispose.then(() => Promise.resolve()),
-      new Promise<void>((resolve) => setTimeout(resolve, DISPOSE_DRAIN_TIMEOUT_MS)),
-    ])
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        // Awaiting the commit chain lets any still-queued firing's
+        // doc.commit() run; one more microtask turn after that gives Loro's
+        // subscribeLocalUpdates callback (scheduled internally on commit,
+        // not synchronously) room to fire and call backend.pushLocalUpdate.
+        chainAtDispose.then(() => Promise.resolve()),
+        new Promise<void>((resolve) => {
+          timeoutId = setTimeout(resolve, DISPOSE_DRAIN_TIMEOUT_MS)
+        }),
+      ])
+    } finally {
+      // On the fast path (commit chain wins) the timer would otherwise stay
+      // armed for the full DISPOSE_DRAIN_TIMEOUT_MS, delaying real-timer test
+      // teardown and holding an event-loop handle needlessly.
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+    }
   }
 
   function dispose(): void {

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -30,6 +30,12 @@ const log = getAppLogger('canvas-sync')
 // indefinitely; upload failure is non-fatal, so falling through is safe.
 const PUT_FILE_TIMEOUT_MS = 15_000
 
+// Upper bound on dispose()'s drain phase (see `dispose()` below). Bounds the
+// wait for the flush-triggered commit's pushLocalUpdate invocation so a
+// stuck commitChain (e.g. a hung putFile upstream of it) cannot leave a
+// disconnect() call pending forever.
+const DISPOSE_DRAIN_TIMEOUT_MS = 2_000
+
 // Small debounce helper with no external dependency.
 function debounce<T extends (...args: Parameters<T>) => void>(
   fn: T,
@@ -117,13 +123,15 @@ export interface SessionDeps {
 
 export interface CanvasSyncSession {
   connect(): void
-  // Flushes any pending debounced edit into this session's own doc BEFORE
-  // disconnecting, so the last edit made against this backend is persisted.
-  // Does NOT itself invalidate in-flight upload/getFile signal delivery —
-  // only a *new* session's construction (which bumps connectionGeneration)
-  // does. A plain dispose (unmount, no successor) leaves a settling
-  // putFile/getFile free to still invoke its (latest-options) callback,
-  // matching pre-extraction behavior.
+  // Flushes any pending debounced edit into this session's own doc, then
+  // defers closing the transport behind a short drain phase so the
+  // flush-triggered commit's pushLocalUpdate call has actually fired before
+  // backend.disconnect() runs (bounded — never waits indefinitely). Does NOT
+  // itself invalidate in-flight upload/getFile signal delivery — only a
+  // *new* session's construction (which bumps connectionGeneration) does. A
+  // plain dispose (unmount, no successor) leaves a settling putFile/getFile
+  // free to still invoke its (latest-options) callback, matching
+  // pre-extraction behavior.
   dispose(): void
   onChange(elements: readonly ExcalidrawElement[], files: BinaryFiles): void
   // Reapplies the current doc to Excalidraw, re-sends clientReady, and
@@ -164,6 +172,12 @@ export function createCanvasSyncSession(
   // the earlier firing's commit finally runs, it writes its own now-stale
   // `elements` snapshot on top, silently reverting the later firing's edits.
   let commitChain: Promise<void> = Promise.resolve()
+  // Counts onSceneChange firings that have been chained onto commitChain but
+  // have not yet settled. Lets dispose() tell "nothing was pending, safe to
+  // disconnect immediately" apart from "a flush-triggered (or still-running)
+  // firing exists" without needing to inspect a Promise's settled state
+  // synchronously (not otherwise observable in plain JS).
+  let pendingCommitCount = 0
 
   function isStale(): boolean {
     return disposed || deps.generations.currentConnectionGeneration() !== myGeneration
@@ -365,7 +379,10 @@ export function createCanvasSyncSession(
     // and the upload path in its own try/catch — so the chain itself never
     // rejects either, or a later firing awaiting it would skip its own
     // commit entirely.
-    commitChain = previousChain.then(runThisFiring)
+    pendingCommitCount++
+    commitChain = previousChain.then(runThisFiring).finally(() => {
+      pendingCommitCount--
+    })
   }, 300)
 
   function connect(): void {
@@ -397,8 +414,11 @@ export function createCanvasSyncSession(
           // microtask AFTER teardown flips `disposed` — which is exactly
           // what happens when onSceneChange.flush() runs during dispose()
           // (doc.commit() fires synchronously, but this subscriber fires on
-          // a later microtask, by which point `disposed` is already true) —
-          // silently losing the last edit made before a canvas switch or
+          // a later microtask, by which point `disposed` is already true).
+          // dispose()'s drain phase is what keeps backend.disconnect() from
+          // running before this callback has had a chance to fire — without
+          // it, the transport could already be closed by the time this push
+          // happens, silently losing the last edit before a canvas switch or
           // unmount.
           void Promise.resolve(backend.pushLocalUpdate(update)).catch(() => {
             if (isStale()) return
@@ -528,6 +548,27 @@ export function createCanvasSyncSession(
     })
   }
 
+  // Waits for the flush-triggered commit (and any commit still queued on
+  // commitChain) to have actually invoked backend.pushLocalUpdate, then
+  // resolves so dispose() can safely close the transport. Does NOT wait for
+  // that pushLocalUpdate call's own promise to settle — only for the call to
+  // have happened, since a real transport call already puts bytes on a
+  // still-open connection regardless of how long its ack takes, and waiting
+  // for an ack could block teardown indefinitely. Bounded by
+  // DISPOSE_DRAIN_TIMEOUT_MS so a stuck commitChain (e.g. a hung putFile)
+  // cannot leave disconnect() pending forever.
+  async function drainBeforePushHasFired(): Promise<void> {
+    const chainAtDispose = commitChain
+    await Promise.race([
+      // Awaiting the commit chain lets any still-queued firing's
+      // doc.commit() run; one more microtask turn after that gives Loro's
+      // subscribeLocalUpdates callback (scheduled internally on commit,
+      // not synchronously) room to fire and call backend.pushLocalUpdate.
+      chainAtDispose.then(() => Promise.resolve()),
+      new Promise<void>((resolve) => setTimeout(resolve, DISPOSE_DRAIN_TIMEOUT_MS)),
+    ])
+  }
+
   function dispose(): void {
     // Flush any pending debounced scene edit into this session's doc BEFORE
     // disconnecting, so the last edit made against this backend is persisted
@@ -546,7 +587,21 @@ export function createCanvasSyncSession(
     // would then write this now-torn-down session's stale content into the
     // (possibly different) live Excalidraw API.
     deps.generations.nextApplyGeneration()
-    backend.disconnect()
+    // dispose() itself stays synchronous (callers do not await it). When the
+    // flush above (or an already-in-flight firing) leaves a commit pending,
+    // the transport close is deferred behind a short drain phase: without
+    // it, that commit's pushLocalUpdate call — fired from Loro's
+    // subscribeLocalUpdates on a later microtask, not synchronously with
+    // doc.commit() — can still be pending when backend.disconnect() runs,
+    // dropping the last edit made just before a canvas switch or unmount.
+    // When nothing was pending (no edit was ever made against this session),
+    // there is nothing to drain, so disconnect happens immediately —
+    // matching every caller that assumes a synchronous teardown.
+    if (pendingCommitCount > 0) {
+      void drainBeforePushHasFired().then(() => backend.disconnect())
+    } else {
+      backend.disconnect()
+    }
   }
 
   function onChange(elements: readonly ExcalidrawElement[], files: BinaryFiles): void {


### PR DESCRIPTION
## Summary

Resolves `canvas-sync-dispose-drain`. `CanvasSyncSession.dispose()` ran `flush() → disposed=true → backend.disconnect()` synchronously, but Loro's `subscribeLocalUpdates` fires on a **later microtask** — so the flush-triggered final commit's `pushLocalUpdate` could run after the WebSocket was already closed. The last edit before a canvas switch / unmount could fail to reach the server (masked by snapshot re-sync on next connect, but a correctness hole).

- `dispose()` stays **synchronous** for callers (no signature change). It tracks in-flight commit-chain firings via `pendingCommitCount`; only when one exists does it defer `disconnect()` behind a **bounded drain** (await commitChain + one microtask turn, capped by `DISPOSE_DRAIN_TIMEOUT_MS = 2000ms`).
- When nothing is pending, `disconnect()` still happens immediately — preserving every caller that assumed synchronous teardown (useCanvasSync hook tests unchanged).
- The supersession-only invalidation contract (a plain dispose does not cancel in-flight upload/getFile) is untouched.

## Test plan

- [x] RED→GREEN call-order test: `pushLocalUpdate` invoked **before** `disconnect()` (using a never-settling push to prove dispose waits for the *call*, not the promise)
- [x] Drain-timeout fall-through test: a hung `putFile` does not block teardown — `disconnect()` proceeds after the 2s cap
- [x] Existing 5 timing-invariant tests preserved un-weakened
- [x] Full apps/web suite green (87 files / 1089 tests), typecheck + lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session shutdown so pending local changes are pushed before disconnecting.
  * Prevented shutdown from waiting indefinitely when an update remains unresolved.
  * Preserved immediate disconnect behavior when no changes are pending.
  * Added safeguards for reliable asynchronous cleanup and update delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->