### PR TITLE
fix(mcp-server): distinguish a stale generated SBOM from a real regression

### DIFF
--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -184,6 +184,16 @@ lockfile-pinned at v4.x):
   ensures the SBOM content regression tests in `sbom-policy.test.ts` always execute on
   the release path.
 
+- **Staleness guard**: `generate-npm-sbom.mjs` also writes a sidecar fingerprint file,
+  `packages/mcp-server/_artifacts/npm-sbom.inputs.json` (SHA-256 of `pnpm-lock.yaml`
+  and `packages/mcp-server/package.json`, plus a SHA-512 of the SBOM file itself).
+  `sbom-policy.test.ts` recomputes the current fingerprint before running its
+  content-policy assertions, so a locally generated SBOM that predates a dependency
+  change fails with an actionable "stale, run `pnpm --filter @kamiazya/whiteboard-mcp
+  generate:sbom:npm`" message instead of reading as a false dependency-policy
+  regression. See `packages/mcp-server/src/server/release/release-signing-provenance-sbom.md`
+  for the full contract (current/stale/absent states).
+
 ---
 
 ## Docker SBOM and Provenance

--- a/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
+++ b/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
@@ -28,11 +28,10 @@
 //   Error context: step name, exit code, stdout/stderr byte lengths only.
 
 import { spawnSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { buildSbomSidecar, computeSbomInputFingerprint } from './sbom-fingerprint.mjs'
+import { buildSbomSidecar, computeSbomInputFingerprint, sha512Hex } from './sbom-fingerprint.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_ROOT = resolve(__dirname, '../..')
@@ -154,13 +153,12 @@ if (sbomBytes.length === 0) {
   fail('sbom-file-empty', 'cyclonedx-npm wrote an empty file')
 }
 
-const sha512Hex = createHash('sha512').update(sbomBytes).digest('hex')
+const sbomSha512 = sha512Hex(sbomBytes)
 
 // Write the staleness sidecar alongside the SBOM. sbom-policy.test.ts compares
 // this fingerprint against a freshly computed one to tell a stale artifact
 // apart from a real dependency-policy regression.
-const inputFingerprint = computeSbomInputFingerprint(WORKSPACE_ROOT)
-const sidecar = buildSbomSidecar(inputFingerprint, sbomBytes)
+const sidecar = buildSbomSidecar(computeSbomInputFingerprint(WORKSPACE_ROOT), sbomBytes)
 writeFileSync(SBOM_SIDECAR_FILE, `${JSON.stringify(sidecar, null, 2)}\n`)
 
 // Extract tool version from SBOM metadata — schema-level field, not dep content.
@@ -188,7 +186,7 @@ process.stdout.write(
       sbomFormat: 'CycloneDX/JSON',
       specVersion: '1.4',
       sbomBytes: sbomBytes.length,
-      checksum: { algorithm: 'SHA-512', hex: sha512Hex },
+      checksum: { algorithm: 'SHA-512', hex: sbomSha512 },
       tool: '@cyclonedx/cyclonedx-npm',
       toolVersion,
     },

--- a/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
+++ b/packages/mcp-server/scripts/release/generate-npm-sbom.mjs
@@ -29,15 +29,17 @@
 
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { buildSbomSidecar, computeSbomInputFingerprint } from './sbom-fingerprint.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_ROOT = resolve(__dirname, '../..')
 const WORKSPACE_ROOT = resolve(PACKAGE_ROOT, '..', '..')
 const OUT_DIR = join(PACKAGE_ROOT, '_artifacts')
 const SBOM_FILE = join(OUT_DIR, 'npm-sbom.cdx.json')
+const SBOM_SIDECAR_FILE = join(OUT_DIR, 'npm-sbom.inputs.json')
 const TMP_DIR = join(OUT_DIR, 'sbom-npm-tmp')
 
 function fail(step, hint) {
@@ -153,6 +155,13 @@ if (sbomBytes.length === 0) {
 }
 
 const sha512Hex = createHash('sha512').update(sbomBytes).digest('hex')
+
+// Write the staleness sidecar alongside the SBOM. sbom-policy.test.ts compares
+// this fingerprint against a freshly computed one to tell a stale artifact
+// apart from a real dependency-policy regression.
+const inputFingerprint = computeSbomInputFingerprint(WORKSPACE_ROOT)
+const sidecar = buildSbomSidecar(inputFingerprint, sbomBytes)
+writeFileSync(SBOM_SIDECAR_FILE, `${JSON.stringify(sidecar, null, 2)}\n`)
 
 // Extract tool version from SBOM metadata — schema-level field, not dep content.
 let toolVersion = 'unknown'

--- a/packages/mcp-server/scripts/release/sbom-fingerprint.mjs
+++ b/packages/mcp-server/scripts/release/sbom-fingerprint.mjs
@@ -1,0 +1,68 @@
+// Shared hashing + sidecar-builder for the generated-SBOM staleness contract.
+//
+// One implementation used by both the writer (generate-npm-sbom.mjs) and the
+// reader (sbom-artifact-state.ts / sbom-policy.test.ts) so the two can never
+// diverge on how the fingerprint is computed.
+//
+// Input set: pnpm-lock.yaml (resolution source of truth for every prod and
+// workspace dependency) and packages/mcp-server/package.json (declares this
+// package's own dependency list, which pnpm-lock.yaml alone does not tie to
+// a specific package). Both are hashed, never re-derived by walking
+// node_modules — that would make the fingerprint itself as slow as the SBOM
+// generation this sidecar exists to avoid re-running on every pre-push.
+
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Repo-relative paths whose contents determine SBOM currency. */
+export const SBOM_FINGERPRINT_INPUT_PATHS = ['pnpm-lock.yaml', 'packages/mcp-server/package.json']
+
+/**
+ * @param {Buffer | string} bytes
+ * @returns {string} lowercase hex SHA-256 digest
+ */
+function sha256Hex(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/**
+ * @param {Buffer | string} bytes
+ * @returns {string} lowercase hex SHA-512 digest
+ */
+export function sha512Hex(bytes) {
+  return createHash('sha512').update(bytes).digest('hex')
+}
+
+/**
+ * Computes a SHA-256 digest for each declared input path, keyed by its
+ * repo-relative path.
+ *
+ * @param {string} workspaceRoot absolute path to the repo root
+ * @returns {Record<string, string>}
+ */
+export function computeSbomInputFingerprint(workspaceRoot) {
+  /** @type {Record<string, string>} */
+  const inputs = {}
+  for (const relPath of SBOM_FINGERPRINT_INPUT_PATHS) {
+    const bytes = readFileSync(join(workspaceRoot, relPath))
+    inputs[relPath] = sha256Hex(bytes)
+  }
+  return inputs
+}
+
+/**
+ * Builds the sidecar JSON object persisted alongside the generated SBOM.
+ *
+ * @param {Record<string, string>} inputs result of computeSbomInputFingerprint
+ * @param {Buffer} sbomBytes the SBOM file's raw bytes
+ * @returns {{schemaVersion: 1, algorithm: 'SHA-256', inputs: Record<string, string>, sbomSha512: string}}
+ */
+export function buildSbomSidecar(inputs, sbomBytes) {
+  return {
+    schemaVersion: 1,
+    algorithm: 'SHA-256',
+    inputs,
+    sbomSha512: sha512Hex(sbomBytes),
+  }
+}

--- a/packages/mcp-server/src/server/release/release-signing-provenance-sbom.md
+++ b/packages/mcp-server/src/server/release/release-signing-provenance-sbom.md
@@ -145,6 +145,39 @@ publish or signing gate:
 - `packages/mcp-server/_artifacts/` is ignored because SBOM files are generated
   release artifacts, not source.
 
+## Generated-artifact staleness contract
+
+A generated SBOM on a developer's machine can predate a dependency change
+(e.g. a package removal), and a bare "does the file exist" guard cannot tell
+that apart from a real dependency-policy regression — it just reports the
+policy assertion as failed, which reads as a false regression. To close that
+gap, `generate:sbom:npm` writes a sidecar,
+`packages/mcp-server/_artifacts/npm-sbom.inputs.json`, alongside the SBOM:
+
+- A SHA-256 digest of each input the SBOM was derived from (`pnpm-lock.yaml`
+  and `packages/mcp-server/package.json`).
+- A SHA-512 digest of the SBOM file itself, so a hand-edited or corrupted SBOM
+  is also caught.
+
+`sbom-policy.test.ts` recomputes the current fingerprint and compares it
+against the sidecar (`sbom-artifact-state.ts`'s `evaluateSbomArtifactState`)
+before running any content-policy assertion:
+
+- **current**: fingerprints match — the content-policy assertions run.
+- **stale**: fingerprints (or the SBOM checksum) don't match — exactly one
+  test fails with an actionable message naming the fix command
+  (`pnpm --filter @kamiazya/whiteboard-mcp generate:sbom:npm`); the
+  content-policy assertions are skipped rather than reporting a false
+  dependency-policy violation.
+- **absent**: no SBOM file at all — an explicitly skipped test, never a
+  silent no-op. This is safe because the `sbom-npm` job in `.github/workflows/ci.yml`
+  regenerates the SBOM and runs this exact test file on every PR/push, so the
+  policy is still enforced in CI even when a local run skips it.
+
+Hashing (`scripts/release/sbom-fingerprint.mjs`) is subprocess-free and reads
+only the two declared input files, so the staleness check adds negligible
+cost to the pre-push gate.
+
 ## What remains before publish gates become runnable matrix entries
 
 - Operator runbook maintenance for the consolidated workflow shape: protected GitHub

--- a/packages/mcp-server/src/server/release/sbom-artifact-state.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-artifact-state.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
+import { buildSbomSidecar } from '../../../scripts/release/sbom-fingerprint.mjs'
+import { evaluateSbomArtifactState, SBOM_REGENERATE_COMMAND } from './sbom-artifact-state.js'
+
+const EXPECTED_INPUTS = {
+  'pnpm-lock.yaml': 'a'.repeat(64),
+  'packages/mcp-server/package.json': 'b'.repeat(64),
+}
+const SBOM_SHA512 = 'c'.repeat(128)
+
+function currentSidecarText(): string {
+  const sidecar = buildSbomSidecar(EXPECTED_INPUTS, Buffer.from('sbom-bytes'))
+  // Force the sbomSha512 in the fixture to match the actualSbomSha512 used by
+  // the tests below without depending on buildSbomSidecar's own hash of an
+  // arbitrary fixture buffer.
+  return JSON.stringify({ ...sidecar, sbomSha512: SBOM_SHA512 })
+}
+
+describe('evaluateSbomArtifactState', () => {
+  it('reports absent when the SBOM artifact itself does not exist', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: false,
+      rawSidecarText: undefined,
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('absent')
+  })
+
+  it('reports current when the sidecar fingerprint matches the current inputs and SBOM bytes', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: currentSidecarText(),
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('current')
+  })
+
+  // RED 1 (regression pin): a stale artifact — its persisted input fingerprint
+  // no longer matches the current lockfile/manifest digests — must be
+  // reported as 'stale' with an actionable, distinguishing message, NOT
+  // surfaced as a dependency-policy violation.
+  it('reports stale (not current) when the persisted input fingerprint no longer matches', () => {
+    const staleSidecar = JSON.stringify({
+      schemaVersion: 1,
+      algorithm: 'SHA-256',
+      inputs: { ...EXPECTED_INPUTS, 'pnpm-lock.yaml': 'f'.repeat(64) },
+      sbomSha512: SBOM_SHA512,
+    })
+
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: staleSidecar,
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+
+    expect(result.status).toBe('stale')
+    if (result.status !== 'stale') throw new Error('unreachable')
+    expect(result.message).toContain(SBOM_REGENERATE_COMMAND)
+    expect(result.message.toLowerCase()).toContain('stale')
+    expect(result.message).not.toMatch(/policy|dev-only|removed package/i)
+  })
+
+  it('reports stale when the SBOM file bytes no longer match the recorded checksum', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: currentSidecarText(),
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: 'd'.repeat(128),
+    })
+    expect(result.status).toBe('stale')
+  })
+
+  it('reports stale when the sidecar file is missing', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: undefined,
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('stale')
+    if (result.status !== 'stale') throw new Error('unreachable')
+    expect(result.reason).toContain('missing')
+  })
+
+  it('reports stale when the sidecar is not valid JSON', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: '{ not json',
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('stale')
+    if (result.status !== 'stale') throw new Error('unreachable')
+    expect(result.reason).toContain('not valid JSON')
+  })
+
+  it('reports stale when the sidecar JSON fails schema validation', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: JSON.stringify({
+        schemaVersion: 2,
+        algorithm: 'SHA-256',
+        inputs: {},
+        sbomSha512: '',
+      }),
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('stale')
+    if (result.status !== 'stale') throw new Error('unreachable')
+    expect(result.reason).toContain('schema')
+  })
+
+  it('reports stale when the input file set differs (added/removed input)', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: JSON.stringify({
+        schemaVersion: 1,
+        algorithm: 'SHA-256',
+        inputs: { 'pnpm-lock.yaml': 'a'.repeat(64) },
+        sbomSha512: SBOM_SHA512,
+      }),
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('stale')
+  })
+
+  it('the stale message contains no absolute-path prefix and no .ts:<line> frame', () => {
+    const result = evaluateSbomArtifactState({
+      sbomExists: true,
+      rawSidecarText: undefined,
+      expectedInputs: EXPECTED_INPUTS,
+      actualSbomSha512: SBOM_SHA512,
+    })
+    expect(result.status).toBe('stale')
+    if (result.status !== 'stale') throw new Error('unreachable')
+    for (const forbidden of ['/home/', '/Users/', '/opt/', '/root/', '/private/', '/tmp/']) {
+      expect(result.message).not.toContain(forbidden)
+    }
+    expect(result.message).not.toMatch(/\.ts:\d/)
+  })
+
+  // PBT: totality over arbitrary JSON-ish raw sidecar text. The evaluator
+  // must never throw regardless of shape, and always resolve to exactly one
+  // of absent | stale | current.
+  const arbitraryJson = fc.anything({ withBigInt: false, withDate: false })
+
+  fcTest.prop([arbitraryJson.map((v) => JSON.stringify(v) ?? 'undefined')], withDefaults())(
+    'is total over arbitrary sidecar JSON text and never throws',
+    (rawSidecarText) => {
+      const result = evaluateSbomArtifactState({
+        sbomExists: true,
+        rawSidecarText,
+        expectedInputs: EXPECTED_INPUTS,
+        actualSbomSha512: SBOM_SHA512,
+      })
+      expect(['absent', 'stale', 'current']).toContain(result.status)
+    },
+  )
+})

--- a/packages/mcp-server/src/server/release/sbom-artifact-state.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-artifact-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { fc, fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
 import { buildSbomSidecar } from '../../../scripts/release/sbom-fingerprint.mjs'
+import { fc, fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
 import { evaluateSbomArtifactState, SBOM_REGENERATE_COMMAND } from './sbom-artifact-state.js'
 
 const EXPECTED_INPUTS = {

--- a/packages/mcp-server/src/server/release/sbom-artifact-state.ts
+++ b/packages/mcp-server/src/server/release/sbom-artifact-state.ts
@@ -1,0 +1,92 @@
+// Distinguishes "generated SBOM artifact is stale" from "SBOM contains a real
+// dependency-policy violation" — the two failure modes a bare existsSync
+// guard could not tell apart (see sbom-policy.test.ts's content-regression
+// describe block for the policy checks this gate protects).
+//
+// Pure and I/O-free by design: callers do all file reads and pass the raw
+// results in, so this module is trivially total and trivially fast — the
+// staleness check must never become a meaningful tax on the pre-push gate.
+
+import { sbomFingerprintSidecarSchema } from './sbom-fingerprint-schema.js'
+
+export const SBOM_ARTIFACT_REL_PATH = 'packages/mcp-server/_artifacts/npm-sbom.cdx.json'
+export const SBOM_SIDECAR_REL_PATH = 'packages/mcp-server/_artifacts/npm-sbom.inputs.json'
+export const SBOM_REGENERATE_COMMAND = 'pnpm --filter @kamiazya/whiteboard-mcp generate:sbom:npm'
+
+export type SbomArtifactState =
+  | { status: 'absent' }
+  | { status: 'stale'; reason: string; message: string }
+  | { status: 'current' }
+
+function staleMessage(reason: string): string {
+  return (
+    `Stale SBOM artifact: ${SBOM_SIDECAR_REL_PATH} (${reason}). ` +
+    `Run \`${SBOM_REGENERATE_COMMAND}\` to regenerate before re-running this check.`
+  )
+}
+
+function stale(reason: string): SbomArtifactState {
+  return { status: 'stale', reason, message: staleMessage(reason) }
+}
+
+/**
+ * Evaluates whether a generated SBOM artifact is safe to run content-policy
+ * assertions against.
+ *
+ * @param sbomExists whether the SBOM artifact file itself exists on disk
+ * @param rawSidecarText the sidecar file's raw text content, or `undefined`
+ *   if the sidecar file does not exist
+ * @param expectedInputs the current SHA-256 fingerprint (from
+ *   computeSbomInputFingerprint) to compare against the persisted one
+ * @param actualSbomSha512 the SHA-512 of the SBOM file's current bytes
+ */
+export function evaluateSbomArtifactState(args: {
+  sbomExists: boolean
+  rawSidecarText: string | undefined
+  expectedInputs: Record<string, string>
+  actualSbomSha512: string
+}): SbomArtifactState {
+  const { sbomExists, rawSidecarText, expectedInputs, actualSbomSha512 } = args
+
+  if (!sbomExists) {
+    return { status: 'absent' }
+  }
+
+  if (rawSidecarText === undefined) {
+    return stale('sidecar file is missing')
+  }
+
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(rawSidecarText)
+  } catch {
+    return stale('sidecar is not valid JSON')
+  }
+
+  const result = sbomFingerprintSidecarSchema.safeParse(parsedJson)
+  if (!result.success) {
+    return stale('sidecar failed schema validation')
+  }
+
+  const sidecar = result.data
+  const expectedKeys = Object.keys(expectedInputs).sort()
+  const actualKeys = Object.keys(sidecar.inputs).sort()
+  const sameKeys =
+    expectedKeys.length === actualKeys.length &&
+    expectedKeys.every((key, i) => key === actualKeys[i])
+  if (!sameKeys) {
+    return stale('input file set has changed since the SBOM was generated')
+  }
+
+  for (const key of expectedKeys) {
+    if (sidecar.inputs[key] !== expectedInputs[key]) {
+      return stale(`input fingerprint mismatch for ${key}`)
+    }
+  }
+
+  if (sidecar.sbomSha512 !== actualSbomSha512) {
+    return stale('SBOM file contents do not match the recorded checksum')
+  }
+
+  return { status: 'current' }
+}

--- a/packages/mcp-server/src/server/release/sbom-fingerprint-schema.ts
+++ b/packages/mcp-server/src/server/release/sbom-fingerprint-schema.ts
@@ -1,0 +1,33 @@
+// Persisted-JSON contract for the generated-SBOM staleness sidecar
+// (packages/mcp-server/_artifacts/npm-sbom.inputs.json). This is the single
+// source of truth for the sidecar shape — the .mjs writer
+// (scripts/release/sbom-fingerprint.mjs) and this schema's readers must never
+// diverge, per this repo's zod-schema-discipline.
+
+import { z } from 'zod'
+
+const hexDigestSchema = (length: number) =>
+  z
+    .string()
+    .regex(
+      new RegExp(`^[0-9a-f]{${length}}$`),
+      `expected a lowercase hex digest of length ${length}`,
+    )
+
+export const sbomFingerprintSidecarSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    algorithm: z.literal('SHA-256'),
+    // Repo-relative input path -> SHA-256 hex digest of that file's bytes.
+    inputs: z
+      .record(z.string().min(1), hexDigestSchema(64))
+      .refine((inputs) => Object.keys(inputs).length > 0, 'inputs must be non-empty'),
+    // SHA-512 of the SBOM file this sidecar was written alongside.
+    sbomSha512: hexDigestSchema(128),
+  })
+  .strict()
+
+// z.infer type kept internal — evaluateSbomArtifactState (sbom-artifact-state.ts)
+// is the only consumer today and reads through sbomFingerprintSidecarSchema.parse
+// directly, so a named exported type would be unused surface per knip.
+type SbomFingerprintSidecar = z.infer<typeof sbomFingerprintSidecarSchema>

--- a/packages/mcp-server/src/server/release/sbom-fingerprint-schema.ts
+++ b/packages/mcp-server/src/server/release/sbom-fingerprint-schema.ts
@@ -26,8 +26,3 @@ export const sbomFingerprintSidecarSchema = z
     sbomSha512: hexDigestSchema(128),
   })
   .strict()
-
-// z.infer type kept internal — evaluateSbomArtifactState (sbom-artifact-state.ts)
-// is the only consumer today and reads through sbomFingerprintSidecarSchema.parse
-// directly, so a named exported type would be unused surface per knip.
-type SbomFingerprintSidecar = z.infer<typeof sbomFingerprintSidecarSchema>

--- a/packages/mcp-server/src/server/release/sbom-fingerprint.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-fingerprint.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildSbomSidecar,
+  computeSbomInputFingerprint,
+  SBOM_FINGERPRINT_INPUT_PATHS,
+} from '../../../scripts/release/sbom-fingerprint.mjs'
+import { sbomFingerprintSidecarSchema } from './sbom-fingerprint-schema.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '../../../../..')
+
+// Builds a throwaway fixture workspace with the two declared input files, so
+// fingerprint tests never depend on this checkout's real lockfile/manifest.
+function makeFixtureWorkspace(fileContents: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'sbom-fingerprint-fixture-'))
+  for (const relPath of SBOM_FINGERPRINT_INPUT_PATHS) {
+    const abs = join(root, relPath)
+    // Every declared input path is a single path segment in this fixture set
+    // today (no nested dirs beyond packages/mcp-server), so a plain
+    // writeFileSync after an explicit mkdir of the parent is enough.
+    const parent = dirname(abs)
+    if (parent !== root) {
+      mkdirSync(parent, { recursive: true })
+    }
+    writeFileSync(abs, fileContents[relPath] ?? relPath)
+  }
+  return root
+}
+
+describe('computeSbomInputFingerprint', () => {
+  it('is deterministic: repeated calls over unchanged inputs return identical digests', () => {
+    const root = makeFixtureWorkspace({})
+    try {
+      const first = computeSbomInputFingerprint(root)
+      const second = computeSbomInputFingerprint(root)
+      expect(second).toEqual(first)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('changes when any tracked input file changes', () => {
+    const root = makeFixtureWorkspace({})
+    try {
+      const before = computeSbomInputFingerprint(root)
+      writeFileSync(join(root, 'pnpm-lock.yaml'), 'mutated-lockfile-content')
+      const after = computeSbomInputFingerprint(root)
+      expect(after['pnpm-lock.yaml']).not.toBe(before['pnpm-lock.yaml'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('completes over the real repo inputs well under a generous time budget', () => {
+    const start = performance.now()
+    computeSbomInputFingerprint(REPO_ROOT)
+    const elapsedMs = performance.now() - start
+    // An order of magnitude above the expected single-digit-ms cost — a
+    // canary for a future regression (e.g. hashing the whole node_modules
+    // tree), not a tight microbenchmark.
+    expect(elapsedMs).toBeLessThan(500)
+  })
+})
+
+describe('buildSbomSidecar / schema conformance', () => {
+  it('every sidecar the writer can produce parses cleanly through the shared schema', () => {
+    const root = makeFixtureWorkspace({})
+    try {
+      const inputs = computeSbomInputFingerprint(root)
+      const sidecar = buildSbomSidecar(inputs, Buffer.from('fake-sbom-bytes'))
+      expect(() => sbomFingerprintSidecarSchema.parse(sidecar)).not.toThrow()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('re-generating from the same fingerprint and bytes is idempotent', () => {
+    const inputs = {
+      'pnpm-lock.yaml': 'a'.repeat(64),
+      'packages/mcp-server/package.json': 'b'.repeat(64),
+    }
+    const bytes = Buffer.from('stable-bytes')
+    expect(buildSbomSidecar(inputs, bytes)).toEqual(buildSbomSidecar(inputs, bytes))
+  })
+})
+
+describe('no-subprocess static guard', () => {
+  const sources = [
+    join(__dirname, '../../../scripts/release/sbom-fingerprint.mjs'),
+    join(__dirname, 'sbom-artifact-state.ts'),
+  ]
+
+  it('neither module imports node:child_process or spawns a subprocess', () => {
+    for (const path of sources) {
+      const src = readFileSync(path, 'utf-8')
+      expect(src, `${path} must not import child_process`).not.toMatch(
+        /from\s+['"](node:)?child_process['"]/,
+      )
+      expect(src, `${path} must not spawn a subprocess`).not.toMatch(
+        /\b(spawnSync|spawn|execSync|execFileSync|execFile|exec|fork)\s*\(/,
+      )
+    }
+  })
+})

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -6,12 +6,14 @@
 //   - Runbook (docs/contributing/releasing.md) covers required keywords.
 // PBT: validateSbomSummary() catches malformed safe-stdout summary shapes.
 
-import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { computeSbomInputFingerprint } from '../../../scripts/release/sbom-fingerprint.mjs'
+import {
+  computeSbomInputFingerprint,
+  sha512Hex,
+} from '../../../scripts/release/sbom-fingerprint.mjs'
 import { fc, fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
 import {
   evaluateSbomArtifactState,
@@ -329,28 +331,20 @@ describe('ci.yml sbom-npm job wiring (drift guard for the absent-artifact skip)'
 // manifest (one explicit 'stale artifact' failure, never a false policy
 // violation — see the module doc comment on sbom-artifact-state.ts).
 
+const SBOM_PATH = join(ROOT, SBOM_ARTIFACT_REL_PATH)
+const SIDECAR_PATH = join(ROOT, SBOM_SIDECAR_REL_PATH)
+const sbomExists = existsSync(SBOM_PATH)
+
+// Evaluated once and shared by both describes below — reading and hashing the
+// artifact twice would only give the two blocks a way to disagree.
+const sbomArtifactState = evaluateSbomArtifactState({
+  sbomExists,
+  rawSidecarText: existsSync(SIDECAR_PATH) ? readFileSync(SIDECAR_PATH, 'utf-8') : undefined,
+  expectedInputs: computeSbomInputFingerprint(ROOT),
+  actualSbomSha512: sbomExists ? sha512Hex(readFileSync(SBOM_PATH)) : '',
+})
+
 describe('generated SBOM artifact currency', () => {
-  const SBOM_PATH = join(ROOT, SBOM_ARTIFACT_REL_PATH)
-  const SIDECAR_PATH = join(ROOT, SBOM_SIDECAR_REL_PATH)
-  const sbomExists = existsSync(SBOM_PATH)
-
-  function artifactState() {
-    const rawSidecarText = existsSync(SIDECAR_PATH)
-      ? readFileSync(SIDECAR_PATH, 'utf-8')
-      : undefined
-    const actualSbomSha512 = sbomExists
-      ? createHash('sha512').update(readFileSync(SBOM_PATH)).digest('hex')
-      : ''
-    return evaluateSbomArtifactState({
-      sbomExists,
-      rawSidecarText,
-      expectedInputs: computeSbomInputFingerprint(ROOT),
-      actualSbomSha512,
-    })
-  }
-
-  const state = sbomExists ? artifactState() : { status: 'absent' as const }
-
   it.skipIf(!sbomExists)(
     'absent artifact: skipped — ci.yml sbom-npm job regenerates and runs this file on every PR/push',
     () => {
@@ -360,29 +354,19 @@ describe('generated SBOM artifact currency', () => {
     },
   )
 
-  it.runIf(sbomExists)(`artifact is current or fails as stale, never silently passes`, () => {
-    if (state.status === 'stale') {
-      expect(state.message, 'stale message must name the exact fix command').toContain(
+  it.runIf(sbomExists)('artifact is current or fails as stale, never silently passes', () => {
+    if (sbomArtifactState.status === 'stale') {
+      expect(sbomArtifactState.message, 'stale message must name the exact fix command').toContain(
         SBOM_REGENERATE_COMMAND,
       )
-      expect.fail(state.message)
+      expect.fail(sbomArtifactState.message)
     }
-    expect(state.status).toBe('current')
+    expect(sbomArtifactState.status).toBe('current')
   })
 })
 
 describe('generated SBOM content regression', () => {
-  const SBOM_PATH = join(ROOT, SBOM_ARTIFACT_REL_PATH)
-  const SIDECAR_PATH = join(ROOT, SBOM_SIDECAR_REL_PATH)
-  const sbomExists = existsSync(SBOM_PATH)
-  const isCurrent =
-    sbomExists &&
-    evaluateSbomArtifactState({
-      sbomExists,
-      rawSidecarText: existsSync(SIDECAR_PATH) ? readFileSync(SIDECAR_PATH, 'utf-8') : undefined,
-      expectedInputs: computeSbomInputFingerprint(ROOT),
-      actualSbomSha512: createHash('sha512').update(readFileSync(SBOM_PATH)).digest('hex'),
-    }).status === 'current'
+  const isCurrent = sbomArtifactState.status === 'current'
 
   type CdxComponent = { name: string; group?: string; purl?: string }
 

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -6,11 +6,19 @@
 //   - Runbook (docs/contributing/releasing.md) covers required keywords.
 // PBT: validateSbomSummary() catches malformed safe-stdout summary shapes.
 
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { computeSbomInputFingerprint } from '../../../scripts/release/sbom-fingerprint.mjs'
 import { fc, fcTest, withDefaults } from '../../shared/test-utils/fast-check.js'
+import {
+  evaluateSbomArtifactState,
+  SBOM_ARTIFACT_REL_PATH,
+  SBOM_REGENERATE_COMMAND,
+  SBOM_SIDECAR_REL_PATH,
+} from './sbom-artifact-state.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '../../../../..')
@@ -193,6 +201,29 @@ describe('runbook (docs/contributing/releasing.md) keyword drift', () => {
   })
 })
 
+// ── SBOM design-note keyword drift ────────────────────────────────────────────
+
+describe('release-signing-provenance-sbom.md keyword drift', () => {
+  const designNote = () =>
+    readFile('packages/mcp-server/src/server/release/release-signing-provenance-sbom.md')
+
+  it('design note mentions the staleness sidecar filename', () => {
+    expect(designNote()).toContain('npm-sbom.inputs.json')
+  })
+
+  it('design note explains the staleness contract', () => {
+    expect(designNote().toLowerCase()).toContain('stale')
+  })
+
+  it('design note names the exact fix command', () => {
+    expect(designNote()).toContain('generate:sbom:npm')
+  })
+
+  it('design note mentions the absent-artifact CI backstop', () => {
+    expect(designNote()).toContain('sbom-npm')
+  })
+})
+
 // ── generate-npm-sbom.mjs non-leak contract ───────────────────────────────────
 
 describe('generate-npm-sbom.mjs non-leak contract', () => {
@@ -268,14 +299,90 @@ describe('ci.yml dry-run SBOM regression safety', () => {
   })
 })
 
+// ── ci.yml sbom-npm wiring (backs the absent-artifact skip) ──────────────────
+// This is what makes the 'absent artifact' skip above honest rather than a
+// silent hole: it must always run, so deleting the CI job that regenerates
+// and validates the SBOM turns the local skip from honest into a failing
+// test here.
+
+describe('ci.yml sbom-npm job wiring (drift guard for the absent-artifact skip)', () => {
+  const CI_WORKFLOW = '.github/workflows/ci.yml'
+
+  const sbomNpmSection = () => jobSection(readFile(CI_WORKFLOW), 'sbom-npm', 'packaged-smoke')
+
+  it('sbom-npm job generates the npm SBOM', () => {
+    expect(sbomNpmSection()).toContain('generate:sbom:npm')
+  })
+
+  it('sbom-npm job runs this exact sbom-policy.test.ts file', () => {
+    expect(sbomNpmSection()).toContain('packages/mcp-server/src/server/release/sbom-policy.test.ts')
+  })
+})
+
 // ── Generated SBOM content regression ────────────────────────────────────────
 // `pnpm check:release-candidate` runs `pnpm generate:sbom:npm` before
-// `pnpm test`, so these tests always run in the release-candidate path.
-// In isolation (`pnpm test` only), they skip if the artifact is absent.
+// `pnpm test`, so these tests always run in the release-candidate path, and
+// the ci.yml `sbom-npm` job (see the drift guard below) regenerates and runs
+// this exact file on every PR/push. In isolation (`pnpm test` only, no fresh
+// generation), the artifact may be absent (skip, visibly — see the 'absent
+// artifact' describe below) or stale relative to the current lockfile/
+// manifest (one explicit 'stale artifact' failure, never a false policy
+// violation — see the module doc comment on sbom-artifact-state.ts).
+
+describe('generated SBOM artifact currency', () => {
+  const SBOM_PATH = join(ROOT, SBOM_ARTIFACT_REL_PATH)
+  const SIDECAR_PATH = join(ROOT, SBOM_SIDECAR_REL_PATH)
+  const sbomExists = existsSync(SBOM_PATH)
+
+  function artifactState() {
+    const rawSidecarText = existsSync(SIDECAR_PATH)
+      ? readFileSync(SIDECAR_PATH, 'utf-8')
+      : undefined
+    const actualSbomSha512 = sbomExists
+      ? createHash('sha512').update(readFileSync(SBOM_PATH)).digest('hex')
+      : ''
+    return evaluateSbomArtifactState({
+      sbomExists,
+      rawSidecarText,
+      expectedInputs: computeSbomInputFingerprint(ROOT),
+      actualSbomSha512,
+    })
+  }
+
+  const state = sbomExists ? artifactState() : { status: 'absent' as const }
+
+  it.skipIf(!sbomExists)(
+    'absent artifact: skipped — ci.yml sbom-npm job regenerates and runs this file on every PR/push',
+    () => {
+      // Intentionally empty: this test's role is to make the skip visible in
+      // run output (see it.skipIf above), never a silent no-op inside a
+      // passing assertion body.
+    },
+  )
+
+  it.runIf(sbomExists)(`artifact is current or fails as stale, never silently passes`, () => {
+    if (state.status === 'stale') {
+      expect(state.message, 'stale message must name the exact fix command').toContain(
+        SBOM_REGENERATE_COMMAND,
+      )
+      expect.fail(state.message)
+    }
+    expect(state.status).toBe('current')
+  })
+})
 
 describe('generated SBOM content regression', () => {
-  const SBOM_PATH = join(ROOT, 'packages/mcp-server/_artifacts/npm-sbom.cdx.json')
+  const SBOM_PATH = join(ROOT, SBOM_ARTIFACT_REL_PATH)
+  const SIDECAR_PATH = join(ROOT, SBOM_SIDECAR_REL_PATH)
   const sbomExists = existsSync(SBOM_PATH)
+  const isCurrent =
+    sbomExists &&
+    evaluateSbomArtifactState({
+      sbomExists,
+      rawSidecarText: existsSync(SIDECAR_PATH) ? readFileSync(SIDECAR_PATH, 'utf-8') : undefined,
+      expectedInputs: computeSbomInputFingerprint(ROOT),
+      actualSbomSha512: createHash('sha512').update(readFileSync(SBOM_PATH)).digest('hex'),
+    }).status === 'current'
 
   type CdxComponent = { name: string; group?: string; purl?: string }
 
@@ -287,8 +394,12 @@ describe('generated SBOM content regression', () => {
   // CycloneDX puts the unscoped name in `name` and scope in `group`.
   // Matching against `purl` (e.g. "pkg:npm/%40vitest/ui@...") is more reliable.
   // Scope separator: `@` → `%40`, `/` is NOT encoded in the purl.
+  //
+  // Guarded by isCurrent (not just sbomExists): a stale artifact must not be
+  // able to produce one of these policy-violation failures — that class of
+  // false regression is reported once, distinctly, by the describe above.
 
-  it.runIf(sbomExists)('generated SBOM contains no known dev-only packages', () => {
+  it.runIf(isCurrent)('generated SBOM contains no known dev-only packages', () => {
     const purls = loadSbomPurls()
     const devOnlyPatterns = [
       'pkg:npm/vitest@', // vitest core
@@ -316,7 +427,7 @@ describe('generated SBOM content regression', () => {
     }
   })
 
-  it.runIf(sbomExists)(
+  it.runIf(isCurrent)(
     'generated SBOM contains none of the packages removed with the Excalidraw headless renderer',
     () => {
       const purls = loadSbomPurls()
@@ -336,7 +447,7 @@ describe('generated SBOM content regression', () => {
     },
   )
 
-  it.runIf(sbomExists)('generated SBOM contains expected production packages', () => {
+  it.runIf(isCurrent)('generated SBOM contains expected production packages', () => {
     const purls = loadSbomPurls()
     const prodPatterns = ['pkg:npm/hono@', 'pkg:npm/jose@', 'pkg:npm/zod@', 'pkg:npm/nanoid@']
     for (const pattern of prodPatterns) {

--- a/packages/mcp-server/src/server/release/sbom-policy.test.ts
+++ b/packages/mcp-server/src/server/release/sbom-policy.test.ts
@@ -346,7 +346,7 @@ const sbomArtifactState = evaluateSbomArtifactState({
 
 describe('generated SBOM artifact currency', () => {
   it.skipIf(!sbomExists)(
-    'absent artifact: skipped — ci.yml sbom-npm job regenerates and runs this file on every PR/push',
+    'marker: when this reports SKIPPED the artifact is absent — ci.yml sbom-npm regenerates and runs this file on every PR/push',
     () => {
       // Intentionally empty: this test's role is to make the skip visible in
       // run output (see it.skipIf above), never a silent no-op inside a


### PR DESCRIPTION
`sbom-policy.test.ts` validated a generated, untracked artifact behind a bare `existsSync` guard, which gave it two failure modes and no way to tell them apart.

**Absent artifact was a silent pass.** On a fresh checkout the file does not exist, so the assertions never ran. A green result meant nothing had been checked — the never-failing-guard shape.

**Stale artifact was a false regression.** An SBOM generated before a dependency removal failed with a message asserting a policy violation that did not exist. Because `pnpm test --project mcp-node` runs in the pre-push gate, that blocked pushes on entirely unrelated branches. This happened: `@excalidraw/utils` was reported present while CI was green, and diagnosing it cost real time because the failure text described a regression rather than a stale input.

## Currency is now a fingerprint, not a guess

`generate-npm-sbom.mjs` writes a sidecar next to the SBOM holding a SHA-256 over the exact inputs it was derived from (`pnpm-lock.yaml`, the package manifest) plus the SHA-512 of the SBOM it just wrote. A pure `evaluateSbomArtifactState` returns `absent | stale | current`, and a missing, unparseable, version-mismatched or hash-mismatched sidecar all map to `stale`.

A stale artifact now fails with one actionable sentence naming the repo-relative path and the exact regeneration command, textually distinct from any policy-violation message — asserted, along with the absence of any absolute path segment.

Two alternatives were considered and are recorded in the design note. Regenerating in-test costs tens of seconds on every pre-push, an unacceptable tax on a gate that runs on every push. Comparing the SBOM's component set against the manifest is blind to transitive re-additions, which is exactly the class the removed-package policy exists to catch.

The added pre-push cost is two file reads and two hashes, and that bound is enforced rather than narrated: a static guard asserts neither new module imports `child_process` or spawns anything.

## The absent case is now a visible skip with a guarded justification

Skipping is defensible here because `ci.yml`'s `sbom-npm` job regenerates the SBOM and runs this exact file on every PR and push, so the policy is enforced where it matters. The skip is an explicitly skipped test that appears in run output, never an invisible early return inside a passing one.

That justification is itself drift-guarded: a test asserts the `sbom-npm` job still contains both the generate step and this test file's path. Deleting the CI job turns the local skip from honest into a failing test.

The content-regression assertions are gated on `current` rather than merely on existence, so a stale artifact can no longer produce a false policy violation at all.

## Verification

`pnpm test --project mcp-node`: 247 files, 3112 passed. Three real scenarios were exercised: artifact present and current (policy tests run and pass), deliberately staled (one stale failure with the actionable message, policy assertions skipped), absent (visible skip plus the passing CI-wiring guard).
