### PR TITLE
feat(arch-lint): extend coverage to canvas-viewer and mcp-server

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -10,15 +10,16 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/canvas-ports` | store/sync port contracts + Symbol `TOKENS` | model, zod |
 | `packages/canvas-workspace` | tree ops, alias derivation, index derivation, link extraction | model, codec, ports, loro-crdt |
 | `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | workspace, render, hono, zod, loro-crdt |
+| `packages/canvas-viewer` | Read-only Excalidraw scene viewer UI, shared between `apps/web` and the MCP Apps widget | (no internal deps) `@excalidraw/excalidraw`, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
 | `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls | workspace, render + port impls |
 
 Absolute rules:
 
-1. Shared-layer packages (model / codec / render / ports / workspace / server-core) must not import `node:*`, DOM globals, or `inversify`.
-2. Dependencies flow only in the table's direction. Composition roots are never imported by shared packages.
+1. Shared-layer packages (model / codec / render / ports / workspace / server-core) must not import `node:*`, DOM globals, or `inversify`. `canvas-viewer` is a browser-runtime UI package, so DOM globals are its normal job — it is held only to the `node:*`/`inversify` half of this rule (plus one exempted build-time `Buffer` use in `widget/build-fonts-module.ts`; see its `exemptBoundaryViolationKinds` entry in `architecture-map.ts`).
+2. Dependencies flow only in the table's direction. Composition roots (`mcp-server`, `apps/web`) are never imported by shared packages or by `canvas-viewer` — `mcp-server` is registered in `architecture-map.ts` with an empty allowed-dependents list specifically so `direction-check.ts` catches a reverse import.
 3. Unsure where code goes → load the `package-placement` skill (planned). DI wiring → `di-container` skill (planned).
 
-These rules are enforced by `tools/arch-lint` (vitest project `arch-lint-node`): a TypeScript-compiler-API scan for banned imports/globals, a package.json dependency-direction check, and a per-package allowed-third-party-dependency check, all against this table's data-driven mirror (`tools/arch-lint/src/architecture-map.ts`). It currently covers all six shared-layer packages: `canvas-model`, `canvas-codec`, `canvas-render`, `canvas-ports`, `canvas-workspace`, and `server-core`; extend its package list as later shared-layer packages land. Per-package details live in `.claude/rules/package-<name>.md` (path-scoped). Note: `./skills/` (product MCP skills) is unrelated to `.claude/skills/` (dev workflow skills).
+These rules are enforced by `tools/arch-lint` (vitest project `arch-lint-node`): a TypeScript-compiler-API scan for banned imports/globals, a package.json dependency-direction check, and a per-package allowed-third-party-dependency check, all against this table's data-driven mirror (`tools/arch-lint/src/architecture-map.ts`). It currently covers all six shared-layer packages (`canvas-model`, `canvas-codec`, `canvas-render`, `canvas-ports`, `canvas-workspace`, `server-core`) plus `canvas-viewer`'s narrower scan; `mcp-server` is registered only for the reverse-dependency-direction guard, not source-scanned (composition roots are allowed `node:*`/`inversify`). Extend the package list as later shared-layer packages land. Per-package details live in `.claude/rules/package-<name>.md` (path-scoped). Note: `./skills/` (product MCP skills) is unrelated to `.claude/skills/` (dev workflow skills).
 
 The LoroDoc<->model bridge originally scoped for `canvas-codec` is DEFERRED to `canvas-workspace` — a single-document codec has no need for CRDT merge semantics, and pulling `loro-crdt` into this package would violate its own "model + remark only" dependency rule.

--- a/tools/arch-lint/src/architecture-map.test.ts
+++ b/tools/arch-lint/src/architecture-map.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { exemptedBoundaryViolationKinds } from './architecture-map.js'
+
+describe('exemptedBoundaryViolationKinds', () => {
+  it('exempts canvas-workspace from loro-crdt-import via allowedThirdParty, not an explicit list', () => {
+    const kinds = exemptedBoundaryViolationKinds('@kamiazya/whiteboard-canvas-workspace')
+    expect(kinds.has('loro-crdt-import')).toBe(true)
+    expect(kinds.has('dom-global')).toBe(false)
+  })
+
+  it('exempts canvas-viewer from dom-global and node-ambient-global but not node-builtin-import', () => {
+    const kinds = exemptedBoundaryViolationKinds('@kamiazya/whiteboard-canvas-viewer')
+    expect(kinds.has('dom-global')).toBe(true)
+    expect(kinds.has('node-ambient-global')).toBe(true)
+    expect(kinds.has('node-builtin-import')).toBe(false)
+    expect(kinds.has('inversify-import')).toBe(false)
+  })
+
+  it('returns an empty set for a package with no exemptions', () => {
+    const kinds = exemptedBoundaryViolationKinds('@kamiazya/whiteboard-canvas-model')
+    expect(kinds.size).toBe(0)
+  })
+
+  it('returns an empty set for an unmapped package name', () => {
+    const kinds = exemptedBoundaryViolationKinds('@kamiazya/not-a-real-package')
+    expect(kinds.size).toBe(0)
+  })
+})

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -1,3 +1,5 @@
+import type { BoundaryViolationKind } from './scanner.js'
+
 /**
  * Data-driven mirror of the "May depend on" column in
  * .claude/rules/architecture-map.md, extended with each package's allowed
@@ -6,10 +8,20 @@
  * feeds `allowed-deps-check.ts` (everything else a `dependencies` entry
  * could name). `devDependencies` are exempt from both — tooling, not
  * runtime coupling — per the same doc.
+ *
+ * `exemptBoundaryViolationKinds` opts a package OUT of specific
+ * `scanner.ts` violation kinds it legitimately needs — e.g. canvas-viewer
+ * is a browser-runtime UI package (DOM globals are its whole job) with one
+ * embedded Node-side build-time module (`widget/build-fonts-module.ts`
+ * uses `Buffer` to base64-encode font bytes at build time), so it is
+ * exempted from `dom-global`/`node-ambient-global` while still banned from
+ * `node-builtin-import`/`inversify-import` like every other shared-layer
+ * package.
  */
 export interface PackageArchEntry {
   readonly allowedInternalDeps: readonly string[]
   readonly allowedThirdParty: readonly string[]
+  readonly exemptBoundaryViolationKinds?: readonly BoundaryViolationKind[]
 }
 
 export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
@@ -59,6 +71,27 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
     ],
     allowedThirdParty: ['hono', 'zod', 'loro-crdt'],
   },
+  '@kamiazya/whiteboard-canvas-viewer': {
+    allowedInternalDeps: [],
+    allowedThirdParty: [
+      '@excalidraw/excalidraw',
+      '@modelcontextprotocol/ext-apps',
+      'react',
+      'react-dom',
+      'zod',
+    ],
+    exemptBoundaryViolationKinds: ['dom-global', 'node-ambient-global'],
+  },
+  // Composition root (Node CLI/daemon), never a runtime dependency of any
+  // shared-layer package. Registered here with an empty allowedInternalDeps
+  // so direction-check.ts flags the reverse import if a shared package ever
+  // adds it as a dependency; its own source is NOT scanned by
+  // repo-coverage.test.ts (it is allowed node:*/inversify — see
+  // architecture-map.md rule 2).
+  '@kamiazya/whiteboard-mcp': {
+    allowedInternalDeps: [],
+    allowedThirdParty: [],
+  },
 }
 
 export function allowedDependencies(packageName: string): readonly string[] {
@@ -79,4 +112,22 @@ export function packagesAllowedToImportLoroCrdt(): readonly string[] {
   return Object.entries(ARCHITECTURE_MAP)
     .filter(([, entry]) => entry.allowedThirdParty.includes('loro-crdt'))
     .map(([packageName]) => packageName)
+}
+
+/**
+ * Every `BoundaryViolationKind` a package's own source is exempt from,
+ * combining the automatic loro-crdt exemption above with each package's
+ * explicit `exemptBoundaryViolationKinds`. `repo-coverage.test.ts` filters
+ * `scanSourceForBoundaryViolations` output through this before asserting
+ * zero violations.
+ */
+export function exemptedBoundaryViolationKinds(
+  packageName: string,
+): ReadonlySet<BoundaryViolationKind> {
+  const entry = ARCHITECTURE_MAP[packageName]
+  const kinds = new Set<BoundaryViolationKind>(entry?.exemptBoundaryViolationKinds ?? [])
+  if (entry?.allowedThirdParty.includes('loro-crdt')) {
+    kinds.add('loro-crdt-import')
+  }
+  return kinds
 }

--- a/tools/arch-lint/src/direction-check.test.ts
+++ b/tools/arch-lint/src/direction-check.test.ts
@@ -42,4 +42,30 @@ describe('checkDependencyDirection', () => {
     })
     expect(violations).toHaveLength(0)
   })
+
+  it('fails a shared-layer package depending on the mcp-server composition root', () => {
+    const violations = checkDependencyDirection({
+      name: '@kamiazya/whiteboard-canvas-model',
+      dependencies: { '@kamiazya/whiteboard-mcp': 'workspace:*' },
+    })
+    expect(violations).toEqual([
+      {
+        packageName: '@kamiazya/whiteboard-canvas-model',
+        dependencyName: '@kamiazya/whiteboard-mcp',
+      },
+    ])
+  })
+
+  it('passes canvas-viewer (no internal deps, only third-party UI libs)', () => {
+    const violations = checkDependencyDirection({
+      name: '@kamiazya/whiteboard-canvas-viewer',
+      dependencies: {
+        '@excalidraw/excalidraw': 'catalog:',
+        react: 'catalog:',
+        'react-dom': 'catalog:',
+        zod: 'catalog:',
+      },
+    })
+    expect(violations).toHaveLength(0)
+  })
 })

--- a/tools/arch-lint/src/repo-coverage.test.ts
+++ b/tools/arch-lint/src/repo-coverage.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { checkAllowedDependencies } from './allowed-deps-check.js'
-import { packagesAllowedToImportLoroCrdt } from './architecture-map.js'
+import { exemptedBoundaryViolationKinds } from './architecture-map.js'
 import { checkDependencyDirection } from './direction-check.js'
 import { scanSourceForBoundaryViolations } from './scanner.js'
 
@@ -15,6 +15,11 @@ const SHARED_LAYER_PACKAGES = [
   'packages/canvas-ports',
   'packages/canvas-workspace',
   'packages/server-core',
+  // Browser-runtime UI package, not a "shared" model/codec/... layer package
+  // in the architecture-map.md sense, but scanned the same way — see its
+  // `exemptBoundaryViolationKinds` entry in architecture-map.ts for why DOM
+  // globals and one build-time `Buffer` use don't trip the scan.
+  'packages/canvas-viewer',
 ]
 
 function listTsFiles(dir: string): string[] {
@@ -37,11 +42,11 @@ describe('shared-layer boundary lint (real source coverage)', () => {
       const manifest = JSON.parse(
         readFileSync(join(REPO_ROOT, packageDir, 'package.json'), 'utf-8'),
       )
-      // loro-crdt is a legitimate import ONLY for packages architecture-map.ts
-      // explicitly lists as allowed to declare it — never an implicit "it's a
-      // dependency, so allow it" heuristic, so an unmapped package that adds
-      // loro-crdt still fails loudly via `allowed-deps-check`.
-      const loroCrdtIsExempt = packagesAllowedToImportLoroCrdt().includes(manifest.name)
+      // A violation kind is a legitimate exemption ONLY for packages
+      // architecture-map.ts explicitly lists it for — never an implicit "it's
+      // used here, so allow it" heuristic, so an unmapped package still fails
+      // loudly.
+      const exemptKinds = exemptedBoundaryViolationKinds(manifest.name)
 
       const srcDir = join(REPO_ROOT, packageDir, 'src')
       const files = listTsFiles(srcDir)
@@ -49,9 +54,7 @@ describe('shared-layer boundary lint (real source coverage)', () => {
 
       for (const file of files) {
         const allViolations = scanSourceForBoundaryViolations(file, readFileSync(file, 'utf-8'))
-        const violations = loroCrdtIsExempt
-          ? allViolations.filter((v) => v.kind !== 'loro-crdt-import')
-          : allViolations
+        const violations = allViolations.filter((v) => !exemptKinds.has(v.kind))
         expect(violations, `${file}: ${JSON.stringify(violations)}`).toHaveLength(0)
       }
     })


### PR DESCRIPTION
## Summary

- Add `canvas-viewer` to arch-lint scanned packages with `exemptBoundaryViolationKinds` for DOM globals (browser-runtime UI package) while still enforcing `node-builtin-import` and `inversify-import` bans
- Register `mcp-server` in the architecture map for direction-check only (reverse-import detection) — composition root source is intentionally not scanned per architecture-map.md rule 1
- Generalize the old loro-crdt-only exemption into a reusable `exemptedBoundaryViolationKinds()` helper on `PackageArchEntry`
- Update `.claude/rules/architecture-map.md` to reflect the new entries

## Test plan

- [x] `pnpm vitest run --project arch-lint-node` — 53 tests pass
- [x] New `architecture-map.test.ts` — 4 cases for `exemptedBoundaryViolationKinds`
- [x] New direction-check cases for mcp-server reverse-import and canvas-viewer
- [x] Mutation check: `git stash` reverts cause 4 test failures, restored green
- [x] `tsc --noEmit` clean in tools/arch-lint