### PR TITLE
test(server-core): add schema, error, and measure unit tests

### DIFF
--- a/packages/server-core/src/render/fallback-measure.test.ts
+++ b/packages/server-core/src/render/fallback-measure.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { fallbackMeasureText } from './fallback-measure.js'
+
+describe('fallbackMeasureText', () => {
+  const font = { sizePx: 16, family: 'sans-serif', weight: 400 as const, style: 'normal' as const }
+
+  it('returns advanceWidth proportional to text length and font size', () => {
+    const metrics = fallbackMeasureText('hello', font)
+    expect(metrics.advanceWidth).toBeCloseTo(5 * 0.55 * 16)
+  })
+
+  it('returns zero advanceWidth for empty text', () => {
+    const metrics = fallbackMeasureText('', font)
+    expect(metrics.advanceWidth).toBe(0)
+  })
+
+  it('scales linearly with font size', () => {
+    const small = fallbackMeasureText('ab', { ...font, sizePx: 10 })
+    const large = fallbackMeasureText('ab', { ...font, sizePx: 20 })
+    expect(large.advanceWidth).toBeCloseTo(small.advanceWidth * 2)
+  })
+
+  it('returns ascent as 80% of sizePx', () => {
+    const metrics = fallbackMeasureText('x', font)
+    expect(metrics.ascent).toBeCloseTo(16 * 0.8)
+  })
+
+  it('returns descent as 20% of sizePx', () => {
+    const metrics = fallbackMeasureText('x', font)
+    expect(metrics.descent).toBeCloseTo(16 * 0.2)
+  })
+
+  it('returns lineGap as 10% of sizePx', () => {
+    const metrics = fallbackMeasureText('x', font)
+    expect(metrics.lineGap).toBeCloseTo(16 * 0.1)
+  })
+
+  it('produces finite values for any non-empty input', () => {
+    const metrics = fallbackMeasureText('日本語テキスト', { ...font, sizePx: 24 })
+    expect(Number.isFinite(metrics.advanceWidth)).toBe(true)
+    expect(Number.isFinite(metrics.ascent)).toBe(true)
+    expect(Number.isFinite(metrics.descent)).toBe(true)
+    expect(Number.isFinite(metrics.lineGap)).toBe(true)
+    expect(metrics.advanceWidth).toBeGreaterThan(0)
+  })
+})

--- a/packages/server-core/src/render/fallback-measure.test.ts
+++ b/packages/server-core/src/render/fallback-measure.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { fallbackMeasureText } from './fallback-measure.js'
 
 describe('fallbackMeasureText', () => {
-  const font = { sizePx: 16, family: 'sans-serif', weight: 400 as const, style: 'normal' as const }
+  const font = {
+    sizePx: 16,
+    family: 'sans-serif',
+    fallbackChain: [] as readonly string[],
+    weight: 400,
+    style: 'normal' as const,
+  }
 
   it('returns advanceWidth proportional to text length and font size', () => {
     const metrics = fallbackMeasureText('hello', font)

--- a/packages/server-core/src/tools/canvas-crud.errors.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CanvasNotFoundError,
+  CanvasParentNotFoundError,
+  CanvasSegmentConflictError,
+} from './canvas-crud.errors.js'
+
+describe('CanvasNotFoundError', () => {
+  it('carries workspaceId and canvasId', () => {
+    const err = new CanvasNotFoundError('ws-1', 'canvas-abc')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('CanvasNotFoundError')
+    expect(err.workspaceId).toBe('ws-1')
+    expect(err.canvasId).toBe('canvas-abc')
+    expect(err.message).toContain('canvas-abc')
+    expect(err.message).toContain('ws-1')
+  })
+})
+
+describe('CanvasSegmentConflictError', () => {
+  it('carries the conflicting segment', () => {
+    const err = new CanvasSegmentConflictError('my-doc')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('CanvasSegmentConflictError')
+    expect(err.segment).toBe('my-doc')
+    expect(err.message).toContain('my-doc')
+  })
+})
+
+describe('CanvasParentNotFoundError', () => {
+  it('carries the parentId', () => {
+    const err = new CanvasParentNotFoundError('parent-xyz')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('CanvasParentNotFoundError')
+    expect(err.parentId).toBe('parent-xyz')
+    expect(err.message).toContain('parent-xyz')
+  })
+})

--- a/packages/server-core/src/tools/canvas-crud.schemas.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.schemas.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createCanvasInputSchema,
+  createCanvasOutputSchema,
+  deleteCanvasInputSchema,
+  deleteCanvasOutputSchema,
+  getCanvasInputSchema,
+  getCanvasOutputSchema,
+  listCanvasesInputSchema,
+  listCanvasesOutputSchema,
+} from './canvas-crud.schemas.js'
+
+const VALID_CANVAS_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const VALID_WORKSPACE_ID = 'my-workspace'
+
+describe('createCanvasInputSchema', () => {
+  it('accepts valid input with segment only', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'my-doc',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid input with optional parentId', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'child',
+      parentId: 'some-tree-node-id',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts single-character segment', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'a',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts segment with hyphens and underscores in the middle', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'my-doc_v2',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects segment with leading hyphen', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: '-leading',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects segment with trailing hyphen', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'trailing-',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty segment', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects segment with spaces', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'has space',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects segment with dots', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'file.txt',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty workspaceId', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: '',
+      segment: 'doc',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'doc',
+      extra: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty parentId', () => {
+    const result = createCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      segment: 'doc',
+      parentId: '',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createCanvasOutputSchema', () => {
+  it('accepts valid output', () => {
+    const result = createCanvasOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      segment: 'my-doc',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid canvasId', () => {
+    const result = createCanvasOutputSchema.safeParse({
+      canvasId: 'not-a-ulid',
+      segment: 'my-doc',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = createCanvasOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      segment: 'my-doc',
+      extra: 1,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('getCanvasInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = getCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing canvasId', () => {
+    const result = getCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = getCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      canvasId: VALID_CANVAS_ID,
+      extra: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('getCanvasOutputSchema', () => {
+  it('accepts valid canvas detail', () => {
+    const result = getCanvasOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      segment: 'my-doc',
+      alias: '/w/ws/c/my-doc',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing alias', () => {
+    const result = getCanvasOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      segment: 'my-doc',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = getCanvasOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      segment: 'my-doc',
+      alias: '/w/ws/c/my-doc',
+      extra: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('listCanvasesInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = listCanvasesInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects workspaceId with slash (path traversal)', () => {
+    const result = listCanvasesInputSchema.safeParse({
+      workspaceId: '../parent',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = listCanvasesInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      extra: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('listCanvasesOutputSchema', () => {
+  it('accepts empty canvases array', () => {
+    const result = listCanvasesOutputSchema.safeParse({
+      canvases: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts array with valid canvas details', () => {
+    const result = listCanvasesOutputSchema.safeParse({
+      canvases: [
+        { canvasId: VALID_CANVAS_ID, segment: 'doc-a', alias: '/c/doc-a' },
+        { canvasId: '01BX5ZZKBKACTAV9WEVGEMMVRZ', segment: 'doc-b', alias: '/c/doc-b' },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects canvas detail with missing segment', () => {
+    const result = listCanvasesOutputSchema.safeParse({
+      canvases: [{ canvasId: VALID_CANVAS_ID, alias: '/c/doc' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = listCanvasesOutputSchema.safeParse({
+      canvases: [],
+      total: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('deleteCanvasInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = deleteCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing workspaceId', () => {
+    const result = deleteCanvasInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('deleteCanvasOutputSchema', () => {
+  it('accepts { deleted: true }', () => {
+    const result = deleteCanvasOutputSchema.safeParse({ deleted: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects { deleted: false }', () => {
+    const result = deleteCanvasOutputSchema.safeParse({ deleted: false })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = deleteCanvasOutputSchema.safeParse({
+      deleted: true,
+      id: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/server-core/src/tools/canvas-crud.schemas.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.schemas.test.ts
@@ -157,6 +157,13 @@ describe('getCanvasInputSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('rejects missing workspaceId', () => {
+    const result = getCanvasInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+
   it('rejects extra keys (strict)', () => {
     const result = getCanvasInputSchema.safeParse({
       workspaceId: VALID_WORKSPACE_ID,
@@ -266,6 +273,22 @@ describe('deleteCanvasInputSchema', () => {
   it('rejects missing workspaceId', () => {
     const result = deleteCanvasInputSchema.safeParse({
       canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing canvasId', () => {
+    const result = deleteCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = deleteCanvasInputSchema.safeParse({
+      workspaceId: VALID_WORKSPACE_ID,
+      canvasId: VALID_CANVAS_ID,
+      force: true,
     })
     expect(result.success).toBe(false)
   })

--- a/packages/server-core/src/tools/version-schemas.test.ts
+++ b/packages/server-core/src/tools/version-schemas.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+import { versionListInputSchema, versionListOutputSchema } from './version-list.js'
+import {
+  VersionNotFoundError,
+  versionRestoreInputSchema,
+  versionRestoreOutputSchema,
+} from './version-restore.js'
+import { versionSaveInputSchema, versionSaveOutputSchema } from './version-save.js'
+
+const VALID_CANVAS_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+describe('versionSaveInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: 'Initial draft',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty label', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects label exceeding 200 characters', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: 'x'.repeat(201),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts label at exactly 200 characters', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: 'x'.repeat(200),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid canvasId', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: 'not-a-ulid',
+      label: 'draft',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = versionSaveInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: 'draft',
+      extra: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('versionSaveOutputSchema', () => {
+  it('accepts valid output', () => {
+    const result = versionSaveOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versionId: 'ver-1',
+      label: 'Initial draft',
+      timestamp: '2026-07-30T00:00:00.000Z',
+      frontier: 'abcdef0123',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing frontier', () => {
+    const result = versionSaveOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versionId: 'ver-1',
+      label: 'draft',
+      timestamp: '2026-07-30T00:00:00.000Z',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('versionListInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = versionListInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = versionListInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      limit: 10,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('versionListOutputSchema', () => {
+  it('accepts empty versions array', () => {
+    const result = versionListOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versions: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts versions with valid entries', () => {
+    const result = versionListOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versions: [
+        { versionId: 'v1', label: 'first', timestamp: '2026-01-01T00:00:00Z', frontier: 'aa' },
+        { versionId: 'v2', label: 'second', timestamp: '2026-01-02T00:00:00Z', frontier: 'bb' },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects version entry missing label', () => {
+    const result = versionListOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versions: [{ versionId: 'v1', timestamp: '2026-01-01T00:00:00Z', frontier: 'aa' }],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('versionRestoreInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = versionRestoreInputSchema.safeParse({
+      workspaceId: 'default',
+      canvasId: VALID_CANVAS_ID,
+      versionId: 'ver-1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty versionId', () => {
+    const result = versionRestoreInputSchema.safeParse({
+      workspaceId: 'default',
+      canvasId: VALID_CANVAS_ID,
+      versionId: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing workspaceId', () => {
+    const result = versionRestoreInputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      versionId: 'ver-1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra keys (strict)', () => {
+    const result = versionRestoreInputSchema.safeParse({
+      workspaceId: 'default',
+      canvasId: VALID_CANVAS_ID,
+      versionId: 'ver-1',
+      force: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('versionRestoreOutputSchema', () => {
+  it('accepts valid output', () => {
+    const result = versionRestoreOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      restoredVersionId: 'ver-1',
+      label: 'Initial draft',
+      frontier: 'abcdef0123',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing restoredVersionId', () => {
+    const result = versionRestoreOutputSchema.safeParse({
+      canvasId: VALID_CANVAS_ID,
+      label: 'draft',
+      frontier: 'aa',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('VersionNotFoundError', () => {
+  it('carries canvasId and versionId', () => {
+    const err = new VersionNotFoundError(VALID_CANVAS_ID, 'ver-99')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('VersionNotFoundError')
+    expect(err.canvasId).toBe(VALID_CANVAS_ID)
+    expect(err.versionId).toBe('ver-99')
+    expect(err.message).toContain('ver-99')
+  })
+})


### PR DESCRIPTION
## Summary

- Add accept/reject tests for all 6 canvas-crud schemas (segment validation, strict mode, workspaceId/canvasId constraints)
- Add error class instantiation tests for `CanvasNotFoundError`, `CanvasSegmentConflictError`, `CanvasParentNotFoundError`
- Add unit tests for `fallbackMeasureText` (proportionality, scaling, finiteness)
- Add accept/reject tests for all 6 version tool schemas (save/list/restore input+output) plus `VersionNotFoundError`

## Test plan

- [x] `pnpm test --project server-core-node` passes (212 tests)
- [x] `pnpm --filter @kamiazya/whiteboard-server-core typecheck` passes