### PR TITLE
feat(mcp-server): compose a canvas-render scene from a spatial canvas

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -194,6 +194,8 @@
   },
   "devDependencies": {
     "@fast-check/vitest": "^0.4.1",
+    "@kamiazya/whiteboard-canvas-codec": "workspace:*",
+    "@kamiazya/whiteboard-canvas-model": "workspace:*",
     "@kamiazya/whiteboard-canvas-ports": "workspace:*",
     "@kamiazya/whiteboard-canvas-render": "workspace:*",
     "@kamiazya/whiteboard-canvas-viewer": "workspace:*",

--- a/packages/mcp-server/src/server/export/scene-transform.test.ts
+++ b/packages/mcp-server/src/server/export/scene-transform.test.ts
@@ -1,0 +1,113 @@
+import type {
+  ListBlockNode,
+  ListItemNode,
+  Scene,
+  TableBlockNode,
+} from '@kamiazya/whiteboard-canvas-render'
+import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, it } from 'vitest'
+
+import { translateScene } from './scene-transform.js'
+
+function paragraphScene(): Scene {
+  return {
+    nodes: [
+      {
+        kind: 'paragraph',
+        bbox: { x: 0, y: 0, w: 100, h: 20 },
+        runs: [{ kind: 'textRun', bbox: { x: 0, y: 16, w: 40, h: 20 }, text: 'hi' }],
+      },
+    ],
+  }
+}
+
+function listScene(): Scene {
+  const item: ListItemNode = {
+    kind: 'listItem',
+    bbox: { x: 24, y: 0, w: 76, h: 20 },
+    children: [
+      {
+        kind: 'paragraph',
+        bbox: { x: 0, y: 0, w: 76, h: 20 },
+        runs: [{ kind: 'textRun', bbox: { x: 0, y: 16, w: 20, h: 20 }, text: 'a' }],
+      },
+    ],
+  }
+  const list: ListBlockNode = {
+    kind: 'list',
+    bbox: { x: 0, y: 0, w: 100, h: 20 },
+    ordered: false,
+    depth: 0,
+    items: [item],
+  }
+  return { nodes: [list] }
+}
+
+describe('translateScene', () => {
+  it('is the identity when translated by (0, 0)', () => {
+    const scene = paragraphScene()
+    expect(translateScene(scene, 0, 0)).toEqual(scene)
+  })
+
+  it('shifts a flat scene bbox by (dx, dy)', () => {
+    const scene = paragraphScene()
+    const shifted = translateScene(scene, 5, 7)
+    expect(shifted.nodes[0]?.bbox).toEqual({ x: 5, y: 7, w: 100, h: 20 })
+  })
+
+  it('shifts a listItem wrapper on x but leaves its descendants wrapper-relative x untouched', () => {
+    const scene = listScene()
+    const shifted = translateScene(scene, 10, 0)
+    const list = shifted.nodes[0] as ListBlockNode
+    const item = list.items[0]!
+    expect(item.bbox.x).toBe(24 + 10)
+    const paragraph = item.children[0]!
+    expect(paragraph.bbox.x).toBe(0) // unchanged: relative to the item's own transform
+  })
+
+  it('composes additively: translate(translate(s,a,b),c,d) === translate(s,a+c,b+d)', () => {
+    const scene = listScene()
+    const twice = translateScene(translateScene(scene, 3, 4), 5, 6)
+    const once = translateScene(scene, 8, 10)
+    expect(twice).toEqual(once)
+  })
+
+  it('produces the correct final drawn x through the SVG backend (no double-shift)', () => {
+    const scene = listScene()
+    const dx = 50
+    const baseline = renderSceneToSvg(scene)
+    const shifted = renderSceneToSvg(translateScene(scene, dx, 0))
+
+    // The listItem wrapper's own transform must shift by exactly dx.
+    const baselineTransform = baseline.match(/transform="translate\(([-\d.]+),0\)"/)
+    const shiftedTransform = shifted.match(/transform="translate\(([-\d.]+),0\)"/)
+    expect(Number(shiftedTransform?.[1])).toBeCloseTo(Number(baselineTransform?.[1]) + dx)
+
+    // The nested text run's own x attribute (relative, inside the <g>) is unchanged.
+    const baselineText = baseline.match(/<text x="([-\d.]+)"/)
+    const shiftedText = shifted.match(/<text x="([-\d.]+)"/)
+    expect(Number(shiftedText?.[1])).toBeCloseTo(Number(baselineText?.[1])!)
+  })
+
+  it('tripwire: exactly listItem and tableCell emit a transform in the SVG backend', () => {
+    const table: TableBlockNode = {
+      kind: 'table',
+      bbox: { x: 0, y: 0, w: 100, h: 24 },
+      rows: [
+        {
+          kind: 'tableRow',
+          bbox: { x: 0, y: 0, w: 100, h: 24 },
+          cells: [{ kind: 'tableCell', bbox: { x: 30, y: 0, w: 70, h: 24 }, runs: [] }],
+        },
+      ],
+    }
+    const scene = listScene()
+    const combined: Scene = { nodes: [...scene.nodes, table] }
+    const svg = renderSceneToSvg(combined)
+    const transformCount = (svg.match(/transform="translate\(/g) ?? []).length
+    // one from the listItem, one from the tableCell — if canvas-render adds
+    // a third translating renderer this count changes and this test fails,
+    // signalling translateScene's x-rule needs to learn about it too.
+    expect(transformCount).toBe(2)
+  })
+})

--- a/packages/mcp-server/src/server/export/scene-transform.ts
+++ b/packages/mcp-server/src/server/export/scene-transform.ts
@@ -1,0 +1,167 @@
+// Pure scene -> scene translation. `layoutMdastBlocks` (canvas-render)
+// always lays out a block tree relative to its own origin (its top-level
+// nodes start at y = 0, `x` = 0 or a list-depth offset) — placing that
+// output at a spatial node's absolute position requires shifting the whole
+// tree by the node's (x, y).
+//
+// The x axis needs special care. `renderListItem`/`renderTableCell` (the
+// SVG backend, canvas-render's svg/backend.ts) are the only renderers that
+// emit `transform="translate(bbox.x,0)"` — everything below such a wrapper
+// is stored **wrapper-relative** on x. Shifting every bbox.x by the same
+// dx would double-shift that subtree: once via the wrapper's own bbox.x
+// (which feeds directly into its transform), and again via each
+// descendant's already-relative bbox.x. So x is only shifted down to (and
+// including) the nearest such wrapper; everything further nested keeps its
+// stored x untouched. y carries no such wrapper transform anywhere in the
+// backend, so it is always shifted unconditionally, at every depth.
+//
+// This mirrors scene-bounds.ts's `subtreeOffsetX`/`childrenOf` walk
+// exactly, because both functions must agree on which nodes are
+// x-transform boundaries — see the tripwire test in spatial-scene.test.ts.
+import type {
+  BlockquoteNode,
+  BoundingBox,
+  EmbedResolvedNode,
+  GroupSceneNode,
+  ListBlockNode,
+  ListItemNode,
+  Scene,
+  SceneNode,
+  TableBlockNode,
+  TableCellSceneNode,
+  TableRowSceneNode,
+} from '@kamiazya/whiteboard-canvas-render'
+
+type TranslatableNode = SceneNode | ListItemNode | TableRowSceneNode | TableCellSceneNode
+
+function translateBbox(bbox: BoundingBox, dx: number, dy: number): BoundingBox {
+  return { x: bbox.x + dx, y: bbox.y + dy, w: bbox.w, h: bbox.h }
+}
+
+/**
+ * `true` when `node` is a wrapper that emits its own x transform in the SVG
+ * backend — its children's stored `bbox.x` is relative to that wrapper and
+ * must NOT receive an additional x shift.
+ */
+function isXTransformBoundary(node: TranslatableNode): boolean {
+  return node.kind === 'listItem' || node.kind === 'tableCell'
+}
+
+/**
+ * Translates one node (and, if it has children, its whole subtree) by
+ * `(dx, dy)`. `shiftX` is `false` once the walk has passed an
+ * x-transform-boundary wrapper, and stays `false` for every node beneath
+ * it, however deep — matching `scene-bounds.ts`'s `offsetX` accumulation.
+ */
+function translateNode(
+  node: TranslatableNode,
+  dx: number,
+  dy: number,
+  shiftX: boolean,
+): TranslatableNode {
+  const appliedDx = shiftX ? dx : 0
+  const childShiftX = shiftX && !isXTransformBoundary(node)
+
+  if (node.kind === 'edge') {
+    return {
+      ...node,
+      path: node.path.map((point) => ({ x: point.x + appliedDx, y: point.y + dy })),
+    }
+  }
+
+  const bbox = translateBbox(node.bbox, appliedDx, dy)
+
+  switch (node.kind) {
+    case 'blockquote': {
+      const blockquote = node as BlockquoteNode
+      return {
+        ...blockquote,
+        bbox,
+        children: blockquote.children.map((child) =>
+          translateNode(child, dx, dy, childShiftX),
+        ) as readonly SceneNode[],
+      }
+    }
+    case 'group': {
+      const group = node as GroupSceneNode
+      return {
+        ...group,
+        bbox,
+        children: group.children.map((child) =>
+          translateNode(child, dx, dy, childShiftX),
+        ) as readonly SceneNode[],
+      }
+    }
+    case 'embedResolved': {
+      const embed = node as EmbedResolvedNode
+      return {
+        ...embed,
+        bbox,
+        children: embed.children.map((child) =>
+          translateNode(child, dx, dy, childShiftX),
+        ) as readonly SceneNode[],
+      }
+    }
+    case 'listItem': {
+      const listItem = node as ListItemNode
+      return {
+        ...listItem,
+        bbox,
+        children: listItem.children.map((child) =>
+          translateNode(child, dx, dy, childShiftX),
+        ) as readonly SceneNode[],
+      }
+    }
+    case 'list': {
+      const list = node as ListBlockNode
+      return {
+        ...list,
+        bbox,
+        items: list.items.map((item) => translateNode(item, dx, dy, childShiftX) as ListItemNode),
+      }
+    }
+    case 'table': {
+      const table = node as TableBlockNode
+      return {
+        ...table,
+        bbox,
+        rows: table.rows.map((row) => translateNode(row, dx, dy, childShiftX) as TableRowSceneNode),
+      }
+    }
+    case 'tableRow': {
+      const row = node as TableRowSceneNode
+      return {
+        ...row,
+        bbox,
+        cells: row.cells.map(
+          (cell) => translateNode(cell, dx, dy, childShiftX) as TableCellSceneNode,
+        ),
+      }
+    }
+    case 'tableCell': {
+      const cell = node as TableCellSceneNode
+      return {
+        ...cell,
+        bbox,
+        runs: cell.runs.map((run) => translateNode(run, dx, dy, childShiftX)),
+      } as TableCellSceneNode
+    }
+    case 'heading':
+    case 'paragraph': {
+      return {
+        ...node,
+        bbox,
+        runs: node.runs.map((run) => translateNode(run, dx, dy, childShiftX)),
+      } as SceneNode
+    }
+    default:
+      return { ...node, bbox } as TranslatableNode
+  }
+}
+
+/** Translates an entire scene by `(dx, dy)`, preserving every non-geometric field. */
+export function translateScene(scene: Scene, dx: number, dy: number): Scene {
+  return {
+    nodes: scene.nodes.map((node) => translateNode(node, dx, dy, true) as SceneNode),
+  }
+}

--- a/packages/mcp-server/src/server/export/scene-transform.ts
+++ b/packages/mcp-server/src/server/export/scene-transform.ts
@@ -19,17 +19,13 @@
 // exactly, because both functions must agree on which nodes are
 // x-transform boundaries — see the tripwire test in spatial-scene.test.ts.
 import type {
-  BlockquoteNode,
   BoundingBox,
-  EmbedResolvedNode,
-  GroupSceneNode,
-  ListBlockNode,
   ListItemNode,
   Scene,
   SceneNode,
-  TableBlockNode,
   TableCellSceneNode,
   TableRowSceneNode,
+  TextRunNode,
 } from '@kamiazya/whiteboard-canvas-render'
 
 type TranslatableNode = SceneNode | ListItemNode | TableRowSceneNode | TableCellSceneNode
@@ -70,92 +66,31 @@ function translateNode(
   }
 
   const bbox = translateBbox(node.bbox, appliedDx, dy)
+  const translateChild = (child: TranslatableNode): TranslatableNode =>
+    translateNode(child, dx, dy, childShiftX)
 
   switch (node.kind) {
-    case 'blockquote': {
-      const blockquote = node as BlockquoteNode
-      return {
-        ...blockquote,
-        bbox,
-        children: blockquote.children.map((child) =>
-          translateNode(child, dx, dy, childShiftX),
-        ) as readonly SceneNode[],
-      }
-    }
-    case 'group': {
-      const group = node as GroupSceneNode
-      return {
-        ...group,
-        bbox,
-        children: group.children.map((child) =>
-          translateNode(child, dx, dy, childShiftX),
-        ) as readonly SceneNode[],
-      }
-    }
-    case 'embedResolved': {
-      const embed = node as EmbedResolvedNode
-      return {
-        ...embed,
-        bbox,
-        children: embed.children.map((child) =>
-          translateNode(child, dx, dy, childShiftX),
-        ) as readonly SceneNode[],
-      }
-    }
-    case 'listItem': {
-      const listItem = node as ListItemNode
-      return {
-        ...listItem,
-        bbox,
-        children: listItem.children.map((child) =>
-          translateNode(child, dx, dy, childShiftX),
-        ) as readonly SceneNode[],
-      }
-    }
-    case 'list': {
-      const list = node as ListBlockNode
-      return {
-        ...list,
-        bbox,
-        items: list.items.map((item) => translateNode(item, dx, dy, childShiftX) as ListItemNode),
-      }
-    }
-    case 'table': {
-      const table = node as TableBlockNode
-      return {
-        ...table,
-        bbox,
-        rows: table.rows.map((row) => translateNode(row, dx, dy, childShiftX) as TableRowSceneNode),
-      }
-    }
-    case 'tableRow': {
-      const row = node as TableRowSceneNode
-      return {
-        ...row,
-        bbox,
-        cells: row.cells.map(
-          (cell) => translateNode(cell, dx, dy, childShiftX) as TableCellSceneNode,
-        ),
-      }
-    }
-    case 'tableCell': {
-      const cell = node as TableCellSceneNode
-      return {
-        ...cell,
-        bbox,
-        runs: cell.runs.map((run) => translateNode(run, dx, dy, childShiftX)),
-      } as TableCellSceneNode
-    }
+    case 'blockquote':
+    case 'group':
+    case 'embedResolved':
+    case 'listItem':
+      return { ...node, bbox, children: node.children.map(translateChild) as readonly SceneNode[] }
     case 'heading':
-    case 'paragraph': {
+    case 'paragraph':
+    case 'tableCell':
+      return { ...node, bbox, runs: node.runs.map(translateChild) as readonly TextRunNode[] }
+    case 'list':
+      return { ...node, bbox, items: node.items.map(translateChild) as readonly ListItemNode[] }
+    case 'table':
+      return { ...node, bbox, rows: node.rows.map(translateChild) as readonly TableRowSceneNode[] }
+    case 'tableRow':
       return {
         ...node,
         bbox,
-        runs: node.runs.map((run) => translateNode(run, dx, dy, childShiftX)),
-      } as SceneNode
-    }
+        cells: node.cells.map(translateChild) as readonly TableCellSceneNode[],
+      }
     default:
-      return { ...node, bbox } as TranslatableNode
+      return { ...node, bbox }
   }
 }
 

--- a/packages/mcp-server/src/server/export/spatial-scene-appearance.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene-appearance.ts
@@ -1,0 +1,40 @@
+// The single named constant block for spatial-scene composition
+// (spatial-scene.ts). canvas-render's layout functions deliberately never
+// invent a fill/stroke/font (see `Appearance` in canvas-render's
+// scene-graph.ts) — that decision belongs to the composition root until the
+// theme layer (Phase 4) lands. Every color/size literal used by this
+// module's chrome and labels lives here, and only here, so the theme layer
+// has one obvious place to replace.
+import type { Appearance } from '@kamiazya/whiteboard-canvas-render'
+
+/** Per spatial-node-kind chrome appearance (the box behind each node). */
+export const SPATIAL_NODE_APPEARANCE: Readonly<
+  Record<'text' | 'file' | 'link' | 'group', Appearance>
+> = {
+  text: { fill: '#ffffff', stroke: '#d0d0d0', strokeWidth: 1 },
+  file: { fill: '#f5f5f5', stroke: '#c0c0c0', strokeWidth: 1 },
+  link: { fill: '#eef4ff', stroke: '#a9c6ff', strokeWidth: 1 },
+  // Groups are deliberately unfilled: a filled group rect emitted after (or
+  // before) a member node in the flat, position-sorted node order would
+  // otherwise risk painting over — or under — that member depending on
+  // sort order. `fill: 'none'` removes the z-order question entirely.
+  group: { fill: 'none', stroke: '#b0b0b0', strokeWidth: 1 },
+} as const
+
+/** Appearance applied to every routed edge. */
+export const EDGE_APPEARANCE: Appearance = { stroke: '#606060', strokeWidth: 1.5 }
+
+/** Appearance applied to the readable label run on `file`/`link`/`group` nodes. */
+export const LABEL_APPEARANCE: Appearance = { fill: '#303030', fontFamily: 'sans-serif' }
+
+/** Uniform padding (px) between a node's box edge and its laid-out content. */
+export const NODE_PADDING_PX = 8
+
+/** Uniform corner radius (px) applied to every node's chrome shape. */
+export const NODE_CORNER_RADIUS_PX = 4
+
+/** Font size (px) used for the `file`/`link`/`group` label run. */
+export const LABEL_FONT_SIZE_PX = 14
+
+/** Floor for a node's derived content width, so padding never drives it negative. */
+export const MIN_CONTENT_WIDTH_PX = 1

--- a/packages/mcp-server/src/server/export/spatial-scene.properties.test.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.properties.test.ts
@@ -1,0 +1,102 @@
+import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
+import fc from 'fast-check'
+import { describe, expect } from 'vitest'
+
+import { fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
+import { composeSpatialScene } from './spatial-scene.js'
+import { createFakeMeasure } from './spatial-scene.test-utils.js'
+
+const measure = createFakeMeasure()
+
+const positionArbitrary = fc.integer({ min: -2000, max: 2000 })
+const sizeArbitrary = fc.integer({ min: 0, max: 2000 })
+const idArbitrary = fc.stringMatching(/^[a-zA-Z0-9_-]{1,12}$/)
+
+const spatialNodeArbitrary: fc.Arbitrary<SpatialNode> = idArbitrary.chain((id) =>
+  fc.oneof(
+    fc.record({
+      id: fc.constant(id),
+      type: fc.constant('text' as const),
+      x: positionArbitrary,
+      y: positionArbitrary,
+      width: sizeArbitrary,
+      height: sizeArbitrary,
+      text: fc.constantFrom('hello', '# Title', 'plain **bold** text', ''),
+    }),
+    fc.record({
+      id: fc.constant(id),
+      type: fc.constant('file' as const),
+      x: positionArbitrary,
+      y: positionArbitrary,
+      width: sizeArbitrary,
+      height: sizeArbitrary,
+      file: fc.constantFrom('a.md', 'notes/b.md'),
+    }),
+    fc.record({
+      id: fc.constant(id),
+      type: fc.constant('link' as const),
+      x: positionArbitrary,
+      y: positionArbitrary,
+      width: sizeArbitrary,
+      height: sizeArbitrary,
+      url: fc.constant('https://example.com'),
+    }),
+    fc.record({
+      id: fc.constant(id),
+      type: fc.constant('group' as const),
+      x: positionArbitrary,
+      y: positionArbitrary,
+      width: sizeArbitrary,
+      height: sizeArbitrary,
+      label: fc.option(fc.constantFrom('Section'), { nil: undefined }),
+    }),
+  ),
+)
+
+function uniqueById(nodes: readonly SpatialNode[]): SpatialNode[] {
+  const seen = new Set<string>()
+  return nodes.filter((node) => {
+    if (seen.has(node.id)) return false
+    seen.add(node.id)
+    return true
+  })
+}
+
+const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
+  .array(spatialNodeArbitrary, { minLength: 0, maxLength: 6 })
+  .map((nodes) => ({ nodes: uniqueById(nodes), edges: [] as CanvasEdge[] }))
+
+describe('composeSpatialScene properties', () => {
+  fcTest.prop([spatialCanvasArbitrary], withDefaults())(
+    'never throws and renders through renderSceneToSvg without throwing',
+    (canvas) => {
+      const scene = composeSpatialScene(canvas, { measure })
+      expect(() => renderSceneToSvg(scene, { padding: 8 })).not.toThrow()
+    },
+  )
+
+  fcTest.prop([spatialCanvasArbitrary, fc.integer({ min: 0, max: 5 })], withDefaults())(
+    'is invariant under permutation of the node array',
+    (canvas, seed) => {
+      const shuffled = [...canvas.nodes]
+      // deterministic pseudo-shuffle from the seed, no RNG dependency
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = (i + seed) % (i + 1)
+        ;[shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!]
+      }
+      const a = composeSpatialScene(canvas, { measure })
+      const b = composeSpatialScene({ ...canvas, nodes: shuffled }, { measure })
+      expect(a).toEqual(b)
+    },
+  )
+
+  fcTest.prop([spatialCanvasArbitrary], withDefaults())(
+    'composing the same canvas twice yields byte-identical SVG',
+    (canvas) => {
+      const svgA = renderSceneToSvg(composeSpatialScene(canvas, { measure }), { padding: 4 })
+      const svgB = renderSceneToSvg(composeSpatialScene(canvas, { measure }), { padding: 4 })
+      expect(svgA).toBe(svgB)
+    },
+  )
+})

--- a/packages/mcp-server/src/server/export/spatial-scene.test-utils.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.test-utils.ts
@@ -1,0 +1,14 @@
+// Deterministic, arithmetic-only measurer local to this test file's suite.
+// Mirrors canvas-render's own internal `createFakeMeasure` test helper
+// (that package does not publish a `test-utils` export subpath), so scene
+// composition tests never depend on a real font/platform text API.
+import type { FontDescriptor, MeasureText, TextMetrics } from '@kamiazya/whiteboard-canvas-render'
+
+export function createFakeMeasure(charWidthFactor = 0.6): MeasureText {
+  return (text: string, font: FontDescriptor): TextMetrics => ({
+    advanceWidth: text.length * charWidthFactor * font.sizePx,
+    ascent: font.sizePx * 0.8,
+    descent: font.sizePx * 0.2,
+    lineGap: font.sizePx * 0.1,
+  })
+}

--- a/packages/mcp-server/src/server/export/spatial-scene.test.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.test.ts
@@ -1,0 +1,259 @@
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type {
+  HeadingBlockNode,
+  Scene,
+  ShapeSceneNode,
+  TextRunNode,
+} from '@kamiazya/whiteboard-canvas-render'
+import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, it, vi } from 'vitest'
+
+import { captureLogsForTests } from '../log.js'
+import { createFakeMeasure } from './spatial-scene.test-utils.js'
+
+// Only `parseMarkdownBody('__THROW__')` is mocked to throw; every other
+// input goes through the real parser. This isolates the malformed-body
+// degradation test from having to find a markdown string that reliably
+// falls outside canvas-codec's own versioned mdast subset — the totality
+// behavior under test belongs to spatial-scene.ts, not to canvas-codec.
+vi.mock('@kamiazya/whiteboard-canvas-codec', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@kamiazya/whiteboard-canvas-codec')>()
+  return {
+    ...actual,
+    parseMarkdownBody: (body: string) => {
+      if (body === '__THROW__') throw new Error('simulated unsupported mdast construct')
+      return actual.parseMarkdownBody(body)
+    },
+  }
+})
+
+const { composeSpatialScene } = await import('./spatial-scene.js')
+
+const measure = createFakeMeasure()
+
+function textNode(
+  overrides: Partial<Extract<SpatialNode, { type: 'text' }>> = {},
+): Extract<SpatialNode, { type: 'text' }> {
+  return {
+    id: 'n1',
+    type: 'text',
+    x: 100,
+    y: 50,
+    width: 200,
+    height: 100,
+    text: '# Title',
+    ...overrides,
+  }
+}
+
+function canvas(nodes: SpatialNode[], edges: SpatialCanvas['edges'] = []): SpatialCanvas {
+  return { nodes, edges }
+}
+
+function shapesOf(scene: Scene): ShapeSceneNode[] {
+  return scene.nodes.filter((n): n is ShapeSceneNode => n.kind === 'shape')
+}
+
+describe('composeSpatialScene', () => {
+  it('emits a chrome shape matching the node box plus its laid-out content', () => {
+    const node = textNode()
+    const scene = composeSpatialScene(canvas([node]), { measure })
+
+    const shape = scene.nodes.find((n): n is ShapeSceneNode => n.kind === 'shape')
+    expect(shape?.bbox).toEqual({ x: 100, y: 50, w: 200, h: 100 })
+
+    const heading = scene.nodes.find((n): n is HeadingBlockNode => n.kind === 'heading')
+    expect(heading).toBeDefined()
+    const run = heading!.runs[0]
+    expect(run.text).toBe('Title')
+  })
+
+  it('positions a laid-out block at the node coordinates plus padding', () => {
+    const node = textNode({ x: 300, y: 150, text: 'plain body' })
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    // layoutMdastBlocks places the first block's own origin at y=0, x=0 —
+    // so after translation it must land exactly at node.y/x + padding.
+    expect(paragraph?.bbox.y).toBe(150 + 8)
+    expect(paragraph?.bbox.x).toBe(300 + 8)
+  })
+
+  it('clamps content width so it never goes negative for a narrow node', () => {
+    const node = textNode({ width: 4, text: 'x' })
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    for (const n of scene.nodes) {
+      if ('bbox' in n) expect(n.bbox.w).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('is deterministic across differently-ordered input describing the same canvas', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0 })
+    const b = textNode({ id: 'b', x: 10, y: 0 })
+    const sceneForward = composeSpatialScene(canvas([a, b]), { measure })
+    const sceneReversed = composeSpatialScene(canvas([b, a]), { measure })
+    expect(sceneForward).toEqual(sceneReversed)
+  })
+
+  it('breaks ties at identical position by id, independent of array order', () => {
+    const a = textNode({ id: 'a', x: 5, y: 5 })
+    const b = textNode({ id: 'b', x: 5, y: 5 })
+    const forward = composeSpatialScene(canvas([a, b]), { measure })
+    const reversed = composeSpatialScene(canvas([b, a]), { measure })
+    expect(forward).toEqual(reversed)
+  })
+
+  it('routes an edge between two nodes, emitted after all node content', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 200, y: 0, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+    const scene = composeSpatialScene(canvas([a, b], [edge]), { measure })
+
+    const edgeIndex = scene.nodes.findIndex((n) => n.kind === 'edge')
+    expect(edgeIndex).toBeGreaterThan(-1)
+    const routedEdge = scene.nodes[edgeIndex]
+    expect(routedEdge?.kind === 'edge' && routedEdge.appearance).toEqual({
+      stroke: '#606060',
+      strokeWidth: 1.5,
+    })
+    // every non-edge node must appear before the edge
+    for (let i = 0; i < edgeIndex; i++) {
+      expect(scene.nodes[i]?.kind).not.toBe('edge')
+    }
+  })
+
+  it('degrades a missing edge endpoint instead of throwing, keeping all nodes', () => {
+    const a = textNode({ id: 'a' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'ghost' }
+    expect(() => composeSpatialScene(canvas([a], [edge]), { measure })).not.toThrow()
+    const scene = composeSpatialScene(canvas([a], [edge]), { measure })
+    expect(shapesOf(scene)).toHaveLength(1)
+  })
+
+  it('degrades an unrecognized node kind to chrome only, without throwing or dropping siblings', () => {
+    const good = textNode({ id: 'good' })
+    const bogus = { ...textNode({ id: 'bogus' }), type: 'bogus' } as unknown as SpatialNode
+    expect(() => composeSpatialScene(canvas([good, bogus]), { measure })).not.toThrow()
+    const scene = composeSpatialScene(canvas([good, bogus]), { measure })
+    expect(shapesOf(scene)).toHaveLength(2)
+  })
+
+  it('degrades a malformed markdown body to a literal text run and logs a warning, leaving other nodes intact', () => {
+    const capture = captureLogsForTests()
+    try {
+      const good = textNode({ id: 'good', text: 'fine' })
+      const bad = textNode({ id: 'bad', x: 400, text: '__THROW__' })
+      const scene = composeSpatialScene(canvas([good, bad]), { measure })
+      expect(shapesOf(scene)).toHaveLength(2)
+      const badLabel = scene.nodes.find(
+        (n): n is TextRunNode => n.kind === 'textRun' && n.text === '__THROW__',
+      )
+      expect(badLabel).toBeDefined()
+      expect(capture.records.some((r) => r.level === 'warning')).toBe(true)
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('composes a zero-size node without throwing, emitting a zero-area shape', () => {
+    const node = textNode({ width: 0, height: 0 })
+    expect(() => composeSpatialScene(canvas([node]), { measure })).not.toThrow()
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    const shape = shapesOf(scene)[0]
+    expect(shape?.bbox.w).toBe(0)
+    expect(shape?.bbox.h).toBe(0)
+  })
+
+  it('renders a file node as chrome plus a label containing the path and subpath', () => {
+    const node: Extract<SpatialNode, { type: 'file' }> = {
+      id: 'f1',
+      type: 'file',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      file: 'notes/a.md',
+      subpath: '#heading',
+    }
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
+    expect(label?.text).toBe('notes/a.md#heading')
+  })
+
+  it('renders a link node as chrome plus a label containing the url', () => {
+    const node: Extract<SpatialNode, { type: 'link' }> = {
+      id: 'l1',
+      type: 'link',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      url: 'https://example.com/page',
+    }
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
+    expect(label?.text).toBe('https://example.com/page')
+  })
+
+  it('renders a group node as chrome plus its label, and chrome-only when unlabeled', () => {
+    const labeled: Extract<SpatialNode, { type: 'group' }> = {
+      id: 'g1',
+      type: 'group',
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      label: 'Section A',
+    }
+    const scene = composeSpatialScene(canvas([labeled]), { measure })
+    const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
+    expect(label?.text).toBe('Section A')
+
+    const unlabeled: Extract<SpatialNode, { type: 'group' }> = {
+      ...labeled,
+      id: 'g2',
+      label: undefined,
+    }
+    const sceneNoLabel = composeSpatialScene(canvas([unlabeled]), { measure })
+    expect(sceneNoLabel.nodes.every((n) => n.kind !== 'textRun')).toBe(true)
+  })
+
+  it('gives every group chrome a "none" fill so it can never occlude a sibling', () => {
+    const node: Extract<SpatialNode, { type: 'group' }> = {
+      id: 'g1',
+      type: 'group',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    }
+    const scene = composeSpatialScene(canvas([node]), { measure })
+    const shape = shapesOf(scene)[0]
+    expect(shape?.appearance?.fill).toBe('none')
+  })
+
+  it('renders the composed scene through renderSceneToSvg with a viewBox containing all content', () => {
+    const a = textNode({ id: 'a', x: 10, y: 20, width: 120, height: 60, text: 'hello' })
+    const b: Extract<SpatialNode, { type: 'file' }> = {
+      id: 'b',
+      type: 'file',
+      x: 400,
+      y: 300,
+      width: 100,
+      height: 50,
+      file: 'x.md',
+    }
+    const scene = composeSpatialScene(canvas([a, b]), { measure })
+    const svg = renderSceneToSvg(scene, { padding: 16 })
+
+    const match = svg.match(/viewBox="([-\d.]+) ([-\d.]+) ([-\d.]+) ([-\d.]+)"/)
+    expect(match).not.toBeNull()
+    const [, vx, vy, vw, vh] = match!.map(Number)
+
+    for (const node of shapesOf(scene)) {
+      expect(node.bbox.x).toBeGreaterThanOrEqual(vx!)
+      expect(node.bbox.y).toBeGreaterThanOrEqual(vy!)
+      expect(node.bbox.x + node.bbox.w).toBeLessThanOrEqual(vx! + vw!)
+      expect(node.bbox.y + node.bbox.h).toBeLessThanOrEqual(vy! + vh!)
+    }
+  })
+})

--- a/packages/mcp-server/src/server/export/spatial-scene.test.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.test.ts
@@ -28,6 +28,7 @@ vi.mock('@kamiazya/whiteboard-canvas-codec', async (importOriginal) => {
 })
 
 const { composeSpatialScene } = await import('./spatial-scene.js')
+const { NODE_CORNER_RADIUS_PX } = await import('./spatial-scene-appearance.js')
 
 const measure = createFakeMeasure()
 
@@ -61,6 +62,9 @@ describe('composeSpatialScene', () => {
 
     const shape = scene.nodes.find((n): n is ShapeSceneNode => n.kind === 'shape')
     expect(shape?.bbox).toEqual({ x: 100, y: 50, w: 200, h: 100 })
+    // Otherwise the radius is only exercised incidentally through the SVG
+    // string, which no test greps for `rx=` — dropping it would go unnoticed.
+    expect(shape?.radius).toBe(NODE_CORNER_RADIUS_PX)
 
     const heading = scene.nodes.find((n): n is HeadingBlockNode => n.kind === 'heading')
     expect(heading).toBeDefined()

--- a/packages/mcp-server/src/server/export/spatial-scene.test.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.test.ts
@@ -28,7 +28,7 @@ vi.mock('@kamiazya/whiteboard-canvas-codec', async (importOriginal) => {
 })
 
 const { composeSpatialScene } = await import('./spatial-scene.js')
-const { NODE_CORNER_RADIUS_PX } = await import('./spatial-scene-appearance.js')
+const { NODE_CORNER_RADIUS_PX, NODE_PADDING_PX } = await import('./spatial-scene-appearance.js')
 
 const measure = createFakeMeasure()
 
@@ -152,6 +152,10 @@ describe('composeSpatialScene', () => {
         (n): n is TextRunNode => n.kind === 'textRun' && n.text === '__THROW__',
       )
       expect(badLabel).toBeDefined()
+      // The fallback run must land inside its own node box. Asserting only
+      // its text would miss an offset applied twice, which puts the literal
+      // text a full node-origin away from the box it belongs to.
+      expect(badLabel?.bbox.x).toBe(400 + NODE_PADDING_PX)
       expect(capture.records.some((r) => r.level === 'warning')).toBe(true)
     } finally {
       capture.restore()
@@ -181,6 +185,10 @@ describe('composeSpatialScene', () => {
     const scene = composeSpatialScene(canvas([node]), { measure })
     const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
     expect(label?.text).toBe('notes/a.md#heading')
+    // Locks the other side of the placement invariant: a label run is
+    // content-origin-relative and is placed by its caller, exactly like
+    // layoutMdastBlocks output. Both paths must agree or one of them drifts.
+    expect(label?.bbox.x).toBe(node.x + NODE_PADDING_PX)
   })
 
   it('renders a link node as chrome plus a label containing the url', () => {

--- a/packages/mcp-server/src/server/export/spatial-scene.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.ts
@@ -71,7 +71,13 @@ function chromeShape(node: SpatialNode): ShapeSceneNode {
   }
 }
 
-function labelRun(node: SpatialNode, text: string, measure: MeasureText): TextRunNode {
+/**
+ * A label run in CONTENT-ORIGIN-RELATIVE coordinates, matching what
+ * `layoutMdastBlocks` produces. Placement is always the caller's job, via
+ * `placeInNode`. An absolute-coordinate variant here would be applied
+ * twice wherever its output also flows through the translation step.
+ */
+function labelRun(text: string, measure: MeasureText): TextRunNode {
   const font = {
     family: LABEL_APPEARANCE.fontFamily ?? 'sans-serif',
     fallbackChain: [],
@@ -83,14 +89,19 @@ function labelRun(node: SpatialNode, text: string, measure: MeasureText): TextRu
   return {
     kind: 'textRun',
     bbox: {
-      x: node.x + NODE_PADDING_PX,
-      y: node.y + NODE_PADDING_PX + metrics.ascent,
+      x: 0,
+      y: metrics.ascent,
       w: metrics.advanceWidth,
       h: metrics.ascent + metrics.descent,
     },
     text,
     appearance: { ...LABEL_APPEARANCE, fontSize: LABEL_FONT_SIZE_PX },
   }
+}
+
+/** Moves a node's content from its own origin to the node's padded top-left. */
+function placeInNode(node: SpatialNode, content: Scene): readonly SceneNode[] {
+  return translateScene(content, node.x + NODE_PADDING_PX, node.y + NODE_PADDING_PX).nodes
 }
 
 /**
@@ -115,11 +126,10 @@ function composeTextNode(
       'text node body failed to parse as markdown; falling back to literal text',
     )
     body = {
-      nodes: [labelRun(node, node.text, measure)],
+      nodes: [labelRun(node.text, measure)],
     }
   }
-  const placed = translateScene(body, node.x + NODE_PADDING_PX, node.y + NODE_PADDING_PX)
-  return [chromeShape(node), ...placed.nodes]
+  return [chromeShape(node), ...placeInNode(node, body)]
 }
 
 /** The readable label of a non-text node, or `undefined` when it has none. */
@@ -145,7 +155,9 @@ function composeNode(node: SpatialNode, measure: MeasureText): readonly SceneNod
     case 'group': {
       const chrome = chromeShape(node)
       const label = labelOf(node)
-      return label === undefined ? [chrome] : [chrome, labelRun(node, label, measure)]
+      return label === undefined
+        ? [chrome]
+        : [chrome, ...placeInNode(node, { nodes: [labelRun(label, measure)] })]
     }
     default: {
       // Defensive branch: `SpatialNode` is a closed discriminated union, so

--- a/packages/mcp-server/src/server/export/spatial-scene.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.ts
@@ -1,0 +1,193 @@
+// Composes a canvas-render `Scene` from a persisted `SpatialCanvas`. This is
+// process-internal (a value in, a value out) — no process boundary is
+// crossed here, so per zod-schema-discipline no Zod schema is warranted;
+// every type is imported (`z.infer`-derived at its own source) rather than
+// hand-restated.
+//
+// Total by construction: canvas-render's own layout/routing entry points
+// already degrade instead of throwing (see package-canvas-render.md), and
+// this module's one addition — `parseMarkdownBody` on a `text` node's body
+// — is wrapped so a markdown construct outside the versioned mdast subset
+// degrades that one node's content to a literal text run instead of
+// aborting the whole canvas.
+import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
+import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type {
+  MeasureText,
+  ResolvedEdgeNode,
+  Scene,
+  SceneNode,
+  ShapeSceneNode,
+  TextRunNode,
+} from '@kamiazya/whiteboard-canvas-render'
+import { layoutMdastBlocks, routeEdge } from '@kamiazya/whiteboard-canvas-render'
+
+import { getLogger } from '../log.js'
+import { translateScene } from './scene-transform.js'
+import {
+  EDGE_APPEARANCE,
+  LABEL_APPEARANCE,
+  LABEL_FONT_SIZE_PX,
+  MIN_CONTENT_WIDTH_PX,
+  NODE_CORNER_RADIUS_PX,
+  NODE_PADDING_PX,
+  SPATIAL_NODE_APPEARANCE,
+} from './spatial-scene-appearance.js'
+
+const log = getLogger('export-spatial-scene')
+
+export interface ComposeSpatialSceneOptions {
+  readonly measure: MeasureText
+}
+
+/** Deterministic total order over spatial nodes: position first, id as the tie-breaker. */
+function compareNodesByPosition(a: SpatialNode, b: SpatialNode): number {
+  if (a.y !== b.y) return a.y - b.y
+  if (a.x !== b.x) return a.x - b.x
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+function compareEdgesById(a: CanvasEdge, b: CanvasEdge): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+function contentWidth(nodeWidth: number): number {
+  const width = nodeWidth - 2 * NODE_PADDING_PX
+  return Number.isFinite(width) && width > MIN_CONTENT_WIDTH_PX ? width : MIN_CONTENT_WIDTH_PX
+}
+
+function chromeShape(node: SpatialNode): ShapeSceneNode {
+  return {
+    kind: 'shape',
+    bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
+    radius: NODE_CORNER_RADIUS_PX,
+    appearance: SPATIAL_NODE_APPEARANCE[node.type],
+  }
+}
+
+function labelRun(node: SpatialNode, text: string, measure: MeasureText): TextRunNode {
+  const font = {
+    family: LABEL_APPEARANCE.fontFamily ?? 'sans-serif',
+    fallbackChain: [],
+    weight: 400,
+    style: 'normal' as const,
+    sizePx: LABEL_FONT_SIZE_PX,
+  }
+  const metrics = measure(text, font)
+  return {
+    kind: 'textRun',
+    bbox: {
+      x: node.x + NODE_PADDING_PX,
+      y: node.y + NODE_PADDING_PX + metrics.ascent,
+      w: metrics.advanceWidth,
+      h: metrics.ascent + metrics.descent,
+    },
+    text,
+    appearance: { ...LABEL_APPEARANCE, fontSize: LABEL_FONT_SIZE_PX },
+  }
+}
+
+/**
+ * Composes a `text` node's chrome plus its laid-out markdown body. A
+ * malformed body (one whose parsed mdast falls outside the versioned
+ * subset `parseMarkdownBody` accepts) degrades to a single literal text
+ * run rather than aborting the canvas — this is the layer's own totality
+ * addition on top of canvas-render's already-total layout functions.
+ */
+function composeTextNode(
+  node: Extract<SpatialNode, { type: 'text' }>,
+  measure: MeasureText,
+): readonly SceneNode[] {
+  const maxWidth = contentWidth(node.width)
+  let body: Scene
+  try {
+    const mdast = parseMarkdownBody(node.text)
+    body = layoutMdastBlocks(mdast, { measure, maxWidth })
+  } catch (err) {
+    log.warning(
+      { nodeId: node.id, err },
+      'text node body failed to parse as markdown; falling back to literal text',
+    )
+    body = {
+      nodes: [labelRun(node, node.text, measure)],
+    }
+  }
+  const placed = translateScene(body, node.x + NODE_PADDING_PX, node.y + NODE_PADDING_PX)
+  return [chromeShape(node), ...placed.nodes]
+}
+
+function composeFileNode(
+  node: Extract<SpatialNode, { type: 'file' }>,
+  measure: MeasureText,
+): readonly SceneNode[] {
+  const label = node.subpath ? `${node.file}${node.subpath}` : node.file
+  return [chromeShape(node), labelRun(node, label, measure)]
+}
+
+function composeLinkNode(
+  node: Extract<SpatialNode, { type: 'link' }>,
+  measure: MeasureText,
+): readonly SceneNode[] {
+  return [chromeShape(node), labelRun(node, node.url, measure)]
+}
+
+function composeGroupNode(
+  node: Extract<SpatialNode, { type: 'group' }>,
+  measure: MeasureText,
+): readonly SceneNode[] {
+  const chrome = chromeShape(node)
+  if (!node.label || node.label.length === 0) return [chrome]
+  return [chrome, labelRun(node, node.label, measure)]
+}
+
+function composeNode(node: SpatialNode, measure: MeasureText): readonly SceneNode[] {
+  switch (node.type) {
+    case 'text':
+      return composeTextNode(node, measure)
+    case 'file':
+      return composeFileNode(node, measure)
+    case 'link':
+      return composeLinkNode(node, measure)
+    case 'group':
+      return composeGroupNode(node, measure)
+    default: {
+      // Defensive branch: `SpatialNode` is a closed discriminated union, so
+      // this is unreachable for schema-valid input. Kept so an unrecognized
+      // `type` (e.g. a value cast past the type system) still degrades to
+      // chrome-only rather than throwing.
+      const unknownNode = node as SpatialNode
+      log.warning(
+        { nodeId: unknownNode.id, type: unknownNode.type },
+        'unrecognized spatial node kind; emitting chrome only',
+      )
+      return [chromeShape(unknownNode)]
+    }
+  }
+}
+
+function composeEdge(canvas: SpatialCanvas, edge: CanvasEdge): ResolvedEdgeNode {
+  // `routeEdge` already degrades a missing endpoint per canvas-render's own
+  // documented contract (package-canvas-render.md) — nothing further to
+  // catch here.
+  return { ...routeEdge(canvas.nodes, edge), appearance: EDGE_APPEARANCE }
+}
+
+/**
+ * Composes a canvas-render `Scene` from a persisted `SpatialCanvas`. Pure:
+ * takes the already-read canvas plus an injected text measurer, and
+ * performs no I/O. Node emission order is a total function of canvas
+ * content (position then id), never of input array or object-key
+ * iteration order — see `compareNodesByPosition`.
+ */
+export function composeSpatialScene(
+  canvas: SpatialCanvas,
+  options: ComposeSpatialSceneOptions,
+): Scene {
+  const sortedNodes = [...canvas.nodes].sort(compareNodesByPosition)
+  const sortedEdges = [...canvas.edges].sort(compareEdgesById)
+
+  const nodeContent = sortedNodes.flatMap((node) => composeNode(node, options.measure))
+  const edgeContent = sortedEdges.map((edge) => composeEdge(canvas, edge))
+
+  return { nodes: [...nodeContent, ...edgeContent] }
+}

--- a/packages/mcp-server/src/server/export/spatial-scene.ts
+++ b/packages/mcp-server/src/server/export/spatial-scene.ts
@@ -40,15 +40,21 @@ export interface ComposeSpatialSceneOptions {
   readonly measure: MeasureText
 }
 
+function compareIds(a: string, b: string): number {
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
 /** Deterministic total order over spatial nodes: position first, id as the tie-breaker. */
 function compareNodesByPosition(a: SpatialNode, b: SpatialNode): number {
   if (a.y !== b.y) return a.y - b.y
   if (a.x !== b.x) return a.x - b.x
-  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  return compareIds(a.id, b.id)
 }
 
 function compareEdgesById(a: CanvasEdge, b: CanvasEdge): number {
-  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  return compareIds(a.id, b.id)
 }
 
 function contentWidth(nodeWidth: number): number {
@@ -116,28 +122,18 @@ function composeTextNode(
   return [chromeShape(node), ...placed.nodes]
 }
 
-function composeFileNode(
-  node: Extract<SpatialNode, { type: 'file' }>,
-  measure: MeasureText,
-): readonly SceneNode[] {
-  const label = node.subpath ? `${node.file}${node.subpath}` : node.file
-  return [chromeShape(node), labelRun(node, label, measure)]
-}
-
-function composeLinkNode(
-  node: Extract<SpatialNode, { type: 'link' }>,
-  measure: MeasureText,
-): readonly SceneNode[] {
-  return [chromeShape(node), labelRun(node, node.url, measure)]
-}
-
-function composeGroupNode(
-  node: Extract<SpatialNode, { type: 'group' }>,
-  measure: MeasureText,
-): readonly SceneNode[] {
-  const chrome = chromeShape(node)
-  if (!node.label || node.label.length === 0) return [chrome]
-  return [chrome, labelRun(node, node.label, measure)]
+/** The readable label of a non-text node, or `undefined` when it has none. */
+function labelOf(
+  node: Extract<SpatialNode, { type: 'file' | 'link' | 'group' }>,
+): string | undefined {
+  switch (node.type) {
+    case 'file':
+      return node.subpath ? `${node.file}${node.subpath}` : node.file
+    case 'link':
+      return node.url
+    case 'group':
+      return node.label && node.label.length > 0 ? node.label : undefined
+  }
 }
 
 function composeNode(node: SpatialNode, measure: MeasureText): readonly SceneNode[] {
@@ -145,11 +141,12 @@ function composeNode(node: SpatialNode, measure: MeasureText): readonly SceneNod
     case 'text':
       return composeTextNode(node, measure)
     case 'file':
-      return composeFileNode(node, measure)
     case 'link':
-      return composeLinkNode(node, measure)
-    case 'group':
-      return composeGroupNode(node, measure)
+    case 'group': {
+      const chrome = chromeShape(node)
+      const label = labelOf(node)
+      return label === undefined ? [chrome] : [chrome, labelRun(node, label, measure)]
+    }
     default: {
       // Defensive branch: `SpatialNode` is a closed discriminated union, so
       // this is unreachable for schema-valid input. Kept so an unrecognized

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,12 @@ importers:
       '@fast-check/vitest':
         specifier: ^0.4.1
         version: 0.4.1(vitest@4.1.10)
+      '@kamiazya/whiteboard-canvas-codec':
+        specifier: workspace:*
+        version: link:../canvas-codec
+      '@kamiazya/whiteboard-canvas-model':
+        specifier: workspace:*
+        version: link:../canvas-model
       '@kamiazya/whiteboard-canvas-ports':
         specifier: workspace:*
         version: link:../canvas-ports


### PR DESCRIPTION
## Why

The last piece missing before the headless renderer can move off Excalidraw. canvas-render can now describe a spatial canvas — it has the document envelope (#385), the shape node and optional `Appearance` (#387), `layoutMdastBlocks`, and `routeEdge` — and mcp-server already supplies the production text measurer (#386). Nothing yet turns a persisted `SpatialCanvas` into a `Scene`.

This adds that composition layer and nothing else. Wiring it into the renderer is the next slice, so no existing renderer, route, or Excalidraw dependency is touched here.

## What changed

`composeSpatialScene(canvas, { measure })` — pure, taking an already-read canvas and the injected measurer:

- Each node emits **chrome** (a `shape` at the node box) followed by its content.
- **Text nodes** go through `parseMarkdownBody` → `layoutMdastBlocks` at the node's content width, then are placed at the node's coordinates via a pure `translateScene`.
- **`file` / `link` / `group`** render chrome plus a readable label — path (with `subpath` when present), URL, or group label. No image loading in this slice.
- **Edges** route through `routeEdge` and are emitted after all node content.

## Appearance lives in one place

canvas-render deliberately never invents colors — appearance is assigned, not invented — so the composition root chooses it. Every appearance and geometry literal sits in a single named constant block (`spatial-scene-appearance.ts`); `spatial-scene.ts` and `scene-transform.ts` contain no color or size literal at all. That block is exactly what the Phase 4 theme layer replaces.

Groups use `fill: 'none'`. That removes the z-order question outright: with no group backdrop, a single flat sort can never hide a member node behind its group, and no second painting pass is needed.

## Determinism

Emission order is a pure function of canvas content, never of object-key iteration: nodes sorted by `(y, x, id)`, edges by `id`, through one documented comparator. `spatialCanvasSchema` guarantees unique ids, so the comparator is a total order and sort stability is irrelevant. No `Object.keys` / `Map` / `Set` iteration order reaches the output — that is what makes the SVG golden discipline hold downstream.

## `translateScene` and the coordinate-space rule

Translation shifts y across the whole tree but shifts x only down to — and including — a translating wrapper. It must **not** shift x inside `listItem.children` or `tableCell.runs`, because `renderListItem` and `renderTableCell` already emit `transform="translate(bbox.x,0)"` and those subtrees are stored wrapper-relative. Doing it anyway would double-apply the offset. This mirrors the rule `sceneBounds` follows (documented in `.claude/rules/package-canvas-render.md`), and a tripwire test fails if canvas-render's set of transform-emitting renderers ever changes.

## Totality

One bad node never aborts the canvas. A malformed markdown body, an edge with a missing endpoint, a zero-size node, and an unrecognized node kind each still produce a scene; degradations log through `getLogger` and never vary the returned value.

The load-bearing test is the end-to-end one: the composed scene, rendered through `renderSceneToSvg` with document options, produces SVG whose `viewBox` actually contains the content — which is precisely what a real exporter will do with it.

## Packaging

`@kamiazya/whiteboard-canvas-codec` and `-canvas-model` become declared **devDependencies** — they were used transitively but never declared. That is the correct home per this repo's Decision B: the `@kamiazya/whiteboard-*` packages are private and unpublished, and `tsup.config.ts`'s `noExternal` already names both, so the published artifact keeps bundling them and no new runtime dependency reaches consumers. The `package-shape` guard added in #386 enforces this.

## Verification

```
pnpm test --project mcp-node    Test Files 249 passed  Tests 3101 passed | 2 skipped
pnpm -r typecheck               exit 0
pnpm build                      exit 0
pnpm knip                       exit 0
```

Review flagged one gap, fixed here: the chrome shape's corner radius was only exercised incidentally through the SVG string, which no test greps for `rx=`, so dropping it from `chromeShape` would have gone unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added spatial canvas scene composition for rendering text, file, link, and group nodes with labels, styling, and connected edges.
  - Added support for laying out markdown content and positioning scene elements consistently.
  - Added scene translation to shift complete compositions while preserving relative positioning.

- **Bug Fixes**
  - Improved resilience when markdown content cannot be parsed or unsupported node types are encountered by using safe fallback rendering.
  - Ensured rendered scenes remain deterministic and correctly positioned across varied canvas layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->