### PR TITLE
test: add round-trip conformance tests for export/import and LoroDoc bridge

### DIFF
--- a/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
+++ b/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
@@ -5,6 +5,16 @@ import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import { resolveReferences } from './resolve.js'
 import { resolveReferencesForExport } from './resolve-for-export.js'
 
+// `]`/`|` are the wikiLink grammar's own delimiters (see findNextReference
+// in resolve.ts) — an alias containing either is an inherent encoding
+// ambiguity, not a round-trip bug, so it is excluded the same way
+// canvas-codec's markdown round-trip property excludes other
+// delimiter-collision classes.
+const wikiLinkAliasArbitrary = fc.option(
+  fc.string({ minLength: 1, maxLength: 12 }).filter((s) => !s.includes(']') && !s.includes('|')),
+  { nil: undefined },
+)
+
 function wikiLinkRoot(canvasId: string, alias: string | undefined): MdastRoot {
   return {
     type: 'root',
@@ -26,23 +36,7 @@ function firstParagraphChild(root: MdastRoot) {
 }
 
 describe('references export/import round-trip properties', () => {
-  fcTest.prop(
-    [
-      canonicalUlidArbitrary,
-      fc.option(
-        // `]`/`|` are the wikiLink grammar's own delimiters (see
-        // findNextReference in resolve.ts) — an alias containing either is
-        // an inherent encoding ambiguity, not a round-trip bug, so it is
-        // excluded the same way canvas-codec's markdown round-trip property
-        // excludes other delimiter-collision classes.
-        fc
-          .string({ minLength: 1, maxLength: 12 })
-          .filter((s) => !s.includes(']') && !s.includes('|')),
-        { nil: undefined },
-      ),
-    ],
-    withDefaults(),
-  )(
+  fcTest.prop([canonicalUlidArbitrary, wikiLinkAliasArbitrary], withDefaults())(
     'unresolved wikiLink degrades to literal text that resolveReferences re-parses into the same canvasId/alias',
     (canvasId, alias) => {
       const exported = resolveReferencesForExport(wikiLinkRoot(canvasId, alias), () => null)
@@ -140,23 +134,7 @@ describe('references export/import round-trip properties', () => {
     },
   )
 
-  fcTest.prop(
-    [
-      canonicalUlidArbitrary,
-      fc.option(
-        // `]`/`|` are the wikiLink grammar's own delimiters (see
-        // findNextReference in resolve.ts) — an alias containing either is
-        // an inherent encoding ambiguity, not a round-trip bug, so it is
-        // excluded the same way canvas-codec's markdown round-trip property
-        // excludes other delimiter-collision classes.
-        fc
-          .string({ minLength: 1, maxLength: 12 })
-          .filter((s) => !s.includes(']') && !s.includes('|')),
-        { nil: undefined },
-      ),
-    ],
-    withDefaults(),
-  )(
+  fcTest.prop([canonicalUlidArbitrary, wikiLinkAliasArbitrary], withDefaults())(
     'resolveReferencesForExport is idempotent for a resolved wikiLink: applying twice equals applying once',
     (canvasId, alias) => {
       const resolver = () => `/notes/${canvasId}.md`

--- a/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
+++ b/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
@@ -1,0 +1,171 @@
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import { canonicalUlidArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { resolveReferences } from './resolve.js'
+import { resolveReferencesForExport } from './resolve-for-export.js'
+
+function wikiLinkRoot(canvasId: string, alias: string | undefined): MdastRoot {
+  return {
+    type: 'root',
+    children: [{ type: 'paragraph', children: [{ type: 'wikiLink', canvasId, alias }] }],
+  }
+}
+
+function embedRoot(canvasId: string): MdastRoot {
+  return {
+    type: 'root',
+    children: [{ type: 'paragraph', children: [{ type: 'embed', canvasId }] }],
+  }
+}
+
+function firstParagraphChild(root: MdastRoot) {
+  const paragraph = root.children[0]
+  if (paragraph.type !== 'paragraph') throw new Error('expected paragraph')
+  return paragraph.children[0]
+}
+
+describe('references export/import round-trip properties', () => {
+  fcTest.prop(
+    [
+      canonicalUlidArbitrary,
+      fc.option(
+        // `]`/`|` are the wikiLink grammar's own delimiters (see
+        // findNextReference in resolve.ts) — an alias containing either is
+        // an inherent encoding ambiguity, not a round-trip bug, so it is
+        // excluded the same way canvas-codec's markdown round-trip property
+        // excludes other delimiter-collision classes.
+        fc
+          .string({ minLength: 1, maxLength: 12 })
+          .filter((s) => !s.includes(']') && !s.includes('|')),
+        { nil: undefined },
+      ),
+    ],
+    withDefaults(),
+  )(
+    'unresolved wikiLink degrades to literal text that resolveReferences re-parses into the same canvasId/alias',
+    (canvasId, alias) => {
+      const exported = resolveReferencesForExport(wikiLinkRoot(canvasId, alias), () => null)
+      const reimported = resolveReferences(exported)
+
+      const node = firstParagraphChild(reimported)
+      expect(node).toEqual({ type: 'wikiLink', canvasId, alias })
+    },
+  )
+
+  fcTest.prop([canonicalUlidArbitrary], withDefaults())(
+    'unresolved embed degrades to literal text that resolveReferences re-parses preserving canvasId',
+    (canvasId) => {
+      const exported = resolveReferencesForExport(embedRoot(canvasId), () => null)
+      const reimported = resolveReferences(exported)
+
+      const node = firstParagraphChild(reimported)
+      // The export fallback text for an embed is indistinguishable from a
+      // wikiLink's (`[[canvas:ID]]`, no `!` marker survives the degrade), so
+      // only the canvasId linkage — not the wikiLink/embed distinction — is
+      // guaranteed to survive this cycle.
+      expect(node.type === 'wikiLink' || node.type === 'embed').toBe(true)
+      if (node.type === 'wikiLink' || node.type === 'embed') {
+        expect(node.canvasId).toBe(canvasId)
+      }
+    },
+  )
+
+  fcTest.prop([canonicalUlidArbitrary, fc.constantFrom('wikiLink', 'embed')], withDefaults())(
+    'a bijective resolver keeps the canvasId recoverable from the exported text',
+    (canvasId, kind) => {
+      const root = kind === 'wikiLink' ? wikiLinkRoot(canvasId, undefined) : embedRoot(canvasId)
+      const path = `/notes/${canvasId}.md`
+      const exported = resolveReferencesForExport(root, (id) => (id === canvasId ? path : null))
+
+      const node = firstParagraphChild(exported)
+      expect(node).toEqual({ type: 'text', value: expect.stringContaining(canvasId) })
+    },
+  )
+
+  fcTest.prop(
+    [fc.uniqueArray(canonicalUlidArbitrary, { minLength: 2, maxLength: 2 })],
+    withDefaults(),
+  )(
+    'a non-bijective resolver (two canvasIds mapping to the same path) never throws and exports both',
+    ([canvasIdA, canvasIdB]) => {
+      const collidingPath = '/notes/shared.md'
+      const resolver = () => collidingPath
+
+      const exportedA = resolveReferencesForExport(wikiLinkRoot(canvasIdA, undefined), resolver)
+      const exportedB = resolveReferencesForExport(wikiLinkRoot(canvasIdB, undefined), resolver)
+
+      expect(firstParagraphChild(exportedA)).toEqual({
+        type: 'text',
+        value: `[${collidingPath}](${collidingPath})`,
+      })
+      expect(firstParagraphChild(exportedB)).toEqual({
+        type: 'text',
+        value: `[${collidingPath}](${collidingPath})`,
+      })
+    },
+  )
+
+  fcTest.prop(
+    [fc.array(fc.tuple(canonicalUlidArbitrary, fc.boolean()), { minLength: 1, maxLength: 5 })],
+    withDefaults(),
+  )(
+    'a partial resolver preserves canvasId for resolvable entries and degrades unresolvable ones to text',
+    (entries) => {
+      const resolvableIds = new Set(
+        entries.filter(([, resolvable]) => resolvable).map(([id]) => id),
+      )
+      const resolver = (id: string) => (resolvableIds.has(id) ? `/notes/${id}.md` : null)
+
+      for (const [canvasId, resolvable] of entries) {
+        const exported = resolveReferencesForExport(wikiLinkRoot(canvasId, undefined), resolver)
+        const value = firstParagraphChild(exported)
+        expect(value.type).toBe('text')
+        if (value.type !== 'text') continue
+
+        if (resolvable) {
+          expect(value.value).toContain(`/notes/${canvasId}.md`)
+        } else {
+          expect(value.value).toBe(`[[canvas:${canvasId}]]`)
+          const reimported = resolveReferences(
+            resolveReferencesForExport(wikiLinkRoot(canvasId, undefined), resolver),
+          )
+          expect(firstParagraphChild(reimported)).toEqual({
+            type: 'wikiLink',
+            canvasId,
+            alias: undefined,
+          })
+        }
+      }
+    },
+  )
+
+  fcTest.prop(
+    [
+      canonicalUlidArbitrary,
+      fc.option(
+        // `]`/`|` are the wikiLink grammar's own delimiters (see
+        // findNextReference in resolve.ts) — an alias containing either is
+        // an inherent encoding ambiguity, not a round-trip bug, so it is
+        // excluded the same way canvas-codec's markdown round-trip property
+        // excludes other delimiter-collision classes.
+        fc
+          .string({ minLength: 1, maxLength: 12 })
+          .filter((s) => !s.includes(']') && !s.includes('|')),
+        { nil: undefined },
+      ),
+    ],
+    withDefaults(),
+  )(
+    'resolveReferencesForExport is idempotent for a resolved wikiLink: applying twice equals applying once',
+    (canvasId, alias) => {
+      const resolver = () => `/notes/${canvasId}.md`
+      const root = wikiLinkRoot(canvasId, alias)
+
+      const once = resolveReferencesForExport(root, resolver)
+      const twice = resolveReferencesForExport(once, resolver)
+
+      expect(twice).toEqual(once)
+    },
+  )
+})

--- a/packages/canvas-workspace/src/loro-bridge.property.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.property.test.ts
@@ -74,12 +74,14 @@ describe('loro-bridge properties', () => {
   )
 
   fcTest.prop([extensionFacetsArbitrary], withDefaults())(
-    'readFacets(writeFacets(doc, facets)) deep-equals facets',
+    'readFacets(writeFacets(doc, facets)) deep-equals facets (up to -0 normalization)',
     (facets) => {
       const doc = new LoroDoc()
       writeFacets(doc, facets)
       const result = readFacets(doc)
-      expect(result).toEqual(facets)
+      // Loro normalizes -0 to 0 during storage; JSON.parse(JSON.stringify())
+      // applies the same normalization so we compare against that.
+      expect(result).toEqual(JSON.parse(JSON.stringify(facets)))
     },
   )
 })

--- a/packages/canvas-workspace/src/loro-bridge.property.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.property.test.ts
@@ -1,0 +1,85 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import {
+  canvasEdgeArbitrary,
+  extensionFacetsArbitrary,
+  spatialNodeArbitrary,
+} from '@kamiazya/whiteboard-canvas-model/test-utils'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect } from 'vitest'
+import { readFacets, readSpatialCanvas, writeFacets, writeSpatialCanvas } from './loro-bridge.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+
+/**
+ * Same construction as canvas-codec's spatial round-trip property
+ * (arbitrary edges wired to arbitrary node ids, deduped by edge id) so both
+ * packages exercise the identical valid-by-construction SpatialCanvas shape.
+ */
+const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
+  .array(spatialNodeArbitrary, { maxLength: 4 })
+  // nodeIdArbitrary has low entropy at small sizes (e.g. shrinks to " "),
+  // so distinct-by-construction node ids need an explicit dedupe — the
+  // model schema rejects duplicate node ids.
+  .map((nodes) => nodes.filter((node, index) => nodes.findIndex((n) => n.id === node.id) === index))
+  .chain((nodes) => {
+    const ids = nodes.map((node) => node.id)
+    const edgeArbitrary =
+      ids.length >= 2
+        ? fc
+            .tuple(fc.constantFrom(...ids), fc.constantFrom(...ids))
+            .chain(([fromNode, toNode]) =>
+              canvasEdgeArbitrary.map((edge) => ({ ...edge, fromNode, toNode })),
+            )
+        : fc.constant(undefined)
+
+    return fc
+      .array(edgeArbitrary, { maxLength: ids.length >= 2 ? 3 : 0 })
+      .map((edges) => ({
+        nodes,
+        edges: edges.filter((edge): edge is NonNullable<typeof edge> => edge !== undefined),
+      }))
+      .map((canvas) => ({
+        ...canvas,
+        edges: canvas.edges.filter(
+          (edge, index) => canvas.edges.findIndex((e) => e.id === edge.id) === index,
+        ),
+      }))
+  })
+
+function byId<T extends { id: string }>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => a.id.localeCompare(b.id))
+}
+
+describe('loro-bridge properties', () => {
+  fcTest.prop([spatialCanvasArbitrary], withDefaults())(
+    'readSpatialCanvas(writeSpatialCanvas(doc, canvas)) deep-equals canvas up to node/edge order',
+    (canvas) => {
+      // LoroMap.keys() iteration order is not insertion order — the bridge
+      // never promises to preserve node/edge array order, only membership
+      // and content (see loro-bridge.test.ts's multi-node cases, which
+      // already compare sorted id sets rather than raw array equality).
+      const doc = new LoroDoc()
+      writeSpatialCanvas(doc, canvas)
+      const result = readSpatialCanvas(doc)
+      expect(byId(result.nodes)).toEqual(byId(canvas.nodes))
+      expect(byId(result.edges)).toEqual(byId(canvas.edges))
+    },
+  )
+
+  fcTest.prop([spatialCanvasArbitrary], withDefaults())(
+    'writeSpatialCanvas is total: never throws on a valid SpatialCanvas',
+    (canvas) => {
+      const doc = new LoroDoc()
+      expect(() => writeSpatialCanvas(doc, canvas)).not.toThrow()
+    },
+  )
+
+  fcTest.prop([extensionFacetsArbitrary], withDefaults())(
+    'readFacets(writeFacets(doc, facets)) deep-equals facets',
+    (facets) => {
+      const doc = new LoroDoc()
+      writeFacets(doc, facets)
+      const result = readFacets(doc)
+      expect(result).toEqual(facets)
+    },
+  )
+})

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -1,0 +1,255 @@
+import { parseSpatial } from '@kamiazya/whiteboard-canvas-codec'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { readFacets, readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
+import {
+  FakeCanvasDocStore,
+  registerCanvasInWorkspace,
+} from '../test-utils/fake-canvas-doc-store.js'
+import { createCanvasExportJsonCanvasTool } from './canvas-export-json-canvas.js'
+import { createCanvasExportOkfTool } from './canvas-export-okf.js'
+import { createCanvasImportOkfTool, OkfParseError } from './canvas-import-okf.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: {} as never, blobStore: {} as never }
+}
+
+async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {
+  const snap = await store.loadSnapshot({ docRef: { kind: 'canvas', canvasId } })
+  if (!snap) throw new Error('no snapshot')
+  const doc = new LoroDoc()
+  doc.import(reassembleSnapshot(snap.manifest, snap.chunks))
+  return doc
+}
+
+describe('canvas_import_okf -> canvas_export_okf composed round-trip', () => {
+  test('preserves body text through the LoroDoc persistence layer', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    const markdown = '---\ntype: note\n---\n# Title\n\nBody text.'
+    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+
+    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.markdown).toContain('# Title\n\nBody text.')
+  })
+
+  test('preserves facets with arbitrary domain keys through the LoroDoc persistence layer', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    const markdown = [
+      '---',
+      'type: issue',
+      'facets:',
+      '  issue/1:',
+      '    status: open',
+      '    priority: high',
+      '---',
+      'Body.',
+    ].join('\n')
+    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+
+    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.frontmatter.facets).toEqual({ 'issue/1': { status: 'open', priority: 'high' } })
+  })
+
+  test('an empty (facets-only) body round-trips to an empty body', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\n',
+    })
+
+    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.markdown.endsWith('---\n')).toBe(true)
+  })
+
+  test('re-import after export is idempotent: the second import produces the same LoroDoc state', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    const markdown = '---\ntype: note\nfacets:\n  kanban/1:\n    status: todo\n---\nOriginal body.'
+    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    const exported = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: exported.markdown,
+    })
+    const doc = await loadDoc(store, CANVAS_ID)
+
+    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+    const canvas = readSpatialCanvas(doc)
+    expect(canvas.nodes).toHaveLength(1)
+    if (canvas.nodes[0].type === 'text') {
+      expect(canvas.nodes[0].text).toBe('Original body.')
+    }
+  })
+})
+
+describe('canvas_import_okf -> canvas_export_json_canvas composed round-trip', () => {
+  test('the imported body appears as a text node in the exported (extended) JSON Canvas', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nHello from OKF.',
+    })
+
+    const result = await exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const parsed = JSON.parse(result.json)
+
+    expect(parsed.nodes).toHaveLength(1)
+    expect(parsed.nodes[0].text).toBe('Hello from OKF.')
+  })
+
+  test('the exported (strict) JSON Canvas has no x-whiteboard extensions', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nHello.',
+    })
+
+    const result = await exportJsonTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      options: { strict: true },
+    })
+    const parsed = JSON.parse(result.json)
+
+    expect(parsed.nodes[0]['x-whiteboard']).toBeUndefined()
+  })
+})
+
+describe('canvas_export_json_canvas output re-parses as valid JSON Canvas', () => {
+  test('parseSpatial succeeds on the exported (extended) JSON', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nRe-parse me.',
+    })
+    const result = await exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    const reparsed = parseSpatial(result.json)
+
+    expect(reparsed.ok).toBe(true)
+  })
+
+  test('parseSpatial succeeds on the exported (strict) JSON', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+
+    await importTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nRe-parse me too.',
+    })
+    const result = await exportJsonTool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      options: { strict: true },
+    })
+
+    const reparsed = parseSpatial(result.json)
+
+    expect(reparsed.ok).toBe(true)
+  })
+})
+
+describe('error paths do not silently produce corrupt output', () => {
+  test('import_okf with no frontmatter rejects before any export is attempted', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    await expect(
+      importTool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        markdown: 'no frontmatter here',
+      }),
+    ).rejects.toThrow(OkfParseError)
+
+    // No snapshot was ever saved, so the composed export attempt surfaces a
+    // clean not-found error rather than reading corrupt/partial state.
+    await expect(
+      exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+    ).rejects.toThrow(CanvasNotFoundError)
+  })
+
+  test('a non-yaml-safe facet value (YAML .nan) imports but rejects on export, never silently exported', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const importTool = createCanvasImportOkfTool(makeDeps(store))
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    // parseOkf's frontmatter schema only validates facet KEYS, not values
+    // (extensionFacetsSchema stores values as z.unknown()) — the yaml-safe
+    // check runs on serialize, so a YAML-native `.nan` scalar (parsed to the
+    // JS NaN, which has no round-trippable YAML representation) imports
+    // successfully but must fail the composed export rather than silently
+    // emitting corrupt YAML.
+    const markdown = '---\ntype: note\nfacets:\n  bad/1:\n    value: .nan\n---\nBody.'
+    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+
+    await expect(
+      exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+    ).rejects.toThrow(/yaml-safe/)
+  })
+
+  test('export_okf on a canvas with no stored snapshot surfaces a clean error', async () => {
+    const store = new FakeCanvasDocStore()
+    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+
+    await expect(
+      exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+    ).rejects.toThrow(CanvasNotFoundError)
+  })
+
+  test('export_json_canvas on a canvas with no stored snapshot surfaces a clean error', async () => {
+    const store = new FakeCanvasDocStore()
+    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+
+    await expect(
+      exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+    ).rejects.toThrow(CanvasNotFoundError)
+  })
+})

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -27,26 +27,32 @@ async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<Lor
   return doc
 }
 
+async function setupTools() {
+  const store = new FakeCanvasDocStore()
+  await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+  const deps = makeDeps(store)
+  return {
+    store,
+    importOkf: createCanvasImportOkfTool(deps),
+    exportOkf: createCanvasExportOkfTool(deps),
+    exportJson: createCanvasExportJsonCanvasTool(deps),
+  }
+}
+
 describe('canvas_import_okf -> canvas_export_okf composed round-trip', () => {
   test('preserves body text through the LoroDoc persistence layer', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { importOkf, exportOkf } = await setupTools()
 
     const markdown = '---\ntype: note\n---\n# Title\n\nBody text.'
-    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
-    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
     expect(result.markdown).toContain('# Title\n\nBody text.')
   })
 
   test('preserves facets with arbitrary domain keys through the LoroDoc persistence layer', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { importOkf, exportOkf } = await setupTools()
 
     const markdown = [
       '---',
@@ -58,41 +64,35 @@ describe('canvas_import_okf -> canvas_export_okf composed round-trip', () => {
       '---',
       'Body.',
     ].join('\n')
-    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
-    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
     expect(result.frontmatter.facets).toEqual({ 'issue/1': { status: 'open', priority: 'high' } })
   })
 
   test('an empty (facets-only) body round-trips to an empty body', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { importOkf, exportOkf } = await setupTools()
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\n',
     })
 
-    const result = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
     expect(result.markdown.endsWith('---\n')).toBe(true)
   })
 
   test('re-import after export is idempotent: the second import produces the same LoroDoc state', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { store, importOkf, exportOkf } = await setupTools()
 
     const markdown = '---\ntype: note\nfacets:\n  kanban/1:\n    status: todo\n---\nOriginal body.'
-    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
-    const exported = await exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    const exported = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: exported.markdown,
@@ -110,18 +110,15 @@ describe('canvas_import_okf -> canvas_export_okf composed round-trip', () => {
 
 describe('canvas_import_okf -> canvas_export_json_canvas composed round-trip', () => {
   test('the imported body appears as a text node in the exported (extended) JSON Canvas', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+    const { importOkf, exportJson } = await setupTools()
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nHello from OKF.',
     })
 
-    const result = await exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const result = await exportJson.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
     const parsed = JSON.parse(result.json)
 
     expect(parsed.nodes).toHaveLength(1)
@@ -129,18 +126,15 @@ describe('canvas_import_okf -> canvas_export_json_canvas composed round-trip', (
   })
 
   test('the exported (strict) JSON Canvas has no x-whiteboard extensions', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+    const { importOkf, exportJson } = await setupTools()
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nHello.',
     })
 
-    const result = await exportJsonTool.execute({
+    const result = await exportJson.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       options: { strict: true },
@@ -153,55 +147,42 @@ describe('canvas_import_okf -> canvas_export_json_canvas composed round-trip', (
 
 describe('canvas_export_json_canvas output re-parses as valid JSON Canvas', () => {
   test('parseSpatial succeeds on the exported (extended) JSON', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+    const { importOkf, exportJson } = await setupTools()
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nRe-parse me.',
     })
-    const result = await exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const result = await exportJson.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
-    const reparsed = parseSpatial(result.json)
-
-    expect(reparsed.ok).toBe(true)
+    expect(parseSpatial(result.json).ok).toBe(true)
   })
 
   test('parseSpatial succeeds on the exported (strict) JSON', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+    const { importOkf, exportJson } = await setupTools()
 
-    await importTool.execute({
+    await importOkf.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nRe-parse me too.',
     })
-    const result = await exportJsonTool.execute({
+    const result = await exportJson.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       options: { strict: true },
     })
 
-    const reparsed = parseSpatial(result.json)
-
-    expect(reparsed.ok).toBe(true)
+    expect(parseSpatial(result.json).ok).toBe(true)
   })
 })
 
 describe('error paths do not silently produce corrupt output', () => {
   test('import_okf with no frontmatter rejects before any export is attempted', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { importOkf, exportOkf } = await setupTools()
 
     await expect(
-      importTool.execute({
+      importOkf.execute({
         workspaceId: WORKSPACE_ID,
         canvasId: CANVAS_ID,
         markdown: 'no frontmatter here',
@@ -211,15 +192,12 @@ describe('error paths do not silently produce corrupt output', () => {
     // No snapshot was ever saved, so the composed export attempt surfaces a
     // clean not-found error rather than reading corrupt/partial state.
     await expect(
-      exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+      exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
     ).rejects.toThrow(CanvasNotFoundError)
   })
 
   test('a non-yaml-safe facet value (YAML .nan) imports but rejects on export, never silently exported', async () => {
-    const store = new FakeCanvasDocStore()
-    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const importTool = createCanvasImportOkfTool(makeDeps(store))
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const { importOkf, exportOkf } = await setupTools()
 
     // parseOkf's frontmatter schema only validates facet KEYS, not values
     // (extensionFacetsSchema stores values as z.unknown()) — the yaml-safe
@@ -228,16 +206,16 @@ describe('error paths do not silently produce corrupt output', () => {
     // successfully but must fail the composed export rather than silently
     // emitting corrupt YAML.
     const markdown = '---\ntype: note\nfacets:\n  bad/1:\n    value: .nan\n---\nBody.'
-    await importTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
     await expect(
-      exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+      exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
     ).rejects.toThrow(/yaml-safe/)
   })
 
   test('export_okf on a canvas with no stored snapshot surfaces a clean error', async () => {
-    const store = new FakeCanvasDocStore()
-    const exportTool = createCanvasExportOkfTool(makeDeps(store))
+    const deps = makeDeps(new FakeCanvasDocStore())
+    const exportTool = createCanvasExportOkfTool(deps)
 
     await expect(
       exportTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
@@ -245,8 +223,8 @@ describe('error paths do not silently produce corrupt output', () => {
   })
 
   test('export_json_canvas on a canvas with no stored snapshot surfaces a clean error', async () => {
-    const store = new FakeCanvasDocStore()
-    const exportJsonTool = createCanvasExportJsonCanvasTool(makeDeps(store))
+    const deps = makeDeps(new FakeCanvasDocStore())
+    const exportJsonTool = createCanvasExportJsonCanvasTool(deps)
 
     await expect(
       exportJsonTool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),


### PR DESCRIPTION
## Summary

- Add tool-level round-trip tests for OKF and JSON Canvas export/import paths (`export-import-roundtrip.test.ts`)
- Add property-based test for references resolve/export cycle (`references-roundtrip.property.test.ts`)
- Add property-based tests for LoroDoc spatial bridge and facets bridge round-trip (`loro-bridge.property.test.ts`)
- Fix -0 normalization in facets PBT: Loro normalizes -0 to 0 during LoroMap storage, test now compares against `JSON.parse(JSON.stringify())` which applies the same normalization

## Test plan

- [x] 290/290 tests pass across canvas-workspace-node, canvas-codec-node, server-core-node
- [x] All PBTs pass with default numRuns
- [x] No pinned seeds