### PR TITLE
chore: modernize Dockerfile.server with 4-stage build and pnpm fetch

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -37,6 +37,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # corepack reads the pnpm version from root package.json's packageManager
 # field — no hardcoded version here.
+ENV CI=true
 RUN corepack enable
 WORKDIR /workspace
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,11 @@
-# syntax=docker/dockerfile:1.4
-#
 # Server-mode image for whiteboard.
+#
+# Stages: base → fetched → build → runtime
+#
+#   base    — Node + pnpm via corepack
+#   fetched — populate the pnpm store from the lockfile (cache-friendly)
+#   build   — install deps, build widget + TypeScript, self-contained deploy
+#   runtime — minimal image with the deploy bundle
 #
 # Runs `whiteboard server run --json` — the OAuth/JWT resource-server path.
 # This image does NOT run the local daemon (`whiteboard daemon run`) and
@@ -21,85 +26,72 @@
 #   WHITEBOARD_SERVER_ALLOWED_ORIGINS  https://whiteboard.example.com
 #
 # Persistent data: mount a volume at /data (WHITEBOARD_DATA_DIR default).
+#
+# NODE_VERSION: single source of truth is `.node-version`. Callers pass the
+# value via --build-arg (no default — fails explicitly if unset).
 
 
-# ── Stage 1: build ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS build
+# ── base — common foundation ───────────────────────────────────────────────
+ARG NODE_VERSION
+FROM node:${NODE_VERSION}-alpine AS base
 
-ENV CI=true
-RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
-
+# corepack reads the pnpm version from root package.json's packageManager
+# field — no hardcoded version here.
+RUN corepack enable
 WORKDIR /workspace
 
-# Install dependencies before copying source (cache-friendly layer order).
-# Every workspace package.json must be present so pnpm can resolve the full
-# workspace graph from the lockfile — a partial set causes resolution failures
-# for transitive deps (e.g. canvas-ports' zod) because pnpm cannot reconcile
-# the lockfile against a workspace where some packages are missing.
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/mcp-server/package.json packages/mcp-server/
-COPY packages/canvas-viewer/package.json packages/canvas-viewer/
-COPY packages/canvas-ports/package.json packages/canvas-ports/
-COPY packages/canvas-model/package.json packages/canvas-model/
-COPY packages/canvas-codec/package.json packages/canvas-codec/
-COPY packages/canvas-render/package.json packages/canvas-render/
-COPY packages/canvas-workspace/package.json packages/canvas-workspace/
-COPY apps/web/package.json apps/web/
-COPY tools/arch-lint/package.json tools/arch-lint/
-COPY tools/checks/package.json tools/checks/
-# GVS (enableGlobalVirtualStore) assumes a persistent global store that
-# survives across installs; inside an ephemeral Docker build layer there is
-# none, so symlinks into the store dangle and workspace deps like zod go
-# unresolved. Disable it for the build.
-RUN pnpm install --frozen-lockfile --config.enable-global-virtual-store=false
 
-# Build the self-contained canvas widget, then compile TypeScript (whose
-# build step copies the widget bundle into mcp-server/dist). canvas-ports and
-# canvas-model are source-only (no build step) — copying their source is
-# enough for mcp-server's tsc to compile against them.
-COPY packages/canvas-viewer/ packages/canvas-viewer/
+# ── fetched — populate the pnpm store from the lockfile ────────────────────
+FROM base AS fetched
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm fetch --store-dir /pnpm/store
+
+
+# ── build — install + compile + deploy bundle ──────────────────────────────
+FROM fetched AS build
+
+# .dockerignore controls the context — adding a new workspace package
+# needs no Dockerfile edit.
+COPY . .
+
+# GVS (enableGlobalVirtualStore) assumes a persistent global store that
+# survives across installs; inside an ephemeral Docker build layer there
+# is none, so symlinks into the store dangle. Disable it for the build.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --offline --frozen-lockfile \
+      --store-dir /pnpm/store \
+      --config.enable-global-virtual-store=false
+
 RUN pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
-COPY packages/canvas-model/ packages/canvas-model/
-COPY packages/canvas-ports/ packages/canvas-ports/
-COPY packages/mcp-server/ packages/mcp-server/
 RUN pnpm --filter @kamiazya/whiteboard-mcp build
 
-# Produce a self-contained production bundle (no devDependencies, no workspace
-# symlinks) suitable for copying into the runtime stage.
-# --legacy is required by pnpm v10+ when inject-workspace-packages is not set.
+# Self-contained production bundle (no devDependencies, no workspace
+# symlinks). --legacy is required by pnpm v10+ without
+# inject-workspace-packages.
 RUN pnpm --filter @kamiazya/whiteboard-mcp deploy --legacy /deploy
 
 
-# ── Stage 2: runtime ───────────────────────────────────────────────────────
-FROM node:22-alpine AS runtime
+# ── runtime — final server image ──────────────────────────────────────────
+FROM node:${NODE_VERSION}-alpine AS runtime
 
-# Non-root application user (UID/GID 1001).
 RUN addgroup -S -g 1001 whiteboard \
  && adduser  -S -u 1001 -G whiteboard -H whiteboard
 
 WORKDIR /app
 
-# Copy self-contained production bundle from the build stage.
 COPY --from=build /deploy .
 
-# Persistent data directory. Mount a volume here to survive container restarts.
-# The server writes its record file and SQLite database under this directory.
 RUN mkdir -p /data && chown whiteboard:whiteboard /data
 VOLUME /data
 
-# WHITEBOARD_DATA_DIR defaults to /data; override by passing a different value
-# at run time. WHITEBOARD_SERVER_PORT sets the bind port.
-# All WHITEBOARD_SERVER_* auth/config vars MUST be supplied at run time —
-# they are intentionally absent here so no credential is baked into the image.
 ENV WHITEBOARD_DATA_DIR=/data \
     WHITEBOARD_SERVER_PORT=3099
 
 EXPOSE 3099
 
-# Healthcheck: poll /api/runtime/ping (public endpoint, response: {ok:true,pid}).
-# Uses the embedded Node.js binary so no extra tools are required.
-# Does NOT use `whiteboard server doctor` to avoid marking the container
-# unhealthy during transient IdP/JWKS outages that do not affect request serving.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD node -e "require('http').get({hostname:'127.0.0.1',port:+(process.env.WHITEBOARD_SERVER_PORT||3099),path:'/api/runtime/ping'},function(r){var d='';r.on('data',function(c){d+=c});r.on('end',function(){try{process.exit(JSON.parse(d).ok===true?0:1)}catch(e){process.exit(1)}})}).on('error',function(){process.exit(1)})"
 

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -5,7 +5,7 @@
 // Output: structured JSON summary to stdout on success; generic message to
 // stderr and exit 1 on failure. Full build logs never reach stdout.
 
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
@@ -40,6 +40,9 @@ mkdirSync(OUT_DIR, { recursive: true })
 // dependency-install and compile layers survive between runs (the plain
 // `docker build` engine and the ACTIONS_CACHE_URL credentials it needs are
 // only available inside a runner, not on a local dev machine).
+// Read NODE_VERSION from .node-version (single source of truth).
+const nodeVersion = readFileSync(join(REPO_ROOT, '.node-version'), 'utf-8').trim()
+
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
 const buildArgs = isGitHubActions
   ? [
@@ -50,6 +53,8 @@ const buildArgs = isGitHubActions
       '--cache-to',
       'type=gha,mode=max',
       '--load',
+      '--build-arg',
+      `NODE_VERSION=${nodeVersion}`,
       '-f',
       DOCKERFILE,
       '-t',
@@ -57,7 +62,17 @@ const buildArgs = isGitHubActions
       '--progress=plain',
       '.',
     ]
-  : ['build', '-f', DOCKERFILE, '-t', IMAGE_TAG, '--progress=plain', '.']
+  : [
+      'build',
+      '--build-arg',
+      `NODE_VERSION=${nodeVersion}`,
+      '-f',
+      DOCKERFILE,
+      '-t',
+      IMAGE_TAG,
+      '--progress=plain',
+      '.',
+    ]
 
 const buildResult = spawnSync('docker', buildArgs, {
   cwd: REPO_ROOT,


### PR DESCRIPTION
## Summary

- Refactor Dockerfile.server from 2-stage to 4-stage pattern: `base → fetched → build → runtime`
- Use `ARG NODE_VERSION` from `.node-version` instead of hardcoded `node:22-alpine`
- Use `corepack enable` (reads `packageManager` from package.json) instead of hardcoded `pnpm@11.12.0`
- Use `pnpm fetch` + `--mount=type=cache` to populate pnpm store from lockfile alone (cache-friendly)
- Use `pnpm install --offline` to reuse cached store without network access
- Replace 10 individual `COPY packages/*/package.json` lines with `COPY . .` (`.dockerignore` controls context)
- Update `publish-dry-run-docker.mjs` to pass `--build-arg NODE_VERSION` from `.node-version`

Adding a new workspace package no longer requires editing the Dockerfile.

## Test plan

- [ ] CI `dry-run-docker` passes (the real verification — local Docker daemon is not running)
- [ ] CI `verify` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Deployment**
  * Improved Docker image builds with faster dependency caching and a streamlined production bundle.
  * Docker builds now automatically use the repository’s specified Node.js version.
  * Runtime containers continue to run as a non-root user and expose the server on port 3099.
* **Release Tooling**
  * Dry-run image publishing now applies the configured Node.js version consistently across supported Docker build methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->