### PR TITLE
fix(mcp-server): render canvas exports headlessly, always

### DIFF
--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -37,9 +37,8 @@ This page describes the **local daemon** in detail first, then server mode.
 Some operations require a connected browser client.
 
 - `viewport_set`
-- `export_canvas({ format: "png" })`
 
-These actions are routed through the daemon to the browser and fail fast when no browser client is connected.
+This action is routed through the daemon to the browser and fails fast when no browser client is connected. `export_canvas` (all formats, including `png`) is rendered headlessly from the persisted document and does not require a connected browser client.
 
 ## WebMCP (experimental, browser-only, read-only)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,7 +7,7 @@ Runtime environment variables and sandbox quirks.
 | Variable | Purpose | Default |
 |---|---|---|
 | `WHITEBOARD_DATA_DIR` | Runtime data directory. Workspaces, snapshots, versions, and exports all live underneath it. | `~/.whiteboard` (falls back to the OS temp directory if unwritable) |
-| `WHITEBOARD_CHROME_PATH` | Override the Chromium binary used for browser automation and `export_canvas({ format: "png" })`. | unset (Playwright-managed Chromium) |
+| `WHITEBOARD_CHROME_PATH` | Override the Chromium binary used for browser automation (`viewport_set` and other browser-dependent operations). `export_canvas` (including `png`) is rendered headlessly and never touches this binary. | unset (Playwright-managed Chromium) |
 | `WHITEBOARD_DEV` | When set to `1`, the dev-launch wrapper enables source-tree watching so a `tsx watch` change restarts the daemon in place. | unset |
 | `WHITEBOARD_MCP_AUTHORIZATION_SERVER(S)` | Authorization Server URL exposed in MCP Protected Resource Metadata, in preparation for remote OAuth 2.1. | unset |
 | `WHITEBOARD_MCP_RESOURCE` | Canonical MCP resource URL exposed in metadata. If unset, `/mcp` is derived from the incoming request URL. | unset |

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -6,7 +6,7 @@ callers that only need SVG.
 
 | `format` | Output | Rendering |
 | --- | --- | --- |
-| `png` | Raster image | Prefers the connected browser client; falls back to headless rendering when no client is connected |
+| `png` | Raster image | Always rendered headlessly from the persisted document |
 | `svg` | Vector image (`.svg`) | Always rendered headlessly from the persisted document — no browser connection required |
 | `json` | Standard `.excalidraw` JSON | Always rendered headlessly from the persisted document |
 
@@ -15,8 +15,9 @@ inside the workspace's `exports/` directory) and `overwrite`. `png` and `svg` ad
 accept `padding`, `frameId`, and `theme`; `png` alone accepts `scale` and `minFontPx`; `json`
 alone accepts `includeCustomFields`.
 
-Because `svg` and `json` never depend on a live browser connection, they are the reliable
-choice for automated export pipelines (CI, scripted diagram linting, doc generation) where no
-whiteboard client may be attached to the canvas.
+All three formats are rendered headlessly from the persisted document and never depend on a
+live browser connection, so they all work equally well for automated export pipelines (CI,
+scripted diagram linting, doc generation) where no whiteboard client may be attached to the
+canvas.
 
 ← Back to [reference](README.md)

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -29,7 +29,7 @@ import { createDaemonAuthMiddleware } from './routes/auth.js'
 import { createBranchesRouter } from './routes/branches.js'
 import { createCanvasRouter } from './routes/canvas.js'
 import { createDebugRouter } from './routes/debug.js'
-import { createExportRouter, resolveExportRequest } from './routes/export.js'
+import { createExportRouter } from './routes/export.js'
 import { createFilesRouter } from './routes/files.js'
 import {
   createOAuthAuthzRouter,
@@ -40,12 +40,7 @@ import { createReconnectRouter } from './routes/reconnect.js'
 import { createRuntimeRouter } from './routes/runtime.js'
 import { createStatusRouter } from './routes/status.js'
 import { createViewportRouter, resolveViewportRequest } from './routes/viewport.js'
-import {
-  broadcastLoroUpdate,
-  sendHeadChanged,
-  setResolveExportFn,
-  setResolveViewportFn,
-} from './routes/ws.js'
+import { broadcastLoroUpdate, sendHeadChanged, setResolveViewportFn } from './routes/ws.js'
 import { createWsTicketRouter } from './routes/ws-ticket.js'
 import { createApiHostGuardMiddleware } from './security/api-host-guard.js'
 import { createApiLoopbackCorsMiddleware } from './security/cors-loopback.js'
@@ -95,7 +90,6 @@ if (shouldLogMcpHttpDebug()) {
   }
 }
 
-setResolveExportFn(resolveExportRequest)
 setResolveViewportFn(resolveViewportRequest)
 
 export function createApp(options: AppOptions) {

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -133,7 +133,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('generates distinct default filePaths for two headless exports in the same millisecond', async () => {
-    mockGetClientCount.mockReturnValue(0)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from('fake-png-bytes'),
       width: 100,
@@ -155,12 +154,11 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     }
   })
 
-  it('returns 404 with canvas_not_found when the canvas does not exist, even with a client connected', async () => {
+  it('returns 404 with canvas_not_found when the canvas does not exist', async () => {
     // Headless rendering does NOT verify the canvas exists: getDoc / loadCanvas
     // return an empty LoroDoc on cache miss, so a typo would otherwise
     // silently produce a blank PNG. Surfaced as 404 unconditionally now that
     // there is only one rendering path.
-    mockGetClientCount.mockReturnValue(1)
     mockCanvasExists.mockResolvedValueOnce(false)
     const app = makeApp()
 
@@ -173,8 +171,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
-  it('returns 500 with headless_export_failed when headless rendering throws, even with a client connected', async () => {
-    mockGetClientCount.mockReturnValue(1)
+  it('returns 500 with headless_export_failed when headless rendering throws', async () => {
     mockExportCanvasHeadless.mockRejectedValue(new Error('boom'))
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
@@ -188,7 +185,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   // resolving slowly (well past the old 10s browser-round-trip default) must
   // still succeed, never 504.
   it('resolves 200 even when headless rendering is slow, with no 504 timeout path', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -201,7 +197,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('passes padding through to exportCanvasHeadless options', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from('fake-png-bytes'),
       width: 100,
@@ -221,7 +216,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('passes scale and minFontPx through to exportCanvasHeadless options', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from('fake-png-bytes'),
       width: 100,
@@ -242,29 +236,9 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     )
   })
 
-  it('forwards theme to the headless export when a WS client is connected', async () => {
-    mockGetClientCount.mockReturnValue(1)
-    const fakePng = Buffer.from('fake-dark-png')
-    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
-    const app = makeApp()
-
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ theme: 'dark', padding: 16 }),
-    })
-    expect(res.status).toBe(200)
-    expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceId: 's1',
-        slug: 'canvas-a',
-        options: expect.objectContaining({ theme: 'dark', padding: 16 }),
-      }),
-    )
-  })
-
-  it('forwards theme to the headless export when no WS client is connected', async () => {
-    mockGetClientCount.mockReturnValue(0)
+  // Client-count independence is covered once by the metamorphic test above,
+  // so this only needs to assert the forwarding itself.
+  it('forwards theme to the headless export', async () => {
     const fakePng = Buffer.from('fake-dark-png')
     mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
     const app = makeApp()
@@ -285,7 +259,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects invalid theme values with 400 invalid_request', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
       method: 'POST',
@@ -298,7 +271,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects an oversized request body with 413 payload_too_large', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const oversized = 'x'.repeat(1024 * 1024 + 1)
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
@@ -312,7 +284,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('passes frameId through to exportCanvasHeadless options', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from('fake-png-bytes'),
       width: 100,
@@ -334,7 +305,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('returns 200 and filePath for a plain export request', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
@@ -351,7 +321,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   // Nested canvas paths such as architecture/overview should create parent
   // directories recursively instead of failing with ENOENT.
   it('writes nested slash-containing slugs without ENOENT', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
@@ -369,7 +338,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('returns 400 for invalid workspaceId or slug without reaching the headless renderer', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
 
     const badSession = await app.request('/api/canvas/bad.sid/canvas-a/export', {
@@ -385,7 +353,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('writes the PNG to an explicit absolute outputPath when provided', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
@@ -408,7 +375,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects outputPath outside the workspace exports dir even if inside DATA_DIR', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     // ${DATA_DIR}/daemon.json is inside DATA_DIR but not inside ${DATA_DIR}/s1/exports
     const daemonFile = join(tempDir, 'daemon.json')
@@ -423,7 +389,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects outputPath outside workspace exports dir (different workspace checkpoints)', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     // ${DATA_DIR}/s1/.checkpoints is inside DATA_DIR/s1 but not in ${DATA_DIR}/s1/exports
     const checkpointFile = join(tempDir, 's1', '.checkpoints', 'v1.json')
@@ -438,7 +403,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects outputPath fully outside DATA_DIR', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
       method: 'POST',
@@ -451,7 +415,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('does not leak internal paths in invalid_output_path error response', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
       method: 'POST',
@@ -466,7 +429,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('does not leak internal paths in output_exists error response', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'exists.png')
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
@@ -484,7 +446,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('rejects a relative PNG outputPath with 400 invalid_output_path', async () => {
-    mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
       method: 'POST',
@@ -497,7 +458,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('refuses to overwrite an existing PNG by default and returns 409', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
@@ -520,7 +480,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   })
 
   it('overwrites an existing PNG when overwrite=true', async () => {
-    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -15,33 +15,19 @@ vi.mock('../config.js', () => ({
   REPO_ROOT: '/tmp',
 }))
 
-// Mock ws.ts so each test can control getClientCount and sendExportRequest.
-type MockedExportOptions = {
-  padding?: number
-  scale?: number
-  minFontPx?: number
-  frameId?: string
-  theme?: 'light' | 'dark'
-}
+// Mock ws.ts purely to observe that export never talks to it. getClientCount
+// is kept as a spy so the metamorphic test can vary it; it must have no
+// effect on export behavior post-headless-only.
 const mockGetClientCount = vi.fn<(workspaceId: string, slug: string) => number>()
-const mockSendExportRequest =
-  vi.fn<
-    (workspaceId: string, slug: string, requestId: string, options?: MockedExportOptions) => void
-  >()
+const mockSendExportRequest = vi.fn<(...args: unknown[]) => void>()
 
 vi.mock('./ws.js', () => ({
   getClientCount: (workspaceId: string, slug: string) => mockGetClientCount(workspaceId, slug),
-  sendExportRequest: (
-    workspaceId: string,
-    slug: string,
-    requestId: string,
-    options?: MockedExportOptions,
-  ) => mockSendExportRequest(workspaceId, slug, requestId, options),
+  sendExportRequest: (...args: unknown[]) => mockSendExportRequest(...args),
 }))
 
 // Stub the headless renderer so route tests do not pull jsdom/canvas/resvg in
-// every run. The fallback path just needs to return a valid PNG buffer for the
-// route to write to disk.
+// every run.
 type MockHeadlessArgs = {
   workspaceId: string
   slug: string
@@ -71,13 +57,16 @@ vi.mock('../store/canvas-store.js', () => ({
   canvasExists: (workspaceId: string, slug: string) => mockCanvasExists(workspaceId, slug),
 }))
 
-const { createExportRouter, resolveExportRequest } = await import('./export.js')
+const { createExportRouter } = await import('./export.js')
 
-function makeApp(options: { timeoutMs?: number } = {}) {
+function makeApp() {
   const app = new Hono()
-  app.route('/', createExportRouter(options))
+  app.route('/', createExportRouter())
   return app
 }
+
+const SAMPLE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 
 describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   beforeEach(async () => {
@@ -85,14 +74,20 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     mockGetClientCount.mockReset()
     mockSendExportRequest.mockReset()
     mockExportCanvasHeadless.mockReset()
+    mockCanvasExists.mockReset()
+    mockCanvasExists.mockResolvedValue(true)
   })
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('falls back to headless rendering when no WS clients are connected', async () => {
-    mockGetClientCount.mockReturnValue(0)
+  // Load-bearing regression test: with a WS client connected, export must
+  // still be served by the headless renderer, and nothing may be pushed to
+  // the socket. Against the pre-change dual-path code this would take the
+  // browser path (sendExportRequest called, no headless call) and fail.
+  it('is served by the headless renderer even when a WS client is connected', async () => {
+    mockGetClientCount.mockReturnValue(2)
     const fakePng = Buffer.from('fake-png-bytes')
     mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
     const app = makeApp()
@@ -101,7 +96,6 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
-    expect(body.filePath).toMatch(/canvas-a-.*\.excalidraw\.png$/)
     expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: 's1', slug: 'canvas-a' }),
     )
@@ -111,10 +105,34 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(written.equals(fakePng)).toBe(true)
   })
 
+  // Metamorphic: client count must not be an input to export behavior at all.
+  it('produces identical status/body/headless-args regardless of WS client count', async () => {
+    const fakePng = Buffer.from('fake-png-bytes')
+    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
+
+    mockGetClientCount.mockReturnValue(0)
+    const resNoClient = await makeApp().request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ padding: 20 }),
+    })
+    const argsNoClient = mockExportCanvasHeadless.mock.calls[0][0]
+
+    mockExportCanvasHeadless.mockClear()
+    mockGetClientCount.mockReturnValue(3)
+    const resWithClients = await makeApp().request('/api/canvas/s1/canvas-a/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ padding: 20 }),
+    })
+    const argsWithClients = mockExportCanvasHeadless.mock.calls[0][0]
+
+    expect(resWithClients.status).toBe(resNoClient.status)
+    expect(argsWithClients).toEqual(argsNoClient)
+    expect(mockSendExportRequest).not.toHaveBeenCalled()
+  })
+
   it('generates distinct default filePaths for two headless exports in the same millisecond', async () => {
-    // The default path used to be slug + millisecond timestamp only, so two
-    // exports issued fast enough to land in the same millisecond would
-    // collide and the second write would silently clobber the first.
     mockGetClientCount.mockReturnValue(0)
     mockExportCanvasHeadless.mockResolvedValue({
       png: Buffer.from('fake-png-bytes'),
@@ -137,11 +155,12 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     }
   })
 
-  it('returns 404 with canvas_not_found when no browser is connected and the canvas does not exist', async () => {
-    // Headless fallback used to silently succeed for unknown canvasIds:
-    // getDoc + loadCanvas hand back an empty LoroDoc on cache miss, so a
-    // typo would happily produce a blank PNG. Surface it as a 404 instead.
-    mockGetClientCount.mockReturnValue(0)
+  it('returns 404 with canvas_not_found when the canvas does not exist, even with a client connected', async () => {
+    // Headless rendering does NOT verify the canvas exists: getDoc / loadCanvas
+    // return an empty LoroDoc on cache miss, so a typo would otherwise
+    // silently produce a blank PNG. Surfaced as 404 unconditionally now that
+    // there is only one rendering path.
+    mockGetClientCount.mockReturnValue(1)
     mockCanvasExists.mockResolvedValueOnce(false)
     const app = makeApp()
 
@@ -154,8 +173,8 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
-  it('returns 500 with headless_export_failed when headless rendering throws', async () => {
-    mockGetClientCount.mockReturnValue(0)
+  it('returns 500 with headless_export_failed when headless rendering throws, even with a client connected', async () => {
+    mockGetClientCount.mockReturnValue(1)
     mockExportCanvasHeadless.mockRejectedValue(new Error('boom'))
     const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
@@ -165,52 +184,28 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(body.message).toBe('boom')
   })
 
-  it('returns 504 and a timeout error when a WS client does not respond', async () => {
+  // No timeout-driven failure mode exists any longer. The headless render
+  // resolving slowly (well past the old 10s browser-round-trip default) must
+  // still succeed, never 504.
+  it('resolves 200 even when headless rendering is slow, with no 504 timeout path', async () => {
     mockGetClientCount.mockReturnValue(1)
-    // Use a short real timeout instead of fake timers because
-    // vi.advanceTimersByTimeAsync cannot advance setTimeout inside Hono async context.
-    const app = makeApp({ timeoutMs: 50 })
-
+    mockExportCanvasHeadless.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ png: Buffer.from('slow-png'), width: 10, height: 10 }), 50)
+        }),
+    )
+    const app = makeApp()
     const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
-
-    expect(res.status).toBe(504)
-    const body = (await res.json()) as { error: string; message: string }
-    expect(body.error).toBe('timeout')
-    expect(body.message).toMatch(/0s|timed out/i)
+    expect(res.status).toBe(200)
   })
 
-  it('clears the timeout timer once the WS client resolves early', async () => {
+  it('passes padding through to exportCanvasHeadless options', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
-    })
-    const app = makeApp({ timeoutMs: 5_000 })
-
-    vi.useFakeTimers()
-    try {
-      const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
-      expect(res.status).toBe(200)
-      // A leaked timer would still be pending here, ticking until timeoutMs.
-      expect(vi.getTimerCount()).toBe(0)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('passes padding through to sendExportRequest options', async () => {
-    mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from('fake-png-bytes'),
+      width: 100,
+      height: 50,
     })
     const app = makeApp()
 
@@ -220,44 +215,17 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ padding: 48 }),
     })
     expect(res.status).toBe(200)
-    expect(mockSendExportRequest).toHaveBeenCalledWith('s1', 'canvas-a', expect.any(String), {
-      padding: 48,
-    })
+    expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
+      expect.objectContaining({ options: expect.objectContaining({ padding: 48 }) }),
+    )
   })
 
-  it('leaves options undefined when the body is missing or padding is omitted', async () => {
+  it('passes scale and minFontPx through to exportCanvasHeadless options', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
-    })
-    const app = makeApp()
-
-    const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
-    expect(res.status).toBe(200)
-    // options should remain undefined here.
-    const call = mockSendExportRequest.mock.calls[0]
-    expect(call[0]).toBe('s1')
-    expect(call[1]).toBe('canvas-a')
-    expect(call[3]?.padding).toBeUndefined()
-  })
-
-  // Route-level responsibility here is just to extract scale / minFontPx from
-  // the body and forward them to sendExportRequest. Browser-side
-  // useWhiteboardSync handles exportScale injection and minFontPx adjustment.
-  it('passes scale and minFontPx through to sendExportRequest options', async () => {
-    mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from('fake-png-bytes'),
+      width: 100,
+      height: 50,
     })
     const app = makeApp()
 
@@ -267,33 +235,32 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ padding: 32, scale: 2, minFontPx: 14 }),
     })
     expect(res.status).toBe(200)
-    expect(mockSendExportRequest).toHaveBeenCalledWith('s1', 'canvas-a', expect.any(String), {
-      padding: 32,
-      scale: 2,
-      minFontPx: 14,
-    })
+    expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ padding: 32, scale: 2, minFontPx: 14 }),
+      }),
+    )
   })
 
-  it('forwards theme to sendExportRequest options when a WS client is connected', async () => {
+  it('forwards theme to the headless export when a WS client is connected', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
-    })
+    const fakePng = Buffer.from('fake-dark-png')
+    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
     const app = makeApp()
 
     const res = await app.request('/api/canvas/s1/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ theme: 'dark' }),
+      body: JSON.stringify({ theme: 'dark', padding: 16 }),
     })
     expect(res.status).toBe(200)
-    const call = mockSendExportRequest.mock.calls[0]
-    expect(call[3]).toEqual({ theme: 'dark' })
+    expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 's1',
+        slug: 'canvas-a',
+        options: expect.objectContaining({ theme: 'dark', padding: 16 }),
+      }),
+    )
   })
 
   it('forwards theme to the headless export when no WS client is connected', async () => {
@@ -327,7 +294,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toMatchObject({ error: 'invalid_request' })
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('rejects an oversized request body with 413 payload_too_large', async () => {
@@ -344,15 +311,12 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(body).toMatchObject({ error: 'payload_too_large' })
   })
 
-  it('passes frameId through to sendExportRequest options', async () => {
+  it('passes frameId through to exportCanvasHeadless options', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from('fake-png-bytes'),
+      width: 100,
+      height: 50,
     })
     const app = makeApp()
 
@@ -362,70 +326,19 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       body: JSON.stringify({ frameId: 'frame-abc', padding: 24 }),
     })
     expect(res.status).toBe(200)
-    expect(mockSendExportRequest).toHaveBeenCalledWith('s1', 'canvas-a', expect.any(String), {
-      frameId: 'frame-abc',
-      padding: 24,
-    })
+    expect(mockExportCanvasHeadless).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ frameId: 'frame-abc', padding: 24 }),
+      }),
+    )
   })
 
-  it('leaves the other options undefined when only frameId is provided', async () => {
+  it('returns 200 and filePath for a plain export request', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
-    })
-    const app = makeApp()
-
-    await app.request('/api/canvas/s1/canvas-a/export', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ frameId: 'frame-xyz' }),
-    })
-    const call = mockSendExportRequest.mock.calls[0]
-    expect(call[3]).toEqual({ frameId: 'frame-xyz' })
-    expect(call[3]?.padding).toBeUndefined()
-    expect(call[3]?.scale).toBeUndefined()
-    expect(call[3]?.minFontPx).toBeUndefined()
-  })
-
-  it('does not include padding in options when only scale is provided', async () => {
-    mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
-    })
-    const app = makeApp()
-
-    await app.request('/api/canvas/s1/canvas-a/export', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scale: 3 }),
-    })
-    const call = mockSendExportRequest.mock.calls[0]
-    expect(call[3]).toEqual({ scale: 3 })
-    expect(call[3]?.padding).toBeUndefined()
-    expect(call[3]?.minFontPx).toBeUndefined()
-  })
-
-  it('returns 200 and filePath when a WS client sends export_response', async () => {
-    mockGetClientCount.mockReturnValue(1)
-    // Capture requestId from sendExportRequest and resolve it through resolveExportRequest.
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      // 1x1 transparent PNG base64
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
     })
     const app = makeApp()
 
@@ -439,13 +352,10 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   // directories recursively instead of failing with ENOENT.
   it('writes nested slash-containing slugs without ENOENT', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
     })
     const app = makeApp()
 
@@ -458,7 +368,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     expect(body.filePath).toMatch(/exports\/architecture\/overview-.*\.png$/)
   })
 
-  it('returns 400 for invalid workspaceId or slug without reaching WS', async () => {
+  it('returns 400 for invalid workspaceId or slug without reaching the headless renderer', async () => {
     mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
 
@@ -471,18 +381,15 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
       method: 'POST',
     })
     expect(badSlug.status).toBe(400)
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('writes the PNG to an explicit absolute outputPath when provided', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'subdir', 'custom.excalidraw.png')
@@ -512,7 +419,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('rejects outputPath outside workspace exports dir (different workspace checkpoints)', async () => {
@@ -527,7 +434,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('rejects outputPath fully outside DATA_DIR', async () => {
@@ -540,7 +447,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('does not leak internal paths in invalid_output_path error response', async () => {
@@ -586,18 +493,15 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toMatchObject({ error: 'invalid_output_path' })
-    expect(mockSendExportRequest).not.toHaveBeenCalled()
+    expect(mockExportCanvasHeadless).not.toHaveBeenCalled()
   })
 
   it('refuses to overwrite an existing PNG by default and returns 409', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'pre-existing.png')
@@ -617,13 +521,10 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
   it('overwrites an existing PNG when overwrite=true', async () => {
     mockGetClientCount.mockReturnValue(1)
-    mockSendExportRequest.mockImplementation((_sid, _slug, requestId) => {
-      queueMicrotask(() => {
-        resolveExportRequest(
-          requestId,
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-        )
-      })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'replace.png')

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -15,33 +15,14 @@ import { OutputPathError, validateOutputPath } from '../output-path.js'
 import { canvasExists } from '../store/canvas-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../validators.js'
 import { toCanvasOutputPathErrorBody } from './canvas-output-path-error.js'
-import { getClientCount, sendExportRequest } from './ws.js'
 
 // The body is a small JSON options object (padding/scale/frameId/theme/
-// outputPath), never canvas content — the PNG is rendered from the browser
-// (WS round-trip) or headless from the persisted doc, not from a
-// client-supplied payload. 1 MiB is a generous ceiling for that shape while
-// still bounding an adversarial request.
+// outputPath), never canvas content — the PNG is always rendered headlessly
+// from the persisted document. 1 MiB is a generous ceiling for that shape
+// while still bounding an adversarial request.
 const EXPORT_OPTIONS_BODY_LIMIT_BYTES = 1024 * 1024
 
-// requestId -> { resolve, reject }
-const pendingExports = new Map<
-  string,
-  { resolve: (data: string) => void; reject: (err: Error) => void }
->()
-
-// Receives WS export_response messages from ws.ts.
-export function resolveExportRequest(requestId: string, base64Data: string): void {
-  pendingExports.get(requestId)?.resolve(base64Data)
-}
-
-export interface CreateExportRouterOptions {
-  // Allow tests to override this with a shorter timeout. Default: 10 seconds.
-  timeoutMs?: number
-}
-
-export function createExportRouter(options: CreateExportRouterOptions = {}) {
-  const timeoutMs = options.timeoutMs ?? 10_000
+export function createExportRouter() {
   const app = new Hono()
 
   // POST /api/canvas/:workspaceId/:slug/export
@@ -69,9 +50,9 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
         throw err
       }
 
-      // The body is optional. Forward { padding?, scale?, minFontPx?, frameId? }
-      // to the browser. Empty body is fine; malformed JSON or schema-invalid
-      // payloads are rejected with 400 instead of being silently dropped.
+      // The body is optional. Empty body is fine; malformed JSON or
+      // schema-invalid payloads are rejected with 400 instead of being
+      // silently dropped.
       const rawText = await c.req.text()
       let body: z.infer<typeof exportRequestSchema> = {}
       if (rawText.length > 0) {
@@ -92,17 +73,10 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
         }
         body = parsed.data
       }
-      const options: Pick<typeof body, 'padding' | 'scale' | 'minFontPx' | 'frameId' | 'theme'> = {}
-      if (body.padding !== undefined) options.padding = body.padding
-      if (body.scale !== undefined) options.scale = body.scale
-      if (body.minFontPx !== undefined) options.minFontPx = body.minFontPx
-      if (body.frameId !== undefined) options.frameId = body.frameId
-      if (body.theme !== undefined) options.theme = body.theme
-      const hasOptions = Object.keys(options).length > 0
 
-      // Validate outputPath up front, before contacting the browser. Reject
-      // relative paths and pre-existing files (unless overwrite=true) so the
-      // caller does not waste a browser round-trip on a write that will fail.
+      // Validate outputPath up front, before rendering. Reject relative
+      // paths and pre-existing files (unless overwrite=true) so the caller
+      // does not waste a render on a write that will fail.
       let outputPath: string | undefined
       if (typeof body.outputPath === 'string' && body.outputPath.length > 0) {
         try {
@@ -121,19 +95,12 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
         outputPath = body.outputPath
       }
 
-      // Two PNG production paths share the same input validation and the same
-      // disk-write step; they only differ in where the bytes come from.
-      //   • browser path:  send a request over WS and wait for a base64 reply
-      //   • headless path: render directly from the LoroDoc using @resvg
-      // The browser path is preferred when a client is connected because it
-      // matches what the user is currently looking at (zoom, selection, etc.).
-      // The headless path operates directly on the LoroDoc and does NOT verify
-      // that the canvas actually exists — getDoc / loadCanvas return an empty
-      // doc on cache miss, so a typoed slug would otherwise emit a blank PNG.
-      // Reject up front with 404 so callers learn about the typo instead of
-      // shipping the silently-empty file.
-      const useHeadless = getClientCount(workspaceId, slug) === 0
-      if (useHeadless && !(await canvasExists(workspaceId, slug))) {
+      // The headless path operates directly on the LoroDoc and does NOT
+      // verify that the canvas actually exists — getDoc / loadCanvas return
+      // an empty doc on cache miss, so a typoed slug would otherwise emit a
+      // blank PNG. Reject up front with 404 so callers learn about the typo
+      // instead of shipping the silently-empty file.
+      if (!(await canvasExists(workspaceId, slug))) {
         const errBody: ExportErrorBody = {
           error: 'canvas_not_found',
           message: `Canvas not found: ${workspaceId}/${slug}`,
@@ -143,28 +110,9 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
 
       let pngBuffer: Buffer
       try {
-        pngBuffer = await (useHeadless
-          ? renderHeadless(workspaceId, slug, body)
-          : renderViaBrowser(workspaceId, slug, options, hasOptions, timeoutMs))
+        pngBuffer = await renderHeadless(workspaceId, slug, body)
       } catch (err) {
-        // Browser path failure where the WS clients have all disconnected
-        // since the count check is recoverable: the headless path can
-        // still produce a PNG. Re-sample the count and only fall back if
-        // the canvas exists, so a typo still surfaces as canvas_not_found
-        // instead of silently rendering blank bytes.
-        if (
-          !useHeadless &&
-          getClientCount(workspaceId, slug) === 0 &&
-          (await canvasExists(workspaceId, slug))
-        ) {
-          try {
-            pngBuffer = await renderHeadless(workspaceId, slug, body)
-          } catch (headlessErr) {
-            return c.json(toErrorBody(headlessErr, timeoutMs), errorStatus(headlessErr))
-          }
-        } else {
-          return c.json(toErrorBody(err, timeoutMs), errorStatus(err))
-        }
+        return c.json(toErrorBody(err), errorStatus(err))
       }
 
       const filePath = outputPath ?? defaultExportPath(workspaceId, slug)
@@ -202,38 +150,6 @@ export function createExportRouter(options: CreateExportRouterOptions = {}) {
       throw new ExportError('headless_export_failed', err)
     }
   }
-
-  async function renderViaBrowser(
-    workspaceId: string,
-    slug: string,
-    options: Pick<
-      z.infer<typeof exportRequestSchema>,
-      'padding' | 'scale' | 'minFontPx' | 'frameId' | 'theme'
-    >,
-    hasOptions: boolean,
-    timeoutMs: number,
-  ): Promise<Buffer> {
-    const requestId = nanoid()
-    let timer: ReturnType<typeof setTimeout> | undefined
-    try {
-      const base64Data = await new Promise<string>((resolve, reject) => {
-        pendingExports.set(requestId, { resolve, reject })
-        sendExportRequest(workspaceId, slug, requestId, hasOptions ? options : undefined)
-        timer = setTimeout(() => {
-          if (pendingExports.has(requestId)) {
-            pendingExports.delete(requestId)
-            reject(new Error('timeout'))
-          }
-        }, timeoutMs)
-      }).finally(() => {
-        pendingExports.delete(requestId)
-        clearTimeout(timer)
-      })
-      return Buffer.from(base64Data.replace(/^data:image\/\w+;base64,/, ''), 'base64')
-    } catch (err) {
-      throw new ExportError('browser_export_failed', err)
-    }
-  }
 }
 
 function defaultExportPath(workspaceId: string, slug: string): string {
@@ -250,7 +166,7 @@ function defaultExportPath(workspaceId: string, slug: string): string {
 
 class ExportError extends Error {
   constructor(
-    public readonly kind: 'browser_export_failed' | 'headless_export_failed',
+    public readonly kind: 'headless_export_failed',
     cause: unknown,
   ) {
     const inner = cause instanceof Error ? cause.message : String(cause)
@@ -259,26 +175,13 @@ class ExportError extends Error {
   }
 }
 
-function toErrorBody(err: unknown, timeoutMs: number): ExportErrorBody {
+function toErrorBody(err: unknown): ExportErrorBody {
   if (err instanceof ExportError) {
-    if (err.kind === 'browser_export_failed' && err.message === 'timeout') {
-      return {
-        error: 'timeout',
-        message: `Export timed out after ${Math.round(timeoutMs / 1000)}s. The browser client did not respond.`,
-      }
-    }
     return { error: err.kind, message: err.message }
   }
   return { error: 'internal', message: err instanceof Error ? err.message : String(err) }
 }
 
-function errorStatus(err: unknown): 500 | 504 {
-  if (
-    err instanceof ExportError &&
-    err.kind === 'browser_export_failed' &&
-    err.message === 'timeout'
-  ) {
-    return 504
-  }
+function errorStatus(_err: unknown): 500 {
   return 500
 }

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -112,7 +112,11 @@ export function createExportRouter() {
       try {
         pngBuffer = await renderHeadless(workspaceId, slug, body)
       } catch (err) {
-        return c.json(toErrorBody(err), errorStatus(err))
+        const errBody: ExportErrorBody = {
+          error: 'headless_export_failed',
+          message: err instanceof Error ? err.message : String(err),
+        }
+        return c.json(errBody, 500)
       }
 
       const filePath = outputPath ?? defaultExportPath(workspaceId, slug)
@@ -125,31 +129,25 @@ export function createExportRouter() {
   )
 
   return app
+}
 
-  // --- helpers --------------------------------------------------------------
-
-  async function renderHeadless(
-    workspaceId: string,
-    slug: string,
-    body: z.infer<typeof exportRequestSchema>,
-  ): Promise<Buffer> {
-    try {
-      const result = await exportCanvasHeadless({
-        workspaceId,
-        slug,
-        options: {
-          padding: body.padding,
-          scale: body.scale,
-          frameId: body.frameId,
-          minFontPx: body.minFontPx,
-          theme: body.theme,
-        },
-      })
-      return result.png
-    } catch (err) {
-      throw new ExportError('headless_export_failed', err)
-    }
-  }
+async function renderHeadless(
+  workspaceId: string,
+  slug: string,
+  body: z.infer<typeof exportRequestSchema>,
+): Promise<Buffer> {
+  const result = await exportCanvasHeadless({
+    workspaceId,
+    slug,
+    options: {
+      padding: body.padding,
+      scale: body.scale,
+      frameId: body.frameId,
+      minFontPx: body.minFontPx,
+      theme: body.theme,
+    },
+  })
+  return result.png
 }
 
 function defaultExportPath(workspaceId: string, slug: string): string {
@@ -162,26 +160,4 @@ function defaultExportPath(workspaceId: string, slug: string): string {
   // uniqueness regardless of call timing.
   const fileName = `${slug}-${timestamp}-${nanoid(6)}.excalidraw.png`
   return join(getDataDir(), workspaceId, 'exports', fileName)
-}
-
-class ExportError extends Error {
-  constructor(
-    public readonly kind: 'headless_export_failed',
-    cause: unknown,
-  ) {
-    const inner = cause instanceof Error ? cause.message : String(cause)
-    super(inner)
-    this.name = 'ExportError'
-  }
-}
-
-function toErrorBody(err: unknown): ExportErrorBody {
-  if (err instanceof ExportError) {
-    return { error: err.kind, message: err.message }
-  }
-  return { error: 'internal', message: err instanceof Error ? err.message : String(err) }
-}
-
-function errorStatus(_err: unknown): 500 {
-  return 500
 }

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -79,12 +79,6 @@ export function broadcastLoroUpdate(
 // Set the broadcastFn used by canvas.ts.
 setBroadcastFn(broadcastLoroUpdate)
 
-// Injected from export.ts: handles export_response messages.
-let resolveExportFn: ((requestId: string, data: string) => void) | null = null
-export function setResolveExportFn(fn: (requestId: string, data: string) => void): void {
-  resolveExportFn = fn
-}
-
 // Injected from canvas.ts: auto-version trigger with built-in throttling.
 // Called after WS binary messages; creates a new version and pushes it to the browser when the interval has elapsed.
 type AutoVersionTrigger = (
@@ -134,25 +128,6 @@ export function sendHeadChanged(workspaceId: string, slug: string, head: string)
 let resolveViewportFn: ((requestId: string) => void) | null = null
 export function setResolveViewportFn(fn: (requestId: string) => void): void {
   resolveViewportFn = fn
-}
-
-export function sendExportRequest(
-  workspaceId: string,
-  slug: string,
-  requestId: string,
-  options: {
-    padding?: number
-    scale?: number
-    minFontPx?: number
-    frameId?: string
-    theme?: 'light' | 'dark'
-  } = {},
-): void {
-  broadcastTextMessage(workspaceId, slug, {
-    type: 'export_request',
-    requestId,
-    ...omitUndefined(options),
-  })
 }
 
 export function sendViewportRequest(
@@ -278,7 +253,10 @@ export async function handleWsUpgrade(
     if (isClosing) return
     runtimeTouch()
     if (!isBinary) {
-      // text frame = JSON（export_response / viewport_response / ws_trace）
+      // text frame = JSON（viewport_response / ws_trace / client_ready）. An
+      // export_response frame still parses and passes scope checks, but is
+      // otherwise inert — the daemon stopped sending export_request in the
+      // headless-only export slice (see shared/ws-messages.ts).
       const text = Buffer.isBuffer(data) ? data.toString() : String(data)
       const msg = parseWsClientTextMessage(text)
       if (msg === null) return
@@ -314,9 +292,7 @@ export async function handleWsUpgrade(
         })
         return
       }
-      if (msg.type === 'export_response') {
-        resolveExportFn?.(msg.requestId, msg.data)
-      } else if (msg.type === 'viewport_response') {
+      if (msg.type === 'viewport_response') {
         resolveViewportFn?.(msg.requestId)
       }
       return

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -22,8 +22,9 @@ export const exportResponseSchema = z.object({
   filePath: z.string(),
 })
 
-// Shared error body. The route emits this for no_client (503), timeout (504),
-// invalid_output_path / output_exists (400 / 409), and internal (500).
+// Shared error body. The route emits this for invalid_request /
+// invalid_output_path (400), canvas_not_found (404), output_exists (409),
+// payload_too_large (413), and headless_export_failed / internal (500).
 // All fields are optional since some 5xx bodies come from proxies that
 // strip `error` without crashing the parser.
 export const exportErrorBodySchema = z.object({

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -24,7 +24,7 @@ export const exportResponseSchema = z.object({
 
 // Shared error body. The route emits this for invalid_request /
 // invalid_output_path (400), canvas_not_found (404), output_exists (409),
-// payload_too_large (413), and headless_export_failed / internal (500).
+// payload_too_large (413), and headless_export_failed (500).
 // All fields are optional since some 5xx bodies come from proxies that
 // strip `error` without crashing the parser.
 export const exportErrorBodySchema = z.object({

--- a/packages/mcp-server/src/shared/ws-messages.ts
+++ b/packages/mcp-server/src/shared/ws-messages.ts
@@ -57,6 +57,9 @@ export const viewportRequestMessageSchema = z.object({
   zoom: z.number().finite().optional(),
 })
 
+// The daemon no longer sends this message — canvas export is headless-only
+// (see server/routes/export.ts). Kept for apps/web's typechecking until the
+// phase that replaces the browser editor removes the last sender.
 export const exportRequestMessageSchema = z.object({
   type: z.literal('export_request'),
   requestId: z.string(),
@@ -98,6 +101,10 @@ export const clientReadyMessageSchema = z.object({
   type: z.literal('client_ready'),
 })
 
+// The daemon no longer awaits this message — canvas export is headless-only
+// (see server/routes/export.ts and routes/ws.ts, which treats an incoming
+// export_response frame as inert). Kept for apps/web's typechecking until the
+// phase that replaces the browser editor removes the last sender.
 export const exportResponseMessageSchema = z.object({
   type: z.literal('export_response'),
   requestId: z.string(),


### PR DESCRIPTION
## Why

`POST /api/canvas/:workspaceId/:slug/export` had two rendering paths. With a WebSocket client connected it sent an export request over the socket, the browser rendered the canvas through its Excalidraw UI, and a base64 PNG came back; otherwise a headless fallback ran. Two renderers producing different bytes under the same filename is the drift the OpenCanvas migration exists to eliminate, and the browser one is Excalidraw-shaped by construction.

It also meant the upcoming headless-renderer rewrite would have silently covered only half the traffic. Backward compatibility is out of scope during this migration, so the path is deleted rather than deprecated.

## What changed

Export is now headless-only, unconditionally. Removed: `renderViaBrowser`, the pending-export request-id bookkeeping, the response timeout and its `504`, the `timeoutMs` option (leaving `createExportRouter()` genuinely argument-less), the resolver wiring in `app.ts`, and `sendExportRequest` / `setResolveExportFn` / the `export_response` dispatch arm in `routes/ws.ts`. `viewport_response` and every other socket message are untouched.

Net −283 lines. The single remaining path let the route collapse further: `ExportError.kind` narrows to one literal and the status union loses `504`.

## Behavior changes worth knowing

- **A missing canvas now returns 404 even with a client connected.** The `canvasExists` pre-check previously ran only on the headless branch, so that request used to produce a browser-rendered blank PNG. This is a fix, but it is observable.
- No response can be `504` any more; there is no timeout-driven failure mode left.

The rest of the contract is unchanged: 200 `{ filePath }`, 400 invalid request / invalid output path, 404 canvas not found, 409 output exists, 413 payload too large, 500 on render failure.

## The test that carries this

The real risk is a browser path that is merely *unreachable* rather than gone — a test exercising only the no-client case would pass just as happily against the old dual-path code. So the load-bearing assertion is the opposite one: with a WebSocket client **connected**, the export is served by the headless renderer *and* nothing is pushed to the socket. It fails against the pre-change code.

`ws-validation.test.ts` still passes unmodified, so the `export_response` schema accepts and rejects exactly as before.

## Kept deliberately

The `export_request` / `export_response` **schemas** in `shared/ws-messages.ts` stay. `serverTextMessageSchema` still unions them and both `shared/daemon-backend.ts` and apps/web parse against them; the browser-side sender goes away with the editor in a later phase. A comment at the declarations records that the daemon no longer sends or consumes them, so the next reader does not assume they are live.

## Docs

`docs/reference/export-formats.md` said png "prefers the connected browser client". The follow-on paragraph contrasting svg/json as the reliable formats *because* they never need a browser was rewritten too rather than left standing — that contrast is now vacuous. `security-model.md` and `configuration.md` had the same assumption baked in.

## Follow-ups found, not fixed here

Both pre-existing, neither created by this change:

- `server/mcp/standalone-help.ts` advertises an `export_canvas({format})` MCP tool, and `routes/status.ts` explains a `canvas_open -> export_canvas` race. **No MCP export tool is registered** — `opencanvas-tools.ts` registers none, so the HTTP route is the only live export surface. That help text is stale.
- `getReadyClientCount` and the `/status` ready-client wait existed largely so a caller could sequence `canvas_open` before a browser export. With browser export gone, viewport is its only remaining justification. The route is a public HTTP contract, so it stays for now.

## Verification

```
pnpm -r typecheck                exit 0
pnpm test --project mcp-node     Test Files 246 passed  Tests 3077 passed | 2 skipped
pnpm build                       exit 0
pnpm knip                        exit 0
pnpm smoke:e2e                   ALL OK
```
