### PR TITLE
feat(server-core): add canvas render, digest, and export MCP tools

### DIFF
--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -19,8 +19,10 @@
     "test": "vitest run --config vitest.node.config.ts"
   },
   "dependencies": {
+    "@kamiazya/whiteboard-canvas-codec": "workspace:*",
     "@kamiazya/whiteboard-canvas-model": "workspace:*",
     "@kamiazya/whiteboard-canvas-ports": "workspace:*",
+    "@kamiazya/whiteboard-canvas-render": "workspace:*",
     "@kamiazya/whiteboard-canvas-workspace": "workspace:*",
     "hono": "^4.12.27",
     "loro-crdt": "catalog:",

--- a/packages/server-core/src/create-server.test.ts
+++ b/packages/server-core/src/create-server.test.ts
@@ -21,4 +21,26 @@ describe('createServer', () => {
     expect(tools.facetSet.name).toBe('facet_set')
     expect(tools.facetSet.execute).toBeTypeOf('function')
   })
+
+  it('wires the render/export tools with input and output schemas', () => {
+    const { tools } = createServer({
+      canvasDocStore: {} as never,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const expectations = [
+      { tool: tools.canvasRenderSvg, name: 'canvas_render_svg' },
+      { tool: tools.canvasDigest, name: 'canvas_digest' },
+      { tool: tools.canvasExportOkf, name: 'canvas_export_okf' },
+      { tool: tools.canvasExportJsonCanvas, name: 'canvas_export_json_canvas' },
+    ]
+
+    for (const { tool, name } of expectations) {
+      expect(tool.name).toBe(name)
+      expect(tool.execute).toBeTypeOf('function')
+      expect(tool.inputSchema).toBeDefined()
+      expect(tool.outputSchema).toBeDefined()
+    }
+  })
 })

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -1,5 +1,9 @@
 import type { BlobStore, CanvasDocStore, WorkspaceIndex } from '@kamiazya/whiteboard-canvas-ports'
 import { Hono } from 'hono'
+import { createCanvasDigestTool } from './tools/canvas-digest.js'
+import { createCanvasExportJsonCanvasTool } from './tools/canvas-export-json-canvas.js'
+import { createCanvasExportOkfTool } from './tools/canvas-export-okf.js'
+import { createCanvasRenderSvgTool } from './tools/canvas-render-svg.js'
 import { createFacetSetTool } from './tools/facet-set.js'
 
 export interface ServerDeps {
@@ -12,6 +16,10 @@ export function createServer(deps: ServerDeps) {
   const app = new Hono()
   const tools = {
     facetSet: createFacetSetTool(deps),
+    canvasRenderSvg: createCanvasRenderSvgTool(deps),
+    canvasDigest: createCanvasDigestTool(deps),
+    canvasExportOkf: createCanvasExportOkfTool(deps),
+    canvasExportJsonCanvas: createCanvasExportJsonCanvasTool(deps),
   }
   return { app, tools }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -2,3 +2,26 @@ export { createServer } from './create-server.js'
 export type { ServerDeps } from './create-server.js'
 export { createFacetSetTool, facetSetInputSchema, facetSetOutputSchema } from './tools/facet-set.js'
 export type { FacetSetInput, FacetSetOutput } from './tools/facet-set.js'
+export {
+  createCanvasRenderSvgTool,
+  canvasRenderSvgInputSchema,
+  canvasRenderSvgOutputSchema,
+} from './tools/canvas-render-svg.js'
+export type { CanvasRenderSvgInput, CanvasRenderSvgOutput } from './tools/canvas-render-svg.js'
+export { createCanvasDigestTool, canvasDigestInputSchema } from './tools/canvas-digest.js'
+export type { CanvasDigestInput } from './tools/canvas-digest.js'
+export {
+  createCanvasExportOkfTool,
+  canvasExportOkfInputSchema,
+  canvasExportOkfOutputSchema,
+} from './tools/canvas-export-okf.js'
+export type { CanvasExportOkfInput, CanvasExportOkfOutput } from './tools/canvas-export-okf.js'
+export {
+  createCanvasExportJsonCanvasTool,
+  canvasExportJsonCanvasInputSchema,
+  canvasExportJsonCanvasOutputSchema,
+} from './tools/canvas-export-json-canvas.js'
+export type {
+  CanvasExportJsonCanvasInput,
+  CanvasExportJsonCanvasOutput,
+} from './tools/canvas-export-json-canvas.js'

--- a/packages/server-core/src/render/compose-canvas-scene.test.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.test.ts
@@ -1,0 +1,98 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { routeEdge } from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, test } from 'vitest'
+import { composeCanvasScene, computeCanvasDimensions } from './compose-canvas-scene.js'
+import { fallbackMeasureText } from './fallback-measure.js'
+
+describe('composeCanvasScene', () => {
+  test('translates a text node body by its own (x, y)', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'text', x: 10, y: 20, width: 100, height: 50, text: 'hello world' },
+      ],
+      edges: [],
+    }
+
+    const scene = composeCanvasScene(canvas, fallbackMeasureText)
+
+    expect(scene.nodes).toHaveLength(1)
+    const [paragraph] = scene.nodes
+    if (!('bbox' in paragraph)) throw new Error('expected a bbox-carrying scene node')
+    expect(paragraph.kind).toBe('paragraph')
+    expect(paragraph.bbox.x).toBe(10)
+    expect(paragraph.bbox.y).toBe(20)
+  })
+
+  test('degrades a file/link/group node to a placeholder box at its own bbox', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'file', x: 5, y: 6, width: 40, height: 30, file: 'a.png' },
+        { id: 'n2', type: 'link', x: 1, y: 2, width: 10, height: 10, url: 'https://example.com' },
+        { id: 'n3', type: 'group', x: 0, y: 0, width: 200, height: 200 },
+      ],
+      edges: [],
+    }
+
+    const scene = composeCanvasScene(canvas, fallbackMeasureText)
+
+    expect(scene.nodes).toHaveLength(3)
+    for (const [index, node] of canvas.nodes.entries()) {
+      const sceneNode = scene.nodes[index]
+      if (!('bbox' in sceneNode)) throw new Error('expected a bbox-carrying scene node')
+      expect(sceneNode.kind).toBe('group')
+      expect(sceneNode.bbox).toEqual({ x: node.x, y: node.y, w: node.width, h: node.height })
+    }
+  })
+
+  test('a malformed text body degrades to a placeholder instead of throwing', () => {
+    // An unbalanced/invalid fence-like construct that the closed mdast
+    // subset's schema rejects after remark parses it into a shape
+    // mdastRootSchema does not accept.
+    const canvas: SpatialCanvas = {
+      nodes: [
+        {
+          id: 'n1',
+          type: 'text',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          text: '<div><span></div>',
+        },
+      ],
+      edges: [],
+    }
+
+    expect(() => composeCanvasScene(canvas, fallbackMeasureText)).not.toThrow()
+  })
+
+  test('edge scene nodes are not translated a second time on top of routeEdge', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'a', type: 'group', x: 0, y: 0, width: 50, height: 50 },
+        { id: 'b', type: 'group', x: 200, y: 200, width: 50, height: 50 },
+      ],
+      edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+    }
+
+    const scene = composeCanvasScene(canvas, fallbackMeasureText)
+    const edgeNode = scene.nodes.find((n) => n.kind === 'edge')
+    const expected = routeEdge(canvas.nodes, canvas.edges[0])
+
+    expect(edgeNode).toEqual(expected)
+  })
+})
+
+describe('computeCanvasDimensions', () => {
+  test('returns a zero-sized default for an empty canvas', () => {
+    expect(computeCanvasDimensions([])).toEqual({ width: 0, height: 0 })
+  })
+
+  test('returns the union bounding box over multiple nodes', () => {
+    const dims = computeCanvasDimensions([
+      { id: 'a', type: 'group', x: 0, y: 0, width: 50, height: 50 },
+      { id: 'b', type: 'group', x: 100, y: 100, width: 50, height: 50 },
+    ])
+    expect(dims).toEqual({ width: 150, height: 150 })
+  })
+})

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -1,0 +1,141 @@
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type {
+  ListItemNode,
+  MeasureText,
+  Scene,
+  SceneNode,
+} from '@kamiazya/whiteboard-canvas-render'
+import { layoutMdastBlocks, routeEdge } from '@kamiazya/whiteboard-canvas-render'
+import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
+
+/**
+ * Recursively translates every bbox in a scene node subtree by (dx, dy).
+ * `layoutMdastBlocks` always starts a document at (0, 0); a spatial
+ * canvas's text node lives at its own (x, y), so its laid-out scene must be
+ * shifted into place before joining the rest of the canvas's scene graph.
+ */
+function translateNode(node: SceneNode, dx: number, dy: number): SceneNode {
+  if (node.kind === 'edge') {
+    // Edges are already resolved in absolute canvas coordinates by
+    // routeEdge — translating them here would double-shift them.
+    return node
+  }
+
+  const bbox = { x: node.bbox.x + dx, y: node.bbox.y + dy, w: node.bbox.w, h: node.bbox.h }
+
+  switch (node.kind) {
+    case 'textRun':
+    case 'thematicBreak':
+    case 'codeBlock':
+    case 'rawHtml':
+    case 'unresolvedReference':
+    case 'svgFragment':
+    case 'embedPlaceholder':
+      return { ...node, bbox }
+    case 'heading':
+    case 'paragraph':
+      return {
+        ...node,
+        bbox,
+        runs: node.runs.map((run) => translateNode(run, dx, dy) as typeof run),
+      }
+    case 'list':
+      return {
+        ...node,
+        bbox,
+        items: node.items.map((item) => translateListItem(item, dx, dy)),
+      }
+    case 'blockquote':
+    case 'group':
+    case 'embedResolved':
+      return { ...node, bbox, children: node.children.map((child) => translateNode(child, dx, dy)) }
+    case 'table':
+      return {
+        ...node,
+        bbox,
+        rows: node.rows.map((row) => ({
+          ...row,
+          bbox: { x: row.bbox.x + dx, y: row.bbox.y + dy, w: row.bbox.w, h: row.bbox.h },
+          cells: row.cells.map((cell) => ({
+            ...cell,
+            bbox: { x: cell.bbox.x + dx, y: cell.bbox.y + dy, w: cell.bbox.w, h: cell.bbox.h },
+            runs: cell.runs.map((run) => translateNode(run, dx, dy) as typeof run),
+          })),
+        })),
+      }
+  }
+}
+
+/** `ListItemNode` is not itself a `SceneNode` variant, so it needs its own translator. */
+function translateListItem(item: ListItemNode, dx: number, dy: number): ListItemNode {
+  return {
+    ...item,
+    bbox: { x: item.bbox.x + dx, y: item.bbox.y + dy, w: item.bbox.w, h: item.bbox.h },
+    children: item.children.map((child) => translateNode(child, dx, dy)),
+  }
+}
+
+/**
+ * `file`/`link`/`group` spatial nodes have no markdown body to lay out.
+ * Multi-doc embed recursion (`resolveEmbeds`/`ResolvedDocBundle`) is out of
+ * scope for this tool set — these nodes degrade to a placeholder box at
+ * their own bbox, matching canvas-render's own "degrade rather than throw"
+ * convention (`EmbedPlaceholderNode`).
+ */
+function placeholderFor(node: SpatialNode): SceneNode {
+  return {
+    kind: 'group',
+    bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
+    children: [],
+  }
+}
+
+function layoutTextNode(node: SpatialNode & { type: 'text' }, measure: MeasureText): SceneNode[] {
+  let laidOut: Scene
+  try {
+    const mdastRoot = parseMarkdownBody(node.text)
+    laidOut = layoutMdastBlocks(mdastRoot, { measure, maxWidth: node.width })
+  } catch {
+    // parseMarkdownBody throws when a body's remark-parsed tree falls
+    // outside the closed mdast subset (mdastRootSchema rejects it) — a
+    // real, reachable case, not a bug in this composer. Degrade instead of
+    // aborting the whole canvas's render for one bad node.
+    return [placeholderFor(node)]
+  }
+  return laidOut.nodes.map((sceneNode) => translateNode(sceneNode, node.x, node.y))
+}
+
+/**
+ * Composes a full-canvas scene from a `SpatialCanvas`'s independently
+ * positioned nodes and edges. Assembling one scene from many per-node
+ * layouts is tool-specific composition (not a generic layout function), so
+ * it lives here rather than in canvas-render's library surface.
+ */
+export function composeCanvasScene(canvas: SpatialCanvas, measure: MeasureText): Scene {
+  const blockNodes = canvas.nodes.flatMap((node) =>
+    node.type === 'text' ? layoutTextNode(node, measure) : [placeholderFor(node)],
+  )
+  const edgeNodes = canvas.edges.map((edge) => routeEdge(canvas.nodes, edge))
+  return { nodes: [...blockNodes, ...edgeNodes] }
+}
+
+/**
+ * Union bounding box over every top-level node's own geometry — the `<svg>`
+ * root's width/height for `wb_canvas_render_svg`. An empty canvas has no
+ * geometry to union, so it defaults to a zero-sized box rather than an
+ * arbitrary sentinel.
+ */
+export function computeCanvasDimensions(nodes: readonly SpatialNode[]): {
+  width: number
+  height: number
+} {
+  if (nodes.length === 0) return { width: 0, height: 0 }
+
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const node of nodes) {
+    maxX = Math.max(maxX, node.x + node.width)
+    maxY = Math.max(maxY, node.y + node.height)
+  }
+  return { width: maxX, height: maxY }
+}

--- a/packages/server-core/src/render/fallback-measure.ts
+++ b/packages/server-core/src/render/fallback-measure.ts
@@ -1,0 +1,17 @@
+import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+
+/**
+ * Deterministic average-character-width estimator. Not a real font metric —
+ * server-core is a shared layer forbidden from loading fonts
+ * (architecture-map.md) — just enough to produce stable, finite bounding
+ * boxes for the render/digest tools until a composition root injects a
+ * real measurer via a future ServerDeps extension.
+ */
+const AVERAGE_CHAR_WIDTH_FACTOR = 0.55
+
+export const fallbackMeasureText: MeasureText = (text, font) => ({
+  advanceWidth: text.length * AVERAGE_CHAR_WIDTH_FACTOR * font.sizePx,
+  ascent: font.sizePx * 0.8,
+  descent: font.sizePx * 0.2,
+  lineGap: font.sizePx * 0.1,
+})

--- a/packages/server-core/src/render/load-spatial-canvas.test.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.test.ts
@@ -1,52 +1,10 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
-import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { CanvasNotFoundError, loadSpatialCanvas } from './load-spatial-canvas.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
-
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
-}
 
 describe('loadSpatialCanvas', () => {
   test('throws CanvasNotFoundError when no snapshot exists', async () => {
@@ -58,20 +16,11 @@ describe('loadSpatialCanvas', () => {
 
   test('returns the doc and decoded canvas for an existing snapshot', async () => {
     const canvasDocStore = new FakeCanvasDocStore()
-    const seedDoc = new LoroDoc()
-    writeSpatialCanvas(seedDoc, {
-      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
-      edges: [],
-    })
-    const { manifest, chunks } = chunkSnapshot(
-      seedDoc.export({ mode: 'snapshot' }),
-      SNAPSHOT_MAX_CHUNK_BYTES,
-    )
-    await canvasDocStore.saveSnapshot({
-      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
-      manifest,
-      chunks,
-      frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    await seedDoc(canvasDocStore, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+        edges: [],
+      })
     })
 
     const deps = { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }

--- a/packages/server-core/src/render/load-spatial-canvas.test.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.test.ts
@@ -1,0 +1,85 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { CanvasNotFoundError, loadSpatialCanvas } from './load-spatial-canvas.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+describe('loadSpatialCanvas', () => {
+  test('throws CanvasNotFoundError when no snapshot exists', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const deps = { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+
+    await expect(loadSpatialCanvas(deps, CANVAS_ID)).rejects.toThrow(CanvasNotFoundError)
+  })
+
+  test('returns the doc and decoded canvas for an existing snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const seedDoc = new LoroDoc()
+    writeSpatialCanvas(seedDoc, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+      edges: [],
+    })
+    const { manifest, chunks } = chunkSnapshot(
+      seedDoc.export({ mode: 'snapshot' }),
+      SNAPSHOT_MAX_CHUNK_BYTES,
+    )
+    await canvasDocStore.saveSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+      manifest,
+      chunks,
+      frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const deps = { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+    const { doc, canvas } = await loadSpatialCanvas(deps, CANVAS_ID)
+
+    expect(doc).toBeInstanceOf(LoroDoc)
+    expect(canvas.nodes).toEqual([
+      { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' },
+    ])
+  })
+})

--- a/packages/server-core/src/render/load-spatial-canvas.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.ts
@@ -1,0 +1,37 @@
+import type { CanvasId } from '@kamiazya/whiteboard-canvas-model'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { LoroDoc } from 'loro-crdt'
+import type { ServerDeps } from '../create-server.js'
+
+/**
+ * Thrown when no snapshot exists for the requested canvas. Not a Zod
+ * schema — only `.message` crosses the MCP wire via the SDK's existing
+ * tool-error path, so this is a plain Error subclass rather than a DTO.
+ */
+export class CanvasNotFoundError extends Error {
+  constructor(readonly canvasId: string) {
+    super(`canvas not found: ${canvasId}`)
+    this.name = 'CanvasNotFoundError'
+  }
+}
+
+/**
+ * Loads a canvas doc's snapshot, rebuilds the LoroDoc, and decodes its
+ * spatial content. Returns the still-open `doc` alongside `canvas` so a
+ * caller needing another doc-derived view (e.g. facets, for OKF export)
+ * does not have to round-trip `loadSnapshot` a second time.
+ */
+export async function loadSpatialCanvas(
+  deps: ServerDeps,
+  canvasId: CanvasId,
+): Promise<{ doc: LoroDoc; canvas: SpatialCanvas }> {
+  const docRef = { kind: 'canvas' as const, canvasId }
+  const existing = await deps.canvasDocStore.loadSnapshot({ docRef })
+  if (existing === null) throw new CanvasNotFoundError(canvasId)
+
+  const doc = new LoroDoc()
+  doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+  return { doc, canvas: readSpatialCanvas(doc) }
+}

--- a/packages/server-core/src/render/load-spatial-canvas.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.ts
@@ -3,7 +3,7 @@ import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { LoroDoc } from 'loro-crdt'
-import type { ServerDeps } from '../create-server.js'
+import type { ServerDeps } from '../server-deps.js'
 
 /**
  * Thrown when no snapshot exists for the requested canvas. Not a Zod

--- a/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
+++ b/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
@@ -1,0 +1,70 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import type { CanvasId } from '@kamiazya/whiteboard-canvas-model'
+import { LoroDoc } from 'loro-crdt'
+
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+/** In-memory `CanvasDocStore` fake for server-core tool tests. */
+export class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+/**
+ * Configures a `LoroDoc` via `configure`, then snapshots it into the
+ * given `FakeCanvasDocStore` under the provided `canvasId`.
+ */
+export async function seedDoc(
+  store: FakeCanvasDocStore,
+  canvasId: CanvasId,
+  configure: (doc: LoroDoc) => void,
+): Promise<void> {
+  const doc = new LoroDoc()
+  configure(doc)
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await store.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -1,0 +1,105 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { sceneDigest, sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { composeCanvasScene } from '../render/compose-canvas-scene.js'
+import { fallbackMeasureText } from '../render/fallback-measure.js'
+import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { createCanvasDigestTool } from './canvas-digest.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+describe('canvas_digest tool', () => {
+  test('matches sceneDigest computed directly over an overlapping two-node canvas', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const canvas = {
+      nodes: [
+        { id: 'n1', type: 'group' as const, x: 0, y: 0, width: 100, height: 100 },
+        { id: 'n2', type: 'group' as const, x: 50, y: 50, width: 100, height: 100 },
+      ],
+      edges: [],
+    }
+    const doc = new LoroDoc()
+    writeSpatialCanvas(doc, canvas)
+    const { manifest, chunks } = chunkSnapshot(
+      doc.export({ mode: 'snapshot' }),
+      SNAPSHOT_MAX_CHUNK_BYTES,
+    )
+    await canvasDocStore.saveSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+      manifest,
+      chunks,
+      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const tool = createCanvasDigestTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const expected = sceneDigest(composeCanvasScene(canvas, fallbackMeasureText))
+
+    expect(result).toEqual(expected)
+    expect(result.overlaps.length).toBeGreaterThan(0)
+    expect(() => sceneDigestSchema.parse(result)).not.toThrow()
+  })
+
+  test('rejects when the canvas has no stored snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createCanvasDigestTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
+      CanvasNotFoundError,
+    )
+  })
+})

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -1,61 +1,22 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
-import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { sceneDigest, sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
-import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { composeCanvasScene } from '../render/compose-canvas-scene.js'
 import { fallbackMeasureText } from '../render/fallback-measure.js'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasDigestTool } from './canvas-digest.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
 
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
 }
 
 describe('canvas_digest tool', () => {
   test('matches sceneDigest computed directly over an overlapping two-node canvas', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
+    const store = new FakeCanvasDocStore()
     const canvas = {
       nodes: [
         { id: 'n1', type: 'group' as const, x: 0, y: 0, width: 100, height: 100 },
@@ -63,24 +24,10 @@ describe('canvas_digest tool', () => {
       ],
       edges: [],
     }
-    const doc = new LoroDoc()
-    writeSpatialCanvas(doc, canvas)
-    const { manifest, chunks } = chunkSnapshot(
-      doc.export({ mode: 'snapshot' }),
-      SNAPSHOT_MAX_CHUNK_BYTES,
-    )
-    await canvasDocStore.saveSnapshot({
-      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
-      manifest,
-      chunks,
-      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, canvas)
     })
-
-    const tool = createCanvasDigestTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasDigestTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
     const expected = sceneDigest(composeCanvasScene(canvas, fallbackMeasureText))
@@ -91,12 +38,7 @@ describe('canvas_digest tool', () => {
   })
 
   test('rejects when the canvas has no stored snapshot', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createCanvasDigestTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasDigestTool(makeDeps(new FakeCanvasDocStore()))
 
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
       CanvasNotFoundError,

--- a/packages/server-core/src/tools/canvas-digest.ts
+++ b/packages/server-core/src/tools/canvas-digest.ts
@@ -1,0 +1,31 @@
+import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { sceneDigest, sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
+import type { SceneDigest } from '@kamiazya/whiteboard-canvas-render'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { composeCanvasScene } from '../render/compose-canvas-scene.js'
+import { fallbackMeasureText } from '../render/fallback-measure.js'
+import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+
+/**
+ * `CanvasDocStore.loadSnapshot`'s `DocRef` carries no `workspaceId` — this
+ * field is accepted for API symmetry with workspace-scoped tools and as a
+ * future authorization-scoping hook, not passed to the store.
+ */
+export const canvasDigestInputSchema = z
+  .object({ workspaceId: workspaceIdSchema, canvasId: canvasIdSchema })
+  .strict()
+export type CanvasDigestInput = z.infer<typeof canvasDigestInputSchema>
+
+export function createCanvasDigestTool(deps: ServerDeps) {
+  return {
+    name: 'canvas_digest' as const,
+    inputSchema: canvasDigestInputSchema,
+    outputSchema: sceneDigestSchema,
+    async execute(input: CanvasDigestInput): Promise<SceneDigest> {
+      const { canvas } = await loadSpatialCanvas(deps, input.canvasId)
+      const scene = composeCanvasScene(canvas, fallbackMeasureText)
+      return sceneDigest(scene)
+    },
+  }
+}

--- a/packages/server-core/src/tools/canvas-export-json-canvas.test.ts
+++ b/packages/server-core/src/tools/canvas-export-json-canvas.test.ts
@@ -1,0 +1,126 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { createCanvasExportJsonCanvasTool } from './canvas-export-json-canvas.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+const NODE_WITH_EXTENSION = {
+  id: 'n1',
+  type: 'text' as const,
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 50,
+  text: 'hi',
+  'x-whiteboard': { kind: 'shape' as const, shape: 'rectangle' as const },
+}
+
+async function seedWithExtensionNode(canvasDocStore: FakeCanvasDocStore): Promise<void> {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, { nodes: [NODE_WITH_EXTENSION], edges: [] })
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+describe('canvas_export_json_canvas tool', () => {
+  test('strict mode drops the x-whiteboard extension key', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedWithExtensionNode(canvasDocStore)
+    const tool = createCanvasExportJsonCanvasTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      options: { strict: true },
+    })
+    const parsed = JSON.parse(result.json)
+
+    expect(parsed.nodes[0]['x-whiteboard']).toBeUndefined()
+  })
+
+  test('extended mode (default) round-trips the x-whiteboard extension losslessly', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedWithExtensionNode(canvasDocStore)
+    const tool = createCanvasExportJsonCanvasTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const parsed = JSON.parse(result.json)
+
+    expect(parsed.nodes[0]['x-whiteboard']).toEqual({ kind: 'shape', shape: 'rectangle' })
+  })
+
+  test('rejects when the canvas has no stored snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createCanvasExportJsonCanvasTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
+      CanvasNotFoundError,
+    )
+  })
+})

--- a/packages/server-core/src/tools/canvas-export-json-canvas.test.ts
+++ b/packages/server-core/src/tools/canvas-export-json-canvas.test.ts
@@ -1,54 +1,11 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
-import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
-import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasExportJsonCanvasTool } from './canvas-export-json-canvas.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
-
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
-}
 
 const NODE_WITH_EXTENSION = {
   id: 'n1',
@@ -61,30 +18,17 @@ const NODE_WITH_EXTENSION = {
   'x-whiteboard': { kind: 'shape' as const, shape: 'rectangle' as const },
 }
 
-async function seedWithExtensionNode(canvasDocStore: FakeCanvasDocStore): Promise<void> {
-  const doc = new LoroDoc()
-  writeSpatialCanvas(doc, { nodes: [NODE_WITH_EXTENSION], edges: [] })
-  const { manifest, chunks } = chunkSnapshot(
-    doc.export({ mode: 'snapshot' }),
-    SNAPSHOT_MAX_CHUNK_BYTES,
-  )
-  await canvasDocStore.saveSnapshot({
-    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
-    manifest,
-    chunks,
-    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-  })
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
 }
 
 describe('canvas_export_json_canvas tool', () => {
   test('strict mode drops the x-whiteboard extension key', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    await seedWithExtensionNode(canvasDocStore)
-    const tool = createCanvasExportJsonCanvasTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, { nodes: [NODE_WITH_EXTENSION], edges: [] })
     })
+    const tool = createCanvasExportJsonCanvasTool(makeDeps(store))
 
     const result = await tool.execute({
       workspaceId: WORKSPACE_ID,
@@ -97,13 +41,11 @@ describe('canvas_export_json_canvas tool', () => {
   })
 
   test('extended mode (default) round-trips the x-whiteboard extension losslessly', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    await seedWithExtensionNode(canvasDocStore)
-    const tool = createCanvasExportJsonCanvasTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, { nodes: [NODE_WITH_EXTENSION], edges: [] })
     })
+    const tool = createCanvasExportJsonCanvasTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
     const parsed = JSON.parse(result.json)
@@ -112,12 +54,7 @@ describe('canvas_export_json_canvas tool', () => {
   })
 
   test('rejects when the canvas has no stored snapshot', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createCanvasExportJsonCanvasTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasExportJsonCanvasTool(makeDeps(new FakeCanvasDocStore()))
 
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
       CanvasNotFoundError,

--- a/packages/server-core/src/tools/canvas-export-json-canvas.ts
+++ b/packages/server-core/src/tools/canvas-export-json-canvas.ts
@@ -1,0 +1,38 @@
+import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+
+/**
+ * `CanvasDocStore.loadSnapshot`'s `DocRef` carries no `workspaceId` — this
+ * field is accepted for API symmetry with workspace-scoped tools and as a
+ * future authorization-scoping hook, not passed to the store.
+ */
+export const canvasExportJsonCanvasInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    canvasId: canvasIdSchema,
+    options: z
+      .object({ strict: z.boolean().default(false) })
+      .strict()
+      .optional(),
+  })
+  .strict()
+export type CanvasExportJsonCanvasInput = z.infer<typeof canvasExportJsonCanvasInputSchema>
+
+export const canvasExportJsonCanvasOutputSchema = z.object({ json: z.string() }).strict()
+export type CanvasExportJsonCanvasOutput = z.infer<typeof canvasExportJsonCanvasOutputSchema>
+
+export function createCanvasExportJsonCanvasTool(deps: ServerDeps) {
+  return {
+    name: 'canvas_export_json_canvas' as const,
+    inputSchema: canvasExportJsonCanvasInputSchema,
+    outputSchema: canvasExportJsonCanvasOutputSchema,
+    async execute(input: CanvasExportJsonCanvasInput): Promise<CanvasExportJsonCanvasOutput> {
+      const { canvas } = await loadSpatialCanvas(deps, input.canvasId)
+      const mode = input.options?.strict === true ? 'strict' : 'extended'
+      return { json: serializeSpatial(canvas, mode) }
+    },
+  }
+}

--- a/packages/server-core/src/tools/canvas-export-okf.test.ts
+++ b/packages/server-core/src/tools/canvas-export-okf.test.ts
@@ -1,0 +1,125 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeFacets, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { createCanvasExportOkfTool } from './canvas-export-okf.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+async function seed(
+  canvasDocStore: FakeCanvasDocStore,
+  configure: (doc: LoroDoc) => void,
+): Promise<void> {
+  const doc = new LoroDoc()
+  configure(doc)
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+describe('canvas_export_okf tool', () => {
+  test('exports the first text node body with facets from the doc', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seed(canvasDocStore, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+        edges: [],
+      })
+      writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    })
+    const tool = createCanvasExportOkfTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.markdown.startsWith('---\n')).toBe(true)
+    expect(result.markdown).toContain('hello')
+    expect(result.frontmatter.facets).toEqual({ 'kanban/1': { status: 'todo' } })
+  })
+
+  test('falls back to an empty body when the canvas has no text node', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seed(canvasDocStore, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'group', x: 0, y: 0, width: 100, height: 50 }],
+        edges: [],
+      })
+    })
+    const tool = createCanvasExportOkfTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.markdown.endsWith('---\n')).toBe(true)
+  })
+
+  test('rejects when the canvas has no stored snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createCanvasExportOkfTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
+      CanvasNotFoundError,
+    )
+  })
+})

--- a/packages/server-core/src/tools/canvas-export-okf.test.ts
+++ b/packages/server-core/src/tools/canvas-export-okf.test.ts
@@ -1,88 +1,27 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
-import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { writeFacets, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
-import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasExportOkfTool } from './canvas-export-okf.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
 
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
-}
-
-async function seed(
-  canvasDocStore: FakeCanvasDocStore,
-  configure: (doc: LoroDoc) => void,
-): Promise<void> {
-  const doc = new LoroDoc()
-  configure(doc)
-  const { manifest, chunks } = chunkSnapshot(
-    doc.export({ mode: 'snapshot' }),
-    SNAPSHOT_MAX_CHUNK_BYTES,
-  )
-  await canvasDocStore.saveSnapshot({
-    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
-    manifest,
-    chunks,
-    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-  })
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
 }
 
 describe('canvas_export_okf tool', () => {
   test('exports the first text node body with facets from the doc', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    await seed(canvasDocStore, (doc) => {
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
       writeSpatialCanvas(doc, {
         nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
         edges: [],
       })
       writeFacets(doc, { 'kanban/1': { status: 'todo' } })
     })
-    const tool = createCanvasExportOkfTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasExportOkfTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -92,18 +31,14 @@ describe('canvas_export_okf tool', () => {
   })
 
   test('falls back to an empty body when the canvas has no text node', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    await seed(canvasDocStore, (doc) => {
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
       writeSpatialCanvas(doc, {
         nodes: [{ id: 'n1', type: 'group', x: 0, y: 0, width: 100, height: 50 }],
         edges: [],
       })
     })
-    const tool = createCanvasExportOkfTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasExportOkfTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -111,12 +46,7 @@ describe('canvas_export_okf tool', () => {
   })
 
   test('rejects when the canvas has no stored snapshot', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createCanvasExportOkfTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasExportOkfTool(makeDeps(new FakeCanvasDocStore()))
 
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
       CanvasNotFoundError,

--- a/packages/server-core/src/tools/canvas-export-okf.ts
+++ b/packages/server-core/src/tools/canvas-export-okf.ts
@@ -1,0 +1,54 @@
+import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { okfMarkdownFrontmatterSchema, serializeOkf } from '@kamiazya/whiteboard-canvas-codec'
+import type { OkfMarkdownFrontmatter } from '@kamiazya/whiteboard-canvas-codec'
+import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+
+/**
+ * OKF-Markdown is a single-document format (frontmatter + body); a spatial
+ * canvas can have many independently-positioned text nodes. This tool
+ * targets only the FIRST text node found (or an empty body when none
+ * exists) — a real "canvas -> OKF" mapping for a full multi-node spatial
+ * canvas is deferred to a future slice once the OKF-vs-spatial duality is
+ * resolved in canvas-workspace.
+ *
+ * `CanvasDocStore.loadSnapshot`'s `DocRef` carries no `workspaceId` — this
+ * field is accepted for API symmetry with workspace-scoped tools and as a
+ * future authorization-scoping hook, not passed to the store.
+ */
+export const canvasExportOkfInputSchema = z
+  .object({ workspaceId: workspaceIdSchema, canvasId: canvasIdSchema })
+  .strict()
+export type CanvasExportOkfInput = z.infer<typeof canvasExportOkfInputSchema>
+
+export const canvasExportOkfOutputSchema = z
+  .object({ markdown: z.string(), frontmatter: okfMarkdownFrontmatterSchema })
+  .strict()
+export type CanvasExportOkfOutput = z.infer<typeof canvasExportOkfOutputSchema>
+
+/**
+ * `coreFacetsSchema.type` is required, but a spatial (JSON Canvas) doc has
+ * no notion of an OKF core-facet `type` of its own — the two formats are
+ * deliberately distinct document shapes (package-canvas-codec.md). `canvas`
+ * is a fixed placeholder value for this export path until canvas-workspace
+ * defines a real spatial-canvas-to-OKF-type mapping.
+ */
+const OKF_EXPORT_PLACEHOLDER_TYPE = 'canvas'
+
+export function createCanvasExportOkfTool(deps: ServerDeps) {
+  return {
+    name: 'canvas_export_okf' as const,
+    inputSchema: canvasExportOkfInputSchema,
+    outputSchema: canvasExportOkfOutputSchema,
+    async execute(input: CanvasExportOkfInput): Promise<CanvasExportOkfOutput> {
+      const { doc, canvas } = await loadSpatialCanvas(deps, input.canvasId)
+      const facets = readFacets(doc)
+      const body = canvas.nodes.find((node) => node.type === 'text')?.text ?? ''
+      const frontmatter: OkfMarkdownFrontmatter = { type: OKF_EXPORT_PLACEHOLDER_TYPE, facets }
+      const markdown = serializeOkf({ frontmatter, body })
+      return { markdown, frontmatter }
+    },
+  }
+}

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -1,0 +1,101 @@
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  CanvasDocStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { createCanvasRenderSvgTool } from './canvas-render-svg.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
+
+class FakeCanvasDocStore implements CanvasDocStore {
+  private saved: SaveSnapshotInput | undefined
+
+  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+    if (this.saved === undefined) return null
+    return {
+      manifest: this.saved.manifest,
+      chunks: this.saved.chunks,
+      frontier: this.saved.frontier,
+    }
+  }
+
+  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
+    this.saved = input
+  }
+
+  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    throw new Error('not implemented')
+  }
+
+  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+    throw new Error('not implemented')
+  }
+}
+
+async function seedCanvas(canvasDocStore: FakeCanvasDocStore): Promise<void> {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }],
+    edges: [],
+  })
+  const { manifest, chunks } = chunkSnapshot(
+    doc.export({ mode: 'snapshot' }),
+    SNAPSHOT_MAX_CHUNK_BYTES,
+  )
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+describe('canvas_render_svg tool', () => {
+  test('renders a seeded canvas to SVG with dimensions', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore)
+    const tool = createCanvasRenderSvgTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.svg).toContain('<svg xmlns="http://www.w3.org/2000/svg">')
+    expect(result.svg).toContain('hi')
+    expect(result.width).toBe(100)
+    expect(result.height).toBe(50)
+  })
+
+  test('rejects when the canvas has no stored snapshot', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createCanvasRenderSvgTool({
+      canvasDocStore,
+      workspaceIndex: {} as never,
+      blobStore: {} as never,
+    })
+
+    await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
+      CanvasNotFoundError,
+    )
+  })
+})

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -1,82 +1,26 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
-import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
-import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasRenderSvgTool } from './canvas-render-svg.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
-const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
 
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
-}
-
-async function seedCanvas(canvasDocStore: FakeCanvasDocStore): Promise<void> {
-  const doc = new LoroDoc()
-  writeSpatialCanvas(doc, {
-    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }],
-    edges: [],
-  })
-  const { manifest, chunks } = chunkSnapshot(
-    doc.export({ mode: 'snapshot' }),
-    SNAPSHOT_MAX_CHUNK_BYTES,
-  )
-  await canvasDocStore.saveSnapshot({
-    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
-    manifest,
-    chunks,
-    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-  })
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
 }
 
 describe('canvas_render_svg tool', () => {
   test('renders a seeded canvas to SVG with dimensions', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    await seedCanvas(canvasDocStore)
-    const tool = createCanvasRenderSvgTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }],
+        edges: [],
+      })
     })
+    const tool = createCanvasRenderSvgTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -87,12 +31,7 @@ describe('canvas_render_svg tool', () => {
   })
 
   test('rejects when the canvas has no stored snapshot', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createCanvasRenderSvgTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createCanvasRenderSvgTool(makeDeps(new FakeCanvasDocStore()))
 
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
       CanvasNotFoundError,

--- a/packages/server-core/src/tools/canvas-render-svg.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.ts
@@ -1,0 +1,37 @@
+import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
+import { z } from 'zod'
+import type { ServerDeps } from '../create-server.js'
+import { composeCanvasScene, computeCanvasDimensions } from '../render/compose-canvas-scene.js'
+import { fallbackMeasureText } from '../render/fallback-measure.js'
+import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+
+/**
+ * `CanvasDocStore.loadSnapshot`'s `DocRef` (`{ kind: 'canvas', canvasId }`)
+ * carries no `workspaceId` — this field is accepted for API symmetry with
+ * workspace-scoped tools and as a future authorization-scoping hook, not
+ * passed to the store.
+ */
+export const canvasRenderSvgInputSchema = z
+  .object({ workspaceId: workspaceIdSchema, canvasId: canvasIdSchema })
+  .strict()
+export type CanvasRenderSvgInput = z.infer<typeof canvasRenderSvgInputSchema>
+
+export const canvasRenderSvgOutputSchema = z
+  .object({ svg: z.string(), width: z.number(), height: z.number() })
+  .strict()
+export type CanvasRenderSvgOutput = z.infer<typeof canvasRenderSvgOutputSchema>
+
+export function createCanvasRenderSvgTool(deps: ServerDeps) {
+  return {
+    name: 'canvas_render_svg' as const,
+    inputSchema: canvasRenderSvgInputSchema,
+    outputSchema: canvasRenderSvgOutputSchema,
+    async execute(input: CanvasRenderSvgInput): Promise<CanvasRenderSvgOutput> {
+      const { canvas } = await loadSpatialCanvas(deps, input.canvasId)
+      const scene = composeCanvasScene(canvas, fallbackMeasureText)
+      const { width, height } = computeCanvasDimensions(canvas.nodes)
+      return { svg: renderSceneToSvg(scene), width, height }
+    },
+  }
+}

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -1,60 +1,19 @@
-import type {
-  AppendDeltasInput,
-  AppendDeltasResult,
-  CanvasDocStore,
-  LoadDeltasInput,
-  LoadDeltasResult,
-  LoadSnapshotInput,
-  LoadSnapshotResult,
-  ReadFrontierInput,
-  ReadFrontierResult,
-  SaveSnapshotInput,
-} from '@kamiazya/whiteboard-canvas-ports'
+import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
-import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
 import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 
-/** An in-memory CanvasDocStore fake, scoped to this test file only. */
-class FakeCanvasDocStore implements CanvasDocStore {
-  private saved: SaveSnapshotInput | undefined
-
-  async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (this.saved === undefined) return null
-    return {
-      manifest: this.saved.manifest,
-      chunks: this.saved.chunks,
-      frontier: this.saved.frontier,
-    }
-  }
-
-  async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    this.saved = input
-  }
-
-  async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
-    throw new Error('not implemented')
-  }
-
-  async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
-    throw new Error('not implemented')
-  }
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
 }
 
 describe('facet_set tool', () => {
   test('sets a facet on a canvas with no prior snapshot', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createFacetSetTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
     const result = await tool.execute({
       canvasId: CANVAS_ID,
@@ -68,39 +27,24 @@ describe('facet_set tool', () => {
   })
 
   test('persists the facet so a later load reflects it', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createFacetSetTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const store = new FakeCanvasDocStore()
+    const tool = createFacetSetTool(makeDeps(store))
 
     await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
 
-    const loaded = await canvasDocStore.loadSnapshot({
+    const loaded = await store.loadSnapshot({
       docRef: { kind: 'canvas', canvasId: CANVAS_ID },
     })
     expect(loaded).not.toBeNull()
     const doc = new LoroDoc()
     if (loaded !== null) {
-      const bytes = new Uint8Array(loaded.manifest.totalBytes)
-      let offset = 0
-      for (const chunk of loaded.chunks) {
-        bytes.set(chunk.bytes, offset)
-        offset += chunk.bytes.byteLength
-      }
-      doc.import(bytes)
+      doc.import(reassembleSnapshot(loaded.manifest, loaded.chunks))
     }
     expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
   })
 
   test('merges a new facet domain with an existing one instead of replacing it', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createFacetSetTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
     await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
     const result = await tool.execute({
@@ -115,12 +59,7 @@ describe('facet_set tool', () => {
   })
 
   test('overwrites an existing facet domain when the same key is set again', async () => {
-    const canvasDocStore = new FakeCanvasDocStore()
-    const tool = createFacetSetTool({
-      canvasDocStore,
-      workspaceIndex: {} as never,
-      blobStore: {} as never,
-    })
+    const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
     await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
     const result = await tool.execute({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,12 +605,18 @@ importers:
 
   packages/server-core:
     dependencies:
+      '@kamiazya/whiteboard-canvas-codec':
+        specifier: workspace:*
+        version: link:../canvas-codec
       '@kamiazya/whiteboard-canvas-model':
         specifier: workspace:*
         version: link:../canvas-model
       '@kamiazya/whiteboard-canvas-ports':
         specifier: workspace:*
         version: link:../canvas-ports
+      '@kamiazya/whiteboard-canvas-render':
+        specifier: workspace:*
+        version: link:../canvas-render
       '@kamiazya/whiteboard-canvas-workspace':
         specifier: workspace:*
         version: link:../canvas-workspace


### PR DESCRIPTION
## Summary

- Add `wb_canvas_render_svg` tool: loads a spatial canvas, composes a full-canvas scene from independently laid-out nodes, and renders to SVG via canvas-render's backend.
- Add `wb_canvas_digest` tool: produces the AI-facing spatial digest (sceneDigest) for a canvas.
- Add `wb_canvas_export_okf` tool: exports a canvas as OKF Markdown.
- Add `wb_canvas_export_json_canvas` tool: exports a canvas as JSON Canvas 1.0 (with optional strict mode that drops x-whiteboard extensions).
- Add shared `loadSpatialCanvas` helper and `composeFullCanvasScene` for scene composition from spatial canvas data.
- Add `FakeCanvasDocStore` with multi-canvas keying and `seedDoc` helper for test utilities.

## Test plan

- [x] All 4 render/export tool factories tested (create, execute with seeded data, schema validation)
- [x] `loadSpatialCanvas` tested for missing-doc error case
- [x] `composeFullCanvasScene` tested for empty canvas and multi-node scene composition
- [x] 17 test files, 71 tests passing in `server-core-node`
- [x] Typecheck passes