### PR TITLE
test(mcp-server): add schema conformance tests for export api-contracts

### DIFF
--- a/packages/mcp-server/src/server/export/headless-export-options.types.test.ts
+++ b/packages/mcp-server/src/server/export/headless-export-options.types.test.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf, it } from 'vitest'
+import type { z } from 'zod'
+import type { exportRequestSchema } from '../../shared/api-contracts/export.js'
+import type { exportSvgRequestSchema } from '../../shared/api-contracts/export-svg.js'
+import type { HeadlessCanvasExportOptions } from './headless-export.js'
+
+// Compile-time only: HeadlessCanvasExportOptions is a hand-written interface
+// that mirrors a subset of exportRequestSchema's/exportSvgRequestSchema's
+// fields rather than deriving from them via z.infer, so it can silently
+// drift from the wire schema — the exact class of bug zod-schema-discipline
+// exists to catch. routes/export.ts forwards padding/scale/frameId/minFontPx/
+// theme from exportRequestSchema; routes/canvas/export-svg.ts forwards only
+// padding/frameId/theme from exportSvgRequestSchema (no scale/minFontPx —
+// vector output has neither raster scale nor a font-bump ceiling).
+
+it('HeadlessCanvasExportOptions matches the PNG route-forwarded exportRequestSchema fields exactly', () => {
+  expectTypeOf<HeadlessCanvasExportOptions>().toEqualTypeOf<
+    Pick<
+      z.infer<typeof exportRequestSchema>,
+      'padding' | 'scale' | 'frameId' | 'minFontPx' | 'theme'
+    >
+  >()
+})
+
+it('the SVG-relevant subset of HeadlessCanvasExportOptions matches exportSvgRequestSchema exactly', () => {
+  expectTypeOf<Pick<HeadlessCanvasExportOptions, 'padding' | 'frameId' | 'theme'>>().toEqualTypeOf<
+    Pick<z.infer<typeof exportSvgRequestSchema>, 'padding' | 'frameId' | 'theme'>
+  >()
+})

--- a/packages/mcp-server/src/server/routes/canvas/export-svg.ts
+++ b/packages/mcp-server/src/server/routes/canvas/export-svg.ts
@@ -4,7 +4,10 @@ import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { nanoid } from 'nanoid'
 import type { ExportErrorBody } from '../../../shared/api-contracts/export.js'
-import { exportSvgRequestSchema } from '../../../shared/api-contracts/export-svg.js'
+import {
+  type ExportSvgRequest,
+  exportSvgRequestSchema,
+} from '../../../shared/api-contracts/export-svg.js'
 import { getDataDir } from '../../config.js'
 import { exportCanvasHeadlessSvg } from '../../export/headless-export.js'
 import { OutputPathError, validateOutputPath } from '../../output-path.js'
@@ -52,7 +55,7 @@ export function createCanvasSvgExportRouter() {
       }
 
       const rawText = await c.req.text()
-      let body: ReturnType<typeof exportSvgRequestSchema.parse> = {}
+      let body: ExportSvgRequest = {}
       if (rawText.length > 0) {
         let json: unknown
         try {

--- a/packages/mcp-server/src/shared/api-contracts/export-svg.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export-svg.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { exportSvgRequestSchema } from './export-svg.js'
+
+describe('exportSvgRequestSchema', () => {
+  it('accepts an empty object (every field optional)', () => {
+    expect(exportSvgRequestSchema.parse({})).toEqual({})
+  })
+
+  it('accepts every field populated', () => {
+    const input = {
+      padding: 16,
+      frameId: 'frame-1',
+      outputPath: '/tmp/out.svg',
+      overwrite: true,
+      theme: 'dark' as const,
+    }
+    expect(exportSvgRequestSchema.parse(input)).toEqual(input)
+  })
+
+  it('rejects a non-string frameId', () => {
+    expect(() => exportSvgRequestSchema.parse({ frameId: 42 })).toThrow()
+  })
+
+  it('rejects a theme outside the light/dark enum', () => {
+    expect(() => exportSvgRequestSchema.parse({ theme: 'sepia' })).toThrow()
+  })
+
+  it('has no scale field (vector output is resolution-independent)', () => {
+    expect(exportSvgRequestSchema.parse({ scale: 2 })).toEqual({})
+  })
+})

--- a/packages/mcp-server/src/shared/api-contracts/export-svg.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export-svg.ts
@@ -14,3 +14,5 @@ export const exportSvgRequestSchema = z.object({
   overwrite: z.boolean().optional(),
   theme: z.enum(['light', 'dark']).optional(),
 })
+
+export type ExportSvgRequest = z.infer<typeof exportSvgRequestSchema>

--- a/packages/mcp-server/src/shared/api-contracts/export-svg.types.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export-svg.types.test.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf, it } from 'vitest'
+import type { z } from 'zod'
+import type { exportSvgRequestSchema, ExportSvgRequest } from './export-svg.js'
+
+// Compile-time only: proves ExportSvgRequest is exactly the z.infer of
+// exportSvgRequestSchema, so a future hand-written edit to the type cannot
+// silently drift from the schema the export-svg route validates against.
+
+it('ExportSvgRequest is exactly z.infer<typeof exportSvgRequestSchema>', () => {
+  expectTypeOf<ExportSvgRequest>().toEqualTypeOf<z.infer<typeof exportSvgRequestSchema>>()
+})

--- a/packages/mcp-server/src/shared/api-contracts/export-svg.types.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export-svg.types.test.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, it } from 'vitest'
 import type { z } from 'zod'
-import type { exportSvgRequestSchema, ExportSvgRequest } from './export-svg.js'
+import type { ExportSvgRequest, exportSvgRequestSchema } from './export-svg.js'
 
 // Compile-time only: proves ExportSvgRequest is exactly the z.infer of
 // exportSvgRequestSchema, so a future hand-written edit to the type cannot

--- a/packages/mcp-server/src/shared/api-contracts/export.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { exportRequestSchema } from './export.js'
+
+describe('exportRequestSchema', () => {
+  it('accepts an empty object (every field optional)', () => {
+    expect(exportRequestSchema.parse({})).toEqual({})
+  })
+
+  it('accepts every field populated', () => {
+    const input = {
+      padding: 16,
+      scale: 2,
+      minFontPx: 12,
+      frameId: 'frame-1',
+      outputPath: '/tmp/out.png',
+      overwrite: true,
+      theme: 'dark' as const,
+    }
+    expect(exportRequestSchema.parse(input)).toEqual(input)
+  })
+
+  it('rejects a non-number padding', () => {
+    expect(() => exportRequestSchema.parse({ padding: '16' })).toThrow()
+  })
+
+  it('rejects a theme outside the light/dark enum', () => {
+    expect(() => exportRequestSchema.parse({ theme: 'sepia' })).toThrow()
+  })
+})

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -18,7 +18,7 @@ export const exportRequestSchema = z.object({
   theme: z.enum(['light', 'dark']).optional(),
 })
 
-const exportResponseSchema = z.object({
+export const exportResponseSchema = z.object({
   filePath: z.string(),
 })
 
@@ -26,7 +26,7 @@ const exportResponseSchema = z.object({
 // invalid_output_path / output_exists (400 / 409), and internal (500).
 // All fields are optional since some 5xx bodies come from proxies that
 // strip `error` without crashing the parser.
-const exportErrorBodySchema = z.object({
+export const exportErrorBodySchema = z.object({
   error: z.string().optional(),
   message: z.string().optional(),
   hint: z.string().optional(),

--- a/packages/mcp-server/src/shared/api-contracts/export.types.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.types.test.ts
@@ -1,10 +1,10 @@
 import { expectTypeOf, it } from 'vitest'
 import type { z } from 'zod'
 import type {
-  exportErrorBodySchema,
-  exportResponseSchema,
   ExportErrorBody,
   ExportResponse,
+  exportErrorBodySchema,
+  exportResponseSchema,
 } from './export.js'
 
 // Compile-time only: proves ExportResponse/ExportErrorBody are exactly the

--- a/packages/mcp-server/src/shared/api-contracts/export.types.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.types.test.ts
@@ -1,0 +1,20 @@
+import { expectTypeOf, it } from 'vitest'
+import type { z } from 'zod'
+import type {
+  exportErrorBodySchema,
+  exportResponseSchema,
+  ExportErrorBody,
+  ExportResponse,
+} from './export.js'
+
+// Compile-time only: proves ExportResponse/ExportErrorBody are exactly the
+// z.infer of their schema, so a future hand-written edit to either type
+// cannot silently drift from the schema the route validates against.
+
+it('ExportResponse is exactly z.infer<typeof exportResponseSchema>', () => {
+  expectTypeOf<ExportResponse>().toEqualTypeOf<z.infer<typeof exportResponseSchema>>()
+})
+
+it('ExportErrorBody is exactly z.infer<typeof exportErrorBodySchema>', () => {
+  expectTypeOf<ExportErrorBody>().toEqualTypeOf<z.infer<typeof exportErrorBodySchema>>()
+})


### PR DESCRIPTION
## Summary

- Add `expectTypeOf` compile-time conformance tests for `ExportResponse`, `ExportErrorBody`, and `ExportSvgRequest` to verify exported types match `z.infer` of their schemas
- Export `exportResponseSchema` and `exportErrorBodySchema` (previously unexported) so conformance tests can reference them
- Add `ExportSvgRequest` type alias (`z.infer<typeof exportSvgRequestSchema>`) and use it in the route handler instead of `ReturnType<typeof schema.parse>`

## Test plan

- [x] `pnpm test --project mcp-node` passes
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` passes
- [x] Mutation check: reverting production changes causes conformance tests to fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency between SVG export request validation and its shared API contract.
  * Made export response and error formats available through the shared contract.

* **Tests**
  * Added compile-time checks to ensure export request, response, and error types stay aligned with their validation schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->