### PR TITLE
feat(canvas-workspace): derive WorkspaceIndex rows from tree + canvas docs

### DIFF
--- a/packages/canvas-workspace/package.json
+++ b/packages/canvas-workspace/package.json
@@ -25,6 +25,8 @@
     "loro-crdt": "catalog:"
   },
   "devDependencies": {
+    "@fast-check/vitest": "^0.4.1",
+    "fast-check": "^4.7.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/canvas-workspace/src/derive-index.properties.test.ts
+++ b/packages/canvas-workspace/src/derive-index.properties.test.ts
@@ -1,0 +1,49 @@
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect } from 'vitest'
+import { deriveAliasResolutionRows, deriveWorkspaceIndexRows } from './derive-index.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+import { buildFixtureWorkspace } from './test-utils/index-fixtures.js'
+import { WorkspaceTree } from './workspace-tree.js'
+
+/** Valid-by-construction segment matching the workspace-tree slug pattern (see workspace-tree.ts). */
+const segmentArbitrary = fc
+  .tuple(
+    fc.stringMatching(/^[a-zA-Z0-9]$/),
+    fc.stringMatching(/^[a-zA-Z0-9_-]{0,8}$/),
+    fc.stringMatching(/^[a-zA-Z0-9]$/),
+  )
+  .map(([first, middle, last]) => first + middle + last)
+
+/** Builds a single root-to-leaf chain (one child per level, so sibling-uniqueness never triggers). */
+function buildChain(segments: readonly string[]): { tree: WorkspaceTree; leafAlias: string } {
+  const doc = new LoroDoc()
+  const tree = new WorkspaceTree(doc)
+  let parent: ReturnType<WorkspaceTree['createNode']> | undefined
+  segments.forEach((segment, index) => {
+    parent = tree.createNode(`canvas-${index}`, segment, parent)
+  })
+  return { tree, leafAlias: segments.join('/') }
+}
+
+describe('derive-index properties', () => {
+  fcTest.prop([fc.array(segmentArbitrary, { minLength: 1, maxLength: 6 })], withDefaults())(
+    "alias-path purity: the derived alias for the leaf equals join('/') of its ancestor segments",
+    (segments) => {
+      const { tree, leafAlias } = buildChain(segments)
+      const rows = deriveAliasResolutionRows(tree)
+      const leafRow = rows.find((row) => row.alias === leafAlias)
+      expect(leafRow).toBeDefined()
+    },
+  )
+
+  fcTest.prop([fc.shuffledSubarray([0, 1, 2], { minLength: 3, maxLength: 3 })], withDefaults())(
+    'order-independence: shuffling the canvases array yields identical assembler output',
+    (order) => {
+      const { tree, canvases } = buildFixtureWorkspace()
+      const forward = deriveWorkspaceIndexRows({ workspaceId: 'ws-1', tree, canvases })
+      const shuffled = order.map((index) => canvases[index])
+      const result = deriveWorkspaceIndexRows({ workspaceId: 'ws-1', tree, canvases: shuffled })
+      expect(result).toEqual(forward)
+    },
+  )
+})

--- a/packages/canvas-workspace/src/derive-index.test.ts
+++ b/packages/canvas-workspace/src/derive-index.test.ts
@@ -35,6 +35,7 @@ describe('deriveFacetIndexRows', () => {
       { facet: 'type', value: 'doc', canvasId: NOTES_ID },
       { facet: 'type', value: 'doc', canvasId: PROJECT_ID },
       { facet: 'type', value: 'spatial', canvasId: DIAGRAM_ID },
+      { facet: 'view', value: 'kanban/1', canvasId: PROJECT_ID },
     ])
     for (const row of rows) expect(() => facetIndexRowSchema.parse(row)).not.toThrow()
   })

--- a/packages/canvas-workspace/src/derive-index.test.ts
+++ b/packages/canvas-workspace/src/derive-index.test.ts
@@ -1,0 +1,120 @@
+import {
+  aliasHistoryRowSchema,
+  aliasResolutionRowSchema,
+  applyRowsInputSchema,
+  backlinkRowSchema,
+  canvasListRowSchema,
+  facetIndexRowSchema,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { describe, expect, test } from 'vitest'
+import {
+  deriveAliasHistoryRows,
+  deriveAliasResolutionRows,
+  deriveBacklinkRows,
+  deriveCanvasListRows,
+  deriveFacetIndexRows,
+  deriveWorkspaceIndexRows,
+} from './derive-index.js'
+import {
+  buildFixtureWorkspace,
+  DIAGRAM_ID,
+  NOTES_ID,
+  PROJECT_ID,
+} from './test-utils/index-fixtures.js'
+
+describe('deriveFacetIndexRows', () => {
+  test('derives exact (facet, value, canvasId) rows sorted deterministically', () => {
+    const { canvases } = buildFixtureWorkspace()
+
+    const rows = deriveFacetIndexRows(canvases)
+
+    expect(rows).toEqual([
+      { facet: 'facets.kanban/1', value: '', canvasId: PROJECT_ID },
+      { facet: 'tags', value: 'inbox', canvasId: NOTES_ID },
+      { facet: 'tags', value: 'urgent', canvasId: NOTES_ID },
+      { facet: 'type', value: 'doc', canvasId: NOTES_ID },
+      { facet: 'type', value: 'doc', canvasId: PROJECT_ID },
+      { facet: 'type', value: 'spatial', canvasId: DIAGRAM_ID },
+    ])
+    for (const row of rows) expect(() => facetIndexRowSchema.parse(row)).not.toThrow()
+  })
+
+  test('returns no rows for a canvas with no facets', () => {
+    expect(deriveFacetIndexRows([{ canvasId: NOTES_ID, updatedAtMs: 0 }])).toEqual([])
+  })
+})
+
+describe('deriveCanvasListRows', () => {
+  test('falls back title from frontmatter to leaf segment', () => {
+    const { tree, canvases } = buildFixtureWorkspace()
+
+    const rows = deriveCanvasListRows(tree, canvases)
+
+    expect(rows).toEqual([
+      { canvasId: NOTES_ID, title: 'notes', updatedAtMs: 1_000 },
+      { canvasId: PROJECT_ID, title: 'Whiteboard Project', updatedAtMs: 2_000 },
+      { canvasId: DIAGRAM_ID, title: 'diagram', updatedAtMs: 3_000 },
+    ])
+    for (const row of rows) expect(() => canvasListRowSchema.parse(row)).not.toThrow()
+  })
+
+  test('falls back to empty title when no tree node and no frontmatter title', () => {
+    const { tree } = buildFixtureWorkspace()
+    const rows = deriveCanvasListRows(tree, [{ canvasId: 'orphan', updatedAtMs: 5 }])
+    expect(rows).toEqual([{ canvasId: 'orphan', title: '', updatedAtMs: 5 }])
+  })
+})
+
+describe('deriveAliasResolutionRows', () => {
+  test('maps every tree node alias (root-to-leaf segment join) to its canvasId', () => {
+    const { tree } = buildFixtureWorkspace()
+
+    const rows = deriveAliasResolutionRows(tree)
+
+    expect(rows).toContainEqual({ alias: 'notes', canvasId: NOTES_ID })
+    expect(rows).toContainEqual({ alias: 'projects/whiteboard', canvasId: PROJECT_ID })
+    expect(rows).toContainEqual({ alias: 'projects/diagram', canvasId: DIAGRAM_ID })
+    for (const row of rows) expect(() => aliasResolutionRowSchema.parse(row)).not.toThrow()
+  })
+})
+
+describe('deriveBacklinkRows', () => {
+  test('matches extractBacklinks output concatenated across canvases, dedup preserved', () => {
+    const { canvases } = buildFixtureWorkspace()
+
+    const rows = deriveBacklinkRows(canvases)
+
+    expect(rows).toEqual([
+      { fromCanvasId: NOTES_ID, toCanvasId: PROJECT_ID },
+      { fromCanvasId: PROJECT_ID, toCanvasId: DIAGRAM_ID },
+    ])
+    for (const row of rows) expect(() => backlinkRowSchema.parse(row)).not.toThrow()
+  })
+
+  test('skips canvases with no resolved body', () => {
+    expect(deriveBacklinkRows([{ canvasId: DIAGRAM_ID, updatedAtMs: 0 }])).toEqual([])
+  })
+})
+
+describe('deriveAliasHistoryRows', () => {
+  test('returns an empty, DTO-typed set (tree retains no history yet)', () => {
+    const rows = deriveAliasHistoryRows()
+    expect(rows).toEqual([])
+    for (const row of rows) expect(() => aliasHistoryRowSchema.parse(row)).not.toThrow()
+  })
+})
+
+describe('deriveWorkspaceIndexRows', () => {
+  test('assembles all five row-sets and validates against applyRowsInputSchema', () => {
+    const { tree, canvases } = buildFixtureWorkspace()
+
+    const result = deriveWorkspaceIndexRows({ workspaceId: 'ws-1', tree, canvases })
+
+    expect(result.canvasList).toHaveLength(3)
+    expect(result.facets.length).toBeGreaterThan(0)
+    expect(result.aliases).toHaveLength(4) // notes + projects folder + whiteboard + diagram
+    expect(result.backlinks).toHaveLength(2)
+    expect(result.aliasHistory).toEqual([])
+    expect(() => applyRowsInputSchema.parse(result)).not.toThrow()
+  })
+})

--- a/packages/canvas-workspace/src/derive-index.ts
+++ b/packages/canvas-workspace/src/derive-index.ts
@@ -1,0 +1,163 @@
+import type { CoreFacets, ExtensionFacets } from '@kamiazya/whiteboard-canvas-model'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type {
+  AliasHistoryRow,
+  AliasResolutionRow,
+  ApplyRowsInput,
+  BacklinkRow,
+  CanvasListRow,
+  FacetIndexRow,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { extractBacklinks } from './extract-backlinks.js'
+import type { WorkspaceTree } from './workspace-tree.js'
+
+/**
+ * Per-canvas input to index derivation. Never crosses a process boundary —
+ * these derivers run in-process against already-loaded tree + doc state —
+ * so, mirroring canvas-render's scene graph, this stays plain TS rather
+ * than a Zod schema. The five *output* row shapes are the schematized
+ * contract (canvas-ports); this input type is derivation-internal.
+ */
+export interface CanvasIndexInput {
+  readonly canvasId: string
+  readonly updatedAtMs: number
+  readonly coreFacets?: CoreFacets
+  readonly extensionFacets?: ExtensionFacets
+  /**
+   * Already reference-resolved mdast body (wikiLink/embed nodes carry a
+   * concrete canvasId, produced by canvas-codec's `resolveReferences`).
+   * Passing raw, unresolved mdast silently yields zero backlink rows since
+   * `extractBacklinks` only recognizes the resolved node shapes. Omit for
+   * non-markdown (spatial) canvases, which have no backlinks to extract.
+   */
+  readonly resolvedBody?: MdastRoot
+}
+
+export interface WorkspaceIndexDeriveInput {
+  readonly workspaceId: ApplyRowsInput['workspaceId']
+  readonly tree: WorkspaceTree
+  readonly canvases: readonly CanvasIndexInput[]
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+/**
+ * Facet index rows: one row per (facet key, value, canvasId). Core `type`/
+ * `view` each produce at most one row per canvas; `tags` produces one row
+ * per tag. Extension domains (`facets.<domain>/<version>`) have no
+ * canonical scalar value in the current row DTO (`{facet, value}` only), so
+ * they index as existence rows (`value: ''`) — a canvas either has the
+ * domain applied or it doesn't; path-scoped equality indexing would need
+ * the row DTO to grow a path field.
+ */
+export function deriveFacetIndexRows(canvases: readonly CanvasIndexInput[]): FacetIndexRow[] {
+  const rows: FacetIndexRow[] = []
+  for (const canvas of canvases) {
+    const { coreFacets, extensionFacets, canvasId } = canvas
+    if (coreFacets?.type !== undefined) {
+      rows.push({ facet: 'type', value: coreFacets.type, canvasId })
+    }
+    for (const tag of coreFacets?.tags ?? []) {
+      rows.push({ facet: 'tags', value: tag, canvasId })
+    }
+    if (coreFacets?.view !== undefined) {
+      rows.push({ facet: 'view', value: coreFacets.view, canvasId })
+    }
+    for (const domainKey of Object.keys(extensionFacets ?? {}).sort(compareStrings)) {
+      rows.push({ facet: `facets.${domainKey}`, value: '', canvasId })
+    }
+  }
+  // Explicit sort (not insertion order) so shuffling the `canvases` input
+  // never changes the derived output — (facet, value, canvasId) is a total
+  // tie-breaker since canvasId is unique per canvas.
+  return rows.sort(
+    (a, b) =>
+      compareStrings(a.facet, b.facet) ||
+      compareStrings(a.value, b.value) ||
+      compareStrings(a.canvasId, b.canvasId),
+  )
+}
+
+/**
+ * Canvas list rows: title falls back from frontmatter `title` to the
+ * canvas's own tree segment (its leaf name, not the full alias path — the
+ * DTO has no alias field, see `deriveAliasResolutionRows`) to `''` when
+ * neither is available (e.g. an orphaned canvas with no tree node).
+ */
+export function deriveCanvasListRows(
+  tree: WorkspaceTree,
+  canvases: readonly CanvasIndexInput[],
+): CanvasListRow[] {
+  const segmentByCanvasId = new Map<string, string>()
+  for (const node of tree.snapshot().nodes) {
+    segmentByCanvasId.set(node.canvasId, node.segment)
+  }
+  const rows = canvases.map((canvas) => ({
+    canvasId: canvas.canvasId,
+    title: canvas.coreFacets?.title ?? segmentByCanvasId.get(canvas.canvasId) ?? '',
+    updatedAtMs: canvas.updatedAtMs,
+  }))
+  return rows.sort((a, b) => compareStrings(a.canvasId, b.canvasId))
+}
+
+/**
+ * Alias resolution rows: current alias (root-to-leaf segment join) -> the
+ * node's canvasId, for every tree node. Uses `WorkspaceTree.resolveAlias`
+ * directly rather than reimplementing the ancestor walk, since
+ * `WorkspaceTreeSnapshot` is a flat node list with no parent pointer.
+ */
+export function deriveAliasResolutionRows(tree: WorkspaceTree): AliasResolutionRow[] {
+  const rows: AliasResolutionRow[] = []
+  for (const node of tree.snapshot().nodes) {
+    const alias = tree.resolveAlias(node.id)
+    if (alias === undefined) continue
+    rows.push({ alias, canvasId: node.canvasId })
+  }
+  return rows.sort((a, b) => compareStrings(a.alias, b.alias))
+}
+
+/**
+ * Backlink rows: reuses `extractBacklinks` (the mdast walk lives there,
+ * once) per canvas and concatenates. No additional cross-doc dedup is
+ * needed beyond `extractBacklinks`' own per-doc dedup — each row's
+ * `fromCanvasId` is that canvas's own ID, so two different source canvases
+ * never produce a colliding (from, to) pair by coincidence.
+ */
+export function deriveBacklinkRows(canvases: readonly CanvasIndexInput[]): BacklinkRow[] {
+  const rows: BacklinkRow[] = []
+  for (const canvas of canvases) {
+    if (canvas.resolvedBody === undefined) continue
+    rows.push(...extractBacklinks(canvas.canvasId, canvas.resolvedBody))
+  }
+  return rows.sort(
+    (a, b) =>
+      compareStrings(a.fromCanvasId, b.fromCanvasId) || compareStrings(a.toCanvasId, b.toCanvasId),
+  )
+}
+
+/**
+ * The workspace tree retains no alias history today — `rename`/`move`
+ * overwrite a node's segment/parent in place with no tombstone of the
+ * previous value. Until the tree gains that tracking, this deriver has no
+ * source data to read and always returns an empty, DTO-typed set.
+ */
+export function deriveAliasHistoryRows(): AliasHistoryRow[] {
+  return []
+}
+
+/** Assembles all five WorkspaceIndex row-sets — the payload 5b-3c's `WorkspaceIndex.applyRows` will consume. */
+export function deriveWorkspaceIndexRows(input: WorkspaceIndexDeriveInput): ApplyRowsInput {
+  const { workspaceId, tree, canvases } = input
+  return {
+    workspaceId,
+    canvasList: deriveCanvasListRows(tree, canvases),
+    facets: deriveFacetIndexRows(canvases),
+    aliases: deriveAliasResolutionRows(tree),
+    backlinks: deriveBacklinkRows(canvases),
+    aliasHistory: deriveAliasHistoryRows(),
+  }
+}

--- a/packages/canvas-workspace/src/index.ts
+++ b/packages/canvas-workspace/src/index.ts
@@ -1,5 +1,14 @@
-export { WorkspaceTree } from './workspace-tree.js'
-export type { WorkspaceNode, WorkspaceTreeSnapshot } from './workspace-tree.js'
 export { createAliasResolver } from './alias-resolver.js'
+export type { CanvasIndexInput, WorkspaceIndexDeriveInput } from './derive-index.js'
+export {
+  deriveAliasHistoryRows,
+  deriveAliasResolutionRows,
+  deriveBacklinkRows,
+  deriveCanvasListRows,
+  deriveFacetIndexRows,
+  deriveWorkspaceIndexRows,
+} from './derive-index.js'
 export { extractBacklinks } from './extract-backlinks.js'
 export { readSpatialCanvas, writeSpatialCanvas } from './loro-bridge.js'
+export type { WorkspaceNode, WorkspaceTreeSnapshot } from './workspace-tree.js'
+export { WorkspaceTree } from './workspace-tree.js'

--- a/packages/canvas-workspace/src/test-utils/fast-check.ts
+++ b/packages/canvas-workspace/src/test-utils/fast-check.ts
@@ -1,0 +1,9 @@
+import { test as fcTest } from '@fast-check/vitest'
+import * as fc from 'fast-check'
+
+export { fc, fcTest }
+
+/** Node-layer properties can afford the library's default numRuns. */
+export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
+  return { numRuns: 200, ...override }
+}

--- a/packages/canvas-workspace/src/test-utils/index-fixtures.ts
+++ b/packages/canvas-workspace/src/test-utils/index-fixtures.ts
@@ -1,0 +1,74 @@
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import { LoroDoc } from 'loro-crdt'
+import type { CanvasIndexInput } from '../derive-index.js'
+import { WorkspaceTree } from '../workspace-tree.js'
+
+export const NOTES_ID = '01J0000000000000000000000A'
+export const PROJECT_ID = '01J0000000000000000000000B'
+export const DIAGRAM_ID = '01J0000000000000000000000C'
+
+/**
+ * Small fixture workspace: a root `notes` canvas (tagged, wikilinks the
+ * nested project doc), a `projects/whiteboard` canvas (has an extension
+ * facet + embeds the diagram), and a `projects/diagram` spatial canvas with
+ * no body to extract links from.
+ */
+export function buildFixtureWorkspace(): {
+  tree: WorkspaceTree
+  canvases: readonly CanvasIndexInput[]
+} {
+  const doc = new LoroDoc()
+  const tree = new WorkspaceTree(doc)
+
+  tree.createNode(NOTES_ID, 'notes')
+  const projectsId = tree.createNode('01J0000000000000000000000D', 'projects')
+  tree.createNode(PROJECT_ID, 'whiteboard', projectsId)
+  tree.createNode(DIAGRAM_ID, 'diagram', projectsId)
+
+  const notesBody: MdastRoot = {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [
+          { type: 'text', value: 'See ' },
+          { type: 'wikiLink', canvasId: PROJECT_ID, alias: 'whiteboard' },
+          { type: 'text', value: '.' },
+        ],
+      },
+    ],
+  }
+
+  const projectBody: MdastRoot = {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [{ type: 'embed', canvasId: DIAGRAM_ID }],
+      },
+    ],
+  }
+
+  const canvases: readonly CanvasIndexInput[] = [
+    {
+      canvasId: NOTES_ID,
+      updatedAtMs: 1_000,
+      coreFacets: { type: 'doc', tags: ['inbox', 'urgent'] },
+      resolvedBody: notesBody,
+    },
+    {
+      canvasId: PROJECT_ID,
+      updatedAtMs: 2_000,
+      coreFacets: { type: 'doc', title: 'Whiteboard Project' },
+      extensionFacets: { 'kanban/1': { columns: ['todo', 'done'] } },
+      resolvedBody: projectBody,
+    },
+    {
+      canvasId: DIAGRAM_ID,
+      updatedAtMs: 3_000,
+      coreFacets: { type: 'spatial' },
+    },
+  ]
+
+  return { tree, canvases }
+}

--- a/packages/canvas-workspace/src/test-utils/index-fixtures.ts
+++ b/packages/canvas-workspace/src/test-utils/index-fixtures.ts
@@ -59,7 +59,7 @@ export function buildFixtureWorkspace(): {
     {
       canvasId: PROJECT_ID,
       updatedAtMs: 2_000,
-      coreFacets: { type: 'doc', title: 'Whiteboard Project' },
+      coreFacets: { type: 'doc', title: 'Whiteboard Project', view: 'kanban/1' },
       extensionFacets: { 'kanban/1': { columns: ['todo', 'done'] } },
       resolvedBody: projectBody,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,12 @@ importers:
         specifier: 'catalog:'
         version: 1.13.6
     devDependencies:
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.1.10)
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.8.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
## What

OpenCanvas slice **5b-3a**: adds the pure **WorkspaceIndex row-derivation** functions to `canvas-workspace` — turning a workspace tree + its canvas docs into the five index row shapes defined by `canvas-ports`. This is the derivation half of canvas-workspace's B-3 (the libSQL `WorkspaceIndex` impl that consumes these is a later mcp-server slice, 5b-3c).

New public surface in `packages/canvas-workspace`:
- `deriveWorkspaceIndexRows(input)` assembler returning `ApplyRowsInput` (workspaceId + the five arrays), plus the five individual derivers.
- Rows: **facet index**, **canvas list**, **alias resolution**, **backlink**, **alias history**.

## Design notes

- Every produced row is typed via a **`canvas-ports` `z.infer` DTO** — no parallel hand-written interface; production code adds no zod runtime import. Tests round-trip every row (and the whole payload) through the matching `canvas-ports` schema `.parse()`.
- **Backlink derivation reuses the existing `extractBacklinks`** (from #319) over resolved mdast — no re-implemented walk; cross-doc concat + dedup preserved.
- **Alias history returns `[]`** (typed `AliasHistoryRow[]`) with a source comment: the tree retains no history yet; the shape is correct so 5b-3c can wire it when history lands.
- **Determinism**: every array is emitted via an explicit sort + documented tie-breaker — no `Object.keys`/`Set`/`Map` iteration order leaks (an order-independence property test guards this).
- Conformed to the **actual** canvas-ports schemas over the ticket prose: `canvasListRow` has no alias-path/format field (alias path lives only in `aliasResolutionRow`).

## Known follow-ons (out of scope, noted)

- Facet-index value encoding is limited by the 2-field `{facet,value}` DTO: extension domains index as existence rows (`value=''`); path-scoped `equals` indexing needs a `path` field on the row DTO — deferred, needs a canvas-ports change if wanted.
- `updatedAtMs` / spatial title are caller-supplied (a pure deriver can't invent them) — 5b-3c wires real mtime.
- Facet-relationship backlinks depend on the issues-v1 schema landing — follow-on.

## Test plan

- [x] `pnpm test --project canvas-workspace-node` (unit + properties: alias-path purity, order-independence, idempotence, backlink dedup, schema round-trip) green
- [x] `pnpm test --project arch-lint-node` — canvas-workspace still passes banned-import + dependency-direction (imports model/codec/ports, not inversify/node:*)
- [x] `pnpm -r typecheck`, `pnpm knip`, `pnpm biome check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace index derivation for facets, canvas listings, aliases, backlinks, and alias history.
  * Added deterministic sorting and aggregation of workspace index data.
  * Exposed the new index derivation capabilities through the package API.

* **Tests**
  * Added comprehensive unit and property-based coverage for index generation, ordering, schemas, fallbacks, and backlink handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->