### PR TITLE
feat(server-core): add node/edge/body patch tools and shared canvas-doc-io helper

### DIFF
--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -1,6 +1,9 @@
 import type { BlobStore, CanvasDocStore, WorkspaceIndex } from '@kamiazya/whiteboard-canvas-ports'
 import { Hono } from 'hono'
+import { createBodyPatchTool } from './tools/body-patch.js'
+import { createEdgePatchTool } from './tools/edge-patch.js'
 import { createFacetSetTool } from './tools/facet-set.js'
+import { createNodePatchTool } from './tools/node-patch.js'
 
 export interface ServerDeps {
   canvasDocStore: CanvasDocStore
@@ -12,6 +15,9 @@ export function createServer(deps: ServerDeps) {
   const app = new Hono()
   const tools = {
     facetSet: createFacetSetTool(deps),
+    nodePatch: createNodePatchTool(deps),
+    edgePatch: createEdgePatchTool(deps),
+    bodyPatch: createBodyPatchTool(deps),
   }
   return { app, tools }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -1,4 +1,32 @@
 export { createServer } from './create-server.js'
 export type { ServerDeps } from './create-server.js'
+export {
+  bodyPatchInputSchema,
+  bodyPatchOutputSchema,
+  bodyPatchRangeSchema,
+  createBodyPatchTool,
+} from './tools/body-patch.js'
+export type { BodyPatchInput, BodyPatchOutput, BodyPatchRange } from './tools/body-patch.js'
+export {
+  createEdgePatchTool,
+  edgePatchFieldsSchema,
+  edgePatchInputSchema,
+  edgePatchOutputSchema,
+} from './tools/edge-patch.js'
+export type { EdgePatchFields, EdgePatchInput, EdgePatchOutput } from './tools/edge-patch.js'
+export {
+  CanvasDocNotFoundError,
+  EdgeNotFoundError,
+  NodeNotFoundError,
+  NotATextNodeError,
+  PatchValidationError,
+} from './tools/errors.js'
 export { createFacetSetTool, facetSetInputSchema, facetSetOutputSchema } from './tools/facet-set.js'
 export type { FacetSetInput, FacetSetOutput } from './tools/facet-set.js'
+export {
+  createNodePatchTool,
+  nodePatchFieldsSchema,
+  nodePatchInputSchema,
+  nodePatchOutputSchema,
+} from './tools/node-patch.js'
+export type { NodePatchFields, NodePatchInput, NodePatchOutput } from './tools/node-patch.js'

--- a/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
+++ b/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
@@ -1,0 +1,46 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+
+/**
+ * An in-memory CanvasDocStore fake shared across server-core tool tests.
+ * Keyed by `docRef.canvasId` so a single fake instance can back multiple
+ * canvases within one test, matching how a real store scopes storage by
+ * DocRef rather than by store instance.
+ */
+export class FakeCanvasDocStore implements CanvasDocStore {
+  private readonly saved = new Map<string, SaveSnapshotInput>()
+
+  async loadSnapshot(input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (input.docRef.kind !== 'canvas') throw new Error('fake store only supports canvas docs')
+    const entry = this.saved.get(input.docRef.canvasId)
+    if (entry === undefined) return null
+    return { manifest: entry.manifest, chunks: entry.chunks, frontier: entry.frontier }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    if (input.docRef.kind !== 'canvas') throw new Error('fake store only supports canvas docs')
+    this.saved.set(input.docRef.canvasId, input)
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}

--- a/packages/server-core/src/tools/body-patch.test.ts
+++ b/packages/server-core/src/tools/body-patch.test.ts
@@ -1,0 +1,123 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { createBodyPatchTool } from './body-patch.js'
+import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+async function seedCanvas(
+  canvasDocStore: FakeCanvasDocStore,
+  canvas: SpatialCanvas,
+): Promise<void> {
+  const seedDoc = new LoroDoc()
+  writeSpatialCanvas(seedDoc, canvas)
+  const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+}
+
+describe('body_patch tool', () => {
+  test('mode "full" replaces the entire text body', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 't1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'line1\nline2' }],
+      edges: [],
+    })
+    const tool = createBodyPatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      mode: 'full',
+      canvasId: CANVAS_ID,
+      nodeId: 't1',
+      body: 'replaced',
+    })
+
+    expect(result.node).toMatchObject({ id: 't1', type: 'text', text: 'replaced' })
+  })
+
+  test('mode "range" splices a subset of lines, preserving lines outside the range', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [
+        {
+          id: 't1',
+          type: 'text',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          text: 'line0\nline1\nline2\nline3',
+        },
+      ],
+      edges: [],
+    })
+    const tool = createBodyPatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      mode: 'range',
+      canvasId: CANVAS_ID,
+      nodeId: 't1',
+      range: { startLine: 1, endLine: 2, replacement: 'NEW' },
+    })
+
+    expect(result.node).toMatchObject({ id: 't1', type: 'text', text: 'line0\nNEW\nline3' })
+  })
+
+  test('throws NotATextNodeError when targeting a non-text node', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 'g1', type: 'group', x: 0, y: 0, width: 100, height: 50 }],
+      edges: [],
+    })
+    const tool = createBodyPatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ mode: 'full', canvasId: CANVAS_ID, nodeId: 'g1', body: 'x' }),
+    ).rejects.toThrow(NotATextNodeError)
+  })
+
+  test('throws PatchValidationError for an out-of-range line splice', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [
+        { id: 't1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'only-one-line' },
+      ],
+      edges: [],
+    })
+    const tool = createBodyPatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({
+        mode: 'range',
+        canvasId: CANVAS_ID,
+        nodeId: 't1',
+        range: { startLine: 0, endLine: 5, replacement: 'x' },
+      }),
+    ).rejects.toThrow(PatchValidationError)
+  })
+
+  test('throws NodeNotFoundError for an unknown nodeId', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 't1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'x' }],
+      edges: [],
+    })
+    const tool = createBodyPatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ mode: 'full', canvasId: CANVAS_ID, nodeId: 'missing', body: 'x' }),
+    ).rejects.toThrow(NodeNotFoundError)
+  })
+})

--- a/packages/server-core/src/tools/body-patch.ts
+++ b/packages/server-core/src/tools/body-patch.ts
@@ -1,0 +1,127 @@
+import {
+  canvasIdSchema,
+  nodeIdSchema,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+} from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
+
+export const bodyPatchRangeSchema = z
+  .object({
+    startLine: z.number().int().nonnegative(),
+    endLine: z.number().int().nonnegative(),
+    replacement: z.string(),
+  })
+  .strict()
+  .refine((value) => value.startLine <= value.endLine, {
+    message: 'startLine must be <= endLine',
+  })
+export type BodyPatchRange = z.infer<typeof bodyPatchRangeSchema>
+
+/**
+ * `mode` is a discriminant rather than two optional sibling fields
+ * (`body` / `range`+`replacement`) so the schema itself rules out an
+ * ambiguous "both present" or "neither present" input, instead of
+ * `execute` branching on which optional field happened to show up.
+ */
+export const bodyPatchInputSchema = z.discriminatedUnion('mode', [
+  z
+    .object({
+      mode: z.literal('full'),
+      canvasId: canvasIdSchema,
+      nodeId: nodeIdSchema,
+      body: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      mode: z.literal('range'),
+      canvasId: canvasIdSchema,
+      nodeId: nodeIdSchema,
+      range: bodyPatchRangeSchema,
+    })
+    .strict(),
+])
+export type BodyPatchInput = z.infer<typeof bodyPatchInputSchema>
+
+export const bodyPatchOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    node: spatialNodeSchema,
+  })
+  .strict()
+export type BodyPatchOutput = z.infer<typeof bodyPatchOutputSchema>
+
+/**
+ * Splices lines `[startLine, endLine]` (inclusive, 0-indexed) out of
+ * `text` and inserts `replacement`'s lines in their place. Out-of-range
+ * indices are rejected by the caller before this runs — silently
+ * clamping would partial-apply the patch without telling the caller,
+ * which is the failure mode canvas-codec's own parsers reject rather
+ * than degrade.
+ */
+function spliceLines(text: string, range: BodyPatchRange): string {
+  const lines = text.split('\n')
+  const replacementLines = range.replacement.split('\n')
+  const before = lines.slice(0, range.startLine)
+  const after = lines.slice(range.endLine + 1)
+  return [...before, ...replacementLines, ...after].join('\n')
+}
+
+export function createBodyPatchTool(deps: ServerDeps) {
+  return {
+    name: 'body_patch' as const,
+    inputSchema: bodyPatchInputSchema,
+    outputSchema: bodyPatchOutputSchema,
+    async execute(input: BodyPatchInput): Promise<BodyPatchOutput> {
+      const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      const node = canvas.nodes.find((candidate) => candidate.id === input.nodeId)
+      if (node === undefined) throw new NodeNotFoundError(input.canvasId, input.nodeId)
+      if (node.type !== 'text') {
+        throw new NotATextNodeError(input.canvasId, input.nodeId, node.type)
+      }
+
+      let newText: string
+      if (input.mode === 'full') {
+        newText = input.body
+      } else {
+        const lineCount = node.text.split('\n').length
+        if (input.range.startLine >= lineCount || input.range.endLine >= lineCount) {
+          throw new PatchValidationError([
+            {
+              code: 'custom',
+              message: `range [${input.range.startLine}, ${input.range.endLine}] is out of bounds for a ${lineCount}-line body`,
+              path: ['range'],
+              input: input.range,
+            },
+          ])
+        }
+        newText = spliceLines(node.text, input.range)
+      }
+
+      const mergedRaw = { ...node, text: newText }
+      const candidateCanvas = {
+        nodes: canvas.nodes.map((existing) =>
+          existing.id === input.nodeId ? mergedRaw : existing,
+        ),
+        edges: canvas.edges,
+      }
+
+      const parsed = spatialCanvasSchema.safeParse(candidateCanvas)
+      if (!parsed.success) throw new PatchValidationError(parsed.error.issues)
+
+      const updatedNode = parsed.data.nodes.find((existing) => existing.id === input.nodeId)
+      if (updatedNode === undefined) {
+        throw new NodeNotFoundError(input.canvasId, input.nodeId)
+      }
+
+      await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+
+      return { canvasId: input.canvasId, node: updatedNode }
+    },
+  }
+}

--- a/packages/server-core/src/tools/canvas-doc-io.test.ts
+++ b/packages/server-core/src/tools/canvas-doc-io.test.ts
@@ -1,0 +1,64 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, test } from 'vitest'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { CanvasDocNotFoundError } from './errors.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+const canvasDeps = (canvasDocStore: FakeCanvasDocStore) => ({
+  canvasDocStore,
+  workspaceIndex: {} as never,
+  blobStore: {} as never,
+})
+
+describe('canvas-doc-io', () => {
+  test('loadCanvasDoc throws CanvasDocNotFoundError when no snapshot exists', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await expect(loadCanvasDoc(canvasDeps(canvasDocStore), CANVAS_ID)).rejects.toThrow(
+      CanvasDocNotFoundError,
+    )
+  })
+
+  test('save then load round trip preserves nodes untouched by the patch', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const deps = canvasDeps(canvasDocStore)
+
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' },
+        { id: 'n2', type: 'text', x: 10, y: 10, width: 100, height: 50, text: 'world' },
+      ],
+      edges: [],
+    }
+
+    // Seed the store directly (bypassing the tool under test).
+    const { LoroDoc } = await import('loro-crdt')
+    const { writeSpatialCanvas } = await import('@kamiazya/whiteboard-canvas-workspace')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-canvas-ports')
+    const seedDoc = new LoroDoc()
+    writeSpatialCanvas(seedDoc, canvas)
+    const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+    await canvasDocStore.saveSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+      manifest,
+      chunks,
+      frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const loaded = await loadCanvasDoc(deps, CANVAS_ID)
+    expect(loaded.canvas.nodes).toHaveLength(2)
+
+    // Simulate a patch that only touches n1, passing the FULL node array back.
+    const patched: SpatialCanvas = {
+      nodes: loaded.canvas.nodes.map((node) => (node.id === 'n1' ? { ...node, x: 99 } : node)),
+      edges: loaded.canvas.edges,
+    }
+    await saveCanvasDoc(deps, CANVAS_ID, loaded.doc, patched)
+
+    const reloaded = await loadCanvasDoc(deps, CANVAS_ID)
+    expect(reloaded.canvas.nodes).toHaveLength(2)
+    const n2 = reloaded.canvas.nodes.find((node) => node.id === 'n2')
+    expect(n2).toEqual(canvas.nodes[1])
+  })
+})

--- a/packages/server-core/src/tools/canvas-doc-io.ts
+++ b/packages/server-core/src/tools/canvas-doc-io.ts
@@ -39,6 +39,47 @@ export async function loadCanvasDoc(
 }
 
 /**
+ * Loads an existing canvas doc or creates a fresh one when no snapshot
+ * exists yet. Used by `facet_set` where setting facets on a never-saved
+ * canvas is valid (unlike spatial patch tools, which require an existing
+ * element to target).
+ */
+export async function loadOrCreateCanvasDoc(
+  deps: ServerDeps,
+  canvasId: CanvasId,
+): Promise<LoroDoc> {
+  const docRef = { kind: 'canvas' as const, canvasId }
+  const existing = await deps.canvasDocStore.loadSnapshot({ docRef })
+  const doc = new LoroDoc()
+  if (existing !== null) {
+    doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+  }
+  return doc
+}
+
+/**
+ * Exports the LoroDoc as a chunked snapshot and persists it. Shared by
+ * `saveCanvasDoc` (spatial patch tools) and `facet_set` (facet-only
+ * mutations) so the chunk+save logic lives in one place.
+ */
+export async function saveDocSnapshot(
+  deps: ServerDeps,
+  canvasId: CanvasId,
+  doc: LoroDoc,
+): Promise<void> {
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await deps.canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+/**
  * Saves a patched canvas doc. `canvas` must be the FULL `nodes`/`edges`
  * arrays (one entry replaced) — `writeSpatialCanvas` deletes any id
  * present in the doc but absent from `canvas`, so passing a lone patched
@@ -57,14 +98,5 @@ export async function saveCanvasDoc(
   canvas: SpatialCanvas,
 ): Promise<void> {
   writeSpatialCanvas(doc, canvas)
-  const { manifest, chunks } = chunkSnapshot(
-    doc.export({ mode: 'snapshot' }),
-    SNAPSHOT_MAX_CHUNK_BYTES,
-  )
-  await deps.canvasDocStore.saveSnapshot({
-    docRef: { kind: 'canvas', canvasId },
-    manifest,
-    chunks,
-    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-  })
+  await saveDocSnapshot(deps, canvasId, doc)
 }

--- a/packages/server-core/src/tools/canvas-doc-io.ts
+++ b/packages/server-core/src/tools/canvas-doc-io.ts
@@ -1,0 +1,70 @@
+import type { CanvasId, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import type { ServerDeps } from '../create-server.js'
+import { CanvasDocNotFoundError } from './errors.js'
+
+/**
+ * A single chunk always fits Loro's snapshot output for the geometry/text
+ * mutations these patch tools perform; this cap only matters once a
+ * store/sync implementation enforces its own message-size limit, which is
+ * out of this shared layer's scope.
+ */
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+export interface LoadedCanvasDoc {
+  doc: LoroDoc
+  canvas: SpatialCanvas
+}
+
+/**
+ * Loads a canvas doc for patching. Unlike `facet_set` (which tolerates a
+ * missing doc — facets can be set on a brand-new canvas), a patch targets
+ * an *existing* element by id, so there is nothing sensible to patch in a
+ * doc that has never been saved. This deliberately throws instead of
+ * falling back to an empty `LoroDoc`.
+ */
+export async function loadCanvasDoc(
+  deps: ServerDeps,
+  canvasId: CanvasId,
+): Promise<LoadedCanvasDoc> {
+  const docRef = { kind: 'canvas' as const, canvasId }
+  const existing = await deps.canvasDocStore.loadSnapshot({ docRef })
+  if (existing === null) throw new CanvasDocNotFoundError(canvasId)
+
+  const doc = new LoroDoc()
+  doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+  return { doc, canvas: readSpatialCanvas(doc) }
+}
+
+/**
+ * Saves a patched canvas doc. `canvas` must be the FULL `nodes`/`edges`
+ * arrays (one entry replaced) — `writeSpatialCanvas` deletes any id
+ * present in the doc but absent from `canvas`, so passing a lone patched
+ * node/edge would silently drop every other element.
+ *
+ * This is a read-modify-write with no optimistic-concurrency check, same
+ * as `workspace-tree-io.ts`'s `saveWorkspaceTree`: two concurrent patches
+ * against the same canvas race, and the later `saveSnapshot` call wins
+ * outright — the earlier patch is silently lost rather than merged. This
+ * is an accepted limitation for now, not an oversight.
+ */
+export async function saveCanvasDoc(
+  deps: ServerDeps,
+  canvasId: CanvasId,
+  doc: LoroDoc,
+  canvas: SpatialCanvas,
+): Promise<void> {
+  writeSpatialCanvas(doc, canvas)
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await deps.canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}

--- a/packages/server-core/src/tools/edge-patch.test.ts
+++ b/packages/server-core/src/tools/edge-patch.test.ts
@@ -1,0 +1,81 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { createEdgePatchTool } from './edge-patch.js'
+import { EdgeNotFoundError, PatchValidationError } from './errors.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+async function seedCanvas(
+  canvasDocStore: FakeCanvasDocStore,
+  canvas: SpatialCanvas,
+): Promise<void> {
+  const seedDoc = new LoroDoc()
+  writeSpatialCanvas(seedDoc, canvas)
+  const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+}
+
+const BASE_CANVAS: SpatialCanvas = {
+  nodes: [
+    { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' },
+    { id: 'n2', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'b' },
+  ],
+  edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+}
+
+describe('edge_patch tool', () => {
+  test('patches color/label/fromSide/toSide on an existing edge', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, BASE_CANVAS)
+    const tool = createEdgePatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      edgeId: 'e1',
+      patch: { color: '3', label: 'connects', fromSide: 'right', toSide: 'left' },
+    })
+
+    expect(result.edge).toEqual({
+      id: 'e1',
+      fromNode: 'n1',
+      toNode: 'n2',
+      color: '3',
+      label: 'connects',
+      fromSide: 'right',
+      toSide: 'left',
+    })
+  })
+
+  test('throws EdgeNotFoundError for an unknown edgeId', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, BASE_CANVAS)
+    const tool = createEdgePatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ canvasId: CANVAS_ID, edgeId: 'missing', patch: { color: '1' } }),
+    ).rejects.toThrow(EdgeNotFoundError)
+  })
+
+  test('retargeting toNode to a nonexistent node id throws PatchValidationError', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, BASE_CANVAS)
+    const tool = createEdgePatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ canvasId: CANVAS_ID, edgeId: 'e1', patch: { toNode: 'does-not-exist' } }),
+    ).rejects.toThrow(PatchValidationError)
+  })
+})

--- a/packages/server-core/src/tools/edge-patch.ts
+++ b/packages/server-core/src/tools/edge-patch.ts
@@ -1,0 +1,82 @@
+import {
+  canvasColorSchema,
+  canvasEdgeSchema,
+  canvasIdSchema,
+  nodeIdSchema,
+  spatialCanvasSchema,
+} from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { EdgeNotFoundError, PatchValidationError } from './errors.js'
+
+export const edgePatchFieldsSchema = z
+  .object({
+    fromNode: nodeIdSchema.optional(),
+    toNode: nodeIdSchema.optional(),
+    fromSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+    toSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+    color: canvasColorSchema.optional(),
+    label: z.string().optional(),
+  })
+  .strict()
+export type EdgePatchFields = z.infer<typeof edgePatchFieldsSchema>
+
+export const edgePatchInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    // canvas-model has no distinct edgeIdSchema — edges and nodes share
+    // the same nanoid-style id shape (`nodeIdSchema` only enforces
+    // non-emptiness), so reusing it here is deliberate, not a copy-paste
+    // mistake.
+    edgeId: nodeIdSchema,
+    patch: edgePatchFieldsSchema,
+  })
+  .strict()
+export type EdgePatchInput = z.infer<typeof edgePatchInputSchema>
+
+export const edgePatchOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    edge: canvasEdgeSchema,
+  })
+  .strict()
+export type EdgePatchOutput = z.infer<typeof edgePatchOutputSchema>
+
+export function createEdgePatchTool(deps: ServerDeps) {
+  return {
+    name: 'edge_patch' as const,
+    inputSchema: edgePatchInputSchema,
+    outputSchema: edgePatchOutputSchema,
+    async execute(input: EdgePatchInput): Promise<EdgePatchOutput> {
+      const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      const edge = canvas.edges.find((candidate) => candidate.id === input.edgeId)
+      if (edge === undefined) throw new EdgeNotFoundError(input.canvasId, input.edgeId)
+
+      const mergedRaw = { ...edge, ...input.patch }
+      const candidateCanvas = {
+        nodes: canvas.nodes,
+        edges: canvas.edges.map((existing) =>
+          existing.id === input.edgeId ? mergedRaw : existing,
+        ),
+      }
+
+      // `spatialCanvasSchema` (not `canvasEdgeSchema`) is the validation
+      // gate here: it is the only schema that owns the endpoint-existence
+      // invariant, so a retargeted fromNode/toNode pointing at a
+      // nonexistent node id surfaces as a PatchValidationError.
+      const parsed = spatialCanvasSchema.safeParse(candidateCanvas)
+      if (!parsed.success) throw new PatchValidationError(parsed.error.issues)
+
+      const updatedEdge = parsed.data.edges.find((existing) => existing.id === input.edgeId)
+      if (updatedEdge === undefined) {
+        throw new EdgeNotFoundError(input.canvasId, input.edgeId)
+      }
+
+      await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+
+      return { canvasId: input.canvasId, edge: updatedEdge }
+    },
+  }
+}

--- a/packages/server-core/src/tools/errors.test.ts
+++ b/packages/server-core/src/tools/errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+import {
+  CanvasDocNotFoundError,
+  EdgeNotFoundError,
+  NodeNotFoundError,
+  NotATextNodeError,
+  PatchValidationError,
+} from './errors.js'
+
+describe('server-core tool errors', () => {
+  test('CanvasDocNotFoundError carries the canvasId and a descriptive message', () => {
+    const err = new CanvasDocNotFoundError('canvas-1')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('CanvasDocNotFoundError')
+    expect(err.canvasId).toBe('canvas-1')
+    expect(err.message).toContain('canvas-1')
+  })
+
+  test('NodeNotFoundError carries canvasId and nodeId', () => {
+    const err = new NodeNotFoundError('canvas-1', 'node-1')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('NodeNotFoundError')
+    expect(err.canvasId).toBe('canvas-1')
+    expect(err.nodeId).toBe('node-1')
+    expect(err.message).toContain('node-1')
+    expect(err.message).toContain('canvas-1')
+  })
+
+  test('EdgeNotFoundError carries canvasId and edgeId', () => {
+    const err = new EdgeNotFoundError('canvas-1', 'edge-1')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('EdgeNotFoundError')
+    expect(err.canvasId).toBe('canvas-1')
+    expect(err.edgeId).toBe('edge-1')
+    expect(err.message).toContain('edge-1')
+    expect(err.message).toContain('canvas-1')
+  })
+
+  test('PatchValidationError carries the issues and joins their messages', () => {
+    const issues = [
+      { code: 'custom', message: 'bad thing', path: ['edges', 0, 'fromNode'] },
+    ] as unknown as import('zod').ZodIssue[]
+    const err = new PatchValidationError(issues)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('PatchValidationError')
+    expect(err.issues).toBe(issues)
+    expect(err.message).toContain('bad thing')
+  })
+
+  test('NotATextNodeError carries canvasId, nodeId, and actualType', () => {
+    const err = new NotATextNodeError('canvas-1', 'node-1', 'file')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('NotATextNodeError')
+    expect(err.canvasId).toBe('canvas-1')
+    expect(err.nodeId).toBe('node-1')
+    expect(err.actualType).toBe('file')
+    expect(err.message).toContain('file')
+  })
+})

--- a/packages/server-core/src/tools/errors.ts
+++ b/packages/server-core/src/tools/errors.ts
@@ -1,0 +1,60 @@
+import type { z } from 'zod'
+
+/** Thrown when a patch tool targets a canvas that has no saved snapshot yet. */
+export class CanvasDocNotFoundError extends Error {
+  constructor(public readonly canvasId: string) {
+    super(`canvas doc not found: ${canvasId}`)
+    this.name = 'CanvasDocNotFoundError'
+  }
+}
+
+/** Thrown when a patch tool targets a nodeId absent from the canvas. */
+export class NodeNotFoundError extends Error {
+  constructor(
+    public readonly canvasId: string,
+    public readonly nodeId: string,
+  ) {
+    super(`node not found: ${nodeId} in canvas ${canvasId}`)
+    this.name = 'NodeNotFoundError'
+  }
+}
+
+/** Thrown when a patch tool targets an edgeId absent from the canvas. */
+export class EdgeNotFoundError extends Error {
+  constructor(
+    public readonly canvasId: string,
+    public readonly edgeId: string,
+  ) {
+    super(`edge not found: ${edgeId} in canvas ${canvasId}`)
+    this.name = 'EdgeNotFoundError'
+  }
+}
+
+/**
+ * Thrown when a patch's merged result fails `spatialCanvasSchema`
+ * validation — e.g. an edge patch retargets `fromNode`/`toNode` to a
+ * nonexistent node id. Reuses the schema's own cross-field invariant
+ * instead of a parallel hand-rolled existence check.
+ */
+export class PatchValidationError extends Error {
+  constructor(public readonly issues: z.ZodIssue[]) {
+    super(`patch produced an invalid canvas: ${issues.map((issue) => issue.message).join('; ')}`)
+    this.name = 'PatchValidationError'
+  }
+}
+
+/**
+ * Thrown when `wb_body_patch` targets a node whose `type` is not `'text'`
+ * — a distinct failure mode from `PatchValidationError` (wrong node kind
+ * chosen by the caller, not a schema violation produced by a valid patch).
+ */
+export class NotATextNodeError extends Error {
+  constructor(
+    public readonly canvasId: string,
+    public readonly nodeId: string,
+    public readonly actualType: string,
+  ) {
+    super(`node ${nodeId} in canvas ${canvasId} is not a text node (type: ${actualType})`)
+    this.name = 'NotATextNodeError'
+  }
+}

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -1,51 +1,10 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
+import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
-import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
 import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
-
-/** An in-memory CanvasDocStore fake, scoped to this test file only. */
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
-}
 
 describe('facet_set tool', () => {
   test('sets a facet on a canvas with no prior snapshot', async () => {

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -3,11 +3,10 @@ import {
   extensionFacetsSchema,
   type ExtensionFacets,
 } from '@kamiazya/whiteboard-canvas-model'
-import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
-import { LoroDoc } from 'loro-crdt'
 import { z } from 'zod'
 import type { ServerDeps } from '../create-server.js'
+import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
 
 /**
  * `extensionFacetsSchema` already enforces the `{domain}/{version}` key
@@ -32,40 +31,18 @@ export const facetSetOutputSchema = z
   .strict()
 export type FacetSetOutput = z.infer<typeof facetSetOutputSchema>
 
-/**
- * A single chunk always fits Loro's snapshot output for a facets-only
- * mutation; this cap only matters once a store/sync implementation enforces
- * its own message-size limit, which is out of this shared layer's scope.
- */
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
-
 export function createFacetSetTool(deps: ServerDeps) {
   return {
     name: 'facet_set' as const,
     inputSchema: facetSetInputSchema,
     outputSchema: facetSetOutputSchema,
     async execute(input: FacetSetInput): Promise<FacetSetOutput> {
-      const docRef = { kind: 'canvas' as const, canvasId: input.canvasId }
-      const existing = await deps.canvasDocStore.loadSnapshot({ docRef })
-
-      const doc = new LoroDoc()
-      if (existing !== null) {
-        doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
-      }
+      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
 
       const mergedFacets: ExtensionFacets = { ...readFacets(doc), ...input.facets }
       writeFacets(doc, mergedFacets)
 
-      const { manifest, chunks } = chunkSnapshot(
-        doc.export({ mode: 'snapshot' }),
-        SNAPSHOT_MAX_CHUNK_BYTES,
-      )
-      await deps.canvasDocStore.saveSnapshot({
-        docRef,
-        manifest,
-        chunks,
-        frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-      })
+      await saveDocSnapshot(deps, input.canvasId, doc)
 
       return { canvasId: input.canvasId, facets: mergedFacets }
     },

--- a/packages/server-core/src/tools/node-patch.test.ts
+++ b/packages/server-core/src/tools/node-patch.test.ts
@@ -1,0 +1,127 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { CanvasDocNotFoundError, NodeNotFoundError } from './errors.js'
+import { createNodePatchTool, nodePatchInputSchema } from './node-patch.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+async function seedCanvas(
+  canvasDocStore: FakeCanvasDocStore,
+  canvas: SpatialCanvas,
+): Promise<void> {
+  const seedDoc = new LoroDoc()
+  writeSpatialCanvas(seedDoc, canvas)
+  const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+}
+
+describe('node_patch tool', () => {
+  test('patches x/y/width/height/color on a text node and persists the change', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+      edges: [],
+    })
+    const tool = createNodePatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      nodeId: 'n1',
+      patch: { x: 42, y: 7, width: 200, height: 90, color: '2' },
+    })
+
+    expect(result.node).toEqual({
+      id: 'n1',
+      type: 'text',
+      x: 42,
+      y: 7,
+      width: 200,
+      height: 90,
+      color: '2',
+      text: 'hello',
+    })
+
+    const reloaded = await canvasDocStore.loadSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    })
+    expect(reloaded).not.toBeNull()
+  })
+
+  test('patches label on a group node', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 'g1', type: 'group', x: 0, y: 0, width: 300, height: 300 }],
+      edges: [],
+    })
+    const tool = createNodePatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      nodeId: 'g1',
+      patch: { label: 'My Group' },
+    })
+
+    expect(result.node).toMatchObject({ id: 'g1', type: 'group', label: 'My Group' })
+  })
+
+  test('silently drops label patched onto a text node (unknown key for that type)', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+      edges: [],
+    })
+    const tool = createNodePatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      canvasId: CANVAS_ID,
+      nodeId: 'n1',
+      patch: { label: 'ignored' },
+    })
+
+    expect(result.node).not.toHaveProperty('label')
+  })
+
+  test('throws NodeNotFoundError for an unknown nodeId', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+      edges: [],
+    })
+    const tool = createNodePatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ canvasId: CANVAS_ID, nodeId: 'missing', patch: { x: 1 } }),
+    ).rejects.toThrow(NodeNotFoundError)
+  })
+
+  test('throws CanvasDocNotFoundError when no snapshot exists yet', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createNodePatchTool(makeDeps(canvasDocStore))
+
+    await expect(
+      tool.execute({ canvasId: CANVAS_ID, nodeId: 'n1', patch: { x: 1 } }),
+    ).rejects.toThrow(CanvasDocNotFoundError)
+  })
+
+  test('rejects a negative width at the input-schema level', () => {
+    const result = nodePatchInputSchema.safeParse({
+      canvasId: CANVAS_ID,
+      nodeId: 'n1',
+      patch: { width: -5 },
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/server-core/src/tools/node-patch.ts
+++ b/packages/server-core/src/tools/node-patch.ts
@@ -1,0 +1,84 @@
+import {
+  canvasColorSchema,
+  canvasIdSchema,
+  nodeIdSchema,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+} from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { NodeNotFoundError, PatchValidationError } from './errors.js'
+
+/**
+ * Deliberately limited to the geometry/style fields every node type
+ * shares plus `label` (which only `groupNodeSchema` declares) — not the
+ * full per-type content field set (`text`/`file`/`subpath`/`url`/
+ * `background`/`backgroundStyle`). Applying `label` to a non-group node
+ * is a silent no-op after re-parse: `spatialNodeSchema`'s per-type
+ * variants are not `.strict()`, so an unrecognized key is stripped, not
+ * rejected. That is existing schema behavior, not new behavior introduced
+ * here.
+ */
+export const nodePatchFieldsSchema = z
+  .object({
+    x: z.number().int().optional(),
+    y: z.number().int().optional(),
+    width: z.number().int().nonnegative().optional(),
+    height: z.number().int().nonnegative().optional(),
+    color: canvasColorSchema.optional(),
+    label: z.string().optional(),
+  })
+  .strict()
+export type NodePatchFields = z.infer<typeof nodePatchFieldsSchema>
+
+export const nodePatchInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    nodeId: nodeIdSchema,
+    patch: nodePatchFieldsSchema,
+  })
+  .strict()
+export type NodePatchInput = z.infer<typeof nodePatchInputSchema>
+
+export const nodePatchOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    node: spatialNodeSchema,
+  })
+  .strict()
+export type NodePatchOutput = z.infer<typeof nodePatchOutputSchema>
+
+export function createNodePatchTool(deps: ServerDeps) {
+  return {
+    name: 'node_patch' as const,
+    inputSchema: nodePatchInputSchema,
+    outputSchema: nodePatchOutputSchema,
+    async execute(input: NodePatchInput): Promise<NodePatchOutput> {
+      const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      const node = canvas.nodes.find((candidate) => candidate.id === input.nodeId)
+      if (node === undefined) throw new NodeNotFoundError(input.canvasId, input.nodeId)
+
+      const mergedRaw = { ...node, ...input.patch }
+      const candidateCanvas = {
+        nodes: canvas.nodes.map((existing) =>
+          existing.id === input.nodeId ? mergedRaw : existing,
+        ),
+        edges: canvas.edges,
+      }
+
+      const parsed = spatialCanvasSchema.safeParse(candidateCanvas)
+      if (!parsed.success) throw new PatchValidationError(parsed.error.issues)
+
+      const updatedNode = parsed.data.nodes.find((existing) => existing.id === input.nodeId)
+      if (updatedNode === undefined) {
+        throw new NodeNotFoundError(input.canvasId, input.nodeId)
+      }
+
+      await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+
+      return { canvasId: input.canvasId, node: updatedNode }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Add `wb_node_patch`, `wb_edge_patch`, `wb_body_patch` MCP tools to server-core for patching spatial canvas elements
- Extract shared `canvas-doc-io.ts` helper (loadCanvasDoc / saveCanvasDoc) from facet-set's inline Loro plumbing
- Refactor `facet-set.ts` to reuse the shared helper
- Add error classes: `CanvasDocNotFoundError`, `NodeNotFoundError`, `EdgeNotFoundError`, `NotATextNodeError`, `PatchValidationError`

## Test plan

- [x] server-core-node tests pass (52 tests across 11 files)
- [x] node-patch: geometry/style field patching, not-found errors, validation
- [x] edge-patch: field patching, not-found errors
- [x] body-patch: full replacement, range replacement, not-a-text-node errors
- [x] facet-set refactored to canvas-doc-io without behavior change
- [x] Merge conflict with main (7a canvas CRUD + 7b facet_set) resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools for updating canvas node properties, edge properties, and text node content.
  * Text updates support replacing the full body or a selected line range.
  * Added clear validation and not-found errors for invalid canvas, node, edge, and patch requests.
  * Canvas documents now support reliable loading, creation, and snapshot persistence.
  * Existing facet updates continue to merge and persist correctly.
* **Tests**
  * Added coverage for patch operations, validation, persistence, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->