### PR TITLE
fix(canvas-render): apply translate on table cells and list items in SVG backend

### DIFF
--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -135,6 +135,87 @@ describe('renderSceneToSvg', () => {
     }
   })
 
+  it('applies translate on table cells so columns do not overlap at x=0', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'table',
+          bbox: { x: 0, y: 0, w: 200, h: 24 },
+          rows: [
+            {
+              kind: 'tableRow',
+              bbox: { x: 0, y: 0, w: 200, h: 24 },
+              cells: [
+                {
+                  kind: 'tableCell',
+                  bbox: { x: 0, y: 0, w: 100, h: 24 },
+                  runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 30, h: 16 }, text: 'A' }],
+                },
+                {
+                  kind: 'tableCell',
+                  bbox: { x: 100, y: 0, w: 100, h: 24 },
+                  runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 30, h: 16 }, text: 'B' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('transform="translate(100,0)"')
+    // The second cell's group must translate so its run renders at x=100
+    // while the first cell (x=0) needs no translate (or translate(0,0))
+  })
+
+  it('applies translate on list items to indent nested items', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'list',
+          bbox: { x: 0, y: 0, w: 200, h: 32 },
+          ordered: false,
+          depth: 0,
+          items: [
+            {
+              kind: 'listItem',
+              bbox: { x: 24, y: 0, w: 176, h: 16 },
+              children: [
+                {
+                  kind: 'paragraph',
+                  bbox: { x: 0, y: 0, w: 176, h: 16 },
+                  runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 40, h: 16 }, text: 'item' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('transform="translate(24,0)"')
+  })
+
+  it('applies translate on blockquote children for visual indent', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'blockquote',
+          bbox: { x: 0, y: 0, w: 200, h: 16 },
+          children: [
+            {
+              kind: 'paragraph',
+              bbox: { x: 0, y: 0, w: 176, h: 16 },
+              runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 40, h: 16 }, text: 'quote' }],
+            },
+          ],
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('role="presentation"')
+  })
+
   it('is deterministic: same scene renders byte-identical output on repeated calls', () => {
     const scene: Scene = {
       nodes: [

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -32,11 +32,15 @@ function renderTextRun(run: TextRunNode): string {
 }
 
 function renderListItem(item: ListItemNode): string {
-  return `<g>${item.children.map(renderNode).join('')}</g>`
+  const tx = item.bbox.x
+  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
+  return `<g${transform}>${item.children.map(renderNode).join('')}</g>`
 }
 
 function renderTableCell(cell: TableCellSceneNode): string {
-  return `<g>${cell.runs.map(renderTextRun).join('')}</g>`
+  const tx = cell.bbox.x
+  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
+  return `<g${transform}>${cell.runs.map(renderTextRun).join('')}</g>`
 }
 
 function renderTableRow(row: TableRowSceneNode): string {

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -33,6 +33,47 @@ export function buildDeterminismGoldenScene(): Scene {
         bbox: { x: 0, y: 72, w: 40, h: 40 },
         svg: '<circle cx="20" cy="20" r="19.999"/>',
       },
+      {
+        kind: 'table',
+        bbox: { x: 0, y: 120, w: 200, h: 24 },
+        rows: [
+          {
+            kind: 'tableRow',
+            bbox: { x: 0, y: 120, w: 200, h: 24 },
+            cells: [
+              {
+                kind: 'tableCell',
+                bbox: { x: 0, y: 120, w: 100, h: 24 },
+                runs: [{ kind: 'textRun', bbox: { x: 0, y: 120, w: 30, h: 16 }, text: 'Col1' }],
+              },
+              {
+                kind: 'tableCell',
+                bbox: { x: 100, y: 120, w: 100, h: 24 },
+                runs: [{ kind: 'textRun', bbox: { x: 0, y: 120, w: 30, h: 16 }, text: 'Col2' }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'list',
+        bbox: { x: 0, y: 152, w: 200, h: 16 },
+        ordered: false,
+        depth: 0,
+        items: [
+          {
+            kind: 'listItem',
+            bbox: { x: 24, y: 152, w: 176, h: 16 },
+            children: [
+              {
+                kind: 'paragraph',
+                bbox: { x: 0, y: 152, w: 176, h: 16 },
+                runs: [{ kind: 'textRun', bbox: { x: 0, y: 152, w: 40, h: 16 }, text: 'Item' }],
+              },
+            ],
+          },
+        ],
+      },
     ],
   }
 }
@@ -48,4 +89,7 @@ export const DETERMINISM_GOLDEN_SVG =
   '<g><a href="https://example.com/a?b=1&amp;c=2"><text x="0" y="40">link text</text></a></g>' +
   '<rect x="0" y="64" width="600" height="1" role="presentation"/>' +
   '<g><circle cx="20" cy="20" r="19.999"/></g>' +
+  '<g><g><g><text x="0" y="120">Col1</text></g>' +
+  '<g transform="translate(100,0)"><text x="0" y="120">Col2</text></g></g></g>' +
+  '<g><g transform="translate(24,0)"><g><text x="0" y="152">Item</text></g></g></g>' +
   '</svg>'


### PR DESCRIPTION
## Summary

- Table cell `bbox.x` (column offset) and list item `bbox.x` (indent depth) were not propagated to the SVG output, causing all table columns to overlap at x=0 and list indentation to not render visually
- Apply `transform="translate(x,0)"` on the container `<g>` element in `renderTableCell` and `renderListItem` so children render at the correct absolute x position
- Add table (2-column) and list (indented item) fixtures to the determinism golden scene to prevent regressions

## Test plan

- [x] New backend tests: `applies translate on table cells so columns do not overlap at x=0`
- [x] New backend tests: `applies translate on list items to indent nested items`
- [x] Updated determinism golden SVG with table/list fixtures — passes on Node
- [x] All 104 canvas-render-node tests pass
- [x] Full test suite passes (5052/5053, 1 unrelated fast-check flake)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected horizontal positioning when rendering table columns and nested list content to SVG.
  * Improved indentation for blockquote content and nested list items.
  * Prevented adjacent table columns from overlapping during SVG rendering.

* **Tests**
  * Added regression coverage for table, list, and blockquote layout positioning.
  * Expanded deterministic rendering coverage with table and list examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->