### PR TITLE
refactor(canvas-model): rename ./internal subpath export to ./mdast

### DIFF
--- a/.claude/rules/package-canvas-model.md
+++ b/.claude/rules/package-canvas-model.md
@@ -7,7 +7,7 @@ paths:
 
 ## What belongs here
 
-- Zod schemas: canvas meta, core/extension/raw facets, spatial canvas (JSON Canvas 1.0 + `x-whiteboard` extension), markdown body, workspace-tree node data, and the internal mdast subset.
+- Zod schemas: canvas meta, core/extension/raw facets, spatial canvas (JSON Canvas 1.0 + `x-whiteboard` extension), markdown body, workspace-tree node data, and the versioned mdast subset (exported via the `./mdast` subpath).
 - Shared fast-check arbitraries in `src/test-utils/` (valid-by-construction; never duplicated per test file).
 
 ## What does NOT belong here

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -34,7 +34,7 @@
 ## Dependency rules
 
 - Runtime dependencies: `@kamiazya/whiteboard-canvas-model` (spatial nodes/
-  edges + the internal mdast subset) and `zod` (via `catalog:`), for
+  edges + the `./mdast` subset) and `zod` (via `catalog:`), for
   `sceneDigestSchema` only.
 - Forbidden imports: `node:*`, DOM globals (`document`/`window`/`navigator`/
   `HTMLElement`), `inversify`. Enforced by `src/import-guard.test.ts`, which

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -67,8 +67,8 @@
     "packages/canvas-model": {
       // Public surface for opencanvas slices 2/3 (serializer, scene/layout);
       // intentionally unreferenced from any existing package until those
-      // land. "./internal" is the mdast subset's deliberately-separate,
-      // not-yet-public subpath. "./test-utils" is a test-only subpath
+      // land. "./mdast" is the mdast subset's deliberately-separate
+      // subpath. "./test-utils" is a test-only subpath
       // (arbitraries + fast-check wrapper) consumed by canvas-codec's tests.
       "entry": ["src/index.ts", "src/mdast/index.ts", "src/test-utils/index.ts"],
       "project": ["src/**/*.ts"]

--- a/packages/canvas-codec/src/markdown/from-remark.ts
+++ b/packages/canvas-codec/src/markdown/from-remark.ts
@@ -6,7 +6,7 @@ import type {
   MdastRoot,
   MdastTableCell,
   MdastTableRow,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 
 /**
  * remark/mdast-util nodes carry `position`, and extension-specific nodes

--- a/packages/canvas-codec/src/markdown/normalize.test.ts
+++ b/packages/canvas-codec/src/markdown/normalize.test.ts
@@ -1,4 +1,4 @@
-import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/internal'
+import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { mdastRootArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe, expect, it } from 'vitest'
 import { fcTest, withDefaults } from '../test-utils/fast-check.js'

--- a/packages/canvas-codec/src/markdown/normalize.ts
+++ b/packages/canvas-codec/src/markdown/normalize.ts
@@ -1,4 +1,4 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 
 /**
  * Markdown text cannot distinguish "explicitly null" from "absent" for any

--- a/packages/canvas-codec/src/markdown/pipeline.ts
+++ b/packages/canvas-codec/src/markdown/pipeline.ts
@@ -1,5 +1,5 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
-import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
+import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/mdast'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import remarkParse from 'remark-parse'

--- a/packages/canvas-codec/src/markdown/to-remark.ts
+++ b/packages/canvas-codec/src/markdown/to-remark.ts
@@ -6,7 +6,7 @@ import type {
   MdastRoot,
   MdastTableCell,
   MdastTableRow,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 
 /**
  * Inverse of from-remark.ts: expands the model subset back into plain

--- a/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
+++ b/packages/canvas-codec/src/references/references-roundtrip.property.test.ts
@@ -1,4 +1,4 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { canonicalUlidArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe, expect } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'

--- a/packages/canvas-codec/src/references/resolve-for-export.ts
+++ b/packages/canvas-codec/src/references/resolve-for-export.ts
@@ -6,7 +6,7 @@ import type {
   MdastRoot,
   MdastTableCell,
   MdastTableRow,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 
 export type CanvasPathResolver = (canvasId: string) => string | null
 

--- a/packages/canvas-codec/src/references/resolve.ts
+++ b/packages/canvas-codec/src/references/resolve.ts
@@ -7,7 +7,7 @@ import type {
   MdastRoot,
   MdastTableCell,
   MdastTableRow,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 
 const CANVAS_ID_PREFIX = 'canvas:'
 

--- a/packages/canvas-model/package.json
+++ b/packages/canvas-model/package.json
@@ -12,7 +12,7 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
-    "./internal": {
+    "./mdast": {
       "types": "./src/mdast/index.ts",
       "import": "./src/mdast/index.ts"
     },

--- a/packages/canvas-model/src/index.ts
+++ b/packages/canvas-model/src/index.ts
@@ -5,6 +5,6 @@ export * from './meta.js'
 export * from './spatial.js'
 export * from './workspace-tree.js'
 
-// The mdast subset is intentionally NOT re-exported here — it is internal
-// and versioned, reached via the package's `./internal` subpath export
-// instead of the stable public surface.
+// The mdast subset is intentionally NOT re-exported here — it is
+// versioned, reached via the package's `./mdast` subpath export instead of
+// the stable public surface.

--- a/packages/canvas-model/src/mdast/index.ts
+++ b/packages/canvas-model/src/mdast/index.ts
@@ -2,10 +2,9 @@ import { z } from 'zod'
 import { canvasIdSchema } from '../ids.js'
 
 /**
- * INTERNAL, versioned mdast subset. Not part of the stable public surface
- * yet — a public release happens once the slice-2 remark pipeline has
- * exercised it against real documents. Exported via the package's
- * `./internal` subpath, not the default `.` export.
+ * Versioned mdast subset. Exported via the package's `./mdast` subpath,
+ * not the default `.` export — kept separate so the content-model
+ * hierarchy below can evolve independently of the stable public surface.
  *
  * Covers CommonMark + GFM (table/tableRow/tableCell/delete) + math
  * (math/inlineMath) + this repo's two official custom nodes: wikiLink and

--- a/packages/canvas-model/src/mdast/smoke.test.ts
+++ b/packages/canvas-model/src/mdast/smoke.test.ts
@@ -1,7 +1,5 @@
-import { describe, expect, it } from 'vitest'
-// Imported by its published specifier, not a relative path, to exercise
-// package.json `exports` resolution the way a real consumer will.
 import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/mdast'
+import { describe, expect, it } from 'vitest'
 
 describe('canvas-model /mdast subpath export', () => {
   it('resolves the published specifier and validates a root node', () => {

--- a/packages/canvas-model/src/mdast/smoke.test.ts
+++ b/packages/canvas-model/src/mdast/smoke.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+// Imported by its published specifier, not a relative path, to exercise
+// package.json `exports` resolution the way a real consumer will.
+import { mdastRootSchema } from '@kamiazya/whiteboard-canvas-model/mdast'
+
+describe('canvas-model /mdast subpath export', () => {
+  it('resolves the published specifier and validates a root node', () => {
+    const root = { type: 'root', children: [] }
+
+    expect(mdastRootSchema.parse(root)).toEqual(root)
+  })
+})

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -1,4 +1,4 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { describe, expect, it } from 'vitest'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
 import { layoutMdastBlocks } from './mdast-blocks.js'

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -4,7 +4,7 @@ import type {
   MdastListItem,
   MdastPhrasingContent,
   MdastRoot,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 import type { MeasureText } from '../measure.js'
 import { clampAdvance } from '../measure.js'
 import type {

--- a/packages/canvas-workspace/src/alias-resolver.test.ts
+++ b/packages/canvas-workspace/src/alias-resolver.test.ts
@@ -1,5 +1,5 @@
 import { resolveReferences } from '@kamiazya/whiteboard-canvas-codec'
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { createAliasResolver } from './alias-resolver.js'

--- a/packages/canvas-workspace/src/derive-index.ts
+++ b/packages/canvas-workspace/src/derive-index.ts
@@ -1,6 +1,6 @@
 import type { CoreFacets, ExtensionFacets } from '@kamiazya/whiteboard-canvas-model'
 import { issueFacetPayloadSchema } from '@kamiazya/whiteboard-canvas-model'
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import type {
   AliasHistoryRow,
   AliasResolutionRow,

--- a/packages/canvas-workspace/src/extract-backlinks.test.ts
+++ b/packages/canvas-workspace/src/extract-backlinks.test.ts
@@ -1,4 +1,4 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { describe, expect, test } from 'vitest'
 import { extractBacklinks } from './extract-backlinks.js'
 

--- a/packages/canvas-workspace/src/extract-backlinks.ts
+++ b/packages/canvas-workspace/src/extract-backlinks.ts
@@ -2,7 +2,7 @@ import type {
   MdastFlowContent,
   MdastPhrasingContent,
   MdastRoot,
-} from '@kamiazya/whiteboard-canvas-model/internal'
+} from '@kamiazya/whiteboard-canvas-model/mdast'
 import type { BacklinkRow } from '@kamiazya/whiteboard-canvas-ports'
 
 export function extractBacklinks(fromCanvasId: string, root: MdastRoot): readonly BacklinkRow[] {

--- a/packages/canvas-workspace/src/test-utils/index-fixtures.ts
+++ b/packages/canvas-workspace/src/test-utils/index-fixtures.ts
@@ -1,4 +1,4 @@
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/internal'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { LoroDoc } from 'loro-crdt'
 import type { CanvasIndexInput } from '../derive-index.js'
 import { WorkspaceTree } from '../workspace-tree.js'


### PR DESCRIPTION
## Summary

- Rename the `./internal` subpath export in canvas-model to `./mdast` — the name `internal` was misleading since this is the mdast type surface actively consumed by canvas-codec, canvas-workspace, and canvas-render
- Update all 15 import sites across consumer packages
- Update smoke test to exercise the new `./mdast` subpath resolution
- Update documentation in `.claude/rules/package-canvas-model.md` and `.claude/rules/package-canvas-render.md`
- Update knip.jsonc comment

## Test plan

- [x] Smoke test imports via `@kamiazya/whiteboard-canvas-model/mdast` specifier
- [x] All canvas-model-node, canvas-codec-node, canvas-workspace-node, canvas-render-node tests pass
- [x] `pnpm -r typecheck` passes
- [x] `pnpm build` passes
- [x] `grep -r 'canvas-model/internal' --include='*.ts' --include='*.json'` returns zero hits