### PR TITLE
refactor(server-core): extract withReindex wrapper for mutation tools

### DIFF
--- a/packages/server-core/src/tools/body-patch.ts
+++ b/packages/server-core/src/tools/body-patch.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 export const bodyPatchRangeSchema = z
@@ -81,7 +81,7 @@ export function createBodyPatchTool(deps: ServerDeps) {
     name: 'body_patch' as const,
     inputSchema: bodyPatchInputSchema,
     outputSchema: bodyPatchOutputSchema,
-    async execute(input: BodyPatchInput): Promise<BodyPatchOutput> {
+    execute: withReindex(deps, async (input: BodyPatchInput): Promise<BodyPatchOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
 
@@ -126,9 +126,8 @@ export function createBodyPatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
-      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, node: updatedNode }
-    },
+    }),
   }
 }

--- a/packages/server-core/src/tools/canvas-crud.ts
+++ b/packages/server-core/src/tools/canvas-crud.ts
@@ -18,7 +18,7 @@ import type {
   listCanvasesOutputSchema,
 } from './canvas-crud.schemas.js'
 import { generateCanvasId } from './generate-canvas-id.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { loadWorkspaceTree, saveWorkspaceTree } from './workspace-tree-io.js'
 
 /**
@@ -37,24 +37,25 @@ export async function wbCanvasCreate(
   deps: ServerDeps,
   input: z.infer<typeof createCanvasInputSchema>,
 ): Promise<z.infer<typeof createCanvasOutputSchema>> {
-  const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
+  return withReindex(deps, async (input: z.infer<typeof createCanvasInputSchema>) => {
+    const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
 
-  const parentId = input.parentId as TreeID | undefined
-  if (parentId !== undefined && tree.getNode(parentId) === undefined) {
-    throw new CanvasParentNotFoundError(input.parentId as string)
-  }
+    const parentId = input.parentId as TreeID | undefined
+    if (parentId !== undefined && tree.getNode(parentId) === undefined) {
+      throw new CanvasParentNotFoundError(input.parentId as string)
+    }
 
-  const conflict = tree.children(parentId).find((sibling) => sibling.segment === input.segment)
-  if (conflict) {
-    throw new CanvasSegmentConflictError(input.segment)
-  }
+    const conflict = tree.children(parentId).find((sibling) => sibling.segment === input.segment)
+    if (conflict) {
+      throw new CanvasSegmentConflictError(input.segment)
+    }
 
-  const canvasId = generateCanvasId()
-  tree.createNode(canvasId, input.segment, parentId)
-  await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
-  await reindexWorkspace(deps, input.workspaceId)
+    const canvasId = generateCanvasId()
+    tree.createNode(canvasId, input.segment, parentId)
+    await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
 
-  return { canvasId, segment: input.segment }
+    return { canvasId, segment: input.segment }
+  })(input)
 }
 
 export async function wbCanvasGet(
@@ -85,10 +86,16 @@ export async function wbCanvasDelete(
   deps: ServerDeps,
   input: z.infer<typeof deleteCanvasInputSchema>,
 ): Promise<z.infer<typeof deleteCanvasOutputSchema>> {
-  const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
-  const node = findNodeOrThrow(tree, input.workspaceId, input.canvasId)
-  tree.delete(node.id)
-  await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
-  await reindexWorkspace(deps, input.workspaceId)
-  return { deleted: true }
+  return withReindex(
+    deps,
+    async (
+      input: z.infer<typeof deleteCanvasInputSchema>,
+    ): Promise<z.infer<typeof deleteCanvasOutputSchema>> => {
+      const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
+      const node = findNodeOrThrow(tree, input.workspaceId, input.canvasId)
+      tree.delete(node.id)
+      await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
+      return { deleted: true }
+    },
+  )(input)
 }

--- a/packages/server-core/src/tools/canvas-export-okf.test.ts
+++ b/packages/server-core/src/tools/canvas-export-okf.test.ts
@@ -1,7 +1,8 @@
 import { writeFacets, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { createInMemoryWorkspaceIndex } from '../test-utils/in-memory-workspace-index.js'
 import { createCanvasExportOkfTool } from './canvas-export-okf.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -51,5 +52,26 @@ describe('canvas_export_okf tool', () => {
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow(
       CanvasNotFoundError,
     )
+  })
+
+  test('never triggers a WorkspaceIndex reindex -- this is a read-only tool', async () => {
+    const store = new FakeCanvasDocStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
+        edges: [],
+      })
+    })
+    const workspaceIndex = createInMemoryWorkspaceIndex()
+    const applyRowsSpy = vi.spyOn(workspaceIndex, 'applyRows')
+    const tool = createCanvasExportOkfTool({
+      canvasDocStore: store,
+      workspaceIndex,
+      blobStore: {} as never,
+    })
+
+    await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(applyRowsSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/server-core/src/tools/canvas-import-okf.ts
+++ b/packages/server-core/src/tools/canvas-import-okf.ts
@@ -4,7 +4,7 @@ import { writeFacets, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-wor
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 const TEXT_NODE_ID = 'okf-body'
@@ -41,41 +41,43 @@ export function createCanvasImportOkfTool(deps: ServerDeps) {
     name: 'canvas_import_okf' as const,
     inputSchema: canvasImportOkfInputSchema,
     outputSchema: canvasImportOkfOutputSchema,
-    async execute(input: CanvasImportOkfInput): Promise<CanvasImportOkfOutput> {
-      await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
+    execute: withReindex(
+      deps,
+      async (input: CanvasImportOkfInput): Promise<CanvasImportOkfOutput> => {
+        await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
 
-      const parsed = parseOkf(input.markdown)
-      if (!parsed.ok) {
-        throw new OkfParseError(parsed.error.stage, parsed.error.message)
-      }
+        const parsed = parseOkf(input.markdown)
+        if (!parsed.ok) {
+          throw new OkfParseError(parsed.error.stage, parsed.error.message)
+        }
 
-      const { frontmatter, body } = parsed.value
-      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+        const { frontmatter, body } = parsed.value
+        const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
 
-      if (frontmatter.facets) {
-        writeFacets(doc, frontmatter.facets)
-      }
+        if (frontmatter.facets) {
+          writeFacets(doc, frontmatter.facets)
+        }
 
-      const nodes =
-        body.length > 0
-          ? [
-              {
-                id: TEXT_NODE_ID,
-                type: 'text' as const,
-                x: 0,
-                y: 0,
-                width: 600,
-                height: 400,
-                text: body,
-              },
-            ]
-          : []
-      writeSpatialCanvas(doc, { nodes, edges: [] })
+        const nodes =
+          body.length > 0
+            ? [
+                {
+                  id: TEXT_NODE_ID,
+                  type: 'text' as const,
+                  x: 0,
+                  y: 0,
+                  width: 600,
+                  height: 400,
+                  text: body,
+                },
+              ]
+            : []
+        writeSpatialCanvas(doc, { nodes, edges: [] })
 
-      await saveDocSnapshot(deps, input.canvasId, doc)
-      await reindexWorkspace(deps, input.workspaceId)
+        await saveDocSnapshot(deps, input.canvasId, doc)
 
-      return { canvasId: input.canvasId, imported: true }
-    },
+        return { canvasId: input.canvasId, imported: true }
+      },
+    ),
   }
 }

--- a/packages/server-core/src/tools/edge-patch.ts
+++ b/packages/server-core/src/tools/edge-patch.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { EdgeNotFoundError, PatchValidationError } from './errors.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 export const edgePatchFieldsSchema = z
@@ -52,7 +52,7 @@ export function createEdgePatchTool(deps: ServerDeps) {
     name: 'edge_patch' as const,
     inputSchema: edgePatchInputSchema,
     outputSchema: edgePatchOutputSchema,
-    async execute(input: EdgePatchInput): Promise<EdgePatchOutput> {
+    execute: withReindex(deps, async (input: EdgePatchInput): Promise<EdgePatchOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
 
@@ -80,9 +80,8 @@ export function createEdgePatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
-      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, edge: updatedEdge }
-    },
+    }),
   }
 }

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -8,7 +8,7 @@ import { readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 /**
@@ -40,7 +40,7 @@ export function createFacetSetTool(deps: ServerDeps) {
     name: 'facet_set' as const,
     inputSchema: facetSetInputSchema,
     outputSchema: facetSetOutputSchema,
-    async execute(input: FacetSetInput): Promise<FacetSetOutput> {
+    execute: withReindex(deps, async (input: FacetSetInput): Promise<FacetSetOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
 
@@ -48,9 +48,8 @@ export function createFacetSetTool(deps: ServerDeps) {
       writeFacets(doc, mergedFacets)
 
       await saveDocSnapshot(deps, input.canvasId, doc)
-      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, facets: mergedFacets }
-    },
+    }),
   }
 }

--- a/packages/server-core/src/tools/no-direct-reindex-import.test.ts
+++ b/packages/server-core/src/tools/no-direct-reindex-import.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const TOOLS_DIR = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Every mutation tool must reindex via `withReindex`, not by importing
+ * `reindexWorkspace` directly — a direct import would bypass the wrapper
+ * and either double-reindex or (if the direct call is later removed by
+ * mistake) silently drop reindexing with no compile-time signal. Only
+ * `reindex-tool.ts` (the manual repair/backfill tool) and `with-reindex.ts`
+ * and `reindex.ts` itself are allowed to import it.
+ */
+const MUTATION_TOOL_FILES = [
+  'canvas-crud.ts',
+  'body-patch.ts',
+  'node-patch.ts',
+  'edge-patch.ts',
+  'facet-set.ts',
+  'canvas-import-okf.ts',
+  'version-restore.ts',
+]
+
+const REINDEX_IMPORT_PATTERN = /from ['"]\.\/reindex\.js['"]/
+
+describe('mutation tools do not import reindexWorkspace directly', () => {
+  for (const file of MUTATION_TOOL_FILES) {
+    it(`${file} has no direct import of reindexWorkspace`, () => {
+      const source = readFileSync(join(TOOLS_DIR, file), 'utf-8')
+      expect(source).not.toMatch(REINDEX_IMPORT_PATTERN)
+    })
+  }
+})

--- a/packages/server-core/src/tools/node-patch.ts
+++ b/packages/server-core/src/tools/node-patch.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { NodeNotFoundError, PatchValidationError } from './errors.js'
-import { reindexWorkspace } from './reindex.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 /**
@@ -58,7 +58,7 @@ export function createNodePatchTool(deps: ServerDeps) {
     name: 'node_patch' as const,
     inputSchema: nodePatchInputSchema,
     outputSchema: nodePatchOutputSchema,
-    async execute(input: NodePatchInput): Promise<NodePatchOutput> {
+    execute: withReindex(deps, async (input: NodePatchInput): Promise<NodePatchOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
 
@@ -82,9 +82,8 @@ export function createNodePatchTool(deps: ServerDeps) {
       }
 
       await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
-      await reindexWorkspace(deps, input.workspaceId)
 
       return { canvasId: input.canvasId, node: updatedNode }
-    },
+    }),
   }
 }

--- a/packages/server-core/src/tools/version-restore.ts
+++ b/packages/server-core/src/tools/version-restore.ts
@@ -4,8 +4,8 @@ import { decodeFrontiers } from 'loro-crdt'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
-import { reindexWorkspace } from './reindex.js'
 import { parseVersionRecord } from './version-record.js'
+import { withReindex } from './with-reindex.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 export const versionRestoreInputSchema = z
@@ -42,43 +42,45 @@ export function createVersionRestoreTool(deps: ServerDeps) {
     name: 'version_restore' as const,
     inputSchema: versionRestoreInputSchema,
     outputSchema: versionRestoreOutputSchema,
-    async execute(input: VersionRestoreInput): Promise<VersionRestoreOutput> {
-      await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
-      const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+    execute: withReindex(
+      deps,
+      async (input: VersionRestoreInput): Promise<VersionRestoreOutput> => {
+        await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
+        const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
 
-      const versions = doc.getMap('versions')
-      const raw = versions.get(input.versionId)
-      if (typeof raw !== 'string') {
-        throw new VersionNotFoundError(input.canvasId, input.versionId)
-      }
+        const versions = doc.getMap('versions')
+        const raw = versions.get(input.versionId)
+        if (typeof raw !== 'string') {
+          throw new VersionNotFoundError(input.canvasId, input.versionId)
+        }
 
-      const record = parseVersionRecord(raw)
-      if (record === null) {
-        throw new VersionNotFoundError(input.canvasId, input.versionId)
-      }
-      const { label, frontier } = record
+        const record = parseVersionRecord(raw)
+        if (record === null) {
+          throw new VersionNotFoundError(input.canvasId, input.versionId)
+        }
+        const { label, frontier } = record
 
-      const frontierBytes = new Uint8Array(
-        (frontier.match(/.{2}/g) ?? []).map((h) => Number.parseInt(h, 16)),
-      )
-      const targetFrontiers = decodeFrontiers(frontierBytes)
+        const frontierBytes = new Uint8Array(
+          (frontier.match(/.{2}/g) ?? []).map((h) => Number.parseInt(h, 16)),
+        )
+        const targetFrontiers = decodeFrontiers(frontierBytes)
 
-      doc.checkout(targetFrontiers)
-      const oldCanvas = readSpatialCanvas(doc)
-      doc.checkoutToLatest()
+        doc.checkout(targetFrontiers)
+        const oldCanvas = readSpatialCanvas(doc)
+        doc.checkoutToLatest()
 
-      writeSpatialCanvas(doc, oldCanvas)
-      doc.commit()
+        writeSpatialCanvas(doc, oldCanvas)
+        doc.commit()
 
-      await saveDocSnapshot(deps, input.canvasId, doc)
-      await reindexWorkspace(deps, input.workspaceId)
+        await saveDocSnapshot(deps, input.canvasId, doc)
 
-      return {
-        canvasId: input.canvasId,
-        restoredVersionId: input.versionId,
-        label,
-        frontier,
-      }
-    },
+        return {
+          canvasId: input.canvasId,
+          restoredVersionId: input.versionId,
+          label,
+          frontier,
+        }
+      },
+    ),
   }
 }

--- a/packages/server-core/src/tools/with-reindex.test.ts
+++ b/packages/server-core/src/tools/with-reindex.test.ts
@@ -47,17 +47,6 @@ describe('withReindex', () => {
     expect(applyRowsSpy).not.toHaveBeenCalled()
   })
 
-  it('propagates the inner execute error unchanged, without swallowing it', async () => {
-    const deps = makeDeps()
-    class CustomError extends Error {}
-    const innerExecute = vi.fn(async () => {
-      throw new CustomError('specific failure')
-    })
-    const wrapped = withReindex(deps, innerExecute)
-
-    await expect(wrapped({ workspaceId: WORKSPACE_ID })).rejects.toBeInstanceOf(CustomError)
-  })
-
   it('still resolves with the mutation result when reindexWorkspace itself fails (fail-open)', async () => {
     const deps = makeDeps()
     deps.workspaceIndex.applyRows = vi.fn().mockRejectedValue(new Error('index write failed'))

--- a/packages/server-core/src/tools/with-reindex.test.ts
+++ b/packages/server-core/src/tools/with-reindex.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as logModule from '../log.js'
+import type { ServerDeps } from '../server-deps.js'
+import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { createInMemoryWorkspaceIndex } from '../test-utils/in-memory-workspace-index.js'
+import { withReindex } from './with-reindex.js'
+
+const WORKSPACE_ID = 'ws-1'
+
+function makeDeps(): ServerDeps {
+  return {
+    canvasDocStore: createInMemoryCanvasDocStore(),
+    workspaceIndex: createInMemoryWorkspaceIndex(),
+    blobStore: {} as never,
+  }
+}
+
+describe('withReindex', () => {
+  it('reindexes the workspace after the inner execute resolves', async () => {
+    const deps = makeDeps()
+    const applyRowsSpy = vi.spyOn(deps.workspaceIndex, 'applyRows')
+    const innerExecute = vi.fn(async (input: { workspaceId: string }) => ({
+      workspaceId: input.workspaceId,
+      ok: true,
+    }))
+    const wrapped = withReindex(deps, innerExecute)
+
+    const result = await wrapped({ workspaceId: WORKSPACE_ID })
+
+    expect(result).toEqual({ workspaceId: WORKSPACE_ID, ok: true })
+    expect(applyRowsSpy).toHaveBeenCalledTimes(1)
+    expect(applyRowsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: WORKSPACE_ID }),
+    )
+  })
+
+  it('does not reindex when the inner execute throws', async () => {
+    const deps = makeDeps()
+    const applyRowsSpy = vi.spyOn(deps.workspaceIndex, 'applyRows')
+    const failure = new Error('mutation failed')
+    const innerExecute = vi.fn(async () => {
+      throw failure
+    })
+    const wrapped = withReindex(deps, innerExecute)
+
+    await expect(wrapped({ workspaceId: WORKSPACE_ID })).rejects.toThrow(failure)
+    expect(applyRowsSpy).not.toHaveBeenCalled()
+  })
+
+  it('propagates the inner execute error unchanged, without swallowing it', async () => {
+    const deps = makeDeps()
+    class CustomError extends Error {}
+    const innerExecute = vi.fn(async () => {
+      throw new CustomError('specific failure')
+    })
+    const wrapped = withReindex(deps, innerExecute)
+
+    await expect(wrapped({ workspaceId: WORKSPACE_ID })).rejects.toBeInstanceOf(CustomError)
+  })
+
+  it('still resolves with the mutation result when reindexWorkspace itself fails (fail-open)', async () => {
+    const deps = makeDeps()
+    deps.workspaceIndex.applyRows = vi.fn().mockRejectedValue(new Error('index write failed'))
+    const innerExecute = vi.fn(async () => ({ done: true }))
+    const wrapped = withReindex(deps, innerExecute)
+
+    await expect(wrapped({ workspaceId: WORKSPACE_ID })).resolves.toEqual({ done: true })
+  })
+
+  it('logs at error level when reindexWorkspace fails, without changing the resolved value', async () => {
+    const deps = makeDeps()
+    deps.workspaceIndex.applyRows = vi.fn().mockRejectedValue(new Error('index write failed'))
+    const errorSpy = vi.fn()
+    logModule.setLogSink((record) => {
+      if (record.level === 'error') errorSpy(record)
+    })
+    const innerExecute = vi.fn(async () => ({ done: true }))
+    const wrapped = withReindex(deps, innerExecute)
+
+    try {
+      await expect(wrapped({ workspaceId: WORKSPACE_ID })).resolves.toEqual({ done: true })
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      logModule.setLogSink(() => {})
+    }
+  })
+})

--- a/packages/server-core/src/tools/with-reindex.ts
+++ b/packages/server-core/src/tools/with-reindex.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceId } from '@kamiazya/whiteboard-canvas-model'
+import { getLogger } from '../log.js'
+import type { ServerDeps } from '../server-deps.js'
+import { reindexWorkspace } from './reindex.js'
+
+const log = getLogger('with-reindex')
+
+/**
+ * Wraps a mutation tool's `execute` so a successful mutation reindexes
+ * the workspace afterward. Apply this INSIDE each mutation tool's
+ * `createXxxTool` factory (canvas-crud, body-patch, node-patch,
+ * edge-patch, facet-set, canvas-import-okf, version-restore) — never at
+ * `create-server.ts`'s registration site, so a read-only tool factory
+ * that never calls `withReindex` is structurally excluded from the
+ * reindex side-effect rather than relying on a central allowlist.
+ *
+ * `workspaceId` is read generically off the input because every mutation
+ * input DTO already carries it; the `{ workspaceId: WorkspaceId }`
+ * constraint on `Input` makes a future mutation tool that forgets the
+ * field a compile error rather than a silent skipped reindex.
+ *
+ * `reindexWorkspace` already swallows its own internal errors (see
+ * reindex.ts — "the index is eventually consistent, not a gate on
+ * mutation success"), but this wrapper guards the call anyway so that
+ * invariant holds even if a future change to `reindexWorkspace` starts
+ * rejecting: a reindex failure is logged, never surfaced to the caller,
+ * and never changes the already-resolved mutation result.
+ */
+export function withReindex<Input extends { workspaceId: WorkspaceId }, Output>(
+  deps: ServerDeps,
+  execute: (input: Input) => Promise<Output>,
+): (input: Input) => Promise<Output> {
+  return async (input: Input): Promise<Output> => {
+    const result = await execute(input)
+    try {
+      await reindexWorkspace(deps, input.workspaceId)
+    } catch (err) {
+      log.error('reindex after mutation failed; mutation result is unaffected', {
+        workspaceId: input.workspaceId,
+        err,
+      })
+    }
+    return result
+  }
+}


### PR DESCRIPTION
## Summary

- Extract `withReindex` higher-order function that wraps mutation tool execute functions to call `reindexWorkspace` automatically after successful execution
- Replace direct `reindexWorkspace` imports in all 7 mutation tools (body-patch, canvas-crud, canvas-import-okf, edge-patch, facet-set, node-patch, version-restore) with the wrapper
- Add meta-test (`no-direct-reindex-import.test.ts`) ensuring no mutation tool directly imports `reindexWorkspace`, enforced at CI time
- Add read-only tool guard test confirming `canvas-export-okf` does not trigger reindex

## Test plan

- [x] 137/137 server-core-node tests pass
- [x] Typecheck passes
- [x] Build passes
- [x] Meta-test catches any future direct `reindexWorkspace` import in mutation tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace indexing after canvas, node, edge, facet, import, patch, and version-restore operations.
  * Mutation results now remain successful even if background indexing encounters an error.
  * Read-only canvas exports are verified not to modify workspace indexes.

* **Tests**
  * Added coverage for indexing behavior, error handling, logging, and mutation-tool safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->