### PR TITLE
fix: prevent DATA_DIR from creating ~/.whiteboard at import time

### DIFF
--- a/packages/mcp-server/src/shared/data-dir-contract.test.ts
+++ b/packages/mcp-server/src/shared/data-dir-contract.test.ts
@@ -209,6 +209,30 @@ describe('getDataDir test-injection seam', () => {
   })
 })
 
+describe('DATA_DIR does not create directories at import time', () => {
+  it('importing data-dir-secure does not mkdir the resolved path', async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), 'dd-no-eager-mkdir-'))
+    try {
+      const homeWhiteboard = join(tempHome, '.whiteboard')
+
+      // resolveDataDir with the default canWriteDir DOES create the dir
+      resolveDataDir({}, { homeDir: tempHome })
+      expect(existsSync(homeWhiteboard)).toBe(true)
+
+      // Clean up to test the read-only probe
+      await rm(homeWhiteboard, { recursive: true, force: true })
+
+      // resolveDataDir with parentIsWritable (used by DATA_DIR) does NOT create the dir
+      const { parentIsWritable } = await import('./data-dir-secure.js')
+      const result = resolveDataDir({}, { homeDir: tempHome, isWritableDir: parentIsWritable })
+      expect(result).toBe(homeWhiteboard)
+      expect(existsSync(homeWhiteboard)).toBe(false)
+    } finally {
+      await rm(tempHome, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('shared/data-dir-secure.ts module boundary', () => {
   it('does not export DIST_WEB_APP_DIR — that is a server-layer concern', async () => {
     // DIST_WEB_APP_DIR (compiled web-asset directory) is meaningful only to

--- a/packages/mcp-server/src/shared/data-dir-secure.ts
+++ b/packages/mcp-server/src/shared/data-dir-secure.ts
@@ -56,11 +56,21 @@ export function resolveDataDir(
   return resolve(options.tmpDir ?? tmpdir(), '.whiteboard')
 }
 
+export function parentIsWritable(path: string): boolean {
+  const parent = resolve(path, '..')
+  try {
+    accessSync(parent, fsConstants.R_OK | fsConstants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
 // Deprecated: a module-load-time snapshot, frozen before a test (or a
 // future dev entrypoint) can redirect where data lives. Prefer getDataDir()
 // for any new call site — it stays lazily resolved so setDataDirForTests()
 // can retarget it before the first real read.
-export const DATA_DIR = resolveDataDir()
+export const DATA_DIR = resolveDataDir(process.env, { isWritableDir: parentIsWritable })
 
 let dataDirOverride: string | undefined
 let memoizedDataDir: string | undefined


### PR DESCRIPTION
## Summary

- `DATA_DIR` module-level const previously triggered `mkdirSync(~/.whiteboard)` as a side effect of importing `data-dir-secure.ts`
- Added `parentIsWritable()` — a read-only probe using `accessSync` on the parent directory (no mkdir)
- `DATA_DIR` now resolves without creating directories; `getDataDir()` still creates on first lazy call

## Test plan

- [x] Red test: assert `resolveDataDir` with `parentIsWritable` resolves correctly but does NOT create the directory
- [x] Green: all 2995 mcp-node tests pass
- [x] Existing `getDataDir() === DATA_DIR` contract test still passes
- [x] Pre-push gate (typecheck + mcp-node + noconsole) green