### PR TITLE
feat(mcp-server): add issue-import-mapper for tmp/issues to OKF Markdown

### DIFF
--- a/packages/mcp-server/src/scripts/issue-import-mapper.test.ts
+++ b/packages/mcp-server/src/scripts/issue-import-mapper.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'vitest'
+import { parseOkf, serializeOkf } from '@kamiazya/whiteboard-canvas-codec'
+import { mapTmpIssueFile } from './issue-import-mapper.js'
+
+const MINIMAL_ISSUE = `---
+id: TEST-001
+status: open
+severity: low
+owner: unassigned
+created: 2026-07-05
+---
+
+# Test issue
+
+Some body text.
+`
+
+describe('mapTmpIssueFile', () => {
+  test('maps status to issue/1 status', () => {
+    const result = mapTmpIssueFile(MINIMAL_ISSUE, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.frontmatter.facets?.['issue/1']).toMatchObject({
+      status: 'open',
+    })
+  })
+
+  test('maps severity to issue/1 priority with case normalization', () => {
+    const content = MINIMAL_ISSUE.replace('severity: low', 'severity: HIGH')
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.frontmatter.facets?.['issue/1']).toMatchObject({
+      priority: 'high',
+    })
+  })
+
+  test('maps owner to issue/1 assignees (skips unassigned)', () => {
+    const result = mapTmpIssueFile(MINIMAL_ISSUE, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const facet = result.document.frontmatter.facets?.['issue/1'] as Record<string, unknown>
+    expect(facet.assignees).toBeUndefined()
+  })
+
+  test('maps owner to issue/1 assignees (wraps in array)', () => {
+    const content = MINIMAL_ISSUE.replace('owner: unassigned', 'owner: alice')
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.frontmatter.facets?.['issue/1']).toMatchObject({
+      assignees: ['alice'],
+    })
+  })
+
+  test('derives segment from id (dots replaced with hyphens)', () => {
+    const content = MINIMAL_ISSUE.replace('id: TEST-001', 'id: foo.bar.baz')
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.segment).toBe('foo-bar-baz')
+  })
+
+  test('appends blocked-by and related as wikilink references', () => {
+    const content = `---
+id: TEST-002
+status: open
+severity: medium
+owner: unassigned
+created: 2026-07-05
+blocked-by:
+  - blocker-a
+  - blocker-b
+related:
+  - related-x
+---
+
+# Issue with refs
+`
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.body).toContain('[[blocker-a]]')
+    expect(result.document.body).toContain('[[blocker-b]]')
+    expect(result.document.body).toContain('[[related-x]]')
+  })
+
+  test('returns ok:false for missing frontmatter', () => {
+    const result = mapTmpIssueFile('# No frontmatter\n\nJust text.', 'test.md')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBeTruthy()
+  })
+
+  test('returns ok:false for missing status field', () => {
+    const content = `---
+id: TEST-003
+severity: low
+owner: unassigned
+created: 2026-07-05
+---
+
+# Missing status
+`
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(false)
+  })
+
+  test('sets frontmatter type to issue', () => {
+    const result = mapTmpIssueFile(MINIMAL_ISSUE, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.frontmatter.type).toBe('issue')
+  })
+
+  test('round-trip: output document is valid OKF Markdown', () => {
+    const result = mapTmpIssueFile(MINIMAL_ISSUE, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const serialized = serializeOkf(result.document)
+    const parsed = parseOkf(serialized)
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.value.frontmatter.facets?.['issue/1']).toMatchObject({
+      status: 'open',
+    })
+  })
+
+  test('handles empty body', () => {
+    const content = `---
+id: TEST-004
+status: done
+severity: low
+owner: unassigned
+created: 2026-07-05
+---
+`
+    const result = mapTmpIssueFile(content, 'test.md')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.document.body).toBe('')
+  })
+})

--- a/packages/mcp-server/src/scripts/issue-import-mapper.ts
+++ b/packages/mcp-server/src/scripts/issue-import-mapper.ts
@@ -1,0 +1,95 @@
+import { parse } from 'yaml'
+import type { OkfMarkdownDocument } from '@kamiazya/whiteboard-canvas-codec'
+import type { IssueFacetPayload } from '@kamiazya/whiteboard-canvas-model'
+
+export type IssueImportResult =
+  | { ok: true; segment: string; document: OkfMarkdownDocument }
+  | { ok: false; reason: string }
+
+interface RawFrontmatter {
+  id?: string
+  status?: string
+  severity?: string
+  owner?: string
+  created?: string
+  'blocked-by'?: string[]
+  related?: string[]
+  [key: string]: unknown
+}
+
+function parseFrontmatter(content: string): { frontmatter: RawFrontmatter; body: string } | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!match) return null
+  try {
+    const frontmatter = parse(match[1]) as RawFrontmatter
+    return { frontmatter, body: match[2] }
+  } catch {
+    return null
+  }
+}
+
+function deriveSegment(id: string): string {
+  return id.replace(/\./g, '-')
+}
+
+function buildReferencesSection(
+  blockedBy: string[] | undefined,
+  related: string[] | undefined,
+): string {
+  const lines: string[] = []
+  if (blockedBy?.length) {
+    lines.push('## Blocked by')
+    lines.push('')
+    for (const ref of blockedBy) lines.push(`- [[${ref}]]`)
+    lines.push('')
+  }
+  if (related?.length) {
+    lines.push('## Related')
+    lines.push('')
+    for (const ref of related) lines.push(`- [[${ref}]]`)
+    lines.push('')
+  }
+  return lines.length > 0 ? `\n${lines.join('\n')}` : ''
+}
+
+export function mapTmpIssueFile(content: string, filename: string): IssueImportResult {
+  const parsed = parseFrontmatter(content)
+  if (!parsed) {
+    return { ok: false, reason: `${filename}: failed to parse YAML frontmatter` }
+  }
+
+  const { frontmatter, body } = parsed
+
+  if (!frontmatter.status) {
+    return { ok: false, reason: `${filename}: missing required field "status"` }
+  }
+
+  const id = frontmatter.id ?? filename.replace(/\.md$/, '')
+  const segment = deriveSegment(id)
+
+  const issueFacet: IssueFacetPayload = {
+    status: frontmatter.status,
+    ...(frontmatter.severity !== undefined && {
+      priority: frontmatter.severity.toLowerCase(),
+    }),
+    ...(frontmatter.owner !== undefined &&
+      frontmatter.owner !== 'unassigned' && {
+        assignees: [frontmatter.owner],
+      }),
+  }
+
+  const refsSection = buildReferencesSection(frontmatter['blocked-by'], frontmatter.related)
+  const fullBody = body + refsSection
+
+  const document: OkfMarkdownDocument = {
+    frontmatter: {
+      type: 'issue',
+      facets: {
+        'issue/1': issueFacet,
+      },
+    },
+    body: fullBody,
+  }
+
+  return { ok: true, segment, document }
+}


### PR DESCRIPTION
## Summary

- Add pure mapping function `mapTmpIssueFile` that converts `tmp/issues/*.md` files (YAML frontmatter + markdown body) into `OkfMarkdownDocument` with `issue/1` extension facets
- Maps: `id` → segment (dots→hyphens), `status` → issue/1 status, `severity` → issue/1 priority (case-normalized), `owner` → issue/1 assignees (skip `unassigned`), `blocked-by`/`related` → wikilink reference sections appended to body
- Total parser: returns `{ ok: false, reason }` for unparseable files, never throws

## Test plan

- [x] status mapping
- [x] severity → priority with case normalization (HIGH → high)
- [x] owner → assignees (skip unassigned, wrap in array)
- [x] segment derivation from id (dots → hyphens)
- [x] blocked-by/related → wikilink references in body
- [x] missing frontmatter → ok:false
- [x] missing status → ok:false
- [x] frontmatter type set to 'issue'
- [x] round-trip: output passes parseOkf
- [x] empty body handling
- [x] `pnpm test --project mcp-node` all 2994 tests pass