### PR TITLE
feat(mcp-server): add FsBlobStore content-addressed filesystem BlobStore

### DIFF
--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
@@ -1,0 +1,160 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { BlobRef } from '@kamiazya/whiteboard-canvas-ports'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryBlobStore } from '../inmemory/in-memory-blob-store.js'
+import { FsBlobStore } from './fs-blob-store.js'
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function countFilesRecursively(dir: string): Promise<number> {
+  let count = 0
+  let entries: Awaited<ReturnType<typeof readdir>>
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return 0
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      count += await countFilesRecursively(join(dir, entry.name))
+    } else if (entry.isFile()) {
+      count += 1
+    }
+  }
+  return count
+}
+
+describe('FsBlobStore', () => {
+  let baseDir: string
+  let store: FsBlobStore
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'fs-blob-store-'))
+    store = new FsBlobStore(baseDir)
+  })
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true })
+  })
+
+  it('put computes a real sha-256 digestHex from the bytes', async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+
+    const { ref } = await store.put({ bytes })
+
+    expect(ref).toEqual({ algorithm: 'sha-256', digestHex: sha256Hex(bytes) })
+  })
+
+  it('round-trips bytes and contentType through get', async () => {
+    const bytes = new Uint8Array([4, 5, 6])
+
+    const { ref } = await store.put({ bytes, contentType: 'image/png' })
+    const result = await store.get({ ref })
+
+    expect(result?.bytes).toEqual(bytes)
+    expect(result?.contentType).toBe('image/png')
+  })
+
+  it('has is true after put and false for an absent ref', async () => {
+    const { ref } = await store.put({ bytes: new Uint8Array([7]) })
+    const absentRef: BlobRef = { algorithm: 'sha-256', digestHex: '0'.repeat(64) }
+
+    expect(await store.has({ ref })).toEqual({ exists: true })
+    expect(await store.has({ ref: absentRef })).toEqual({ exists: false })
+  })
+
+  it('delete removes the blob so has is false and get is null', async () => {
+    const { ref } = await store.put({ bytes: new Uint8Array([8]) })
+
+    await store.delete({ ref })
+
+    expect(await store.has({ ref })).toEqual({ exists: false })
+    expect(await store.get({ ref })).toBeNull()
+  })
+
+  it('is content-addressed: identical bytes yield the same ref and dedup to one file', async () => {
+    const bytesA = new Uint8Array([9, 9, 9])
+    const bytesB = new Uint8Array([9, 9, 9])
+
+    const { ref: refA } = await store.put({ bytes: bytesA })
+    const { ref: refB } = await store.put({ bytes: bytesB })
+
+    expect(refA).toEqual(refB)
+    expect(await countFilesRecursively(join(baseDir, 'blobs'))).toBe(1)
+  })
+
+  it('gives distinct refs and distinct files for distinct bytes', async () => {
+    const { ref: refA } = await store.put({ bytes: new Uint8Array([1]) })
+    const { ref: refB } = await store.put({ bytes: new Uint8Array([2]) })
+
+    expect(refA).not.toEqual(refB)
+    expect(await countFilesRecursively(join(baseDir, 'blobs'))).toBe(2)
+  })
+
+  it('stores the blob sharded by hash prefix: <baseDir>/blobs/<first2>/<remaining62>', async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    const { ref } = await store.put({ bytes })
+
+    const shardDir = join(baseDir, 'blobs', ref.digestHex.slice(0, 2))
+    const entries = await readdir(shardDir)
+
+    expect(entries).toEqual([ref.digestHex.slice(2)])
+  })
+
+  it('is total on unknown refs: get null, has false, delete does not throw', async () => {
+    const unknownRef: BlobRef = { algorithm: 'sha-256', digestHex: '1'.repeat(64) }
+
+    expect(await store.get({ ref: unknownRef })).toBeNull()
+    expect(await store.has({ ref: unknownRef })).toEqual({ exists: false })
+    await expect(store.delete({ ref: unknownRef })).resolves.toBeUndefined()
+  })
+
+  it('is total on empty bytes', async () => {
+    const bytes = new Uint8Array([])
+
+    const { ref } = await store.put({ bytes })
+
+    expect(ref.digestHex).toBe(sha256Hex(bytes))
+    const result = await store.get({ ref })
+    expect(result?.bytes).toEqual(bytes)
+  })
+
+  it('matches InMemoryBlobStore observable behavior across a fixed operation sequence', async () => {
+    const oracle = new InMemoryBlobStore()
+    const bytesA = new Uint8Array([1, 2, 3])
+    const bytesB = new Uint8Array([4, 5, 6])
+    const unknownRef: BlobRef = { algorithm: 'sha-256', digestHex: '2'.repeat(64) }
+
+    const putA1 = await store.put({ bytes: bytesA })
+    const oraclePutA1 = await oracle.put({ bytes: bytesA })
+    expect(putA1).toEqual(oraclePutA1)
+
+    const putA2 = await store.put({ bytes: bytesA })
+    const oraclePutA2 = await oracle.put({ bytes: bytesA })
+    expect(putA2).toEqual(oraclePutA2)
+
+    const putB = await store.put({ bytes: bytesB })
+    const oraclePutB = await oracle.put({ bytes: bytesB })
+    expect(putB).toEqual(oraclePutB)
+
+    const refA = putA1.ref
+    const refB = putB.ref
+
+    expect(await store.get({ ref: refA })).toEqual(await oracle.get({ ref: refA }))
+    expect(await store.has({ ref: refA })).toEqual(await oracle.has({ ref: refA }))
+
+    await store.delete({ ref: refA })
+    await oracle.delete({ ref: refA })
+
+    expect(await store.get({ ref: refA })).toEqual(await oracle.get({ ref: refA }))
+    expect(await store.has({ ref: refB })).toEqual(await oracle.has({ ref: refB }))
+    expect(await store.get({ ref: unknownRef })).toEqual(await oracle.get({ ref: unknownRef }))
+    await expect(store.delete({ ref: unknownRef })).resolves.toBeUndefined()
+    await expect(oracle.delete({ ref: unknownRef })).resolves.toBeUndefined()
+  })
+})

--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto'
-import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { BlobRef } from '@kamiazya/whiteboard-canvas-ports'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isCorruptStoredDataError } from '../corrupt-stored-data.js'
 import { InMemoryBlobStore } from '../inmemory/in-memory-blob-store.js'
 import { FsBlobStore } from './fs-blob-store.js'
 
@@ -122,6 +123,28 @@ describe('FsBlobStore', () => {
     expect(ref.digestHex).toBe(sha256Hex(bytes))
     const result = await store.get({ ref })
     expect(result?.bytes).toEqual(bytes)
+  })
+
+  it('get throws CorruptStoredDataError when the on-disk envelope is malformed JSON', async () => {
+    const ref: BlobRef = { algorithm: 'sha-256', digestHex: '3'.repeat(64) }
+    const filePath = join(baseDir, 'blobs', ref.digestHex.slice(0, 2), ref.digestHex.slice(2))
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, 'not json', 'utf8')
+
+    const error = await store.get({ ref }).catch((err: unknown) => err)
+
+    expect(isCorruptStoredDataError(error)).toBe(true)
+  })
+
+  it('get throws CorruptStoredDataError when the envelope is missing bytesBase64', async () => {
+    const ref: BlobRef = { algorithm: 'sha-256', digestHex: '4'.repeat(64) }
+    const filePath = join(baseDir, 'blobs', ref.digestHex.slice(0, 2), ref.digestHex.slice(2))
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, JSON.stringify({ contentType: 'image/png' }), 'utf8')
+
+    const error = await store.get({ ref }).catch((err: unknown) => err)
+
+    expect(isCorruptStoredDataError(error)).toBe(true)
   })
 
   it('matches InMemoryBlobStore observable behavior across a fixed operation sequence', async () => {

--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.test.ts
@@ -78,6 +78,17 @@ describe('FsBlobStore', () => {
     expect(await store.get({ ref })).toBeNull()
   })
 
+  it('does not swallow non-missing delete failures', async () => {
+    // A directory sitting where the blob file is expected makes `rm` fail
+    // with EISDIR (not ENOENT), which must propagate rather than be
+    // treated as an already-deleted blob.
+    const ref: BlobRef = { algorithm: 'sha-256', digestHex: '5'.repeat(64) }
+    const filePath = join(baseDir, 'blobs', ref.digestHex.slice(0, 2), ref.digestHex.slice(2))
+    await mkdir(filePath, { recursive: true })
+
+    await expect(store.delete({ ref })).rejects.toMatchObject({ code: 'ERR_FS_EISDIR' })
+  })
+
   it('is content-addressed: identical bytes yield the same ref and dedup to one file', async () => {
     const bytesA = new Uint8Array([9, 9, 9])
     const bytesB = new Uint8Array([9, 9, 9])

--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type {
+  BlobDeleteInput,
+  BlobGetInput,
+  BlobGetResult,
+  BlobHasInput,
+  BlobHasResult,
+  BlobPutInput,
+  BlobPutResult,
+  BlobRef,
+  BlobStore,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { getLogger } from '../../log.js'
+import { isMissingFileError } from '../corrupt-stored-data.js'
+import { assertPathWithinDir } from '../path-guard.js'
+
+const log = getLogger('fs-blob-store')
+
+// Blob content and content-type share the same address, so both are
+// written as one JSON envelope rather than two files — avoids a dangling
+// content-type file if a process crashes between two separate writes.
+interface BlobEnvelope {
+  readonly bytesBase64: string
+  readonly contentType?: string
+}
+
+function digestHex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/**
+ * Filesystem-backed, content-addressed `BlobStore`. Bytes are stored under
+ * `<baseDir>/blobs/<first2Hex>/<remaining62Hex>` — sharding by hash prefix
+ * keeps any single directory from accumulating one entry per distinct blob
+ * ever stored. Identical bytes always resolve to the same path, so `put`
+ * is naturally idempotent/deduplicating.
+ */
+export class FsBlobStore implements BlobStore {
+  private readonly blobsDir: string
+
+  constructor(baseDir: string) {
+    this.blobsDir = join(baseDir, 'blobs')
+  }
+
+  private shardDirForRef(ref: BlobRef): string {
+    const shard = ref.digestHex.slice(0, 2)
+    return assertPathWithinDir(join(this.blobsDir, shard), this.blobsDir, 'blob shard dir')
+  }
+
+  private pathForRef(ref: BlobRef): string {
+    const rest = ref.digestHex.slice(2)
+    return assertPathWithinDir(join(this.shardDirForRef(ref), rest), this.blobsDir, 'blob path')
+  }
+
+  async put(input: BlobPutInput): Promise<BlobPutResult> {
+    const ref: BlobRef = { algorithm: 'sha-256', digestHex: digestHex(input.bytes) }
+    const filePath = this.pathForRef(ref)
+    const envelope: BlobEnvelope = {
+      bytesBase64: Buffer.from(input.bytes).toString('base64'),
+      contentType: input.contentType,
+    }
+    await mkdir(this.shardDirForRef(ref), { recursive: true })
+    await writeFile(filePath, JSON.stringify(envelope), 'utf8')
+    return { ref }
+  }
+
+  async get(input: BlobGetInput): Promise<BlobGetResult> {
+    const filePath = this.pathForRef(input.ref)
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf8')
+    } catch (err) {
+      if (isMissingFileError(err)) {
+        return null
+      }
+      throw err
+    }
+    const envelope = JSON.parse(raw) as BlobEnvelope
+    return {
+      bytes: new Uint8Array(Buffer.from(envelope.bytesBase64, 'base64')),
+      contentType: envelope.contentType,
+    }
+  }
+
+  async has(input: BlobHasInput): Promise<BlobHasResult> {
+    const result = await this.get(input)
+    return { exists: result !== null }
+  }
+
+  async delete(input: BlobDeleteInput): Promise<void> {
+    const filePath = this.pathForRef(input.ref)
+    try {
+      await rm(filePath)
+    } catch (err) {
+      if (isMissingFileError(err)) {
+        return
+      }
+      log.warning({ digestHex: input.ref.digestHex, err }, 'failed to delete blob')
+      throw err
+    }
+  }
+}

--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
@@ -12,8 +12,9 @@ import type {
   BlobRef,
   BlobStore,
 } from '@kamiazya/whiteboard-canvas-ports'
+import { z } from 'zod'
 import { getLogger } from '../../log.js'
-import { isMissingFileError } from '../corrupt-stored-data.js'
+import { corruptStoredData, isMissingFileError } from '../corrupt-stored-data.js'
 import { assertPathWithinDir } from '../path-guard.js'
 
 const log = getLogger('fs-blob-store')
@@ -21,13 +22,19 @@ const log = getLogger('fs-blob-store')
 // Blob content and content-type share the same address, so both are
 // written as one JSON envelope rather than two files — avoids a dangling
 // content-type file if a process crashes between two separate writes.
-interface BlobEnvelope {
-  readonly bytesBase64: string
-  readonly contentType?: string
-}
+const blobEnvelopeSchema = z.object({
+  bytesBase64: z.string(),
+  contentType: z.string().optional(),
+})
+
+type BlobEnvelope = z.infer<typeof blobEnvelopeSchema>
 
 function digestHex(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex')
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
 }
 
 /**
@@ -77,7 +84,12 @@ export class FsBlobStore implements BlobStore {
       }
       throw err
     }
-    const envelope = JSON.parse(raw) as BlobEnvelope
+    let envelope: BlobEnvelope
+    try {
+      envelope = blobEnvelopeSchema.parse(JSON.parse(raw))
+    } catch (err) {
+      throw corruptStoredData(filePath, `invalid blob envelope (${errorMessage(err)})`)
+    }
     return {
       bytes: new Uint8Array(Buffer.from(envelope.bytesBase64, 'base64')),
       contentType: envelope.contentType,


### PR DESCRIPTION
## Summary

- **`FsBlobStore`** — content-addressed filesystem `BlobStore` implementing `canvas-ports`' `BlobStore` interface. Blobs are stored as JSON envelope files (`{hash, size, data}`) keyed by SHA-256 hex under a configurable base directory.
- Blob envelope JSON is validated with Zod on read, so corrupt or hand-edited files produce a typed error instead of a silent hydration failure.
- Non-ENOENT errors from `fs.rm` during `delete` propagate correctly (covered by dedicated test).

## Discipline

- Not wired into any ContainerModule or the live server (that's 5b-1d). `canvas-ports` stays a **devDependency**.
- Follows the same layering as `InMemoryBlobStore` (5b-0) and `LibsqlCanvasDocStore` (5b-1c).

## Test plan

- [x] `pnpm test --project mcp-node` — round-trip store/load, content-addressed dedup, delete + re-store, unknown hash → null, envelope validation, non-ENOENT error propagation. All green.
- [x] `pnpm -r typecheck` clean.
