### PR TITLE
fix(mcp-server): skip node --watch in dev-mode daemon when WHITEBOARD_NO_WATCH is set

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-codex-cli-smoke.mjs
@@ -78,7 +78,7 @@ const configOverride = [
   'transport="stdio",',
   'command="node",',
   `args=["${join(root, 'scripts/dev/mcp-dev-launch.mjs')}"],`,
-  `env={WHITEBOARD_DATA_DIR="${tmpDataDir}",WHITEBOARD_DEV="1"}`,
+  `env={WHITEBOARD_DATA_DIR="${tmpDataDir}",WHITEBOARD_DEV="1",WHITEBOARD_NO_WATCH="1"}`,
   '}',
 ].join('')
 

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -29,7 +29,7 @@ const childArgs = entry.endsWith('.ts') ? ['--import', 'tsx/esm', entry] : [entr
 
 const child = spawn('node', childArgs, {
   cwd: root,
-  env: { ...process.env, WHITEBOARD_DATA_DIR: tmpDataDir },
+  env: { ...process.env, WHITEBOARD_DATA_DIR: tmpDataDir, WHITEBOARD_NO_WATCH: '1' },
   stdio: ['pipe', 'pipe', 'pipe'],
 })
 

--- a/packages/mcp-server/src/daemon/ensure-daemon.test.ts
+++ b/packages/mcp-server/src/daemon/ensure-daemon.test.ts
@@ -146,6 +146,39 @@ describe('ensureDaemon', () => {
     expect(args).toContain('--port=45002')
   })
 
+  it('omits --watch in dev mode when WHITEBOARD_NO_WATCH is set to avoid EMFILE on fd-heavy machines', async () => {
+    loadDaemonRecordMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      pid: 889,
+      port: 45003,
+      token: 'no-watch-token',
+      version: '0.1.0',
+      startedAt: '2026-04-23T00:05:00.000Z',
+    })
+    spawnMock.mockReturnValue({
+      pid: 889,
+      unref: vi.fn(),
+    })
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    ) as typeof globalThis.fetch
+
+    await ensureDaemon({
+      dataDir: '/tmp/excalidraw-data',
+      env: { WHITEBOARD_DEV: '1', WHITEBOARD_NO_WATCH: '1' },
+      startPort: 45003,
+      startupTimeoutMs: 500,
+    })
+
+    expect(spawnMock).toHaveBeenCalledOnce()
+    const [command, args] = spawnMock.mock.calls[0]
+    expect(command).toBe('node')
+    expect(args).not.toContain('--watch')
+    expect(args).toContain('--import')
+    expect(args).toContain('tsx/esm')
+    expect(args).toContain('/repo/packages/mcp-server/src/server/index.ts')
+    expect(args).toContain('--daemon')
+  })
+
   it('re-checks the registry after taking the startup lock and reuses a daemon started by another caller', async () => {
     loadDaemonRecordMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
       pid: 91,

--- a/packages/mcp-server/src/daemon/ensure-daemon.ts
+++ b/packages/mcp-server/src/daemon/ensure-daemon.ts
@@ -102,15 +102,11 @@ function buildDaemonSpawnArgs(options: {
   ]
 
   if (env.WHITEBOARD_DEV === '1') {
+    const nodeArgs =
+      env.WHITEBOARD_NO_WATCH === '1' ? ['--import', 'tsx/esm'] : ['--watch', '--import', 'tsx/esm']
     return {
       command: 'node',
-      args: [
-        '--watch',
-        '--import',
-        'tsx/esm',
-        join(WHITEBOARD_ROOT, 'src/server/index.ts'),
-        ...baseArgs,
-      ],
+      args: [...nodeArgs, join(WHITEBOARD_ROOT, 'src/server/index.ts'), ...baseArgs],
     }
   }
 


### PR DESCRIPTION
## Summary

- `ensureDaemon` dev-mode spawn adds `--watch` which recursively watches the entire module graph + `node_modules`, hitting the kqueue/fd limit on fd-heavy developer machines (concurrent dev daemons, editor watches, etc.) and causing EMFILE → daemon instant death → "Daemon startup timeout"
- Added `WHITEBOARD_NO_WATCH=1` env check: when set alongside `WHITEBOARD_DEV=1`, `--watch` is omitted while keeping the tsx/esm source-mode spawn
- Smoke scripts (`mcp-e2e-smoke.mjs`, `mcp-codex-cli-smoke.mjs`) now set `WHITEBOARD_NO_WATCH=1` since hot-reload is never needed in smoke runs

## Test plan

- [x] Unit test: `omits --watch in dev mode when WHITEBOARD_NO_WATCH is set` (RED → GREEN)
- [x] Existing test: `uses node --watch + tsx/esm in dev mode` still passes (no regression)
- [x] Full `mcp-node` suite passes (2999 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-mode server startup by allowing watch mode to be explicitly disabled when needed.
  - Reduced unwanted file-watching behavior during command-line and end-to-end operations, improving reliability and avoiding unnecessary restarts.

- **Tests**
  - Added coverage to verify that development services start correctly without watch mode when explicitly configured.
  - Updated smoke tests to consistently run with file watching disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->