### PR TITLE
feat(canvas-workspace): deep-index issue/1 facet payload fields

### DIFF
--- a/packages/canvas-workspace/src/derive-index.test.ts
+++ b/packages/canvas-workspace/src/derive-index.test.ts
@@ -44,7 +44,7 @@ describe('deriveFacetIndexRows', () => {
     expect(deriveFacetIndexRows([{ canvasId: NOTES_ID, updatedAtMs: 0 }])).toEqual([])
   })
 
-  test('indexes a issue/1 extension facet payload as an existence row, same as any other domain', () => {
+  test('indexes a issue/1 extension facet payload as existence + deep per-field rows', () => {
     const rows = deriveFacetIndexRows([
       {
         canvasId: NOTES_ID,
@@ -53,8 +53,116 @@ describe('deriveFacetIndexRows', () => {
       },
     ])
 
-    expect(rows).toEqual([{ facet: 'facets.issue/1', value: '', canvasId: NOTES_ID }])
+    expect(rows).toEqual([
+      { facet: 'facets.issue/1', value: '', canvasId: NOTES_ID },
+      { facet: 'facets.issue/1.assignees', value: 'alice', canvasId: NOTES_ID },
+      { facet: 'facets.issue/1.status', value: 'open', canvasId: NOTES_ID },
+    ])
     for (const row of rows) expect(() => facetIndexRowSchema.parse(row)).not.toThrow()
+  })
+
+  test('emits one deep row per array element for assignees and labels, plus scalar fields', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: {
+          'issue/1': {
+            status: 'open',
+            priority: 'high',
+            assignees: ['alice', 'bob'],
+            labels: ['bug'],
+            due: '2026-08-01T00:00:00.000Z',
+            summary: 'fix it',
+          },
+        },
+      },
+    ])
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { facet: 'facets.issue/1', value: '', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.status', value: 'open', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.priority', value: 'high', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.assignees', value: 'alice', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.assignees', value: 'bob', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.labels', value: 'bug', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.due', value: '2026-08-01T00:00:00.000Z', canvasId: NOTES_ID },
+        { facet: 'facets.issue/1.summary', value: 'fix it', canvasId: NOTES_ID },
+      ]),
+    )
+    // existence + status + priority + due + summary (4 scalars) + 2 assignees + 1 label
+    expect(rows).toHaveLength(1 + 4 + 2 + 1)
+    for (const row of rows) expect(() => facetIndexRowSchema.parse(row)).not.toThrow()
+  })
+
+  test('emits no deep rows for absent optional fields or empty arrays', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: { 'issue/1': { status: 'open', assignees: [], labels: [] } },
+      },
+    ])
+
+    expect(rows).toEqual([
+      { facet: 'facets.issue/1', value: '', canvasId: NOTES_ID },
+      { facet: 'facets.issue/1.status', value: 'open', canvasId: NOTES_ID },
+    ])
+  })
+
+  test('treats non-issue/1 extension domains as existence-only (no regression)', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: { 'kanban/1': { columns: ['todo', 'done'] } },
+      },
+    ])
+
+    expect(rows).toEqual([{ facet: 'facets.kanban/1', value: '', canvasId: NOTES_ID }])
+  })
+
+  test('falls back to existence-only row when issue/1 payload is not an object (never throws)', () => {
+    for (const malformed of ['open', 42, null]) {
+      const rows = deriveFacetIndexRows([
+        { canvasId: NOTES_ID, updatedAtMs: 0, extensionFacets: { 'issue/1': malformed } },
+      ])
+      expect(rows).toEqual([{ facet: 'facets.issue/1', value: '', canvasId: NOTES_ID }])
+    }
+  })
+
+  test('falls back to existence-only row when issue/1 payload is missing required status (never throws)', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: { 'issue/1': { assignees: ['alice'] } },
+      },
+    ])
+    expect(rows).toEqual([{ facet: 'facets.issue/1', value: '', canvasId: NOTES_ID }])
+  })
+
+  test('falls back to existence-only row when issue/1 payload has wrong field types (never throws)', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: { 'issue/1': { status: 42, assignees: 'not-an-array' } },
+      },
+    ])
+    expect(rows).toEqual([{ facet: 'facets.issue/1', value: '', canvasId: NOTES_ID }])
+  })
+
+  test('falls back to existence-only row when issue/1 payload has extra unknown keys (strict rejection, never throws)', () => {
+    const rows = deriveFacetIndexRows([
+      {
+        canvasId: NOTES_ID,
+        updatedAtMs: 0,
+        extensionFacets: { 'issue/1': { status: 'open', extra: 'nope' } },
+      },
+    ])
+    expect(rows).toEqual([{ facet: 'facets.issue/1', value: '', canvasId: NOTES_ID }])
   })
 })
 

--- a/packages/canvas-workspace/src/derive-index.ts
+++ b/packages/canvas-workspace/src/derive-index.ts
@@ -1,4 +1,5 @@
 import type { CoreFacets, ExtensionFacets } from '@kamiazya/whiteboard-canvas-model'
+import { issueFacetPayloadSchema } from '@kamiazya/whiteboard-canvas-model'
 import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
 import type {
   AliasHistoryRow,
@@ -45,14 +46,55 @@ function compareStrings(a: string, b: string): number {
   return 0
 }
 
+/** Scalar `issue/1` fields deep-indexed as one row each, in a fixed emission order. */
+const ISSUE_FACET_SCALAR_FIELDS = ['status', 'priority', 'due', 'summary'] as const
+
+/** Array `issue/1` fields deep-indexed as one row per element, in a fixed emission order. */
+const ISSUE_FACET_ARRAY_FIELDS = ['assignees', 'labels'] as const
+
+/**
+ * Deep-indexes a known `issue/1` extension-facet payload into one row per
+ * present scalar field and one row per array element, in addition to the
+ * existence row every domain gets. `extensionFacetsSchema` validates the
+ * bucket key shape only (`z.unknown()` payload), so a value stored under
+ * `issue/1` is not guaranteed to match `issueFacetPayloadSchema` — a
+ * `safeParse` failure falls back to no deep rows (existence-only) rather
+ * than throwing, so one malformed payload never aborts indexing for the
+ * rest of the workspace.
+ */
+function deriveIssueFacetDeepRows(
+  domainKey: string,
+  payload: unknown,
+  canvasId: string,
+): FacetIndexRow[] {
+  const parsed = issueFacetPayloadSchema.safeParse(payload)
+  if (!parsed.success) return []
+
+  const rows: FacetIndexRow[] = []
+  for (const field of ISSUE_FACET_SCALAR_FIELDS) {
+    const value = parsed.data[field]
+    if (value !== undefined) {
+      rows.push({ facet: `facets.${domainKey}.${field}`, value, canvasId })
+    }
+  }
+  for (const field of ISSUE_FACET_ARRAY_FIELDS) {
+    for (const value of parsed.data[field] ?? []) {
+      rows.push({ facet: `facets.${domainKey}.${field}`, value, canvasId })
+    }
+  }
+  return rows
+}
+
 /**
  * Facet index rows: one row per (facet key, value, canvasId). Core `type`/
  * `view` each produce at most one row per canvas; `tags` produces one row
- * per tag. Extension domains (`facets.<domain>/<version>`) have no
- * canonical scalar value in the current row DTO (`{facet, value}` only), so
- * they index as existence rows (`value: ''`) — a canvas either has the
- * domain applied or it doesn't; path-scoped equality indexing would need
- * the row DTO to grow a path field.
+ * per tag. Extension domains (`facets.<domain>/<version>`) always index as
+ * existence rows (`value: ''`) — a canvas either has the domain applied or
+ * it doesn't. The `issue/1` domain additionally deep-indexes its known
+ * fields (`facets.issue/1.status`, `.assignees`, etc.) since its shape is
+ * schematized; other domains have no canonical scalar value in the current
+ * row DTO (`{facet, value}` only) and stay existence-only until the row DTO
+ * grows a path field.
  */
 export function deriveFacetIndexRows(canvases: readonly CanvasIndexInput[]): FacetIndexRow[] {
   const rows: FacetIndexRow[] = []
@@ -69,6 +111,9 @@ export function deriveFacetIndexRows(canvases: readonly CanvasIndexInput[]): Fac
     }
     for (const domainKey of Object.keys(extensionFacets ?? {}).sort(compareStrings)) {
       rows.push({ facet: `facets.${domainKey}`, value: '', canvasId })
+      if (domainKey === 'issue/1') {
+        rows.push(...deriveIssueFacetDeepRows(domainKey, extensionFacets?.[domainKey], canvasId))
+      }
     }
   }
   // Explicit sort (not insertion order) so shuffling the `canvases` input

--- a/packages/canvas-workspace/src/derive-index.ts
+++ b/packages/canvas-workspace/src/derive-index.ts
@@ -109,10 +109,11 @@ export function deriveFacetIndexRows(canvases: readonly CanvasIndexInput[]): Fac
     if (coreFacets?.view !== undefined) {
       rows.push({ facet: 'view', value: coreFacets.view, canvasId })
     }
-    for (const domainKey of Object.keys(extensionFacets ?? {}).sort(compareStrings)) {
+    const extensions = extensionFacets ?? {}
+    for (const domainKey of Object.keys(extensions).sort(compareStrings)) {
       rows.push({ facet: `facets.${domainKey}`, value: '', canvasId })
       if (domainKey === 'issue/1') {
-        rows.push(...deriveIssueFacetDeepRows(domainKey, extensionFacets?.[domainKey], canvasId))
+        rows.push(...deriveIssueFacetDeepRows(domainKey, extensions[domainKey], canvasId))
       }
     }
   }


### PR DESCRIPTION
## Summary

- Extract coalesced `extensionFacets` local variable in `deriveFacetIndexRows` to remove redundant optional chaining
- Deep-index `issue/1` extension facet payload fields: per-field rows (`facets.issue/1.status=open`, `facets.issue/1.labels=bug`, etc.) in addition to the existing existence-only row
- Uses `issueFacetPayloadSchema.safeParse()` — malformed payloads fall back to existence-only indexing without aborting

## Details

Scalar fields (`status`, `priority`, `summary`, `due`) produce one row each when present.
Array fields (`assignees`, `labels`) produce one row per element.
Unknown extension domains remain existence-only.

## Test plan

- [x] Per-field row generation for all scalar/array fields
- [x] Empty/absent optional fields produce no deep rows
- [x] Unknown domains still get existence-only row
- [x] safeParse fallback for malformed payloads
- [x] PBT: row count invariant (core rows + extension rows + deep rows)
- [x] `pnpm test --project canvas-workspace-node` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deeper indexing for issue facets, enabling searches and filters by status, priority, due date, summary, assignees, and labels.
  * Preserved basic facet availability when optional fields are missing or arrays are empty.
* **Bug Fixes**
  * Improved resilience for malformed issue facet data, preventing errors and falling back to standard indexing.
  * Maintained existing indexing behavior for other extension facet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->