### PR TITLE
chore: add engines.node >=22 to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@11.12.0",
+  "engines": {
+    "node": ">=22"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kamiazya/whiteboard.git"


### PR DESCRIPTION
## Summary

- Add `engines.node >= 22` to the root `package.json`, matching the existing constraint in `packages/mcp-server/package.json`.
- Ensures contributors on older Node versions get an early install-time error instead of cryptic runtime failures.

## Test plan

- [x] Config-only change — no runtime behavior affected
- [x] `.node-version` is 24, CI uses Node 24 — constraint is satisfied