### PR TITLE
feat(canvas-render): add a shape scene node and optional resolved appearance

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -112,6 +112,36 @@
    a negative width/height on `viewBox`, unlike `x`/`y` which may be a
    negative offset), -> derived instead of the caller's value.
 
+6. **The `shape` node and optional resolved `Appearance`** (`scene-graph.ts`):
+   `ShapeSceneNode` (`kind: 'shape'`, `bbox`, optional `radius`) is the box
+   chrome of a spatial canvas node — a rect with an optional uniform corner
+   radius. Deliberately minimal: a rect covers every spatial node kind
+   today, so ellipse/polygon/path are NOT added speculatively. `Appearance`
+   (`fill?`, `stroke?`, `strokeWidth?`, `fontFamily?`, `fontSize?`, all
+   optional) is ONE named type reused as an optional `appearance?` field on
+   exactly three variants — `ShapeSceneNode`, `TextRunNode`,
+   `ResolvedEdgeNode` — never a per-kind ad-hoc field. Appearance is
+   **assigned, not invented**: this package's own layout functions never
+   choose a color, font, or stroke width — that is a composition-root
+   concern today and the exact seam the later theme layer fills in (a pure
+   scene-graph -> scene-graph transform). The SVG backend emits presence-only
+   attributes in the FIXED order `fill stroke stroke-width font-family
+   font-size`, appended after geometry; an absent or unusable field is
+   OMITTED, never defaulted, which is what keeps a scene built without
+   appearance byte-identical to the pre-existing output (the additivity
+   guarantee both `DETERMINISM_GOLDEN_SVG` and `DETERMINISM_GOLDEN_DOCUMENT_SVG`
+   depend on — a new, separate golden covers shape/appearance instead of
+   regenerating those two). Degenerate-value fallbacks, all "omit, never
+   throw": a color/font-family that is not a non-empty string -> omitted; a
+   non-finite or negative `strokeWidth`/`fontSize` -> omitted (zero is a
+   legitimate value and is kept); `radius` emits `rx` only when finite and
+   `> 0` (SVG rejects a negative `rx`, and `rx="0"` is pure noise); a shape
+   whose `bbox` has any non-finite field renders as the empty string rather
+   than reaching `formatCoord` (which throws by contract) — zero-size and
+   negative-w/h boxes DO render (valid, invisible SVG), only non-finite is
+   dropped. `shape` emits no `transform`, so it needs no entry in
+   `subtreeOffsetX` and the two-renderer tripwire above is unaffected.
+
 ## Conventions
 
 - Every scene-node variant retains semantic provenance (heading `level`,

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -8,6 +8,7 @@ export { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
 export type { SceneDigest } from './scene-digest.js'
 export { sceneDigest, sceneDigestSchema } from './scene-digest.js'
 export type {
+  Appearance,
   BlockquoteNode,
   BoundingBox,
   CodeBlockNode,
@@ -24,6 +25,7 @@ export type {
   ResolvedEdgeNode,
   Scene,
   SceneNode,
+  ShapeSceneNode,
   SvgFragmentNode,
   TableBlockNode,
   TableCellSceneNode,

--- a/packages/canvas-render/src/properties.test.ts
+++ b/packages/canvas-render/src/properties.test.ts
@@ -81,6 +81,47 @@ describe('SVG serializer well-formedness (PBT)', () => {
   )
 })
 
+/** Includes adversarial numbers/strings so totality/well-formedness properties cover degenerate appearance. */
+const adversarialAppearanceArb = fc.record(
+  {
+    fill: fc.string({ maxLength: 20 }),
+    stroke: fc.string({ maxLength: 20 }),
+    strokeWidth: fc.oneof(
+      fc.integer({ min: -100, max: 100 }),
+      fc.constant(Number.NaN),
+      fc.constant(Number.POSITIVE_INFINITY),
+    ),
+    fontFamily: fc.string({ maxLength: 20 }),
+    fontSize: fc.oneof(
+      fc.integer({ min: -100, max: 100 }),
+      fc.constant(Number.NaN),
+      fc.constant(Number.POSITIVE_INFINITY),
+    ),
+  },
+  { requiredKeys: [] },
+)
+
+const adversarialRadiusArb = fc.oneof(
+  fc.integer({ min: -50, max: 50 }),
+  fc.constant(Number.NaN),
+  fc.constant(Number.POSITIVE_INFINITY),
+)
+
+/** A shape bbox mixing normal geometry with non-finite fields, so the "skip, don't throw" fallback is exercised. */
+const shapeBboxArb = fc.record({
+  x: fc.oneof(fc.integer({ min: -300, max: 300 }), fc.constant(Number.NaN)),
+  y: fc.integer({ min: -300, max: 300 }),
+  w: fc.integer({ min: -100, max: 100 }),
+  h: fc.integer({ min: -100, max: 100 }),
+})
+
+const shapeNodeArb: fc.Arbitrary<SceneNode> = fc
+  .record(
+    { bbox: shapeBboxArb, radius: adversarialRadiusArb, appearance: adversarialAppearanceArb },
+    { requiredKeys: ['bbox'] },
+  )
+  .map(({ bbox, radius, appearance }) => ({ kind: 'shape' as const, bbox, radius, appearance }))
+
 const sceneNodeArb: fc.Arbitrary<SceneNode> = fc.oneof(
   bboxArb.map((bbox) => ({ kind: 'thematicBreak' as const, bbox })),
   fc
@@ -97,6 +138,7 @@ const sceneNodeArb: fc.Arbitrary<SceneNode> = fc.oneof(
       fromSide: 'right' as const,
       toSide: 'left' as const,
     })),
+  shapeNodeArb,
 )
 
 const sceneArb: fc.Arbitrary<Scene> = fc
@@ -160,10 +202,17 @@ describe('renderSceneToSvg document envelope (PBT)', () => {
 
       for (const node of scene.nodes) {
         if (node.kind === 'edge') {
-          for (const p of node.path) expect(contains(p.x, p.y)).toBe(true)
+          for (const p of node.path) {
+            if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue
+            expect(contains(p.x, p.y)).toBe(true)
+          }
         } else {
-          expect(contains(node.bbox.x, node.bbox.y)).toBe(true)
-          expect(contains(node.bbox.x + node.bbox.w, node.bbox.y + node.bbox.h)).toBe(true)
+          // A non-finite bbox field is skipped by sceneBounds (documented
+          // degenerate fallback), so it contributes no containment claim.
+          const { x, y, w, h } = node.bbox
+          if (![x, y, w, h].every(Number.isFinite)) continue
+          expect(contains(x, y)).toBe(true)
+          expect(contains(x + w, y + h)).toBe(true)
         }
       }
     },
@@ -189,6 +238,34 @@ describe('renderSceneToSvg document envelope (PBT)', () => {
       expect(Number(height)).toBeGreaterThanOrEqual(0)
       expect(Number(w)).toBeGreaterThanOrEqual(0)
       expect(Number(h)).toBeGreaterThanOrEqual(0)
+    },
+  )
+
+  fcTest.prop([sceneArb], withDefaults({ numRuns: 50 }))(
+    'produces well-formed XML for any generated scene, including shapes with adversarial appearance',
+    (scene) => {
+      expect(isWellFormedXmlFragment(renderSceneToSvg(scene))).toBe(true)
+    },
+  )
+})
+
+/** A scene-node arbitrary with NO appearance/radius fields, for the additivity property below. */
+const appearanceFreeSceneNodeArb: fc.Arbitrary<SceneNode> = fc.oneof(
+  bboxArb.map((bbox) => ({ kind: 'thematicBreak' as const, bbox })),
+  bboxArb.map((bbox) => ({ kind: 'shape' as const, bbox })),
+)
+const appearanceFreeSceneArb: fc.Arbitrary<Scene> = fc
+  .array(appearanceFreeSceneNodeArb, { maxLength: 6 })
+  .map((nodes) => ({ nodes }))
+
+describe('renderSceneToSvg additivity (PBT)', () => {
+  fcTest.prop([appearanceFreeSceneArb], withDefaults({ numRuns: 50 }))(
+    'an appearance-free scene never emits a presentation attribute (fill/stroke/font-*)',
+    (scene) => {
+      const svg = renderSceneToSvg(scene)
+      for (const attr of ['fill=', 'stroke=', 'stroke-width=', 'font-family=', 'font-size=']) {
+        expect(svg).not.toContain(attr)
+      }
     },
   )
 })

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -324,6 +324,42 @@ describe('sceneBounds', () => {
     expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))
   })
 
+  it('includes a top-level shape bbox', () => {
+    const scene: Scene = {
+      nodes: [
+        { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        { kind: 'shape', bbox: { x: 500, y: 500, w: 10, h: 10 } },
+      ],
+    }
+    const bounds = sceneBounds(scene)
+    expect(bounds.w).toBeGreaterThanOrEqual(510)
+    expect(bounds.h).toBeGreaterThanOrEqual(510)
+  })
+
+  it('applies the list-item offset to a nested shape, which is item-relative', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'list',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          ordered: false,
+          depth: 0,
+          items: [
+            {
+              kind: 'listItem',
+              bbox: { x: 40, y: 0, w: 10, h: 10 },
+              children: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 100, h: 10 } }],
+            },
+          ],
+        },
+      ],
+    }
+    // The shape is drawn at 40..140, not 0..100.
+    const bounds = sceneBounds(scene)
+    expect(bounds.x).toBe(0)
+    expect(bounds.x + bounds.w).toBe(140)
+  })
+
   it('does not overflow the stack on deep nesting (iterative walk)', () => {
     const DEPTH = 10000
     let node: Scene['nodes'][number] = { kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 1, h: 1 } }

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -28,6 +28,24 @@ export interface Dimensions {
   readonly h: number
 }
 
+/**
+ * Resolved paint attributes for a shape, text run, or edge. Optional and
+ * assigned, never invented: layout produces geometry and semantics only,
+ * and this package's own layout functions must not choose a fill, stroke,
+ * or font — that is a composition-root concern today and the exact seam
+ * the planned theme layer fills in later (a pure scene-graph ->
+ * scene-graph transform). One named type is reused across every paintable
+ * variant rather than ad-hoc per-kind fields, and every field is optional
+ * so an appearance-free scene renders exactly as it always has.
+ */
+export interface Appearance {
+  readonly fill?: string
+  readonly stroke?: string
+  readonly strokeWidth?: number
+  readonly fontFamily?: string
+  readonly fontSize?: number
+}
+
 /** A single styled run of inline text, positioned within its parent block. */
 export interface TextRunNode {
   readonly kind: 'textRun'
@@ -39,6 +57,21 @@ export interface TextRunNode {
   readonly deleted?: boolean
   /** Present when this run is (or is inside) a link/wikiLink/reference. */
   readonly link?: LinkProvenance
+  readonly appearance?: Appearance
+}
+
+/**
+ * The box chrome of a spatial canvas node: a rectangle with an optional
+ * uniform corner radius. Deliberately minimal — a rect covers every
+ * spatial node kind today, so ellipse/polygon/path are not added
+ * speculatively (see package-canvas-render.md).
+ */
+export interface ShapeSceneNode {
+  readonly kind: 'shape'
+  readonly bbox: BoundingBox
+  /** Uniform corner radius. Non-finite or <= 0 omits `rx` entirely. */
+  readonly radius?: number
+  readonly appearance?: Appearance
 }
 
 /** Semantic provenance for an inline link-like run. Never flattened away. */
@@ -172,6 +205,7 @@ export interface ResolvedEdgeNode {
   readonly path: readonly { readonly x: number; readonly y: number }[]
   readonly fromSide: 'top' | 'right' | 'bottom' | 'left'
   readonly toSide: 'top' | 'right' | 'bottom' | 'left'
+  readonly appearance?: Appearance
 }
 
 export type SceneNode =
@@ -190,6 +224,7 @@ export type SceneNode =
   | GroupSceneNode
   | TextRunNode
   | ResolvedEdgeNode
+  | ShapeSceneNode
 
 /** A fully laid-out document: ordered top-level scene nodes in paint order. */
 export interface Scene {

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -231,6 +231,197 @@ describe('renderSceneToSvg', () => {
   })
 })
 
+describe('renderSceneToSvg — shape node', () => {
+  it('emits a rect with rx when radius is set', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 100, h: 60 }, radius: 8 }],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100" height="60" rx="8"/></svg>',
+    )
+  })
+
+  it('omits rx entirely when radius is absent', () => {
+    const scene: Scene = { nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 100, h: 60 } }] }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="100" height="60"/></svg>',
+    )
+  })
+
+  it.each([
+    0,
+    -4,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('omits rx for a degenerate radius (%s), never emitting rx="0" or throwing', (radius) => {
+    const scene: Scene = {
+      nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 10, h: 10 }, radius }],
+    }
+    let svg = ''
+    expect(() => {
+      svg = renderSceneToSvg(scene)
+    }).not.toThrow()
+    expect(svg).not.toContain('rx=')
+  })
+
+  it('emits appearance attributes in fixed order: fill stroke stroke-width', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'shape',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          appearance: { fill: '#fff', stroke: '#000', strokeWidth: 2 },
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toContain('fill="#fff" stroke="#000" stroke-width="2"')
+  })
+
+  it('an empty appearance object and an absent appearance both render byte-identically', () => {
+    const withEmpty: Scene = {
+      nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 10, h: 10 }, appearance: {} }],
+    }
+    const withoutAppearance: Scene = {
+      nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    }
+    expect(renderSceneToSvg(withEmpty)).toBe(renderSceneToSvg(withoutAppearance))
+  })
+
+  it('renders as the empty string (contributes no output) for a non-finite bbox field, never throwing', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'shape', bbox: { x: Number.NaN, y: 0, w: 10, h: 10 } }],
+    }
+    expect(() => renderSceneToSvg(scene)).not.toThrow()
+    expect(renderSceneToSvg(scene)).toBe('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+  })
+
+  it('renders a zero-size or negative w/h shape without throwing (valid, invisible SVG)', () => {
+    const zeroSize: Scene = { nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: 0, h: 0 } }] }
+    const negative: Scene = { nodes: [{ kind: 'shape', bbox: { x: 0, y: 0, w: -5, h: -5 } }] }
+    expect(() => renderSceneToSvg(zeroSize)).not.toThrow()
+    expect(() => renderSceneToSvg(negative)).not.toThrow()
+  })
+
+  it('omits a degenerate strokeWidth/fontSize (NaN/Infinity/negative) rather than emitting or throwing', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'shape',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          appearance: { strokeWidth: Number.NaN },
+        },
+      ],
+    }
+    expect(() => renderSceneToSvg(scene)).not.toThrow()
+    expect(renderSceneToSvg(scene)).not.toContain('stroke-width=')
+  })
+
+  it('omits an empty-string color/font-family rather than emitting fill="" etc.', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'shape',
+          bbox: { x: 0, y: 0, w: 10, h: 10 },
+          appearance: { fill: '', fontFamily: '' },
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).not.toContain('fill=')
+    expect(svg).not.toContain('font-family=')
+  })
+})
+
+describe('renderSceneToSvg — appearance on textRun and edge', () => {
+  it('emits appearance attributes on a text run, keeping the link wrapper unchanged', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'paragraph',
+          bbox: { x: 0, y: 0, w: 100, h: 16 },
+          runs: [
+            {
+              kind: 'textRun',
+              bbox: { x: 0, y: 0, w: 40, h: 16 },
+              text: 'styled link',
+              link: { kind: 'link', href: 'https://example.com' },
+              appearance: { fill: '#111', fontFamily: 'Inter', fontSize: 14 },
+            },
+          ],
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain(
+      '<a href="https://example.com"><text x="0" y="0" fill="#111" font-family="Inter" font-size="14">styled link</text></a>',
+    )
+  })
+
+  it('an appearance-free text run is byte-identical to before', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'paragraph',
+          bbox: { x: 0, y: 0, w: 100, h: 16 },
+          runs: [{ kind: 'textRun', bbox: { x: 0, y: 0, w: 40, h: 16 }, text: 'plain' }],
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><g><text x="0" y="0">plain</text></g></svg>',
+    )
+  })
+
+  it('emits appearance attributes on an edge polyline before role=presentation', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 10, y: 10 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          appearance: { stroke: '#888', strokeWidth: 1.5 },
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" stroke="#888" stroke-width="1.5" role="presentation"/></svg>',
+    )
+  })
+
+  it('an appearance-free edge is byte-identical to before', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [{ x: 0, y: 0 }],
+          fromSide: 'right',
+          toSide: 'left',
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0" role="presentation"/></svg>',
+    )
+  })
+
+  it('produces well-formed XML for quote/ampersand-bearing appearance strings', () => {
+    const scene: Scene = {
+      nodes: [
+        { kind: 'shape', bbox: { x: 0, y: 0, w: 10, h: 10 }, appearance: { fill: 'a"b<c&d' } },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('fill="a&quot;b&lt;c&amp;d"')
+    expect(isWellFormedXmlFragment(svg)).toBe(true)
+  })
+})
+
 describe('renderSceneToSvg — document envelope options', () => {
   const scene: Scene = {
     nodes: [{ kind: 'thematicBreak', bbox: { x: 0, y: 0, w: 100, h: 10 } }],

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,9 +1,11 @@
 import { sceneBounds } from '../scene-bounds.js'
 import type {
+  Appearance,
   BoundingBox,
   ListItemNode,
   Scene,
   SceneNode,
+  ShapeSceneNode,
   TableCellSceneNode,
   TableRowSceneNode,
   TextRunNode,
@@ -23,13 +25,73 @@ function rectAttrs(bbox: BoundingBox): string {
   return `x="${formatCoord(bbox.x)}" y="${formatCoord(bbox.y)}" width="${formatCoord(bbox.w)}" height="${formatCoord(bbox.h)}"`
 }
 
+function isFiniteBbox(bbox: BoundingBox): boolean {
+  return [bbox.x, bbox.y, bbox.w, bbox.h].every(Number.isFinite)
+}
+
+function isUsableColor(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+/** Non-finite or negative is dropped; zero is a legitimate stroke-width/font-size. */
+function isUsableNonNegativeNumber(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function withLeadingSpace(attrs: string): string {
+  return attrs === '' ? '' : ` ${attrs}`
+}
+
+/**
+ * Presence-only presentation attributes for a shape/text-run/edge, in the
+ * fixed order `fill stroke stroke-width font-family font-size`. An absent
+ * or unusable field is omitted rather than defaulted — see the
+ * `Appearance` doc comment for why the backend never invents a value.
+ */
+function appearanceAttrs(appearance?: Appearance): string {
+  if (!appearance) return ''
+  const parts: string[] = []
+  if (isUsableColor(appearance.fill)) parts.push(`fill="${escapeXmlAttr(appearance.fill)}"`)
+  if (isUsableColor(appearance.stroke)) parts.push(`stroke="${escapeXmlAttr(appearance.stroke)}"`)
+  if (isUsableNonNegativeNumber(appearance.strokeWidth)) {
+    parts.push(`stroke-width="${formatCoord(appearance.strokeWidth)}"`)
+  }
+  if (isUsableColor(appearance.fontFamily)) {
+    parts.push(`font-family="${escapeXmlAttr(appearance.fontFamily)}"`)
+  }
+  if (isUsableNonNegativeNumber(appearance.fontSize)) {
+    parts.push(`font-size="${formatCoord(appearance.fontSize)}"`)
+  }
+  return parts.join(' ')
+}
+
 function renderTextRun(run: TextRunNode): string {
   const attrs = [`x="${formatCoord(run.bbox.x)}"`, `y="${formatCoord(run.bbox.y)}"`]
+  const appearance = appearanceAttrs(run.appearance)
+  if (appearance) attrs.push(appearance)
+  const attrStr = attrs.join(' ')
   if (run.link) {
     const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.canvasId
-    return `<a href="${escapeXmlAttr(href)}"><text ${attrs.join(' ')}>${escapeXmlText(run.text)}</text></a>`
+    return `<a href="${escapeXmlAttr(href)}"><text ${attrStr}>${escapeXmlText(run.text)}</text></a>`
   }
-  return `<text ${attrs.join(' ')}>${escapeXmlText(run.text)}</text>`
+  return `<text ${attrStr}>${escapeXmlText(run.text)}</text>`
+}
+
+/**
+ * The box chrome of a spatial canvas node. A non-finite bbox field is a
+ * layout bug this package must not crash on — it renders as the empty
+ * string rather than reaching `formatCoord`, which throws by contract.
+ * `radius` emits `rx` only when finite and > 0: SVG treats a negative
+ * `rx` as an error and `rx="0"` is noise, so both are omitted.
+ */
+function renderShape(node: ShapeSceneNode): string {
+  if (!isFiniteBbox(node.bbox)) return ''
+  const rx =
+    node.radius !== undefined && Number.isFinite(node.radius) && node.radius > 0
+      ? ` rx="${formatCoord(node.radius)}"`
+      : ''
+  const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
+  return `<rect ${rectAttrs(node.bbox)}${rx}${appearance}/>`
 }
 
 function renderListItem(item: ListItemNode): string {
@@ -85,8 +147,11 @@ function renderNode(node: SceneNode): string {
       return `<g>${node.children.map(renderNode).join('')}</g>`
     case 'edge': {
       const points = node.path.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
-      return `<polyline points="${points}" ${PRESENTATION_ATTR}/>`
+      const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
+      return `<polyline points="${points}"${appearance} ${PRESENTATION_ATTR}/>`
     }
+    case 'shape':
+      return renderShape(node)
   }
 }
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -25,17 +25,22 @@ function rectAttrs(bbox: BoundingBox): string {
   return `x="${formatCoord(bbox.x)}" y="${formatCoord(bbox.y)}" width="${formatCoord(bbox.w)}" height="${formatCoord(bbox.h)}"`
 }
 
-function isFiniteBbox(bbox: BoundingBox): boolean {
-  return [bbox.x, bbox.y, bbox.w, bbox.h].every(Number.isFinite)
+function isFiniteBox(box: BoundingBox): boolean {
+  return [box.x, box.y, box.w, box.h].every(Number.isFinite)
 }
 
-function isUsableColor(value: string | undefined): value is string {
+function isNonEmptyString(value: string | undefined): value is string {
   return typeof value === 'string' && value.length > 0
 }
 
 /** Non-finite or negative is dropped; zero is a legitimate stroke-width/font-size. */
-function isUsableNonNegativeNumber(value: number | undefined): value is number {
+function isNonNegativeLength(value: number | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+/** SVG treats a negative `rx` as an error and `rx="0"` is noise, so both are omitted. */
+function isPositiveLength(value: number | undefined): value is number {
+  return isNonNegativeLength(value) && value > 0
 }
 
 function withLeadingSpace(attrs: string): string {
@@ -51,45 +56,38 @@ function withLeadingSpace(attrs: string): string {
 function appearanceAttrs(appearance?: Appearance): string {
   if (!appearance) return ''
   const parts: string[] = []
-  if (isUsableColor(appearance.fill)) parts.push(`fill="${escapeXmlAttr(appearance.fill)}"`)
-  if (isUsableColor(appearance.stroke)) parts.push(`stroke="${escapeXmlAttr(appearance.stroke)}"`)
-  if (isUsableNonNegativeNumber(appearance.strokeWidth)) {
+  if (isNonEmptyString(appearance.fill)) parts.push(`fill="${escapeXmlAttr(appearance.fill)}"`)
+  if (isNonEmptyString(appearance.stroke)) {
+    parts.push(`stroke="${escapeXmlAttr(appearance.stroke)}"`)
+  }
+  if (isNonNegativeLength(appearance.strokeWidth)) {
     parts.push(`stroke-width="${formatCoord(appearance.strokeWidth)}"`)
   }
-  if (isUsableColor(appearance.fontFamily)) {
+  if (isNonEmptyString(appearance.fontFamily)) {
     parts.push(`font-family="${escapeXmlAttr(appearance.fontFamily)}"`)
   }
-  if (isUsableNonNegativeNumber(appearance.fontSize)) {
+  if (isNonNegativeLength(appearance.fontSize)) {
     parts.push(`font-size="${formatCoord(appearance.fontSize)}"`)
   }
   return parts.join(' ')
 }
 
 function renderTextRun(run: TextRunNode): string {
-  const attrs = [`x="${formatCoord(run.bbox.x)}"`, `y="${formatCoord(run.bbox.y)}"`]
-  const appearance = appearanceAttrs(run.appearance)
-  if (appearance) attrs.push(appearance)
-  const attrStr = attrs.join(' ')
-  if (run.link) {
-    const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.canvasId
-    return `<a href="${escapeXmlAttr(href)}"><text ${attrStr}>${escapeXmlText(run.text)}</text></a>`
-  }
-  return `<text ${attrStr}>${escapeXmlText(run.text)}</text>`
+  const appearance = withLeadingSpace(appearanceAttrs(run.appearance))
+  const text = `<text x="${formatCoord(run.bbox.x)}" y="${formatCoord(run.bbox.y)}"${appearance}>${escapeXmlText(run.text)}</text>`
+  if (!run.link) return text
+  const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.canvasId
+  return `<a href="${escapeXmlAttr(href)}">${text}</a>`
 }
 
 /**
  * The box chrome of a spatial canvas node. A non-finite bbox field is a
  * layout bug this package must not crash on — it renders as the empty
  * string rather than reaching `formatCoord`, which throws by contract.
- * `radius` emits `rx` only when finite and > 0: SVG treats a negative
- * `rx` as an error and `rx="0"` is noise, so both are omitted.
  */
 function renderShape(node: ShapeSceneNode): string {
-  if (!isFiniteBbox(node.bbox)) return ''
-  const rx =
-    node.radius !== undefined && Number.isFinite(node.radius) && node.radius > 0
-      ? ` rx="${formatCoord(node.radius)}"`
-      : ''
+  if (!isFiniteBox(node.bbox)) return ''
+  const rx = isPositiveLength(node.radius) ? ` rx="${formatCoord(node.radius)}"` : ''
   const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
   return `<rect ${rectAttrs(node.bbox)}${rx}${appearance}/>`
 }
@@ -191,10 +189,10 @@ function hasEnvelopeOptions(
 /**
  * A negative width/height is invalid on both the root `<svg>` element and
  * `viewBox` (SVG spec) — `x`/`y` may be negative (an offset), but `w`/`h`
- * must not be, so this is checked separately from plain finiteness.
+ * must not be, so this is checked on top of plain finiteness.
  */
-function isFiniteBox(box: BoundingBox): boolean {
-  return [box.x, box.y, box.w, box.h].every(Number.isFinite) && box.w >= 0 && box.h >= 0
+function isUsableViewBox(box: BoundingBox): boolean {
+  return isFiniteBox(box) && box.w >= 0 && box.h >= 0
 }
 
 /** Non-finite or negative padding is not a valid expansion amount — treated as 0 so the function stays total. */
@@ -209,7 +207,7 @@ function expandBox(box: BoundingBox, padding: number): BoundingBox {
 }
 
 function resolveViewBox(scene: Scene, options: SvgDocumentOptions): BoundingBox {
-  if (options.viewBox && isFiniteBox(options.viewBox)) return options.viewBox
+  if (options.viewBox && isUsableViewBox(options.viewBox)) return options.viewBox
   return expandBox(sceneBounds(scene), sanitizePadding(options.padding))
 }
 

--- a/packages/canvas-render/src/svg/determinism.browser.test.ts
+++ b/packages/canvas-render/src/svg/determinism.browser.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDeterminismGoldenScene,
+  buildShapeAppearanceGoldenScene,
   DETERMINISM_DOCUMENT_OPTIONS,
   DETERMINISM_GOLDEN_DOCUMENT_SVG,
   DETERMINISM_GOLDEN_SVG,
+  SHAPE_APPEARANCE_GOLDEN_SVG,
 } from '../test-utils/golden-scene.js'
 import { renderSceneToSvg } from './backend.js'
 
@@ -16,5 +18,10 @@ describe('renderSceneToSvg — cross-platform determinism (browser)', () => {
   it('matches the same committed document-envelope golden SVG string byte-for-byte as the node project', () => {
     const svg = renderSceneToSvg(buildDeterminismGoldenScene(), DETERMINISM_DOCUMENT_OPTIONS)
     expect(svg).toBe(DETERMINISM_GOLDEN_DOCUMENT_SVG)
+  })
+
+  it('matches the same committed shape/appearance golden SVG string byte-for-byte as the node project', () => {
+    const svg = renderSceneToSvg(buildShapeAppearanceGoldenScene())
+    expect(svg).toBe(SHAPE_APPEARANCE_GOLDEN_SVG)
   })
 })

--- a/packages/canvas-render/src/svg/determinism.test.ts
+++ b/packages/canvas-render/src/svg/determinism.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDeterminismGoldenScene,
+  buildShapeAppearanceGoldenScene,
   DETERMINISM_DOCUMENT_OPTIONS,
   DETERMINISM_GOLDEN_DOCUMENT_SVG,
   DETERMINISM_GOLDEN_SVG,
+  SHAPE_APPEARANCE_GOLDEN_SVG,
 } from '../test-utils/golden-scene.js'
 import { renderSceneToSvg } from './backend.js'
 
@@ -16,5 +18,10 @@ describe('renderSceneToSvg — cross-platform determinism (node)', () => {
   it('matches the committed document-envelope golden SVG string byte-for-byte', () => {
     const svg = renderSceneToSvg(buildDeterminismGoldenScene(), DETERMINISM_DOCUMENT_OPTIONS)
     expect(svg).toBe(DETERMINISM_GOLDEN_DOCUMENT_SVG)
+  })
+
+  it('matches the committed shape/appearance golden SVG string byte-for-byte', () => {
+    const svg = renderSceneToSvg(buildShapeAppearanceGoldenScene())
+    expect(svg).toBe(SHAPE_APPEARANCE_GOLDEN_SVG)
   })
 })

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -120,3 +120,61 @@ export const DETERMINISM_GOLDEN_DOCUMENT_SVG =
   '<g transform="translate(100,0)"><text x="0" y="120">Col2</text></g></g></g>' +
   '<g><g transform="translate(24,0)"><g><text x="0" y="152">Item</text></g></g></g>' +
   '</svg>'
+
+/**
+ * A second, separate fixed scene covering the `shape` node kind and the
+ * optional `appearance` field on shape/textRun/edge — kept apart from
+ * `buildDeterminismGoldenScene` so the original golden never has to be
+ * regenerated as this surface grows.
+ */
+export function buildShapeAppearanceGoldenScene(): Scene {
+  return {
+    nodes: [
+      { kind: 'shape', bbox: { x: 0, y: 0, w: 100, h: 60 }, radius: 8 },
+      { kind: 'shape', bbox: { x: 120, y: 0, w: 100, h: 60 } },
+      {
+        kind: 'shape',
+        bbox: { x: 240, y: 0, w: 100, h: 60 },
+        radius: 4,
+        appearance: { fill: '#fff', stroke: '#000', strokeWidth: 2 },
+      },
+      {
+        kind: 'paragraph',
+        bbox: { x: 0, y: 80, w: 200, h: 16 },
+        runs: [
+          {
+            kind: 'textRun',
+            bbox: { x: 0, y: 80, w: 80, h: 16 },
+            text: 'Styled',
+            appearance: { fill: '#111', fontFamily: 'Inter', fontSize: 14 },
+          },
+        ],
+      },
+      {
+        kind: 'edge',
+        id: 'e1',
+        path: [
+          { x: 0, y: 120 },
+          { x: 100, y: 120 },
+        ],
+        fromSide: 'right',
+        toSide: 'left',
+        appearance: { stroke: '#888', strokeWidth: 1.5 },
+      },
+    ],
+  }
+}
+
+/**
+ * Committed golden SVG string for `buildShapeAppearanceGoldenScene`.
+ * Regenerate only as a deliberate, separately-reviewed serializer-format
+ * change — same discipline as the two goldens above.
+ */
+export const SHAPE_APPEARANCE_GOLDEN_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg">' +
+  '<rect x="0" y="0" width="100" height="60" rx="8"/>' +
+  '<rect x="120" y="0" width="100" height="60"/>' +
+  '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
+  '<g><text x="0" y="80" fill="#111" font-family="Inter" font-size="14">Styled</text></g>' +
+  '<polyline points="0,120 100,120" stroke="#888" stroke-width="1.5" role="presentation"/>' +
+  '</svg>'

--- a/packages/server-core/src/render/compose-canvas-scene.test.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.test.ts
@@ -1,8 +1,24 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { routeEdge } from '@kamiazya/whiteboard-canvas-render'
 import { describe, expect, test } from 'vitest'
-import { composeCanvasScene, computeCanvasDimensions } from './compose-canvas-scene.js'
+import {
+  composeCanvasScene,
+  computeCanvasDimensions,
+  translateNode,
+} from './compose-canvas-scene.js'
 import { fallbackMeasureText } from './fallback-measure.js'
+
+describe('translateNode', () => {
+  test('translates a shape node bbox like other leaf scene nodes', () => {
+    const translated = translateNode(
+      { kind: 'shape', bbox: { x: 5, y: 6, w: 40, h: 30 }, radius: 4 },
+      10,
+      20,
+    )
+
+    expect(translated).toEqual({ kind: 'shape', bbox: { x: 15, y: 26, w: 40, h: 30 }, radius: 4 })
+  })
+})
 
 describe('composeCanvasScene', () => {
   test('translates a text node body by its own (x, y)', () => {

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -14,7 +14,7 @@ import { layoutMdastBlocks, routeEdge } from '@kamiazya/whiteboard-canvas-render
  * canvas's text node lives at its own (x, y), so its laid-out scene must be
  * shifted into place before joining the rest of the canvas's scene graph.
  */
-function translateNode(node: SceneNode, dx: number, dy: number): SceneNode {
+export function translateNode(node: SceneNode, dx: number, dy: number): SceneNode {
   if (node.kind === 'edge') {
     // Edges are already resolved in absolute canvas coordinates by
     // routeEdge — translating them here would double-shift them.
@@ -31,6 +31,7 @@ function translateNode(node: SceneNode, dx: number, dy: number): SceneNode {
     case 'unresolvedReference':
     case 'svgFragment':
     case 'embedPlaceholder':
+    case 'shape':
       return { ...node, bbox }
     case 'heading':
     case 'paragraph':


### PR DESCRIPTION
## Why

Second half of closing canvas-render's output-layer gap (#385 was the first). The scene graph had kinds for text runs, mdast blocks, groups and edges, but **nothing that draws a box** — a spatial canvas rendered as text floating over routed edges, with no borders or backgrounds. It also carried no appearance at all, so the backend had nothing to emit: `<text>` got no font or fill, `<polyline>` no stroke, and the output was effectively invisible in a real renderer.

Every consumer needs both — the Node export path, the browser viewer, and the web editor — so putting them here is what stops the same thing being invented three times.

## What changed

- **`ShapeSceneNode`** — a rectangle with an optional uniform corner radius. Deliberately minimal: a rect covers every spatial node kind that exists today, so no ellipse/polygon/path was added on speculation.
- **One `Appearance` type** (`fill`, `stroke`, `strokeWidth`, `fontFamily`, `fontSize`) referenced as an optional field by exactly three variants — shape, text run, and edge. One named type rather than ad-hoc fields per kind, so there is a single place for a future field to land.
- **The SVG backend renders both**, with appearance emitted through one helper in a fixed attribute order, colors through `escapeXmlAttr` and numbers through `formatCoord`, consistent with the package's existing canonical-serialization discipline.

## Appearance is optional, and that is the point

The backend omits every attribute that is absent. Three things follow, and they are why the design is shaped this way rather than "give nodes a style":

**The change is additive.** A scene built without appearance renders exactly as before, so `DETERMINISM_GOLDEN_SVG` and `DETERMINISM_GOLDEN_DOCUMENT_SVG` are untouched and both determinism tests pass unmodified — the golden-scene diff adds lines and edits none. A *new* golden covers shapes and appearance, asserted byte-identical in both the node and browser projects, so the cross-platform guarantee extends to the new surface.

**Layout still produces geometry and semantics, never appearance.** canvas-render's layout functions do not choose colors; appearance is assigned by the composition root. Semantic provenance is added alongside, never replaced.

**It is the seam the Phase 4 theme layer needs.** A theme becomes a pure scene-graph → scene-graph function that fills these fields in. Baking appearance into the backend instead would make that layer impossible to write.

## Degenerate input

Every case omits rather than throws, per the package's never-throw rule: a non-positive or non-finite radius emits no `rx` (SVG treats a negative `rx` as an error); a color or font family that is not a non-empty string is dropped; a non-finite or negative `strokeWidth`/`fontSize` is dropped; a shape whose bbox has a non-finite field contributes no output rather than reaching `formatCoord`, which rejects non-finite by contract. Zero-size and negative-w/h boxes do render — they are valid, merely invisible.

## Union widening

`SceneNode` gains a member, which is source-breaking for any exhaustive `switch`. One existed: `translateNode` in server-core, fixed in the same increment. `childrenOf` in `scene-bounds.ts` has a `default` arm and needed no change, and `sceneDigest` collects `node.bbox` generically so shapes are picked up with no schema edit. Worth knowing for any future exhaustive consumer.

The shape renderer emits no `transform`, so the `scene-bounds` tripwire guarding the set of translating renderers still passes unmodified.

## Verification

```
pnpm -r typecheck                                              exit 0
pnpm test --project canvas-render-node --project server-core-node --project arch-lint-node
                                       Test Files 47 passed   Tests 436 passed
pnpm test --project canvas-render-browser                      Tests 3 passed
pnpm knip                                                      exit 0
```

`.claude/rules/package-canvas-render.md` records the shape node, the optional-appearance rule with its rationale, the fixed attribute order, and the degenerate-value fallbacks.
