### PR TITLE
fix(mcp-server): add branchName to versionCreatedPayloadSchema

### DIFF
--- a/apps/web/src/hooks/useCanvasSync.test.ts
+++ b/apps/web/src/hooks/useCanvasSync.test.ts
@@ -622,6 +622,7 @@ describe('useCanvasSync', () => {
         elementCount: 3,
         auto: false,
         hasThumbnail: false,
+        branchName: 'main',
       }
       act(() => {
         backend._ctrl.handlers!.onVersionCreated(payload)
@@ -1777,6 +1778,7 @@ describe('useCanvasSync', () => {
         elementCount: 3,
         auto: false,
         hasThumbnail: false,
+        branchName: 'main',
       }
       act(() => {
         backend._ctrl.handlers!.onVersionCreated(payload)
@@ -1809,6 +1811,7 @@ describe('useCanvasSync', () => {
           elementCount: 0,
           auto: false,
           hasThumbnail: false,
+          branchName: 'main',
         })
       })
 
@@ -1829,6 +1832,7 @@ describe('useCanvasSync', () => {
           elementCount: 0,
           auto: false,
           hasThumbnail: false,
+          branchName: 'main',
         })
       })
 

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -1620,6 +1620,7 @@ describe('DaemonCanvasPage', () => {
           elementCount: 1,
           auto: false,
           hasThumbnail: false,
+          branchName: 'main',
         })
       })
 

--- a/packages/mcp-server/src/shared/ws-messages.test.ts
+++ b/packages/mcp-server/src/shared/ws-messages.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { versionCreatedMessageSchema } from './ws-messages.js'
+
+const VALID_VERSION_CREATED = {
+  type: 'version_created' as const,
+  version: {
+    id: 'ver-1',
+    slug: 'my-canvas',
+    createdAt: '2026-07-30T00:00:00.000Z',
+    elementCount: 42,
+    auto: false,
+    hasThumbnail: true,
+    branchName: 'main',
+  },
+}
+
+describe('versionCreatedMessageSchema', () => {
+  it('accepts valid version_created with branchName', () => {
+    const result = versionCreatedMessageSchema.safeParse(VALID_VERSION_CREATED)
+    expect(result.success).toBe(true)
+  })
+
+  it('preserves branchName through parse', () => {
+    const result = versionCreatedMessageSchema.parse(VALID_VERSION_CREATED)
+    expect(result.version.branchName).toBe('main')
+  })
+
+  it('accepts with optional label and operator', () => {
+    const result = versionCreatedMessageSchema.safeParse({
+      ...VALID_VERSION_CREATED,
+      version: {
+        ...VALID_VERSION_CREATED.version,
+        label: 'snapshot',
+        operator: { kind: 'ai', peerId: 'agent-1' },
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing branchName', () => {
+    const { branchName: _, ...versionWithout } = VALID_VERSION_CREATED.version
+    const result = versionCreatedMessageSchema.safeParse({
+      ...VALID_VERSION_CREATED,
+      version: versionWithout,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing elementCount', () => {
+    const { elementCount: _, ...versionWithout } = VALID_VERSION_CREATED.version
+    const result = versionCreatedMessageSchema.safeParse({
+      ...VALID_VERSION_CREATED,
+      version: versionWithout,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/shared/ws-messages.ts
+++ b/packages/mcp-server/src/shared/ws-messages.ts
@@ -23,6 +23,7 @@ const versionCreatedPayloadSchema = z.object({
   auto: z.boolean(),
   label: z.string().optional(),
   hasThumbnail: z.boolean(),
+  branchName: z.string(),
   operator: operatorInfoSchema.optional(),
 })
 


### PR DESCRIPTION
## Summary

- `versionCreatedPayloadSchema` in `ws-messages.ts` was missing `branchName`, causing Zod `.parse()` on the client side to silently strip the field from `version_created` WebSocket messages.
- Added `branchName: z.string()` to the schema and created `ws-messages.test.ts` with accept/reject tests.
- Updated test payloads in `useCanvasSync.test.ts` and `DaemonCanvasPage.test.tsx` to include the now-required field.

## Test plan

- [x] New `ws-messages.test.ts` verifies `branchName` is preserved through parse and rejected when missing
- [x] `pnpm test --project mcp-node` — all 3500 tests pass
- [x] `pnpm -r typecheck` — all packages pass