### PR TITLE
feat(release): add expectedCommandSubstrings to aggregate gate coverage

### DIFF
--- a/packages/mcp-server/src/server/release/gate-isomorphism.test.ts
+++ b/packages/mcp-server/src/server/release/gate-isomorphism.test.ts
@@ -10,9 +10,8 @@
 //    a specific ci.yml job, and neither the job nor the step may be gated
 //    behind an `if:` outside the pinned always-true-on-PR allowlist below.
 //  - 'aggregate': a coarser claim — the named ci.yml job exists and is
-//    PR-reachable. (Full recursive package.json-script expansion with cycle
-//    detection is a known simplification deferred to a follow-up; see the
-//    tmp/issues note filed alongside this PR.)
+//    PR-reachable, and its step `run` commands contain every substring
+//    listed in `expectedCommandSubstrings`.
 //  - 'exception': a reasoned, pinned-allowlist opt-out (docker gates only).
 
 import { readFileSync } from 'node:fs'
@@ -37,6 +36,7 @@ interface PrCoverage {
   jobId?: string
   stepName?: string
   reason?: string
+  expectedCommandSubstrings?: string[]
 }
 
 interface ReleaseGate {
@@ -187,6 +187,44 @@ describe('gate isomorphism: aggregate coverage resolves to a PR-reachable job', 
       expect(
         substantiveSteps.length,
         `gate "${gate.id}": job "${coverage.jobId}" has no steps with a run command left — an aggregate coverage claim requires the job to still do something`,
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  it('every aggregate prCoverage with expectedCommandSubstrings finds each substring in a job step run command', async () => {
+    const { extractWorkflowJobs } = await loadExtractor()
+    const jobs = extractWorkflowJobs(ciYaml)
+    for (const gate of releaseOnlyGates(matrix.gates)) {
+      const coverage = gate.prCoverage
+      if (coverage?.kind !== 'aggregate') continue
+      if (!coverage.expectedCommandSubstrings || coverage.expectedCommandSubstrings.length === 0)
+        continue
+      const job = jobs.find((j) => j.id === coverage.jobId)
+      expect(job).toBeDefined()
+      const allRunCommands = job!.steps
+        .filter((s) => s.run !== null)
+        .map((s) => s.run!)
+        .join('\n')
+      for (const substring of coverage.expectedCommandSubstrings) {
+        expect(
+          allRunCommands,
+          `gate "${gate.id}": expectedCommandSubstring "${substring}" not found in any run step of job "${coverage.jobId}"`,
+        ).toContain(substring)
+      }
+    }
+  })
+
+  it('every aggregate gate declares expectedCommandSubstrings', () => {
+    for (const gate of releaseOnlyGates(matrix.gates)) {
+      const coverage = gate.prCoverage
+      if (coverage?.kind !== 'aggregate') continue
+      expect(
+        coverage.expectedCommandSubstrings,
+        `gate "${gate.id}": aggregate prCoverage must declare expectedCommandSubstrings`,
+      ).toBeDefined()
+      expect(
+        coverage.expectedCommandSubstrings!.length,
+        `gate "${gate.id}": expectedCommandSubstrings must be non-empty`,
       ).toBeGreaterThan(0)
     }
   })

--- a/tests/e2e/distribution/release-gate-matrix.json
+++ b/tests/e2e/distribution/release-gate-matrix.json
@@ -12,7 +12,8 @@
       "prCoverage": {
         "kind": "aggregate",
         "workflow": "ci.yml",
-        "jobId": "test-unit"
+        "jobId": "test-unit",
+        "expectedCommandSubstrings": ["vitest run"]
       }
     },
     {
@@ -41,7 +42,8 @@
       "prCoverage": {
         "kind": "aggregate",
         "workflow": "ci.yml",
-        "jobId": "test-unit"
+        "jobId": "test-unit",
+        "expectedCommandSubstrings": ["--project=mcp-node"]
       }
     },
     {
@@ -175,7 +177,8 @@
       "prCoverage": {
         "kind": "aggregate",
         "workflow": "ci.yml",
-        "jobId": "verify"
+        "jobId": "verify",
+        "expectedCommandSubstrings": ["test:distribution:only"]
       }
     },
     {

--- a/tools/checks/src/release-gate-matrix-schema.mjs
+++ b/tools/checks/src/release-gate-matrix-schema.mjs
@@ -84,6 +84,25 @@ export function validatePrCoverage(prCoverage) {
       if (p.kind === 'workflow-step' && !isNonEmptyString(p.stepName)) {
         return { ok: false, reason: 'prCoverage.stepName must be a non-empty string' }
       }
+      if (p.kind === 'aggregate') {
+        if ('expectedCommandSubstrings' in p) {
+          if (
+            !Array.isArray(p.expectedCommandSubstrings) ||
+            p.expectedCommandSubstrings.length === 0
+          ) {
+            return {
+              ok: false,
+              reason: 'prCoverage.expectedCommandSubstrings must be a non-empty array when present',
+            }
+          }
+          if (p.expectedCommandSubstrings.some((s) => !isNonEmptyString(s))) {
+            return {
+              ok: false,
+              reason: 'prCoverage.expectedCommandSubstrings entries must be non-empty strings',
+            }
+          }
+        }
+      }
       break
     }
     case 'exception': {


### PR DESCRIPTION
## Summary

- Aggregate `prCoverage` declarations now require an `expectedCommandSubstrings` array
- Each substring must appear in at least one `run` step of the referenced CI job
- Narrows the aggregate coverage gap: previously the check only verified the job existed, not that it still ran the gate's command

## Changes

- `release-gate-matrix.json`: Added `expectedCommandSubstrings` to all 3 aggregate gates (`test`, `test:mcp-node`, `test:e2e:distribution`)
- `release-gate-matrix-schema.mjs`: Schema validator accepts and validates the new field (non-empty array of non-empty strings when present)
- `gate-isomorphism.test.ts`: Two new assertions — every aggregate gate must declare `expectedCommandSubstrings`, and each substring must appear in the referenced job's step commands

## Test plan

- [x] RED: Test fails when aggregate gates lack `expectedCommandSubstrings`
- [x] GREEN: All 3001 tests pass after adding the field to all aggregate gates
- [x] Schema validator accepts valid declarations and rejects malformed ones (empty array, non-string entries)