### PR TITLE
feat(server-core): add server-core package skeleton with createServer factory

### DIFF
--- a/.claude/rules/package-server-core.md
+++ b/.claude/rules/package-server-core.md
@@ -1,0 +1,56 @@
+# server-core — /api/v1 Hono routes + MCP tool definitions, createServer(deps) factory
+
+## What belongs here
+
+- The `createServer(deps)` factory: assembles a `Hono` app from the
+  store/sync ports supplied via `ServerDeps`, and returns `{ app }`.
+- `/api/v1` Hono route definitions (future slices).
+- MCP tool definitions and MCP resource definitions (future slices) —
+  their `inputSchema`/`outputSchema` and `execute` handlers, wired to the
+  injected deps.
+- Response-schema declarations shared with typed clients (declared once as
+  Zod, imported via `z.infer` on both sides).
+
+## What does NOT belong here
+
+- Store/sync **implementations** (local libSQL/fs, IndexedDB, Durable
+  Objects/D1/R2) — those live in composition roots (`mcp-server`,
+  `apps/web`, future Cloudflare root). This package receives them through
+  the factory as `ServerDeps`.
+- CLI, stdio transport, daemon startup/registry logic, resvg, or any
+  process lifecycle — `mcp-server` owns that.
+- InversifyJS or any DI container wiring — composition roots only.
+- Scene graph, layout, rendering internals — `canvas-render`.
+- Tree ops, alias/index derivation — `canvas-workspace`.
+
+## Dependency rules
+
+- Runtime dependencies: `canvas-model`, `canvas-codec`, `canvas-render`,
+  `canvas-ports`, `canvas-workspace`, `hono`, and `zod` (via `catalog:` or
+  `workspace:*`).
+- Forbidden imports: `node:*`, DOM globals (`document`/`window`/`navigator`),
+  `inversify`.
+- Enforced by `tools/arch-lint` (`arch-lint-node` vitest project) and the
+  dependency-direction check against `architecture-map.ts`.
+
+## Conventions
+
+- Tools and routes receive their dependencies from the `createServer`
+  factory (via `ServerDeps`), never through direct module imports of a
+  store/sync implementation. The shared layer only knows the port
+  contracts from `canvas-ports`.
+- Every contract crossing a process boundary (MCP tool I/O, HTTP response
+  shape) is declared once as a Zod schema and consumed via `z.infer` — no
+  hand-written interface next to a schema.
+
+## Tests
+
+- Vitest project: `server-core-node` (registered in root `vitest.config.ts`).
+- Smoke: `createServer` returns an app whose `fetch` is callable.
+
+## Common mistakes (append as review finds them)
+
+- Importing a store/sync implementation directly instead of taking it via
+  `ServerDeps`.
+- Importing `node:*` or DOM globals in this shared-layer package.
+- Adding a hand-written interface next to a Zod schema instead of `z.infer`.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -180,7 +180,7 @@ pnpm typecheck   # tsc --noEmit (~10s)
 pnpm smoke:e2e   # stdio MCP subprocess: canvas_create -> version save/restore -> viewport no_client -> export_canvas (png/svg)
 ```
 
-For a fast, narrow pass while iterating on `packages/mcp-server` (selects only the `mcp-node` project out of the sixteen configured in root `vitest.config.ts`, so it also skips `mcp-smoke`, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom, apps/web node/jsdom, and all three browser projects — not just the Playwright browser project):
+For a fast, narrow pass while iterating on `packages/mcp-server` (selects only the `mcp-node` project out of the sixteen configured in root `vitest.config.ts`, so it also skips `mcp-smoke`, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node, canvas-viewer node/jsdom, apps/web node/jsdom, and all three browser projects (canvas-render-browser, canvas-viewer-browser, web-browser)):
 
 ```bash
 pnpm test --project mcp-node

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -175,12 +175,12 @@ pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
 Default regression triple after a change:
 
 ```bash
-pnpm test        # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser (Playwright projects are slower)
+pnpm test        # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser (Playwright projects are slower)
 pnpm typecheck   # tsc --noEmit (~10s)
 pnpm smoke:e2e   # stdio MCP subprocess: canvas_create -> version save/restore -> viewport no_client -> export_canvas (png/svg)
 ```
 
-For a fast, narrow pass while iterating on `packages/mcp-server` (selects only the `mcp-node` project out of the fifteen configured in root `vitest.config.ts`, so it also skips `mcp-smoke`, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom, apps/web node/jsdom, and all three browser projects — not just the Playwright browser project):
+For a fast, narrow pass while iterating on `packages/mcp-server` (selects only the `mcp-node` project out of the sixteen configured in root `vitest.config.ts`, so it also skips `mcp-smoke`, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom, apps/web node/jsdom, and all three browser projects — not just the Playwright browser project):
 
 ```bash
 pnpm test --project mcp-node

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -352,7 +352,7 @@ Common commands are also summarized in [CONTRIBUTING.md](../../CONTRIBUTING.md#q
 ```bash
 pnpm lint           # Biome — must be green before review
 pnpm typecheck      # TypeScript — must be green before review
-pnpm test           # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser
+pnpm test           # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser
 pnpm test:browser   # canvas-viewer-browser + web-browser + canvas-render-browser (the real-browser projects)
 pnpm smoke:e2e      # stdio MCP smoke (also covered by pnpm test via mcp-smoke)
 ```

--- a/packages/mcp-server/src/server/docs-contract.test.ts
+++ b/packages/mcp-server/src/server/docs-contract.test.ts
@@ -50,6 +50,7 @@ describe('docs/ contract', () => {
       'packages/canvas-codec': 'canvas-codec',
       'packages/canvas-render': 'canvas-render',
       'packages/canvas-workspace': 'canvas-workspace',
+      'packages/server-core': 'server-core',
       'packages/canvas-viewer': 'canvas-viewer',
       'apps/web': 'web',
     }

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -19,12 +19,8 @@
     "test": "vitest run --config vitest.node.config.ts"
   },
   "dependencies": {
-    "@kamiazya/whiteboard-canvas-model": "workspace:*",
     "@kamiazya/whiteboard-canvas-ports": "workspace:*",
-    "@kamiazya/whiteboard-canvas-render": "workspace:*",
-    "@kamiazya/whiteboard-canvas-workspace": "workspace:*",
-    "hono": "^4.12.27",
-    "zod": "catalog:"
+    "hono": "^4.12.27"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@kamiazya/whiteboard-server-core",
+  "private": true,
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "description": "Server core: /api/v1 Hono routes and MCP tool definitions, exposed as createServer(deps).",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.node.config.ts"
+  },
+  "dependencies": {
+    "@kamiazya/whiteboard-canvas-model": "workspace:*",
+    "@kamiazya/whiteboard-canvas-ports": "workspace:*",
+    "@kamiazya/whiteboard-canvas-render": "workspace:*",
+    "@kamiazya/whiteboard-canvas-workspace": "workspace:*",
+    "hono": "^4.12.27",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/server-core/src/create-server.test.ts
+++ b/packages/server-core/src/create-server.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createServer } from './create-server.js'
+
+describe('createServer', () => {
+  it('returns an app', () => {
+    const { app } = createServer({
+      canvasDocStore: {} as never,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+    expect(app).toBeDefined()
+    expect(app.fetch).toBeTypeOf('function')
+  })
+})

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -1,0 +1,14 @@
+import type { BlobStore, CanvasDocStore, WorkspaceIndex } from '@kamiazya/whiteboard-canvas-ports'
+import { Hono } from 'hono'
+
+export interface ServerDeps {
+  canvasDocStore: CanvasDocStore
+  workspaceIndex: WorkspaceIndex
+  blobStore: BlobStore
+}
+
+export function createServer(deps: ServerDeps) {
+  void deps
+  const app = new Hono()
+  return { app }
+}

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -1,0 +1,2 @@
+export { createServer } from './create-server.js'
+export type { ServerDeps } from './create-server.js'

--- a/packages/server-core/tsconfig.json
+++ b/packages/server-core/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vitest.node.config.ts"]
+}

--- a/packages/server-core/vitest.node.config.ts
+++ b/packages/server-core/vitest.node.config.ts
@@ -1,0 +1,9 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    name: 'server-core-node',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,24 +605,12 @@ importers:
 
   packages/server-core:
     dependencies:
-      '@kamiazya/whiteboard-canvas-model':
-        specifier: workspace:*
-        version: link:../canvas-model
       '@kamiazya/whiteboard-canvas-ports':
         specifier: workspace:*
         version: link:../canvas-ports
-      '@kamiazya/whiteboard-canvas-render':
-        specifier: workspace:*
-        version: link:../canvas-render
-      '@kamiazya/whiteboard-canvas-workspace':
-        specifier: workspace:*
-        version: link:../canvas-workspace
       hono:
         specifier: ^4.12.27
         version: 4.12.27
-      zod:
-        specifier: 'catalog:'
-        version: 4.4.3
     devDependencies:
       typescript:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/server-core:
+    dependencies:
+      '@kamiazya/whiteboard-canvas-model':
+        specifier: workspace:*
+        version: link:../canvas-model
+      '@kamiazya/whiteboard-canvas-ports':
+        specifier: workspace:*
+        version: link:../canvas-ports
+      '@kamiazya/whiteboard-canvas-render':
+        specifier: workspace:*
+        version: link:../canvas-render
+      '@kamiazya/whiteboard-canvas-workspace':
+        specifier: workspace:*
+        version: link:../canvas-workspace
+      hono:
+        specifier: ^4.12.27
+        version: 4.12.27
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.5(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
   tools/arch-lint:
     dependencies:
       typescript:

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -13,6 +13,13 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, readonly string[]>> = {
     '@kamiazya/whiteboard-canvas-codec',
     '@kamiazya/whiteboard-canvas-ports',
   ],
+  '@kamiazya/whiteboard-server-core': [
+    '@kamiazya/whiteboard-canvas-model',
+    '@kamiazya/whiteboard-canvas-codec',
+    '@kamiazya/whiteboard-canvas-render',
+    '@kamiazya/whiteboard-canvas-ports',
+    '@kamiazya/whiteboard-canvas-workspace',
+  ],
 }
 
 export function allowedDependencies(packageName: string): readonly string[] {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'packages/canvas-codec/vitest.node.config.ts',
       'tools/arch-lint/vitest.node.config.ts',
       'packages/canvas-workspace/vitest.node.config.ts',
+      'packages/server-core/vitest.node.config.ts',
       'packages/canvas-render/vitest.node.config.ts',
       'packages/canvas-render/vitest.browser.config.ts',
       'packages/canvas-viewer/vitest.node.config.ts',


### PR DESCRIPTION
## Summary

- Add `packages/server-core` — the shared-layer package that will host `/api/v1` Hono routes and MCP tool definitions, exposed as `createServer(deps)`.
- Wire `ServerDeps` interface to canvas-ports contracts (`CanvasDocStore`, `WorkspaceIndex`, `BlobStore`).
- Register `server-core-node` vitest project in the root config.
- Add arch-lint coverage for the new package's dependency rules.
- Add path-scoped rule `.claude/rules/package-server-core.md`.
- Update contributing docs to enumerate server-core in the `pnpm test` description.

## Test plan

- [x] `createServer` smoke test passes (`server-core-node` project)
- [x] arch-lint validates dependency rules
- [x] `docs-contract.test.ts` passes with the new token map entry
- [x] `pnpm test --project mcp-node` all 258 files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new server-core package with a publicly accessible server factory.
  * Added strict dependency and architecture guidelines for server-core development.
  * Integrated server-core tests into the default test suite.

* **Documentation**
  * Updated development and testing documentation to describe the expanded regression checks and test coverage.

* **Tests**
  * Added coverage confirming the server factory returns a usable application with a fetch interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->