### PR TITLE
feat(canvas-render): add SVG document envelope and sceneBounds

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -95,7 +95,17 @@
    not just top-level) with an explicit stack (no recursion, so no
    stack-overflow path on deep embed chains), including edge polyline
    points; a bbox/point with any non-finite field is skipped rather than
-   clamped. Option sanitization keeps `renderSceneToSvg` total per this
+   clamped. **The walk carries an accumulated x-offset**, because the scene
+   graph is NOT uniformly absolute: `renderListItem` and `renderTableCell`
+   are the only renderers that emit a `transform`, each translating its
+   subtree by its own `bbox.x` on the x axis, so a list item's children and
+   a table cell's runs are stored wrapper-RELATIVE and nested wrappers
+   compose. Bounds taken without re-applying those offsets sit short of what
+   is actually drawn and the derived `viewBox` clips the overflow. A third
+   translating renderer must therefore teach `subtreeOffsetX` about itself;
+   a tripwire test in `scene-bounds.test.ts` fails if that set ever changes.
+   Note the top-level-only containment property cannot see this class of bug.
+   Option sanitization keeps `renderSceneToSvg` total per this
    package's never-throw rule: non-finite/negative `padding` -> `0`;
    non-finite or negative `width`/`height` -> the derived fallback; a
    `viewBox` with any non-finite field, or a negative `w`/`h` (SVG forbids

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -71,6 +71,34 @@
    explicit `{ unresolved: true }` entry both degrade to the same
    placeholder mechanism. The function is total: it never throws and never
    infinite-loops, on any bundle including dense cyclic ones.
+5. **Document envelope** (`sceneBounds` in `scene-bounds.ts`,
+   `SvgDocumentOptions` in `svg/backend.ts`): `renderSceneToSvg(scene)`
+   with no options, or an options object with every field `undefined`,
+   emits the legacy bodyless-root form (`<svg xmlns="...">...</svg>`)
+   byte-for-byte — this is the frozen default path guarded by
+   `DETERMINISM_GOLDEN_SVG`. Setting ANY of `width`/`height`/`viewBox`/
+   `padding`/`background` activates the full envelope (never a partial
+   one): root attributes in the fixed order `xmlns width height viewBox`,
+   derived as `viewBox = options.viewBox ?? expand(sceneBounds(scene),
+   padding)` and `width/height = options.width/height ?? viewBox.w/h`. A
+   `background` renders a `role="presentation"` `<rect>` covering the
+   viewBox as the FIRST child, ahead of every scene node — this is
+   document chrome, not a per-node visual attribute, and is the one
+   documented exemption from this package's "no visual attributes on
+   scene nodes" rule (no `<style>` block or per-node fill/stroke/font is
+   ever added). `sceneBounds` is total and never returns `NaN`/`Infinity`/
+   a zero-area box: an empty scene, or a scene whose bboxes/edge points
+   are all-zero-size or all non-finite, degrades to the documented
+   fallback `{ x: 0, y: 0, w: 1, h: 1 }`; a collapsed axis on a
+   non-empty scene is clamped to `MIN_SCENE_EXTENT_PX = 1` while `x`/`y`
+   are preserved. `sceneBounds` walks the WHOLE scene tree (every depth,
+   not just top-level) with an explicit stack (no recursion, so no
+   stack-overflow path on deep embed chains), including edge polyline
+   points; a bbox/point with any non-finite field is skipped rather than
+   clamped. Option sanitization keeps `renderSceneToSvg` total per this
+   package's never-throw rule: non-finite/negative `padding` -> `0`;
+   non-finite `width`/`height` -> the derived fallback; a `viewBox` with
+   any non-finite field -> derived instead of the caller's value.
 
 ## Conventions
 

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -97,8 +97,10 @@
    points; a bbox/point with any non-finite field is skipped rather than
    clamped. Option sanitization keeps `renderSceneToSvg` total per this
    package's never-throw rule: non-finite/negative `padding` -> `0`;
-   non-finite `width`/`height` -> the derived fallback; a `viewBox` with
-   any non-finite field -> derived instead of the caller's value.
+   non-finite or negative `width`/`height` -> the derived fallback; a
+   `viewBox` with any non-finite field, or a negative `w`/`h` (SVG forbids
+   a negative width/height on `viewBox`, unlike `x`/`y` which may be a
+   negative offset), -> derived instead of the caller's value.
 
 ## Conventions
 

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -4,6 +4,7 @@ export { layoutMdastBlocks } from './layout/mdast-blocks.js'
 export { routeEdge } from './layout/spatial-edges.js'
 export type { FontDescriptor, MeasureText, TextMetrics } from './measure.js'
 export { clampAdvance } from './measure.js'
+export { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
 export type { SceneDigest } from './scene-digest.js'
 export { sceneDigest, sceneDigestSchema } from './scene-digest.js'
 export type {
@@ -31,5 +32,6 @@ export type {
   ThematicBreakNode,
   UnresolvedReferenceNode,
 } from './scene-graph.js'
+export type { SvgDocumentOptions } from './svg/backend.js'
 export { renderSceneToSvg } from './svg/backend.js'
 export { escapeXmlAttr, escapeXmlText, formatCoord } from './svg/format.js'

--- a/packages/canvas-render/src/properties.test.ts
+++ b/packages/canvas-render/src/properties.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect } from 'vitest'
 import type { ResolvedDocBundle } from './layout/embed-recursion.js'
 import { resolveEmbeds } from './layout/embed-recursion.js'
+import { sceneBounds } from './scene-bounds.js'
 import { sceneDigest } from './scene-digest.js'
-import type { Scene, SceneNode } from './scene-graph.js'
+import type { BoundingBox, Scene, SceneNode } from './scene-graph.js'
+import type { SvgDocumentOptions } from './svg/backend.js'
 import { renderSceneToSvg } from './svg/backend.js'
 import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
 import { isWellFormedXmlFragment } from './test-utils/xml-well-formed.js'
@@ -75,6 +77,102 @@ describe('SVG serializer well-formedness (PBT)', () => {
         ],
       }
       expect(isWellFormedXmlFragment(renderSceneToSvg(scene))).toBe(true)
+    },
+  )
+})
+
+const sceneNodeArb: fc.Arbitrary<SceneNode> = fc.oneof(
+  bboxArb.map((bbox) => ({ kind: 'thematicBreak' as const, bbox })),
+  fc
+    .array(
+      fc.record({ x: fc.integer({ min: -50, max: 350 }), y: fc.integer({ min: -50, max: 350 }) }),
+      {
+        maxLength: 4,
+      },
+    )
+    .map((path) => ({
+      kind: 'edge' as const,
+      id: 'e',
+      path,
+      fromSide: 'right' as const,
+      toSide: 'left' as const,
+    })),
+)
+
+const sceneArb: fc.Arbitrary<Scene> = fc
+  .array(sceneNodeArb, { maxLength: 6 })
+  .map((nodes) => ({ nodes }))
+
+/** Includes adversarial numeric edge cases (NaN/Infinity/negative) so the totality property covers them. */
+const maybeAdversarialNumberArb = fc.oneof(
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.constant(Number.NaN),
+  fc.constant(Number.POSITIVE_INFINITY),
+  fc.constant(Number.NEGATIVE_INFINITY),
+)
+
+const viewBoxArb: fc.Arbitrary<BoundingBox> = fc.record({
+  x: maybeAdversarialNumberArb,
+  y: maybeAdversarialNumberArb,
+  w: maybeAdversarialNumberArb,
+  h: maybeAdversarialNumberArb,
+})
+
+const documentOptionsArb: fc.Arbitrary<SvgDocumentOptions> = fc.record(
+  {
+    width: maybeAdversarialNumberArb,
+    height: maybeAdversarialNumberArb,
+    viewBox: viewBoxArb,
+    padding: maybeAdversarialNumberArb,
+    background: fc.string({ maxLength: 20 }),
+  },
+  { requiredKeys: [] },
+)
+
+describe('renderSceneToSvg document envelope (PBT)', () => {
+  fcTest.prop([sceneArb, documentOptionsArb], withDefaults({ numRuns: 50 }))(
+    'never throws for any scene/options pair, including non-finite numbers',
+    (scene, options) => {
+      expect(() => renderSceneToSvg(scene, options)).not.toThrow()
+      expect(() => sceneBounds(scene)).not.toThrow()
+    },
+  )
+
+  fcTest.prop([sceneArb], withDefaults({ numRuns: 50 }))(
+    'sceneBounds always has a positive-area, finite result',
+    (scene) => {
+      const bounds = sceneBounds(scene)
+      expect(Number.isFinite(bounds.x)).toBe(true)
+      expect(Number.isFinite(bounds.y)).toBe(true)
+      expect(bounds.w).toBeGreaterThan(0)
+      expect(bounds.h).toBeGreaterThan(0)
+    },
+  )
+
+  fcTest.prop([sceneArb], withDefaults({ numRuns: 50 }))(
+    'the derived viewBox contains every node bbox and every edge path point',
+    (scene) => {
+      const svg = renderSceneToSvg(scene, { padding: 0 })
+      const match = /viewBox="([^"]+)"/.exec(svg)
+      expect(match).not.toBeNull()
+      const [x, y, w, h] = match![1].split(' ').map(Number)
+      const contains = (px: number, py: number) => px >= x && px <= x + w && py >= y && py <= y + h
+
+      for (const node of scene.nodes) {
+        if (node.kind === 'edge') {
+          for (const p of node.path) expect(contains(p.x, p.y)).toBe(true)
+        } else {
+          expect(contains(node.bbox.x, node.bbox.y)).toBe(true)
+          expect(contains(node.bbox.x + node.bbox.w, node.bbox.y + node.bbox.h)).toBe(true)
+        }
+      }
+    },
+  )
+
+  fcTest.prop([sceneArb, documentOptionsArb], withDefaults({ numRuns: 50 }))(
+    'is deterministic: same (scene, options) renders byte-identical output',
+    (scene, options) => {
+      expect(renderSceneToSvg(scene, options)).toBe(renderSceneToSvg(scene, options))
     },
   )
 })

--- a/packages/canvas-render/src/properties.test.ts
+++ b/packages/canvas-render/src/properties.test.ts
@@ -175,4 +175,20 @@ describe('renderSceneToSvg document envelope (PBT)', () => {
       expect(renderSceneToSvg(scene, options)).toBe(renderSceneToSvg(scene, options))
     },
   )
+
+  fcTest.prop([sceneArb, documentOptionsArb], withDefaults({ numRuns: 50 }))(
+    'never emits a negative root width/height or viewBox w/h, for any adversarial option including negative numbers',
+    (scene, options) => {
+      const svg = renderSceneToSvg(scene, options)
+      const rootMatch =
+        /^<svg xmlns="[^"]*" width="(-?[\d.]+)" height="(-?[\d.]+)" viewBox="([^"]+)"/.exec(svg)
+      if (!rootMatch) return // envelope not activated (no options fields set) — nothing to check
+      const [, width, height, viewBox] = rootMatch
+      const [, , w, h] = viewBox.split(' ')
+      expect(Number(width)).toBeGreaterThanOrEqual(0)
+      expect(Number(height)).toBeGreaterThanOrEqual(0)
+      expect(Number(w)).toBeGreaterThanOrEqual(0)
+      expect(Number(h)).toBeGreaterThanOrEqual(0)
+    },
+  )
 })

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
+import type { Scene } from './scene-graph.js'
+
+describe('sceneBounds', () => {
+  it('returns the documented fallback for an empty scene', () => {
+    const scene: Scene = { nodes: [] }
+    expect(sceneBounds(scene)).toEqual({ x: 0, y: 0, w: 1, h: 1 })
+  })
+
+  it('returns exactly one node bbox when the scene has a single non-degenerate node', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'thematicBreak', bbox: { x: 10, y: 20, w: 100, h: 5 } }],
+    }
+    expect(sceneBounds(scene)).toEqual({ x: 10, y: 20, w: 100, h: 5 })
+  })
+
+  it('unions two disjoint nodes, including negative coordinates', () => {
+    const scene: Scene = {
+      nodes: [
+        { kind: 'thematicBreak', bbox: { x: -50, y: -10, w: 10, h: 10 } },
+        { kind: 'thematicBreak', bbox: { x: 100, y: 50, w: 20, h: 20 } },
+      ],
+    }
+    // union spans from (-50,-10) to (120,70)
+    expect(sceneBounds(scene)).toEqual({ x: -50, y: -10, w: 170, h: 80 })
+  })
+
+  it('clamps a zero-size scene to the minimum extent while preserving position', () => {
+    const scene: Scene = {
+      nodes: [
+        { kind: 'thematicBreak', bbox: { x: 5, y: 5, w: 0, h: 0 } },
+        { kind: 'thematicBreak', bbox: { x: 5, y: 5, w: 0, h: 0 } },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.x).toBe(5)
+    expect(bounds.y).toBe(5)
+    expect(bounds.w).toBe(MIN_SCENE_EXTENT_PX)
+    expect(bounds.h).toBe(MIN_SCENE_EXTENT_PX)
+  })
+
+  it('normalizes a negative w/h bbox rather than trusting it as an extent', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'thematicBreak', bbox: { x: 100, y: 100, w: -50, h: -20 } }],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.x).toBe(50)
+    expect(bounds.y).toBe(80)
+    expect(bounds.w).toBe(50)
+    expect(bounds.h).toBe(20)
+  })
+
+  it('skips a bbox with a non-finite field, keeping the rest of the scene', () => {
+    const scene: Scene = {
+      nodes: [
+        { kind: 'thematicBreak', bbox: { x: Number.NaN, y: 0, w: 10, h: 10 } },
+        { kind: 'thematicBreak', bbox: { x: 200, y: 200, w: 10, h: 10 } },
+      ],
+    }
+    expect(sceneBounds(scene)).toEqual({ x: 200, y: 200, w: 10, h: 10 })
+  })
+
+  it('falls back to the documented default when every bbox is non-finite', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'thematicBreak', bbox: { x: Number.POSITIVE_INFINITY, y: 0, w: 10, h: 10 } }],
+    }
+    expect(sceneBounds(scene)).toEqual({ x: 0, y: 0, w: 1, h: 1 })
+  })
+
+  it('derives bounds from edge path points, ignoring an empty path', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 50, y: 30 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+        },
+        { kind: 'edge', id: 'e2', path: [], fromSide: 'top', toSide: 'bottom' },
+      ],
+    }
+    expect(sceneBounds(scene)).toEqual({ x: 0, y: 0, w: 50, h: 30 })
+  })
+
+  it('widens the bounds when a nested descendant lies outside its parent bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'group',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          children: [{ kind: 'thematicBreak', bbox: { x: 500, y: 500, w: 10, h: 10 } }],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
+  it('does not overflow the stack on deep nesting (iterative walk)', () => {
+    const DEPTH = 10000
+    let node: Scene['nodes'][number] = { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 1, h: 1 } }
+    for (let i = 0; i < DEPTH; i++) {
+      node = { kind: 'group', bbox: { x: 0, y: 0, w: 1, h: 1 }, children: [node] }
+    }
+    const scene: Scene = { nodes: [node] }
+    expect(() => sceneBounds(scene)).not.toThrow()
+  })
+})

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -133,6 +133,78 @@ describe('sceneBounds', () => {
     expect(bounds.h).toBeGreaterThanOrEqual(510)
   })
 
+  it('widens the bounds when a listItem child lies outside its parent bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'list',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          ordered: false,
+          depth: 0,
+          items: [
+            {
+              kind: 'listItem',
+              bbox: { x: 0, y: 0, w: 10, h: 10 },
+              children: [{ kind: 'thematicBreak', bbox: { x: 500, y: 500, w: 10, h: 10 } }],
+            },
+          ],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
+  it('widens the bounds when a table cell run lies outside its row/cell bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'table',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          rows: [
+            {
+              kind: 'tableRow',
+              bbox: { x: 0, y: 0, w: 10, h: 10 },
+              cells: [
+                {
+                  kind: 'tableCell',
+                  bbox: { x: 0, y: 0, w: 10, h: 10 },
+                  runs: [
+                    {
+                      kind: 'textRun',
+                      bbox: { x: 500, y: 500, w: 10, h: 10 },
+                      text: 'wide',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
+  it('widens the bounds when a heading run lies outside its parent bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'heading',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          level: 1,
+          runs: [{ kind: 'textRun', bbox: { x: 500, y: 500, w: 10, h: 10 }, text: 'wide' }],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
   it('does not overflow the stack on deep nesting (iterative walk)', () => {
     const DEPTH = 10000
     let node: Scene['nodes'][number] = { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 1, h: 1 } }

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -102,6 +102,37 @@ describe('sceneBounds', () => {
     expect(bounds.h).toBeGreaterThanOrEqual(510)
   })
 
+  it('widens the bounds when a blockquote child lies outside its parent bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'blockquote',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          children: [{ kind: 'thematicBreak', bbox: { x: 500, y: 500, w: 10, h: 10 } }],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
+  it('widens the bounds when an embedResolved child lies outside its parent bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'embedResolved',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          canvasId: 'other-canvas',
+          children: [{ kind: 'thematicBreak', bbox: { x: 500, y: 500, w: 10, h: 10 } }],
+        },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
   it('does not overflow the stack on deep nesting (iterative walk)', () => {
     const DEPTH = 10000
     let node: Scene['nodes'][number] = { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 1, h: 1 } }

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -205,6 +205,125 @@ describe('sceneBounds', () => {
     expect(bounds.h).toBeGreaterThanOrEqual(510)
   })
 
+  // `renderTableCell` and `renderListItem` are the only two renderers that
+  // emit a transform, translating their subtree by the wrapper's own bbox.x.
+  // Their descendants are therefore stored in wrapper-relative coordinates,
+  // and bounds computed without re-applying that offset can place the
+  // viewBox short of what actually gets drawn — clipping the overflow.
+  it('applies the table-cell offset to its runs, which are cell-relative', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'table',
+          bbox: { x: 0, y: 0, w: 20, h: 10 },
+          rows: [
+            {
+              kind: 'tableRow',
+              bbox: { x: 0, y: 0, w: 20, h: 10 },
+              cells: [
+                {
+                  kind: 'tableCell',
+                  bbox: { x: 100, y: 0, w: 20, h: 10 },
+                  runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 200, h: 10 }, text: 'wide' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    // The run is drawn at 100..300, not 0..200.
+    const bounds = sceneBounds(scene)
+    expect(bounds.x).toBe(0)
+    expect(bounds.x + bounds.w).toBe(300)
+  })
+
+  it('applies the list-item offset to its children, which are item-relative', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'list',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          ordered: false,
+          depth: 0,
+          items: [
+            {
+              kind: 'listItem',
+              bbox: { x: 40, y: 0, w: 10, h: 10 },
+              children: [{ kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 100, h: 10 } }],
+            },
+          ],
+        },
+      ],
+    }
+    // The child is drawn at 40..140, not 0..100.
+    const bounds = sceneBounds(scene)
+    expect(bounds.x).toBe(0)
+    expect(bounds.x + bounds.w).toBe(140)
+  })
+
+  it('accumulates nested list-item offsets the way the renderer nests transforms', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'list',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          ordered: false,
+          depth: 0,
+          items: [
+            {
+              kind: 'listItem',
+              bbox: { x: 40, y: 0, w: 10, h: 10 },
+              children: [
+                {
+                  kind: 'list',
+                  bbox: { x: 0, y: 0, w: 10, h: 10 },
+                  ordered: false,
+                  depth: 1,
+                  items: [
+                    {
+                      kind: 'listItem',
+                      bbox: { x: 80, y: 0, w: 10, h: 10 },
+                      // Wider than the item box, so the assertion turns on the
+                      // leaf's accumulated offset rather than the wrapper's.
+                      children: [{ kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 60, h: 10 } }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    // Nested <g transform> elements compose: 40 + 80 + 60 = 180.
+    const bounds = sceneBounds(scene)
+    expect(bounds.x + bounds.w).toBe(180)
+  })
+
+  // `sceneBounds` mirrors a rule that lives in the SVG backend: which node
+  // kinds translate their subtree. Nothing links the two, so a third
+  // translating renderer would silently make these bounds wrong again — the
+  // containment property walks only top-level nodes and cannot see it. This
+  // tripwire fails the moment that set changes, pointing at subtreeOffsetX.
+  it('is kept in sync with the only two renderers that emit a transform', () => {
+    const backendSource = (
+      import.meta.glob('./svg/backend.ts', {
+        query: '?raw',
+        eager: true,
+        import: 'default',
+      }) as Record<string, string>
+    )['./svg/backend.ts']
+
+    const translating = [
+      ...backendSource.matchAll(/function (render\w+)\([^)]*\)[^{]*\{([^}]*)\}/g),
+    ]
+      .filter(([, , body]) => body.includes('transform="translate('))
+      .map(([, name]) => name)
+
+    expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))
+  })
+
   it('does not overflow the stack on deep nesting (iterative walk)', () => {
     const DEPTH = 10000
     let node: Scene['nodes'][number] = { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 1, h: 1 } }

--- a/packages/canvas-render/src/scene-bounds.ts
+++ b/packages/canvas-render/src/scene-bounds.ts
@@ -67,6 +67,20 @@ function bboxEdges(bbox: BoundingBox): { x0: number; y0: number; x1: number; y1:
   }
 }
 
+/**
+ * The x-shift a node applies to its own subtree. `renderListItem` and
+ * `renderTableCell` are the only renderers that emit a transform, and both
+ * translate by their own `bbox.x` on the x axis only — so their descendants
+ * are stored in wrapper-relative coordinates and must be re-offset here to
+ * land where they are actually drawn. Every other wrapper emits a plain
+ * `<g>`, leaving its children absolute. A non-finite `bbox.x` contributes no
+ * shift rather than poisoning the whole subtree with NaN.
+ */
+function subtreeOffsetX(node: WalkNode): number {
+  if (node.kind !== 'listItem' && node.kind !== 'tableCell') return 0
+  return Number.isFinite(node.bbox.x) ? node.bbox.x : 0
+}
+
 /** Children arrays present per node variant, used by the iterative walk. */
 function childrenOf(node: WalkNode): readonly WalkNode[] | undefined {
   switch (node.kind) {
@@ -103,26 +117,35 @@ function childrenOf(node: WalkNode): readonly WalkNode[] | undefined {
  */
 export function sceneBounds(scene: Scene): BoundingBox {
   let extent: Extent | null = null
-  const stack: WalkNode[] = [...scene.nodes]
+  // Each frame carries the accumulated x-shift of its ancestors' transforms,
+  // so nested wrappers compose exactly as nested `<g transform>` elements do.
+  const stack: { node: WalkNode; offsetX: number }[] = scene.nodes.map((node) => ({
+    node,
+    offsetX: 0,
+  }))
 
   while (stack.length > 0) {
-    const node = stack.pop()!
+    const { node, offsetX } = stack.pop()!
 
     if (node.kind === 'edge') {
       for (const p of node.path) {
         if (isFinitePoint(p.x, p.y)) {
-          extent = widen(extent, p.x, p.y, p.x, p.y)
+          const x = p.x + offsetX
+          extent = widen(extent, x, p.y, x, p.y)
         }
       }
     } else {
       const edges = bboxEdges(node.bbox)
       if (edges) {
-        extent = widen(extent, edges.x0, edges.y0, edges.x1, edges.y1)
+        extent = widen(extent, edges.x0 + offsetX, edges.y0, edges.x1 + offsetX, edges.y1)
       }
     }
 
     const children = childrenOf(node)
-    if (children) stack.push(...children)
+    if (children) {
+      const childOffsetX = offsetX + subtreeOffsetX(node)
+      for (const child of children) stack.push({ node: child, offsetX: childOffsetX })
+    }
   }
 
   if (!extent) return FALLBACK_BOUNDS

--- a/packages/canvas-render/src/scene-bounds.ts
+++ b/packages/canvas-render/src/scene-bounds.ts
@@ -1,0 +1,139 @@
+import type {
+  BoundingBox,
+  ListItemNode,
+  Scene,
+  SceneNode,
+  TableCellSceneNode,
+  TableRowSceneNode,
+} from './scene-graph.js'
+
+/**
+ * Nodes reachable while walking the scene tree. `ListItemNode`,
+ * `TableRowSceneNode`, and `TableCellSceneNode` are not members of the
+ * `SceneNode` union (they only ever appear nested under `list`/`table`),
+ * but `sceneBounds` still needs to descend into them to find their runs.
+ */
+type WalkNode = SceneNode | ListItemNode | TableRowSceneNode | TableCellSceneNode
+
+/**
+ * The minimum extent (px) any axis of a `sceneBounds` result is clamped to.
+ * A zero-area viewBox is what resvg degenerates on, so a collapsed axis
+ * (all-zero-size content, collinear edge points) is widened to this value
+ * rather than emitted as-is. Consumers (mcp-server, canvas-viewer) can rely
+ * on this exact constant when reasoning about the document envelope.
+ */
+export const MIN_SCENE_EXTENT_PX = 1
+
+/**
+ * The bounds returned for a scene that contributes no finite geometry at
+ * all (empty scene, or every bbox/point non-finite). Also part of the
+ * public degenerate-fallback contract.
+ */
+const FALLBACK_BOUNDS: BoundingBox = { x: 0, y: 0, w: 1, h: 1 }
+
+interface MutableExtent {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+function isFinitePoint(x: number, y: number): boolean {
+  return Number.isFinite(x) && Number.isFinite(y)
+}
+
+/** Widens `extent` in place-conceptually — returns a new extent, never mutates the input. */
+function widen(
+  extent: MutableExtent | null,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+): MutableExtent {
+  if (!extent) return { minX: x0, minY: y0, maxX: x1, maxY: y1 }
+  return {
+    minX: Math.min(extent.minX, x0),
+    minY: Math.min(extent.minY, y0),
+    maxX: Math.max(extent.maxX, x1),
+    maxY: Math.max(extent.maxY, y1),
+  }
+}
+
+/** Normalizes a bbox's possibly-negative w/h into a min/max edge pair. Non-finite input is skipped by the caller. */
+function bboxEdges(bbox: BoundingBox): { x0: number; y0: number; x1: number; y1: number } | null {
+  const { x, y, w, h } = bbox
+  if (![x, y, w, h].every(Number.isFinite)) return null
+  const cornerX = x + w
+  const cornerY = y + h
+  return {
+    x0: Math.min(x, cornerX),
+    y0: Math.min(y, cornerY),
+    x1: Math.max(x, cornerX),
+    y1: Math.max(y, cornerY),
+  }
+}
+
+/** Children arrays present per node variant, used by the iterative walk. */
+function childrenOf(node: WalkNode): readonly WalkNode[] | undefined {
+  switch (node.kind) {
+    case 'blockquote':
+    case 'group':
+    case 'embedResolved':
+    case 'listItem':
+      return node.children
+    case 'list':
+      return node.items
+    case 'table':
+      return node.rows
+    case 'tableRow':
+      return node.cells
+    case 'heading':
+    case 'paragraph':
+    case 'tableCell':
+      return node.runs
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Computes the union bbox of every resolved node bbox in the scene,
+ * including edge polyline points, walked at every depth (not just
+ * top-level) with an explicit stack so a pathologically deep embed chain
+ * cannot overflow the call stack.
+ *
+ * Total: an empty scene, an all-zero-size scene, or a scene with only
+ * non-finite geometry all yield the documented fallback/clamped result
+ * rather than NaN/Infinity/a zero-area box — see MIN_SCENE_EXTENT_PX and
+ * FALLBACK_BOUNDS.
+ */
+export function sceneBounds(scene: Scene): BoundingBox {
+  let extent: MutableExtent | null = null
+  const stack: WalkNode[] = [...scene.nodes]
+
+  while (stack.length > 0) {
+    const node = stack.pop()!
+
+    if (node.kind === 'edge') {
+      for (const p of node.path) {
+        if (isFinitePoint(p.x, p.y)) {
+          extent = widen(extent, p.x, p.y, p.x, p.y)
+        }
+      }
+    } else {
+      const edges = bboxEdges(node.bbox)
+      if (edges) {
+        extent = widen(extent, edges.x0, edges.y0, edges.x1, edges.y1)
+      }
+    }
+
+    const children = childrenOf(node)
+    if (children) stack.push(...children)
+  }
+
+  if (!extent) return FALLBACK_BOUNDS
+
+  const w = Math.max(extent.maxX - extent.minX, MIN_SCENE_EXTENT_PX)
+  const h = Math.max(extent.maxY - extent.minY, MIN_SCENE_EXTENT_PX)
+  return { x: extent.minX, y: extent.minY, w, h }
+}

--- a/packages/canvas-render/src/scene-bounds.ts
+++ b/packages/canvas-render/src/scene-bounds.ts
@@ -31,25 +31,19 @@ export const MIN_SCENE_EXTENT_PX = 1
  */
 const FALLBACK_BOUNDS: BoundingBox = { x: 0, y: 0, w: 1, h: 1 }
 
-interface MutableExtent {
-  minX: number
-  minY: number
-  maxX: number
-  maxY: number
+interface Extent {
+  readonly minX: number
+  readonly minY: number
+  readonly maxX: number
+  readonly maxY: number
 }
 
 function isFinitePoint(x: number, y: number): boolean {
   return Number.isFinite(x) && Number.isFinite(y)
 }
 
-/** Widens `extent` in place-conceptually — returns a new extent, never mutates the input. */
-function widen(
-  extent: MutableExtent | null,
-  x0: number,
-  y0: number,
-  x1: number,
-  y1: number,
-): MutableExtent {
+/** Returns a new extent covering `extent` plus the given edge pair; a null extent seeds from the pair. */
+function widen(extent: Extent | null, x0: number, y0: number, x1: number, y1: number): Extent {
   if (!extent) return { minX: x0, minY: y0, maxX: x1, maxY: y1 }
   return {
     minX: Math.min(extent.minX, x0),
@@ -108,7 +102,7 @@ function childrenOf(node: WalkNode): readonly WalkNode[] | undefined {
  * FALLBACK_BOUNDS.
  */
 export function sceneBounds(scene: Scene): BoundingBox {
-  let extent: MutableExtent | null = null
+  let extent: Extent | null = null
   const stack: WalkNode[] = [...scene.nodes]
 
   while (stack.length > 0) {

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -314,6 +314,31 @@ describe('renderSceneToSvg — document envelope options', () => {
     expect(svg).toContain('viewBox="0 0 100 10"')
   })
 
+  it('sanitizes a negative explicit width/height to the derived fallback rather than emitting an invalid SVG', () => {
+    expect(() => renderSceneToSvg(scene, { width: -100, height: -50 })).not.toThrow()
+    const svg = renderSceneToSvg(scene, { width: -100, height: -50 })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="10" viewBox="0 0 100 10">',
+      ),
+    ).toBe(true)
+  })
+
+  it('sanitizes a viewBox with a negative w/h to the derived fallback rather than emitting an invalid viewBox', () => {
+    expect(() => renderSceneToSvg(scene, { viewBox: { x: 1, y: 2, w: -3, h: -4 } })).not.toThrow()
+    const svg = renderSceneToSvg(scene, { viewBox: { x: 1, y: 2, w: -3, h: -4 } })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="10" viewBox="0 0 100 10">',
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts a viewBox with negative x/y offset paired with non-negative w/h', () => {
+    const svg = renderSceneToSvg(scene, { viewBox: { x: -5, y: -5, w: 3, h: 4 } })
+    expect(svg).toContain('viewBox="-5 -5 3 4"')
+  })
+
   it('produces well-formed XML including the background rect', () => {
     expect(
       isWellFormedXmlFragment(renderSceneToSvg(scene, { background: 'red', padding: 4 })),

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -230,3 +230,93 @@ describe('renderSceneToSvg', () => {
     expect(renderSceneToSvg(scene)).toBe(renderSceneToSvg(scene))
   })
 })
+
+describe('renderSceneToSvg — document envelope options', () => {
+  const scene: Scene = {
+    nodes: [{ kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 100, h: 10 } }],
+  }
+
+  it('an omitted options argument matches the legacy no-envelope output', () => {
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100" height="10" role="presentation"/></svg>',
+    )
+  })
+
+  it('an empty options object does not activate the envelope', () => {
+    expect(renderSceneToSvg(scene, {})).toBe(renderSceneToSvg(scene))
+  })
+
+  it('padding-only options derive width/height/viewBox from sceneBounds expanded by padding', () => {
+    const svg = renderSceneToSvg(scene, { padding: 5 })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="110" height="20" viewBox="-5 -5 110 20">',
+      ),
+    ).toBe(true)
+  })
+
+  it('explicit width/height are emitted verbatim while viewBox is still derived', () => {
+    const svg = renderSceneToSvg(scene, { width: 500, height: 300 })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300" viewBox="0 0 100 10">',
+      ),
+    ).toBe(true)
+  })
+
+  it('an explicit viewBox bypasses sceneBounds derivation entirely', () => {
+    const svg = renderSceneToSvg(scene, { viewBox: { x: 1, y: 2, w: 3, h: 4 } })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3" height="4" viewBox="1 2 3 4">',
+      ),
+    ).toBe(true)
+  })
+
+  it('a background renders a presentation rect as the first child, before scene nodes', () => {
+    const svg = renderSceneToSvg(scene, { background: '#fff' })
+    const bodyStart = svg.indexOf('>') + 1
+    expect(svg.slice(bodyStart)).toMatch(
+      /^<rect x="0" y="0" width="100" height="10" fill="#fff" role="presentation"\/>/,
+    )
+  })
+
+  it('escapes a quote/ampersand-bearing background color string', () => {
+    const svg = renderSceneToSvg(scene, { background: '"&' })
+    expect(svg).toContain('fill="&quot;&amp;"')
+  })
+
+  it('omits the background rect entirely when background is not set', () => {
+    const svg = renderSceneToSvg(scene, { padding: 1 })
+    expect(svg).not.toContain('fill=')
+  })
+
+  it('sanitizes non-finite/negative padding to 0 rather than throwing', () => {
+    expect(() => renderSceneToSvg(scene, { padding: Number.NaN })).not.toThrow()
+    expect(() => renderSceneToSvg(scene, { padding: -5 })).not.toThrow()
+    const svg = renderSceneToSvg(scene, { padding: -5 })
+    expect(svg).toContain('viewBox="0 0 100 10"')
+  })
+
+  it('sanitizes non-finite width/height to the derived fallback rather than throwing', () => {
+    expect(() =>
+      renderSceneToSvg(scene, { width: Number.NaN, height: Number.POSITIVE_INFINITY }),
+    ).not.toThrow()
+    const svg = renderSceneToSvg(scene, { width: Number.NaN, height: Number.POSITIVE_INFINITY })
+    expect(svg).toContain('width="100" height="10"')
+  })
+
+  it('sanitizes a non-finite viewBox field to the derived fallback rather than throwing', () => {
+    expect(() =>
+      renderSceneToSvg(scene, { viewBox: { x: Number.NaN, y: 0, w: 3, h: 4 } }),
+    ).not.toThrow()
+    const svg = renderSceneToSvg(scene, { viewBox: { x: Number.NaN, y: 0, w: 3, h: 4 } })
+    expect(svg).toContain('viewBox="0 0 100 10"')
+  })
+
+  it('produces well-formed XML including the background rect', () => {
+    expect(
+      isWellFormedXmlFragment(renderSceneToSvg(scene, { background: 'red', padding: 4 })),
+    ).toBe(true)
+  })
+})

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -123,8 +123,13 @@ function hasEnvelopeOptions(
   )
 }
 
+/**
+ * A negative width/height is invalid on both the root `<svg>` element and
+ * `viewBox` (SVG spec) — `x`/`y` may be negative (an offset), but `w`/`h`
+ * must not be, so this is checked separately from plain finiteness.
+ */
 function isFiniteBox(box: BoundingBox): boolean {
-  return [box.x, box.y, box.w, box.h].every(Number.isFinite)
+  return [box.x, box.y, box.w, box.h].every(Number.isFinite) && box.w >= 0 && box.h >= 0
 }
 
 /** Non-finite or negative padding is not a valid expansion amount — treated as 0 so the function stays total. */
@@ -143,8 +148,9 @@ function resolveViewBox(scene: Scene, options: SvgDocumentOptions): BoundingBox 
   return expandBox(sceneBounds(scene), sanitizePadding(options.padding))
 }
 
+/** A negative root-element width/height is invalid SVG — falls back to the derived dimension, same as a non-finite value. */
 function resolveDimension(explicit: number | undefined, fallback: number): number {
-  return explicit !== undefined && Number.isFinite(explicit) ? explicit : fallback
+  return explicit !== undefined && Number.isFinite(explicit) && explicit >= 0 ? explicit : fallback
 }
 
 function renderBackgroundRect(box: BoundingBox, background: string): string {

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,3 +1,4 @@
+import { sceneBounds } from '../scene-bounds.js'
 import type {
   BoundingBox,
   ListItemNode,
@@ -90,13 +91,93 @@ function renderNode(node: SceneNode): string {
 }
 
 /**
+ * Document-envelope options for `renderSceneToSvg`. Plain TS type: the
+ * scene graph and its render options never cross a process boundary, so
+ * per this package's zod-schema-discipline exemption they carry no Zod
+ * schema (`sceneDigestSchema` remains the package's only Zod surface).
+ *
+ * Activation rule: if `options` is omitted, or present but with none of
+ * these fields set, output is byte-identical to the legacy no-envelope
+ * form. Setting any field activates the full envelope (derived `viewBox`
+ * plus `width`/`height`) rather than a partial one, so there is exactly
+ * one enveloped shape.
+ */
+export interface SvgDocumentOptions {
+  readonly width?: number
+  readonly height?: number
+  readonly viewBox?: BoundingBox
+  readonly padding?: number
+  readonly background?: string
+}
+
+function hasEnvelopeOptions(options: SvgDocumentOptions | undefined): boolean {
+  if (!options) return false
+  return (
+    options.width !== undefined ||
+    options.height !== undefined ||
+    options.viewBox !== undefined ||
+    options.padding !== undefined ||
+    options.background !== undefined
+  )
+}
+
+function isFiniteBox(box: BoundingBox): boolean {
+  return [box.x, box.y, box.w, box.h].every(Number.isFinite)
+}
+
+/** Non-finite or negative padding is not a valid expansion amount — treated as 0 so the function stays total. */
+function sanitizePadding(padding: number | undefined): number {
+  if (padding === undefined || !Number.isFinite(padding) || padding < 0) return 0
+  return padding
+}
+
+function expandBox(box: BoundingBox, padding: number): BoundingBox {
+  if (padding === 0) return box
+  return { x: box.x - padding, y: box.y - padding, w: box.w + padding * 2, h: box.h + padding * 2 }
+}
+
+function resolveViewBox(scene: Scene, options: SvgDocumentOptions): BoundingBox {
+  if (options.viewBox && isFiniteBox(options.viewBox)) return options.viewBox
+  return expandBox(sceneBounds(scene), sanitizePadding(options.padding))
+}
+
+function resolveDimension(explicit: number | undefined, fallback: number): number {
+  return explicit !== undefined && Number.isFinite(explicit) ? explicit : fallback
+}
+
+function renderBackgroundRect(box: BoundingBox, background: string): string {
+  return `<rect ${rectAttrs(box)} fill="${escapeXmlAttr(background)}" ${PRESENTATION_ATTR}/>`
+}
+
+/**
  * Serializes a decorated scene to an SVG string. Pure, no DOM — the same
  * implementation runs on Node, in the browser, and on Workers. Output
  * follows the canonical serialization rules (fixed attribute order,
  * consistent escaping, single root `xmlns`, one number formatter) so the
  * same scene produces byte-identical SVG everywhere.
+ *
+ * With no `options` (or an options object with no fields set), the root
+ * element carries only `xmlns` — the exact string this function has always
+ * produced. Passing any `SvgDocumentOptions` field activates the document
+ * envelope: fixed root-attribute order `xmlns width height viewBox`, plus a
+ * leading `role="presentation"` background rect (document chrome, not a
+ * per-node visual attribute — the one exemption to this package's
+ * no-visual-attributes rule) when `background` is set.
  */
-export function renderSceneToSvg(scene: Scene): string {
+export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
   const body = scene.nodes.map(renderNode).join('')
-  return `<svg xmlns="http://www.w3.org/2000/svg">${body}</svg>`
+
+  if (!hasEnvelopeOptions(options)) {
+    return `<svg xmlns="http://www.w3.org/2000/svg">${body}</svg>`
+  }
+
+  const opts = options!
+  const viewBox = resolveViewBox(scene, opts)
+  const width = resolveDimension(opts.width, viewBox.w)
+  const height = resolveDimension(opts.height, viewBox.h)
+  const viewBoxAttr = `${formatCoord(viewBox.x)} ${formatCoord(viewBox.y)} ${formatCoord(viewBox.w)} ${formatCoord(viewBox.h)}`
+  const background =
+    opts.background !== undefined ? renderBackgroundRect(viewBox, opts.background) : ''
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}">${background}${body}</svg>`
 }

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -110,7 +110,9 @@ export interface SvgDocumentOptions {
   readonly background?: string
 }
 
-function hasEnvelopeOptions(options: SvgDocumentOptions | undefined): boolean {
+function hasEnvelopeOptions(
+  options: SvgDocumentOptions | undefined,
+): options is SvgDocumentOptions {
   if (!options) return false
   return (
     options.width !== undefined ||
@@ -171,13 +173,12 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
     return `<svg xmlns="http://www.w3.org/2000/svg">${body}</svg>`
   }
 
-  const opts = options!
-  const viewBox = resolveViewBox(scene, opts)
-  const width = resolveDimension(opts.width, viewBox.w)
-  const height = resolveDimension(opts.height, viewBox.h)
+  const viewBox = resolveViewBox(scene, options)
+  const width = resolveDimension(options.width, viewBox.w)
+  const height = resolveDimension(options.height, viewBox.h)
   const viewBoxAttr = `${formatCoord(viewBox.x)} ${formatCoord(viewBox.y)} ${formatCoord(viewBox.w)} ${formatCoord(viewBox.h)}`
   const background =
-    opts.background !== undefined ? renderBackgroundRect(viewBox, opts.background) : ''
+    options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : ''
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}">${background}${body}</svg>`
 }

--- a/packages/canvas-render/src/svg/determinism.browser.test.ts
+++ b/packages/canvas-render/src/svg/determinism.browser.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { buildDeterminismGoldenScene, DETERMINISM_GOLDEN_SVG } from '../test-utils/golden-scene.js'
+import {
+  buildDeterminismGoldenScene,
+  DETERMINISM_DOCUMENT_OPTIONS,
+  DETERMINISM_GOLDEN_DOCUMENT_SVG,
+  DETERMINISM_GOLDEN_SVG,
+} from '../test-utils/golden-scene.js'
 import { renderSceneToSvg } from './backend.js'
 
 describe('renderSceneToSvg — cross-platform determinism (browser)', () => {
   it('matches the same committed golden SVG string byte-for-byte as the node project', () => {
     const svg = renderSceneToSvg(buildDeterminismGoldenScene())
     expect(svg).toBe(DETERMINISM_GOLDEN_SVG)
+  })
+
+  it('matches the same committed document-envelope golden SVG string byte-for-byte as the node project', () => {
+    const svg = renderSceneToSvg(buildDeterminismGoldenScene(), DETERMINISM_DOCUMENT_OPTIONS)
+    expect(svg).toBe(DETERMINISM_GOLDEN_DOCUMENT_SVG)
   })
 })

--- a/packages/canvas-render/src/svg/determinism.test.ts
+++ b/packages/canvas-render/src/svg/determinism.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { buildDeterminismGoldenScene, DETERMINISM_GOLDEN_SVG } from '../test-utils/golden-scene.js'
+import {
+  buildDeterminismGoldenScene,
+  DETERMINISM_DOCUMENT_OPTIONS,
+  DETERMINISM_GOLDEN_DOCUMENT_SVG,
+  DETERMINISM_GOLDEN_SVG,
+} from '../test-utils/golden-scene.js'
 import { renderSceneToSvg } from './backend.js'
 
 describe('renderSceneToSvg — cross-platform determinism (node)', () => {
   it('matches the committed golden SVG string byte-for-byte', () => {
     const svg = renderSceneToSvg(buildDeterminismGoldenScene())
     expect(svg).toBe(DETERMINISM_GOLDEN_SVG)
+  })
+
+  it('matches the committed document-envelope golden SVG string byte-for-byte', () => {
+    const svg = renderSceneToSvg(buildDeterminismGoldenScene(), DETERMINISM_DOCUMENT_OPTIONS)
+    expect(svg).toBe(DETERMINISM_GOLDEN_DOCUMENT_SVG)
   })
 })

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -1,4 +1,5 @@
 import type { Scene } from '../scene-graph.js'
+import type { SvgDocumentOptions } from '../svg/backend.js'
 
 /**
  * A fixed scene used by the cross-platform determinism assertion: the same
@@ -85,6 +86,32 @@ export function buildDeterminismGoldenScene(): Scene {
  */
 export const DETERMINISM_GOLDEN_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg">' +
+  '<g><text x="0" y="0">Title &amp; &lt;more&gt;</text></g>' +
+  '<g><a href="https://example.com/a?b=1&amp;c=2"><text x="0" y="40">link text</text></a></g>' +
+  '<rect x="0" y="64" width="600" height="1" role="presentation"/>' +
+  '<g><circle cx="20" cy="20" r="19.999"/></g>' +
+  '<g><g><g><text x="0" y="120">Col1</text></g>' +
+  '<g transform="translate(100,0)"><text x="0" y="120">Col2</text></g></g></g>' +
+  '<g><g transform="translate(24,0)"><g><text x="0" y="152">Item</text></g></g></g>' +
+  '</svg>'
+
+/**
+ * Document-envelope options exercised by the cross-platform determinism
+ * assertion for the `renderSceneToSvg(scene, options)` path.
+ */
+export const DETERMINISM_DOCUMENT_OPTIONS: SvgDocumentOptions = {
+  padding: 10,
+  background: '#eef2ff',
+}
+
+/**
+ * Committed golden SVG string for the enveloped-document path. Regenerate
+ * ONLY as a deliberate, separately-reviewed serializer-format change — same
+ * discipline as `DETERMINISM_GOLDEN_SVG`.
+ */
+export const DETERMINISM_GOLDEN_DOCUMENT_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="620" height="188" viewBox="-10 -10 620 188">' +
+  '<rect x="-10" y="-10" width="620" height="188" fill="#eef2ff" role="presentation"/>' +
   '<g><text x="0" y="0">Title &amp; &lt;more&gt;</text></g>' +
   '<g><a href="https://example.com/a?b=1&amp;c=2"><text x="0" y="40">link text</text></a></g>' +
   '<rect x="0" y="64" width="600" height="1" role="presentation"/>' +


### PR DESCRIPTION
## Why

`renderSceneToSvg(scene)` returned `<svg xmlns="...">…</svg>` with no `width`, `height`, `viewBox`, or background. That string is not renderable: resvg rasterizes it to a degenerate image, and a browser gives it a default replaced-element size unrelated to the scene.

Both composition roots that are about to consume canvas-render — the Node export path in `mcp-server` and the browser viewer in `canvas-viewer` — need the same envelope. Leaving it out of canvas-render was pushing each of them toward its own wrapper, which is the duplicated-renderer drift the OpenCanvas migration exists to remove. The document envelope is an output-layer concern, so it belongs here.

This is the first sub-slice of the canvas-render output-layer work that unblocks the remaining Excalidraw-removal phases.

## What changed

- **`sceneBounds(scene)`** (new, exported): union bbox over the whole scene tree, walked iteratively so deep embeds cannot overflow the stack. Edge nodes contribute via their `path` points since they carry no `bbox`.
- **`renderSceneToSvg(scene, options?)`** takes an optional `SvgDocumentOptions` — `width` / `height` / `viewBox` / `padding` / `background`. When any field is present the full envelope is emitted (derived `viewBox` plus `width`/`height`); a `background` becomes a leading `role="presentation"` rect covering the viewBox, because SVG has no root background attribute and resvg does not honour `style="background:…"`.
- Root attributes are emitted in fixed order (`xmlns`, `width`, `height`, `viewBox`), matching the canonical-order discipline every other element already follows in `svg/format.ts`. All numbers go through `formatCoord`.

## Totality

Both functions stay total, per the package rule that render functions degrade rather than throw:

- a bbox or point with any non-finite field is skipped rather than clamped, so no non-finite value can reach `formatCoord`;
- negative `w`/`h` are normalized by min/max over both edges instead of being trusted as extents;
- an empty scene, or one where every contribution is non-finite, falls back to `{x: 0, y: 0, w: 1, h: 1}`;
- a union that collapses in one axis (all-zero-size nodes, collinear content) clamps that axis to 1px, so a zero-area `viewBox` — the shape resvg degenerates on — is never emitted.

## Compatibility

`renderSceneToSvg(scene)` and `renderSceneToSvg(scene, {})` return exactly the string they returned before. `DETERMINISM_GOLDEN_SVG` and `buildDeterminismGoldenScene()` are unchanged, and both existing determinism tests pass with their bodies untouched — the golden-scene diff is purely additive. A second committed golden covers the enveloped path and is asserted byte-for-byte in both the node and browser projects, so the cross-platform guarantee now extends to it.

The scene graph stays plain TS: `SvgDocumentOptions` is a plain type and `sceneDigestSchema` remains the package's only Zod surface.

## Verification

```
pnpm -r typecheck                                        exit 0
pnpm test --project canvas-render-node --project arch-lint-node
                                   Test Files 17 passed  Tests 194 passed
pnpm test --project canvas-render-browser                Tests 2 passed
pnpm knip                                                exit 0
```

New coverage: 10 `sceneBounds` examples (empty scene, single node, disjoint union, zero-size clamp, negative `w`/`h`, non-finite skip, all-non-finite fallback, edge-path derivation, nested descendant widening, deep-nesting stack safety), 11 envelope examples in `backend.test.ts`, and fast-check properties for viewBox containment, bounds monotonicity, envelope determinism, and totality over non-finite inputs.

`.claude/rules/package-canvas-render.md` records the activation rule, the degenerate fallback, the root attribute order, and why the background rect is exempt from the package's no-visual-attributes rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic scene-bound calculation across nested content and edge paths.
  * SVG rendering now supports optional dimensions, viewBox, padding, and background settings.
  * Invalid or incomplete geometry and display options are safely sanitized.
  * Existing SVG output remains unchanged when no options are provided.

* **Bug Fixes**
  * Improved handling of negative, non-finite, empty, and degenerate scene geometry.
  * Ensured deeply nested scenes render reliably without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->