### PR TITLE
fix(canvas-codec,canvas-render): stop a markdown list degrading a whole node body

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -612,3 +612,129 @@ describe('SpatialEditor (browser)', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * Regression coverage for four spatial-text-layout defects fixed together:
+ * a clipped first heading line, a markdown list flattening to inline text,
+ * unwrapped text overflowing its node's right edge, and an undrawn edge
+ * label. Uses the real Canvas 2D measurer (no `measure` override) so the
+ * geometry reflects an actual browser render, not a fake fixed-width one.
+ */
+function fourDefectCanvas(): SpatialCanvas {
+  return {
+    nodes: [
+      {
+        id: 'heading-node',
+        type: 'text',
+        x: 20,
+        y: 20,
+        width: 220,
+        height: 110,
+        text: '# Heading\n\nSome body text.',
+      },
+      {
+        id: 'list-node',
+        type: 'text',
+        x: 280,
+        y: 20,
+        width: 220,
+        height: 110,
+        text: 'Second node\n\n- list item\n- another',
+      },
+      {
+        id: 'overflow-node',
+        type: 'text',
+        x: 20,
+        y: 170,
+        width: 160,
+        height: 90,
+        text: 'This is a long line of text that should wrap inside its node instead of overflowing the right edge',
+      },
+    ],
+    edges: [{ id: 'e1', fromNode: 'heading-node', toNode: 'list-node', label: 'edge label' }],
+  }
+}
+
+describe('SpatialEditor (browser) — spatial text layout defects', () => {
+  it('renders a heading, a list, wrapped overflow text, and an edge label without the four defects', async () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <div style={{ width: 900, height: 600 }}>
+        <SpatialEditor canvas={fourDefectCanvas()} onChange={onChange} />
+      </div>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('svg text').length).toBeGreaterThan(0)
+    })
+
+    await page.screenshot({
+      // Resolved relative to this test file's own directory by vitest's
+      // browser screenshot API — walk up to the repo-root tmp/ bucket
+      // rather than nesting a tmp/ under this source directory.
+      path: '../../../../../tmp/screenshots/spatial-editor-four-defects-after.png',
+    })
+
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+
+    // Defect 1: the heading's first line must sit below the node chrome's
+    // top edge (not straddle it) — compare the heading run's rendered
+    // client rect against the node's own chrome rect.
+    const nodeRects = Array.from(container.querySelectorAll('svg rect'))
+    const headingRect = nodeRects[0]
+    expect(headingRect).toBeTruthy()
+    const headingTexts = Array.from(container.querySelectorAll('svg text'))
+    const headingRun = headingTexts.find((t) => t.textContent === 'Heading')
+    expect(headingRun).toBeTruthy()
+    if (headingRect && headingRun) {
+      const chromeBox = headingRect.getBoundingClientRect()
+      const runBox = headingRun.getBoundingClientRect()
+      expect(runBox.top).toBeGreaterThanOrEqual(chromeBox.top)
+    }
+
+    // Defect 2: the list body renders each list item as its own run on its
+    // own line, not flattened into a single inline line with the preceding
+    // paragraph (the pre-fix output was the single merged line
+    // "Second node - list item - another").
+    const secondNodeRun = headingTexts.find((t) => t.textContent === 'Second node')
+    const listItemRun = headingTexts.find((t) => t.textContent === 'list item')
+    const anotherRun = headingTexts.find((t) => t.textContent === 'another')
+    expect(secondNodeRun).toBeTruthy()
+    expect(listItemRun).toBeTruthy()
+    expect(anotherRun).toBeTruthy()
+    const flattenedRun = headingTexts.find((t) =>
+      t.textContent?.includes('Second node - list item - another'),
+    )
+    expect(flattenedRun).toBeUndefined()
+    if (secondNodeRun && listItemRun && anotherRun) {
+      const secondNodeY = secondNodeRun.getBoundingClientRect().top
+      const listItemY = listItemRun.getBoundingClientRect().top
+      const anotherY = anotherRun.getBoundingClientRect().top
+      expect(listItemY).toBeGreaterThan(secondNodeY)
+      expect(anotherY).toBeGreaterThan(listItemY)
+    }
+
+    // Defect 3: no run's right edge should extend past its node's chrome
+    // rect (allowing the single-unbreakable-token fallback is not exercised
+    // by this body, since every word here is shorter than the node width).
+    const overflowChrome = nodeRects[2]
+    expect(overflowChrome).toBeTruthy()
+    if (overflowChrome) {
+      const chromeBox = overflowChrome.getBoundingClientRect()
+      const overflowRuns = headingTexts.filter(
+        (t) => t.textContent && chromeBox.left <= t.getBoundingClientRect().left,
+      )
+      for (const run of overflowRuns) {
+        const runBox = run.getBoundingClientRect()
+        if (runBox.top >= chromeBox.top && runBox.bottom <= chromeBox.bottom + 1) {
+          expect(runBox.right).toBeLessThanOrEqual(chromeBox.right + 1)
+        }
+      }
+    }
+
+    // Defect 4: the edge label text is present in the rendered SVG.
+    const edgeLabel = headingTexts.find((t) => t.textContent === 'edge label')
+    expect(edgeLabel).toBeTruthy()
+  })
+})

--- a/packages/canvas-codec/src/markdown/from-remark.ts
+++ b/packages/canvas-codec/src/markdown/from-remark.ts
@@ -96,9 +96,13 @@ function toFlow(node: RemarkNode): MdastFlowContent {
     case 'list':
       return {
         type: 'list',
-        ordered: node.ordered as boolean | undefined,
-        start: node.start as number | undefined,
-        spread: node.spread as boolean | undefined,
+        // remark represents an absent value as `null` (e.g. `start` on an
+        // unordered list), not `undefined` — `mdastRootSchema`'s `.optional()`
+        // fields reject `null`, so this must be coerced at the boundary
+        // rather than cast straight through.
+        ordered: (node.ordered as boolean | null | undefined) ?? undefined,
+        start: (node.start as number | null | undefined) ?? undefined,
+        spread: (node.spread as boolean | null | undefined) ?? undefined,
         children: (node.children ?? []).map(toListItem),
       }
     case 'code':
@@ -141,7 +145,7 @@ function toListItem(node: RemarkNode): MdastListItem {
   return {
     type: 'listItem',
     checked: node.checked as boolean | null | undefined,
-    spread: node.spread as boolean | undefined,
+    spread: (node.spread as boolean | null | undefined) ?? undefined,
     children: (node.children ?? []).map(toFlow),
   }
 }

--- a/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
+++ b/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
@@ -1,6 +1,6 @@
 import { mdastFlowContentArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe } from 'vitest'
-import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { fc, fcTest, hasNoEmptyContainer, withDefaults } from '../test-utils/fast-check.js'
 import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 
 // A strictly weaker sibling to round-trip.property.test.ts's equality
@@ -10,9 +10,17 @@ import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 // 'list' from the equality property doesn't affect a totality check. This
 // is the property that would have caught the `list.start: null` boundary
 // coercion bug (see from-remark.ts).
+//
+// Still excludes empty containers (see hasNoEmptyContainer's doc comment):
+// an empty paragraph as the first child of a checked list item serializes
+// to markdown that mdast-util-gfm-task-list-item's own re-parse cannot
+// handle — a real upstream limitation on a genuinely contentless node, the
+// same class round-trip.property.test.ts already excludes for a different
+// reason (equality, not totality).
 const rootArbitrary = fc
   .array(mdastFlowContentArbitrary(2), { minLength: 1, maxLength: 4 })
   .map((children) => ({ type: 'root' as const, children }))
+  .filter((root) => hasNoEmptyContainer(root))
 
 describe('markdown body parse totality (including lists)', () => {
   fcTest.prop([rootArbitrary], withDefaults({ numRuns: 100 }))(

--- a/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
+++ b/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
@@ -1,0 +1,25 @@
+import { mdastFlowContentArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
+import { describe } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
+
+// A strictly weaker sibling to round-trip.property.test.ts's equality
+// property: this one admits 'list' (and every other flow-content kind)
+// because it only asserts totality (parse never throws), not round-trip
+// equality — the bullet/tightness ambiguity that legitimately excludes
+// 'list' from the equality property doesn't affect a totality check. This
+// is the property that would have caught the `list.start: null` boundary
+// coercion bug (see from-remark.ts).
+const rootArbitrary = fc
+  .array(mdastFlowContentArbitrary(2), { minLength: 1, maxLength: 4 })
+  .map((children) => ({ type: 'root' as const, children }))
+
+describe('markdown body parse totality (including lists)', () => {
+  fcTest.prop([rootArbitrary], withDefaults({ numRuns: 100 }))(
+    'parseMarkdownBody(stringifyMarkdownBody(x)) never throws',
+    (root) => {
+      const text = stringifyMarkdownBody(root)
+      parseMarkdownBody(text)
+    },
+  )
+})

--- a/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
+++ b/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
@@ -10,17 +10,12 @@ import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 // 'list' from the equality property doesn't affect a totality check. This
 // is the property that would have caught the `list.start: null` boundary
 // coercion bug (see from-remark.ts).
-//
-// Still excludes empty containers (see hasNoEmptyContainer's doc comment):
-// an empty paragraph as the first child of a checked list item serializes
-// to markdown that mdast-util-gfm-task-list-item's own re-parse cannot
-// handle — a real upstream limitation on a genuinely contentless node, the
-// same class round-trip.property.test.ts already excludes for a different
-// reason (equality, not totality).
+// Empty containers are still excluded — that limitation is upstream and
+// breaks re-parse outright, not just equality (see hasNoEmptyContainer).
 const rootArbitrary = fc
   .array(mdastFlowContentArbitrary(2), { minLength: 1, maxLength: 4 })
   .map((children) => ({ type: 'root' as const, children }))
-  .filter((root) => hasNoEmptyContainer(root))
+  .filter(hasNoEmptyContainer)
 
 describe('markdown body parse totality (including lists)', () => {
   fcTest.prop([rootArbitrary], withDefaults({ numRuns: 100 }))(

--- a/packages/canvas-codec/src/markdown/pipeline.test.ts
+++ b/packages/canvas-codec/src/markdown/pipeline.test.ts
@@ -30,4 +30,35 @@ describe('markdown pipeline pinned examples', () => {
     expect(text).toContain('Hello')
     expect(text).toContain('world')
   })
+
+  it('parses an unordered list without throwing, keeping ordered false and start absent', () => {
+    const root = parseMarkdownBody('- a\n- b\n')
+    const list = root.children[0]
+    expect(list.type).toBe('list')
+    if (list.type === 'list') {
+      expect(list.ordered).toBe(false)
+      expect(list.start).toBeUndefined()
+      expect(list.children).toHaveLength(2)
+    }
+  })
+
+  it('parses an ordered list keeping its start value', () => {
+    const root = parseMarkdownBody('1. a\n2. b\n')
+    const list = root.children[0]
+    expect(list.type).toBe('list')
+    if (list.type === 'list') {
+      expect(list.ordered).toBe(true)
+      expect(list.start).toBe(1)
+    }
+  })
+
+  it('parses a task list item keeping checked false', () => {
+    const root = parseMarkdownBody('- [ ] a\n')
+    const list = root.children[0]
+    expect(list.type).toBe('list')
+    if (list.type === 'list') {
+      const [item] = list.children
+      expect(item.checked).toBe(false)
+    }
+  })
 })

--- a/packages/canvas-codec/src/markdown/round-trip.property.test.ts
+++ b/packages/canvas-codec/src/markdown/round-trip.property.test.ts
@@ -1,6 +1,6 @@
 import { mdastFlowContentArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe, expect } from 'vitest'
-import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { fc, fcTest, hasNoEmptyContainer, withDefaults } from '../test-utils/fast-check.js'
 import { normalizeMdast } from './normalize.js'
 import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 
@@ -22,19 +22,6 @@ const EXCLUDED_ROUND_TRIP_TYPES = new Set([
   'linkReference',
   'imageReference',
 ])
-
-function hasNoEmptyContainer(node: any): boolean {
-  if (node === null || typeof node !== 'object') return true
-  if (Array.isArray(node.children)) {
-    // An empty container (e.g. a paragraph/blockquote with zero children)
-    // stringifies to nothing and a re-parse simply omits it — real
-    // information loss for a genuinely contentless node, not a normalization
-    // gap. Excluded from this property rather than special-cased away.
-    if (node.children.length === 0) return false
-    return node.children.every(hasNoEmptyContainer)
-  }
-  return true
-}
 
 function hasNoExcludedDescendant(node: any): boolean {
   if (node === null || typeof node !== 'object') return true

--- a/packages/canvas-codec/src/test-utils/fast-check.ts
+++ b/packages/canvas-codec/src/test-utils/fast-check.ts
@@ -6,3 +6,24 @@ export { fc, fcTest }
 export function withDefaults(override?: fc.Parameters<never>): fc.Parameters<never> {
   return { numRuns: 200, ...override }
 }
+
+/**
+ * Rejects a generated mdast tree containing any container node (one with a
+ * `children` array) that is empty. An empty container (e.g. a paragraph or
+ * list item with zero children) stringifies to nothing and a re-parse
+ * simply omits it — real information loss for a genuinely contentless node,
+ * not a normalizeMdast/codec bug, and in at least one combination (an empty
+ * paragraph as the first child of a checked list item) serializes to
+ * malformed markdown that a downstream remark plugin cannot re-parse at
+ * all. Shared by every property in this package that generates arbitrary
+ * mdast trees, so the exclusion is defined once.
+ */
+export function hasNoEmptyContainer(node: unknown): boolean {
+  if (node === null || typeof node !== 'object') return true
+  const record = node as { children?: unknown }
+  if (Array.isArray(record.children)) {
+    if (record.children.length === 0) return false
+    return record.children.every(hasNoEmptyContainer)
+  }
+  return true
+}

--- a/packages/canvas-render/src/layout/__snapshots__/mdast-blocks.test.ts.snap
+++ b/packages/canvas-render/src/layout/__snapshots__/mdast-blocks.test.ts.snap
@@ -14,6 +14,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
       "level": 1,
       "runs": [
         {
+          "baseline": 25.6,
           "bbox": {
             "h": 32,
             "w": 57.599999999999994,
@@ -35,6 +36,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
       "kind": "paragraph",
       "runs": [
         {
+          "baseline": 12.8,
           "bbox": {
             "h": 16,
             "w": 153.6,
@@ -73,6 +75,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
               "kind": "paragraph",
               "runs": [
                 {
+                  "baseline": 12.8,
                   "bbox": {
                     "h": 16,
                     "w": 48,
@@ -111,6 +114,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                       "kind": "paragraph",
                       "runs": [
                         {
+                          "baseline": 12.8,
                           "bbox": {
                             "h": 16,
                             "w": 57.599999999999994,
@@ -164,6 +168,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
               "kind": "tableCell",
               "runs": [
                 {
+                  "baseline": 12.8,
                   "bbox": {
                     "h": 16,
                     "w": 9.6,
@@ -185,6 +190,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
               "kind": "tableCell",
               "runs": [
                 {
+                  "baseline": 12.8,
                   "bbox": {
                     "h": 16,
                     "w": 9.6,
@@ -230,6 +236,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
           "kind": "paragraph",
           "runs": [
             {
+              "baseline": 12.8,
               "bbox": {
                 "h": 16,
                 "w": 57.599999999999994,

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -464,6 +464,45 @@ describe('layoutMdastBlocks — word wrap', () => {
     )
   })
 
+  it('adds exactly one separator space before the first word of a wrapped chunk with leading whitespace', () => {
+    // A chunk whose own text begins with whitespace (e.g. the second of two
+    // adjacent phrasing children "prose" + " word rest...") overflows as a
+    // whole even though its first word alone still fits on the current
+    // line. The leading-whitespace pre-add in `wrapAndPush` must not stack
+    // with the per-word loop's own separator-add on that first iteration —
+    // the gap before the first word must be exactly one space, not two.
+    const narrow = { measure, maxWidth: 100 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'aaaaa' },
+            { type: 'strong', children: [{ type: 'text', value: ` bb ${'c'.repeat(21)}` }] },
+          ],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    const firstRun = paragraph.runs.find((r) => r.text === 'aaaaa')
+    const bbRun = paragraph.runs.find((r) => r.text === 'bb')
+    expect(firstRun).toBeDefined()
+    expect(bbRun).toBeDefined()
+    if (!firstRun || !bbRun) throw new Error('unreachable')
+    const spaceWidth = measure(' ', {
+      family: 'test',
+      fallbackChain: [],
+      weight: 400,
+      style: 'normal',
+      sizePx: 16,
+    }).advanceWidth
+    expect(bbRun.bbox.x).toBeCloseTo(firstRun.bbox.x + firstRun.bbox.w + spaceWidth, 5)
+  })
+
   it('keeps an overflowing inline math run whole instead of splitting it at whitespace', () => {
     const narrow = { measure, maxWidth: 60 }
     const root: MdastRoot = {

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -318,6 +318,74 @@ describe('layoutMdastBlocks — inline cursor', () => {
   })
 })
 
+describe('layoutMdastBlocks — text run baseline', () => {
+  it('carries a measured ascent baseline while leaving bbox.y as the line top', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [{ type: 'heading', depth: 1, children: [{ type: 'text', value: 'Heading' }] }],
+    }
+    const scene = layoutMdastBlocks(root, options)
+    const heading = scene.nodes.find((n) => n.kind === 'heading')
+    expect(heading?.kind).toBe('heading')
+    if (heading?.kind !== 'heading') throw new Error('unreachable')
+    const [run] = heading.runs
+    // fake measure: ascent = fontSizePx * 0.8
+    expect(run.baseline).toBe(32 * 0.8)
+    // bbox.y must stay the line TOP (unaffected by baseline) so sceneBounds
+    // keeps measuring a true top-left box.
+    expect(run.bbox.y).toBe(0)
+  })
+})
+
+describe('layoutMdastBlocks — word wrap', () => {
+  it('wraps a paragraph whose text overflows maxWidth onto multiple lines, each run contained', () => {
+    const narrow = { measure, maxWidth: 60 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'one two three four' }] }],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs.length).toBeGreaterThan(1)
+    for (const run of paragraph.runs) {
+      expect(run.bbox.x).toBeGreaterThanOrEqual(0)
+      expect(run.bbox.x + run.bbox.w).toBeLessThanOrEqual(narrow.maxWidth)
+    }
+    // block height grows with the number of lines produced.
+    const lineHeight = paragraph.runs[0].bbox.h
+    const lineCount = new Set(paragraph.runs.map((r) => r.bbox.y)).size
+    expect(lineCount).toBeGreaterThan(1)
+    expect(paragraph.bbox.h).toBe(lineCount * lineHeight)
+  })
+
+  it('keeps a single unbreakable token wider than maxWidth as one overflowing run', () => {
+    const narrow = { measure, maxWidth: 10 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'unbreakabletoken' }] }],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs).toHaveLength(1)
+    expect(paragraph.runs[0].bbox.w).toBeGreaterThan(narrow.maxWidth)
+  })
+
+  it('does not throw and produces no wrap for a non-finite or non-positive maxWidth', () => {
+    for (const badWidth of [0, -10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const bad = { measure, maxWidth: badWidth }
+      const root: MdastRoot = {
+        type: 'root',
+        children: [{ type: 'paragraph', children: [{ type: 'text', value: 'one two three' }] }],
+      }
+      expect(() => layoutMdastBlocks(root, bad)).not.toThrow()
+    }
+  })
+})
+
 describe('layoutMdastBlocks — single render path', () => {
   it('produces a deep-equal scene for preview, spatial-text-node, and export callers', () => {
     const root: MdastRoot = {

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -384,6 +384,63 @@ describe('layoutMdastBlocks — word wrap', () => {
       expect(() => layoutMdastBlocks(root, bad)).not.toThrow()
     }
   })
+
+  it('keeps an overflowing inline code span whole instead of splitting it at whitespace', () => {
+    const narrow = { measure, maxWidth: 60 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'inlineCode', value: 'function call with spaces()' }],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs).toHaveLength(1)
+    expect(paragraph.runs[0].text).toBe('function call with spaces()')
+  })
+
+  it('keeps an overflowing raw html run whole instead of splitting it at whitespace', () => {
+    const narrow = { measure, maxWidth: 60 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'html', value: '<span class="a b c" data-x="y">' }],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs).toHaveLength(1)
+    expect(paragraph.runs[0].text).toBe('<span class="a b c" data-x="y">')
+  })
+
+  it('keeps an overflowing inline math run whole instead of splitting it at whitespace', () => {
+    const narrow = { measure, maxWidth: 60 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'inlineMath', value: 'a + b + c + d + e' }],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs).toHaveLength(1)
+    expect(paragraph.runs[0].text).toBe('a + b + c + d + e')
+  })
 })
 
 describe('layoutMdastBlocks — single render path', () => {

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -423,6 +423,47 @@ describe('layoutMdastBlocks — word wrap', () => {
     expect(paragraph.runs[0].text).toBe('<span class="a b c" data-x="y">')
   })
 
+  it('preserves a space between a wrapped chunk and the next inline sibling', () => {
+    // mdast represents "long line " + strong("word") as two adjacent
+    // phrasing children: a text node ending in a space, then a styled run.
+    // The trailing space belongs to the wrapped chunk, not the sibling, so
+    // it must still separate them even when the chunk wraps mid-word.
+    const narrow = { measure, maxWidth: 50 }
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'long line ' },
+            { type: 'strong', children: [{ type: 'text', value: 'word' }] },
+          ],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, narrow)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    const lastWrappedRun = paragraph.runs.find((r) => r.text === 'line')
+    const siblingRun = paragraph.runs.find((r) => r.text === 'word')
+    expect(lastWrappedRun).toBeDefined()
+    expect(siblingRun).toBeDefined()
+    if (!lastWrappedRun || !siblingRun) throw new Error('unreachable')
+    // Same line, so a real gap (a space's width) must separate them.
+    expect(siblingRun.bbox.y).toBe(lastWrappedRun.bbox.y)
+    const spaceWidth = measure(' ', {
+      family: 'test',
+      fallbackChain: [],
+      weight: 400,
+      style: 'normal',
+      sizePx: 16,
+    }).advanceWidth
+    expect(siblingRun.bbox.x).toBeGreaterThanOrEqual(
+      lastWrappedRun.bbox.x + lastWrappedRun.bbox.w + spaceWidth,
+    )
+  })
+
   it('keeps an overflowing inline math run whole instead of splitting it at whitespace', () => {
     const narrow = { measure, maxWidth: 60 }
     const root: MdastRoot = {

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -109,7 +109,10 @@ interface PhrasingLayout {
  * A single word wider than `maxWidth` on its own line is a deliberate
  * exception: it is left as one overflowing run rather than broken mid-word.
  * Wrapping is skipped entirely when `maxWidth` is non-finite or <= 0 (no
- * meaningful width to wrap against).
+ * meaningful width to wrap against). Inline code, raw HTML, and inline math
+ * runs are atomic — their source text may contain whitespace that is not a
+ * word boundary (a code span's argument list, an HTML tag's attributes),
+ * so they are always emitted as one run even when they overflow.
  */
 function layoutPhrasing(
   children: readonly (MdastPhrasingContent | MdastCellPhrasingContent)[],
@@ -164,8 +167,12 @@ function layoutPhrasing(
     text: string,
     extra: Partial<TextRunNode> = {},
     runStyle: { emphasis?: boolean; strong?: boolean; deleted?: boolean } = style,
+    // Atomic runs (inline code, raw HTML, inline math) must never be split
+    // mid-token at a whitespace boundary — unlike prose, an internal space
+    // in their source text is not a word boundary.
+    wrappable = true,
   ) => {
-    if (canWrap) {
+    if (canWrap && wrappable) {
       const fullWidth = measureRunWidth(options.measure, text, fontSizePx)
       const overflows = line.x + fullWidth > options.maxWidth
       if (overflows && /\s/.test(text)) {
@@ -199,14 +206,14 @@ function layoutPhrasing(
           emit(child.value, {}, currentStyle)
           break
         case 'inlineCode':
-          emit(child.value, { code: true }, currentStyle)
+          emit(child.value, { code: true }, currentStyle, false)
           break
         case 'break':
           line.x = 0
           line.index += 1
           break
         case 'html':
-          emit(child.value, {}, currentStyle)
+          emit(child.value, {}, currentStyle, false)
           break
         case 'emphasis':
           walk(child.children, { ...currentStyle, emphasis: true })
@@ -242,7 +249,7 @@ function layoutPhrasing(
           emit(child.alt ?? child.identifier, {}, currentStyle)
           break
         case 'inlineMath':
-          emit(child.value, {}, currentStyle)
+          emit(child.value, {}, currentStyle, false)
           break
         case 'wikiLink':
           emit(

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -151,6 +151,13 @@ function layoutPhrasing(
   ) => {
     const words = text.split(/\s+/).filter((word) => word.length > 0)
     const spaceWidth = measureRunWidth(options.measure, ' ', fontSizePx)
+    // `split(/\s+/)` discards this chunk's own leading/trailing whitespace.
+    // mdast represents "prose " + strong("word") as two adjacent phrasing
+    // children, so a trailing space stripped here would otherwise vanish
+    // between this chunk's last word and the next sibling's first run.
+    if (words.length > 0 && line.x > 0 && /^\s/.test(text)) {
+      line.x += spaceWidth
+    }
     for (const word of words) {
       const width = measureRunWidth(options.measure, word, fontSizePx)
       if (line.x > 0 && line.x + spaceWidth + width > options.maxWidth) {
@@ -160,6 +167,9 @@ function layoutPhrasing(
         line.x += spaceWidth
       }
       pushRun(word, extra, runStyle)
+    }
+    if (words.length > 0 && /\s$/.test(text)) {
+      line.x += spaceWidth
     }
   }
 

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -154,20 +154,25 @@ function layoutPhrasing(
     // `split(/\s+/)` discards this chunk's own leading/trailing whitespace.
     // mdast represents "prose " + strong("word") as two adjacent phrasing
     // children, so a trailing space stripped here would otherwise vanish
-    // between this chunk's last word and the next sibling's first run.
-    if (words.length > 0 && line.x > 0 && /^\s/.test(text)) {
-      line.x += spaceWidth
-    }
-    for (const word of words) {
+    // between this chunk's last word and the next sibling's first run — a
+    // separator is due before the loop's first word in that case exactly
+    // like it is due before every subsequent word in this chunk, so both
+    // cases share the same separator-add-or-wrap logic below (a chunk's
+    // interior words are always whitespace-separated by construction).
+    const chunkHasLeadingSpace = /^\s/.test(text)
+    words.forEach((word, index) => {
       const width = measureRunWidth(options.measure, word, fontSizePx)
-      if (line.x > 0 && line.x + spaceWidth + width > options.maxWidth) {
-        line.x = 0
-        line.index += 1
-      } else if (line.x > 0) {
-        line.x += spaceWidth
+      const needsSeparator = index === 0 ? chunkHasLeadingSpace : true
+      if (needsSeparator && line.x > 0) {
+        if (line.x + spaceWidth + width > options.maxWidth) {
+          line.x = 0
+          line.index += 1
+        } else {
+          line.x += spaceWidth
+        }
       }
       pushRun(word, extra, runStyle)
-    }
+    })
     if (words.length > 0 && /\s$/.test(text)) {
       line.x += spaceWidth
     }

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -96,12 +96,20 @@ interface PhrasingLayout {
  * Flattens phrasing content into an ordered list of styled text runs,
  * starting at the block's top-left corner (`cursor.y`, x = 0).
  *
- * This is a minimal non-wrapping inline cursor: within one line, each run's
- * `bbox.x` is the running horizontal cursor (previous runs' widths summed),
- * so sibling runs never overlap. Word-wrap at `options.maxWidth` is still
- * deferred to the future theme/line-layout slice — a single line can exceed
- * `maxWidth` — but a hard break (mdast `break`) always resets the cursor to
- * the block's left edge and advances to a new line one `fontSizePx` down.
+ * Within one line, each run's `bbox.x` is the running horizontal cursor
+ * (previous runs' widths summed), so sibling runs never overlap. A hard
+ * break (mdast `break`) always resets the cursor to the block's left edge
+ * and advances to a new line one `fontSizePx` down.
+ *
+ * Word-wrap: a chunk of text that would exceed `options.maxWidth` on its
+ * current line splits into per-word runs at whitespace boundaries, packed
+ * greedily onto successive lines. A chunk that already fits (the common
+ * case) stays a single run, unchanged from before wrapping existed — this
+ * keeps wrapping's blast radius limited to the cases that actually overflow.
+ * A single word wider than `maxWidth` on its own line is a deliberate
+ * exception: it is left as one overflowing run rather than broken mid-word.
+ * Wrapping is skipped entirely when `maxWidth` is non-finite or <= 0 (no
+ * meaningful width to wrap against).
  */
 function layoutPhrasing(
   children: readonly (MdastPhrasingContent | MdastCellPhrasingContent)[],
@@ -112,21 +120,60 @@ function layoutPhrasing(
 ): PhrasingLayout {
   const runs: TextRunNode[] = []
   const line = { x: 0, index: 0 }
+  const canWrap = Number.isFinite(options.maxWidth) && options.maxWidth > 0
+
+  const pushRun = (
+    text: string,
+    extra: Partial<TextRunNode>,
+    runStyle: { emphasis?: boolean; strong?: boolean; deleted?: boolean },
+  ) => {
+    const metrics = options.measure(text, bodyFont(fontSizePx))
+    const width = clampAdvance(metrics.advanceWidth)
+    const baseline = clampAdvance(metrics.ascent)
+    runs.push({
+      kind: 'textRun',
+      bbox: { x: line.x, y: cursor.y + line.index * fontSizePx, w: width, h: fontSizePx },
+      baseline,
+      text,
+      ...runStyle,
+      ...extra,
+    })
+    line.x += width
+  }
+
+  const wrapAndPush = (
+    text: string,
+    extra: Partial<TextRunNode>,
+    runStyle: { emphasis?: boolean; strong?: boolean; deleted?: boolean },
+  ) => {
+    const words = text.split(/\s+/).filter((word) => word.length > 0)
+    const spaceWidth = measureRunWidth(options.measure, ' ', fontSizePx)
+    for (const word of words) {
+      const width = measureRunWidth(options.measure, word, fontSizePx)
+      if (line.x > 0 && line.x + spaceWidth + width > options.maxWidth) {
+        line.x = 0
+        line.index += 1
+      } else if (line.x > 0) {
+        line.x += spaceWidth
+      }
+      pushRun(word, extra, runStyle)
+    }
+  }
 
   const emit = (
     text: string,
     extra: Partial<TextRunNode> = {},
     runStyle: { emphasis?: boolean; strong?: boolean; deleted?: boolean } = style,
   ) => {
-    const width = measureRunWidth(options.measure, text, fontSizePx)
-    runs.push({
-      kind: 'textRun',
-      bbox: { x: line.x, y: cursor.y + line.index * fontSizePx, w: width, h: fontSizePx },
-      text,
-      ...runStyle,
-      ...extra,
-    })
-    line.x += width
+    if (canWrap) {
+      const fullWidth = measureRunWidth(options.measure, text, fontSizePx)
+      const overflows = line.x + fullWidth > options.maxWidth
+      if (overflows && /\s/.test(text)) {
+        wrapAndPush(text, extra, runStyle)
+        return
+      }
+    }
+    pushRun(text, extra, runStyle)
   }
 
   /** Walk `nodes`, then stamp `link` provenance onto every run they produced. */

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -147,6 +147,41 @@ describe('layoutSpatialCanvas', () => {
     }
   })
 
+  it('emits a label run for an edge that carries one, centered on the routed path midpoint', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 200, y: 0, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b', label: 'edge label' }
+    const scene = layoutSpatialCanvas(canvas([a, b], [edge]), baseOptions())
+
+    const label = scene.nodes.find(
+      (n): n is TextRunNode => n.kind === 'textRun' && n.text === 'edge label',
+    )
+    expect(label).toBeDefined()
+    expect(label?.appearance?.fill).toBe('#303030')
+  })
+
+  it('emits no label run for an edge with no label', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 200, y: 0, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+    const scene = layoutSpatialCanvas(canvas([a, b], [edge]), baseOptions())
+    expect(scene.nodes.some((n) => n.kind === 'textRun' && n.text === 'edge label')).toBe(false)
+  })
+
+  it('emits no label run for an edge with an empty-string label', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 200, y: 0, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b', label: '' }
+    const scene = layoutSpatialCanvas(canvas([a, b], [edge]), baseOptions())
+    expect(scene.nodes.some((n) => n.kind === 'textRun' && n.bbox.w === 0)).toBe(false)
+  })
+
+  it('degrades a labelled edge with a missing endpoint instead of throwing', () => {
+    const a = textNode({ id: 'a' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'ghost', label: 'edge label' }
+    expect(() => layoutSpatialCanvas(canvas([a], [edge]), baseOptions())).not.toThrow()
+  })
+
   it('degrades a missing edge endpoint instead of throwing, keeping all nodes', () => {
     const a = textNode({ id: 'a' })
     const edge = { id: 'e1', fromNode: 'a', toNode: 'ghost' }

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -176,10 +176,16 @@ describe('layoutSpatialCanvas', () => {
     expect(scene.nodes.some((n) => n.kind === 'textRun' && n.bbox.w === 0)).toBe(false)
   })
 
-  it('degrades a labelled edge with a missing endpoint instead of throwing', () => {
+  it('drops the label of an edge whose endpoint is missing, rather than floating it', () => {
     const a = textNode({ id: 'a' })
     const edge = { id: 'e1', fromNode: 'a', toNode: 'ghost', label: 'edge label' }
-    expect(() => layoutSpatialCanvas(canvas([a], [edge]), baseOptions())).not.toThrow()
+    let scene!: ReturnType<typeof layoutSpatialCanvas>
+    expect(() => {
+      scene = layoutSpatialCanvas(canvas([a], [edge]), baseOptions())
+    }).not.toThrow()
+    // Not-throwing alone would still pass with the label drawn on the
+    // unrouted edge's lone fallback point — text with no line attached.
+    expect(scene.nodes.some((n) => n.kind === 'textRun' && n.text === 'edge label')).toBe(false)
   })
 
   it('degrades a missing edge endpoint instead of throwing, keeping all nodes', () => {

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -195,14 +195,21 @@ function composeEdge(
  * arc-length midpoint — the midpoint of the two vertices straddling the
  * path's index midpoint — which is exact for the common 2-point straight
  * edge and a stable, deterministic approximation for a multi-point routed
- * path (e.g. a self-edge loop). A degenerate 0/1-point path (the missing-
- * endpoint fallback) degrades to that lone point rather than throwing.
+ * path (e.g. a self-edge loop).
+ *
+ * Returns `undefined` when the path draws no line — fewer than two points,
+ * or every point at the same place. `routeEdge`'s missing-endpoint fallback
+ * is that second case specifically: it degrades to `[origin, origin]`, a
+ * two-point path of zero length. A point-count check alone would miss it and
+ * center the label on the canvas origin, leaving text floating with nothing
+ * attached to it.
  */
 function edgeMidpoint(
   path: readonly { readonly x: number; readonly y: number }[],
 ): { readonly x: number; readonly y: number } | undefined {
-  if (path.length === 0) return undefined
-  if (path.length === 1) return path[0]
+  const first = path[0]
+  if (path.length < 2 || first === undefined) return undefined
+  if (path.every((p) => p.x === first.x && p.y === first.y)) return undefined
   const mid = (path.length - 1) / 2
   const lower = path[Math.floor(mid)]!
   const upper = path[Math.ceil(mid)]!

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -191,6 +191,59 @@ function composeEdge(
 }
 
 /**
+ * The point along `path` used to center an edge's label. Not an exact
+ * arc-length midpoint — the midpoint of the two vertices straddling the
+ * path's index midpoint — which is exact for the common 2-point straight
+ * edge and a stable, deterministic approximation for a multi-point routed
+ * path (e.g. a self-edge loop). A degenerate 0/1-point path (the missing-
+ * endpoint fallback) degrades to that lone point rather than throwing.
+ */
+function edgeMidpoint(
+  path: readonly { readonly x: number; readonly y: number }[],
+): { readonly x: number; readonly y: number } | undefined {
+  if (path.length === 0) return undefined
+  if (path.length === 1) return path[0]
+  const mid = (path.length - 1) / 2
+  const lower = path[Math.floor(mid)]!
+  const upper = path[Math.ceil(mid)]!
+  return { x: (lower.x + upper.x) / 2, y: (lower.y + upper.y) / 2 }
+}
+
+/**
+ * Composes a centered label run for an edge that carries one. Returns
+ * `undefined` for no label, an empty/whitespace-only label, or a
+ * degenerate path — `layoutSpatialCanvas` stays total either way.
+ */
+function composeEdgeLabel(
+  edge: CanvasEdge,
+  routed: ResolvedEdgeNode,
+  options: SpatialLayoutOptions,
+): TextRunNode | undefined {
+  if (edge.label === undefined || edge.label.trim().length === 0) return undefined
+  const center = edgeMidpoint(routed.path)
+  if (!center) return undefined
+
+  const labelAppearance = options.appearance.resolveLabel()
+  const font = {
+    family: labelAppearance.fontFamily ?? 'sans-serif',
+    fallbackChain: [],
+    weight: 400,
+    style: 'normal' as const,
+    sizePx: options.appearance.labelFontSizePx,
+  }
+  const metrics = options.measure(edge.label, font)
+  const width = metrics.advanceWidth
+  const height = metrics.ascent + metrics.descent
+  return {
+    kind: 'textRun',
+    bbox: { x: center.x - width / 2, y: center.y - height / 2, w: width, h: height },
+    baseline: metrics.ascent,
+    text: edge.label,
+    appearance: { ...labelAppearance, fontSize: options.appearance.labelFontSizePx },
+  }
+}
+
+/**
  * Composes a canvas-render `Scene` from a `SpatialCanvas`. Pure: takes the
  * already-read canvas plus injected measurer/body-parser/appearance, and
  * performs no I/O.
@@ -198,5 +251,8 @@ function composeEdge(
 export function layoutSpatialCanvas(canvas: SpatialCanvas, options: SpatialLayoutOptions): Scene {
   const nodeContent = canvas.nodes.flatMap((node) => composeNode(node, options))
   const edgeContent = canvas.edges.map((edge) => composeEdge(canvas, edge, options))
-  return { nodes: [...nodeContent, ...edgeContent] }
+  const labelContent = canvas.edges
+    .map((edge, index) => composeEdgeLabel(edge, edgeContent[index]!, options))
+    .filter((label): label is TextRunNode => label !== undefined)
+  return { nodes: [...nodeContent, ...edgeContent, ...labelContent] }
 }

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -58,6 +58,14 @@ export interface TextRunNode {
   /** Present when this run is (or is inside) a link/wikiLink/reference. */
   readonly link?: LinkProvenance
   readonly appearance?: Appearance
+  /**
+   * Distance (px) from `bbox.y` (the line TOP) down to the text baseline,
+   * i.e. the measured font ascent. `bbox` stays a true top-left box either
+   * way — sceneBounds/sceneDigest read `bbox`, never this field — so an
+   * absent `baseline` renders exactly as it always has (SVG `y = bbox.y`),
+   * and a present one only shifts where the glyphs paint within that box.
+   */
+  readonly baseline?: number
 }
 
 /**

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -38,6 +38,37 @@ describe('renderSceneToSvg', () => {
     expect(svg).toContain('a &amp; b &lt; c &gt; d')
   })
 
+  it('emits a text run with no baseline exactly as before (byte-identical additivity)', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'textRun', bbox: { x: 0, y: 10, w: 20, h: 16 }, text: 'hi' }],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('<text x="0" y="10">hi</text>')
+  })
+
+  it('shifts a text run down by its baseline offset when present', () => {
+    const scene: Scene = {
+      nodes: [{ kind: 'textRun', bbox: { x: 0, y: 10, w: 20, h: 16 }, text: 'hi', baseline: 12.8 }],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('<text x="0" y="22.8">hi</text>')
+  })
+
+  it('omits a non-finite baseline rather than reaching formatCoord', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'textRun',
+          bbox: { x: 0, y: 10, w: 20, h: 16 },
+          text: 'hi',
+          baseline: Number.NaN,
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('<text x="0" y="10">hi</text>')
+  })
+
   it('emits an already-validated SVG fragment verbatim, wrapped in a group', () => {
     const scene: Scene = {
       nodes: [

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -72,9 +72,23 @@ function appearanceAttrs(appearance?: Appearance): string {
   return parts.join(' ')
 }
 
+/**
+ * SVG `<text y>` is the BASELINE, not the top of the glyph box — `bbox.y`
+ * is deliberately the line TOP (so sceneBounds/sceneDigest keep reading a
+ * true top-left box), so the two must never be conflated. A non-finite
+ * baseline is omitted rather than reaching `formatCoord` (which throws by
+ * contract); an absent baseline reproduces the pre-baseline `y = bbox.y`
+ * output byte-for-byte, which is what keeps `DETERMINISM_GOLDEN_SVG` frozen.
+ */
+function textBaselineY(run: TextRunNode): number {
+  return run.baseline !== undefined && Number.isFinite(run.baseline)
+    ? run.bbox.y + run.baseline
+    : run.bbox.y
+}
+
 function renderTextRun(run: TextRunNode): string {
   const appearance = withLeadingSpace(appearanceAttrs(run.appearance))
-  const text = `<text x="${formatCoord(run.bbox.x)}" y="${formatCoord(run.bbox.y)}"${appearance}>${escapeXmlText(run.text)}</text>`
+  const text = `<text x="${formatCoord(run.bbox.x)}" y="${formatCoord(textBaselineY(run))}"${appearance}>${escapeXmlText(run.text)}</text>`
   if (!run.link) return text
   const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.canvasId
   return `<a href="${escapeXmlAttr(href)}">${text}</a>`


### PR DESCRIPTION
Four layout defects were visible in a real browser on a canvas with content. Investigating the flattened-list one turned out to matter far more than it looked.

## A markdown list silently destroyed the whole node body

The reported symptom was "a list renders as one inline run". The cause is not list layout.

`canvas-codec`'s `from-remark.ts` passed remark's `start: null` straight through as `node.start as number | undefined` — a cast that lies about the value. `mdastRootSchema`'s `start: z.number().int().optional()` rejects `null`, so `parseMarkdownBody` **threw** on any unordered list, and `composeTextNode`'s try/catch degraded the **entire body** — headings, paragraphs, everything — to a single literal text run.

So every text node whose markdown contained a bullet list lost all of its structure, in the editor, the viewer, and the exported SVG alike. The visible "flattened list" was the tail of that.

The fix coerces at the boundary (`?? undefined`), matching the precedent already used for `lang`/`meta`/`title`/`alt` a few lines above. `mdastRootSchema` is deliberately **not** relaxed: an unordered list genuinely has no `start`, so the contract was right and the boundary was wrong.

`layoutMdastBlocks` was verified innocent before any of this was touched — given a hand-built list mdast it already emitted correctly indented items.

## Why no test caught it

`markdown/pipeline.test.ts` had no list case at all, and `round-trip.property.test.ts` excludes `'list'` from its arbitrary. That exclusion is legitimate for an equality round-trip (bullet-marker and tightness ambiguity), but it also removed lists from the only generative coverage of the parse path. This PR adds an example parse test plus a weaker **totality** property that does admit lists — mutation-checked: reverting only the `start` coercion turns three tests red, including that property.

## The other three, each fixed in its owning layer

- **Heading clipped by the node's top border** — `renderTextRun` emitted `<text y="${bbox.y}">`, but SVG's `y` on `<text>` is the *baseline* while layout writes `bbox.y` as the line *top*. An optional `baseline?: number` now carries the measured ascent, and the backend emits `y = bbox.y + (baseline ?? 0)`. Absent field ⇒ byte-identical output, so the frozen determinism goldens are untouched.
- **Text overflowing the node's right edge** — `layoutPhrasing` documented word-wrap as deferred and emitted one run per phrasing child regardless of width. It now wraps at whitespace boundaries. A single unbreakable token wider than the content box still overflows rather than being broken mid-word; that is the deliberate fallback and it is pinned by a test rather than left implicit.
- **Edge labels never drawn** — `composeEdge` never read `edge.label`, even though the appearance seam already exposed `resolveLabel`/`labelFontSizePx`. Labels are emitted as sibling top-level runs so neither `sceneBounds` nor the backend needs a new transform-emitting renderer (which would have required teaching decision #5's `subtreeOffsetX` tripwire about a third case).

Everything lands in `canvas-codec` and `canvas-render`. `apps/web`'s `scene-render.ts` and `editor-appearance.ts` were confirmed to be thin wrappers and end this change unmodified — one regression test per defect now protects the export, the viewer and the editor together.

## Visual repro

Before — heading straddling the border, list collapsed to one line, text past the right edge, unlabelled edge:

![spatial-editor-four-defects-before.png](https://github.com/user-attachments/assets/df7f4ae3-cd8b-4837-bd94-2670386c724b)

After:

![spatial-editor-four-defects-after.png](https://github.com/user-attachments/assets/736403c6-3f9e-49d2-a480-2cb3bbc89ea7)

## Verification

`pnpm test`: 508 files, 5918 passed. `pnpm -r typecheck` clean. The determinism goldens are unchanged — the baseline field is additive by design, and a new separate golden covers baseline + wrap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown rendering for ordered, unordered, and task lists.
  - Added automatic wrapping for prose within available canvas width while preserving code, HTML, and math content.
  - Corrected text baseline positioning to prevent clipped or misaligned heading lines.
  - Added centered labels to routed canvas edges, with graceful handling for missing or empty labels.
  - Prevented overflowing text and improved whitespace handling across wrapped content.

- **Tests**
  - Added browser and regression coverage for text layout, Markdown parsing, wrapping, and edge-label rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->