### PR TITLE
docs(tutorials): fix root-level pnpm install instructions

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -4,9 +4,10 @@ Learning-oriented, guided lessons. A tutorial takes a newcomer from nothing to a
 result by following concrete steps — it teaches by doing and does not stop to explain every
 option (that is what [Reference](../reference/) and [Explanation](../explanation/) are for).
 
+- **[Getting started](getting-started.md)** — run the browser app from a checkout, draw, and see it persist.
+
 Planned tutorials (added in a later migration slice):
 
-- **First browser-local canvas** — open the browser app, draw, and see it persist.
 - **Connect an AI agent** — wire an MCP client and have an agent draw with you.
 - **Try the local daemon** — run the daemon and persist to your filesystem.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -9,9 +9,9 @@ and pnpm (run `corepack enable` if you don't already have pnpm).
 
 ```bash
 git clone https://github.com/kamiazya/whiteboard.git
-cd whiteboard/apps/web
+cd whiteboard      # pnpm workspace root — required for catalog: dependency resolution
 pnpm install
-pnpm dev          # open http://localhost:5173
+pnpm --filter @kamiazya/whiteboard-web dev   # open http://localhost:5173
 ```
 
 The page mounts a full Excalidraw canvas. Pick the rectangle tool from the


### PR DESCRIPTION
## Summary

- Fix getting-started tutorial: `cd whiteboard/apps/web` → `cd whiteboard` (workspace root required for `catalog:` dependency resolution)
- Update `pnpm dev` to `pnpm --filter @kamiazya/whiteboard-web dev`
- Move getting-started from "Planned" to linked tutorial in tutorials/README.md

## Test plan

- [x] Instructions verified against CONTRIBUTING.md root-install pattern
- [x] No code changes — docs only