### PR TITLE
feat(server-core): wire reindex after canvas mutations

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -510,6 +510,7 @@ async function main() {
   console.log(`[e2e] wb_canvas_create → ${versionCanvas.canvasId}`)
 
   const facets = await callTool('facet_set', {
+    workspaceId,
     canvasId: versionCanvas.canvasId,
     facets: { 'e2e/1': { note: 'before-save' } },
   })
@@ -534,6 +535,7 @@ async function main() {
   console.log(`[e2e] version_save → ${saved.versionId}`)
 
   const restored = await callTool('version_restore', {
+    workspaceId,
     canvasId: versionCanvas.canvasId,
     versionId: saved.versionId,
   })

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -327,6 +327,7 @@ export async function runE2eCheckpointSmoke({
     console.log(`[e2e] wb_canvas_create → ${versionCanvas.canvasId}`)
 
     const facets = await callTool('facet_set', {
+      workspaceId,
       canvasId: versionCanvas.canvasId,
       facets: { 'e2e/1': { note: 'before-save' } },
     })
@@ -361,6 +362,7 @@ export async function runE2eCheckpointSmoke({
     console.log(`[e2e] version_list → ${versionEntries.length} version(s)`)
 
     const restored = await callTool('version_restore', {
+      workspaceId,
       canvasId: versionCanvas.canvasId,
       versionId: saved.versionId,
     })

--- a/packages/server-core/src/canvas-routes.test.ts
+++ b/packages/server-core/src/canvas-routes.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { createServer } from './create-server.js'
 import { createCanvasOutputSchema, listCanvasesOutputSchema } from './tools/canvas-crud.schemas.js'
 import { createInMemoryCanvasDocStore } from './test-utils/in-memory-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from './test-utils/fake-workspace-index.js'
 
 function makeApp() {
   const { app } = createServer({
     canvasDocStore: createInMemoryCanvasDocStore(),
-    workspaceIndex: {} as never,
+    workspaceIndex: new FakeWorkspaceIndex(),
     blobStore: {} as never,
   })
   return app

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -21,6 +21,7 @@ import { createCanvasRenderSvgTool } from './tools/canvas-render-svg.js'
 import { createEdgePatchTool } from './tools/edge-patch.js'
 import { createFacetSetTool } from './tools/facet-set.js'
 import { createNodePatchTool } from './tools/node-patch.js'
+import { createReindexTool } from './tools/reindex-tool.js'
 import { createVersionListTool } from './tools/version-list.js'
 import { createVersionRestoreTool } from './tools/version-restore.js'
 import { createVersionSaveTool } from './tools/version-save.js'
@@ -98,6 +99,7 @@ export function createServer(deps: ServerDeps) {
     versionSave: createVersionSaveTool(deps),
     versionList: createVersionListTool(deps),
     versionRestore: createVersionRestoreTool(deps),
+    reindex: createReindexTool(deps),
   }
   return { app, tools }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -89,3 +89,10 @@ export {
   VersionNotFoundError,
 } from './tools/version-restore.js'
 export type { VersionRestoreInput, VersionRestoreOutput } from './tools/version-restore.js'
+export { reindexWorkspace } from './tools/reindex.js'
+export {
+  createReindexTool,
+  reindexInputSchema,
+  reindexOutputSchema,
+} from './tools/reindex-tool.js'
+export type { ReindexInput, ReindexOutput } from './tools/reindex-tool.js'

--- a/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
+++ b/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
@@ -2,6 +2,7 @@ import type {
   AppendDeltasInput,
   AppendDeltasResult,
   CanvasDocStore,
+  DocRef,
   LoadDeltasInput,
   LoadDeltasResult,
   LoadSnapshotInput,
@@ -16,25 +17,29 @@ import { LoroDoc } from 'loro-crdt'
 
 const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
 
+function docRefKey(docRef: DocRef): string {
+  return docRef.kind === 'canvas'
+    ? `canvas:${docRef.canvasId}`
+    : `workspace-tree:${docRef.workspaceId}`
+}
+
 /**
  * An in-memory CanvasDocStore fake shared across server-core tool tests.
- * Keyed by `docRef.canvasId` so a single fake instance can back multiple
- * canvases within one test, matching how a real store scopes storage by
- * DocRef rather than by store instance.
+ * Keyed by `DocRef` (canvas or workspace-tree) so a single fake instance
+ * can back both a mutation tool's canvas doc and the `reindexWorkspace`
+ * call it triggers, which reads the workspace-tree doc.
  */
 export class FakeCanvasDocStore implements CanvasDocStore {
   private readonly saved = new Map<string, SaveSnapshotInput>()
 
   async loadSnapshot(input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-    if (input.docRef.kind !== 'canvas') throw new Error('fake store only supports canvas docs')
-    const entry = this.saved.get(input.docRef.canvasId)
+    const entry = this.saved.get(docRefKey(input.docRef))
     if (entry === undefined) return null
     return { manifest: entry.manifest, chunks: entry.chunks, frontier: entry.frontier }
   }
 
   async saveSnapshot(input: SaveSnapshotInput): Promise<void> {
-    if (input.docRef.kind !== 'canvas') throw new Error('fake store only supports canvas docs')
-    this.saved.set(input.docRef.canvasId, input)
+    this.saved.set(docRefKey(input.docRef), input)
   }
 
   async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {

--- a/packages/server-core/src/test-utils/fake-workspace-index.ts
+++ b/packages/server-core/src/test-utils/fake-workspace-index.ts
@@ -1,0 +1,47 @@
+import type {
+  ApplyRowsInput,
+  ListBacklinksInput,
+  ListBacklinksResult,
+  ListCanvasesInput,
+  ListCanvasesResult,
+  QueryFacetInput,
+  QueryFacetResult,
+  ResolveAliasHistoryInput,
+  ResolveAliasInput,
+  ResolveAliasResult,
+  WorkspaceIndex,
+} from '@kamiazya/whiteboard-canvas-ports'
+
+/**
+ * A no-op `WorkspaceIndex` fake for tool tests that only exercise a
+ * mutation's own effect (canvas doc / workspace tree), not the reindex it
+ * triggers as a side effect. `applyRows` records every call so a test can
+ * still assert on reindex behavior when that is the point under test.
+ */
+export class FakeWorkspaceIndex implements WorkspaceIndex {
+  readonly applyRowsCalls: ApplyRowsInput[] = []
+
+  async applyRows(input: ApplyRowsInput): Promise<void> {
+    this.applyRowsCalls.push(input)
+  }
+
+  async resolveAlias(_input: ResolveAliasInput): Promise<ResolveAliasResult> {
+    return null
+  }
+
+  async resolveAliasHistory(_input: ResolveAliasHistoryInput): Promise<ResolveAliasResult> {
+    return null
+  }
+
+  async listCanvases(_input: ListCanvasesInput): Promise<ListCanvasesResult> {
+    return { rows: [] }
+  }
+
+  async queryFacet(_input: QueryFacetInput): Promise<QueryFacetResult> {
+    return { canvasIds: [] }
+  }
+
+  async listBacklinks(_input: ListBacklinksInput): Promise<ListBacklinksResult> {
+    return { rows: [] }
+  }
+}

--- a/packages/server-core/src/tools/body-patch.test.ts
+++ b/packages/server-core/src/tools/body-patch.test.ts
@@ -4,10 +4,12 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import { createBodyPatchTool } from './body-patch.js'
 import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
 
 async function seedCanvas(
   canvasDocStore: FakeCanvasDocStore,
@@ -25,7 +27,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+  return { canvasDocStore, workspaceIndex: new FakeWorkspaceIndex(), blobStore: {} as never }
 }
 
 describe('body_patch tool', () => {
@@ -39,6 +41,7 @@ describe('body_patch tool', () => {
 
     const result = await tool.execute({
       mode: 'full',
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 't1',
       body: 'replaced',
@@ -67,6 +70,7 @@ describe('body_patch tool', () => {
 
     const result = await tool.execute({
       mode: 'range',
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 't1',
       range: { startLine: 1, endLine: 2, replacement: 'NEW' },
@@ -84,7 +88,13 @@ describe('body_patch tool', () => {
     const tool = createBodyPatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ mode: 'full', canvasId: CANVAS_ID, nodeId: 'g1', body: 'x' }),
+      tool.execute({
+        mode: 'full',
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'g1',
+        body: 'x',
+      }),
     ).rejects.toThrow(NotATextNodeError)
   })
 
@@ -101,6 +111,7 @@ describe('body_patch tool', () => {
     await expect(
       tool.execute({
         mode: 'range',
+        workspaceId: WORKSPACE_ID,
         canvasId: CANVAS_ID,
         nodeId: 't1',
         range: { startLine: 0, endLine: 5, replacement: 'x' },
@@ -117,7 +128,13 @@ describe('body_patch tool', () => {
     const tool = createBodyPatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ mode: 'full', canvasId: CANVAS_ID, nodeId: 'missing', body: 'x' }),
+      tool.execute({
+        mode: 'full',
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'missing',
+        body: 'x',
+      }),
     ).rejects.toThrow(NodeNotFoundError)
   })
 })

--- a/packages/server-core/src/tools/body-patch.ts
+++ b/packages/server-core/src/tools/body-patch.ts
@@ -3,11 +3,13 @@ import {
   nodeIdSchema,
   spatialCanvasSchema,
   spatialNodeSchema,
+  workspaceIdSchema,
 } from '@kamiazya/whiteboard-canvas-model'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
+import { reindexWorkspace } from './reindex.js'
 
 export const bodyPatchRangeSchema = z
   .object({
@@ -31,6 +33,7 @@ export const bodyPatchInputSchema = z.discriminatedUnion('mode', [
   z
     .object({
       mode: z.literal('full'),
+      workspaceId: workspaceIdSchema,
       canvasId: canvasIdSchema,
       nodeId: nodeIdSchema,
       body: z.string(),
@@ -39,6 +42,7 @@ export const bodyPatchInputSchema = z.discriminatedUnion('mode', [
   z
     .object({
       mode: z.literal('range'),
+      workspaceId: workspaceIdSchema,
       canvasId: canvasIdSchema,
       nodeId: nodeIdSchema,
       range: bodyPatchRangeSchema,
@@ -120,6 +124,7 @@ export function createBodyPatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, node: updatedNode }
     },

--- a/packages/server-core/src/tools/canvas-crud.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.test.ts
@@ -2,6 +2,7 @@ import { canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
 import type { ServerDeps } from '../server-deps.js'
 import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
@@ -12,7 +13,7 @@ import { wbCanvasCreate, wbCanvasDelete, wbCanvasGet, wbCanvasList } from './can
 function makeDeps(): ServerDeps {
   return {
     canvasDocStore: createInMemoryCanvasDocStore(),
-    workspaceIndex: {} as never,
+    workspaceIndex: new FakeWorkspaceIndex(),
     blobStore: {} as never,
   }
 }

--- a/packages/server-core/src/tools/canvas-crud.ts
+++ b/packages/server-core/src/tools/canvas-crud.ts
@@ -18,6 +18,7 @@ import type {
   listCanvasesOutputSchema,
 } from './canvas-crud.schemas.js'
 import { generateCanvasId } from './generate-canvas-id.js'
+import { reindexWorkspace } from './reindex.js'
 import { loadWorkspaceTree, saveWorkspaceTree } from './workspace-tree-io.js'
 
 /**
@@ -51,6 +52,7 @@ export async function wbCanvasCreate(
   const canvasId = generateCanvasId()
   tree.createNode(canvasId, input.segment, parentId)
   await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
+  await reindexWorkspace(deps, input.workspaceId)
 
   return { canvasId, segment: input.segment }
 }
@@ -87,5 +89,6 @@ export async function wbCanvasDelete(
   const node = findNodeOrThrow(tree, input.workspaceId, input.canvasId)
   tree.delete(node.id)
   await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
+  await reindexWorkspace(deps, input.workspaceId)
   return { deleted: true }
 }

--- a/packages/server-core/src/tools/edge-patch.test.ts
+++ b/packages/server-core/src/tools/edge-patch.test.ts
@@ -4,10 +4,12 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import { createEdgePatchTool } from './edge-patch.js'
 import { EdgeNotFoundError, PatchValidationError } from './errors.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
 
 async function seedCanvas(
   canvasDocStore: FakeCanvasDocStore,
@@ -25,7 +27,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+  return { canvasDocStore, workspaceIndex: new FakeWorkspaceIndex(), blobStore: {} as never }
 }
 
 const BASE_CANVAS: SpatialCanvas = {
@@ -43,6 +45,7 @@ describe('edge_patch tool', () => {
     const tool = createEdgePatchTool(makeDeps(canvasDocStore))
 
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       edgeId: 'e1',
       patch: { color: '3', label: 'connects', fromSide: 'right', toSide: 'left' },
@@ -65,7 +68,12 @@ describe('edge_patch tool', () => {
     const tool = createEdgePatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ canvasId: CANVAS_ID, edgeId: 'missing', patch: { color: '1' } }),
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        edgeId: 'missing',
+        patch: { color: '1' },
+      }),
     ).rejects.toThrow(EdgeNotFoundError)
   })
 
@@ -75,7 +83,12 @@ describe('edge_patch tool', () => {
     const tool = createEdgePatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ canvasId: CANVAS_ID, edgeId: 'e1', patch: { toNode: 'does-not-exist' } }),
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        edgeId: 'e1',
+        patch: { toNode: 'does-not-exist' },
+      }),
     ).rejects.toThrow(PatchValidationError)
   })
 })

--- a/packages/server-core/src/tools/edge-patch.ts
+++ b/packages/server-core/src/tools/edge-patch.ts
@@ -4,11 +4,13 @@ import {
   canvasIdSchema,
   nodeIdSchema,
   spatialCanvasSchema,
+  workspaceIdSchema,
 } from '@kamiazya/whiteboard-canvas-model'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { EdgeNotFoundError, PatchValidationError } from './errors.js'
+import { reindexWorkspace } from './reindex.js'
 
 export const edgePatchFieldsSchema = z
   .object({
@@ -24,6 +26,7 @@ export type EdgePatchFields = z.infer<typeof edgePatchFieldsSchema>
 
 export const edgePatchInputSchema = z
   .object({
+    workspaceId: workspaceIdSchema,
     canvasId: canvasIdSchema,
     // canvas-model has no distinct edgeIdSchema — edges and nodes share
     // the same nanoid-style id shape (`nodeIdSchema` only enforces
@@ -75,6 +78,7 @@ export function createEdgePatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, edge: updatedEdge }
     },

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -3,12 +3,14 @@ import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+  return { canvasDocStore, workspaceIndex: new FakeWorkspaceIndex(), blobStore: {} as never }
 }
 
 describe('facet_set tool', () => {
@@ -16,6 +18,7 @@ describe('facet_set tool', () => {
     const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       facets: { 'kanban/1': { status: 'todo' } },
     })
@@ -30,7 +33,11 @@ describe('facet_set tool', () => {
     const store = new FakeCanvasDocStore()
     const tool = createFacetSetTool(makeDeps(store))
 
-    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
 
     const loaded = await store.loadSnapshot({
       docRef: { kind: 'canvas', canvasId: CANVAS_ID },
@@ -46,8 +53,13 @@ describe('facet_set tool', () => {
   test('merges a new facet domain with an existing one instead of replacing it', async () => {
     const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
-    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       facets: { 'priority/1': { level: 'high' } },
     })
@@ -61,8 +73,13 @@ describe('facet_set tool', () => {
   test('overwrites an existing facet domain when the same key is set again', async () => {
     const tool = createFacetSetTool(makeDeps(new FakeCanvasDocStore()))
 
-    await tool.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       facets: { 'kanban/1': { status: 'done' } },
     })

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -1,12 +1,14 @@
 import {
   canvasIdSchema,
   extensionFacetsSchema,
+  workspaceIdSchema,
   type ExtensionFacets,
 } from '@kamiazya/whiteboard-canvas-model'
 import { readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
+import { reindexWorkspace } from './reindex.js'
 
 /**
  * `extensionFacetsSchema` already enforces the `{domain}/{version}` key
@@ -17,6 +19,7 @@ import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
  */
 export const facetSetInputSchema = z
   .object({
+    workspaceId: workspaceIdSchema,
     canvasId: canvasIdSchema,
     facets: extensionFacetsSchema,
   })
@@ -43,6 +46,7 @@ export function createFacetSetTool(deps: ServerDeps) {
       writeFacets(doc, mergedFacets)
 
       await saveDocSnapshot(deps, input.canvasId, doc)
+      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, facets: mergedFacets }
     },

--- a/packages/server-core/src/tools/node-patch.test.ts
+++ b/packages/server-core/src/tools/node-patch.test.ts
@@ -4,10 +4,12 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import { CanvasDocNotFoundError, NodeNotFoundError } from './errors.js'
 import { createNodePatchTool, nodePatchInputSchema } from './node-patch.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
 
 async function seedCanvas(
   canvasDocStore: FakeCanvasDocStore,
@@ -25,7 +27,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+  return { canvasDocStore, workspaceIndex: new FakeWorkspaceIndex(), blobStore: {} as never }
 }
 
 describe('node_patch tool', () => {
@@ -38,6 +40,7 @@ describe('node_patch tool', () => {
     const tool = createNodePatchTool(makeDeps(canvasDocStore))
 
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 'n1',
       patch: { x: 42, y: 7, width: 200, height: 90, color: '2' },
@@ -69,6 +72,7 @@ describe('node_patch tool', () => {
     const tool = createNodePatchTool(makeDeps(canvasDocStore))
 
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 'g1',
       patch: { label: 'My Group' },
@@ -86,6 +90,7 @@ describe('node_patch tool', () => {
     const tool = createNodePatchTool(makeDeps(canvasDocStore))
 
     const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 'n1',
       patch: { label: 'ignored' },
@@ -103,7 +108,12 @@ describe('node_patch tool', () => {
     const tool = createNodePatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ canvasId: CANVAS_ID, nodeId: 'missing', patch: { x: 1 } }),
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'missing',
+        patch: { x: 1 },
+      }),
     ).rejects.toThrow(NodeNotFoundError)
   })
 
@@ -112,12 +122,18 @@ describe('node_patch tool', () => {
     const tool = createNodePatchTool(makeDeps(canvasDocStore))
 
     await expect(
-      tool.execute({ canvasId: CANVAS_ID, nodeId: 'n1', patch: { x: 1 } }),
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'n1',
+        patch: { x: 1 },
+      }),
     ).rejects.toThrow(CanvasDocNotFoundError)
   })
 
   test('rejects a negative width at the input-schema level', () => {
     const result = nodePatchInputSchema.safeParse({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       nodeId: 'n1',
       patch: { width: -5 },

--- a/packages/server-core/src/tools/node-patch.ts
+++ b/packages/server-core/src/tools/node-patch.ts
@@ -4,11 +4,13 @@ import {
   nodeIdSchema,
   spatialCanvasSchema,
   spatialNodeSchema,
+  workspaceIdSchema,
 } from '@kamiazya/whiteboard-canvas-model'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { NodeNotFoundError, PatchValidationError } from './errors.js'
+import { reindexWorkspace } from './reindex.js'
 
 /**
  * Deliberately limited to the geometry/style fields every node type
@@ -34,6 +36,7 @@ export type NodePatchFields = z.infer<typeof nodePatchFieldsSchema>
 
 export const nodePatchInputSchema = z
   .object({
+    workspaceId: workspaceIdSchema,
     canvasId: canvasIdSchema,
     nodeId: nodeIdSchema,
     patch: nodePatchFieldsSchema,
@@ -77,6 +80,7 @@ export function createNodePatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, node: updatedNode }
     },

--- a/packages/server-core/src/tools/reindex-tool.test.ts
+++ b/packages/server-core/src/tools/reindex-tool.test.ts
@@ -1,0 +1,52 @@
+import { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
+import { createFacetSetTool } from './facet-set.js'
+import { createReindexTool } from './reindex-tool.js'
+import { saveWorkspaceTree } from './workspace-tree-io.js'
+
+const WORKSPACE_ID = 'ws-1'
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+describe('reindex tool', () => {
+  test('returns canvasCount 0 for a workspace with no indexed canvases', async () => {
+    const canvasDocStore = createInMemoryCanvasDocStore()
+    const deps = {
+      canvasDocStore,
+      workspaceIndex: new FakeWorkspaceIndex(),
+      blobStore: {} as never,
+    }
+    const tool = createReindexTool(deps)
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID })
+
+    expect(result).toEqual({ reindexed: true, canvasCount: 0 })
+  })
+
+  test('reports the number of canvases with a saved snapshot after a manual reindex', async () => {
+    const canvasDocStore = createInMemoryCanvasDocStore()
+    const workspaceIndex = new FakeWorkspaceIndex()
+    const deps = { canvasDocStore, workspaceIndex, blobStore: {} as never }
+
+    const tree = new WorkspaceTree(new LoroDoc())
+    tree.createNode(CANVAS_ID, 'my-canvas')
+    await saveWorkspaceTree(canvasDocStore, WORKSPACE_ID, tree)
+
+    const facetSet = createFacetSetTool(deps)
+    await facetSet.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
+
+    const tool = createReindexTool(deps)
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID })
+
+    expect(result).toEqual({ reindexed: true, canvasCount: 1 })
+    expect(workspaceIndex.applyRowsCalls.at(-1)?.facets).toEqual([
+      { facet: 'facets.kanban/1', value: '', canvasId: CANVAS_ID },
+    ])
+  })
+})

--- a/packages/server-core/src/tools/reindex-tool.ts
+++ b/packages/server-core/src/tools/reindex-tool.ts
@@ -1,0 +1,38 @@
+import { workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { reindexWorkspace } from './reindex.js'
+
+export const reindexInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+  })
+  .strict()
+export type ReindexInput = z.infer<typeof reindexInputSchema>
+
+export const reindexOutputSchema = z
+  .object({
+    reindexed: z.boolean(),
+    canvasCount: z.number().int().min(0),
+  })
+  .strict()
+export type ReindexOutput = z.infer<typeof reindexOutputSchema>
+
+/**
+ * Manual full-workspace reindex tool. Every mutation tool already triggers
+ * `reindexWorkspace` as part of its own save, so this is a recovery/repair
+ * lever — rebuilding WorkspaceIndex rows from scratch after e.g. restoring
+ * a workspace-tree snapshot out of band or suspecting index drift — not
+ * part of the normal write path.
+ */
+export function createReindexTool(deps: ServerDeps) {
+  return {
+    name: 'reindex' as const,
+    inputSchema: reindexInputSchema,
+    outputSchema: reindexOutputSchema,
+    async execute(input: ReindexInput): Promise<ReindexOutput> {
+      const canvasCount = await reindexWorkspace(deps, input.workspaceId)
+      return { reindexed: true, canvasCount }
+    },
+  }
+}

--- a/packages/server-core/src/tools/reindex.test.ts
+++ b/packages/server-core/src/tools/reindex.test.ts
@@ -1,0 +1,107 @@
+import type {
+  ApplyRowsInput,
+  CanvasDocStore,
+  WorkspaceIndex,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { createFacetSetTool } from './facet-set.js'
+import { reindexWorkspace } from './reindex.js'
+import { saveWorkspaceTree } from './workspace-tree-io.js'
+
+const WORKSPACE_ID = 'ws-1'
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+
+class RecordingWorkspaceIndex implements WorkspaceIndex {
+  readonly calls: ApplyRowsInput[] = []
+
+  async applyRows(input: ApplyRowsInput): Promise<void> {
+    this.calls.push(input)
+  }
+
+  async resolveAlias(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
+  async resolveAliasHistory(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
+  async listCanvases(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
+  async queryFacet(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
+  async listBacklinks(): Promise<never> {
+    throw new Error('not implemented')
+  }
+}
+
+function makeDeps(canvasDocStore: CanvasDocStore, workspaceIndex: WorkspaceIndex) {
+  return { canvasDocStore, workspaceIndex, blobStore: {} as never }
+}
+
+describe('reindexWorkspace', () => {
+  test('applies empty rows for a workspace with no tree nodes', async () => {
+    const canvasDocStore = createInMemoryCanvasDocStore()
+    const workspaceIndex = new RecordingWorkspaceIndex()
+
+    await reindexWorkspace(makeDeps(canvasDocStore, workspaceIndex), WORKSPACE_ID)
+
+    expect(workspaceIndex.calls).toHaveLength(1)
+    expect(workspaceIndex.calls[0]).toEqual({
+      workspaceId: WORKSPACE_ID,
+      canvasList: [],
+      facets: [],
+      aliases: [],
+      backlinks: [],
+      aliasHistory: [],
+    })
+  })
+
+  test('derives canvas list, alias, and facet rows from a saved tree + canvas doc', async () => {
+    const canvasDocStore = createInMemoryCanvasDocStore()
+    const workspaceIndex = new RecordingWorkspaceIndex()
+
+    const tree = new WorkspaceTree(new LoroDoc())
+    tree.createNode(CANVAS_ID, 'my-canvas')
+    await saveWorkspaceTree(canvasDocStore, WORKSPACE_ID, tree)
+
+    const deps = makeDeps(canvasDocStore, workspaceIndex)
+    const facetSet = createFacetSetTool(deps)
+    await facetSet.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+
+    await reindexWorkspace(deps, WORKSPACE_ID)
+
+    expect(workspaceIndex.calls).toHaveLength(1)
+    const applied = workspaceIndex.calls[0]
+    expect(applied.workspaceId).toBe(WORKSPACE_ID)
+    expect(applied.canvasList).toEqual([
+      { canvasId: CANVAS_ID, title: 'my-canvas', updatedAtMs: expect.any(Number) },
+    ])
+    expect(applied.aliases).toEqual([{ alias: 'my-canvas', canvasId: CANVAS_ID }])
+    expect(applied.facets).toEqual([{ facet: 'facets.kanban/1', value: '', canvasId: CANVAS_ID }])
+  })
+
+  test('skips a tree node whose canvas has no saved snapshot yet', async () => {
+    const canvasDocStore = createInMemoryCanvasDocStore()
+    const workspaceIndex = new RecordingWorkspaceIndex()
+
+    const tree = new WorkspaceTree(new LoroDoc())
+    tree.createNode(CANVAS_ID, 'unsaved-canvas')
+    await saveWorkspaceTree(canvasDocStore, WORKSPACE_ID, tree)
+
+    await reindexWorkspace(makeDeps(canvasDocStore, workspaceIndex), WORKSPACE_ID)
+
+    const applied = workspaceIndex.calls[0]
+    expect(applied.facets).toEqual([])
+    // the alias row is still derived from the tree itself, independent of doc state
+    expect(applied.aliases).toEqual([{ alias: 'unsaved-canvas', canvasId: CANVAS_ID }])
+    expect(applied.canvasList).toEqual([])
+  })
+})

--- a/packages/server-core/src/tools/reindex.test.ts
+++ b/packages/server-core/src/tools/reindex.test.ts
@@ -74,12 +74,18 @@ describe('reindexWorkspace', () => {
 
     const deps = makeDeps(canvasDocStore, workspaceIndex)
     const facetSet = createFacetSetTool(deps)
-    await facetSet.execute({ canvasId: CANVAS_ID, facets: { 'kanban/1': { status: 'todo' } } })
+    await facetSet.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'kanban/1': { status: 'todo' } },
+    })
 
+    // facet_set already triggers its own reindex; this call is redundant but
+    // must be idempotent against unchanged state.
     await reindexWorkspace(deps, WORKSPACE_ID)
 
-    expect(workspaceIndex.calls).toHaveLength(1)
-    const applied = workspaceIndex.calls[0]
+    expect(workspaceIndex.calls).toHaveLength(2)
+    const applied = workspaceIndex.calls[1]
     expect(applied.workspaceId).toBe(WORKSPACE_ID)
     expect(applied.canvasList).toEqual([
       { canvasId: CANVAS_ID, title: 'my-canvas', updatedAtMs: expect.any(Number) },

--- a/packages/server-core/src/tools/reindex.ts
+++ b/packages/server-core/src/tools/reindex.ts
@@ -17,8 +17,14 @@ import { loadWorkspaceTree } from './workspace-tree-io.js'
  * `resolvedBody` (backlinks, requiring the markdown resolve pipeline) are
  * not wired yet — this reindexes on tree membership + extension facets
  * only, matching what canvas docs persist today.
+ *
+ * Returns the number of canvases whose rows were derived (tree nodes with
+ * a saved doc snapshot), for callers that report a reindex result.
  */
-export async function reindexWorkspace(deps: ServerDeps, workspaceId: WorkspaceId): Promise<void> {
+export async function reindexWorkspace(
+  deps: ServerDeps,
+  workspaceId: WorkspaceId,
+): Promise<number> {
   const tree = await loadWorkspaceTree(deps.canvasDocStore, workspaceId)
 
   const canvases: CanvasIndexInput[] = []
@@ -40,4 +46,5 @@ export async function reindexWorkspace(deps: ServerDeps, workspaceId: WorkspaceI
 
   const rows = deriveWorkspaceIndexRows({ workspaceId, tree, canvases })
   await deps.workspaceIndex.applyRows(rows)
+  return canvases.length
 }

--- a/packages/server-core/src/tools/reindex.ts
+++ b/packages/server-core/src/tools/reindex.ts
@@ -1,0 +1,43 @@
+import type { WorkspaceId } from '@kamiazya/whiteboard-canvas-model'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import type { CanvasIndexInput } from '@kamiazya/whiteboard-canvas-workspace'
+import { deriveWorkspaceIndexRows, readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import type { ServerDeps } from '../server-deps.js'
+import { loadWorkspaceTree } from './workspace-tree-io.js'
+
+/**
+ * Rebuilds `workspaceId`'s WorkspaceIndex rows from the current tree +
+ * canvas docs. A tree node whose canvas has no saved snapshot yet (a
+ * freshly created, still-empty canvas) is skipped — there is no doc to
+ * derive facet/backlink rows from, so it only shows up via the tree
+ * itself once a doc is saved.
+ *
+ * `coreFacets` (title/type/tags/view, sourced from OKF frontmatter) and
+ * `resolvedBody` (backlinks, requiring the markdown resolve pipeline) are
+ * not wired yet — this reindexes on tree membership + extension facets
+ * only, matching what canvas docs persist today.
+ */
+export async function reindexWorkspace(deps: ServerDeps, workspaceId: WorkspaceId): Promise<void> {
+  const tree = await loadWorkspaceTree(deps.canvasDocStore, workspaceId)
+
+  const canvases: CanvasIndexInput[] = []
+  for (const node of tree.snapshot().nodes) {
+    const snapshot = await deps.canvasDocStore.loadSnapshot({
+      docRef: { kind: 'canvas', canvasId: node.canvasId },
+    })
+    if (snapshot === null) continue
+
+    const doc = new LoroDoc()
+    doc.import(reassembleSnapshot(snapshot.manifest, snapshot.chunks))
+
+    canvases.push({
+      canvasId: node.canvasId,
+      updatedAtMs: Date.now(),
+      extensionFacets: readFacets(doc),
+    })
+  }
+
+  const rows = deriveWorkspaceIndexRows({ workspaceId, tree, canvases })
+  await deps.workspaceIndex.applyRows(rows)
+}

--- a/packages/server-core/src/tools/version-restore.ts
+++ b/packages/server-core/src/tools/version-restore.ts
@@ -1,13 +1,15 @@
-import { canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
+import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { decodeFrontiers } from 'loro-crdt'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
+import { reindexWorkspace } from './reindex.js'
 import { parseVersionRecord } from './version-record.js'
 
 export const versionRestoreInputSchema = z
   .object({
+    workspaceId: workspaceIdSchema,
     canvasId: canvasIdSchema.describe('Canvas ID (ULID) to restore a version onto, in place.'),
     versionId: z.string().min(1).describe('Version id returned by version_save or version_list.'),
   })
@@ -67,6 +69,7 @@ export function createVersionRestoreTool(deps: ServerDeps) {
       doc.commit()
 
       await saveDocSnapshot(deps, input.canvasId, doc)
+      await reindexWorkspace(deps, input.workspaceId)
 
       return {
         canvasId: input.canvasId,

--- a/packages/server-core/src/tools/version-restore.ts
+++ b/packages/server-core/src/tools/version-restore.ts
@@ -9,7 +9,9 @@ import { parseVersionRecord } from './version-record.js'
 
 export const versionRestoreInputSchema = z
   .object({
-    workspaceId: workspaceIdSchema,
+    workspaceId: workspaceIdSchema.describe(
+      'Workspace ID that owns the canvas, used to reindex after restore.',
+    ),
     canvasId: canvasIdSchema.describe('Canvas ID (ULID) to restore a version onto, in place.'),
     versionId: z.string().min(1).describe('Version id returned by version_save or version_list.'),
   })

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -3,15 +3,17 @@ import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { FakeWorkspaceIndex } from '../test-utils/fake-workspace-index.js'
 import { createVersionListTool } from './version-list.js'
 import { createVersionRestoreTool } from './version-restore.js'
 import { VersionNotFoundError } from './version-restore.js'
 import { createVersionSaveTool } from './version-save.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+  return { canvasDocStore, workspaceIndex: new FakeWorkspaceIndex(), blobStore: {} as never }
 }
 
 async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {
@@ -146,6 +148,7 @@ describe('version_restore tool', () => {
     if (beforeNode.type === 'text') expect(beforeNode.text).toBe('modified')
 
     const result = await restoreTool.execute({
+      workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       versionId: saved.versionId,
     })
@@ -165,7 +168,11 @@ describe('version_restore tool', () => {
     const restoreTool = createVersionRestoreTool(deps)
 
     await expect(
-      restoreTool.execute({ canvasId: CANVAS_ID, versionId: 'nonexistent' }),
+      restoreTool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        versionId: 'nonexistent',
+      }),
     ).rejects.toThrow(VersionNotFoundError)
   })
 
@@ -181,7 +188,11 @@ describe('version_restore tool', () => {
     })
 
     await expect(
-      restoreTool.execute({ canvasId: CANVAS_ID, versionId: 'corrupt-version' }),
+      restoreTool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        versionId: 'corrupt-version',
+      }),
     ).rejects.toThrow(VersionNotFoundError)
   })
 })


### PR DESCRIPTION
## Summary
- Add `reindexWorkspace` helper that loads workspace tree + canvas docs, derives index rows via `deriveWorkspaceIndexRows`, and calls `workspaceIndex.applyRows`
- Wire reindex after every mutating tool: canvas create/delete, facet set, node/edge/body patch, version restore
- Add `wb_reindex` manual reindex MCP tool
- Add `workspaceId` to patch/facet/version-restore input schemas (required for reindex scope)

## Test plan
- [x] `reindex.test.ts`: empty workspace, derived rows from tree+facets, skip unsaved canvas
- [x] `reindex-tool.test.ts`: manual reindex returns canvasCount
- [x] All existing tool tests updated with `workspaceId` and `FakeWorkspaceIndex`
- [x] `pnpm test --project server-core-node` — 90/90 pass
- [x] `pnpm test --project mcp-node` — 3737 pass (no cross-package regression)
- [x] `pnpm -r typecheck` — all 11 packages clean