### PR TITLE
fix(ci): install CJK fallback font for widget-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install CJK fallback font
+        run: sudo apt-get update -qq && sudo apt-get install -yqq fonts-noto-cjk
+
       - name: Build canvas-viewer widget
         run: pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
 


### PR DESCRIPTION
## Summary

- `ubuntu-latest` runners lack CJK fonts, causing the widget smoke's Japanese-text assertion (`jpDarkPixels >= 50`) to flake when glyphs render as blank tofu
- Install `fonts-noto-cjk` before the widget-smoke step so the fallback-glyph pixel count is deterministic
- CI-only change — no application code modified

## Test plan

- [x] The `widget-smoke` job on this PR's CI should pass reliably (the assertion that was flaking)
- [x] No other jobs affected (font install is scoped to the widget-smoke job only)