### PR TITLE
chore: update stale comment in StorageReportCard schema

### DIFF
--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -21,12 +21,9 @@ import {
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { formatBytes } from '../lib/format-bytes.js'
 
-// Mirrors userLibrarySummarySchema / listUserLibrariesResponseSchema in
-// packages/mcp-server/src/shared/api-contracts/libraries.ts. That module is
-// deliberately kept off the public `./api-contracts` npm subpath (see the
-// barrel comment there and api-contracts-barrel.test.ts), so this schema is
-// duplicated here rather than imported, pending a decision to widen the
-// published surface.
+// Schema for the daemon's /api/v1/user-libraries response.
+// This is the sole definition — the former api-contracts/libraries.ts was
+// removed during the OpenCanvas migration.
 const userLibraryRowSchema = z.object({
   name: z.string(),
   path: z.string(),


### PR DESCRIPTION
## Summary

- Update stale comment in `apps/web/src/components/StorageReportCard.tsx` that referenced the now-deleted `packages/mcp-server/src/shared/api-contracts/libraries.ts`
- The former file was removed during the OpenCanvas migration, leaving this as the sole schema definition

## Test plan

- [x] Comment-only change, no behavior change
- [x] Pre-push gate passed (typecheck + mcp-node tests + noconsole)