### PR TITLE
feat(server-core): add version_save, version_list, version_restore tools

### DIFF
--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -21,6 +21,9 @@ import { createCanvasRenderSvgTool } from './tools/canvas-render-svg.js'
 import { createEdgePatchTool } from './tools/edge-patch.js'
 import { createFacetSetTool } from './tools/facet-set.js'
 import { createNodePatchTool } from './tools/node-patch.js'
+import { createVersionListTool } from './tools/version-list.js'
+import { createVersionRestoreTool } from './tools/version-restore.js'
+import { createVersionSaveTool } from './tools/version-save.js'
 
 export function createServer(deps: ServerDeps) {
   const app = new Hono()
@@ -92,6 +95,9 @@ export function createServer(deps: ServerDeps) {
     canvasDigest: createCanvasDigestTool(deps),
     canvasExportOkf: createCanvasExportOkfTool(deps),
     canvasExportJsonCanvas: createCanvasExportJsonCanvasTool(deps),
+    versionSave: createVersionSaveTool(deps),
+    versionList: createVersionListTool(deps),
+    versionRestore: createVersionRestoreTool(deps),
   }
   return { app, tools }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -70,3 +70,22 @@ export type {
   CanvasExportJsonCanvasInput,
   CanvasExportJsonCanvasOutput,
 } from './tools/canvas-export-json-canvas.js'
+export {
+  createVersionSaveTool,
+  versionSaveInputSchema,
+  versionSaveOutputSchema,
+} from './tools/version-save.js'
+export type { VersionSaveInput, VersionSaveOutput } from './tools/version-save.js'
+export {
+  createVersionListTool,
+  versionListInputSchema,
+  versionListOutputSchema,
+} from './tools/version-list.js'
+export type { VersionListInput, VersionListOutput } from './tools/version-list.js'
+export {
+  createVersionRestoreTool,
+  versionRestoreInputSchema,
+  versionRestoreOutputSchema,
+  VersionNotFoundError,
+} from './tools/version-restore.js'
+export type { VersionRestoreInput, VersionRestoreOutput } from './tools/version-restore.js'

--- a/packages/server-core/src/tools/version-list.ts
+++ b/packages/server-core/src/tools/version-list.ts
@@ -1,0 +1,64 @@
+import { canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { loadOrCreateCanvasDoc } from './canvas-doc-io.js'
+
+const versionEntrySchema = z
+  .object({
+    versionId: z.string(),
+    label: z.string(),
+    timestamp: z.string(),
+    frontier: z.string(),
+  })
+  .strict()
+
+export const versionListInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+  })
+  .strict()
+export type VersionListInput = z.infer<typeof versionListInputSchema>
+
+export const versionListOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    versions: z.array(versionEntrySchema),
+  })
+  .strict()
+export type VersionListOutput = z.infer<typeof versionListOutputSchema>
+
+export function createVersionListTool(deps: ServerDeps) {
+  return {
+    name: 'version_list' as const,
+    inputSchema: versionListInputSchema,
+    outputSchema: versionListOutputSchema,
+    async execute(input: VersionListInput): Promise<VersionListOutput> {
+      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+
+      const versions = doc.getMap('versions')
+      const entries: z.infer<typeof versionEntrySchema>[] = []
+
+      for (const versionId of versions.keys()) {
+        const raw = versions.get(versionId)
+        if (typeof raw !== 'string') continue
+        try {
+          const parsed = JSON.parse(raw) as Record<string, unknown>
+          const { label, timestamp, frontier } = parsed
+          if (
+            typeof label === 'string' &&
+            typeof timestamp === 'string' &&
+            typeof frontier === 'string'
+          ) {
+            entries.push({ versionId, label, timestamp, frontier })
+          }
+        } catch {
+          continue
+        }
+      }
+
+      entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+
+      return { canvasId: input.canvasId, versions: entries }
+    },
+  }
+}

--- a/packages/server-core/src/tools/version-restore.ts
+++ b/packages/server-core/src/tools/version-restore.ts
@@ -1,0 +1,85 @@
+import { canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { decodeFrontiers } from 'loro-crdt'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
+
+export const versionRestoreInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    versionId: z.string().min(1),
+  })
+  .strict()
+export type VersionRestoreInput = z.infer<typeof versionRestoreInputSchema>
+
+export const versionRestoreOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    restoredVersionId: z.string(),
+    label: z.string(),
+    frontier: z.string(),
+  })
+  .strict()
+export type VersionRestoreOutput = z.infer<typeof versionRestoreOutputSchema>
+
+export class VersionNotFoundError extends Error {
+  constructor(
+    public readonly canvasId: string,
+    public readonly versionId: string,
+  ) {
+    super(`version not found: ${versionId} in canvas ${canvasId}`)
+    this.name = 'VersionNotFoundError'
+  }
+}
+
+export function createVersionRestoreTool(deps: ServerDeps) {
+  return {
+    name: 'version_restore' as const,
+    inputSchema: versionRestoreInputSchema,
+    outputSchema: versionRestoreOutputSchema,
+    async execute(input: VersionRestoreInput): Promise<VersionRestoreOutput> {
+      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+
+      const versions = doc.getMap('versions')
+      const raw = versions.get(input.versionId)
+      if (typeof raw !== 'string') {
+        throw new VersionNotFoundError(input.canvasId, input.versionId)
+      }
+
+      let label: string
+      let frontier: string
+      try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>
+        if (typeof parsed.label !== 'string' || typeof parsed.frontier !== 'string') {
+          throw new VersionNotFoundError(input.canvasId, input.versionId)
+        }
+        label = parsed.label
+        frontier = parsed.frontier
+      } catch {
+        throw new VersionNotFoundError(input.canvasId, input.versionId)
+      }
+
+      const frontierBytes = new Uint8Array(
+        (frontier.match(/.{2}/g) ?? []).map((h) => Number.parseInt(h, 16)),
+      )
+      const targetFrontiers = decodeFrontiers(frontierBytes)
+
+      doc.checkout(targetFrontiers)
+      const oldCanvas = readSpatialCanvas(doc)
+      doc.checkoutToLatest()
+
+      writeSpatialCanvas(doc, oldCanvas)
+      doc.commit()
+
+      await saveDocSnapshot(deps, input.canvasId, doc)
+
+      return {
+        canvasId: input.canvasId,
+        restoredVersionId: input.versionId,
+        label,
+        frontier,
+      }
+    },
+  }
+}

--- a/packages/server-core/src/tools/version-save.ts
+++ b/packages/server-core/src/tools/version-save.ts
@@ -1,0 +1,55 @@
+import { canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { encodeFrontiers } from 'loro-crdt'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
+import { generateCanvasId } from './generate-canvas-id.js'
+
+export const versionSaveInputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    label: z.string().min(1).max(200),
+  })
+  .strict()
+export type VersionSaveInput = z.infer<typeof versionSaveInputSchema>
+
+export const versionSaveOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    versionId: z.string(),
+    label: z.string(),
+    timestamp: z.string(),
+    frontier: z.string(),
+  })
+  .strict()
+export type VersionSaveOutput = z.infer<typeof versionSaveOutputSchema>
+
+export function createVersionSaveTool(deps: ServerDeps) {
+  return {
+    name: 'version_save' as const,
+    inputSchema: versionSaveInputSchema,
+    outputSchema: versionSaveOutputSchema,
+    async execute(input: VersionSaveInput): Promise<VersionSaveOutput> {
+      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+
+      const versionId = generateCanvasId()
+      const timestamp = new Date().toISOString()
+      const frontierBytes = encodeFrontiers(doc.oplogFrontiers())
+      const frontier = Array.from(frontierBytes, (b) => b.toString(16).padStart(2, '0')).join('')
+
+      const versions = doc.getMap('versions')
+      versions.set(versionId, JSON.stringify({ label: input.label, timestamp, frontier }))
+      doc.commit()
+
+      await saveDocSnapshot(deps, input.canvasId, doc)
+
+      return {
+        canvasId: input.canvasId,
+        versionId,
+        label: input.label,
+        timestamp,
+        frontier,
+      }
+    },
+  }
+}

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -1,0 +1,141 @@
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { createVersionListTool } from './version-list.js'
+import { createVersionRestoreTool } from './version-restore.js'
+import { VersionNotFoundError } from './version-restore.js'
+import { createVersionSaveTool } from './version-save.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+}
+
+async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {
+  const snapshot = await store.loadSnapshot({ docRef: { kind: 'canvas', canvasId } })
+  const doc = new LoroDoc()
+  if (snapshot !== null) {
+    doc.import(reassembleSnapshot(snapshot.manifest, snapshot.chunks))
+  }
+  return doc
+}
+
+describe('version_save tool', () => {
+  test('saves a version and returns metadata', async () => {
+    const tool = createVersionSaveTool(makeDeps(new FakeCanvasDocStore()))
+
+    const result = await tool.execute({ canvasId: CANVAS_ID, label: 'v1' })
+
+    expect(result.canvasId).toBe(CANVAS_ID)
+    expect(result.label).toBe('v1')
+    expect(result.versionId).toBeTruthy()
+    expect(result.timestamp).toBeTruthy()
+    expect(result.frontier).toBeTruthy()
+  })
+
+  test('each save produces a unique versionId', async () => {
+    const tool = createVersionSaveTool(makeDeps(new FakeCanvasDocStore()))
+
+    const r1 = await tool.execute({ canvasId: CANVAS_ID, label: 'v1' })
+    const r2 = await tool.execute({ canvasId: CANVAS_ID, label: 'v2' })
+
+    expect(r1.versionId).not.toBe(r2.versionId)
+  })
+})
+
+describe('version_list tool', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('returns empty list for a canvas with no versions', async () => {
+    const tool = createVersionListTool(makeDeps(new FakeCanvasDocStore()))
+
+    const result = await tool.execute({ canvasId: CANVAS_ID })
+
+    expect(result).toEqual({ canvasId: CANVAS_ID, versions: [] })
+  })
+
+  test('lists saved versions newest-first', async () => {
+    const deps = makeDeps(new FakeCanvasDocStore())
+    const saveTool = createVersionSaveTool(deps)
+    const listTool = createVersionListTool(deps)
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    await saveTool.execute({ canvasId: CANVAS_ID, label: 'first' })
+
+    vi.setSystemTime(new Date('2026-01-02T00:00:00Z'))
+    await saveTool.execute({ canvasId: CANVAS_ID, label: 'second' })
+
+    const result = await listTool.execute({ canvasId: CANVAS_ID })
+
+    expect(result.versions).toHaveLength(2)
+    expect(result.versions[0].label).toBe('second')
+    expect(result.versions[1].label).toBe('first')
+  })
+})
+
+describe('version_restore tool', () => {
+  test('restores spatial canvas content from a saved version', async () => {
+    const store = new FakeCanvasDocStore()
+    const deps = makeDeps(store)
+    const saveTool = createVersionSaveTool(deps)
+    const restoreTool = createVersionRestoreTool(deps)
+
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'original' }],
+        edges: [],
+      })
+    })
+
+    const saved = await saveTool.execute({ canvasId: CANVAS_ID, label: 'before-edit' })
+
+    const doc = await loadDoc(store, CANVAS_ID)
+    writeSpatialCanvas(doc, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'modified' }],
+      edges: [],
+    })
+    doc.commit()
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-canvas-ports')
+    const { manifest, chunks } = chunkSnapshot(doc.export({ mode: 'snapshot' }), 1_000_000)
+    await store.saveSnapshot({
+      docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+      manifest,
+      chunks,
+      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const beforeRestore = await loadDoc(store, CANVAS_ID)
+    const beforeCanvas = readSpatialCanvas(beforeRestore)
+    expect(beforeCanvas.nodes[0].text).toBe('modified')
+
+    const result = await restoreTool.execute({
+      canvasId: CANVAS_ID,
+      versionId: saved.versionId,
+    })
+
+    expect(result.restoredVersionId).toBe(saved.versionId)
+    expect(result.label).toBe('before-edit')
+
+    const afterRestore = await loadDoc(store, CANVAS_ID)
+    const afterCanvas = readSpatialCanvas(afterRestore)
+    expect(afterCanvas.nodes[0].text).toBe('original')
+  })
+
+  test('throws VersionNotFoundError for unknown versionId', async () => {
+    const deps = makeDeps(new FakeCanvasDocStore())
+    const restoreTool = createVersionRestoreTool(deps)
+
+    await expect(
+      restoreTool.execute({ canvasId: CANVAS_ID, versionId: 'nonexistent' }),
+    ).rejects.toThrow(VersionNotFoundError)
+  })
+})

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -115,7 +115,9 @@ describe('version_restore tool', () => {
 
     const beforeRestore = await loadDoc(store, CANVAS_ID)
     const beforeCanvas = readSpatialCanvas(beforeRestore)
-    expect(beforeCanvas.nodes[0].text).toBe('modified')
+    const beforeNode = beforeCanvas.nodes[0]
+    expect(beforeNode.type).toBe('text')
+    if (beforeNode.type === 'text') expect(beforeNode.text).toBe('modified')
 
     const result = await restoreTool.execute({
       canvasId: CANVAS_ID,
@@ -127,7 +129,9 @@ describe('version_restore tool', () => {
 
     const afterRestore = await loadDoc(store, CANVAS_ID)
     const afterCanvas = readSpatialCanvas(afterRestore)
-    expect(afterCanvas.nodes[0].text).toBe('original')
+    const afterNode = afterCanvas.nodes[0]
+    expect(afterNode.type).toBe('text')
+    if (afterNode.type === 'text') expect(afterNode.text).toBe('original')
   })
 
   test('throws VersionNotFoundError for unknown versionId', async () => {


### PR DESCRIPTION
## Summary

- Add three version management MCP tools to server-core: `version_save` (records labeled oplog frontier snapshots), `version_list` (enumerates versions newest-first), `version_restore` (time-travels via Loro checkout and applies old spatial canvas as new content)
- Version metadata stored as plain JSON strings in LoroDoc's `versions` map — no nested LoroMap containers, consistent with the workspace convention
- Platform-agnostic hex encoding (no `Buffer` dependency) to keep the shared-layer package portable across Node/browser/Workers

## Test plan

- [x] `version_save` returns metadata with unique versionId per call
- [x] `version_list` returns empty for no versions, newest-first with fake timers
- [x] `version_restore` round-trips spatial canvas content through save→modify→restore
- [x] `version_restore` throws `VersionNotFoundError` for unknown versionId
- [x] Typecheck passes (`pnpm -r typecheck`)
- [x] All server-core-node tests pass (77/77)