### PR TITLE
feat(canvas-workspace): add WorkspaceTree persistence bridge

### DIFF
--- a/packages/canvas-workspace/src/workspace-tree.test.ts
+++ b/packages/canvas-workspace/src/workspace-tree.test.ts
@@ -157,6 +157,49 @@ describe('WorkspaceTree', () => {
     })
   })
 
+  describe('snapshot round-trip', () => {
+    it('exports a Uint8Array snapshot', () => {
+      const { tree } = makeTree()
+      tree.createNode('c-1', 'alpha')
+      const bytes = tree.exportSnapshot()
+      expect(bytes).toBeInstanceOf(Uint8Array)
+      expect(bytes.byteLength).toBeGreaterThan(0)
+    })
+
+    it('round-trips tree state through exportSnapshot / fromSnapshot', () => {
+      const { tree } = makeTree()
+      const parentId = tree.createNode('folder', 'projects')
+      tree.createNode('c-1', 'alpha', parentId)
+      tree.createNode('c-2', 'beta', parentId)
+
+      const bytes = tree.exportSnapshot()
+      const restored = WorkspaceTree.fromSnapshot(bytes)
+
+      const roots = restored.children()
+      expect(roots).toHaveLength(1)
+      expect(roots[0]!.segment).toBe('projects')
+
+      const kids = restored.children(roots[0]!.id)
+      expect(kids).toHaveLength(2)
+      expect(kids.map((k) => k.segment).sort()).toEqual(['alpha', 'beta'])
+    })
+
+    it('preserves alias resolution after round-trip', () => {
+      const { tree } = makeTree()
+      const folderId = tree.createNode('f', 'docs')
+      const leafId = tree.createNode('c-1', 'readme', folderId)
+      const alias = tree.resolveAlias(leafId)
+
+      const restored = WorkspaceTree.fromSnapshot(tree.exportSnapshot())
+      const restoredLeaf = restored.findByAlias('docs/readme')
+      expect(restoredLeaf).toBeDefined()
+      expect(restoredLeaf!.canvasId).toBe('c-1')
+
+      const restoredAlias = restored.resolveAlias(restoredLeaf!.id)
+      expect(restoredAlias).toBe(alias)
+    })
+  })
+
   describe('CRDT merge', () => {
     it('merges two independent trees via snapshot import', () => {
       const { doc: doc1, tree: tree1 } = makeTree()

--- a/packages/canvas-workspace/src/workspace-tree.ts
+++ b/packages/canvas-workspace/src/workspace-tree.ts
@@ -1,4 +1,4 @@
-import type { LoroDoc, LoroTree, LoroTreeNode, TreeID } from 'loro-crdt'
+import { LoroDoc, type LoroTree, type LoroTreeNode, type TreeID } from 'loro-crdt'
 
 const TREE_KEY = 'tree'
 const SEGMENT_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$/
@@ -23,6 +23,20 @@ export class WorkspaceTree {
       canvasId: string
       segment: string
     }>
+  }
+
+  static fromSnapshot(bytes: Uint8Array): WorkspaceTree {
+    const doc = LoroDoc.fromSnapshot(bytes)
+    return new WorkspaceTree(doc)
+  }
+
+  exportSnapshot(): Uint8Array {
+    return this.#doc.export({ mode: 'snapshot' })
+  }
+
+  exportFrontier(): Uint8Array<ArrayBuffer> {
+    const encoded = this.#doc.version().encode()
+    return new Uint8Array(encoded)
   }
 
   createNode(canvasId: string, segment: string, parent?: TreeID, index?: number): TreeID {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -195,6 +195,7 @@
   "devDependencies": {
     "@fast-check/vitest": "^0.4.1",
     "@kamiazya/whiteboard-canvas-ports": "workspace:*",
+    "@kamiazya/whiteboard-canvas-workspace": "workspace:*",
     "@kamiazya/whiteboard-canvas-viewer": "workspace:*",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",

--- a/packages/mcp-server/src/server/store/workspace-tree-persistence.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-tree-persistence.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LoroDoc } from 'loro-crdt'
+import { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createIsolatedDb } from './db/test-helpers.js'
+import { LibsqlCanvasDocStore } from './libsql/libsql-canvas-doc-store.js'
+import { loadWorkspaceTree, saveWorkspaceTree } from './workspace-tree-persistence.js'
+
+let tempDir: string
+let handle: Awaited<ReturnType<typeof createIsolatedDb>>
+let store: LibsqlCanvasDocStore
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-tree-persist-test-'))
+  handle = await createIsolatedDb({ dataDir: tempDir })
+  store = new LibsqlCanvasDocStore(handle.db)
+})
+
+afterEach(async () => {
+  await handle.dispose()
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('workspace tree persistence', () => {
+  it('returns null when no tree has been saved', async () => {
+    const result = await loadWorkspaceTree(store, 'ws-nonexistent')
+    expect(result).toBeNull()
+  })
+
+  it('round-trips a workspace tree through save and load', async () => {
+    const doc = new LoroDoc()
+    const tree = new WorkspaceTree(doc)
+    const folderId = tree.createNode('folder-canvas', 'projects')
+    tree.createNode('c-alpha', 'alpha', folderId)
+    tree.createNode('c-beta', 'beta', folderId)
+
+    await saveWorkspaceTree(store, 'ws-1', tree)
+
+    const restored = await loadWorkspaceTree(store, 'ws-1')
+    expect(restored).not.toBeNull()
+
+    const roots = restored!.children()
+    expect(roots).toHaveLength(1)
+    expect(roots[0]!.segment).toBe('projects')
+
+    const kids = restored!.children(roots[0]!.id)
+    expect(kids).toHaveLength(2)
+    expect(kids.map((k) => k.segment).sort()).toEqual(['alpha', 'beta'])
+  })
+
+  it('preserves alias resolution after round-trip', async () => {
+    const doc = new LoroDoc()
+    const tree = new WorkspaceTree(doc)
+    const folderId = tree.createNode('f', 'docs')
+    tree.createNode('c-readme', 'readme', folderId)
+
+    await saveWorkspaceTree(store, 'ws-alias', tree)
+    const restored = await loadWorkspaceTree(store, 'ws-alias')
+
+    const found = restored!.findByAlias('docs/readme')
+    expect(found).toBeDefined()
+    expect(found!.canvasId).toBe('c-readme')
+    expect(restored!.resolveAlias(found!.id)).toBe('docs/readme')
+  })
+
+  it('overwrites a previously saved tree', async () => {
+    const doc = new LoroDoc()
+    const tree = new WorkspaceTree(doc)
+    tree.createNode('c-1', 'first')
+    await saveWorkspaceTree(store, 'ws-overwrite', tree)
+
+    tree.createNode('c-2', 'second')
+    await saveWorkspaceTree(store, 'ws-overwrite', tree)
+
+    const restored = await loadWorkspaceTree(store, 'ws-overwrite')
+    const roots = restored!.children()
+    expect(roots).toHaveLength(2)
+    expect(roots.map((r) => r.segment).sort()).toEqual(['first', 'second'])
+  })
+
+  it('isolates trees by workspace id', async () => {
+    const doc1 = new LoroDoc()
+    const tree1 = new WorkspaceTree(doc1)
+    tree1.createNode('c-a', 'from-ws1')
+    await saveWorkspaceTree(store, 'ws-a', tree1)
+
+    const doc2 = new LoroDoc()
+    const tree2 = new WorkspaceTree(doc2)
+    tree2.createNode('c-b', 'from-ws2')
+    await saveWorkspaceTree(store, 'ws-b', tree2)
+
+    const restoredA = await loadWorkspaceTree(store, 'ws-a')
+    const restoredB = await loadWorkspaceTree(store, 'ws-b')
+
+    expect(restoredA!.children().map((n) => n.segment)).toEqual(['from-ws1'])
+    expect(restoredB!.children().map((n) => n.segment)).toEqual(['from-ws2'])
+  })
+})

--- a/packages/mcp-server/src/server/store/workspace-tree-persistence.ts
+++ b/packages/mcp-server/src/server/store/workspace-tree-persistence.ts
@@ -1,0 +1,35 @@
+import type { CanvasDocStore, DocRef } from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
+
+const DEFAULT_MAX_CHUNK_BYTES = 1024 * 1024
+
+function workspaceTreeDocRef(workspaceId: string): DocRef {
+  return { kind: 'workspace-tree', workspaceId }
+}
+
+export async function loadWorkspaceTree(
+  store: CanvasDocStore,
+  workspaceId: string,
+): Promise<WorkspaceTree | null> {
+  const docRef = workspaceTreeDocRef(workspaceId)
+  const result = await store.loadSnapshot({ docRef })
+  if (!result) return null
+
+  const bytes = reassembleSnapshot(result.manifest, result.chunks)
+  return WorkspaceTree.fromSnapshot(bytes)
+}
+
+export async function saveWorkspaceTree(
+  store: CanvasDocStore,
+  workspaceId: string,
+  tree: WorkspaceTree,
+  maxChunkBytes = DEFAULT_MAX_CHUNK_BYTES,
+): Promise<void> {
+  const docRef = workspaceTreeDocRef(workspaceId)
+  const snapshot = tree.exportSnapshot()
+  const frontier = tree.exportFrontier()
+  const { manifest, chunks } = chunkSnapshot(snapshot, maxChunkBytes)
+
+  await store.saveSnapshot({ docRef, manifest, chunks, frontier })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
       '@kamiazya/whiteboard-canvas-viewer':
         specifier: workspace:*
         version: link:../canvas-viewer
+      '@kamiazya/whiteboard-canvas-workspace':
+        specifier: workspace:*
+        version: link:../canvas-workspace
       '@stryker-mutator/core':
         specifier: ^9.6.1
         version: 9.6.1(@types/node@24.12.2)


### PR DESCRIPTION
## Summary

- Add `exportSnapshot()`, `exportFrontier()`, and `static fromSnapshot(bytes)` to `WorkspaceTree` — enables LoroDoc snapshot round-trip without exposing the private `#doc` field.
- Add `loadWorkspaceTree` / `saveWorkspaceTree` bridge functions in mcp-server that wire `WorkspaceTree` to `CanvasDocStore` via `chunkSnapshot` / `reassembleSnapshot` from canvas-ports.
- Add `canvas-workspace` as a devDependency of mcp-server (already in tsup `noExternal` for bundling).

Part of OpenCanvas slice 5b-2a (storage foundation Track A).

## Test plan

- [x] WorkspaceTree snapshot round-trip tests (3 new tests in `workspace-tree.test.ts`)
- [x] Persistence bridge integration tests against real LibsqlCanvasDocStore (5 new tests)
- [x] Typecheck passes (`pnpm --filter @kamiazya/whiteboard-mcp typecheck`)
- [x] Full mcp-node suite green (258 files, 3642 tests)
- [x] Full canvas-workspace-node suite green (6 files, 62 tests)