### PR TITLE
fix(web): move module-scope side effects into React lifecycle in App.tsx

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -46,10 +46,7 @@ const DaemonCanvasPage = lazy(() =>
 // Excalidraw + useCanvasSync (which imports loro-crdt), and it is the
 // default render path (no daemon, no pairing fragment) — so it was the one
 // making Excalidraw/loro-crdt part of every session's initial paint even
-// though DaemonCanvasPage above was already lazy. Module-scope side effects
-// that must run before React lifecycle begins (browserLocalStore,
-// userSettingsStore, provider-state resolution just below) stay at THIS
-// file's module scope, unaffected by which page component is lazy.
+// though DaemonCanvasPage above was already lazy.
 const BrowserLocalCanvasPage = lazy(() =>
   import('./pages/BrowserLocalCanvasPage.js').then((m) => ({ default: m.BrowserLocalCanvasPage })),
 )
@@ -68,16 +65,6 @@ const DaemonIndexPage = lazy(() =>
 // DaemonRoute's shape (rather than a parallel type) since this state IS the
 // route — app-routes.ts's parse/build functions keep the two in sync.
 type DaemonView = DaemonRoute
-
-const browserLocalStore = new IndexedDBStore()
-const userSettingsStore = createUserSettingsStore()
-
-const _defaultProviderState: ProviderState = resolveHostedProviderStateFromRaw(
-  typeof window !== 'undefined'
-    ? ((window as { __WHITEBOARD_RUNTIME_CONFIG__?: unknown }).__WHITEBOARD_RUNTIME_CONFIG__ ?? {})
-    : {},
-  typeof window !== 'undefined' ? window.location.origin : undefined,
-)
 
 interface AppProps {
   providerState?: ProviderState
@@ -130,6 +117,15 @@ function BackendConfigChip({ state }: BackendConfigChipProps) {
 }
 
 export function App({ providerState }: AppProps) {
+  const [browserLocalStore] = useState(() => new IndexedDBStore())
+  const [userSettingsStore] = useState(() => createUserSettingsStore())
+  const [defaultProviderState] = useState<ProviderState>(() =>
+    resolveHostedProviderStateFromRaw(
+      (window as { __WHITEBOARD_RUNTIME_CONFIG__?: unknown }).__WHITEBOARD_RUNTIME_CONFIG__ ?? {},
+      window.location.origin,
+    ),
+  )
+
   // Routed BEFORE providerState resolution: a #wb= pairing fragment always
   // wins over the runtime-config-driven provider state (which governs the
   // separate same-origin local-daemon / browser-local split). 'none' (no
@@ -432,7 +428,7 @@ export function App({ providerState }: AppProps) {
     }
   }
 
-  const state = providerState ?? _defaultProviderState
+  const state = providerState ?? defaultProviderState
 
   // The 'Continue in browser-local' escape hatch collapses a local-daemon OR
   // invalid-config state to browser-local capabilities, so every downstream


### PR DESCRIPTION
## Summary

- `IndexedDBStore`, `createUserSettingsStore()`, and `resolveHostedProviderStateFromRaw()` were executing at module load time (import side effects), opening IndexedDB and reading `window` globals before any component rendered.
- Moved all three into `useState` lazy initializers inside `App`, so they run on first render instead of at import time.
- Removed the now-unnecessary `typeof window !== 'undefined'` guards since `App` only runs in a browser context.

## Test plan

- [x] All 1094 existing jsdom tests pass (including the comprehensive `App.test.tsx` suite)
- [x] All 43 node tests pass
- [x] TypeScript typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application startup handling for local settings and provider configuration.
  * Preserved existing runtime configuration behavior while making initialization more reliable within the app lifecycle.
  * No user-facing feature changes or workflow changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->