### PR TITLE
fix(mcp-server): resolve repo root via git for worktree port derivation

### DIFF
--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -11,8 +11,7 @@
 import { spawn } from 'node:child_process'
 import { mkdir, open } from 'node:fs/promises'
 import { createServer } from 'node:net'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import {
   buildMcpHttpDevSpawnArgs,
@@ -21,10 +20,13 @@ import {
   verifyDevDaemonIdentity,
   waitForAuthenticatedMcp,
 } from './ensure-http-dev-daemon-lib.mjs'
-import { readDevDaemonMarker, resolveDevDataDirEnv } from './with-dev-data-dir-lib.mjs'
+import {
+  readDevDaemonMarker,
+  resolveDevDataDirEnv,
+  resolveRepoRootFromGit,
+} from './with-dev-data-dir-lib.mjs'
 
-const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
-const REPO_ROOT = resolve(SCRIPT_DIR, '..', '..', '..', '..')
+const REPO_ROOT = resolveRepoRootFromGit(process.cwd())
 const PORT = deriveDevPort({
   repoRoot: REPO_ROOT,
   isMainCheckout: isMainCheckout(REPO_ROOT),

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
@@ -34,9 +35,28 @@ export function ensureDevDataDirSecured(dir, platformName = process.platform) {
  * launched from the repo root (and wrong again from a worktree).
  *
  * dev -> scripts -> mcp-server -> packages -> repoRoot.
+ *
+ * @deprecated Use {@link resolveRepoRootFromGit} instead — this function
+ * resolves from the script's physical filesystem location, which in a pnpm
+ * workspace always points to the main checkout even when the script is
+ * invoked from a worktree (pnpm resolves through symlinked node_modules).
  */
 export function resolveRepoRootFromScriptDir(scriptDir) {
   return resolve(scriptDir, '../../../..')
+}
+
+/**
+ * Resolves the repo root via `git rev-parse --show-toplevel`, which always
+ * returns the correct worktree root when called from inside one. This is
+ * the only reliable method because pnpm resolves dev scripts through
+ * symlinked node_modules back to the main checkout, making import.meta.url-
+ * based resolution wrong for worktrees.
+ *
+ * @param {string} cwd - The working directory to resolve from.
+ * @returns {string}
+ */
+export function resolveRepoRootFromGit(cwd) {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim()
 }
 
 /**

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -242,6 +242,31 @@ describe('dev daemon identity marker', () => {
   }
 })
 
+describe('resolveRepoRootFromGit', () => {
+  it('returns the git toplevel for the current working directory', async () => {
+    const { resolveRepoRootFromGit } = await import('./with-dev-data-dir-lib.mjs')
+    const result = resolveRepoRootFromGit(process.cwd())
+
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+    expect(existsSync(join(result, '.git'))).toBe(true)
+  })
+
+  it('resolves to the worktree root, not the main checkout, when cwd is inside a worktree', async () => {
+    const { resolveRepoRootFromGit } = await import('./with-dev-data-dir-lib.mjs')
+    const result = resolveRepoRootFromGit(process.cwd())
+    const gitPath = join(result, '.git')
+
+    // If we're running inside a worktree, .git is a file not a directory.
+    // If we're running in the main checkout, .git is a directory.
+    // Either way the result must match the cwd's own git toplevel.
+    expect(existsSync(gitPath)).toBe(true)
+
+    // The resolved root must be an ancestor of (or equal to) the cwd.
+    expect(resolve(process.cwd()).startsWith(resolve(result))).toBe(true)
+  })
+})
+
 describe('resolveTsxWatchSpawn', () => {
   it('spawns node directly against tsx dist/cli.mjs, not the node_modules/.bin shim', () => {
     const result = resolveTsxWatchSpawn(

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import {
   ensureDevDataDirSecured,
@@ -11,7 +10,7 @@ import {
   reraiseSignalOrExit,
   resolveDevDataDirEnv,
   resolveEffectivePort,
-  resolveRepoRootFromScriptDir,
+  resolveRepoRootFromGit,
   resolveTsxWatchSpawn,
   writeDevDaemonMarker,
 } from './with-dev-data-dir-lib.mjs'
@@ -20,9 +19,8 @@ import {
 // shells out to it — mcp:debug:http, the SessionStart ensure-http-dev-daemon
 // hook) out of the real ~/.whiteboard by default. A node wrapper (not a
 // shell `VAR=x` prefix in package.json) so this stays correct on Windows.
-const scriptDir = dirname(fileURLToPath(import.meta.url))
-const packageRoot = resolve(scriptDir, '../..')
-const repoRoot = resolveRepoRootFromScriptDir(scriptDir)
+const repoRoot = resolveRepoRootFromGit(process.cwd())
+const packageRoot = resolve(repoRoot, 'packages/mcp-server')
 const hadExplicitDataDirOverride = Boolean(process.env.WHITEBOARD_DATA_DIR)
 const env = resolveDevDataDirEnv(process.env, repoRoot)
 


### PR DESCRIPTION
## Summary

- Add `resolveRepoRootFromGit(cwd)` using `git rev-parse --show-toplevel` to correctly resolve the repo root when running inside a git worktree
- Wire both caller scripts (`with-dev-data-dir.mjs` and `ensure-http-dev-daemon.mjs`) to use it instead of the script-dir-based resolution that always pointed to the main checkout via pnpm symlinks
- Mark `resolveRepoRootFromScriptDir` as `@deprecated`

## Problem

`resolveRepoRootFromScriptDir` walks up from `import.meta.url`, which in a pnpm workspace always resolves through symlinked `node_modules` back to the main checkout — even when invoked from a worktree. This causes worktree daemons to bind port 3099 (main checkout's port) instead of their derived worktree-specific port, leading to port collisions between the main checkout and worktree daemons.

## Test plan

- [x] `resolveRepoRootFromGit` unit tests (returns git toplevel, ancestor of cwd)
- [x] Full mcp-node suite green (2997 tests)
- [x] Pre-push gate (typecheck + noconsole + mcp-node) green