### PR TITLE
feat(mcp-server): add store-local DI module for real store bindings

### DIFF
--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -1,17 +1,8 @@
-import { Container } from 'inversify'
+import { Container, type ContainerModule } from 'inversify'
 import { storeMemoryModule } from './store-memory.module.js'
 
-/**
- * Builds this repo's first InversifyJS composition root: a plain
- * `Container` with `ContainerModule`s loaded synchronously (every binding
- * here is sync, so `load` — not `loadAsync` — is correct). No decorators or
- * `reflect-metadata` are involved; every binding uses `toDynamicValue`
- * against the canvas-ports Symbol tokens.
- *
- * Test-level composition only for now — see `no-production-wiring.test.ts`.
- */
-export function createContainer(): Container {
+export function createContainer(storeModule: ContainerModule = storeMemoryModule): Container {
   const container = new Container()
-  container.load(storeMemoryModule)
+  container.load(storeModule)
   return container
 }

--- a/packages/mcp-server/src/di/store-local.module.test.ts
+++ b/packages/mcp-server/src/di/store-local.module.test.ts
@@ -1,0 +1,38 @@
+import type { BlobStore, CanvasDocStore, WorkspaceIndex } from '@kamiazya/whiteboard-canvas-ports'
+import { TOKENS } from '@kamiazya/whiteboard-canvas-ports'
+import { Container } from 'inversify'
+import { describe, expect, it } from 'vitest'
+import { FsBlobStore } from '../server/store/fs/fs-blob-store.js'
+import { LibsqlCanvasDocStore } from '../server/store/libsql/libsql-canvas-doc-store.js'
+import { LibsqlWorkspaceIndex } from '../server/store/libsql/libsql-workspace-index.js'
+import { createStoreLocalModule } from './store-local.module.js'
+
+describe('createStoreLocalModule', () => {
+  it('binds all three store tokens to real implementations', () => {
+    const fakeDb = {} as Parameters<typeof createStoreLocalModule>[0]['db']
+    const mod = createStoreLocalModule({ db: fakeDb, blobDir: '/tmp/blobs' })
+
+    const container = new Container()
+    container.load(mod)
+
+    const docStore = container.get<CanvasDocStore>(TOKENS.CanvasDocStore)
+    const blobStore = container.get<BlobStore>(TOKENS.BlobStore)
+    const wsIndex = container.get<WorkspaceIndex>(TOKENS.WorkspaceIndex)
+
+    expect(docStore).toBeInstanceOf(LibsqlCanvasDocStore)
+    expect(blobStore).toBeInstanceOf(FsBlobStore)
+    expect(wsIndex).toBeInstanceOf(LibsqlWorkspaceIndex)
+  })
+
+  it('returns singletons for repeated gets', () => {
+    const fakeDb = {} as Parameters<typeof createStoreLocalModule>[0]['db']
+    const mod = createStoreLocalModule({ db: fakeDb, blobDir: '/tmp/blobs' })
+
+    const container = new Container()
+    container.load(mod)
+
+    const a = container.get<CanvasDocStore>(TOKENS.CanvasDocStore)
+    const b = container.get<CanvasDocStore>(TOKENS.CanvasDocStore)
+    expect(a).toBe(b)
+  })
+})

--- a/packages/mcp-server/src/di/store-local.module.ts
+++ b/packages/mcp-server/src/di/store-local.module.ts
@@ -1,0 +1,26 @@
+import { TOKENS } from '@kamiazya/whiteboard-canvas-ports'
+import { ContainerModule } from 'inversify'
+import type { Kysely } from 'kysely'
+import type { DatabaseSchema } from '../server/store/db/schema.js'
+import { FsBlobStore } from '../server/store/fs/fs-blob-store.js'
+import { LibsqlCanvasDocStore } from '../server/store/libsql/libsql-canvas-doc-store.js'
+import { LibsqlWorkspaceIndex } from '../server/store/libsql/libsql-workspace-index.js'
+
+export interface StoreLocalModuleOptions {
+  db: Kysely<DatabaseSchema>
+  blobDir: string
+}
+
+export function createStoreLocalModule(opts: StoreLocalModuleOptions): ContainerModule {
+  return new ContainerModule(({ bind }) => {
+    bind(TOKENS.CanvasDocStore)
+      .toDynamicValue(() => new LibsqlCanvasDocStore(opts.db))
+      .inSingletonScope()
+    bind(TOKENS.BlobStore)
+      .toDynamicValue(() => new FsBlobStore(opts.blobDir))
+      .inSingletonScope()
+    bind(TOKENS.WorkspaceIndex)
+      .toDynamicValue(() => new LibsqlWorkspaceIndex(opts.db))
+      .inSingletonScope()
+  })
+}


### PR DESCRIPTION
## Summary

- Add `createStoreLocalModule({ db, blobDir })` factory that binds `TOKENS.CanvasDocStore`, `TOKENS.BlobStore`, and `TOKENS.WorkspaceIndex` to their real implementations (`LibsqlCanvasDocStore`, `FsBlobStore`, `LibsqlWorkspaceIndex`)
- Update `createContainer` to accept an optional `ContainerModule` parameter, defaulting to the in-memory module for tests
- Add unit tests verifying binding correctness and singleton behavior

## Test plan

- [x] `pnpm test --project mcp-node` — all 257 files pass (3637 tests)
- [x] Pre-push hook: typecheck + noconsole + mcp-node all green