### PR TITLE
feat(mcp-server): wire DI container into production boot path

### DIFF
--- a/packages/mcp-server/src/di/container.test.ts
+++ b/packages/mcp-server/src/di/container.test.ts
@@ -1,9 +1,10 @@
 import { TOKENS } from '@kamiazya/whiteboard-canvas-ports'
+import { Container, ContainerModule } from 'inversify'
 import { describe, expect, it } from 'vitest'
 import { InMemoryBlobStore } from '../server/store/inmemory/in-memory-blob-store.js'
 import { InMemoryCanvasDocStore } from '../server/store/inmemory/in-memory-canvas-doc-store.js'
 import { InMemoryWorkspaceIndex } from '../server/store/inmemory/in-memory-workspace-index.js'
-import { createContainer } from './container.js'
+import { createContainer, resolveServerDeps } from './container.js'
 
 describe('createContainer', () => {
   it('resolves TOKENS.CanvasDocStore to an InMemoryCanvasDocStore', () => {
@@ -27,6 +28,27 @@ describe('createContainer', () => {
     expect(container.get(TOKENS.CanvasDocStore)).toBe(container.get(TOKENS.CanvasDocStore))
     expect(container.get(TOKENS.BlobStore)).toBe(container.get(TOKENS.BlobStore))
     expect(container.get(TOKENS.WorkspaceIndex)).toBe(container.get(TOKENS.WorkspaceIndex))
+  })
+})
+
+describe('resolveServerDeps', () => {
+  it('assembles ServerDeps from container.get(TOKENS.X) for all three ports', () => {
+    const container = createContainer()
+
+    const deps = resolveServerDeps(container)
+
+    expect(deps.canvasDocStore).toBeInstanceOf(InMemoryCanvasDocStore)
+    expect(deps.workspaceIndex).toBeInstanceOf(InMemoryWorkspaceIndex)
+    expect(deps.blobStore).toBeInstanceOf(InMemoryBlobStore)
+    expect(deps.canvasDocStore).toBe(container.get(TOKENS.CanvasDocStore))
+  })
+
+  it('throws a clear, descriptive error when a token is not bound in the container', () => {
+    const emptyModule = new ContainerModule(() => {})
+    const container = new Container()
+    container.load(emptyModule)
+
+    expect(() => resolveServerDeps(container)).toThrow(/CanvasDocStore/)
   })
 })
 

--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -1,8 +1,24 @@
+import { TOKENS } from '@kamiazya/whiteboard-canvas-ports'
 import { Container, type ContainerModule } from 'inversify'
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { storeMemoryModule } from './store-memory.module.js'
 
 export function createContainer(storeModule: ContainerModule = storeMemoryModule): Container {
   const container = new Container()
   container.load(storeModule)
   return container
+}
+
+/**
+ * Assembles ServerDeps by resolving the three store/sync port tokens from a
+ * DI container. Inversify already throws a descriptive "not bound" error
+ * when a token has no binding, so this simply surfaces that failure instead
+ * of letting a missing binding silently produce undefined deps.
+ */
+export function resolveServerDeps(container: Container): ServerDeps {
+  return {
+    canvasDocStore: container.get(TOKENS.CanvasDocStore),
+    workspaceIndex: container.get(TOKENS.WorkspaceIndex),
+    blobStore: container.get(TOKENS.BlobStore),
+  }
 }

--- a/packages/mcp-server/src/di/no-production-wiring.test.ts
+++ b/packages/mcp-server/src/di/no-production-wiring.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 /**
- * storeMemoryModule/createContainer/the InMemory doubles are a test-level
- * composition, not something the live server wires up yet. Real store
- * implementations (libSQL/fs) land in a later slice and bind into the same
- * container factory — until then, production entrypoints must stay free of
- * this surface so a reviewer sees at a glance that it isn't load-bearing.
+ * storeMemoryModule/the InMemory doubles are test-only composition and must
+ * never leak into production wiring. createContainer/createStoreLocalModule
+ * ARE the production boot path now (real libSQL/fs implementations bound
+ * through the DI container) — but the boot path must construct stores only
+ * through that container, never by importing the concrete store classes
+ * directly, so a reviewer can see at a glance that DI is the single wiring
+ * point.
  *
  * Sources are captured via Vite's build-time `import.meta.glob` (raw text),
  * not `node:fs` at runtime, so a bad glob pattern fails loudly (empty match)
@@ -42,15 +44,29 @@ const FORBIDDEN_PATTERNS: readonly { name: string; pattern: RegExp }[] = [
     name: 'static import of di/store-memory.module',
     pattern: /from\s+['"].*di\/store-memory\.module/,
   },
-  { name: 'static import of di/container', pattern: /from\s+['"].*di\/container/ },
   {
     name: 'dynamic import of di/store-memory.module',
     pattern: /import\(['"].*di\/store-memory\.module/,
   },
-  { name: 'dynamic import of di/container', pattern: /import\(['"].*di\/container/ },
   { name: 'server/store/inmemory import', pattern: /server\/store\/inmemory/ },
-  { name: 'bare createContainer identifier', pattern: /\bcreateContainer\b/ },
   { name: 'bare storeMemoryModule identifier', pattern: /\bstoreMemoryModule\b/ },
+]
+
+// The boot path (server/mcp/index.ts) must construct stores only through the
+// DI container (createContainer + createStoreLocalModule), never by
+// importing a concrete store class directly — that would let a manual
+// `new LibsqlCanvasDocStore(...)` construction bypass the container and
+// silently drift from what the container actually binds.
+const FORBIDDEN_MANUAL_STORE_IMPORTS_IN_BOOT_PATH: readonly { name: string; pattern: RegExp }[] = [
+  {
+    name: 'direct import of LibsqlCanvasDocStore',
+    pattern: /from\s+['"].*libsql-canvas-doc-store/,
+  },
+  {
+    name: 'direct import of LibsqlWorkspaceIndex',
+    pattern: /from\s+['"].*libsql-workspace-index/,
+  },
+  { name: 'direct import of FsBlobStore', pattern: /from\s+['"].*fs-blob-store/ },
 ]
 
 function isProductionSource(path: string): boolean {
@@ -68,6 +84,20 @@ describe('DI/in-memory composition stays out of production wiring', () => {
 
   it.each(productionEntries)('%s does not import the DI/in-memory surface', (path, contents) => {
     for (const { name, pattern } of FORBIDDEN_PATTERNS) {
+      expect(pattern.test(contents), `${path} matched forbidden pattern: ${name}`).toBe(false)
+    }
+  })
+
+  const bootPathEntries = productionEntries.filter(([path]) => path.includes('server/mcp/index.ts'))
+
+  it('scans the mcp boot path entrypoint', () => {
+    expect(bootPathEntries.length).toBe(1)
+  })
+
+  it.each(
+    bootPathEntries,
+  )('%s constructs stores only through the DI container, not by direct class import', (path, contents) => {
+    for (const { name, pattern } of FORBIDDEN_MANUAL_STORE_IMPORTS_IN_BOOT_PATH) {
       expect(pattern.test(contents), `${path} matched forbidden pattern: ${name}`).toBe(false)
     }
   })

--- a/packages/mcp-server/src/server/mcp/index.test.ts
+++ b/packages/mcp-server/src/server/mcp/index.test.ts
@@ -39,14 +39,16 @@ vi.mock('./opencanvas-tools.js', () => ({
 vi.mock('../store/db/index.js', () => ({
   getDb: vi.fn(async () => ({})),
 }))
-vi.mock('../store/libsql/libsql-canvas-doc-store.js', () => ({
-  LibsqlCanvasDocStore: vi.fn(),
+vi.mock('../../di/store-local.module.js', () => ({
+  createStoreLocalModule: vi.fn(() => 'fake-store-local-module'),
 }))
-vi.mock('../store/libsql/libsql-workspace-index.js', () => ({
-  LibsqlWorkspaceIndex: vi.fn(),
-}))
-vi.mock('../store/fs/fs-blob-store.js', () => ({
-  FsBlobStore: vi.fn(),
+vi.mock('../../di/container.js', () => ({
+  createContainer: vi.fn(() => 'fake-container'),
+  resolveServerDeps: vi.fn(() => ({
+    canvasDocStore: {},
+    workspaceIndex: {},
+    blobStore: {},
+  })),
 }))
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: vi.fn(function FakeMcpServer(this: Record<string, unknown>) {

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -17,9 +17,8 @@ import {
 } from './standalone-help.js'
 import { registerOpenCanvasTools } from './opencanvas-tools.js'
 import { getDb } from '../store/db/index.js'
-import { LibsqlCanvasDocStore } from '../store/libsql/libsql-canvas-doc-store.js'
-import { LibsqlWorkspaceIndex } from '../store/libsql/libsql-workspace-index.js'
-import { FsBlobStore } from '../store/fs/fs-blob-store.js'
+import { createContainer, resolveServerDeps } from '../../di/container.js'
+import { createStoreLocalModule } from '../../di/store-local.module.js'
 
 export async function createMcpServer() {
   // ensureWorkspaceId memoizes the resolve+save sequence per getDataDir() so the
@@ -107,11 +106,8 @@ export async function createMcpServer() {
 
   const dataDir = getDataDir()
   const db = await getDb(dataDir)
-  registerOpenCanvasTools(server, {
-    canvasDocStore: new LibsqlCanvasDocStore(db),
-    workspaceIndex: new LibsqlWorkspaceIndex(db),
-    blobStore: new FsBlobStore(dataDir),
-  })
+  const container = createContainer(createStoreLocalModule({ db, blobDir: dataDir }))
+  registerOpenCanvasTools(server, resolveServerDeps(container))
 
   return server
 }


### PR DESCRIPTION
## Summary

- Wire `createMcpServer()` through the Inversify container instead of manually constructing store implementations
- Add `resolveServerDeps(container)` helper in `container.ts` that resolves `TOKENS.CanvasDocStore`, `WorkspaceIndex`, and `BlobStore` from the container
- Replace direct `new LibsqlCanvasDocStore(db)` / `new LibsqlWorkspaceIndex(db)` / `new FsBlobStore(dataDir)` calls with `createContainer(createStoreLocalModule({ db, blobDir }))` + `resolveServerDeps()`
- Extend `no-production-wiring.test.ts` guard to also forbid direct store constructor imports in the boot path

## Test plan

- [x] `pnpm test --project mcp-node` — 224 files, 2993 passed
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` — clean
- [ ] CI `verify` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * MCP server setup now uses centralized dependency wiring for storage and workspace services.
  * Reduced direct construction of storage implementations during server startup.

* **Bug Fixes**
  * Improved error reporting when required server dependencies are unavailable.
  * Preserved server initialization and shutdown behavior while using the shared wiring path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->