### PR TITLE
fix(web): make CapabilityTeaser inert when no onAction is wired

### DIFF
--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
@@ -45,11 +45,40 @@ describe('CapabilityTeaser', () => {
     expect(onAncestorClick).not.toHaveBeenCalled()
   })
 
-  it('mutation-check: drops aria-disabled and the sr-only description once the capability is enabled', () => {
-    render(<CapabilityTeaser label="Merge" enabled={true} />)
+  it('mutation-check: drops aria-disabled and the sr-only description once enabled with onAction wired', () => {
+    render(<CapabilityTeaser label="Merge" enabled={true} onAction={vi.fn()} />)
     const control = screen.getByRole('button', { name: 'Merge' })
     expect(control.getAttribute('aria-disabled')).toBeNull()
     expect(control.getAttribute('aria-describedby')).toBeNull()
     expect(screen.queryByText('Connect a local daemon (MCP) to enable Merge')).toBeNull()
+  })
+
+  it('stays aria-disabled with a tooltip when enabled but no onAction is wired', () => {
+    render(<CapabilityTeaser label="Merge" enabled={true} />)
+    const control = screen.getByRole('button', { name: 'Merge' })
+    expect(control.getAttribute('aria-disabled')).toBe('true')
+    const describedById = control.getAttribute('aria-describedby')
+    expect(describedById).toBeTruthy()
+    const description = document.getElementById(describedById as string)
+    expect(description?.textContent).toBe('This feature is not yet available')
+  })
+
+  it('does not call onAction when clicked while disabled', () => {
+    const onAction = vi.fn()
+    render(<CapabilityTeaser label="Merge" enabled={false} onAction={onAction} />)
+    screen.getByRole('button', { name: 'Merge' }).click()
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('does not call onAction when enabled but no onAction is wired', () => {
+    render(<CapabilityTeaser label="Merge" enabled={true} />)
+    screen.getByRole('button', { name: 'Merge' }).click()
+  })
+
+  it('calls onAction when enabled and onAction is wired', () => {
+    const onAction = vi.fn()
+    render(<CapabilityTeaser label="Merge" enabled={true} onAction={onAction} />)
+    screen.getByRole('button', { name: 'Merge' }).click()
+    expect(onAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 interface CapabilityTeaserProps {
   label: string
   enabled: boolean
+  onAction?: () => void
 }
 
 // Daemon-only feature affordance shown while the capability is unavailable
@@ -14,18 +15,24 @@ interface CapabilityTeaserProps {
 // keyboard. The sr-only description is always rendered (not just while a
 // Radix tooltip happens to be open) so assistive tech gets it via
 // aria-describedby regardless of hover/focus timing.
-export function CapabilityTeaser({ label, enabled }: CapabilityTeaserProps) {
+export function CapabilityTeaser({ label, enabled, onAction }: CapabilityTeaserProps) {
   const descriptionId = useId()
-  const description = `Connect a local daemon (MCP) to enable ${label}`
+  // `enabled` alone is not enough to make this control interactive: without a
+  // wired onAction it would look clickable but do nothing, which reads as a
+  // broken control rather than a genuinely inert affordance.
+  const isInteractive = enabled && onAction !== undefined
+  const description = enabled
+    ? 'This feature is not yet available'
+    : `Connect a local daemon (MCP) to enable ${label}`
 
   const button = (
     <button
       type="button"
-      aria-disabled={enabled ? undefined : true}
-      aria-describedby={enabled ? undefined : descriptionId}
+      aria-disabled={isInteractive ? undefined : true}
+      aria-describedby={isInteractive ? undefined : descriptionId}
       tabIndex={0}
       onClick={(event) => {
-        if (!enabled) {
+        if (!isInteractive) {
           // aria-disabled (unlike native `disabled`) still dispatches and bubbles
           // click events, so stop it here to stay truly inert even inside a
           // clickable ancestor.
@@ -33,8 +40,7 @@ export function CapabilityTeaser({ label, enabled }: CapabilityTeaserProps) {
           event.stopPropagation()
           return
         }
-        // Daemon-mode wiring for this feature ships in a later slice; treat
-        // as a no-op affordance until then rather than a broken control.
+        onAction()
       }}
       className="rounded-md border px-3 py-1 text-xs font-medium transition-colors aria-disabled:cursor-not-allowed aria-disabled:opacity-50 hover:aria-disabled:bg-transparent hover:not-aria-disabled:bg-accent"
     >
@@ -42,7 +48,7 @@ export function CapabilityTeaser({ label, enabled }: CapabilityTeaserProps) {
     </button>
   )
 
-  if (enabled) {
+  if (isInteractive) {
     return button
   }
 


### PR DESCRIPTION
## Summary

- Add optional `onAction` callback prop to `CapabilityTeaser`
- Button is now inert (aria-disabled, click suppressed, tooltip shown) unless BOTH `enabled` is true AND `onAction` is provided
- When enabled but no `onAction`: shows "This feature is not yet available" tooltip
- When disabled: shows existing daemon-connect tooltip
- Existing callers pass no `onAction`, so they correctly render inert without changes

## Test plan

- [x] 9/9 jsdom tests pass (disabled/enabled-no-action/enabled-with-action scenarios)
- [x] 139 browser tests pass (existing CapabilityTeaser.browser.test.tsx unchanged)
- [x] Typecheck clean
- [ ] CI verify pass