### PR TITLE
feat(arch-lint): extend coverage to all shared-layer packages

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -7,9 +7,9 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/canvas-model` | Zod schemas for the OpenCanvas data model (single source of truth) | zod only |
 | `packages/canvas-codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
 | `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, zod |
-| `packages/canvas-ports` | store/sync port contracts + Symbol `TOKENS` | model |
-| `packages/canvas-workspace` | tree ops, alias derivation, index derivation, link extraction | model, codec, ports |
-| `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render |
+| `packages/canvas-ports` | store/sync port contracts + Symbol `TOKENS` | model, zod |
+| `packages/canvas-workspace` | tree ops, alias derivation, index derivation, link extraction | model, codec, ports, loro-crdt |
+| `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render, hono, zod, loro-crdt |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
 | `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls | workspace, render + port impls |
 

--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -8,8 +8,8 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/canvas-codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
 | `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, zod |
 | `packages/canvas-ports` | store/sync port contracts + Symbol `TOKENS` | model |
-| `packages/canvas-workspace` (planned) | tree ops, alias derivation, index derivation, link extraction | model, codec, ports |
-| `packages/server-core` (planned) | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render |
+| `packages/canvas-workspace` | tree ops, alias derivation, index derivation, link extraction | model, codec, ports |
+| `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
 | `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls | workspace, render + port impls |
 
@@ -19,6 +19,6 @@ Absolute rules:
 2. Dependencies flow only in the table's direction. Composition roots are never imported by shared packages.
 3. Unsure where code goes → load the `package-placement` skill (planned). DI wiring → `di-container` skill (planned).
 
-These rules are enforced by `tools/arch-lint` (vitest project `arch-lint-node`): a TypeScript-compiler-API scan for banned imports/globals, plus a package.json dependency-direction check against this table's data-driven mirror (`tools/arch-lint/src/architecture-map.ts`). It currently covers `canvas-model` and `canvas-codec`; extend its package list as later shared-layer packages land. Per-package details live in `.claude/rules/package-<name>.md` (path-scoped). Note: `./skills/` (product MCP skills) is unrelated to `.claude/skills/` (dev workflow skills).
+These rules are enforced by `tools/arch-lint` (vitest project `arch-lint-node`): a TypeScript-compiler-API scan for banned imports/globals, a package.json dependency-direction check, and a per-package allowed-third-party-dependency check, all against this table's data-driven mirror (`tools/arch-lint/src/architecture-map.ts`). It currently covers all six shared-layer packages: `canvas-model`, `canvas-codec`, `canvas-render`, `canvas-ports`, `canvas-workspace`, and `server-core`; extend its package list as later shared-layer packages land. Per-package details live in `.claude/rules/package-<name>.md` (path-scoped). Note: `./skills/` (product MCP skills) is unrelated to `.claude/skills/` (dev workflow skills).
 
 The LoroDoc<->model bridge originally scoped for `canvas-codec` is DEFERRED to `canvas-workspace` — a single-document codec has no need for CRDT merge semantics, and pulling `loro-crdt` into this package would violate its own "model + remark only" dependency rule.

--- a/tools/arch-lint/src/allowed-deps-check.test.ts
+++ b/tools/arch-lint/src/allowed-deps-check.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { checkAllowedDependencies } from './allowed-deps-check.js'
+
+describe('checkAllowedDependencies', () => {
+  it('passes when all non-internal deps are in the allowlist', () => {
+    const violations = checkAllowedDependencies({
+      name: '@kamiazya/whiteboard-canvas-model',
+      dependencies: { zod: '^4.0.0' },
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('fails when an unlisted third-party dep appears', () => {
+    const violations = checkAllowedDependencies({
+      name: '@kamiazya/whiteboard-canvas-model',
+      dependencies: { zod: '^4.0.0', lodash: '^4.17.0' },
+    })
+    expect(violations).toEqual([
+      { packageName: '@kamiazya/whiteboard-canvas-model', dependencyName: 'lodash' },
+    ])
+  })
+
+  it('ignores devDependencies entirely (only "dependencies" is inspected)', () => {
+    const violations = checkAllowedDependencies({
+      name: '@kamiazya/whiteboard-canvas-model',
+      dependencies: {},
+      devDependencies: { lodash: '^4.17.0' },
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('ignores internal workspace deps (already covered by direction-check)', () => {
+    const violations = checkAllowedDependencies({
+      name: '@kamiazya/whiteboard-canvas-codec',
+      dependencies: { '@kamiazya/whiteboard-canvas-model': 'workspace:*' },
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('allows catalog: version specifiers', () => {
+    const violations = checkAllowedDependencies({
+      name: '@kamiazya/whiteboard-canvas-codec',
+      dependencies: { zod: 'catalog:', unified: 'catalog:' },
+    })
+    expect(violations).toHaveLength(0)
+  })
+})

--- a/tools/arch-lint/src/allowed-deps-check.ts
+++ b/tools/arch-lint/src/allowed-deps-check.ts
@@ -1,0 +1,28 @@
+import { ARCHITECTURE_MAP, allowedThirdPartyDependencies } from './architecture-map.js'
+import type { PackageManifest } from './direction-check.js'
+
+export interface AllowedDepsViolation {
+  readonly packageName: string
+  readonly dependencyName: string
+}
+
+/**
+ * A dependency that names another package in the architecture map is
+ * direction-check.ts's concern, not this one — this check only inspects
+ * the remaining, non-internal entries of a `package.json` "dependencies"
+ * object against the package's declared `allowedThirdParty` list.
+ * `devDependencies` are never inspected.
+ */
+export function checkAllowedDependencies(manifest: PackageManifest): AllowedDepsViolation[] {
+  const violations: AllowedDepsViolation[] = []
+  const allowedThirdParty = new Set(allowedThirdPartyDependencies(manifest.name))
+
+  for (const dependencyName of Object.keys(manifest.dependencies ?? {})) {
+    const isInternalPackage = dependencyName in ARCHITECTURE_MAP
+    if (!isInternalPackage && !allowedThirdParty.has(dependencyName)) {
+      violations.push({ packageName: manifest.name, dependencyName })
+    }
+  }
+
+  return violations
+}

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -1,29 +1,82 @@
 /**
  * Data-driven mirror of the "May depend on" column in
- * .claude/rules/architecture-map.md. Each entry lists every package this
- * package's non-dev dependencies are allowed to name — a package.json
- * dependency not on its own list is a direction violation. `devDependencies`
- * are exempt (tooling, not runtime coupling) per the same doc.
+ * .claude/rules/architecture-map.md, extended with each package's allowed
+ * third-party (non-workspace) dependencies. `allowedInternalDeps` feeds
+ * `direction-check.ts` (internal-package direction); `allowedThirdParty`
+ * feeds `allowed-deps-check.ts` (everything else a `dependencies` entry
+ * could name). `devDependencies` are exempt from both — tooling, not
+ * runtime coupling — per the same doc.
  */
-export const ARCHITECTURE_MAP: Readonly<Record<string, readonly string[]>> = {
-  '@kamiazya/whiteboard-canvas-model': [],
-  '@kamiazya/whiteboard-canvas-codec': ['@kamiazya/whiteboard-canvas-model'],
-  '@kamiazya/whiteboard-canvas-render': ['@kamiazya/whiteboard-canvas-model'],
-  '@kamiazya/whiteboard-canvas-ports': ['@kamiazya/whiteboard-canvas-model'],
-  '@kamiazya/whiteboard-canvas-workspace': [
-    '@kamiazya/whiteboard-canvas-model',
-    '@kamiazya/whiteboard-canvas-codec',
-    '@kamiazya/whiteboard-canvas-ports',
-  ],
-  '@kamiazya/whiteboard-server-core': [
-    '@kamiazya/whiteboard-canvas-model',
-    '@kamiazya/whiteboard-canvas-codec',
-    '@kamiazya/whiteboard-canvas-render',
-    '@kamiazya/whiteboard-canvas-ports',
-    '@kamiazya/whiteboard-canvas-workspace',
-  ],
+export interface PackageArchEntry {
+  readonly allowedInternalDeps: readonly string[]
+  readonly allowedThirdParty: readonly string[]
+}
+
+export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
+  '@kamiazya/whiteboard-canvas-model': {
+    allowedInternalDeps: [],
+    allowedThirdParty: ['zod'],
+  },
+  '@kamiazya/whiteboard-canvas-codec': {
+    allowedInternalDeps: ['@kamiazya/whiteboard-canvas-model'],
+    allowedThirdParty: [
+      'zod',
+      'unified',
+      'remark-parse',
+      'remark-stringify',
+      'remark-gfm',
+      'remark-math',
+      'yaml',
+    ],
+  },
+  '@kamiazya/whiteboard-canvas-render': {
+    allowedInternalDeps: ['@kamiazya/whiteboard-canvas-model'],
+    allowedThirdParty: ['zod'],
+  },
+  '@kamiazya/whiteboard-canvas-ports': {
+    allowedInternalDeps: ['@kamiazya/whiteboard-canvas-model'],
+    allowedThirdParty: ['zod'],
+  },
+  '@kamiazya/whiteboard-canvas-workspace': {
+    allowedInternalDeps: [
+      '@kamiazya/whiteboard-canvas-model',
+      '@kamiazya/whiteboard-canvas-codec',
+      '@kamiazya/whiteboard-canvas-ports',
+    ],
+    // loro-crdt: this package owns the LoroDoc<->model bridge (see
+    // .claude/rules/package-canvas-workspace.md), so it's the one shared-
+    // layer package (besides server-core, which re-exposes the bridge via
+    // its Loro-backed store ports) allowed to import it directly.
+    allowedThirdParty: ['loro-crdt'],
+  },
+  '@kamiazya/whiteboard-server-core': {
+    allowedInternalDeps: [
+      '@kamiazya/whiteboard-canvas-model',
+      '@kamiazya/whiteboard-canvas-codec',
+      '@kamiazya/whiteboard-canvas-render',
+      '@kamiazya/whiteboard-canvas-ports',
+      '@kamiazya/whiteboard-canvas-workspace',
+    ],
+    allowedThirdParty: ['hono', 'zod', 'loro-crdt'],
+  },
 }
 
 export function allowedDependencies(packageName: string): readonly string[] {
-  return ARCHITECTURE_MAP[packageName] ?? []
+  return ARCHITECTURE_MAP[packageName]?.allowedInternalDeps ?? []
+}
+
+export function allowedThirdPartyDependencies(packageName: string): readonly string[] {
+  return ARCHITECTURE_MAP[packageName]?.allowedThirdParty ?? []
+}
+
+/**
+ * The scanner's loro-crdt exemption (see `scanner.ts` / `repo-coverage.test.ts`)
+ * is data-driven from this set, not an ad hoc heuristic: a package may import
+ * `loro-crdt` from source iff it's declared here as an allowed third-party
+ * dependency.
+ */
+export function packagesAllowedToImportLoroCrdt(): readonly string[] {
+  return Object.entries(ARCHITECTURE_MAP)
+    .filter(([, entry]) => entry.allowedThirdParty.includes('loro-crdt'))
+    .map(([packageName]) => packageName)
 }

--- a/tools/arch-lint/src/direction-check.ts
+++ b/tools/arch-lint/src/direction-check.ts
@@ -8,6 +8,7 @@ export interface DirectionViolation {
 export interface PackageManifest {
   readonly name: string
   readonly dependencies?: Readonly<Record<string, string>>
+  readonly devDependencies?: Readonly<Record<string, string>>
 }
 
 /**

--- a/tools/arch-lint/src/repo-coverage.test.ts
+++ b/tools/arch-lint/src/repo-coverage.test.ts
@@ -1,10 +1,13 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { checkAllowedDependencies } from './allowed-deps-check.js'
+import { packagesAllowedToImportLoroCrdt } from './architecture-map.js'
 import { checkDependencyDirection } from './direction-check.js'
 import { scanSourceForBoundaryViolations } from './scanner.js'
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..', '..')
+const ARCHITECTURE_MAP_DOC = join(REPO_ROOT, '.claude', 'rules', 'architecture-map.md')
 const SHARED_LAYER_PACKAGES = [
   'packages/canvas-model',
   'packages/canvas-codec',
@@ -34,10 +37,11 @@ describe('shared-layer boundary lint (real source coverage)', () => {
       const manifest = JSON.parse(
         readFileSync(join(REPO_ROOT, packageDir, 'package.json'), 'utf-8'),
       )
-      // loro-crdt is a declared runtime dependency (and thus a legitimate
-      // import) for packages that own the LoroDoc<->model bridge —
-      // everywhere else it's still a boundary violation.
-      const loroCrdtIsDeclaredDependency = 'loro-crdt' in (manifest.dependencies ?? {})
+      // loro-crdt is a legitimate import ONLY for packages architecture-map.ts
+      // explicitly lists as allowed to declare it — never an implicit "it's a
+      // dependency, so allow it" heuristic, so an unmapped package that adds
+      // loro-crdt still fails loudly via `allowed-deps-check`.
+      const loroCrdtIsExempt = packagesAllowedToImportLoroCrdt().includes(manifest.name)
 
       const srcDir = join(REPO_ROOT, packageDir, 'src')
       const files = listTsFiles(srcDir)
@@ -45,7 +49,7 @@ describe('shared-layer boundary lint (real source coverage)', () => {
 
       for (const file of files) {
         const allViolations = scanSourceForBoundaryViolations(file, readFileSync(file, 'utf-8'))
-        const violations = loroCrdtIsDeclaredDependency
+        const violations = loroCrdtIsExempt
           ? allViolations.filter((v) => v.kind !== 'loro-crdt-import')
           : allViolations
         expect(violations, `${file}: ${JSON.stringify(violations)}`).toHaveLength(0)
@@ -59,5 +63,28 @@ describe('shared-layer boundary lint (real source coverage)', () => {
       const violations = checkDependencyDirection(manifest)
       expect(violations).toHaveLength(0)
     })
+
+    it(`${packageDir}/package.json has no unlisted third-party dependency`, () => {
+      const manifest = JSON.parse(
+        readFileSync(join(REPO_ROOT, packageDir, 'package.json'), 'utf-8'),
+      )
+      const violations = checkAllowedDependencies(manifest)
+      expect(violations).toHaveLength(0)
+    })
   }
+})
+
+describe('architecture-map.md doc sync', () => {
+  const doc = readFileSync(ARCHITECTURE_MAP_DOC, 'utf-8')
+
+  it('lists every SHARED_LAYER_PACKAGES entry in its prose', () => {
+    const missing = SHARED_LAYER_PACKAGES.map(
+      (packageDir) => packageDir.split('/').pop() as string,
+    ).filter((basename) => !doc.includes(basename))
+    expect(missing).toHaveLength(0)
+  })
+
+  it('no longer contains the stale "currently covers canvas-model and canvas-codec" claim', () => {
+    expect(doc).not.toContain('It currently covers `canvas-model` and `canvas-codec`')
+  })
 })


### PR DESCRIPTION
## Summary

- Extend arch-lint from covering only canvas-model and canvas-codec to all six shared-layer packages: canvas-model, canvas-codec, canvas-render, canvas-ports, canvas-workspace, and server-core.
- Add per-package allowed-third-party-dependency check (`allowed-deps-check.ts`) alongside the existing banned-import scan and dependency-direction check.
- Make the loro-crdt scanner exemption data-driven from `architecture-map.ts` instead of an ad-hoc heuristic.
- Update `.claude/rules/architecture-map.md` to reflect actual coverage.

## Test plan

- [x] `pnpm test --project arch-lint-node` — all 44 tests pass
- [ ] CI `verify` workflow passes
- [ ] No regressions in existing arch-lint checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation to detect unapproved third-party dependencies while allowing internal workspace packages and catalog-based versions.
  - Strengthened package boundary checks and centralized permitted dependency rules.

- **Tests**
  - Expanded automated coverage for dependency allowlists, development-only dependencies, workspace packages, and repository-wide architecture compliance.

- **Documentation**
  - Updated the architecture guide with current dependency allowances and details about enforced validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->