### PR TITLE
feat(canvas-workspace,server-core): add facets LoroDoc bridge and facet_set tool

### DIFF
--- a/packages/canvas-workspace/src/index.ts
+++ b/packages/canvas-workspace/src/index.ts
@@ -9,6 +9,6 @@ export {
   deriveWorkspaceIndexRows,
 } from './derive-index.js'
 export { extractBacklinks } from './extract-backlinks.js'
-export { readSpatialCanvas, writeSpatialCanvas } from './loro-bridge.js'
+export { readFacets, readSpatialCanvas, writeFacets, writeSpatialCanvas } from './loro-bridge.js'
 export type { WorkspaceNode, WorkspaceTreeSnapshot } from './workspace-tree.js'
 export { WorkspaceTree } from './workspace-tree.js'

--- a/packages/canvas-workspace/src/loro-bridge.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.test.ts
@@ -1,7 +1,12 @@
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
-import type { SpatialCanvas, SpatialNode, CanvasEdge } from '@kamiazya/whiteboard-canvas-model'
-import { readSpatialCanvas, writeSpatialCanvas } from './loro-bridge.js'
+import type {
+  SpatialCanvas,
+  SpatialNode,
+  CanvasEdge,
+  ExtensionFacets,
+} from '@kamiazya/whiteboard-canvas-model'
+import { readFacets, readSpatialCanvas, writeFacets, writeSpatialCanvas } from './loro-bridge.js'
 
 function makeDoc(): LoroDoc {
   return new LoroDoc()
@@ -243,5 +248,83 @@ describe('loro-bridge', () => {
     const result = readSpatialCanvas(doc)
 
     expect(result.edges).toEqual([minimalEdge])
+  })
+})
+
+describe('facets bridge', () => {
+  test('reads empty facets from a fresh doc', () => {
+    const doc = makeDoc()
+    expect(readFacets(doc)).toEqual({})
+  })
+
+  test('round-trips a single facet domain', () => {
+    const doc = makeDoc()
+    const facets: ExtensionFacets = { 'kanban/1': { status: 'in-progress' } }
+
+    writeFacets(doc, facets)
+
+    expect(readFacets(doc)).toEqual(facets)
+  })
+
+  test('round-trips multiple facet domains', () => {
+    const doc = makeDoc()
+    const facets: ExtensionFacets = {
+      'kanban/1': { status: 'in-progress' },
+      'priority/1': { level: 'high' },
+    }
+
+    writeFacets(doc, facets)
+
+    expect(readFacets(doc)).toEqual(facets)
+  })
+
+  test('merges new facet keys with existing ones on write', () => {
+    const doc = makeDoc()
+
+    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc, {
+      'kanban/1': { status: 'done' },
+      'priority/1': { level: 'low' },
+    })
+
+    expect(readFacets(doc)).toEqual({
+      'kanban/1': { status: 'done' },
+      'priority/1': { level: 'low' },
+    })
+  })
+
+  test('deletes facet keys absent from a later write', () => {
+    const doc = makeDoc()
+
+    writeFacets(doc, {
+      'kanban/1': { status: 'todo' },
+      'priority/1': { level: 'low' },
+    })
+    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+
+    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+  })
+
+  test('CRDT merge: two docs add different facet domains', () => {
+    const doc1 = new LoroDoc()
+    const doc2 = new LoroDoc()
+
+    writeFacets(doc1, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc2, { 'priority/1': { level: 'high' } })
+
+    doc1.import(doc2.export({ mode: 'snapshot' }))
+
+    expect(readFacets(doc1)).toEqual({
+      'kanban/1': { status: 'todo' },
+      'priority/1': { level: 'high' },
+    })
+  })
+
+  test('ignores a malformed facet key found in the underlying map', () => {
+    const doc = makeDoc()
+    doc.getMap('facets').set('not-a-valid-key', { anything: true })
+    doc.commit()
+
+    expect(readFacets(doc)).toEqual({})
   })
 })

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -2,13 +2,16 @@ import type { LoroDoc } from 'loro-crdt'
 import {
   spatialNodeSchema,
   canvasEdgeSchema,
+  extensionFacetsSchema,
   type SpatialCanvas,
   type SpatialNode,
   type CanvasEdge,
+  type ExtensionFacets,
 } from '@kamiazya/whiteboard-canvas-model'
 
 const NODES_KEY = 'nodes'
 const EDGES_KEY = 'edges'
+const FACETS_KEY = 'facets'
 
 type Fields = Record<string, unknown>
 
@@ -107,4 +110,41 @@ export function readSpatialCanvas(doc: LoroDoc): SpatialCanvas {
   }
 
   return { nodes, edges }
+}
+
+/**
+ * Extension facets (the `{domain}/{version}` keyed bucket from
+ * canvas-model's `extensionFacetsSchema`) are stored the same way as
+ * nodes/edges above: a plain-object-valued `LoroMap` keyed by facet key, so
+ * one domain's CRDT merge never overwrites another's.
+ */
+export function writeFacets(doc: LoroDoc, facets: ExtensionFacets): void {
+  const facetsMap = doc.getMap(FACETS_KEY)
+  const existingKeys = new Set<string>(facetsMap.keys())
+  const incomingKeys = new Set<string>(Object.keys(facets))
+
+  for (const [key, value] of Object.entries(facets)) {
+    facetsMap.set(key, value)
+  }
+  for (const key of existingKeys) {
+    if (!incomingKeys.has(key)) facetsMap.delete(key)
+  }
+
+  doc.commit()
+}
+
+/**
+ * A per-key parse (rather than one whole-record parse) means a single
+ * corrupt entry in the underlying LoroMap is dropped instead of failing the
+ * entire read — consistent with readSpatialCanvas's per-node tolerance.
+ */
+export function readFacets(doc: LoroDoc): ExtensionFacets {
+  const facetsMap = doc.getMap(FACETS_KEY)
+  const result: ExtensionFacets = {}
+  for (const key of facetsMap.keys()) {
+    const value = facetsMap.get(key)
+    const parsed = extensionFacetsSchema.safeParse({ [key]: value })
+    if (parsed.success) result[key] = parsed.data[key]
+  }
+  return result
 }

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -19,8 +19,12 @@
     "test": "vitest run --config vitest.node.config.ts"
   },
   "dependencies": {
+    "@kamiazya/whiteboard-canvas-model": "workspace:*",
     "@kamiazya/whiteboard-canvas-ports": "workspace:*",
-    "hono": "^4.12.27"
+    "@kamiazya/whiteboard-canvas-workspace": "workspace:*",
+    "hono": "^4.12.27",
+    "loro-crdt": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/server-core/src/create-server.test.ts
+++ b/packages/server-core/src/create-server.test.ts
@@ -11,4 +11,14 @@ describe('createServer', () => {
     expect(app).toBeDefined()
     expect(app.fetch).toBeTypeOf('function')
   })
+
+  it('wires the facet_set tool', () => {
+    const { tools } = createServer({
+      canvasDocStore: {} as never,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+    expect(tools.facetSet.name).toBe('facet_set')
+    expect(tools.facetSet.execute).toBeTypeOf('function')
+  })
 })

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -1,5 +1,6 @@
 import type { BlobStore, CanvasDocStore, WorkspaceIndex } from '@kamiazya/whiteboard-canvas-ports'
 import { Hono } from 'hono'
+import { createFacetSetTool } from './tools/facet-set.js'
 
 export interface ServerDeps {
   canvasDocStore: CanvasDocStore
@@ -8,7 +9,9 @@ export interface ServerDeps {
 }
 
 export function createServer(deps: ServerDeps) {
-  void deps
   const app = new Hono()
-  return { app }
+  const tools = {
+    facetSet: createFacetSetTool(deps),
+  }
+  return { app, tools }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -1,2 +1,4 @@
 export { createServer } from './create-server.js'
 export type { ServerDeps } from './create-server.js'
+export { createFacetSetTool, facetSetInputSchema, facetSetOutputSchema } from './tools/facet-set.js'
+export type { FacetSetInput, FacetSetOutput } from './tools/facet-set.js'

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -1,0 +1,142 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+/** An in-memory CanvasDocStore fake, scoped to this test file only. */
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+describe('facet_set tool', () => {
+  test('sets a facet on a canvas with no prior snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createFacetSetTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
+
+    expect(result).toEqual({
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
+  })
+
+  test('persists the facet so a later load reflects it', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createFacetSetTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+
+    const loaded = await canvasDocStore.loadSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    })
+    expect(loaded).not.toBeNull()
+    const doc = new LoroDoc()
+    if (loaded !== null) {
+      const bytes = new Uint8Array(loaded.manifest.totalBytes)
+      let offset = 0
+      for (const chunk of loaded.chunks) {
+        bytes.set(chunk.bytes, offset)
+        offset += chunk.bytes.byteLength
+      }
+      doc.import(bytes)
+    }
+    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+  })
+
+  test('merges a new facet domain with an existing one instead of replacing it', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createFacetSetTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      facets: { 'priority/1': { level: 'high' } },
+    })
+
+    expect(result.facets).toEqual({
+      'kanban/1': { status: 'todo' },
+      'priority/1': { level: 'high' },
+    })
+  })
+
+  test('overwrites an existing facet domain when the same key is set again', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createFacetSetTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'done' } },
+    })
+
+    expect(result.facets).toEqual({ 'kanban/1': { status: 'done' } })
+  })
+
+  test('rejects a facet key outside the {domain}/{version} pattern', () => {
+    expect(() =>
+      facetSetInputSchema.parse({
+        canvasId: CANVAS_ID,
+        facets: { title: 'not an extension facet' },
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -1,0 +1,73 @@
+import {
+  canvasIdSchema,
+  extensionFacetsSchema,
+  type ExtensionFacets,
+} from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+
+/**
+ * `extensionFacetsSchema` already enforces the `{domain}/{version}` key
+ * pattern (canvas-model's `EXTENSION_FACET_KEY_PATTERN`), so a caller can
+ * never use this tool to set a core facet (`type`/`title`/`tags`/`view`) or
+ * the raw `facets` root key itself — those don't match the pattern and are
+ * rejected at parse time rather than needing a separate namespace guard.
+ */
+export const facetSetInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    facets: extensionFacetsSchema,
+  })
+  .strict()
+export type FacetSetInput = z.infer<typeof facetSetInputSchema>
+
+export const facetSetOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    facets: extensionFacetsSchema,
+  })
+  .strict()
+export type FacetSetOutput = z.infer<typeof facetSetOutputSchema>
+
+/**
+ * A single chunk always fits Loro's snapshot output for a facets-only
+ * mutation; this cap only matters once a store/sync implementation enforces
+ * its own message-size limit, which is out of this shared layer's scope.
+ */
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+export function createFacetSetTool(deps: ServerDeps) {
+  return {
+    name: 'facet_set' as const,
+    inputSchema: facetSetInputSchema,
+    outputSchema: facetSetOutputSchema,
+    async execute(input: FacetSetInput): Promise<FacetSetOutput> {
+      const docRef = { kind: 'canvas' as const, canvasId: input.canvasId }
+      const existing = await deps.canvasDocStore.loadSnapshot({ docRef })
+
+      const doc = new LoroDoc()
+      if (existing !== null) {
+        doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+      }
+
+      const mergedFacets: ExtensionFacets = { ...readFacets(doc), ...input.facets }
+      writeFacets(doc, mergedFacets)
+
+      const { manifest, chunks } = chunkSnapshot(
+        doc.export({ mode: 'snapshot' }),
+        SNAPSHOT_MAX_CHUNK_BYTES,
+      )
+      await deps.canvasDocStore.saveSnapshot({
+        docRef,
+        manifest,
+        chunks,
+        frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+      })
+
+      return { canvasId: input.canvasId, facets: mergedFacets }
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,7 +562,7 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -598,19 +598,31 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+        version: 8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/server-core:
     dependencies:
+      '@kamiazya/whiteboard-canvas-model':
+        specifier: workspace:*
+        version: link:../canvas-model
       '@kamiazya/whiteboard-canvas-ports':
         specifier: workspace:*
         version: link:../canvas-ports
+      '@kamiazya/whiteboard-canvas-workspace':
+        specifier: workspace:*
+        version: link:../canvas-workspace
       hono:
         specifier: ^4.12.27
         version: 4.12.27
+      loro-crdt:
+        specifier: 'catalog:'
+        version: 1.13.6
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -11477,7 +11489,7 @@ snapshots:
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       tslib: 2.8.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@swc/core-darwin-arm64@1.15.24':
     optional: true
@@ -11879,13 +11891,13 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@vitest/browser-playwright@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11905,16 +11917,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -11964,14 +11976,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.5(@types/node@24.12.2)(typescript@6.0.3)
-      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(msw@2.13.5(@types/node@24.13.1)(typescript@6.0.3))(vite@8.1.5(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -16007,7 +16019,7 @@ snapshots:
     dependencies:
       vite: 8.1.5(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
+  vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -16016,7 +16028,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.2
-      esbuild: 0.28.1
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
@@ -16039,10 +16051,10 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -16059,12 +16071,12 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
-      '@vitest/browser-playwright': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.13.5(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       happy-dom: 20.9.0
       jsdom: 29.1.1(canvas@3.2.3)


### PR DESCRIPTION
## Summary

- Add `readFacets`/`writeFacets` functions to canvas-workspace's LoroDoc bridge, following the same per-key safe-parse tolerance pattern as `readSpatialCanvas`/`writeSpatialCanvas`
- Add `facet_set` tool in server-core that loads a canvas doc snapshot, merges extension facets, and persists the updated document
- Namespace guard relies on `extensionFacetsSchema`'s `{domain}/{version}` key pattern — core facet keys are structurally rejected

## Test plan

- [ ] canvas-workspace: 7 new facets bridge tests (round-trip, per-key tolerance, key deletion, CRDT merge)
- [ ] server-core: 6 new facet_set tests + 1 wiring test (happy path, merge semantics, empty facets, not-found)
- [ ] arch-lint: passes (no banned imports)
- [ ] typecheck: all packages pass