### PR TITLE
feat(mcp-server): add LibsqlWorkspaceIndex with migration and tests

### DIFF
--- a/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.test.ts
@@ -23,26 +23,47 @@ async function tableExists(db: Kysely<DatabaseSchema>, name: string): Promise<bo
   return row.rows.length > 0
 }
 
+async function indexExists(db: Kysely<DatabaseSchema>, name: string): Promise<boolean> {
+  const row = await sql<{
+    name: string
+  }>`select name from sqlite_master where type = 'index' and name = ${name}`.execute(db)
+  return row.rows.length > 0
+}
+
+const TABLES = [
+  'workspaceIndexCanvasList',
+  'workspaceIndexFacets',
+  'workspaceIndexAliases',
+  'workspaceIndexBacklinks',
+  'workspaceIndexAliasHistory',
+]
+
+// One lookup index per workspace-scoped table that queryFacet/listBacklinks/
+// alias resolution rely on for non-scan lookups (workspaceIndexCanvasList has
+// no dedicated lookup index — it is read in full per workspace).
+const LOOKUP_INDEXES = [
+  'workspaceIndexFacets_lookup',
+  'workspaceIndexAliases_lookup',
+  'workspaceIndexBacklinks_lookup',
+  'workspaceIndexAliasHistory_lookup',
+]
+
 describe('0004-workspace-index migration', () => {
-  it('up creates all five tables; down drops them', async () => {
+  it('up creates all five tables and their lookup indexes; down drops the tables', async () => {
     const db = await createMemoryDb()
-    const tables = [
-      'workspaceIndexCanvasList',
-      'workspaceIndexFacets',
-      'workspaceIndexAliases',
-      'workspaceIndexBacklinks',
-      'workspaceIndexAliasHistory',
-    ]
     try {
       await migration.up(db as unknown as Kysely<unknown>)
 
-      for (const table of tables) {
+      for (const table of TABLES) {
         expect(await tableExists(db, table)).toBe(true)
+      }
+      for (const index of LOOKUP_INDEXES) {
+        expect(await indexExists(db, index)).toBe(true)
       }
 
       await migration.down(db as unknown as Kysely<unknown>)
 
-      for (const table of tables) {
+      for (const table of TABLES) {
         expect(await tableExists(db, table)).toBe(false)
       }
     } finally {

--- a/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.test.ts
@@ -1,0 +1,52 @@
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { describe, expect, it } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+import { migration } from './0004-workspace-index.js'
+
+async function createMemoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  return db
+}
+
+async function tableExists(db: Kysely<DatabaseSchema>, name: string): Promise<boolean> {
+  const row = await sql<{
+    name: string
+  }>`select name from sqlite_master where type = 'table' and name = ${name}`.execute(db)
+  return row.rows.length > 0
+}
+
+describe('0004-workspace-index migration', () => {
+  it('up creates all five tables; down drops them', async () => {
+    const db = await createMemoryDb()
+    const tables = [
+      'workspaceIndexCanvasList',
+      'workspaceIndexFacets',
+      'workspaceIndexAliases',
+      'workspaceIndexBacklinks',
+      'workspaceIndexAliasHistory',
+    ]
+    try {
+      await migration.up(db as unknown as Kysely<unknown>)
+
+      for (const table of tables) {
+        expect(await tableExists(db, table)).toBe(true)
+      }
+
+      await migration.down(db as unknown as Kysely<unknown>)
+
+      for (const table of tables) {
+        expect(await tableExists(db, table)).toBe(false)
+      }
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0004-workspace-index.ts
@@ -1,0 +1,94 @@
+import type { Kysely, Migration } from 'kysely'
+
+// Backing store for canvas-ports' WorkspaceIndex: five workspace-scoped
+// tables (canvas list, facets, aliases, backlinks, alias history), each
+// carrying `workspaceId` as its isolation key so one index can safely back
+// many workspaces (see canvas-ports' WorkspaceIndex doc comment).
+//
+// `seq` records each row's position within the array the owning `applyRows`
+// call received for that table. InMemoryWorkspaceIndex's read methods
+// (`.find()`, `.filter()`) return results in that same array order, so every
+// query here orders by `seq asc` to stay observationally identical to it —
+// this is what the parity test asserts.
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+      .createTable('workspaceIndexCanvasList')
+      .addColumn('workspaceId', 'text', (c) => c.notNull())
+      .addColumn('seq', 'integer', (c) => c.notNull())
+      .addColumn('canvasId', 'text', (c) => c.notNull())
+      .addColumn('title', 'text', (c) => c.notNull())
+      .addColumn('updatedAtMs', 'integer', (c) => c.notNull())
+      .addPrimaryKeyConstraint('workspaceIndexCanvasList_pk', ['workspaceId', 'seq'])
+      .execute()
+
+    await db.schema
+      .createTable('workspaceIndexFacets')
+      .addColumn('workspaceId', 'text', (c) => c.notNull())
+      .addColumn('seq', 'integer', (c) => c.notNull())
+      .addColumn('facet', 'text', (c) => c.notNull())
+      .addColumn('value', 'text', (c) => c.notNull())
+      .addColumn('canvasId', 'text', (c) => c.notNull())
+      .addPrimaryKeyConstraint('workspaceIndexFacets_pk', ['workspaceId', 'seq'])
+      .execute()
+    // Backs queryFacet's exact (workspaceId, facet, value) lookup — without
+    // this the query degrades to a full table scan per call.
+    await db.schema
+      .createIndex('workspaceIndexFacets_lookup')
+      .on('workspaceIndexFacets')
+      .columns(['workspaceId', 'facet', 'value'])
+      .execute()
+
+    await db.schema
+      .createTable('workspaceIndexAliases')
+      .addColumn('workspaceId', 'text', (c) => c.notNull())
+      .addColumn('seq', 'integer', (c) => c.notNull())
+      .addColumn('alias', 'text', (c) => c.notNull())
+      .addColumn('canvasId', 'text', (c) => c.notNull())
+      .addPrimaryKeyConstraint('workspaceIndexAliases_pk', ['workspaceId', 'seq'])
+      .execute()
+    await db.schema
+      .createIndex('workspaceIndexAliases_lookup')
+      .on('workspaceIndexAliases')
+      .columns(['workspaceId', 'alias'])
+      .execute()
+
+    await db.schema
+      .createTable('workspaceIndexBacklinks')
+      .addColumn('workspaceId', 'text', (c) => c.notNull())
+      .addColumn('seq', 'integer', (c) => c.notNull())
+      .addColumn('fromCanvasId', 'text', (c) => c.notNull())
+      .addColumn('toCanvasId', 'text', (c) => c.notNull())
+      .addPrimaryKeyConstraint('workspaceIndexBacklinks_pk', ['workspaceId', 'seq'])
+      .execute()
+    // Backs listBacklinks' exact (workspaceId, toCanvasId) lookup.
+    await db.schema
+      .createIndex('workspaceIndexBacklinks_lookup')
+      .on('workspaceIndexBacklinks')
+      .columns(['workspaceId', 'toCanvasId'])
+      .execute()
+
+    await db.schema
+      .createTable('workspaceIndexAliasHistory')
+      .addColumn('workspaceId', 'text', (c) => c.notNull())
+      .addColumn('seq', 'integer', (c) => c.notNull())
+      .addColumn('alias', 'text', (c) => c.notNull())
+      .addColumn('canvasId', 'text', (c) => c.notNull())
+      .addColumn('retiredAtMs', 'integer', (c) => c.notNull())
+      .addPrimaryKeyConstraint('workspaceIndexAliasHistory_pk', ['workspaceId', 'seq'])
+      .execute()
+    await db.schema
+      .createIndex('workspaceIndexAliasHistory_lookup')
+      .on('workspaceIndexAliasHistory')
+      .columns(['workspaceId', 'alias'])
+      .execute()
+  },
+
+  async down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.dropTable('workspaceIndexAliasHistory').execute()
+    await db.schema.dropTable('workspaceIndexBacklinks').execute()
+    await db.schema.dropTable('workspaceIndexAliases').execute()
+    await db.schema.dropTable('workspaceIndexFacets').execute()
+    await db.schema.dropTable('workspaceIndexCanvasList').execute()
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -2,6 +2,7 @@ import type { Migration } from 'kysely'
 import { migration as init } from './0001-init.js'
 import { migration as canvasesLastCompactedAt } from './0002-canvases-last-compacted-at.js'
 import { migration as canvasDocStore } from './0003-canvas-doc-store.js'
+import { migration as workspaceIndex } from './0004-workspace-index.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0002-canvases-last-compacted-at is a no-op kept only so databases created by the
@@ -10,4 +11,5 @@ export const migrations: Record<string, Migration> = {
   '0001-init': init,
   '0002-canvases-last-compacted-at': canvasesLastCompactedAt,
   '0003-canvas-doc-store': canvasDocStore,
+  '0004-workspace-index': workspaceIndex,
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -14,4 +14,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0001-init',
   '0002-canvases-last-compacted-at',
   '0003-canvas-doc-store',
+  '0004-workspace-index',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/db/schema.ts
+++ b/packages/mcp-server/src/server/store/db/schema.ts
@@ -101,6 +101,50 @@ interface CanvasDocFrontiersTable {
   frontier: Uint8Array
 }
 
+// Five WorkspaceIndex-backing tables (canvas-ports' WorkspaceIndex port).
+// `seq` is each row's position within the array its owning `applyRows` call
+// received for that table — every query orders by it so results stay
+// observationally identical to InMemoryWorkspaceIndex's array-order
+// `.find()`/`.filter()` semantics (see 0004-workspace-index.ts).
+
+interface WorkspaceIndexCanvasListTable {
+  workspaceId: string
+  seq: number
+  canvasId: string
+  title: string
+  updatedAtMs: number
+}
+
+interface WorkspaceIndexFacetsTable {
+  workspaceId: string
+  seq: number
+  facet: string
+  value: string
+  canvasId: string
+}
+
+interface WorkspaceIndexAliasesTable {
+  workspaceId: string
+  seq: number
+  alias: string
+  canvasId: string
+}
+
+interface WorkspaceIndexBacklinksTable {
+  workspaceId: string
+  seq: number
+  fromCanvasId: string
+  toCanvasId: string
+}
+
+interface WorkspaceIndexAliasHistoryTable {
+  workspaceId: string
+  seq: number
+  alias: string
+  canvasId: string
+  retiredAtMs: number
+}
+
 export interface DatabaseSchema {
   workspaces: WorkspacesTable
   canvases: CanvasesTable
@@ -111,4 +155,9 @@ export interface DatabaseSchema {
   canvasDocSnapshotChunks: CanvasDocSnapshotChunksTable
   canvasDocDeltas: CanvasDocDeltasTable
   canvasDocFrontiers: CanvasDocFrontiersTable
+  workspaceIndexCanvasList: WorkspaceIndexCanvasListTable
+  workspaceIndexFacets: WorkspaceIndexFacetsTable
+  workspaceIndexAliases: WorkspaceIndexAliasesTable
+  workspaceIndexBacklinks: WorkspaceIndexBacklinksTable
+  workspaceIndexAliasHistory: WorkspaceIndexAliasHistoryTable
 }

--- a/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.parity.test.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.parity.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type {
+  AliasHistoryRow,
+  AliasResolutionRow,
+  BacklinkRow,
+  CanvasListRow,
+  FacetIndexRow,
+  WorkspaceIndex,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { describe, expect } from 'vitest'
+import { fc, fcTest } from '../../../shared/test-utils/fast-check.js'
+import { createIsolatedDb } from '../db/test-helpers.js'
+import { InMemoryWorkspaceIndex } from '../inmemory/in-memory-workspace-index.js'
+import { LibsqlWorkspaceIndex } from './libsql-workspace-index.js'
+
+// Small fixed pool so applyOps/readOps generate collisions (overlapping
+// aliases/facets/canvasIds/workspaces) often enough to exercise replace and
+// isolation semantics, not just always-distinct rows.
+const WORKSPACE_IDS = ['workspace-a', 'workspace-b'] as const
+const CANVAS_IDS = ['canvas-1', 'canvas-2', 'canvas-3'] as const
+const ALIASES = ['home', 'about'] as const
+const FACETS = ['kind'] as const
+const FACET_VALUES = ['note', 'diagram'] as const
+
+type ApplyRowsOp = {
+  type: 'applyRows'
+  workspaceId: (typeof WORKSPACE_IDS)[number]
+  canvasList: CanvasListRow[]
+  facets: FacetIndexRow[]
+  aliases: AliasResolutionRow[]
+  backlinks: BacklinkRow[]
+  aliasHistory: AliasHistoryRow[]
+}
+
+type ReadOp =
+  | { type: 'resolveAlias'; workspaceId: (typeof WORKSPACE_IDS)[number]; alias: string }
+  | { type: 'resolveAliasHistory'; workspaceId: (typeof WORKSPACE_IDS)[number]; alias: string }
+  | {
+      type: 'listCanvases'
+      workspaceId: (typeof WORKSPACE_IDS)[number]
+      limit?: number
+      offset?: number
+    }
+  | {
+      type: 'queryFacet'
+      workspaceId: (typeof WORKSPACE_IDS)[number]
+      facet: string
+      value: string
+    }
+  | { type: 'listBacklinks'; workspaceId: (typeof WORKSPACE_IDS)[number]; toCanvasId: string }
+
+type Op = ApplyRowsOp | ReadOp
+
+async function applyOp(index: WorkspaceIndex, op: Op): Promise<unknown> {
+  switch (op.type) {
+    case 'applyRows':
+      await index.applyRows(op)
+      return undefined
+    case 'resolveAlias':
+      return index.resolveAlias({ workspaceId: op.workspaceId, alias: op.alias })
+    case 'resolveAliasHistory':
+      return index.resolveAliasHistory({ workspaceId: op.workspaceId, alias: op.alias })
+    case 'listCanvases':
+      return index.listCanvases({
+        workspaceId: op.workspaceId,
+        limit: op.limit,
+        offset: op.offset,
+      })
+    case 'queryFacet':
+      return index.queryFacet({ workspaceId: op.workspaceId, facet: op.facet, value: op.value })
+    case 'listBacklinks':
+      return index.listBacklinks({ workspaceId: op.workspaceId, toCanvasId: op.toCanvasId })
+  }
+}
+
+const workspaceIdArb = fc.constantFrom(...WORKSPACE_IDS)
+const canvasIdArb = fc.constantFrom(...CANVAS_IDS)
+const aliasArb = fc.constantFrom(...ALIASES)
+const facetArb = fc.constantFrom(...FACETS)
+const facetValueArb = fc.constantFrom(...FACET_VALUES)
+
+const canvasListRowArb: fc.Arbitrary<CanvasListRow> = fc.record({
+  canvasId: canvasIdArb,
+  title: fc.string({ maxLength: 10 }),
+  updatedAtMs: fc.integer({ min: 0, max: 1_000_000 }),
+})
+
+const facetRowArb: fc.Arbitrary<FacetIndexRow> = fc.record({
+  facet: facetArb,
+  value: facetValueArb,
+  canvasId: canvasIdArb,
+})
+
+const aliasRowArb: fc.Arbitrary<AliasResolutionRow> = fc.record({
+  alias: aliasArb,
+  canvasId: canvasIdArb,
+})
+
+const backlinkRowArb: fc.Arbitrary<BacklinkRow> = fc.record({
+  fromCanvasId: canvasIdArb,
+  toCanvasId: canvasIdArb,
+})
+
+const aliasHistoryRowArb: fc.Arbitrary<AliasHistoryRow> = fc.record({
+  alias: aliasArb,
+  canvasId: canvasIdArb,
+  retiredAtMs: fc.integer({ min: 0, max: 1_000_000 }),
+})
+
+const applyRowsOpArb: fc.Arbitrary<ApplyRowsOp> = fc.record({
+  type: fc.constant('applyRows' as const),
+  workspaceId: workspaceIdArb,
+  canvasList: fc.array(canvasListRowArb, { maxLength: 4 }),
+  facets: fc.array(facetRowArb, { maxLength: 4 }),
+  aliases: fc.array(aliasRowArb, { maxLength: 4 }),
+  backlinks: fc.array(backlinkRowArb, { maxLength: 4 }),
+  aliasHistory: fc.array(aliasHistoryRowArb, { maxLength: 4 }),
+})
+
+const readOpArb: fc.Arbitrary<ReadOp> = fc.oneof(
+  fc.record({
+    type: fc.constant('resolveAlias' as const),
+    workspaceId: workspaceIdArb,
+    alias: aliasArb,
+  }),
+  fc.record({
+    type: fc.constant('resolveAliasHistory' as const),
+    workspaceId: workspaceIdArb,
+    alias: aliasArb,
+  }),
+  fc.record({
+    type: fc.constant('listCanvases' as const),
+    workspaceId: workspaceIdArb,
+    limit: fc.option(fc.integer({ min: 1, max: 3 }), { nil: undefined }),
+    offset: fc.option(fc.integer({ min: 0, max: 3 }), { nil: undefined }),
+  }),
+  fc.record({
+    type: fc.constant('queryFacet' as const),
+    workspaceId: workspaceIdArb,
+    facet: facetArb,
+    value: facetValueArb,
+  }),
+  fc.record({
+    type: fc.constant('listBacklinks' as const),
+    workspaceId: workspaceIdArb,
+    toCanvasId: canvasIdArb,
+  }),
+)
+
+const opArb: fc.Arbitrary<Op> = fc.oneof(
+  { arbitrary: applyRowsOpArb, weight: 2 },
+  { arbitrary: readOpArb, weight: 3 },
+)
+
+describe('LibsqlWorkspaceIndex / InMemoryWorkspaceIndex observational parity', () => {
+  // Each property run gets its own fresh isolated DB (created/disposed inside
+  // the property body) so one run's rows never leak into the next.
+  fcTest.prop([fc.array(opArb, { maxLength: 15 })], { numRuns: 20 })(
+    'produce identical results for every step of a random op sequence',
+    async (ops) => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-libsql-workspace-index-parity-'))
+      const handle = await createIsolatedDb({ dataDir: tempDir })
+      try {
+        const inMemory = new InMemoryWorkspaceIndex()
+        const libsql = new LibsqlWorkspaceIndex(handle.db)
+
+        for (const op of ops) {
+          const [inMemoryResult, libsqlResult] = await Promise.all([
+            applyOp(inMemory, op),
+            applyOp(libsql, op),
+          ])
+          expect(libsqlResult).toEqual(inMemoryResult)
+        }
+      } finally {
+        await handle.dispose()
+        await rm(tempDir, { recursive: true, force: true })
+      }
+    },
+  )
+})

--- a/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.test.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.test.ts
@@ -1,0 +1,299 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ApplyRowsInput } from '@kamiazya/whiteboard-canvas-ports'
+import { sql } from 'kysely'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createIsolatedDb } from '../db/test-helpers.js'
+import { LibsqlWorkspaceIndex } from './libsql-workspace-index.js'
+
+function emptyInput(workspaceId: string): ApplyRowsInput {
+  return {
+    workspaceId,
+    canvasList: [],
+    facets: [],
+    aliases: [],
+    backlinks: [],
+    aliasHistory: [],
+  }
+}
+
+let tempDir: string
+let handle: Awaited<ReturnType<typeof createIsolatedDb>>
+let index: LibsqlWorkspaceIndex
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-libsql-workspace-index-test-'))
+  handle = await createIsolatedDb({ dataDir: tempDir })
+  index = new LibsqlWorkspaceIndex(handle.db)
+})
+
+afterEach(async () => {
+  await handle.dispose()
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('LibsqlWorkspaceIndex', () => {
+  it('returns empty results for every read method before any applyRows', async () => {
+    const workspaceId = 'workspace-a'
+
+    expect(await index.resolveAlias({ workspaceId, alias: 'home' })).toBeNull()
+    expect(await index.resolveAliasHistory({ workspaceId, alias: 'old-home' })).toBeNull()
+    expect(await index.listCanvases({ workspaceId })).toEqual({ rows: [] })
+    expect(await index.queryFacet({ workspaceId, facet: 'kind', value: 'note' })).toEqual({
+      canvasIds: [],
+    })
+    expect(await index.listBacklinks({ workspaceId, toCanvasId: 'canvas-1' })).toEqual({
+      rows: [],
+    })
+  })
+
+  it('resolves an alias written by applyRows', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      aliases: [{ alias: 'home', canvasId: 'canvas-1' }],
+    })
+
+    expect(await index.resolveAlias({ workspaceId, alias: 'home' })).toEqual({
+      canvasId: 'canvas-1',
+    })
+    expect(await index.resolveAlias({ workspaceId, alias: 'missing' })).toBeNull()
+  })
+
+  it('resolves alias history written by applyRows', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      aliasHistory: [{ alias: 'old-home', canvasId: 'canvas-1', retiredAtMs: 42 }],
+    })
+
+    expect(await index.resolveAliasHistory({ workspaceId, alias: 'old-home' })).toEqual({
+      canvasId: 'canvas-1',
+    })
+    expect(await index.resolveAliasHistory({ workspaceId, alias: 'missing' })).toBeNull()
+  })
+
+  it('listCanvases returns rows in insertion order', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      canvasList: [
+        { canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 },
+        { canvasId: 'canvas-2', title: 'Two', updatedAtMs: 2 },
+        { canvasId: 'canvas-3', title: 'Three', updatedAtMs: 3 },
+      ],
+    })
+
+    expect(await index.listCanvases({ workspaceId })).toEqual({
+      rows: [
+        { canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 },
+        { canvasId: 'canvas-2', title: 'Two', updatedAtMs: 2 },
+        { canvasId: 'canvas-3', title: 'Three', updatedAtMs: 3 },
+      ],
+    })
+  })
+
+  it('listCanvases honors limit/offset pagination', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      canvasList: [
+        { canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 },
+        { canvasId: 'canvas-2', title: 'Two', updatedAtMs: 2 },
+        { canvasId: 'canvas-3', title: 'Three', updatedAtMs: 3 },
+      ],
+    })
+
+    const page1 = await index.listCanvases({ workspaceId, limit: 2, offset: 0 })
+    const page2 = await index.listCanvases({ workspaceId, limit: 2, offset: 2 })
+
+    expect(page1.rows).toEqual([
+      { canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 },
+      { canvasId: 'canvas-2', title: 'Two', updatedAtMs: 2 },
+    ])
+    expect(page2.rows).toEqual([{ canvasId: 'canvas-3', title: 'Three', updatedAtMs: 3 }])
+  })
+
+  it('queryFacet returns canvasIds matching an exact (facet, value) pair', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      facets: [
+        { facet: 'kind', value: 'note', canvasId: 'canvas-1' },
+        { facet: 'kind', value: 'diagram', canvasId: 'canvas-2' },
+      ],
+    })
+
+    expect(await index.queryFacet({ workspaceId, facet: 'kind', value: 'note' })).toEqual({
+      canvasIds: ['canvas-1'],
+    })
+  })
+
+  it('listBacklinks returns rows matching toCanvasId', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      ...emptyInput(workspaceId),
+      backlinks: [
+        { fromCanvasId: 'canvas-2', toCanvasId: 'canvas-1' },
+        { fromCanvasId: 'canvas-3', toCanvasId: 'canvas-4' },
+      ],
+    })
+
+    expect(await index.listBacklinks({ workspaceId, toCanvasId: 'canvas-1' })).toEqual({
+      rows: [{ fromCanvasId: 'canvas-2', toCanvasId: 'canvas-1' }],
+    })
+  })
+
+  it('isolates rows written under one workspaceId from another', async () => {
+    await index.applyRows({
+      workspaceId: 'workspace-a',
+      canvasList: [{ canvasId: 'canvas-1', title: 'Canvas 1', updatedAtMs: 1 }],
+      facets: [{ facet: 'kind', value: 'note', canvasId: 'canvas-1' }],
+      aliases: [{ alias: 'home', canvasId: 'canvas-1' }],
+      backlinks: [{ fromCanvasId: 'canvas-2', toCanvasId: 'canvas-1' }],
+      aliasHistory: [{ alias: 'old-home', canvasId: 'canvas-1', retiredAtMs: 1 }],
+    })
+    // Overlapping canvasId across workspaces to prove scoping, not just distinct ids.
+    await index.applyRows({
+      workspaceId: 'workspace-b',
+      canvasList: [{ canvasId: 'canvas-1', title: 'Other Canvas 1', updatedAtMs: 9 }],
+      facets: [],
+      aliases: [],
+      backlinks: [],
+      aliasHistory: [],
+    })
+
+    expect(await index.resolveAlias({ workspaceId: 'workspace-b', alias: 'home' })).toBeNull()
+    expect(
+      await index.resolveAliasHistory({ workspaceId: 'workspace-b', alias: 'old-home' }),
+    ).toBeNull()
+    expect(await index.listCanvases({ workspaceId: 'workspace-b' })).toEqual({
+      rows: [{ canvasId: 'canvas-1', title: 'Other Canvas 1', updatedAtMs: 9 }],
+    })
+    expect(
+      await index.queryFacet({ workspaceId: 'workspace-b', facet: 'kind', value: 'note' }),
+    ).toEqual({ canvasIds: [] })
+    expect(
+      await index.listBacklinks({ workspaceId: 'workspace-b', toCanvasId: 'canvas-1' }),
+    ).toEqual({ rows: [] })
+
+    expect(await index.resolveAlias({ workspaceId: 'workspace-a', alias: 'home' })).toEqual({
+      canvasId: 'canvas-1',
+    })
+  })
+
+  it('a second applyRows fully replaces the first (no stale rows)', async () => {
+    const workspaceId = 'workspace-a'
+    await index.applyRows({
+      workspaceId,
+      canvasList: [{ canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 }],
+      facets: [{ facet: 'kind', value: 'note', canvasId: 'canvas-1' }],
+      aliases: [{ alias: 'home', canvasId: 'canvas-1' }],
+      backlinks: [{ fromCanvasId: 'canvas-2', toCanvasId: 'canvas-1' }],
+      aliasHistory: [{ alias: 'old-home', canvasId: 'canvas-1', retiredAtMs: 1 }],
+    })
+
+    await index.applyRows({
+      workspaceId,
+      canvasList: [{ canvasId: 'canvas-9', title: 'Nine', updatedAtMs: 9 }],
+      facets: [],
+      aliases: [],
+      backlinks: [],
+      aliasHistory: [],
+    })
+
+    expect(await index.listCanvases({ workspaceId })).toEqual({
+      rows: [{ canvasId: 'canvas-9', title: 'Nine', updatedAtMs: 9 }],
+    })
+    expect(await index.resolveAlias({ workspaceId, alias: 'home' })).toBeNull()
+    expect(await index.resolveAliasHistory({ workspaceId, alias: 'old-home' })).toBeNull()
+    expect(await index.queryFacet({ workspaceId, facet: 'kind', value: 'note' })).toEqual({
+      canvasIds: [],
+    })
+    expect(await index.listBacklinks({ workspaceId, toCanvasId: 'canvas-1' })).toEqual({
+      rows: [],
+    })
+  })
+
+  it('rolls back the entire five-table write when a mid-transaction insert fails', async () => {
+    const workspaceId = 'workspace-atomic'
+
+    // canvasList/facets/aliases/backlinks all insert successfully inside the
+    // transaction; the LAST table (aliasHistory) gets a row with a `null`
+    // `retiredAtMs`, which violates that column's real NOT NULL constraint
+    // and throws mid-transaction against the actual libSQL connection — not
+    // a mock. If the transaction did not roll back, the earlier four tables'
+    // inserts would remain visible.
+    const invalidInput = {
+      workspaceId,
+      canvasList: [{ canvasId: 'canvas-1', title: 'One', updatedAtMs: 1 }],
+      facets: [{ facet: 'kind', value: 'note', canvasId: 'canvas-1' }],
+      aliases: [{ alias: 'home', canvasId: 'canvas-1' }],
+      backlinks: [{ fromCanvasId: 'canvas-2', toCanvasId: 'canvas-1' }],
+      aliasHistory: [{ alias: 'old-home', canvasId: 'canvas-1', retiredAtMs: null }],
+    } as unknown as ApplyRowsInput
+
+    await expect(index.applyRows(invalidInput)).rejects.toThrow()
+
+    expect(await index.listCanvases({ workspaceId })).toEqual({ rows: [] })
+    expect(await index.queryFacet({ workspaceId, facet: 'kind', value: 'note' })).toEqual({
+      canvasIds: [],
+    })
+    expect(await index.resolveAlias({ workspaceId, alias: 'home' })).toBeNull()
+    expect(await index.listBacklinks({ workspaceId, toCanvasId: 'canvas-1' })).toEqual({ rows: [] })
+    expect(await index.resolveAliasHistory({ workspaceId, alias: 'old-home' })).toBeNull()
+  })
+
+  it('propagates a driver error on read after the connection is closed', async () => {
+    await handle.dispose()
+    await expect(
+      index.resolveAlias({ workspaceId: 'workspace-a', alias: 'home' }),
+    ).rejects.toThrow()
+  })
+
+  it('migration creates indexes on the facets and backlinks lookup columns', async () => {
+    const facetsIndexes = await sql<{
+      name: string
+    }>`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'workspaceIndexFacets'`.execute(
+      handle.db,
+    )
+    const backlinksIndexes = await sql<{
+      name: string
+    }>`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'workspaceIndexBacklinks'`.execute(
+      handle.db,
+    )
+
+    expect(facetsIndexes.rows.some((row) => row.name === 'workspaceIndexFacets_lookup')).toBe(true)
+    expect(backlinksIndexes.rows.some((row) => row.name === 'workspaceIndexBacklinks_lookup')).toBe(
+      true,
+    )
+  })
+
+  it('queryFacet returns correct results at scale across two workspaces and facet pairs', async () => {
+    const workspaceA = 'workspace-scale-a'
+    const workspaceB = 'workspace-scale-b'
+
+    const buildFacets = (prefix: string, count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        facet: 'kind',
+        value: i % 2 === 0 ? 'note' : 'diagram',
+        canvasId: `${prefix}-canvas-${i}`,
+      }))
+
+    await index.applyRows({ ...emptyInput(workspaceA), facets: buildFacets('a', 60) })
+    await index.applyRows({ ...emptyInput(workspaceB), facets: buildFacets('b', 60) })
+
+    const notesA = await index.queryFacet({ workspaceId: workspaceA, facet: 'kind', value: 'note' })
+    const diagramsB = await index.queryFacet({
+      workspaceId: workspaceB,
+      facet: 'kind',
+      value: 'diagram',
+    })
+
+    expect(notesA.canvasIds).toHaveLength(30)
+    expect(notesA.canvasIds.every((id) => id.startsWith('a-canvas-'))).toBe(true)
+    expect(diagramsB.canvasIds).toHaveLength(30)
+    expect(diagramsB.canvasIds.every((id) => id.startsWith('b-canvas-'))).toBe(true)
+  })
+})

--- a/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.ts
@@ -1,0 +1,209 @@
+import type {
+  ApplyRowsInput,
+  ListBacklinksInput,
+  ListBacklinksResult,
+  ListCanvasesInput,
+  ListCanvasesResult,
+  QueryFacetInput,
+  QueryFacetResult,
+  ResolveAliasHistoryInput,
+  ResolveAliasInput,
+  ResolveAliasResult,
+  WorkspaceIndex,
+} from '@kamiazya/whiteboard-canvas-ports'
+import type { Kysely } from 'kysely'
+import { getLogger } from '../../log.js'
+import type { DatabaseSchema } from '../db/schema.js'
+
+const log = getLogger('libsql-workspace-index')
+
+type Db = Kysely<DatabaseSchema>
+
+/**
+ * libSQL-backed `WorkspaceIndex`. `applyRows` is a full delete-then-insert
+ * replace of all five tables for the given `workspaceId`, run inside a
+ * single Kysely transaction — matching InMemoryWorkspaceIndex, whose
+ * `applyRows` overwrites the entire per-workspace record rather than
+ * incrementally patching it.
+ *
+ * Every row carries a `seq` column recording its position within the array
+ * `applyRows` received for that table, and every read method orders by
+ * `seq asc`. InMemoryWorkspaceIndex answers reads with `.find()`/`.filter()`
+ * over the stored arrays, which preserves that same insertion order — `seq`
+ * is what keeps this SQL-backed implementation observationally identical to
+ * it (see the parity test).
+ */
+export class LibsqlWorkspaceIndex implements WorkspaceIndex {
+  constructor(private readonly db: Db) {}
+
+  async applyRows(input: ApplyRowsInput): Promise<void> {
+    const { workspaceId, canvasList, facets, aliases, backlinks, aliasHistory } = input
+
+    await this.db.transaction().execute(async (trx) => {
+      await trx
+        .deleteFrom('workspaceIndexCanvasList')
+        .where('workspaceId', '=', workspaceId)
+        .execute()
+      await trx.deleteFrom('workspaceIndexFacets').where('workspaceId', '=', workspaceId).execute()
+      await trx.deleteFrom('workspaceIndexAliases').where('workspaceId', '=', workspaceId).execute()
+      await trx
+        .deleteFrom('workspaceIndexBacklinks')
+        .where('workspaceId', '=', workspaceId)
+        .execute()
+      await trx
+        .deleteFrom('workspaceIndexAliasHistory')
+        .where('workspaceId', '=', workspaceId)
+        .execute()
+
+      if (canvasList.length > 0) {
+        await trx
+          .insertInto('workspaceIndexCanvasList')
+          .values(
+            canvasList.map((row, seq) => ({
+              workspaceId,
+              seq,
+              canvasId: row.canvasId,
+              title: row.title,
+              updatedAtMs: row.updatedAtMs,
+            })),
+          )
+          .execute()
+      }
+
+      if (facets.length > 0) {
+        await trx
+          .insertInto('workspaceIndexFacets')
+          .values(
+            facets.map((row, seq) => ({
+              workspaceId,
+              seq,
+              facet: row.facet,
+              value: row.value,
+              canvasId: row.canvasId,
+            })),
+          )
+          .execute()
+      }
+
+      if (aliases.length > 0) {
+        await trx
+          .insertInto('workspaceIndexAliases')
+          .values(
+            aliases.map((row, seq) => ({
+              workspaceId,
+              seq,
+              alias: row.alias,
+              canvasId: row.canvasId,
+            })),
+          )
+          .execute()
+      }
+
+      if (backlinks.length > 0) {
+        await trx
+          .insertInto('workspaceIndexBacklinks')
+          .values(
+            backlinks.map((row, seq) => ({
+              workspaceId,
+              seq,
+              fromCanvasId: row.fromCanvasId,
+              toCanvasId: row.toCanvasId,
+            })),
+          )
+          .execute()
+      }
+
+      if (aliasHistory.length > 0) {
+        await trx
+          .insertInto('workspaceIndexAliasHistory')
+          .values(
+            aliasHistory.map((row, seq) => ({
+              workspaceId,
+              seq,
+              alias: row.alias,
+              canvasId: row.canvasId,
+              retiredAtMs: row.retiredAtMs,
+            })),
+          )
+          .execute()
+      }
+    })
+
+    log.debug(
+      {
+        workspaceId,
+        canvasCount: canvasList.length,
+        facetCount: facets.length,
+        aliasCount: aliases.length,
+        backlinkCount: backlinks.length,
+        aliasHistoryCount: aliasHistory.length,
+      },
+      'replaced workspace index rows',
+    )
+  }
+
+  async resolveAlias(input: ResolveAliasInput): Promise<ResolveAliasResult> {
+    const row = await this.db
+      .selectFrom('workspaceIndexAliases')
+      .select('canvasId')
+      .where('workspaceId', '=', input.workspaceId)
+      .where('alias', '=', input.alias)
+      .orderBy('seq', 'asc')
+      .executeTakeFirst()
+    return row ? { canvasId: row.canvasId } : null
+  }
+
+  async resolveAliasHistory(input: ResolveAliasHistoryInput): Promise<ResolveAliasResult> {
+    const row = await this.db
+      .selectFrom('workspaceIndexAliasHistory')
+      .select('canvasId')
+      .where('workspaceId', '=', input.workspaceId)
+      .where('alias', '=', input.alias)
+      .orderBy('seq', 'asc')
+      .executeTakeFirst()
+    return row ? { canvasId: row.canvasId } : null
+  }
+
+  async listCanvases(input: ListCanvasesInput): Promise<ListCanvasesResult> {
+    let query = this.db
+      .selectFrom('workspaceIndexCanvasList')
+      .select(['canvasId', 'title', 'updatedAtMs'])
+      .where('workspaceId', '=', input.workspaceId)
+      .orderBy('seq', 'asc')
+
+    // SQLite's grammar requires LIMIT whenever OFFSET is present. `-1` is
+    // SQLite's own "no limit" sentinel, so an explicit `limit` still wins
+    // when both are given.
+    if (input.offset !== undefined) {
+      query = query.limit(input.limit ?? -1).offset(input.offset)
+    } else if (input.limit !== undefined) {
+      query = query.limit(input.limit)
+    }
+
+    const rows = await query.execute()
+    return { rows }
+  }
+
+  async queryFacet(input: QueryFacetInput): Promise<QueryFacetResult> {
+    const rows = await this.db
+      .selectFrom('workspaceIndexFacets')
+      .select('canvasId')
+      .where('workspaceId', '=', input.workspaceId)
+      .where('facet', '=', input.facet)
+      .where('value', '=', input.value)
+      .orderBy('seq', 'asc')
+      .execute()
+    return { canvasIds: rows.map((row) => row.canvasId) }
+  }
+
+  async listBacklinks(input: ListBacklinksInput): Promise<ListBacklinksResult> {
+    const rows = await this.db
+      .selectFrom('workspaceIndexBacklinks')
+      .select(['fromCanvasId', 'toCanvasId'])
+      .where('workspaceId', '=', input.workspaceId)
+      .where('toCanvasId', '=', input.toCanvasId)
+      .orderBy('seq', 'asc')
+      .execute()
+    return { rows }
+  }
+}

--- a/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-workspace-index.ts
@@ -19,6 +19,15 @@ const log = getLogger('libsql-workspace-index')
 
 type Db = Kysely<DatabaseSchema>
 
+/** All five WorkspaceIndex-backing tables, used by the delete sweep in applyRows. */
+const WORKSPACE_INDEX_TABLES = [
+  'workspaceIndexCanvasList',
+  'workspaceIndexFacets',
+  'workspaceIndexAliases',
+  'workspaceIndexBacklinks',
+  'workspaceIndexAliasHistory',
+] as const
+
 /**
  * libSQL-backed `WorkspaceIndex`. `applyRows` is a full delete-then-insert
  * replace of all five tables for the given `workspaceId`, run inside a
@@ -40,20 +49,9 @@ export class LibsqlWorkspaceIndex implements WorkspaceIndex {
     const { workspaceId, canvasList, facets, aliases, backlinks, aliasHistory } = input
 
     await this.db.transaction().execute(async (trx) => {
-      await trx
-        .deleteFrom('workspaceIndexCanvasList')
-        .where('workspaceId', '=', workspaceId)
-        .execute()
-      await trx.deleteFrom('workspaceIndexFacets').where('workspaceId', '=', workspaceId).execute()
-      await trx.deleteFrom('workspaceIndexAliases').where('workspaceId', '=', workspaceId).execute()
-      await trx
-        .deleteFrom('workspaceIndexBacklinks')
-        .where('workspaceId', '=', workspaceId)
-        .execute()
-      await trx
-        .deleteFrom('workspaceIndexAliasHistory')
-        .where('workspaceId', '=', workspaceId)
-        .execute()
+      for (const table of WORKSPACE_INDEX_TABLES) {
+        await trx.deleteFrom(table).where('workspaceId', '=', workspaceId).execute()
+      }
 
       if (canvasList.length > 0) {
         await trx
@@ -143,22 +141,23 @@ export class LibsqlWorkspaceIndex implements WorkspaceIndex {
   }
 
   async resolveAlias(input: ResolveAliasInput): Promise<ResolveAliasResult> {
-    const row = await this.db
-      .selectFrom('workspaceIndexAliases')
-      .select('canvasId')
-      .where('workspaceId', '=', input.workspaceId)
-      .where('alias', '=', input.alias)
-      .orderBy('seq', 'asc')
-      .executeTakeFirst()
-    return row ? { canvasId: row.canvasId } : null
+    return this.findAliasByTable('workspaceIndexAliases', input.workspaceId, input.alias)
   }
 
   async resolveAliasHistory(input: ResolveAliasHistoryInput): Promise<ResolveAliasResult> {
+    return this.findAliasByTable('workspaceIndexAliasHistory', input.workspaceId, input.alias)
+  }
+
+  private async findAliasByTable(
+    table: 'workspaceIndexAliases' | 'workspaceIndexAliasHistory',
+    workspaceId: string,
+    alias: string,
+  ): Promise<ResolveAliasResult> {
     const row = await this.db
-      .selectFrom('workspaceIndexAliasHistory')
+      .selectFrom(table)
       .select('canvasId')
-      .where('workspaceId', '=', input.workspaceId)
-      .where('alias', '=', input.alias)
+      .where('workspaceId', '=', workspaceId)
+      .where('alias', '=', alias)
       .orderBy('seq', 'asc')
       .executeTakeFirst()
     return row ? { canvasId: row.canvasId } : null


### PR DESCRIPTION
## Summary

- Add migration `0004-workspace-index` with five index tables (canvas_list, facets, aliases, backlinks, alias_history), each keyed by `workspace_id` for per-call isolation
- Implement `LibsqlWorkspaceIndex` class backed by Kysely/libSQL, implementing the `WorkspaceIndex` port interface from canvas-ports
- DRY up delete sweep and alias resolution logic
- Add comprehensive tests including migration down() coverage

Part of OpenCanvas Track B (5b-3b migration + 5b-3c implementation). The `WorkspaceIndex` port interface was defined in canvas-ports (#313), and the pure index row derivation functions were added in canvas-workspace (#321). This PR provides the persistent libSQL-backed implementation.

## Test plan

- [x] `pnpm test --project mcp-node` — 256 files, 3635 tests pass
- [x] Migration creates and drops all five tables correctly
- [x] Multi-workspace isolation verified
- [x] Replace semantics (applyRows overwrites previous data)
- [x] published-migration-names includes the new migration