### PR TITLE
feat(canvas-model): add OpenCanvas data-model Zod schema package

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -1,0 +1,22 @@
+# Architecture Map (OpenCanvas)
+
+Package boundaries are cut by **runtime requirements**, not by feature. The shared layer must run unchanged on Node, the browser, and Cloudflare Workers.
+
+| Package | Role | May depend on |
+|---|---|---|
+| `packages/canvas-model` | Zod schemas for the OpenCanvas data model (single source of truth) | zod only |
+| `packages/canvas-codec` (planned) | OKF Markdown / JSON Canvas serialize+parse, remark pipeline, Loro⇔model | model, loro-crdt, remark |
+| `packages/canvas-render` (planned) | scene graph, layout, themes, SVG backend, sceneDigest | model |
+| `packages/canvas-ports` (planned) | store/sync port contracts + Symbol `TOKENS` | model |
+| `packages/canvas-workspace` (planned) | tree ops, alias derivation, index derivation, link extraction | model, codec, ports |
+| `packages/server-core` (planned) | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render |
+| `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
+| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls | workspace, render + port impls |
+
+Absolute rules:
+
+1. Shared-layer packages (model / codec / render / ports / workspace / server-core) must not import `node:*`, DOM globals, or `inversify`.
+2. Dependencies flow only in the table's direction. Composition roots are never imported by shared packages.
+3. Unsure where code goes → load the `package-placement` skill (planned). DI wiring → `di-container` skill (planned).
+
+These rules are enforced by boundary lint + dependency-direction tests (introduced with canvas-codec); until those land, review against this table. Per-package details live in `.claude/rules/package-<name>.md` (path-scoped). Note: `./skills/` (product MCP skills) is unrelated to `.claude/skills/` (dev workflow skills).

--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -46,6 +46,8 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 **Docs sync**: a user-visible / API / contract / config change ships with its docs in the same increment (`technical-writer` + `docs-sync` skill; honesty — document the shipped state, never the aspiration). **`./docs/**` is USER docs (Diátaxis); developer docs are OSS-convention root files (README / SECURITY / CONTRIBUTING / CODE_OF_CONDUCT / .github). All project docs are in ENGLISH.** Marketing/release notes are drafts only (`marketing` agent), human ships.
 
+**コード配置とパッケージ境界**は `.claude/rules/architecture-map.md`（常時）と `.claude/rules/package-*.md`（パス駆動）が正。新パッケージの PR にはパス指定 rule を同梱する。
+
 ## Ticketing (no GitHub Issues — all local-private)
 
 Native **Task list** = live board (in-flight / blocked / done; main session owns status). **tmp/issues/*.md** = durable private backlog (frontmatter: id/status/severity/owner/blocked-by/related/created; delete on resolve). `tmp/` is gitignored = local to this machine; `.claude/` shared tooling (workflows, agents, skills, rules, scripts, settings.json) is tracked in git, so `tmp/issues` is the private-backlog half of the split, not `.claude/` as a whole. See the `ticketing` skill.

--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -46,7 +46,7 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 **Docs sync**: a user-visible / API / contract / config change ships with its docs in the same increment (`technical-writer` + `docs-sync` skill; honesty — document the shipped state, never the aspiration). **`./docs/**` is USER docs (Diátaxis); developer docs are OSS-convention root files (README / SECURITY / CONTRIBUTING / CODE_OF_CONDUCT / .github). All project docs are in ENGLISH.** Marketing/release notes are drafts only (`marketing` agent), human ships.
 
-**コード配置とパッケージ境界**は `.claude/rules/architecture-map.md`（常時）と `.claude/rules/package-*.md`（パス駆動）が正。新パッケージの PR にはパス指定 rule を同梱する。
+**Code placement and package boundaries** are governed by `.claude/rules/architecture-map.md` (always-on) and `.claude/rules/package-*.md` (path-scoped). Every PR that adds a package ships its path-scoped rule in the same increment.
 
 ## Ticketing (no GitHub Issues — all local-private)
 

--- a/.claude/rules/package-canvas-model.md
+++ b/.claude/rules/package-canvas-model.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "packages/canvas-model/**"
+---
+
+# canvas-model — OpenCanvas data-model Zod schemas (single source of truth)
+
+## What belongs here
+
+- Zod schemas: canvas meta, core/extension/raw facets, spatial canvas (JSON Canvas 1.0 + `x-whiteboard` extension), markdown body, workspace-tree node data, and the internal mdast subset.
+- Shared fast-check arbitraries in `src/test-utils/` (valid-by-construction; never duplicated per test file).
+
+## What does NOT belong here
+
+- File parsing/serialization (goes to `canvas-codec`, planned), Loro containers, storage, rendering, HTTP/MCP surfaces.
+- Any runtime behavior beyond schema validation.
+
+## Dependency rules
+
+- Only runtime dependency: `zod` (via `catalog:`). Forbidden imports: `node:*`, DOM globals, `inversify`, `loro-crdt`, remark packages.
+
+## Conventions
+
+- Every exported type is `z.infer`-derived. Sole exception: mutually-recursive mdast category types use the documented explicit `z.ZodType<T>` annotation, guarded by a compile-time assignability test.
+- Facet buckets are disjoint by construction: extension facets live only under the reserved `facets` key (`{domain}/{version}` keys; malformed keys are rejected, not dropped). Unknown ROOT-level frontmatter keys belong to `facetsRaw`, never to extension facets.
+- mdast schemas follow the mdast spec content-model hierarchy (flow / phrasing / list / table / row content). Do not widen a parent's `children` back to the flat node union.
+- IDs: canvas ID = canonical ULID (first char `[0-7]`); node ID = nanoid (charset deliberately unenforced — documented looseness).
+- JSON Canvas geometry is integer; extension (`x-whiteboard`) coordinates may be non-integer (outside the spec's rule, documented in-source).
+
+## Tests
+
+- Vitest project: `canvas-model-node` (registered in root `vitest.config.ts`).
+- Every schema has accept + reject example tests; cross-schema invariants live in `src/properties.test.ts` (fast-check).
+- New invariants start with a red test (repo TDD rule). Never pin a fast-check seed.
+
+## Common mistakes (append as review finds them)
+
+- Adding a hand-written interface next to a schema instead of `z.infer` — this is the exact drift class the package exists to prevent.
+- Validating extension-facet keys leniently (silent drop). The contract is reject-not-drop.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -175,7 +175,7 @@ pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
 Default regression triple after a change:
 
 ```bash
-pnpm test        # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser (Playwright projects are slower)
+pnpm test        # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser (Playwright projects are slower)
 pnpm typecheck   # tsc --noEmit (~10s)
 pnpm smoke:e2e   # stdio MCP subprocess: canvas_create -> version save/restore -> viewport no_client -> export_canvas (png/svg/json)
 ```

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -351,7 +351,7 @@ Common commands are also summarized in [CONTRIBUTING.md](../../CONTRIBUTING.md#q
 ```bash
 pnpm lint           # Biome — must be green before review
 pnpm typecheck      # TypeScript — must be green before review
-pnpm test           # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser
+pnpm test           # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser
 pnpm test:browser   # canvas-viewer-browser + web-browser (the real-browser projects)
 pnpm smoke:e2e      # stdio MCP smoke (also covered by pnpm test via mcp-smoke)
 ```

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -57,6 +57,14 @@
         "src/server/security/auth-strategy.ts": ["duplicates"]
       }
     },
+    "packages/canvas-model": {
+      // Public surface for opencanvas slices 2/3 (serializer, scene/layout);
+      // intentionally unreferenced from any existing package until those
+      // land. "./internal" is the mdast subset's deliberately-separate,
+      // not-yet-public subpath.
+      "entry": ["src/index.ts", "src/mdast/index.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "packages/canvas-viewer": {
       // widget-entry.ts and widget/refresh-control.ts are owned by a
       // concurrent in-flight lane — deliberately left unconfigured here so

--- a/packages/canvas-model/README.md
+++ b/packages/canvas-model/README.md
@@ -1,0 +1,46 @@
+# @kamiazya/whiteboard-canvas-model
+
+OpenCanvas data-model Zod schemas (meta / facets / spatial / markdown /
+workspace-tree / mdast subset). Named `canvas-model` — sibling to
+`packages/canvas-viewer` in this monorepo's per-concern `packages/*`
+layout — to make clear this package is the pure data-model contract, not
+rendering or serialization. Private; not published to npm.
+
+## What's here
+
+- `meta.ts` — canvas envelope metadata (`format`, `schemaVersion`).
+- `facets.ts` — core facets (`type`/`title`/`tags`/`view`), the
+  `{domain}/{version}`-keyed extension facet bucket, and `facetsRaw` for
+  unrecognized root frontmatter keys. The schema layer enforces that a key
+  can never legally live in more than one of these buckets.
+- `spatial.ts` — JSON Canvas 1.0-aligned node/edge schemas plus the
+  `x-whiteboard` namespaced extension (freehand strokes, shapes, embeds).
+- `markdown.ts` — the markdown-format canvas envelope (plain-text body).
+- `workspace-tree.ts` — the payload carried by each node of the workspace's
+  Loro movable-tree, plus workspace-level metadata.
+- `ids.ts` — canvas ID (canonical ULID) and node ID (nanoid-shaped) schemas.
+- `mdast/` — an **internal, versioned** mdast subset (CommonMark + GFM +
+  math + the `wikiLink`/`embed` custom nodes), reached through this
+  package's `./internal` subpath export rather than the stable public `.`
+  export. It is not published as a standalone contract yet.
+
+## Types
+
+Every exported type is `z.infer<typeof someSchema>` — there is no
+hand-written type that parallels a schema. The one deliberate exception is
+`mdast/index.ts`'s `MdastNode`: mdast is self-referential (a paragraph's
+children can contain a link whose children are more phrasing content), and
+Zod's `z.lazy()` cannot infer a recursive type back through itself without
+an explicit type parameter to break the cycle for the compiler. `MdastNode`
+is the type the schema is written against (`z.ZodType<MdastNode>`), and
+`src/types.test.ts` pins that the two stay in sync.
+
+## Testing
+
+```bash
+pnpm --filter @kamiazya/whiteboard-canvas-model test
+pnpm --filter @kamiazya/whiteboard-canvas-model typecheck
+```
+
+Shared fast-check arbitraries live in `src/test-utils/` and are imported by
+example and property tests rather than duplicated per file.

--- a/packages/canvas-model/package.json
+++ b/packages/canvas-model/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@kamiazya/whiteboard-canvas-model",
+  "private": true,
+  "version": "0.0.0",
+  "description": "OpenCanvas data-model Zod schemas (meta/facets/spatial/markdown/workspace-tree/mdast subset). Package name chosen to match the monorepo's per-concern packages/* layout (sibling to canvas-viewer); \"canvas-model\" reflects that this is the pure data-model contract, not rendering or serialization.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./internal": {
+      "types": "./src/mdast/index.ts",
+      "import": "./src/mdast/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.node.config.ts"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@fast-check/vitest": "^0.4.1",
+    "fast-check": "^4.7.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/canvas-model/package.json
+++ b/packages/canvas-model/package.json
@@ -2,6 +2,7 @@
   "name": "@kamiazya/whiteboard-canvas-model",
   "private": true,
   "version": "0.0.0",
+  "license": "Apache-2.0",
   "description": "OpenCanvas data-model Zod schemas (meta/facets/spatial/markdown/workspace-tree/mdast subset). Package name chosen to match the monorepo's per-concern packages/* layout (sibling to canvas-viewer); \"canvas-model\" reflects that this is the pure data-model contract, not rendering or serialization.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/canvas-model/src/facets.test.ts
+++ b/packages/canvas-model/src/facets.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  coreFacetsSchema,
+  extensionFacetsSchema,
+  facetsRawSchema,
+  RESERVED_ROOT_KEYS,
+} from './facets.js'
+
+describe('coreFacetsSchema', () => {
+  it('accepts the minimal shape with only type', () => {
+    expect(coreFacetsSchema.safeParse({ type: 'note' }).success).toBe(true)
+  })
+
+  it('accepts the full shape with title, tags, and view', () => {
+    const result = coreFacetsSchema.safeParse({
+      type: 'note',
+      title: 'My note',
+      tags: ['a', 'b'],
+      view: 'kanban/1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a missing type', () => {
+    expect(coreFacetsSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('rejects an empty type', () => {
+    expect(coreFacetsSchema.safeParse({ type: '' }).success).toBe(false)
+  })
+
+  it('rejects tags that are not an array of strings', () => {
+    expect(coreFacetsSchema.safeParse({ type: 'note', tags: 'a' }).success).toBe(false)
+    expect(coreFacetsSchema.safeParse({ type: 'note', tags: [1] }).success).toBe(false)
+  })
+})
+
+describe('extensionFacetsSchema', () => {
+  it('accepts a well-formed {domain}/{version} key and preserves the payload verbatim', () => {
+    const payload = { kanban: { columns: ['todo', 'done'] } }
+    const result = extensionFacetsSchema.safeParse({ 'kanban/1': payload.kanban })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data['kanban/1']).toEqual(payload.kanban)
+    }
+  })
+
+  it.each([
+    'kanban',
+    'kanban/',
+    'Kanban/1',
+    'kanban/v1',
+    '/1',
+    'kanban//1',
+  ])('rejects (not silently drops) a malformed key %s', (badKey) => {
+    const result = extensionFacetsSchema.safeParse({ [badKey]: {} })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts an empty record', () => {
+    expect(extensionFacetsSchema.safeParse({}).success).toBe(true)
+  })
+})
+
+describe('facetsRawSchema', () => {
+  it('preserves arbitrary non-reserved root keys verbatim', () => {
+    const result = facetsRawSchema.safeParse({ someFutureKey: { nested: 1 } })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.someFutureKey).toEqual({ nested: 1 })
+    }
+  })
+
+  it.each(RESERVED_ROOT_KEYS)('rejects the reserved root key %s', (reservedKey) => {
+    const result = facetsRawSchema.safeParse({ [reservedKey]: 'anything' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts an empty record', () => {
+    expect(facetsRawSchema.safeParse({}).success).toBe(true)
+  })
+})

--- a/packages/canvas-model/src/facets.ts
+++ b/packages/canvas-model/src/facets.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+
+export const coreFacetsSchema = z.object({
+  type: z.string().min(1),
+  title: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  // Explicit default-View override, used when multiple extension facets
+  // apply to the same canvas and the reader must pick one deterministically.
+  view: z.string().optional(),
+})
+
+export type CoreFacets = z.infer<typeof coreFacetsSchema>
+
+const EXTENSION_FACET_KEY_PATTERN = /^[a-z][a-z0-9-]*\/[0-9]+$/
+
+/**
+ * Extension facets live under the reserved root key `facets`, keyed by
+ * `{domain}/{version}` (e.g. `kanban/1`). Values are intentionally
+ * `z.unknown()` — an unknown domain's payload round-trips unvalidated so
+ * this package doesn't need to know every extension ever registered.
+ *
+ * A malformed key is rejected (via superRefine issuing a ZodError), not
+ * silently dropped from the record: `z.record` with a validated key schema
+ * can drop non-matching keys instead of failing, which would hide data
+ * loss. Rejecting the whole parse instead makes the bug visible to the
+ * caller.
+ */
+export const extensionFacetsSchema = z.record(z.string(), z.unknown()).superRefine((value, ctx) => {
+  for (const key of Object.keys(value)) {
+    if (!EXTENSION_FACET_KEY_PATTERN.test(key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `extension facet key "${key}" must match {domain}/{version}, e.g. "kanban/1"`,
+        path: [key],
+      })
+    }
+  }
+})
+
+export type ExtensionFacets = z.infer<typeof extensionFacetsSchema>
+
+/**
+ * Root-level frontmatter keys that are NOT free for `facetsRaw` to preserve:
+ * the core facet fields plus the `facets` extension bucket itself. Keeping
+ * this list exported means both `coreFacetsSchema` consumers and
+ * `facetsRawSchema` share one definition of "reserved", so a key can never
+ * legally live in two buckets at once.
+ */
+export const RESERVED_ROOT_KEYS = ['type', 'title', 'tags', 'view', 'facets'] as const
+
+/**
+ * Unknown root-level frontmatter keys are preserved verbatim as future
+ * official keys (not extension facets — those live under `facets`).
+ * Routing an arbitrary parsed frontmatter object's keys into this bucket
+ * vs. `coreFacetsSchema`/`extensionFacetsSchema` is slice-2 parser
+ * behavior; this schema only makes the reserved/non-reserved split
+ * unrepresentable as an overlap.
+ */
+export const facetsRawSchema = z.record(z.string(), z.unknown()).superRefine((value, ctx) => {
+  for (const key of Object.keys(value)) {
+    if ((RESERVED_ROOT_KEYS as readonly string[]).includes(key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `"${key}" is a reserved root key and cannot appear in facetsRaw`,
+        path: [key],
+      })
+    }
+  }
+})
+
+export type FacetsRaw = z.infer<typeof facetsRawSchema>

--- a/packages/canvas-model/src/ids.test.ts
+++ b/packages/canvas-model/src/ids.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { canvasIdSchema, nodeIdSchema } from './ids.js'
+
+describe('canvasIdSchema', () => {
+  it('accepts a canonical 26-char ULID starting with 0-7', () => {
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAV').success).toBe(true)
+    expect(canvasIdSchema.safeParse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ').success).toBe(true)
+  })
+
+  it('rejects a string that is 25 or 27 characters long', () => {
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FA').success).toBe(false)
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAVX').success).toBe(false)
+  })
+
+  it('rejects Crockford-excluded characters I, L, O, U', () => {
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAI').success).toBe(false)
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAL').success).toBe(false)
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAO').success).toBe(false)
+    expect(canvasIdSchema.safeParse('01ARZ3NDEKTSV4RRFFQ69G5FAU').success).toBe(false)
+  })
+
+  it('rejects a first character outside 0-7 (128-bit overflow constraint)', () => {
+    expect(canvasIdSchema.safeParse('8ZZZZZZZZZZZZZZZZZZZZZZZZZ').success).toBe(false)
+    expect(canvasIdSchema.safeParse('ZZZZZZZZZZZZZZZZZZZZZZZZZZ').success).toBe(false)
+  })
+})
+
+describe('nodeIdSchema', () => {
+  it('accepts any non-empty string (nanoid convention, charset not enforced)', () => {
+    expect(nodeIdSchema.safeParse('V1StGXR8_Z5jdHi6B-myT').success).toBe(true)
+  })
+
+  it('rejects an empty string', () => {
+    expect(nodeIdSchema.safeParse('').success).toBe(false)
+  })
+})

--- a/packages/canvas-model/src/ids.ts
+++ b/packages/canvas-model/src/ids.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+// Canonical ULID: 26 chars of Crockford base32 (excludes I, L, O, U to avoid
+// visual confusion with 1, 1, 0, V). The first character is additionally
+// restricted to 0-7 because a ULID packs a 48-bit timestamp + 80-bit
+// randomness into 128 bits total; the leading base32 digit only ever
+// contributes its low 3 bits to that 128-bit value, so 8-Z there would
+// overflow the spec's bit layout. See https://github.com/ulid/spec.
+const ULID_PATTERN = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+/** Canvas identifiers are canonical ULIDs (sortable, collision-resistant). */
+export const canvasIdSchema = z.string().regex(ULID_PATTERN, 'must be a canonical ULID')
+
+/**
+ * Node identifiers are nanoid-style strings. The charset is deliberately not
+ * enforced here — nanoid's default alphabet may change or be swapped for a
+ * custom one — only non-emptiness is a real invariant.
+ */
+export const nodeIdSchema = z.string().min(1, 'node id must not be empty')
+
+export type CanvasId = z.infer<typeof canvasIdSchema>
+export type NodeId = z.infer<typeof nodeIdSchema>

--- a/packages/canvas-model/src/index.ts
+++ b/packages/canvas-model/src/index.ts
@@ -1,0 +1,10 @@
+export * from './facets.js'
+export * from './ids.js'
+export * from './markdown.js'
+export * from './meta.js'
+export * from './spatial.js'
+export * from './workspace-tree.js'
+
+// The mdast subset is intentionally NOT re-exported here — it is internal
+// and versioned, reached via the package's `./internal` subpath export
+// instead of the stable public surface.

--- a/packages/canvas-model/src/markdown.test.ts
+++ b/packages/canvas-model/src/markdown.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { markdownCanvasSchema } from './markdown.js'
+
+describe('markdownCanvasSchema', () => {
+  it('accepts an arbitrary string body, including one with wiki-link-shaped text', () => {
+    expect(
+      markdownCanvasSchema.safeParse({ body: '# Title\n\n[[canvas:01ARZ3NDEKTSV4RRFFQ69G5FAV]]' })
+        .success,
+    ).toBe(true)
+  })
+
+  it('accepts an empty body', () => {
+    expect(markdownCanvasSchema.safeParse({ body: '' }).success).toBe(true)
+  })
+
+  it('rejects a non-string body', () => {
+    expect(markdownCanvasSchema.safeParse({ body: 42 }).success).toBe(false)
+  })
+})

--- a/packages/canvas-model/src/markdown.ts
+++ b/packages/canvas-model/src/markdown.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+/**
+ * Markdown-format canvases carry a plain-text body — no structural schema.
+ * Wiki links stay plain text (`[[canvas:<ULID>]]`) inside that string; the
+ * markdown parser (mdast subset) is a separate concern from this envelope.
+ */
+export const markdownCanvasSchema = z.object({
+  body: z.string(),
+})
+
+export type MarkdownCanvas = z.infer<typeof markdownCanvasSchema>

--- a/packages/canvas-model/src/mdast/index.test.ts
+++ b/packages/canvas-model/src/mdast/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { mdastNodeSchema } from './index.js'
+import {
+  mdastFlowContentArbitrary,
+  mdastPhrasingContentArbitrary,
+  mdastRootArbitrary,
+  mdastTableRowArbitrary,
+} from '../test-utils/arbitraries.js'
+import { fc } from '../test-utils/fast-check.js'
+import { mdastFlowContentSchema, mdastNodeSchema, mdastRootSchema } from './index.js'
 
 describe('mdastNodeSchema', () => {
   it('parses a paragraph containing text, emphasis, and strong', () => {
@@ -168,10 +175,217 @@ describe('mdastNodeSchema', () => {
   })
 
   it('parses an arbitrarily deep nesting of blockquotes without stack failure', () => {
-    let node: unknown = { type: 'text', value: 'leaf' }
+    // blockquote children are FlowContent, so the innermost leaf must be a
+    // flow node (paragraph), not a bare phrasing `text` node.
+    let node: unknown = { type: 'paragraph', children: [{ type: 'text', value: 'leaf' }] }
     for (let i = 0; i < 200; i++) {
       node = { type: 'blockquote', children: [node] }
     }
     expect(mdastNodeSchema.safeParse(node).success).toBe(true)
+  })
+
+  it('parses a math node with meta:null, as mdast-util-math emits for a plain fence', () => {
+    expect(mdastNodeSchema.safeParse({ type: 'math', value: 'E=mc^2', meta: null }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts html as both a flow child and a phrasing child (dual-category)', () => {
+    expect(
+      mdastRootSchema.safeParse({
+        type: 'root',
+        children: [{ type: 'html', value: '<div>flow</div>' }],
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'paragraph',
+        children: [{ type: 'html', value: '<span>inline</span>' }],
+      }).success,
+    ).toBe(true)
+  })
+
+  it('accepts a root document with a top-level definition', () => {
+    const result = mdastRootSchema.safeParse({
+      type: 'root',
+      children: [
+        { type: 'definition', identifier: 'foo', url: 'https://example.com' },
+        { type: 'paragraph', children: [{ type: 'text', value: 'body' }] },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('still accepts a standalone structurally-valid listItem/tableRow/tableCell via mdastNodeSchema', () => {
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'listItem',
+        children: [{ type: 'paragraph', children: [{ type: 'text', value: 'item' }] }],
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'tableRow',
+        children: [{ type: 'tableCell', children: [{ type: 'text', value: 'a' }] }],
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'tableCell',
+        children: [{ type: 'text', value: 'a' }],
+      }).success,
+    ).toBe(true)
+  })
+})
+
+describe('mdast content-model placement (contextual, via parent/root schemas)', () => {
+  it('rejects a root whose child is root (root never appears as a child)', () => {
+    expect(
+      mdastRootSchema.safeParse({
+        type: 'root',
+        children: [{ type: 'root', children: [] }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a paragraph containing root', () => {
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'paragraph',
+        children: [{ type: 'root', children: [] }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects bare text directly under blockquote (blockquote children are flow-only)', () => {
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'blockquote',
+        children: [{ type: 'text', value: 'bare' }],
+      }).success,
+    ).toBe(false)
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'blockquote',
+        children: [{ type: 'paragraph', children: [{ type: 'text', value: 'ok' }] }],
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects listItem outside a list (e.g. as a blockquote child), accepts it inside a list', () => {
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'blockquote',
+        children: [
+          {
+            type: 'listItem',
+            children: [{ type: 'paragraph', children: [{ type: 'text', value: 'item' }] }],
+          },
+        ],
+      }).success,
+    ).toBe(false)
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'list',
+        children: [
+          {
+            type: 'listItem',
+            children: [{ type: 'paragraph', children: [{ type: 'text', value: 'item' }] }],
+          },
+        ],
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects tableRow outside a table (e.g. as a blockquote child), accepts it inside a table', () => {
+    const tableRow = {
+      type: 'tableRow',
+      children: [{ type: 'tableCell', children: [{ type: 'text', value: 'a' }] }],
+    }
+    expect(
+      mdastFlowContentSchema.safeParse({ type: 'blockquote', children: [tableRow] }).success,
+    ).toBe(false)
+    expect(mdastFlowContentSchema.safeParse({ type: 'table', children: [tableRow] }).success).toBe(
+      true,
+    )
+  })
+
+  it('rejects tableCell as a direct child of table (skipping tableRow)', () => {
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'table',
+        children: [{ type: 'tableCell', children: [{ type: 'text', value: 'a' }] }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('generates trees that cover every supported node kind (arbitrary coverage)', () => {
+    const expectedKinds = new Set([
+      'root',
+      'paragraph',
+      'heading',
+      'text',
+      'emphasis',
+      'strong',
+      'inlineCode',
+      'code',
+      'blockquote',
+      'list',
+      'listItem',
+      'thematicBreak',
+      'break',
+      'link',
+      'image',
+      'html',
+      'definition',
+      'linkReference',
+      'imageReference',
+      'table',
+      'tableRow',
+      'tableCell',
+      'delete',
+      'math',
+      'inlineMath',
+      'wikiLink',
+      'embed',
+    ])
+
+    const seenKinds = new Set<string>()
+    const collect = (node: unknown): void => {
+      if (node === null || typeof node !== 'object') return
+      const record = node as Record<string, unknown>
+      if (typeof record.type === 'string') seenKinds.add(record.type)
+      if (Array.isArray(record.children)) {
+        for (const child of record.children) collect(child)
+      }
+    }
+
+    for (const sample of fc.sample(mdastRootArbitrary(3), 300)) collect(sample)
+    for (const sample of fc.sample(mdastFlowContentArbitrary(3), 300)) collect(sample)
+    for (const sample of fc.sample(mdastPhrasingContentArbitrary(3), 300)) collect(sample)
+    for (const sample of fc.sample(mdastTableRowArbitrary(3), 300)) collect(sample)
+
+    const missing = [...expectedKinds].filter((kind) => !seenKinds.has(kind))
+    expect(missing).toEqual([])
+  })
+
+  it('rejects break inside a tableCell, accepts break inside a paragraph', () => {
+    const table = {
+      type: 'table',
+      children: [
+        {
+          type: 'tableRow',
+          children: [{ type: 'tableCell', children: [{ type: 'break' }] }],
+        },
+      ],
+    }
+    expect(mdastFlowContentSchema.safeParse(table).success).toBe(false)
+
+    expect(
+      mdastFlowContentSchema.safeParse({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'a' }, { type: 'break' }, { type: 'text', value: 'b' }],
+      }).success,
+    ).toBe(true)
   })
 })

--- a/packages/canvas-model/src/mdast/index.test.ts
+++ b/packages/canvas-model/src/mdast/index.test.ts
@@ -106,6 +106,67 @@ describe('mdastNodeSchema', () => {
     )
   })
 
+  it('parses a code node with null lang and meta, as real parsers emit for a plain fence', () => {
+    const result = mdastNodeSchema.safeParse({
+      type: 'code',
+      lang: null,
+      meta: null,
+      value: 'plain fence',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses a link and image with a null title, as real parsers emit when no title is given', () => {
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'link',
+        url: 'https://example.com',
+        title: null,
+        children: [{ type: 'text', value: 'link' }],
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'image',
+        url: 'https://example.com/a.png',
+        title: null,
+        alt: null,
+      }).success,
+    ).toBe(true)
+  })
+
+  it('parses a definition node', () => {
+    const result = mdastNodeSchema.safeParse({
+      type: 'definition',
+      identifier: 'foo',
+      label: 'Foo',
+      url: 'https://example.com',
+      title: null,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses linkReference and imageReference nodes', () => {
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'linkReference',
+        identifier: 'foo',
+        label: 'Foo',
+        referenceType: 'full',
+        children: [{ type: 'text', value: 'foo' }],
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'imageReference',
+        identifier: 'foo',
+        label: 'Foo',
+        referenceType: 'collapsed',
+        alt: null,
+      }).success,
+    ).toBe(true)
+  })
+
   it('parses an arbitrarily deep nesting of blockquotes without stack failure', () => {
     let node: unknown = { type: 'text', value: 'leaf' }
     for (let i = 0; i < 200; i++) {

--- a/packages/canvas-model/src/mdast/index.test.ts
+++ b/packages/canvas-model/src/mdast/index.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { mdastNodeSchema } from './index.js'
+
+describe('mdastNodeSchema', () => {
+  it('parses a paragraph containing text, emphasis, and strong', () => {
+    const result = mdastNodeSchema.safeParse({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'plain ' },
+        { type: 'emphasis', children: [{ type: 'text', value: 'em' }] },
+        { type: 'strong', children: [{ type: 'text', value: 'strong' }] },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses a heading with depth 1-6', () => {
+    for (const depth of [1, 2, 3, 4, 5, 6]) {
+      expect(
+        mdastNodeSchema.safeParse({
+          type: 'heading',
+          depth,
+          children: [{ type: 'text', value: 'h' }],
+        }).success,
+      ).toBe(true)
+    }
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'heading',
+        depth: 7,
+        children: [{ type: 'text', value: 'h' }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('parses a list containing a listItem', () => {
+    const result = mdastNodeSchema.safeParse({
+      type: 'list',
+      ordered: false,
+      children: [
+        {
+          type: 'listItem',
+          checked: null,
+          children: [{ type: 'paragraph', children: [{ type: 'text', value: 'item' }] }],
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses a GFM table with tableRow/tableCell', () => {
+    const result = mdastNodeSchema.safeParse({
+      type: 'table',
+      align: ['left', null, 'center'],
+      children: [
+        {
+          type: 'tableRow',
+          children: [
+            { type: 'tableCell', children: [{ type: 'text', value: 'a' }] },
+            { type: 'tableCell', children: [{ type: 'text', value: 'b' }] },
+          ],
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses a code node, including a mermaid diagram via lang', () => {
+    // Diagrams ride the standard code node (lang: 'mermaid') — no dedicated
+    // diagram node kind exists in this subset.
+    const result = mdastNodeSchema.safeParse({
+      type: 'code',
+      lang: 'mermaid',
+      value: 'graph TD; A-->B;',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses math and inlineMath nodes', () => {
+    expect(mdastNodeSchema.safeParse({ type: 'math', value: 'E = mc^2' }).success).toBe(true)
+    expect(mdastNodeSchema.safeParse({ type: 'inlineMath', value: 'x^2' }).success).toBe(true)
+  })
+
+  it('parses wikiLink and embed custom nodes with a canvasId', () => {
+    expect(
+      mdastNodeSchema.safeParse({
+        type: 'wikiLink',
+        canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        alias: 'Architecture',
+      }).success,
+    ).toBe(true)
+    expect(
+      mdastNodeSchema.safeParse({ type: 'embed', canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a wikiLink with a malformed canvasId', () => {
+    expect(mdastNodeSchema.safeParse({ type: 'wikiLink', canvasId: 'not-a-ulid' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an unsupported node type', () => {
+    expect(mdastNodeSchema.safeParse({ type: 'footnoteReference', identifier: 'x' }).success).toBe(
+      false,
+    )
+  })
+
+  it('parses an arbitrarily deep nesting of blockquotes without stack failure', () => {
+    let node: unknown = { type: 'text', value: 'leaf' }
+    for (let i = 0; i < 200; i++) {
+      node = { type: 'blockquote', children: [node] }
+    }
+    expect(mdastNodeSchema.safeParse(node).success).toBe(true)
+  })
+})

--- a/packages/canvas-model/src/mdast/index.ts
+++ b/packages/canvas-model/src/mdast/index.ts
@@ -217,30 +217,29 @@ const mathNodeSchema = z.object({
   meta: z.string().nullish(),
 })
 
+// Recursive (children-bearing) node schemas. Each is defined exactly once
+// below and shared by every union that can contain it, so a node's shape has
+// a single source of truth. The category unions above forward-reference these
+// through `z.lazy`, which is why the definitions can appear after the unions
+// that list them.
+//
+// Phrasing and cell-phrasing variants stay separate because their children
+// differ (a table cell's phrasing excludes `break`); they cannot share the
+// recursive objects the way the leaf schemas are shared.
+
 export const mdastPhrasingContentSchema: z.ZodType<MdastPhrasingContent> = z.lazy(() =>
   z.discriminatedUnion('type', [
     textNodeSchema,
-    z.object({ type: z.literal('emphasis'), children: z.array(mdastPhrasingContentSchema) }),
-    z.object({ type: z.literal('strong'), children: z.array(mdastPhrasingContentSchema) }),
+    emphasisNodeSchema,
+    strongNodeSchema,
     inlineCodeNodeSchema,
     breakNodeSchema,
     htmlNodeSchema,
-    z.object({
-      type: z.literal('link'),
-      url: z.string(),
-      title: z.string().nullish(),
-      children: z.array(mdastPhrasingContentSchema),
-    }),
+    linkNodeSchema,
     imageNodeSchema,
-    z.object({
-      type: z.literal('linkReference'),
-      identifier: z.string(),
-      label: z.string().nullish(),
-      referenceType: referenceTypeSchema,
-      children: z.array(mdastPhrasingContentSchema),
-    }),
+    linkReferenceNodeSchema,
     imageReferenceNodeSchema,
-    z.object({ type: z.literal('delete'), children: z.array(mdastPhrasingContentSchema) }),
+    deleteNodeSchema,
     inlineMathNodeSchema,
     wikiLinkNodeSchema,
     embedNodeSchema,
@@ -250,26 +249,15 @@ export const mdastPhrasingContentSchema: z.ZodType<MdastPhrasingContent> = z.laz
 export const mdastCellPhrasingContentSchema: z.ZodType<MdastCellPhrasingContent> = z.lazy(() =>
   z.discriminatedUnion('type', [
     textNodeSchema,
-    z.object({ type: z.literal('emphasis'), children: z.array(mdastCellPhrasingContentSchema) }),
-    z.object({ type: z.literal('strong'), children: z.array(mdastCellPhrasingContentSchema) }),
+    cellEmphasisNodeSchema,
+    cellStrongNodeSchema,
     inlineCodeNodeSchema,
     htmlNodeSchema,
-    z.object({
-      type: z.literal('link'),
-      url: z.string(),
-      title: z.string().nullish(),
-      children: z.array(mdastCellPhrasingContentSchema),
-    }),
+    cellLinkNodeSchema,
     imageNodeSchema,
-    z.object({
-      type: z.literal('linkReference'),
-      identifier: z.string(),
-      label: z.string().nullish(),
-      referenceType: referenceTypeSchema,
-      children: z.array(mdastCellPhrasingContentSchema),
-    }),
+    cellLinkReferenceNodeSchema,
     imageReferenceNodeSchema,
-    z.object({ type: z.literal('delete'), children: z.array(mdastCellPhrasingContentSchema) }),
+    cellDeleteNodeSchema,
     inlineMathNodeSchema,
     wikiLinkNodeSchema,
     embedNodeSchema,
@@ -278,54 +266,123 @@ export const mdastCellPhrasingContentSchema: z.ZodType<MdastCellPhrasingContent>
 
 export const mdastFlowContentSchema: z.ZodType<MdastFlowContent> = z.lazy(() =>
   z.discriminatedUnion('type', [
-    z.object({ type: z.literal('paragraph'), children: z.array(mdastPhrasingContentSchema) }),
-    z.object({
-      type: z.literal('heading'),
-      depth: headingDepthSchema,
-      children: z.array(mdastPhrasingContentSchema),
-    }),
-    z.object({ type: z.literal('blockquote'), children: z.array(mdastFlowContentSchema) }),
-    z.object({
-      type: z.literal('list'),
-      ordered: z.boolean().optional(),
-      start: z.number().int().optional(),
-      spread: z.boolean().optional(),
-      children: z.array(mdastListItemSchema),
-    }),
+    paragraphNodeSchema,
+    headingNodeSchema,
+    blockquoteNodeSchema,
+    listNodeSchema,
     codeNodeSchema,
     htmlNodeSchema,
     thematicBreakNodeSchema,
     definitionNodeSchema,
-    z.object({
-      type: z.literal('table'),
-      align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
-      children: z.array(mdastTableRowSchema),
-    }),
+    tableNodeSchema,
     mathNodeSchema,
   ]),
 )
 
-export const mdastListItemSchema: z.ZodType<MdastListItem> = z.lazy(() =>
-  z.object({
-    type: z.literal('listItem'),
-    checked: z.boolean().nullable().optional(),
-    spread: z.boolean().optional(),
-    children: z.array(mdastFlowContentSchema),
-  }),
-)
+export const mdastListItemSchema: z.ZodType<MdastListItem> = z.lazy(() => listItemNodeSchema)
 
-export const mdastTableCellSchema: z.ZodType<MdastTableCell> = z.lazy(() =>
-  z.object({ type: z.literal('tableCell'), children: z.array(mdastCellPhrasingContentSchema) }),
-)
+export const mdastTableCellSchema: z.ZodType<MdastTableCell> = z.lazy(() => tableCellNodeSchema)
 
-export const mdastTableRowSchema: z.ZodType<MdastTableRow> = z.lazy(() =>
-  z.object({ type: z.literal('tableRow'), children: z.array(mdastTableCellSchema) }),
-)
+export const mdastTableRowSchema: z.ZodType<MdastTableRow> = z.lazy(() => tableRowNodeSchema)
 
-export const mdastRootSchema: z.ZodType<MdastRoot> = z.object({
+const emphasisNodeSchema = z.object({
+  type: z.literal('emphasis'),
+  children: z.array(mdastPhrasingContentSchema),
+})
+const strongNodeSchema = z.object({
+  type: z.literal('strong'),
+  children: z.array(mdastPhrasingContentSchema),
+})
+const linkNodeSchema = z.object({
+  type: z.literal('link'),
+  url: z.string(),
+  title: z.string().nullish(),
+  children: z.array(mdastPhrasingContentSchema),
+})
+const linkReferenceNodeSchema = z.object({
+  type: z.literal('linkReference'),
+  identifier: z.string(),
+  label: z.string().nullish(),
+  referenceType: referenceTypeSchema,
+  children: z.array(mdastPhrasingContentSchema),
+})
+const deleteNodeSchema = z.object({
+  type: z.literal('delete'),
+  children: z.array(mdastPhrasingContentSchema),
+})
+
+// Cell-phrasing counterparts: same shapes, but children exclude `break`.
+const cellEmphasisNodeSchema = z.object({
+  type: z.literal('emphasis'),
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+const cellStrongNodeSchema = z.object({
+  type: z.literal('strong'),
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+const cellLinkNodeSchema = z.object({
+  type: z.literal('link'),
+  url: z.string(),
+  title: z.string().nullish(),
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+const cellLinkReferenceNodeSchema = z.object({
+  type: z.literal('linkReference'),
+  identifier: z.string(),
+  label: z.string().nullish(),
+  referenceType: referenceTypeSchema,
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+const cellDeleteNodeSchema = z.object({
+  type: z.literal('delete'),
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+
+const paragraphNodeSchema = z.object({
+  type: z.literal('paragraph'),
+  children: z.array(mdastPhrasingContentSchema),
+})
+const headingNodeSchema = z.object({
+  type: z.literal('heading'),
+  depth: headingDepthSchema,
+  children: z.array(mdastPhrasingContentSchema),
+})
+const blockquoteNodeSchema = z.object({
+  type: z.literal('blockquote'),
+  children: z.array(mdastFlowContentSchema),
+})
+const listNodeSchema = z.object({
+  type: z.literal('list'),
+  ordered: z.boolean().optional(),
+  start: z.number().int().optional(),
+  spread: z.boolean().optional(),
+  children: z.array(mdastListItemSchema),
+})
+const listItemNodeSchema = z.object({
+  type: z.literal('listItem'),
+  checked: z.boolean().nullable().optional(),
+  spread: z.boolean().optional(),
+  children: z.array(mdastFlowContentSchema),
+})
+const tableNodeSchema = z.object({
+  type: z.literal('table'),
+  align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
+  children: z.array(mdastTableRowSchema),
+})
+const tableRowNodeSchema = z.object({
+  type: z.literal('tableRow'),
+  children: z.array(mdastTableCellSchema),
+})
+const tableCellNodeSchema = z.object({
+  type: z.literal('tableCell'),
+  children: z.array(mdastCellPhrasingContentSchema),
+})
+const rootNodeSchema = z.object({
   type: z.literal('root'),
   children: z.array(mdastFlowContentSchema),
 })
+
+export const mdastRootSchema: z.ZodType<MdastRoot> = rootNodeSchema
 
 /**
  * Union of every supported node kind, each with per-kind structurally-valid
@@ -334,59 +391,29 @@ export const mdastRootSchema: z.ZodType<MdastRoot> = z.object({
  */
 export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
   z.discriminatedUnion('type', [
-    z.object({ type: z.literal('root'), children: z.array(mdastFlowContentSchema) }),
-    z.object({ type: z.literal('paragraph'), children: z.array(mdastPhrasingContentSchema) }),
-    z.object({
-      type: z.literal('heading'),
-      depth: headingDepthSchema,
-      children: z.array(mdastPhrasingContentSchema),
-    }),
+    rootNodeSchema,
+    paragraphNodeSchema,
+    headingNodeSchema,
     textNodeSchema,
-    z.object({ type: z.literal('emphasis'), children: z.array(mdastPhrasingContentSchema) }),
-    z.object({ type: z.literal('strong'), children: z.array(mdastPhrasingContentSchema) }),
+    emphasisNodeSchema,
+    strongNodeSchema,
     inlineCodeNodeSchema,
     codeNodeSchema,
-    z.object({ type: z.literal('blockquote'), children: z.array(mdastFlowContentSchema) }),
-    z.object({
-      type: z.literal('list'),
-      ordered: z.boolean().optional(),
-      start: z.number().int().optional(),
-      spread: z.boolean().optional(),
-      children: z.array(mdastListItemSchema),
-    }),
-    z.object({
-      type: z.literal('listItem'),
-      checked: z.boolean().nullable().optional(),
-      spread: z.boolean().optional(),
-      children: z.array(mdastFlowContentSchema),
-    }),
+    blockquoteNodeSchema,
+    listNodeSchema,
+    listItemNodeSchema,
     thematicBreakNodeSchema,
     breakNodeSchema,
-    z.object({
-      type: z.literal('link'),
-      url: z.string(),
-      title: z.string().nullish(),
-      children: z.array(mdastPhrasingContentSchema),
-    }),
+    linkNodeSchema,
     imageNodeSchema,
     htmlNodeSchema,
     definitionNodeSchema,
-    z.object({
-      type: z.literal('linkReference'),
-      identifier: z.string(),
-      label: z.string().nullish(),
-      referenceType: referenceTypeSchema,
-      children: z.array(mdastPhrasingContentSchema),
-    }),
+    linkReferenceNodeSchema,
     imageReferenceNodeSchema,
-    z.object({
-      type: z.literal('table'),
-      align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
-      children: z.array(mdastTableRowSchema),
-    }),
-    z.object({ type: z.literal('tableRow'), children: z.array(mdastTableCellSchema) }),
-    z.object({ type: z.literal('tableCell'), children: z.array(mdastCellPhrasingContentSchema) }),
-    z.object({ type: z.literal('delete'), children: z.array(mdastPhrasingContentSchema) }),
+    tableNodeSchema,
+    tableRowNodeSchema,
+    tableCellNodeSchema,
+    deleteNodeSchema,
     mathNodeSchema,
     inlineMathNodeSchema,
     wikiLinkNodeSchema,

--- a/packages/canvas-model/src/mdast/index.ts
+++ b/packages/canvas-model/src/mdast/index.ts
@@ -37,15 +37,36 @@ export type MdastNode =
   | { type: 'emphasis'; children: MdastNode[] }
   | { type: 'strong'; children: MdastNode[] }
   | { type: 'inlineCode'; value: string }
-  | { type: 'code'; value: string; lang?: string; meta?: string }
+  | { type: 'code'; value: string; lang?: string | null; meta?: string | null }
   | { type: 'blockquote'; children: MdastNode[] }
   | { type: 'list'; ordered?: boolean; start?: number; spread?: boolean; children: MdastNode[] }
   | { type: 'listItem'; checked?: boolean | null; spread?: boolean; children: MdastNode[] }
   | { type: 'thematicBreak' }
   | { type: 'break' }
-  | { type: 'link'; url: string; title?: string; children: MdastNode[] }
-  | { type: 'image'; url: string; title?: string; alt?: string }
+  | { type: 'link'; url: string; title?: string | null; children: MdastNode[] }
+  | { type: 'image'; url: string; title?: string | null; alt?: string | null }
   | { type: 'html'; value: string }
+  | {
+      type: 'definition'
+      identifier: string
+      label?: string | null
+      url: string
+      title?: string | null
+    }
+  | {
+      type: 'linkReference'
+      identifier: string
+      label?: string | null
+      referenceType: 'shortcut' | 'collapsed' | 'full'
+      children: MdastNode[]
+    }
+  | {
+      type: 'imageReference'
+      identifier: string
+      label?: string | null
+      referenceType: 'shortcut' | 'collapsed' | 'full'
+      alt?: string | null
+    }
   | { type: 'table'; align?: MdastAlign[]; children: MdastNode[] }
   | { type: 'tableRow'; children: MdastNode[] }
   | { type: 'tableCell'; children: MdastNode[] }
@@ -80,8 +101,8 @@ export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
     z.object({
       type: z.literal('code'),
       value: z.string(),
-      lang: z.string().optional(),
-      meta: z.string().optional(),
+      lang: z.string().nullish(),
+      meta: z.string().nullish(),
     }),
     z.object({ type: z.literal('blockquote'), children: z.array(mdastNodeSchema) }),
     z.object({
@@ -102,16 +123,37 @@ export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
     z.object({
       type: z.literal('link'),
       url: z.string(),
-      title: z.string().optional(),
+      title: z.string().nullish(),
       children: z.array(mdastNodeSchema),
     }),
     z.object({
       type: z.literal('image'),
       url: z.string(),
-      title: z.string().optional(),
-      alt: z.string().optional(),
+      title: z.string().nullish(),
+      alt: z.string().nullish(),
     }),
     z.object({ type: z.literal('html'), value: z.string() }),
+    z.object({
+      type: z.literal('definition'),
+      identifier: z.string(),
+      label: z.string().nullish(),
+      url: z.string(),
+      title: z.string().nullish(),
+    }),
+    z.object({
+      type: z.literal('linkReference'),
+      identifier: z.string(),
+      label: z.string().nullish(),
+      referenceType: z.enum(['shortcut', 'collapsed', 'full']),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({
+      type: z.literal('imageReference'),
+      identifier: z.string(),
+      label: z.string().nullish(),
+      referenceType: z.enum(['shortcut', 'collapsed', 'full']),
+      alt: z.string().nullish(),
+    }),
     z.object({
       type: z.literal('table'),
       align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),

--- a/packages/canvas-model/src/mdast/index.ts
+++ b/packages/canvas-model/src/mdast/index.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod'
+import { canvasIdSchema } from '../ids.js'
+
+/**
+ * INTERNAL, versioned mdast subset. Not part of the stable public surface
+ * yet — a public release happens once the slice-2 remark pipeline has
+ * exercised it against real documents. Exported via the package's
+ * `./internal` subpath, not the default `.` export.
+ *
+ * Covers CommonMark + GFM (table/tableRow/tableCell/delete) + math
+ * (math/inlineMath) + this repo's two official custom nodes: wikiLink and
+ * embed. Diagrams are NOT a distinct node kind — a ```mermaid fence is a
+ * standard `code` node with `lang: 'mermaid'`; this subset does not add
+ * diagram-specific structure.
+ *
+ * mdast is inherently recursive (e.g. a paragraph's children can contain a
+ * link whose own children are more phrasing content). Zod's `z.lazy()`
+ * cannot have its return type inferred back into a self-referential type
+ * without an explicit type parameter to break the cycle for the compiler —
+ * this is a documented Zod limitation, not a case of hand-writing a type
+ * that z.infer could otherwise produce on its own. `MdastNode` below is
+ * intentionally the single type the schema is written AGAINST (via
+ * `z.ZodType<MdastNode>`); the mutation-relevant guard is that
+ * `z.infer<typeof mdastNodeSchema>` must stay assignable to `MdastNode`,
+ * which `pnpm -r typecheck` enforces because `mdastNodeSchema`'s explicit
+ * annotation makes any drift a compile error, not a silent widening to
+ * `any`.
+ */
+
+export type MdastAlign = 'left' | 'right' | 'center' | null
+
+export type MdastNode =
+  | { type: 'root'; children: MdastNode[] }
+  | { type: 'paragraph'; children: MdastNode[] }
+  | { type: 'heading'; depth: 1 | 2 | 3 | 4 | 5 | 6; children: MdastNode[] }
+  | { type: 'text'; value: string }
+  | { type: 'emphasis'; children: MdastNode[] }
+  | { type: 'strong'; children: MdastNode[] }
+  | { type: 'inlineCode'; value: string }
+  | { type: 'code'; value: string; lang?: string; meta?: string }
+  | { type: 'blockquote'; children: MdastNode[] }
+  | { type: 'list'; ordered?: boolean; start?: number; spread?: boolean; children: MdastNode[] }
+  | { type: 'listItem'; checked?: boolean | null; spread?: boolean; children: MdastNode[] }
+  | { type: 'thematicBreak' }
+  | { type: 'break' }
+  | { type: 'link'; url: string; title?: string; children: MdastNode[] }
+  | { type: 'image'; url: string; title?: string; alt?: string }
+  | { type: 'html'; value: string }
+  | { type: 'table'; align?: MdastAlign[]; children: MdastNode[] }
+  | { type: 'tableRow'; children: MdastNode[] }
+  | { type: 'tableCell'; children: MdastNode[] }
+  | { type: 'delete'; children: MdastNode[] }
+  | { type: 'math'; value: string; meta?: string }
+  | { type: 'inlineMath'; value: string }
+  // Official custom nodes. Internal link representation is ID-based:
+  // wikiLink/embed carry a canvasId (ULID) rather than a file path.
+  | { type: 'wikiLink'; canvasId: string; alias?: string }
+  | { type: 'embed'; canvasId: string }
+
+export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    z.object({ type: z.literal('root'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('paragraph'), children: z.array(mdastNodeSchema) }),
+    z.object({
+      type: z.literal('heading'),
+      depth: z.union([
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6),
+      ]),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({ type: z.literal('text'), value: z.string() }),
+    z.object({ type: z.literal('emphasis'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('strong'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('inlineCode'), value: z.string() }),
+    z.object({
+      type: z.literal('code'),
+      value: z.string(),
+      lang: z.string().optional(),
+      meta: z.string().optional(),
+    }),
+    z.object({ type: z.literal('blockquote'), children: z.array(mdastNodeSchema) }),
+    z.object({
+      type: z.literal('list'),
+      ordered: z.boolean().optional(),
+      start: z.number().int().optional(),
+      spread: z.boolean().optional(),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({
+      type: z.literal('listItem'),
+      checked: z.boolean().nullable().optional(),
+      spread: z.boolean().optional(),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({ type: z.literal('thematicBreak') }),
+    z.object({ type: z.literal('break') }),
+    z.object({
+      type: z.literal('link'),
+      url: z.string(),
+      title: z.string().optional(),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({
+      type: z.literal('image'),
+      url: z.string(),
+      title: z.string().optional(),
+      alt: z.string().optional(),
+    }),
+    z.object({ type: z.literal('html'), value: z.string() }),
+    z.object({
+      type: z.literal('table'),
+      align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
+      children: z.array(mdastNodeSchema),
+    }),
+    z.object({ type: z.literal('tableRow'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('tableCell'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('delete'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('math'), value: z.string(), meta: z.string().optional() }),
+    z.object({ type: z.literal('inlineMath'), value: z.string() }),
+    z.object({
+      type: z.literal('wikiLink'),
+      canvasId: canvasIdSchema,
+      alias: z.string().optional(),
+    }),
+    z.object({ type: z.literal('embed'), canvasId: canvasIdSchema }),
+  ]),
+)

--- a/packages/canvas-model/src/mdast/index.ts
+++ b/packages/canvas-model/src/mdast/index.ts
@@ -13,39 +13,121 @@ import { canvasIdSchema } from '../ids.js'
  * standard `code` node with `lang: 'mermaid'`; this subset does not add
  * diagram-specific structure.
  *
+ * Parent-child relations follow the mdast content-model categories
+ * (https://github.com/syntax-tree/mdast#content-model): FlowContent (block
+ * level — paragraph/heading/blockquote/list/code/html/thematicBreak/
+ * definition/table/math), PhrasingContent (inline — text/emphasis/strong/
+ * inlineCode/break/html/link/image/linkReference/imageReference/delete/
+ * inlineMath/wikiLink/embed), ListContent (listItem only), TableContent
+ * (tableRow only), and RowContent (tableCell only). `html` is dual-category
+ * (both flow and phrasing) per spec. `wikiLink`/`embed` are this repo's
+ * custom nodes and are phrasing-level, matching how they sit inline in a
+ * sentence.
+ *
+ * Per https://github.com/syntax-tree/mdast#tablecell, TableCell content is
+ * phrasing WITHOUT `break` (GFM table cells cannot contain a hard line
+ * break) — `mdastCellPhrasingContentSchema` encodes that narrower category
+ * instead of reusing `mdastPhrasingContentSchema` inside a table cell.
+ *
+ * `mdastRootSchema` is an intentionally narrower APPLICATION SUBSET of
+ * upstream mdast Root (https://github.com/syntax-tree/mdast#root): upstream
+ * permits a Root's children to be any ONE homogeneous content category
+ * (e.g. a root of only phrasing content is valid mdast). This subset fixes
+ * Root to FlowContent only, which is what a remark document AST actually
+ * produces for a parsed markdown file. This is a deliberate narrowing, not
+ * a claim of full content-model conformance.
+ *
+ * `mdastNodeSchema` remains the union of every supported node kind with
+ * per-kind structurally-valid children (so a single, unparented node —
+ * e.g. a standalone `listItem` — still validates on its own); it does NOT
+ * enforce where a node kind is allowed to appear. Contextual placement
+ * (e.g. "a listItem must be inside a list") is only enforced when parsing
+ * through a parent category schema or `mdastRootSchema`.
+ *
  * mdast is inherently recursive (e.g. a paragraph's children can contain a
  * link whose own children are more phrasing content). Zod's `z.lazy()`
  * cannot have its return type inferred back into a self-referential type
  * without an explicit type parameter to break the cycle for the compiler —
  * this is a documented Zod limitation, not a case of hand-writing a type
- * that z.infer could otherwise produce on its own. `MdastNode` below is
- * intentionally the single type the schema is written AGAINST (via
- * `z.ZodType<MdastNode>`); the mutation-relevant guard is that
- * `z.infer<typeof mdastNodeSchema>` must stay assignable to `MdastNode`,
- * which `pnpm -r typecheck` enforces because `mdastNodeSchema`'s explicit
- * annotation makes any drift a compile error, not a silent widening to
- * `any`.
+ * that z.infer could otherwise produce on its own. Every recursive category
+ * type below is intentionally the type the matching schema is written
+ * AGAINST (via `z.ZodType<...>`); the mutation-relevant guard is that each
+ * schema's `z.infer<>` must stay assignable to its annotated type, which
+ * `pnpm -r typecheck` enforces because the explicit annotation makes any
+ * drift a compile error, not a silent widening to `any`.
  */
 
 export type MdastAlign = 'left' | 'right' | 'center' | null
 
-export type MdastNode =
-  | { type: 'root'; children: MdastNode[] }
-  | { type: 'paragraph'; children: MdastNode[] }
-  | { type: 'heading'; depth: 1 | 2 | 3 | 4 | 5 | 6; children: MdastNode[] }
+type MdastReferenceType = 'shortcut' | 'collapsed' | 'full'
+type MdastHeadingDepth = 1 | 2 | 3 | 4 | 5 | 6
+
+export type MdastPhrasingContent =
   | { type: 'text'; value: string }
-  | { type: 'emphasis'; children: MdastNode[] }
-  | { type: 'strong'; children: MdastNode[] }
+  | { type: 'emphasis'; children: MdastPhrasingContent[] }
+  | { type: 'strong'; children: MdastPhrasingContent[] }
   | { type: 'inlineCode'; value: string }
-  | { type: 'code'; value: string; lang?: string | null; meta?: string | null }
-  | { type: 'blockquote'; children: MdastNode[] }
-  | { type: 'list'; ordered?: boolean; start?: number; spread?: boolean; children: MdastNode[] }
-  | { type: 'listItem'; checked?: boolean | null; spread?: boolean; children: MdastNode[] }
-  | { type: 'thematicBreak' }
   | { type: 'break' }
-  | { type: 'link'; url: string; title?: string | null; children: MdastNode[] }
-  | { type: 'image'; url: string; title?: string | null; alt?: string | null }
   | { type: 'html'; value: string }
+  | { type: 'link'; url: string; title?: string | null; children: MdastPhrasingContent[] }
+  | { type: 'image'; url: string; title?: string | null; alt?: string | null }
+  | {
+      type: 'linkReference'
+      identifier: string
+      label?: string | null
+      referenceType: MdastReferenceType
+      children: MdastPhrasingContent[]
+    }
+  | {
+      type: 'imageReference'
+      identifier: string
+      label?: string | null
+      referenceType: MdastReferenceType
+      alt?: string | null
+    }
+  | { type: 'delete'; children: MdastPhrasingContent[] }
+  | { type: 'inlineMath'; value: string }
+  // Official custom nodes. Internal link representation is ID-based:
+  // wikiLink/embed carry a canvasId (ULID) rather than a file path.
+  | { type: 'wikiLink'; canvasId: string; alias?: string }
+  | { type: 'embed'; canvasId: string }
+
+/** PhrasingContent minus `break` — see the TableCell note above. */
+export type MdastCellPhrasingContent =
+  | { type: 'text'; value: string }
+  | { type: 'emphasis'; children: MdastCellPhrasingContent[] }
+  | { type: 'strong'; children: MdastCellPhrasingContent[] }
+  | { type: 'inlineCode'; value: string }
+  | { type: 'html'; value: string }
+  | { type: 'link'; url: string; title?: string | null; children: MdastCellPhrasingContent[] }
+  | { type: 'image'; url: string; title?: string | null; alt?: string | null }
+  | {
+      type: 'linkReference'
+      identifier: string
+      label?: string | null
+      referenceType: MdastReferenceType
+      children: MdastCellPhrasingContent[]
+    }
+  | {
+      type: 'imageReference'
+      identifier: string
+      label?: string | null
+      referenceType: MdastReferenceType
+      alt?: string | null
+    }
+  | { type: 'delete'; children: MdastCellPhrasingContent[] }
+  | { type: 'inlineMath'; value: string }
+  | { type: 'wikiLink'; canvasId: string; alias?: string }
+  | { type: 'embed'; canvasId: string }
+
+export type MdastFlowContent =
+  | { type: 'paragraph'; children: MdastPhrasingContent[] }
+  | { type: 'heading'; depth: MdastHeadingDepth; children: MdastPhrasingContent[] }
+  | { type: 'blockquote'; children: MdastFlowContent[] }
+  | { type: 'list'; ordered?: boolean; start?: number; spread?: boolean; children: MdastListItem[] }
+  | { type: 'code'; value: string; lang?: string | null; meta?: string | null }
+  | { type: 'html'; value: string }
+  | { type: 'thematicBreak' }
   | {
       type: 'definition'
       identifier: string
@@ -53,122 +135,261 @@ export type MdastNode =
       url: string
       title?: string | null
     }
-  | {
-      type: 'linkReference'
-      identifier: string
-      label?: string | null
-      referenceType: 'shortcut' | 'collapsed' | 'full'
-      children: MdastNode[]
-    }
-  | {
-      type: 'imageReference'
-      identifier: string
-      label?: string | null
-      referenceType: 'shortcut' | 'collapsed' | 'full'
-      alt?: string | null
-    }
-  | { type: 'table'; align?: MdastAlign[]; children: MdastNode[] }
-  | { type: 'tableRow'; children: MdastNode[] }
-  | { type: 'tableCell'; children: MdastNode[] }
-  | { type: 'delete'; children: MdastNode[] }
-  | { type: 'math'; value: string; meta?: string }
-  | { type: 'inlineMath'; value: string }
-  // Official custom nodes. Internal link representation is ID-based:
-  // wikiLink/embed carry a canvasId (ULID) rather than a file path.
-  | { type: 'wikiLink'; canvasId: string; alias?: string }
-  | { type: 'embed'; canvasId: string }
+  | { type: 'table'; align?: MdastAlign[]; children: MdastTableRow[] }
+  | { type: 'math'; value: string; meta?: string | null }
 
-export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
+export type MdastListItem = {
+  type: 'listItem'
+  checked?: boolean | null
+  spread?: boolean
+  children: MdastFlowContent[]
+}
+
+export type MdastTableRow = { type: 'tableRow'; children: MdastTableCell[] }
+export type MdastTableCell = { type: 'tableCell'; children: MdastCellPhrasingContent[] }
+
+/** Document root. See the doc comment above re: the flow-only application subset. */
+export type MdastRoot = { type: 'root'; children: MdastFlowContent[] }
+
+export type MdastNode =
+  | MdastRoot
+  | MdastFlowContent
+  | MdastPhrasingContent
+  | MdastListItem
+  | MdastTableRow
+  | MdastTableCell
+
+const referenceTypeSchema = z.enum(['shortcut', 'collapsed', 'full'])
+const headingDepthSchema = z.union([
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+  z.literal(6),
+])
+
+// Leaf / no-recursion node schemas — identical shape no matter which
+// content category reaches them, so defined once and reused.
+const textNodeSchema = z.object({ type: z.literal('text'), value: z.string() })
+const inlineCodeNodeSchema = z.object({ type: z.literal('inlineCode'), value: z.string() })
+const breakNodeSchema = z.object({ type: z.literal('break') })
+const htmlNodeSchema = z.object({ type: z.literal('html'), value: z.string() })
+const imageNodeSchema = z.object({
+  type: z.literal('image'),
+  url: z.string(),
+  title: z.string().nullish(),
+  alt: z.string().nullish(),
+})
+const imageReferenceNodeSchema = z.object({
+  type: z.literal('imageReference'),
+  identifier: z.string(),
+  label: z.string().nullish(),
+  referenceType: referenceTypeSchema,
+  alt: z.string().nullish(),
+})
+const inlineMathNodeSchema = z.object({ type: z.literal('inlineMath'), value: z.string() })
+const wikiLinkNodeSchema = z.object({
+  type: z.literal('wikiLink'),
+  canvasId: canvasIdSchema,
+  alias: z.string().optional(),
+})
+const embedNodeSchema = z.object({ type: z.literal('embed'), canvasId: canvasIdSchema })
+const thematicBreakNodeSchema = z.object({ type: z.literal('thematicBreak') })
+const definitionNodeSchema = z.object({
+  type: z.literal('definition'),
+  identifier: z.string(),
+  label: z.string().nullish(),
+  url: z.string(),
+  title: z.string().nullish(),
+})
+const codeNodeSchema = z.object({
+  type: z.literal('code'),
+  value: z.string(),
+  lang: z.string().nullish(),
+  meta: z.string().nullish(),
+})
+// mdast-util-math emits `meta: null` for a plain ```math fence (no meta
+// string), so `meta` must accept null, not just be absent.
+const mathNodeSchema = z.object({
+  type: z.literal('math'),
+  value: z.string(),
+  meta: z.string().nullish(),
+})
+
+export const mdastPhrasingContentSchema: z.ZodType<MdastPhrasingContent> = z.lazy(() =>
   z.discriminatedUnion('type', [
-    z.object({ type: z.literal('root'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('paragraph'), children: z.array(mdastNodeSchema) }),
+    textNodeSchema,
+    z.object({ type: z.literal('emphasis'), children: z.array(mdastPhrasingContentSchema) }),
+    z.object({ type: z.literal('strong'), children: z.array(mdastPhrasingContentSchema) }),
+    inlineCodeNodeSchema,
+    breakNodeSchema,
+    htmlNodeSchema,
+    z.object({
+      type: z.literal('link'),
+      url: z.string(),
+      title: z.string().nullish(),
+      children: z.array(mdastPhrasingContentSchema),
+    }),
+    imageNodeSchema,
+    z.object({
+      type: z.literal('linkReference'),
+      identifier: z.string(),
+      label: z.string().nullish(),
+      referenceType: referenceTypeSchema,
+      children: z.array(mdastPhrasingContentSchema),
+    }),
+    imageReferenceNodeSchema,
+    z.object({ type: z.literal('delete'), children: z.array(mdastPhrasingContentSchema) }),
+    inlineMathNodeSchema,
+    wikiLinkNodeSchema,
+    embedNodeSchema,
+  ]),
+)
+
+export const mdastCellPhrasingContentSchema: z.ZodType<MdastCellPhrasingContent> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    textNodeSchema,
+    z.object({ type: z.literal('emphasis'), children: z.array(mdastCellPhrasingContentSchema) }),
+    z.object({ type: z.literal('strong'), children: z.array(mdastCellPhrasingContentSchema) }),
+    inlineCodeNodeSchema,
+    htmlNodeSchema,
+    z.object({
+      type: z.literal('link'),
+      url: z.string(),
+      title: z.string().nullish(),
+      children: z.array(mdastCellPhrasingContentSchema),
+    }),
+    imageNodeSchema,
+    z.object({
+      type: z.literal('linkReference'),
+      identifier: z.string(),
+      label: z.string().nullish(),
+      referenceType: referenceTypeSchema,
+      children: z.array(mdastCellPhrasingContentSchema),
+    }),
+    imageReferenceNodeSchema,
+    z.object({ type: z.literal('delete'), children: z.array(mdastCellPhrasingContentSchema) }),
+    inlineMathNodeSchema,
+    wikiLinkNodeSchema,
+    embedNodeSchema,
+  ]),
+)
+
+export const mdastFlowContentSchema: z.ZodType<MdastFlowContent> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    z.object({ type: z.literal('paragraph'), children: z.array(mdastPhrasingContentSchema) }),
     z.object({
       type: z.literal('heading'),
-      depth: z.union([
-        z.literal(1),
-        z.literal(2),
-        z.literal(3),
-        z.literal(4),
-        z.literal(5),
-        z.literal(6),
-      ]),
-      children: z.array(mdastNodeSchema),
+      depth: headingDepthSchema,
+      children: z.array(mdastPhrasingContentSchema),
     }),
-    z.object({ type: z.literal('text'), value: z.string() }),
-    z.object({ type: z.literal('emphasis'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('strong'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('inlineCode'), value: z.string() }),
-    z.object({
-      type: z.literal('code'),
-      value: z.string(),
-      lang: z.string().nullish(),
-      meta: z.string().nullish(),
-    }),
-    z.object({ type: z.literal('blockquote'), children: z.array(mdastNodeSchema) }),
+    z.object({ type: z.literal('blockquote'), children: z.array(mdastFlowContentSchema) }),
     z.object({
       type: z.literal('list'),
       ordered: z.boolean().optional(),
       start: z.number().int().optional(),
       spread: z.boolean().optional(),
-      children: z.array(mdastNodeSchema),
+      children: z.array(mdastListItemSchema),
+    }),
+    codeNodeSchema,
+    htmlNodeSchema,
+    thematicBreakNodeSchema,
+    definitionNodeSchema,
+    z.object({
+      type: z.literal('table'),
+      align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
+      children: z.array(mdastTableRowSchema),
+    }),
+    mathNodeSchema,
+  ]),
+)
+
+export const mdastListItemSchema: z.ZodType<MdastListItem> = z.lazy(() =>
+  z.object({
+    type: z.literal('listItem'),
+    checked: z.boolean().nullable().optional(),
+    spread: z.boolean().optional(),
+    children: z.array(mdastFlowContentSchema),
+  }),
+)
+
+export const mdastTableCellSchema: z.ZodType<MdastTableCell> = z.lazy(() =>
+  z.object({ type: z.literal('tableCell'), children: z.array(mdastCellPhrasingContentSchema) }),
+)
+
+export const mdastTableRowSchema: z.ZodType<MdastTableRow> = z.lazy(() =>
+  z.object({ type: z.literal('tableRow'), children: z.array(mdastTableCellSchema) }),
+)
+
+export const mdastRootSchema: z.ZodType<MdastRoot> = z.object({
+  type: z.literal('root'),
+  children: z.array(mdastFlowContentSchema),
+})
+
+/**
+ * Union of every supported node kind, each with per-kind structurally-valid
+ * children — but NOT contextual placement (see the module doc comment).
+ * Useful for validating a single node in isolation.
+ */
+export const mdastNodeSchema: z.ZodType<MdastNode> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    z.object({ type: z.literal('root'), children: z.array(mdastFlowContentSchema) }),
+    z.object({ type: z.literal('paragraph'), children: z.array(mdastPhrasingContentSchema) }),
+    z.object({
+      type: z.literal('heading'),
+      depth: headingDepthSchema,
+      children: z.array(mdastPhrasingContentSchema),
+    }),
+    textNodeSchema,
+    z.object({ type: z.literal('emphasis'), children: z.array(mdastPhrasingContentSchema) }),
+    z.object({ type: z.literal('strong'), children: z.array(mdastPhrasingContentSchema) }),
+    inlineCodeNodeSchema,
+    codeNodeSchema,
+    z.object({ type: z.literal('blockquote'), children: z.array(mdastFlowContentSchema) }),
+    z.object({
+      type: z.literal('list'),
+      ordered: z.boolean().optional(),
+      start: z.number().int().optional(),
+      spread: z.boolean().optional(),
+      children: z.array(mdastListItemSchema),
     }),
     z.object({
       type: z.literal('listItem'),
       checked: z.boolean().nullable().optional(),
       spread: z.boolean().optional(),
-      children: z.array(mdastNodeSchema),
+      children: z.array(mdastFlowContentSchema),
     }),
-    z.object({ type: z.literal('thematicBreak') }),
-    z.object({ type: z.literal('break') }),
+    thematicBreakNodeSchema,
+    breakNodeSchema,
     z.object({
       type: z.literal('link'),
       url: z.string(),
       title: z.string().nullish(),
-      children: z.array(mdastNodeSchema),
+      children: z.array(mdastPhrasingContentSchema),
     }),
-    z.object({
-      type: z.literal('image'),
-      url: z.string(),
-      title: z.string().nullish(),
-      alt: z.string().nullish(),
-    }),
-    z.object({ type: z.literal('html'), value: z.string() }),
-    z.object({
-      type: z.literal('definition'),
-      identifier: z.string(),
-      label: z.string().nullish(),
-      url: z.string(),
-      title: z.string().nullish(),
-    }),
+    imageNodeSchema,
+    htmlNodeSchema,
+    definitionNodeSchema,
     z.object({
       type: z.literal('linkReference'),
       identifier: z.string(),
       label: z.string().nullish(),
-      referenceType: z.enum(['shortcut', 'collapsed', 'full']),
-      children: z.array(mdastNodeSchema),
+      referenceType: referenceTypeSchema,
+      children: z.array(mdastPhrasingContentSchema),
     }),
-    z.object({
-      type: z.literal('imageReference'),
-      identifier: z.string(),
-      label: z.string().nullish(),
-      referenceType: z.enum(['shortcut', 'collapsed', 'full']),
-      alt: z.string().nullish(),
-    }),
+    imageReferenceNodeSchema,
     z.object({
       type: z.literal('table'),
       align: z.array(z.enum(['left', 'right', 'center']).nullable()).optional(),
-      children: z.array(mdastNodeSchema),
+      children: z.array(mdastTableRowSchema),
     }),
-    z.object({ type: z.literal('tableRow'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('tableCell'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('delete'), children: z.array(mdastNodeSchema) }),
-    z.object({ type: z.literal('math'), value: z.string(), meta: z.string().optional() }),
-    z.object({ type: z.literal('inlineMath'), value: z.string() }),
-    z.object({
-      type: z.literal('wikiLink'),
-      canvasId: canvasIdSchema,
-      alias: z.string().optional(),
-    }),
-    z.object({ type: z.literal('embed'), canvasId: canvasIdSchema }),
+    z.object({ type: z.literal('tableRow'), children: z.array(mdastTableCellSchema) }),
+    z.object({ type: z.literal('tableCell'), children: z.array(mdastCellPhrasingContentSchema) }),
+    z.object({ type: z.literal('delete'), children: z.array(mdastPhrasingContentSchema) }),
+    mathNodeSchema,
+    inlineMathNodeSchema,
+    wikiLinkNodeSchema,
+    embedNodeSchema,
   ]),
 )

--- a/packages/canvas-model/src/meta.test.ts
+++ b/packages/canvas-model/src/meta.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { CANVAS_SCHEMA_VERSION, canvasMetaSchema } from './meta.js'
+
+describe('canvasMetaSchema', () => {
+  it('accepts a markdown canvas meta at the current schema version', () => {
+    const result = canvasMetaSchema.safeParse({
+      format: 'markdown',
+      schemaVersion: CANVAS_SCHEMA_VERSION,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a spatial canvas meta', () => {
+    expect(canvasMetaSchema.safeParse({ format: 'spatial', schemaVersion: 1 }).success).toBe(true)
+  })
+
+  it('rejects an unknown format', () => {
+    expect(canvasMetaSchema.safeParse({ format: 'html', schemaVersion: 1 }).success).toBe(false)
+  })
+
+  it('rejects a missing schemaVersion', () => {
+    expect(canvasMetaSchema.safeParse({ format: 'markdown' }).success).toBe(false)
+  })
+
+  it('rejects any schemaVersion other than the pinned literal 1', () => {
+    expect(canvasMetaSchema.safeParse({ format: 'markdown', schemaVersion: 0 }).success).toBe(false)
+    expect(canvasMetaSchema.safeParse({ format: 'markdown', schemaVersion: 2 }).success).toBe(false)
+    expect(canvasMetaSchema.safeParse({ format: 'markdown', schemaVersion: '1' }).success).toBe(
+      false,
+    )
+  })
+})

--- a/packages/canvas-model/src/meta.ts
+++ b/packages/canvas-model/src/meta.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+/**
+ * Current OpenCanvas schema version for this repo. Pinned as a literal so
+ * unknown/future versions fail parse loudly rather than being silently
+ * accepted. When a v2 model lands, replace `z.literal(CANVAS_SCHEMA_VERSION)`
+ * with a discriminated union keyed on `schemaVersion` (1 | 2) so both shapes
+ * can be parsed side by side during migration.
+ */
+export const CANVAS_SCHEMA_VERSION = 1 as const
+
+export const canvasMetaSchema = z.object({
+  format: z.enum(['markdown', 'spatial']),
+  schemaVersion: z.literal(CANVAS_SCHEMA_VERSION),
+})
+
+export type CanvasMeta = z.infer<typeof canvasMetaSchema>

--- a/packages/canvas-model/src/properties.test.ts
+++ b/packages/canvas-model/src/properties.test.ts
@@ -7,7 +7,11 @@ import {
 } from './facets.js'
 import { canvasIdSchema } from './ids.js'
 import { markdownCanvasSchema } from './markdown.js'
-import { mdastNodeSchema } from './mdast/index.js'
+import {
+  mdastFlowContentSchema,
+  mdastPhrasingContentSchema,
+  mdastRootSchema,
+} from './mdast/index.js'
 import { canvasMetaSchema } from './meta.js'
 import {
   canvasEdgeSchema,
@@ -23,7 +27,9 @@ import {
   extensionFacetsArbitrary,
   facetsRawArbitrary,
   markdownCanvasArbitrary,
-  mdastNodeArbitrary,
+  mdastFlowContentArbitrary,
+  mdastPhrasingContentArbitrary,
+  mdastRootArbitrary,
   spatialNodeArbitrary,
   workspaceMetaArbitrary,
   workspaceTreeNodeDataArbitrary,
@@ -81,10 +87,88 @@ describe('arbitrary-conformance: every generator agrees with its schema', () => 
   })
 
   fcTest.prop(
-    [fc.integer({ min: 1, max: 3 }).chain((depth) => mdastNodeArbitrary(depth))],
+    [fc.integer({ min: 0, max: 3 }).chain((depth) => mdastPhrasingContentArbitrary(depth))],
     withDefaults({ numRuns: 50 }),
-  )('mdastNodeSchema', (value) => {
-    expect(mdastNodeSchema.safeParse(value).success).toBe(true)
+  )('mdastPhrasingContentSchema', (value) => {
+    expect(mdastPhrasingContentSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop(
+    [fc.integer({ min: 0, max: 3 }).chain((depth) => mdastFlowContentArbitrary(depth))],
+    withDefaults({ numRuns: 50 }),
+  )('mdastFlowContentSchema', (value) => {
+    expect(mdastFlowContentSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop(
+    [fc.integer({ min: 0, max: 3 }).chain((depth) => mdastRootArbitrary(depth))],
+    withDefaults({ numRuns: 50 }),
+  )('mdastRootSchema', (value) => {
+    expect(mdastRootSchema.safeParse(value).success).toBe(true)
+  })
+})
+
+describe('mdast content-model: disallowed cross-category child always rejects', () => {
+  // A misplaced-child pool built from kinds whose content category is
+  // genuinely disjoint from a paragraph's allowed content (phrasing only).
+  // `html` is deliberately excluded — it is dual-category (both flow and
+  // phrasing) so grafting it under a paragraph is actually valid mdast.
+  const flowOnlyNodeArbitrary = fc.oneof(
+    fc.constant({ type: 'thematicBreak' }),
+    fc
+      .record({ value: fc.string({ maxLength: 10 }) })
+      .map(({ value }) => ({ type: 'code', value })),
+    fc
+      .record({ identifier: fc.string({ minLength: 1, maxLength: 10 }), url: fc.webUrl() })
+      .map(({ identifier, url }) => ({ type: 'definition', identifier, url })),
+    fc.constant({ type: 'root', children: [] }),
+    fc.constant({ type: 'listItem', children: [] }),
+    fc.constant({ type: 'tableRow', children: [] }),
+  )
+
+  fcTest.prop([flowOnlyNodeArbitrary], withDefaults())(
+    'a flow-only or structural node grafted as a paragraph child fails to parse',
+    (misplacedChild) => {
+      const grafted = { type: 'paragraph', children: [misplacedChild] }
+      expect(mdastFlowContentSchema.safeParse(grafted).success).toBe(false)
+    },
+  )
+
+  const nonFlowNodeArbitrary = fc.oneof(
+    fc
+      .record({ value: fc.string({ maxLength: 10 }) })
+      .map(({ value }) => ({ type: 'text', value })),
+    fc.constant({ type: 'break' }),
+    fc.constant({ type: 'root', children: [] }),
+    fc.constant({ type: 'tableCell', children: [] }),
+  )
+
+  fcTest.prop([nonFlowNodeArbitrary], withDefaults())(
+    'a non-flow node grafted as a blockquote child fails to parse',
+    (misplacedChild) => {
+      const grafted = { type: 'blockquote', children: [misplacedChild] }
+      expect(mdastFlowContentSchema.safeParse(grafted).success).toBe(false)
+    },
+  )
+})
+
+describe('mdast schemas are pure and idempotent', () => {
+  fcTest.prop(
+    [fc.integer({ min: 0, max: 3 }).chain((depth) => mdastFlowContentArbitrary(depth))],
+    withDefaults(),
+  )('safeParse does not mutate its input', (value) => {
+    const before = structuredClone(value)
+    mdastFlowContentSchema.safeParse(value)
+    expect(value).toEqual(before)
+  })
+
+  fcTest.prop(
+    [fc.integer({ min: 0, max: 3 }).chain((depth) => mdastFlowContentArbitrary(depth))],
+    withDefaults(),
+  )('parsing the same valid tree twice yields deeply-equal outputs', (value) => {
+    const once = mdastFlowContentSchema.parse(value)
+    const twice = mdastFlowContentSchema.parse(once)
+    expect(twice).toEqual(once)
   })
 })
 

--- a/packages/canvas-model/src/properties.test.ts
+++ b/packages/canvas-model/src/properties.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect } from 'vitest'
+import {
+  coreFacetsSchema,
+  extensionFacetsSchema,
+  facetsRawSchema,
+  RESERVED_ROOT_KEYS,
+} from './facets.js'
+import { canvasIdSchema } from './ids.js'
+import { markdownCanvasSchema } from './markdown.js'
+import { mdastNodeSchema } from './mdast/index.js'
+import { canvasMetaSchema } from './meta.js'
+import {
+  canvasEdgeSchema,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+  xWhiteboardSchema,
+} from './spatial.js'
+import {
+  canonicalUlidArbitrary,
+  canvasEdgeArbitrary,
+  canvasMetaArbitrary,
+  coreFacetsArbitrary,
+  extensionFacetsArbitrary,
+  facetsRawArbitrary,
+  markdownCanvasArbitrary,
+  mdastNodeArbitrary,
+  spatialNodeArbitrary,
+  workspaceMetaArbitrary,
+  workspaceTreeNodeDataArbitrary,
+  xWhiteboardArbitrary,
+} from './test-utils/arbitraries.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+import { workspaceMetaSchema, workspaceTreeNodeDataSchema } from './workspace-tree.js'
+
+describe('arbitrary-conformance: every generator agrees with its schema', () => {
+  fcTest.prop([canvasMetaArbitrary], withDefaults())('canvasMetaSchema', (value) => {
+    expect(canvasMetaSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([coreFacetsArbitrary], withDefaults())('coreFacetsSchema', (value) => {
+    expect(coreFacetsSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([extensionFacetsArbitrary], withDefaults())('extensionFacetsSchema', (value) => {
+    expect(extensionFacetsSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([facetsRawArbitrary], withDefaults())('facetsRawSchema', (value) => {
+    expect(facetsRawSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([spatialNodeArbitrary], withDefaults())('spatialNodeSchema', (value) => {
+    expect(spatialNodeSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([canvasEdgeArbitrary], withDefaults())('canvasEdgeSchema', (value) => {
+    expect(canvasEdgeSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([xWhiteboardArbitrary], withDefaults())('xWhiteboardSchema', (value) => {
+    expect(xWhiteboardSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([markdownCanvasArbitrary], withDefaults())('markdownCanvasSchema', (value) => {
+    expect(markdownCanvasSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([workspaceTreeNodeDataArbitrary], withDefaults())(
+    'workspaceTreeNodeDataSchema',
+    (value) => {
+      expect(workspaceTreeNodeDataSchema.safeParse(value).success).toBe(true)
+    },
+  )
+
+  fcTest.prop([workspaceMetaArbitrary], withDefaults())('workspaceMetaSchema', (value) => {
+    expect(workspaceMetaSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop([canonicalUlidArbitrary], withDefaults())('canvasIdSchema', (value) => {
+    expect(canvasIdSchema.safeParse(value).success).toBe(true)
+  })
+
+  fcTest.prop(
+    [fc.integer({ min: 1, max: 3 }).chain((depth) => mdastNodeArbitrary(depth))],
+    withDefaults({ numRuns: 50 }),
+  )('mdastNodeSchema', (value) => {
+    expect(mdastNodeSchema.safeParse(value).success).toBe(true)
+  })
+})
+
+describe('parse idempotence', () => {
+  fcTest.prop([coreFacetsArbitrary], withDefaults())('coreFacetsSchema', (value) => {
+    const once = coreFacetsSchema.parse(value)
+    const twice = coreFacetsSchema.parse(once)
+    expect(twice).toEqual(once)
+  })
+
+  fcTest.prop([spatialNodeArbitrary], withDefaults())('spatialNodeSchema', (value) => {
+    const once = spatialNodeSchema.parse(value)
+    const twice = spatialNodeSchema.parse(once)
+    expect(twice).toEqual(once)
+  })
+})
+
+describe('unknown-domain / unknown-root-key preservation', () => {
+  fcTest.prop([extensionFacetsArbitrary], withDefaults())(
+    'extensionFacetsSchema preserves unknown-domain payloads byte-identical',
+    (value) => {
+      const parsed = extensionFacetsSchema.parse(value)
+      expect(parsed).toEqual(value)
+    },
+  )
+
+  fcTest.prop([facetsRawArbitrary], withDefaults())(
+    'facetsRawSchema preserves non-reserved root keys byte-identical',
+    (value) => {
+      const parsed = facetsRawSchema.parse(value)
+      expect(parsed).toEqual(value)
+    },
+  )
+})
+
+describe('bucket disjointness', () => {
+  fcTest.prop([fc.constantFrom(...RESERVED_ROOT_KEYS)], withDefaults())(
+    'a reserved root key is never valid as a lone facetsRaw key',
+    (key) => {
+      expect(facetsRawSchema.safeParse({ [key]: 'x' }).success).toBe(false)
+    },
+  )
+})
+
+describe('JSON Canvas 1.0 conformance invariants', () => {
+  fcTest.prop(
+    [
+      fc.record({
+        id: fc.string({ minLength: 1, maxLength: 10 }),
+        x: fc.float({ noNaN: true }).filter((n) => !Number.isInteger(n)),
+        y: fc.integer(),
+        width: fc.integer(),
+        height: fc.integer(),
+        type: fc.constant('text' as const),
+        text: fc.string(),
+      }),
+    ],
+    withDefaults(),
+  )('non-integer geometry always rejects', (value) => {
+    expect(spatialNodeSchema.safeParse(value).success).toBe(false)
+  })
+
+  fcTest.prop([fc.tuple(spatialNodeArbitrary, spatialNodeArbitrary)], withDefaults())(
+    'duplicating a node id flips spatialCanvasSchema from accept to reject',
+    ([nodeA, nodeB]) => {
+      const distinct = {
+        nodes: [
+          { ...nodeA, id: 'a' },
+          { ...nodeB, id: 'b' },
+        ],
+        edges: [],
+      }
+      const duplicated = {
+        nodes: [
+          { ...nodeA, id: 'a' },
+          { ...nodeB, id: 'a' },
+        ],
+        edges: [],
+      }
+      expect(spatialCanvasSchema.safeParse(distinct).success).toBe(true)
+      expect(spatialCanvasSchema.safeParse(duplicated).success).toBe(false)
+    },
+  )
+})
+
+describe('canvasIdSchema ULID mutations always reject', () => {
+  fcTest.prop([canonicalUlidArbitrary], withDefaults())(
+    'truncating the last character rejects',
+    (ulid) => {
+      expect(canvasIdSchema.safeParse(ulid.slice(0, -1)).success).toBe(false)
+    },
+  )
+
+  fcTest.prop([canonicalUlidArbitrary], withDefaults())(
+    'appending an extra character rejects',
+    (ulid) => {
+      expect(canvasIdSchema.safeParse(`${ulid}0`).success).toBe(false)
+    },
+  )
+
+  fcTest.prop([canonicalUlidArbitrary, fc.constantFrom('I', 'L', 'O', 'U')], withDefaults())(
+    'replacing the second character with an excluded Crockford char rejects',
+    (ulid, excludedChar) => {
+      const mutated = ulid[0] + excludedChar + ulid.slice(2)
+      expect(canvasIdSchema.safeParse(mutated).success).toBe(false)
+    },
+  )
+
+  fcTest.prop([canonicalUlidArbitrary, fc.constantFrom('8', '9', 'A', 'Z')], withDefaults())(
+    'replacing the first character with 8-9/A-Z rejects',
+    (ulid, firstChar) => {
+      const mutated = firstChar + ulid.slice(1)
+      expect(canvasIdSchema.safeParse(mutated).success).toBe(false)
+    },
+  )
+})

--- a/packages/canvas-model/src/spatial.test.ts
+++ b/packages/canvas-model/src/spatial.test.ts
@@ -43,6 +43,30 @@ describe('spatialNodeSchema (text)', () => {
       spatialNodeSchema.safeParse({ ...baseGeometry, x: 1.5, type: 'text', text: 'hi' }).success,
     ).toBe(false)
   })
+
+  it('rejects negative width and height', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, width: -1, type: 'text', text: 'hi' }).success,
+    ).toBe(false)
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, height: -1, type: 'text', text: 'hi' })
+        .success,
+    ).toBe(false)
+  })
+
+  it('accepts zero width/height (degenerate freehand bounding boxes) and negative x/y', () => {
+    expect(
+      spatialNodeSchema.safeParse({
+        ...baseGeometry,
+        x: -50,
+        y: -50,
+        width: 0,
+        height: 0,
+        type: 'text',
+        text: 'hi',
+      }).success,
+    ).toBe(true)
+  })
 })
 
 describe('spatialNodeSchema (file)', () => {

--- a/packages/canvas-model/src/spatial.test.ts
+++ b/packages/canvas-model/src/spatial.test.ts
@@ -259,4 +259,42 @@ describe('spatialCanvasSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  it('accepts an empty document with both arrays omitted, per JSON Canvas 1.0 optionality', () => {
+    const result = spatialCanvasSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ nodes: [], edges: [] })
+    }
+  })
+
+  it('accepts a document with only nodes present', () => {
+    const result = spatialCanvasSchema.safeParse({ nodes: [node1] })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.edges).toEqual([])
+    }
+  })
+
+  it('accepts a document with only edges present (edges referencing nothing)', () => {
+    const result = spatialCanvasSchema.safeParse({ edges: [] })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.nodes).toEqual([])
+    }
+  })
+
+  it('rejects an edge whose fromNode or toNode references a nonexistent node id', () => {
+    const missingFrom = spatialCanvasSchema.safeParse({
+      nodes: [node2],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    expect(missingFrom.success).toBe(false)
+
+    const missingTo = spatialCanvasSchema.safeParse({
+      nodes: [node1],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    expect(missingTo.success).toBe(false)
+  })
 })

--- a/packages/canvas-model/src/spatial.test.ts
+++ b/packages/canvas-model/src/spatial.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canvasColorSchema,
+  canvasEdgeSchema,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+  xWhiteboardSchema,
+} from './spatial.js'
+
+const baseGeometry = { id: 'n1', x: 0, y: 0, width: 100, height: 100 }
+
+describe('canvasColorSchema', () => {
+  it('accepts preset colors 1-6', () => {
+    for (const preset of ['1', '2', '3', '4', '5', '6']) {
+      expect(canvasColorSchema.safeParse(preset).success).toBe(true)
+    }
+  })
+
+  it('accepts a 6-digit hex color', () => {
+    expect(canvasColorSchema.safeParse('#a1B2c3').success).toBe(true)
+  })
+
+  it('rejects preset 7, a 3-digit hex, and a named color', () => {
+    expect(canvasColorSchema.safeParse('7').success).toBe(false)
+    expect(canvasColorSchema.safeParse('#abc').success).toBe(false)
+    expect(canvasColorSchema.safeParse('red').success).toBe(false)
+  })
+})
+
+describe('spatialNodeSchema (text)', () => {
+  it('accepts a minimal text node', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, type: 'text', text: 'hello' }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a text node missing text', () => {
+    expect(spatialNodeSchema.safeParse({ ...baseGeometry, type: 'text' }).success).toBe(false)
+  })
+
+  it('rejects non-integer geometry', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, x: 1.5, type: 'text', text: 'hi' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('spatialNodeSchema (file)', () => {
+  it('accepts a file node with a #-prefixed subpath', () => {
+    expect(
+      spatialNodeSchema.safeParse({
+        ...baseGeometry,
+        type: 'file',
+        file: 'a.md',
+        subpath: '#heading',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('accepts a file node without subpath', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, type: 'file', file: 'a.md' }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a subpath not starting with #', () => {
+    expect(
+      spatialNodeSchema.safeParse({
+        ...baseGeometry,
+        type: 'file',
+        file: 'a.md',
+        subpath: 'heading',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a file node missing file', () => {
+    expect(spatialNodeSchema.safeParse({ ...baseGeometry, type: 'file' }).success).toBe(false)
+  })
+})
+
+describe('spatialNodeSchema (link)', () => {
+  it('accepts a link node with a url', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, type: 'link', url: 'https://example.com' })
+        .success,
+    ).toBe(true)
+  })
+
+  it('rejects an invalid url', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, type: 'link', url: 'not a url' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('spatialNodeSchema (group)', () => {
+  it('accepts a minimal group node', () => {
+    expect(spatialNodeSchema.safeParse({ ...baseGeometry, type: 'group' }).success).toBe(true)
+  })
+
+  it('accepts a full group node', () => {
+    const result = spatialNodeSchema.safeParse({
+      ...baseGeometry,
+      type: 'group',
+      label: 'Section',
+      background: 'bg.png',
+      backgroundStyle: 'cover',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid backgroundStyle', () => {
+    expect(
+      spatialNodeSchema.safeParse({ ...baseGeometry, type: 'group', backgroundStyle: 'stretch' })
+        .success,
+    ).toBe(false)
+  })
+})
+
+describe('x-whiteboard extension', () => {
+  it('accepts a node without x-whiteboard (strict JSON Canvas 1.0 doc unchanged)', () => {
+    expect(spatialNodeSchema.safeParse({ ...baseGeometry, type: 'text', text: 'hi' }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts a freehand payload with 2+ points', () => {
+    const result = xWhiteboardSchema.safeParse({
+      kind: 'freehand',
+      points: [
+        [0, 0],
+        [1, 1],
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a freehand payload with a single point', () => {
+    expect(xWhiteboardSchema.safeParse({ kind: 'freehand', points: [[0, 0]] }).success).toBe(false)
+  })
+
+  it('rejects freehand pressures whose length does not match points', () => {
+    const result = xWhiteboardSchema.safeParse({
+      kind: 'freehand',
+      points: [
+        [0, 0],
+        [1, 1],
+      ],
+      pressures: [0.5],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a pressure outside [0, 1]', () => {
+    const result = xWhiteboardSchema.safeParse({
+      kind: 'freehand',
+      points: [
+        [0, 0],
+        [1, 1],
+      ],
+      pressures: [0.5, 1.2],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a shape payload with a valid shape name and rejects an unknown one', () => {
+    expect(xWhiteboardSchema.safeParse({ kind: 'shape', shape: 'ellipse' }).success).toBe(true)
+    expect(xWhiteboardSchema.safeParse({ kind: 'shape', shape: 'star' }).success).toBe(false)
+  })
+
+  it('accepts an embed payload with a valid canvasId and rejects a malformed one', () => {
+    expect(
+      xWhiteboardSchema.safeParse({ kind: 'embed', canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV' })
+        .success,
+    ).toBe(true)
+    expect(xWhiteboardSchema.safeParse({ kind: 'embed', canvasId: 'not-a-ulid' }).success).toBe(
+      false,
+    )
+  })
+
+  it('attaches to a node under the x-whiteboard key', () => {
+    const result = spatialNodeSchema.safeParse({
+      ...baseGeometry,
+      type: 'text',
+      text: 'hi',
+      'x-whiteboard': { kind: 'shape', shape: 'rectangle' },
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('canvasEdgeSchema', () => {
+  it('accepts a minimal edge', () => {
+    expect(canvasEdgeSchema.safeParse({ id: 'e1', fromNode: 'n1', toNode: 'n2' }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts a full edge', () => {
+    const result = canvasEdgeSchema.safeParse({
+      id: 'e1',
+      fromNode: 'n1',
+      toNode: 'n2',
+      fromSide: 'top',
+      toSide: 'bottom',
+      fromEnd: 'none',
+      toEnd: 'arrow',
+      color: '1',
+      label: 'connects',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid side and end', () => {
+    expect(
+      canvasEdgeSchema.safeParse({ id: 'e1', fromNode: 'n1', toNode: 'n2', fromSide: 'north' })
+        .success,
+    ).toBe(false)
+    expect(
+      canvasEdgeSchema.safeParse({ id: 'e1', fromNode: 'n1', toNode: 'n2', toEnd: 'diamond' })
+        .success,
+    ).toBe(false)
+  })
+
+  it('rejects a missing fromNode or toNode', () => {
+    expect(canvasEdgeSchema.safeParse({ id: 'e1', toNode: 'n2' }).success).toBe(false)
+    expect(canvasEdgeSchema.safeParse({ id: 'e1', fromNode: 'n1' }).success).toBe(false)
+  })
+})
+
+describe('spatialCanvasSchema', () => {
+  const node1 = { ...baseGeometry, id: 'n1', type: 'text', text: 'a' }
+  const node2 = { ...baseGeometry, id: 'n2', type: 'text', text: 'b' }
+
+  it('accepts distinct node and edge ids', () => {
+    const result = spatialCanvasSchema.safeParse({
+      nodes: [node1, node2],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects duplicate node ids', () => {
+    const result = spatialCanvasSchema.safeParse({
+      nodes: [node1, { ...node2, id: 'n1' }],
+      edges: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects duplicate edge ids', () => {
+    const result = spatialCanvasSchema.safeParse({
+      nodes: [node1, node2],
+      edges: [
+        { id: 'e1', fromNode: 'n1', toNode: 'n2' },
+        { id: 'e1', fromNode: 'n2', toNode: 'n1' },
+      ],
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/canvas-model/src/spatial.ts
+++ b/packages/canvas-model/src/spatial.ts
@@ -54,14 +54,17 @@ export const xWhiteboardSchema = z.discriminatedUnion('kind', [
 export type XWhiteboard = z.infer<typeof xWhiteboardSchema>
 
 // JSON Canvas 1.0 geometry is specified in integer pixels.
-const geometryFieldSchema = z.number().int()
+const positionFieldSchema = z.number().int()
+// Sizes reject negatives. Zero stays valid: a straight-line freehand stroke carried
+// via x-whiteboard legitimately has a zero-width or zero-height bounding box.
+const sizeFieldSchema = z.number().int().nonnegative()
 
 const sharedNodeFieldsSchema = z.object({
   id: nodeIdSchema,
-  x: geometryFieldSchema,
-  y: geometryFieldSchema,
-  width: geometryFieldSchema,
-  height: geometryFieldSchema,
+  x: positionFieldSchema,
+  y: positionFieldSchema,
+  width: sizeFieldSchema,
+  height: sizeFieldSchema,
   color: canvasColorSchema.optional(),
   'x-whiteboard': xWhiteboardSchema.optional(),
 })

--- a/packages/canvas-model/src/spatial.ts
+++ b/packages/canvas-model/src/spatial.ts
@@ -123,8 +123,10 @@ function findDuplicateId(ids: string[]): string | undefined {
 
 export const spatialCanvasSchema = z
   .object({
-    nodes: z.array(spatialNodeSchema),
-    edges: z.array(canvasEdgeSchema),
+    // JSON Canvas 1.0 declares both top-level arrays optional; a bare `{}`
+    // is a valid (empty) canvas.
+    nodes: z.array(spatialNodeSchema).default([]),
+    edges: z.array(canvasEdgeSchema).default([]),
   })
   .superRefine((value, ctx) => {
     const duplicateNodeId = findDuplicateId(value.nodes.map((node) => node.id))
@@ -144,6 +146,24 @@ export const spatialCanvasSchema = z
         path: ['edges'],
       })
     }
+
+    const nodeIds = new Set(value.nodes.map((node) => node.id))
+    value.edges.forEach((edge, index) => {
+      if (!nodeIds.has(edge.fromNode)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `edge "${edge.id}" references nonexistent fromNode "${edge.fromNode}"`,
+          path: ['edges', index, 'fromNode'],
+        })
+      }
+      if (!nodeIds.has(edge.toNode)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `edge "${edge.id}" references nonexistent toNode "${edge.toNode}"`,
+          path: ['edges', index, 'toNode'],
+        })
+      }
+    })
   })
 
 export type SpatialCanvas = z.infer<typeof spatialCanvasSchema>

--- a/packages/canvas-model/src/spatial.ts
+++ b/packages/canvas-model/src/spatial.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import { canvasIdSchema, nodeIdSchema } from './ids.js'
+
+// JSON Canvas 1.0 (https://jsoncanvas.org/spec/1.0/): color is either one of
+// six numbered presets or a 6-digit hex string.
+export const canvasColorSchema = z.union([
+  z.enum(['1', '2', '3', '4', '5', '6']),
+  z.string().regex(/^#[0-9a-fA-F]{6}$/, 'must be a 6-digit hex color'),
+])
+
+export type CanvasColor = z.infer<typeof canvasColorSchema>
+
+/**
+ * `x-whiteboard` is a namespaced extension carried on spatial nodes to
+ * preserve the original Excalidraw-derived attributes that JSON Canvas 1.0
+ * has no room for. Its absence is always valid — a strict JSON Canvas 1.0
+ * document parses unchanged.
+ *
+ * Arrow-decoration attributes (they attach to edges, not nodes, and their
+ * strict-export degrade rule is undecided) are deliberately out of scope
+ * here and deferred to the slice that builds the strict exporter.
+ */
+export const xWhiteboardSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('freehand'),
+      // Node-local coordinates. Unlike JSON Canvas's node geometry, these
+      // are not required to be integers — freehand strokes need sub-pixel
+      // precision and this field sits outside the spec's integer rule.
+      points: z.array(z.tuple([z.number(), z.number()])).min(2),
+      pressures: z.array(z.number().min(0).max(1)).optional(),
+      strokeWidth: z.number().positive().optional(),
+    })
+    .superRefine((value, ctx) => {
+      if (value.pressures !== undefined && value.pressures.length !== value.points.length) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'pressures length must match points length',
+          path: ['pressures'],
+        })
+      }
+    }),
+  z.object({
+    kind: z.literal('shape'),
+    shape: z.enum(['rectangle', 'ellipse', 'diamond']),
+  }),
+  z.object({
+    kind: z.literal('embed'),
+    canvasId: canvasIdSchema,
+    versionRef: z.string().min(1).optional(),
+  }),
+])
+
+export type XWhiteboard = z.infer<typeof xWhiteboardSchema>
+
+// JSON Canvas 1.0 geometry is specified in integer pixels.
+const geometryFieldSchema = z.number().int()
+
+const sharedNodeFieldsSchema = z.object({
+  id: nodeIdSchema,
+  x: geometryFieldSchema,
+  y: geometryFieldSchema,
+  width: geometryFieldSchema,
+  height: geometryFieldSchema,
+  color: canvasColorSchema.optional(),
+  'x-whiteboard': xWhiteboardSchema.optional(),
+})
+
+const textNodeSchema = sharedNodeFieldsSchema.extend({
+  type: z.literal('text'),
+  text: z.string(),
+})
+
+const fileNodeSchema = sharedNodeFieldsSchema.extend({
+  type: z.literal('file'),
+  file: z.string(),
+  subpath: z.string().startsWith('#').optional(),
+})
+
+const linkNodeSchema = sharedNodeFieldsSchema.extend({
+  type: z.literal('link'),
+  url: z.url(),
+})
+
+const groupNodeSchema = sharedNodeFieldsSchema.extend({
+  type: z.literal('group'),
+  label: z.string().optional(),
+  background: z.string().optional(),
+  backgroundStyle: z.enum(['cover', 'ratio', 'repeat']).optional(),
+})
+
+export const spatialNodeSchema = z.discriminatedUnion('type', [
+  textNodeSchema,
+  fileNodeSchema,
+  linkNodeSchema,
+  groupNodeSchema,
+])
+
+export type SpatialNode = z.infer<typeof spatialNodeSchema>
+
+export const canvasEdgeSchema = z.object({
+  id: nodeIdSchema,
+  fromNode: nodeIdSchema,
+  toNode: nodeIdSchema,
+  fromSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+  toSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+  fromEnd: z.enum(['none', 'arrow']).optional(),
+  toEnd: z.enum(['none', 'arrow']).optional(),
+  color: canvasColorSchema.optional(),
+  label: z.string().optional(),
+})
+
+export type CanvasEdge = z.infer<typeof canvasEdgeSchema>
+
+function findDuplicateId(ids: string[]): string | undefined {
+  const seen = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) return id
+    seen.add(id)
+  }
+  return undefined
+}
+
+export const spatialCanvasSchema = z
+  .object({
+    nodes: z.array(spatialNodeSchema),
+    edges: z.array(canvasEdgeSchema),
+  })
+  .superRefine((value, ctx) => {
+    const duplicateNodeId = findDuplicateId(value.nodes.map((node) => node.id))
+    if (duplicateNodeId !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `duplicate node id "${duplicateNodeId}"`,
+        path: ['nodes'],
+      })
+    }
+
+    const duplicateEdgeId = findDuplicateId(value.edges.map((edge) => edge.id))
+    if (duplicateEdgeId !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `duplicate edge id "${duplicateEdgeId}"`,
+        path: ['edges'],
+      })
+    }
+  })
+
+export type SpatialCanvas = z.infer<typeof spatialCanvasSchema>

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -1,0 +1,191 @@
+import type { MdastNode } from '../mdast/index.js'
+import { fc } from './fast-check.js'
+
+const CROCKFORD_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+const ULID_FIRST_CHARS = '01234567'
+
+/** Generates canonical ULIDs: first char restricted to 0-7 (see ids.ts). */
+export const canonicalUlidArbitrary: fc.Arbitrary<string> = fc
+  .tuple(
+    fc.constantFrom(...ULID_FIRST_CHARS.split('')),
+    fc.array(fc.constantFrom(...CROCKFORD_CHARS.split('')), { minLength: 25, maxLength: 25 }),
+  )
+  .map(([first, rest]) => first + rest.join(''))
+
+const nodeIdArbitrary: fc.Arbitrary<string> = fc.string({ minLength: 1, maxLength: 24 })
+
+export const canvasMetaArbitrary = fc.record({
+  format: fc.constantFrom('markdown' as const, 'spatial' as const),
+  schemaVersion: fc.constant(1 as const),
+})
+
+export const coreFacetsArbitrary = fc.record(
+  {
+    type: fc.string({ minLength: 1, maxLength: 20 }),
+    title: fc.string({ maxLength: 40 }),
+    tags: fc.array(fc.string({ maxLength: 10 }), { maxLength: 5 }),
+    view: fc.string({ maxLength: 20 }),
+  },
+  { requiredKeys: ['type'] },
+)
+
+const domainArbitrary = fc
+  .stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
+  .filter((domain) => /^[a-z]/.test(domain))
+const versionArbitrary = fc.integer({ min: 0, max: 99 }).map((n) => String(n))
+
+const extensionFacetKeyArbitrary: fc.Arbitrary<string> = fc
+  .tuple(domainArbitrary, versionArbitrary)
+  .map(([domain, version]) => `${domain}/${version}`)
+
+export const extensionFacetsArbitrary = fc.dictionary(extensionFacetKeyArbitrary, fc.jsonValue(), {
+  maxKeys: 4,
+})
+
+const RESERVED_ROOT_KEYS = ['type', 'title', 'tags', 'view', 'facets'] as const
+
+const facetsRawKeyArbitrary: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 15 })
+  .filter((key) => !(RESERVED_ROOT_KEYS as readonly string[]).includes(key))
+
+export const facetsRawArbitrary = fc.dictionary(facetsRawKeyArbitrary, fc.jsonValue(), {
+  maxKeys: 4,
+})
+
+const geometryArbitrary = fc.integer({ min: -10_000, max: 10_000 })
+const canvasColorArbitrary: fc.Arbitrary<string> = fc.oneof(
+  fc.constantFrom('1', '2', '3', '4', '5', '6'),
+  fc
+    .array(fc.constantFrom(...'0123456789abcdef'.split('')), { minLength: 6, maxLength: 6 })
+    .map((chars) => `#${chars.join('')}`),
+)
+
+const sharedNodeGeometryArbitrary = {
+  id: nodeIdArbitrary,
+  x: geometryArbitrary,
+  y: geometryArbitrary,
+  width: geometryArbitrary,
+  height: geometryArbitrary,
+  color: fc.option(canvasColorArbitrary, { nil: undefined }),
+}
+
+const spatialTextNodeArbitrary = fc.record({
+  ...sharedNodeGeometryArbitrary,
+  type: fc.constant('text' as const),
+  text: fc.string({ maxLength: 50 }),
+})
+
+const spatialFileNodeArbitrary = fc.record({
+  ...sharedNodeGeometryArbitrary,
+  type: fc.constant('file' as const),
+  file: fc.string({ minLength: 1, maxLength: 30 }),
+})
+
+const spatialLinkNodeArbitrary = fc.record({
+  ...sharedNodeGeometryArbitrary,
+  type: fc.constant('link' as const),
+  url: fc.webUrl(),
+})
+
+const spatialGroupNodeArbitrary = fc.record({
+  ...sharedNodeGeometryArbitrary,
+  type: fc.constant('group' as const),
+})
+
+export const spatialNodeArbitrary = fc.oneof(
+  spatialTextNodeArbitrary,
+  spatialFileNodeArbitrary,
+  spatialLinkNodeArbitrary,
+  spatialGroupNodeArbitrary,
+)
+
+export const canvasEdgeArbitrary = fc.record({
+  id: nodeIdArbitrary,
+  fromNode: nodeIdArbitrary,
+  toNode: nodeIdArbitrary,
+  color: fc.option(canvasColorArbitrary, { nil: undefined }),
+})
+
+const xWhiteboardFreehandArbitrary = fc.record({
+  kind: fc.constant('freehand' as const),
+  points: fc.array(
+    fc.tuple(
+      fc.float({ noNaN: true, noDefaultInfinity: true }),
+      fc.float({ noNaN: true, noDefaultInfinity: true }),
+    ),
+    { minLength: 2, maxLength: 6 },
+  ),
+})
+
+const xWhiteboardShapeArbitrary = fc.record({
+  kind: fc.constant('shape' as const),
+  shape: fc.constantFrom('rectangle' as const, 'ellipse' as const, 'diamond' as const),
+})
+
+const xWhiteboardEmbedArbitrary = fc.record({
+  kind: fc.constant('embed' as const),
+  canvasId: canonicalUlidArbitrary,
+})
+
+export const xWhiteboardArbitrary = fc.oneof(
+  xWhiteboardFreehandArbitrary,
+  xWhiteboardShapeArbitrary,
+  xWhiteboardEmbedArbitrary,
+)
+
+export const markdownCanvasArbitrary = fc.record({ body: fc.string({ maxLength: 200 }) })
+
+const segmentArbitrary: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 20 })
+  .filter((segment) => !segment.includes('/'))
+
+export const workspaceTreeNodeDataArbitrary = fc.record({
+  canvasId: canonicalUlidArbitrary,
+  segment: segmentArbitrary,
+})
+
+export const workspaceMetaArbitrary = fc.dictionary(
+  fc.string({ minLength: 1, maxLength: 15 }),
+  fc.jsonValue(),
+  {
+    maxKeys: 4,
+  },
+)
+
+const mdastTextLeafArbitrary: fc.Arbitrary<MdastNode> = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'text', value }))
+
+/**
+ * Bounded-depth mdast tree generator. `maxDepth` guards fast-check's own
+ * recursion (and the parser's) from unbounded growth while still exercising
+ * genuinely nested structures.
+ */
+export function mdastNodeArbitrary(maxDepth = 4): fc.Arbitrary<MdastNode> {
+  if (maxDepth <= 0) return mdastTextLeafArbitrary
+
+  const childArbitrary = mdastNodeArbitrary(maxDepth - 1)
+  const childrenArbitrary = fc.array(childArbitrary, { minLength: 0, maxLength: 3 })
+
+  return fc.oneof(
+    { weight: 1, arbitrary: mdastTextLeafArbitrary },
+    {
+      weight: 1,
+      arbitrary: childrenArbitrary.map(
+        (children) => ({ type: 'paragraph', children }) as MdastNode,
+      ),
+    },
+    {
+      weight: 1,
+      arbitrary: childrenArbitrary.map(
+        (children) => ({ type: 'blockquote', children }) as MdastNode,
+      ),
+    },
+    {
+      weight: 1,
+      arbitrary: canonicalUlidArbitrary.map(
+        (canvasId) => ({ type: 'embed', canvasId }) as MdastNode,
+      ),
+    },
+  )
+}

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -1,4 +1,12 @@
-import type { MdastNode } from '../mdast/index.js'
+import type {
+  MdastCellPhrasingContent,
+  MdastFlowContent,
+  MdastListItem,
+  MdastPhrasingContent,
+  MdastRoot,
+  MdastTableCell,
+  MdastTableRow,
+} from '../mdast/index.js'
 import { fc } from './fast-check.js'
 
 const CROCKFORD_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
@@ -150,40 +158,276 @@ export const workspaceMetaArbitrary = fc.dictionary(
   },
 )
 
-const mdastTextLeafArbitrary: fc.Arbitrary<MdastNode> = fc
+// ---------------------------------------------------------------------------
+// mdast content-model arbitraries. Valid-by-construction: each function only
+// ever generates a tree that is legal under the matching category schema in
+// ../mdast/index.ts (phrasing/cellPhrasing/flow/listItem/tableRow/tableCell/
+// root). `maxDepth` guards fast-check's own recursion (and the parser's)
+// from unbounded growth while still exercising genuinely nested structures.
+// ---------------------------------------------------------------------------
+
+const optionalNullableString = fc.option(fc.string({ maxLength: 10 }), { nil: null })
+const referenceTypeArbitrary = fc.constantFrom(
+  'shortcut' as const,
+  'collapsed' as const,
+  'full' as const,
+)
+
+// These leaf arbitraries are intentionally left untyped (no explicit
+// fc.Arbitrary<MdastPhrasingContent> annotation): they have no `children`
+// field, so their inferred literal shapes are structurally assignable to
+// BOTH MdastPhrasingContent and MdastCellPhrasingContent's matching
+// variants. Annotating them with the wider union type would make TS check
+// against the whole union (including children-bearing variants) and reject
+// reuse from `mdastCellPhrasingContentArbitrary`.
+const textLeafArbitrary = fc
   .string({ maxLength: 20 })
-  .map((value) => ({ type: 'text', value }))
+  .map((value) => ({ type: 'text' as const, value }))
+const inlineCodeLeafArbitrary = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'inlineCode' as const, value }))
+const breakLeafArbitrary: fc.Arbitrary<{ type: 'break' }> = fc.constant({ type: 'break' })
+const htmlLeafArbitrary = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'html' as const, value }))
+const imageLeafArbitrary = fc
+  .record({ url: fc.webUrl(), title: optionalNullableString, alt: optionalNullableString })
+  .map(({ url, title, alt }) => ({ type: 'image' as const, url, title, alt }))
+const imageReferenceLeafArbitrary = fc
+  .record({
+    identifier: fc.string({ minLength: 1, maxLength: 10 }),
+    label: optionalNullableString,
+    referenceType: referenceTypeArbitrary,
+    alt: optionalNullableString,
+  })
+  .map(({ identifier, label, referenceType, alt }) => ({
+    type: 'imageReference' as const,
+    identifier,
+    label,
+    referenceType,
+    alt,
+  }))
+const inlineMathLeafArbitrary = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'inlineMath' as const, value }))
+const wikiLinkLeafArbitrary = fc
+  .record({
+    canvasId: canonicalUlidArbitrary,
+    alias: fc.option(fc.string({ maxLength: 10 }), { nil: undefined }),
+  })
+  .map(({ canvasId, alias }) => ({ type: 'wikiLink' as const, canvasId, alias }))
+const embedLeafArbitrary = canonicalUlidArbitrary.map((canvasId) => ({
+  type: 'embed' as const,
+  canvasId,
+}))
 
-/**
- * Bounded-depth mdast tree generator. `maxDepth` guards fast-check's own
- * recursion (and the parser's) from unbounded growth while still exercising
- * genuinely nested structures.
- */
-export function mdastNodeArbitrary(maxDepth = 4): fc.Arbitrary<MdastNode> {
-  if (maxDepth <= 0) return mdastTextLeafArbitrary
+/** Leaves shared by both PhrasingContent and TableCell's phrasing-minus-break. */
+const cellPhrasingLeafArbitraries = [
+  textLeafArbitrary,
+  inlineCodeLeafArbitrary,
+  htmlLeafArbitrary,
+  imageLeafArbitrary,
+  imageReferenceLeafArbitrary,
+  inlineMathLeafArbitrary,
+  wikiLinkLeafArbitrary,
+  embedLeafArbitrary,
+] as const
 
-  const childArbitrary = mdastNodeArbitrary(maxDepth - 1)
-  const childrenArbitrary = fc.array(childArbitrary, { minLength: 0, maxLength: 3 })
+/** Bounded-depth PhrasingContent generator (includes `break`). */
+export function mdastPhrasingContentArbitrary(maxDepth = 3): fc.Arbitrary<MdastPhrasingContent> {
+  const leaves = fc.oneof(...cellPhrasingLeafArbitraries, breakLeafArbitrary)
+  if (maxDepth <= 0) return leaves
+
+  const childArbitrary = mdastPhrasingContentArbitrary(maxDepth - 1)
+  const childrenArbitrary = fc.array(childArbitrary, { maxLength: 3 })
 
   return fc.oneof(
-    { weight: 1, arbitrary: mdastTextLeafArbitrary },
-    {
-      weight: 1,
-      arbitrary: childrenArbitrary.map(
-        (children) => ({ type: 'paragraph', children }) as MdastNode,
+    leaves,
+    childrenArbitrary.map((children) => ({ type: 'emphasis', children }) as const),
+    childrenArbitrary.map((children) => ({ type: 'strong', children }) as const),
+    fc
+      .record({ url: fc.webUrl(), title: optionalNullableString, children: childrenArbitrary })
+      .map(({ url, title, children }) => ({ type: 'link', url, title, children }) as const),
+    fc
+      .record({
+        identifier: fc.string({ minLength: 1, maxLength: 10 }),
+        label: optionalNullableString,
+        referenceType: referenceTypeArbitrary,
+        children: childrenArbitrary,
+      })
+      .map(
+        ({ identifier, label, referenceType, children }) =>
+          ({ type: 'linkReference', identifier, label, referenceType, children }) as const,
       ),
-    },
-    {
-      weight: 1,
-      arbitrary: childrenArbitrary.map(
-        (children) => ({ type: 'blockquote', children }) as MdastNode,
-      ),
-    },
-    {
-      weight: 1,
-      arbitrary: canonicalUlidArbitrary.map(
-        (canvasId) => ({ type: 'embed', canvasId }) as MdastNode,
-      ),
-    },
+    childrenArbitrary.map((children) => ({ type: 'delete', children }) as const),
   )
+}
+
+/**
+ * PhrasingContent minus `break` — mdast's TableCell content model. Not
+ * imported directly outside this file; used by `mdastTableCellArbitrary`
+ * below and kept top-level (rather than nested) so its recursion stays
+ * bounded and easy to follow independently of its caller.
+ */
+function mdastCellPhrasingContentArbitrary(maxDepth = 3): fc.Arbitrary<MdastCellPhrasingContent> {
+  const leaves = fc.oneof(...cellPhrasingLeafArbitraries)
+  if (maxDepth <= 0) return leaves
+
+  const childArbitrary = mdastCellPhrasingContentArbitrary(maxDepth - 1)
+  const childrenArbitrary = fc.array(childArbitrary, { maxLength: 3 })
+
+  return fc.oneof(
+    leaves,
+    childrenArbitrary.map((children) => ({ type: 'emphasis', children }) as const),
+    childrenArbitrary.map((children) => ({ type: 'strong', children }) as const),
+    fc
+      .record({ url: fc.webUrl(), title: optionalNullableString, children: childrenArbitrary })
+      .map(({ url, title, children }) => ({ type: 'link', url, title, children }) as const),
+    fc
+      .record({
+        identifier: fc.string({ minLength: 1, maxLength: 10 }),
+        label: optionalNullableString,
+        referenceType: referenceTypeArbitrary,
+        children: childrenArbitrary,
+      })
+      .map(
+        ({ identifier, label, referenceType, children }) =>
+          ({ type: 'linkReference', identifier, label, referenceType, children }) as const,
+      ),
+    childrenArbitrary.map((children) => ({ type: 'delete', children }) as const),
+  )
+}
+
+const codeLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
+  .record({
+    value: fc.string({ maxLength: 20 }),
+    lang: fc.option(fc.string({ maxLength: 10 }), { nil: null }),
+    meta: fc.option(fc.string({ maxLength: 10 }), { nil: null }),
+  })
+  .map(({ value, lang, meta }) => ({ type: 'code', value, lang, meta }))
+const thematicBreakLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc.constant({
+  type: 'thematicBreak',
+})
+const definitionLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
+  .record({
+    identifier: fc.string({ minLength: 1, maxLength: 10 }),
+    label: optionalNullableString,
+    url: fc.webUrl(),
+    title: optionalNullableString,
+  })
+  .map(({ identifier, label, url, title }) => ({
+    type: 'definition',
+    identifier,
+    label,
+    url,
+    title,
+  }))
+const flowHtmlLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'html', value }))
+const mathLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
+  .record({
+    value: fc.string({ maxLength: 20 }),
+    meta: fc.option(fc.string({ maxLength: 10 }), { nil: null }),
+  })
+  .map(({ value, meta }) => ({ type: 'math', value, meta }))
+
+/** Bounded-depth FlowContent generator. */
+export function mdastFlowContentArbitrary(maxDepth = 3): fc.Arbitrary<MdastFlowContent> {
+  const leaves = fc.oneof(
+    codeLeafArbitrary,
+    thematicBreakLeafArbitrary,
+    definitionLeafArbitrary,
+    flowHtmlLeafArbitrary,
+    mathLeafArbitrary,
+  )
+  if (maxDepth <= 0) return leaves
+
+  const phrasingChildren = fc.array(mdastPhrasingContentArbitrary(maxDepth - 1), { maxLength: 3 })
+  const flowChildren = fc.array(mdastFlowContentArbitrary(maxDepth - 1), { maxLength: 3 })
+  const listItemChildren = fc.array(mdastListItemArbitrary(maxDepth - 1), { maxLength: 3 })
+  const tableRowChildren = fc.array(mdastTableRowArbitrary(maxDepth - 1), { maxLength: 3 })
+
+  return fc.oneof(
+    leaves,
+    phrasingChildren.map((children) => ({ type: 'paragraph', children }) as const),
+    fc
+      .record({
+        depth: fc.constantFrom(
+          1 as const,
+          2 as const,
+          3 as const,
+          4 as const,
+          5 as const,
+          6 as const,
+        ),
+        children: phrasingChildren,
+      })
+      .map(({ depth, children }) => ({ type: 'heading', depth, children }) as const),
+    flowChildren.map((children) => ({ type: 'blockquote', children }) as const),
+    fc
+      .record({
+        ordered: fc.option(fc.boolean(), { nil: undefined }),
+        start: fc.option(fc.nat(9), { nil: undefined }),
+        spread: fc.option(fc.boolean(), { nil: undefined }),
+        children: listItemChildren,
+      })
+      .map(
+        ({ ordered, start, spread, children }) =>
+          ({ type: 'list', ordered, start, spread, children }) as const,
+      ),
+    fc
+      .record({
+        align: fc.option(
+          fc.array(fc.constantFrom('left' as const, 'right' as const, 'center' as const, null), {
+            maxLength: 3,
+          }),
+          { nil: undefined },
+        ),
+        children: tableRowChildren,
+      })
+      .map(({ align, children }) => ({ type: 'table', align, children }) as const),
+  )
+}
+
+/**
+ * ListContent — a listItem's children are FlowContent. Not imported
+ * directly outside this file; used by `mdastFlowContentArbitrary`'s `list`
+ * variant.
+ */
+function mdastListItemArbitrary(maxDepth = 3): fc.Arbitrary<MdastListItem> {
+  return fc
+    .record({
+      checked: fc.option(fc.boolean(), { nil: undefined }),
+      spread: fc.option(fc.boolean(), { nil: undefined }),
+      children: fc.array(mdastFlowContentArbitrary(maxDepth), { maxLength: 3 }),
+    })
+    .map(({ checked, spread, children }) => ({ type: 'listItem', checked, spread, children }))
+}
+
+/**
+ * RowContent — a tableCell's children are phrasing minus `break`. Not
+ * imported directly outside this file; used by `mdastTableRowArbitrary`.
+ */
+function mdastTableCellArbitrary(maxDepth = 3): fc.Arbitrary<MdastTableCell> {
+  return fc
+    .array(mdastCellPhrasingContentArbitrary(maxDepth), { maxLength: 3 })
+    .map((children) => ({ type: 'tableCell', children }))
+}
+
+/** TableContent — a tableRow's children are tableCells. */
+export function mdastTableRowArbitrary(maxDepth = 3): fc.Arbitrary<MdastTableRow> {
+  return fc
+    .array(mdastTableCellArbitrary(maxDepth), { maxLength: 3 })
+    .map((children) => ({ type: 'tableRow', children }))
+}
+
+/**
+ * Document root — an intentionally flow-only application subset of upstream
+ * mdast Root (see ../mdast/index.ts).
+ */
+export function mdastRootArbitrary(maxDepth = 3): fc.Arbitrary<MdastRoot> {
+  return fc
+    .array(mdastFlowContentArbitrary(maxDepth), { maxLength: 3 })
+    .map((children) => ({ type: 'root', children }))
 }

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -59,6 +59,7 @@ export const facetsRawArbitrary = fc.dictionary(facetsRawKeyArbitrary, fc.jsonVa
 })
 
 const geometryArbitrary = fc.integer({ min: -10_000, max: 10_000 })
+const sizeArbitrary = fc.integer({ min: 0, max: 10_000 })
 const canvasColorArbitrary: fc.Arbitrary<string> = fc.oneof(
   fc.constantFrom('1', '2', '3', '4', '5', '6'),
   fc
@@ -70,8 +71,8 @@ const sharedNodeGeometryArbitrary = {
   id: nodeIdArbitrary,
   x: geometryArbitrary,
   y: geometryArbitrary,
-  width: geometryArbitrary,
-  height: geometryArbitrary,
+  width: sizeArbitrary,
+  height: sizeArbitrary,
   color: fc.option(canvasColorArbitrary, { nil: undefined }),
 }
 
@@ -143,7 +144,7 @@ export const markdownCanvasArbitrary = fc.record({ body: fc.string({ maxLength: 
 
 const segmentArbitrary: fc.Arbitrary<string> = fc
   .string({ minLength: 1, maxLength: 20 })
-  .filter((segment) => !segment.includes('/'))
+  .filter((segment) => !segment.includes('/') && segment !== '.' && segment !== '..')
 
 export const workspaceTreeNodeDataArbitrary = fc.record({
   canvasId: canonicalUlidArbitrary,

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -29,9 +29,7 @@ export const coreFacetsArbitrary = fc.record(
   { requiredKeys: ['type'] },
 )
 
-const domainArbitrary = fc
-  .stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
-  .filter((domain) => /^[a-z]/.test(domain))
+const domainArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
 const versionArbitrary = fc.integer({ min: 0, max: 99 }).map((n) => String(n))
 
 const extensionFacetKeyArbitrary: fc.Arbitrary<string> = fc

--- a/packages/canvas-model/src/test-utils/fast-check.ts
+++ b/packages/canvas-model/src/test-utils/fast-check.ts
@@ -1,0 +1,8 @@
+import { test as fcTest } from '@fast-check/vitest'
+import * as fc from 'fast-check'
+
+export { fc, fcTest }
+
+export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
+  return { numRuns: 200, ...override }
+}

--- a/packages/canvas-model/src/types.test.ts
+++ b/packages/canvas-model/src/types.test.ts
@@ -1,0 +1,59 @@
+import { expectTypeOf, it } from 'vitest'
+import type { z } from 'zod'
+import type {
+  CoreFacets,
+  coreFacetsSchema,
+  ExtensionFacets,
+  extensionFacetsSchema,
+  FacetsRaw,
+  facetsRawSchema,
+} from './facets.js'
+import type { CanvasId, canvasIdSchema, NodeId, nodeIdSchema } from './ids.js'
+import type { MarkdownCanvas, markdownCanvasSchema } from './markdown.js'
+import type { MdastNode } from './mdast/index.js'
+import { mdastNodeSchema } from './mdast/index.js'
+import type { CanvasMeta, canvasMetaSchema } from './meta.js'
+import type {
+  CanvasColor,
+  CanvasEdge,
+  canvasColorSchema,
+  canvasEdgeSchema,
+  SpatialCanvas,
+  SpatialNode,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+  XWhiteboard,
+  xWhiteboardSchema,
+} from './spatial.js'
+import type {
+  WorkspaceMeta,
+  WorkspaceTreeNodeData,
+  workspaceMetaSchema,
+  workspaceTreeNodeDataSchema,
+} from './workspace-tree.js'
+
+// Compile-time only: this file asserts every exported type is exactly
+// z.infer<typeof schema> for its schema, catching a hand-written type that
+// has drifted from its schema (the create_frame assignedMembers bug's
+// shape) without needing a runtime check.
+it('type-source invariant: exported types equal z.infer of their schema', () => {
+  expectTypeOf<CanvasMeta>().toEqualTypeOf<z.infer<typeof canvasMetaSchema>>()
+  expectTypeOf<CoreFacets>().toEqualTypeOf<z.infer<typeof coreFacetsSchema>>()
+  expectTypeOf<ExtensionFacets>().toEqualTypeOf<z.infer<typeof extensionFacetsSchema>>()
+  expectTypeOf<FacetsRaw>().toEqualTypeOf<z.infer<typeof facetsRawSchema>>()
+  expectTypeOf<CanvasId>().toEqualTypeOf<z.infer<typeof canvasIdSchema>>()
+  expectTypeOf<NodeId>().toEqualTypeOf<z.infer<typeof nodeIdSchema>>()
+  expectTypeOf<CanvasColor>().toEqualTypeOf<z.infer<typeof canvasColorSchema>>()
+  expectTypeOf<SpatialNode>().toEqualTypeOf<z.infer<typeof spatialNodeSchema>>()
+  expectTypeOf<CanvasEdge>().toEqualTypeOf<z.infer<typeof canvasEdgeSchema>>()
+  expectTypeOf<SpatialCanvas>().toEqualTypeOf<z.infer<typeof spatialCanvasSchema>>()
+  expectTypeOf<XWhiteboard>().toEqualTypeOf<z.infer<typeof xWhiteboardSchema>>()
+  expectTypeOf<MarkdownCanvas>().toEqualTypeOf<z.infer<typeof markdownCanvasSchema>>()
+  expectTypeOf<WorkspaceTreeNodeData>().toEqualTypeOf<z.infer<typeof workspaceTreeNodeDataSchema>>()
+  expectTypeOf<WorkspaceMeta>().toEqualTypeOf<z.infer<typeof workspaceMetaSchema>>()
+})
+
+it('mdast: the lazy recursive schema stays typed as MdastNode, not any', () => {
+  expectTypeOf(mdastNodeSchema).toEqualTypeOf<z.ZodType<MdastNode>>()
+  expectTypeOf<z.infer<typeof mdastNodeSchema>>().not.toBeAny()
+})

--- a/packages/canvas-model/src/workspace-tree.test.ts
+++ b/packages/canvas-model/src/workspace-tree.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { workspaceMetaSchema, workspaceTreeNodeDataSchema } from './workspace-tree.js'
+
+describe('workspaceTreeNodeDataSchema', () => {
+  it('accepts a valid canvasId and segment', () => {
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({
+        canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        segment: 'architecture',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a segment containing a slash', () => {
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({
+        canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        segment: 'a/b',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an empty segment', () => {
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({ canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', segment: '' })
+        .success,
+    ).toBe(false)
+  })
+
+  it('rejects a malformed canvasId', () => {
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({ canvasId: 'not-a-ulid', segment: 'a' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('workspaceMetaSchema', () => {
+  it('accepts an empty object', () => {
+    expect(workspaceMetaSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('accepts arbitrary entries (no required keys by design — kept authz-free)', () => {
+    expect(
+      workspaceMetaSchema.safeParse({ label: 'My Workspace', anything: [1, 2, 3] }).success,
+    ).toBe(true)
+  })
+})

--- a/packages/canvas-model/src/workspace-tree.test.ts
+++ b/packages/canvas-model/src/workspace-tree.test.ts
@@ -20,6 +20,21 @@ describe('workspaceTreeNodeDataSchema', () => {
     ).toBe(false)
   })
 
+  it('rejects "." and ".." traversal segments', () => {
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({
+        canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        segment: '.',
+      }).success,
+    ).toBe(false)
+    expect(
+      workspaceTreeNodeDataSchema.safeParse({
+        canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        segment: '..',
+      }).success,
+    ).toBe(false)
+  })
+
   it('rejects an empty segment', () => {
     expect(
       workspaceTreeNodeDataSchema.safeParse({ canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', segment: '' })

--- a/packages/canvas-model/src/workspace-tree.ts
+++ b/packages/canvas-model/src/workspace-tree.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { canvasIdSchema } from './ids.js'
+
+/**
+ * Payload carried by each node of the workspace's Loro movable-tree
+ * (this schema models the tree's node data, not the tree container
+ * itself). `segment` is a single path segment, so it must not itself
+ * contain a path separator.
+ */
+export const workspaceTreeNodeDataSchema = z.object({
+  canvasId: canvasIdSchema,
+  segment: z
+    .string()
+    .min(1)
+    .refine((value) => !value.includes('/'), {
+      message: 'segment must not contain "/"',
+    }),
+})
+
+export type WorkspaceTreeNodeData = z.infer<typeof workspaceTreeNodeDataSchema>
+
+/**
+ * Workspace-level metadata is deliberately a fully open record with no
+ * required keys. Membership/authorization must NOT live here: the tree
+ * document syncs to every device with access to the workspace, so putting
+ * access-control data in this map would leak it to every peer. Keeping the
+ * schema open (rather than picking a fixed shape now) avoids baking that
+ * mistake in before the actual authz model is decided.
+ */
+export const workspaceMetaSchema = z.record(z.string(), z.unknown())
+
+export type WorkspaceMeta = z.infer<typeof workspaceMetaSchema>

--- a/packages/canvas-model/src/workspace-tree.ts
+++ b/packages/canvas-model/src/workspace-tree.ts
@@ -12,8 +12,8 @@ export const workspaceTreeNodeDataSchema = z.object({
   segment: z
     .string()
     .min(1)
-    .refine((value) => !value.includes('/'), {
-      message: 'segment must not contain "/"',
+    .refine((value) => !value.includes('/') && value !== '.' && value !== '..', {
+      message: 'segment must not contain "/" and must not be "." or ".."',
     }),
 })
 

--- a/packages/canvas-model/tsconfig.json
+++ b/packages/canvas-model/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vitest.node.config.ts"]
+}

--- a/packages/canvas-model/vitest.node.config.ts
+++ b/packages/canvas-model/vitest.node.config.ts
@@ -1,0 +1,9 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    name: 'canvas-model-node',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/mcp-server/src/server/docs-contract.test.ts
+++ b/packages/mcp-server/src/server/docs-contract.test.ts
@@ -45,6 +45,7 @@ describe('docs/ contract', () => {
     // of requiring an exact directory-name match.
     const docMentionTokenForPackageDir: Record<string, string> = {
       'packages/mcp-server': 'mcp',
+      'packages/canvas-model': 'canvas-model',
       'packages/canvas-viewer': 'canvas-viewer',
       'apps/web': 'web',
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,25 @@ importers:
         specifier: ^4.105.0
         version: 4.105.0
 
+  packages/canvas-model:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.1.9)
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.8.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/canvas-viewer:
     dependencies:
       '@excalidraw/excalidraw':
@@ -6135,10 +6154,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -6845,10 +6860,6 @@ packages:
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -8548,7 +8559,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.9)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.0.2(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -13449,8 +13460,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
 
   pino-abstract-transport@3.0.0:
@@ -14341,11 +14350,6 @@ snapshots:
 
   tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -14673,11 +14677,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -14705,11 +14709,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -14737,11 +14741,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       'packages/mcp-server/vitest.node.config.ts',
       'packages/mcp-server/vitest.smoke.config.ts',
+      'packages/canvas-model/vitest.node.config.ts',
       'packages/canvas-viewer/vitest.node.config.ts',
       'packages/canvas-viewer/vitest.jsdom.config.ts',
       'packages/canvas-viewer/vitest.browser.config.ts',


### PR DESCRIPTION
## Summary

First slice of the OpenCanvas migration (design: user-approved 2026-07-26): a new pure-schema package `packages/canvas-model` (`@kamiazya/whiteboard-canvas-model`) that is the Zod single source of truth for the OpenCanvas data model. Pure addition — no existing package imports it yet.

- **Canvas meta**: `format: 'markdown' | 'spatial'`, `schemaVersion` pinned as literal `1`.
- **Facets**: core facets (`type` required; `title` / `tags` / `view` optional) at frontmatter root; extension facets only under the reserved `facets` key with `{domain}/{version}` keys (malformed keys are rejected, not dropped); unknown root keys route to `facetsRaw`. Bucket disjointness is enforced at the schema layer.
- **Spatial canvas**: JSON Canvas 1.0-aligned nodes/edges (verified against the live spec: integer geometry, preset-or-hex colors, `file.subpath` must start with `#`, document-level node/edge ID uniqueness, optional `nodes`/`edges` arrays) plus the namespaced `x-whiteboard` extension (freehand / shape / embed with ULID `canvasId` + optional `versionRef`).
- **Markdown canvas**: plain-text `body` (no structure by design).
- **Workspace tree**: `{canvasId, segment}` node data (segments reject `/`, `.`, `..`) + deliberately authz-free workspace meta.
- **mdast subset (internal)**: full mdast **content-model hierarchy** (FlowContent / PhrasingContent / ListContent / TableContent / RowContent; html dual-category; TableCell phrasing-without-break; math ext + GFM + custom `wikiLink` / `embed` phrasing nodes). Structurally invalid trees (root-in-paragraph, text-under-blockquote, listItem-outside-list, ...) are rejected.
- **IDs**: canvas = canonical ULID (first char `[0-7]`), node = nanoid.
- All exported types are `z.infer`-derived (compile-time-guarded); the only exception is the documented `z.ZodType<T>` annotation required for mutual recursion.
- Also adds `.claude/rules/architecture-map.md` (always-on package map) and `.claude/rules/package-canvas-model.md` (path-scoped rule) so sessions and agents recall the boundaries when touching this package.

## Test plan

- [x] `pnpm test --project canvas-model-node` — 132 tests (accept/reject examples per schema + fast-check properties: arbitrary-conformance, parse idempotence, unknown-key preservation, bucket disjointness, JSON Canvas invariants, ULID mutation-rejection, contextual content-model rejects)
- [x] `pnpm -r typecheck`
- [x] `pnpm knip` (new workspace entry registered with reason)
- [x] `biome check packages/canvas-model`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validated canvas data-model package covering metadata, IDs, facets, Markdown, spatial canvases, workspace trees, and supported MDAST content.
  * Added validation for canvas structure, identifiers, geometry, relationships, extensions, and document hierarchy.
  * Added package documentation and public schema/type exports.

* **Documentation**
  * Updated development and testing guidance to include the canvas-model test suite.
  * Added architecture and package-boundary guidance.

* **Tests**
  * Added comprehensive unit, type-level, and property-based validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->