### PR TITLE
feat(web): let a human create, place, and delete nodes on a canvas

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -1141,6 +1141,9 @@ describe('SpatialEditor (browser) — spatial text layout defects', () => {
     // Defect 4: the edge label text is present in the rendered SVG.
     const edgeLabel = headingTexts.find((t) => t.textContent === 'edge label')
     expect(edgeLabel).toBeTruthy()
+  })
+})
+
 function boxesOverlap(
   a: { x: number; y: number; width: number; height: number },
   b: { x: number; y: number; width: number; height: number },

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -6,7 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { page } from 'vitest/browser'
+import { page, userEvent } from 'vitest/browser'
 // Real app styles — needed so the Add-note-button affordance test's
 // getComputedStyle assertions reflect the actual shipped CSS, not
 // unstyled-DOM defaults.
@@ -688,15 +688,11 @@ describe('SpatialEditor (browser)', () => {
     const button = page.getByTestId('add-node-button')
     ;(button.element() as HTMLButtonElement).focus()
     expect(document.activeElement).toBe(button.element())
-    await button
-      .element()
-      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
-    // A native <button> fires 'click' on Enter keyup, not keydown; simulate
-    // the browser's own follow-through since dispatching a synthetic keydown
-    // alone does not trigger it.
-    await button
-      .element()
-      .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    // A real key press through the browser, not a synthetic keydown followed
+    // by a synthetic click: dispatching the click ourselves would exercise
+    // the mouse path and prove nothing about keyboard reachability, which is
+    // the whole point of this case.
+    await userEvent.keyboard('{Enter}')
 
     expect(onChange).toHaveBeenCalledTimes(1)
   })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -4,8 +4,10 @@
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, render, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+import type { EditorCommand } from './commands.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 function fakeMeasure() {
@@ -20,6 +22,39 @@ function twoNodeCanvas(): SpatialCanvas {
     ],
     edges: [],
   }
+}
+
+/**
+ * SpatialEditor is CONTROLLED and owns no state of its own — a real host
+ * (canvas-sync-session's synchronous `currentCanvas = next; notify(...)`,
+ * see canvas-sync-session.ts) feeds the `onChange` result straight back as
+ * the next `canvas` prop. Several create/delete scenarios below depend on
+ * that feedback loop (e.g. a newly-created node's own TextNodeEditor only
+ * renders once `canvas.nodes` actually contains it), so this thin wrapper
+ * reproduces the real host's behavior instead of leaving onChange a
+ * feedback-free spy.
+ */
+function ControlledEditor({
+  initial,
+  onChange,
+  createId,
+}: {
+  initial: SpatialCanvas
+  onChange: (next: SpatialCanvas, command: EditorCommand) => void
+  createId?: () => string
+}) {
+  const [canvas, setCanvas] = useState(initial)
+  return (
+    <SpatialEditor
+      canvas={canvas}
+      onChange={(next, command) => {
+        setCanvas(next)
+        onChange(next, command)
+      }}
+      measure={fakeMeasure}
+      createId={createId}
+    />
+  )
 }
 
 afterEach(() => {
@@ -572,6 +607,372 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointermove', { bubbles: true, clientX: 90, clientY: 90, pointerId: 3 }),
       )
     expect(() => unmount()).not.toThrow()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('double-clicking empty canvas space creates a node and opens it for typing immediately (no second double-click)', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <ControlledEditor
+          initial={twoNodeCanvas()}
+          onChange={onChange}
+          createId={() => 'new-node'}
+        />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    // Empty space: far from both node "a" (20,20-120,80) and node "b" (250,20-330,60).
+    await editor.element().dispatchEvent(
+      new MouseEvent('dblclick', {
+        bubbles: true,
+        clientX: 500,
+        clientY: 300,
+      }),
+    )
+
+    const textEditor = page.getByTestId('text-node-editor')
+    expect(textEditor.element()).toBeTruthy()
+    expect(document.activeElement).toBe(textEditor.element())
+
+    await textEditor.fill('my first note')
+    ;(textEditor.element() as HTMLTextAreaElement).blur()
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+    const [firstNext, firstCommand] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
+    expect(firstCommand).toMatchObject({ kind: 'create-node', node: { id: 'new-node', text: '' } })
+    expect(firstNext.nodes.map((n) => n.id)).toContain('new-node')
+    const [, secondCommand] = onChange.mock.calls[1] as [SpatialCanvas, unknown]
+    expect(secondCommand).toEqual({ kind: 'set-text', id: 'new-node', text: 'my first note' })
+  })
+
+  it('the Add note button creates a node at viewport center via a real click', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+          createId={() => 'add-note-1'}
+        />
+      </div>,
+    )
+    const button = page.getByTestId('add-node-button')
+    await button
+      .element()
+      .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
+    expect(command).toMatchObject({ kind: 'create-node', node: { id: 'add-note-1' } })
+    expect(next.nodes.map((n) => n.id)).toContain('add-note-1')
+  })
+
+  it('the Add note button is reachable and activatable via keyboard (Enter)', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+          createId={() => 'add-note-2'}
+        />
+      </div>,
+    )
+    const button = page.getByTestId('add-node-button')
+    ;(button.element() as HTMLButtonElement).focus()
+    expect(document.activeElement).toBe(button.element())
+    await button
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    // A native <button> fires 'click' on Enter keyup, not keydown; simulate
+    // the browser's own follow-through since dispatching a synthetic keydown
+    // alone does not trigger it.
+    await button
+      .element()
+      .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('select a node then Delete removes it from the next canvas and clears the selection overlay', async () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 40,
+        pointerId: 60,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 60 }),
+      )
+    expect(container.querySelector('[data-testid="resize-handle-se"]')).not.toBeNull()
+
+    await editor
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
+    expect(command).toEqual({ kind: 'delete-node', id: 'a' })
+    expect(next.nodes.map((n) => n.id)).toEqual(['b'])
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="resize-handle-se"]')).toBeNull()
+    })
+  })
+
+  it('select a node then Backspace also deletes it', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 40,
+        pointerId: 61,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 61 }),
+      )
+    await editor
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
+    expect(command).toEqual({ kind: 'delete-node', id: 'a' })
+  })
+
+  it('while the text editor is open, Backspace edits the textarea and does NOT delete the node', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 40,
+        pointerId: 62,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 62 }),
+      )
+    await editor.element().dispatchEvent(
+      new MouseEvent('dblclick', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 40,
+      }),
+    )
+
+    const textEditor = page.getByTestId('text-node-editor')
+    await textEditor.fill('hell')
+    await textEditor
+      .element()
+      .dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+      )
+
+    // The node must still exist — the reducer's editing-text guard means no
+    // delete-node command was ever emitted from this keystroke.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(page.getByTestId('text-node-editor').element()).toBeTruthy()
+    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
+    expect(command).toEqual({ kind: 'set-text', id: 'a', text: 'hell' })
+  })
+
+  it('creating two nodes, connecting them, then deleting one leaves no dangling edge in the canvas or the rendered SVG', async () => {
+    const onChange = vi.fn()
+    let ids = 0
+    const { container } = render(
+      <div style={{ width: 600, height: 400 }}>
+        <ControlledEditor
+          initial={{ nodes: [], edges: [] }}
+          onChange={onChange}
+          createId={() => `id-${++ids}`}
+        />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+
+    // Create node 1 at (100, 100), commit empty text via blur.
+    await editor
+      .element()
+      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 100, clientY: 100 }))
+    let textEditor = page.getByTestId('text-node-editor')
+    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    let canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    expect(canvas.nodes).toHaveLength(1)
+    // Wait for ControlledEditor's setCanvas to actually flush and re-render
+    // SpatialEditor with the updated `canvas` prop (evidenced by the
+    // TextNodeEditor unmounting) — otherwise the next dblclick's handler
+    // closure still sees the PRE-create (empty) canvas, and the next create
+    // silently overwrites node 1 instead of adding node 2.
+    await waitFor(() => {
+      expect(() => page.getByTestId('text-node-editor').element()).toThrow()
+    })
+
+    // Create node 2 at (400, 100), commit.
+    await editor
+      .element()
+      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 400, clientY: 100 }))
+    textEditor = page.getByTestId('text-node-editor')
+    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    expect(canvas.nodes).toHaveLength(2)
+    await waitFor(() => {
+      expect(() => page.getByTestId('text-node-editor').element()).toThrow()
+    })
+
+    // Select node 1, connect it to node 2 via the connect handle.
+    const node1Box = canvas.nodes[0]!
+    const node2Box = canvas.nodes[1]!
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: node1Box.x + 10,
+        clientY: node1Box.y + 10,
+        pointerId: 70,
+        button: 0,
+      }),
+    )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: node1Box.x + 10,
+        clientY: node1Box.y + 10,
+        pointerId: 70,
+      }),
+    )
+    const connectHandle = page.getByTestId('connect-handle')
+    await connectHandle.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: node1Box.x + node1Box.width,
+        clientY: node1Box.y + node1Box.height / 2,
+        pointerId: 71,
+        button: 0,
+      }),
+    )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: node2Box.x + 10,
+        clientY: node2Box.y + 10,
+        pointerId: 71,
+      }),
+    )
+    canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    expect(canvas.edges).toHaveLength(1)
+    const edgeId = canvas.edges[0]!.id
+    expect(canvas.edges[0]).toEqual({ id: edgeId, fromNode: node1Box.id, toNode: node2Box.id })
+
+    // Select node 1 again, delete it.
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: node1Box.x + 10,
+        clientY: node1Box.y + 10,
+        pointerId: 72,
+        button: 0,
+      }),
+    )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: node1Box.x + 10,
+        clientY: node1Box.y + 10,
+        pointerId: 72,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+
+    canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    expect(canvas.nodes.map((n) => n.id)).toEqual([node2Box.id])
+    expect(canvas.edges).toEqual([])
+
+    await waitFor(() => {
+      const svgText = container.querySelector('[data-testid="spatial-editor"]')?.innerHTML ?? ''
+      expect(svgText).not.toContain(edgeId)
+    })
+  })
+
+  it('deleting the node an in-flight move gesture targets (canvas replaced mid-drag) does not throw and commits nothing', async () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 40,
+        pointerId: 80,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 60, clientY: 60, pointerId: 80 }),
+      )
+
+    const withoutA: SpatialCanvas = { nodes: [twoNodeCanvas().nodes[1]!], edges: [] }
+    expect(() =>
+      rerender(
+        <div style={{ width: 600, height: 400 }}>
+          <SpatialEditor
+            canvas={withoutA}
+            onChange={onChange}
+            measure={fakeMeasure}
+            externalVersion={1}
+          />
+        </div>,
+      ),
+    ).not.toThrow()
+
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 60, clientY: 60, pointerId: 80 }),
+      )
     expect(onChange).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -7,6 +7,10 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+// Real app styles — needed so the Add-note-button affordance test's
+// getComputedStyle assertions reflect the actual shipped CSS, not
+// unstyled-DOM defaults.
+import '../../index.css'
 import type { EditorCommand } from './commands.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -1137,5 +1141,130 @@ describe('SpatialEditor (browser) — spatial text layout defects', () => {
     // Defect 4: the edge label text is present in the rendered SVG.
     const edgeLabel = headingTexts.find((t) => t.textContent === 'edge label')
     expect(edgeLabel).toBeTruthy()
+function boxesOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+describe('node placement and affordances', () => {
+  it('two consecutive Add note clicks with no other interaction do not overlap', async () => {
+    const onChange = vi.fn()
+    let ids = 0
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <ControlledEditor
+          initial={{ nodes: [], edges: [] }}
+          onChange={onChange}
+          createId={() => `add-note-${++ids}`}
+        />
+      </div>,
+    )
+    const button = page.getByTestId('add-node-button')
+    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await waitFor(() => {
+      const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+      expect(canvas.nodes).toHaveLength(1)
+    })
+    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await waitFor(() => {
+      const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+      expect(canvas.nodes).toHaveLength(2)
+    })
+    const finalCanvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    const [first, second] = finalCanvas.nodes
+    expect(first).toBeDefined()
+    expect(second).toBeDefined()
+    expect(boxesOverlap(first!, second!)).toBe(false)
+  })
+
+  it('clicking empty canvas commits typed text instead of losing it (click-away commits)', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <ControlledEditor
+          initial={{ nodes: [], edges: [] }}
+          onChange={onChange}
+          createId={() => 'note-1'}
+        />
+      </div>,
+    )
+    const editor = page.getByTestId('spatial-editor')
+    const button = page.getByTestId('add-node-button')
+    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    const textEditor = page.getByTestId('text-node-editor')
+    await textEditor.fill('typed before clicking away')
+
+    // Click far-away empty canvas space rather than blurring the textarea
+    // directly — this is the pointerdown-empty path the reducer must commit
+    // through, not commit-text-edit dispatched directly.
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 580,
+        clientY: 380,
+        pointerId: 90,
+        button: 0,
+      }),
+    )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: 580,
+        clientY: 380,
+        pointerId: 90,
+      }),
+    )
+
+    await waitFor(() => {
+      const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+      const node = canvas.nodes.find((n) => n.id === 'note-1')
+      expect(node?.type === 'text' ? node.text : undefined).toBe('typed before clicking away')
+    })
+  })
+
+  it('pressing Escape still discards typed text (the one documented discard path)', async () => {
+    const onChange = vi.fn()
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <ControlledEditor
+          initial={{ nodes: [], edges: [] }}
+          onChange={onChange}
+          createId={() => 'note-2'}
+        />
+      </div>,
+    )
+    const button = page.getByTestId('add-node-button')
+    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    const textEditor = page.getByTestId('text-node-editor')
+    await textEditor.fill('should be discarded')
+    await textEditor
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
+    const node = canvas.nodes.find((n) => n.id === 'note-2')
+    expect(node?.type === 'text' ? node.text : undefined).toBe('')
+  })
+
+  it('the Add note button has real, visible button affordance (not a bare, transparent element)', async () => {
+    render(
+      <div style={{ width: 600, height: 400 }}>
+        <SpatialEditor canvas={{ nodes: [], edges: [] }} onChange={vi.fn()} measure={fakeMeasure} />
+      </div>,
+    )
+    const button = page.getByTestId('add-node-button').element() as HTMLButtonElement
+    const style = getComputedStyle(button)
+    const hasVisibleBackground = style.backgroundColor !== 'rgba(0, 0, 0, 0)'
+    const hasVisibleBorder = Number.parseFloat(style.borderWidth) > 0
+    expect(hasVisibleBackground || hasVisibleBorder).toBe(true)
+    expect(
+      Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingLeft),
+    ).toBeGreaterThan(0)
+    button.focus()
+    expect(document.activeElement).toBe(button)
   })
 })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -33,6 +33,18 @@ afterEach(() => {
   cleanup()
 })
 
+describe('Add note button', () => {
+  it('exists as a real, accessibly-named button reachable without a selection', () => {
+    const { getByTestId } = render(
+      <SpatialEditor canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+    )
+    const button = getByTestId('add-node-button') as HTMLButtonElement
+    expect(button.tagName).toBe('BUTTON')
+    expect(button.textContent).toBe('Add note')
+    expect(button.disabled).toBe(false)
+  })
+})
+
 describe('SpatialEditorHandle', () => {
   it('setViewport applies the given viewport to the rendered transform', () => {
     const ref = createRef<SpatialEditorHandle>()

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -41,9 +41,9 @@ import {
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
-import { hitTest, indexNodeBoxes, resizeBoxByDelta } from './geometry.js'
+import { findFreeSpot, hitTest, indexNodeBoxes, resizeBoxByDelta } from './geometry.js'
 import type { GestureState } from './gestures.js'
-import { createIdleState, reduceGesture } from './gestures.js'
+import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
@@ -221,11 +221,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         ? { id: selectedId, box: selectedBox }
         : undefined
 
+    /**
+     * Folds `result.commands` in order over a LOCAL running canvas (seeded
+     * from `canvasRef.current`, never re-read from the ref between steps) so
+     * a multi-command result — e.g. a pending-text commit ordered ahead of a
+     * create-node — can never lose its first command to a stale read. Each
+     * command still gets its own `onChange` call, one canvas/command pair
+     * per mutation, matching this component's pre-existing one-call-per-
+     * command contract for the (still common) single-command case.
+     */
     const applyResult = (result: ReturnType<typeof reduceGesture>) => {
       setGestureState(result.state)
       if (result.selectedId !== undefined) setSelectedId(result.selectedId)
-      if (result.command !== undefined) {
-        onChange(applyCommand(canvasRef.current, result.command), result.command)
+      let running = canvasRef.current
+      for (const command of result.commands) {
+        running = applyCommand(running, command)
+        onChange(running, command)
       }
     }
 
@@ -434,11 +445,26 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       createNodeAt(point)
     }
 
+    /**
+     * The button path (unlike double-click, whose point comes straight from
+     * the pointer) always resolves to the same viewport-center point, so
+     * without a placement rule every click here would stack an identical,
+     * unreachable rect on the last one. `findFreeSpot` cascades off the
+     * CURRENT node boxes (read from `canvasRef.current`, not the possibly-
+     * stale `canvas` prop) so two rapid clicks still see each other's result.
+     */
     const createNodeAtViewportCenter = () => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      createNodeAt(screenToCanvas(centerScreen, viewport))
+      const preferred = screenToCanvas(centerScreen, viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point = findFreeSpot(
+        preferred,
+        { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT },
+        occupied,
+      )
+      createNodeAt(point)
     }
 
     return (
@@ -477,7 +503,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           type="button"
           data-testid="add-node-button"
           onClick={createNodeAtViewportCenter}
-          style={{ position: 'absolute', top: 8, left: 8, zIndex: 1 }}
+          className="absolute z-10 rounded-md border bg-background px-3 py-1.5 text-sm shadow-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          style={{ top: 8, left: 8 }}
         >
           Add note
         </button>

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,6 +50,7 @@ import { TextNodeEditor } from './TextNodeEditor.js'
 import {
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
+  type Point,
   panBy,
   screenToCanvas,
   type Viewport,
@@ -399,6 +400,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return () => root.removeEventListener('wheel', onWheel)
     }, [])
 
+    /** Creates a text node centered on `point` (canvas space) and opens it for typing. */
+    const createNodeAt = (point: Point) => {
+      applyResult(
+        reduceGesture(gestureState, canvas, { type: 'dblclick-empty', point }, { createId }),
+      )
+    }
+
     const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
@@ -423,19 +431,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }
         return
       }
-      applyResult(
-        reduceGesture(gestureState, canvas, { type: 'dblclick-empty', point }, { createId }),
-      )
+      createNodeAt(point)
     }
 
     const createNodeAtViewportCenter = () => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const point = screenToCanvas(centerScreen, viewport)
-      applyResult(
-        reduceGesture(gestureState, canvas, { type: 'dblclick-empty', point }, { createId }),
-      )
+      createNodeAt(screenToCanvas(centerScreen, viewport))
     }
 
     return (

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -11,7 +11,11 @@
  * cancels), connect an edge (drag from a selected node's connect handle
  * onto another node, OR Enter/Space the connect handle then Tab to a
  * target node's connect-target control and Enter/Space it; Escape cancels
- * an in-flight gesture from the keyboard too).
+ * an in-flight gesture from the keyboard too), create a node (double-click
+ * empty canvas space, or the keyboard-reachable "Add note" button — both
+ * open the new node for typing immediately), and delete the current
+ * selection (Delete/Backspace, disabled while its text editor is open so
+ * Backspace-while-typing edits text instead of deleting the node).
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -85,7 +89,7 @@ export interface SpatialEditorProps {
   readonly externalVersion?: number
   /** Injection seam for tests; defaults to the real Canvas 2D measurer. */
   readonly measure?: MeasureText
-  /** Injection seam for deterministic edge-id tests; defaults to crypto.randomUUID. */
+  /** Injection seam for deterministic node/edge-id tests; defaults to crypto.randomUUID. */
   readonly createId?: () => string
   readonly className?: string
   readonly testId?: string
@@ -287,7 +291,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           gestureState,
           canvas,
           { type: 'pointerup', point, targetNodeId },
-          { createEdgeId: createId },
+          { createId },
         ),
       )
     }
@@ -303,6 +307,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (e.key === 'Escape' && gestureState.kind !== 'idle') {
         e.preventDefault()
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+        return
+      }
+      // Delete/Backspace deletes the current selection — but never while the
+      // event's own target is a text-entry surface (the open TextNodeEditor's
+      // textarea, or any other input this root might contain), or Backspace
+      // while typing would delete the node instead of a character. The
+      // reducer's own editing-text guard is the second, machine-checkable
+      // layer of that same policy (see gestures.ts's delete-selection arm).
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selection !== undefined) {
+        const target = e.target as HTMLElement | null
+        const tag = target?.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return
+        e.preventDefault()
+        applyResult(
+          reduceGesture(gestureState, canvas, { type: 'delete-selection', nodeId: selection.id }),
+        )
       }
     }
 
@@ -379,14 +399,42 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return () => root.removeEventListener('wheel', onWheel)
     }, [])
 
-    const handleDoubleClick = () => {
-      if (selectedNode?.type !== 'text') return
+    const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      const root = rootRef.current
+      if (root === null) return
+      const screenPoint = clientPointToRootLocal(e, root)
+      const point = screenToCanvas(screenPoint, viewport)
+      // Hit-test the ACTUAL double-click point rather than trusting whatever
+      // happens to be selected: a text-edit commit does not clear selection
+      // (see gestures.ts's commit-text-edit), so a later double-click
+      // elsewhere on empty space would otherwise reopen the previously
+      // selected node's editor instead of creating a new node.
+      const hitId = hitTest(boxes, point)
+      if (hitId !== undefined) {
+        const node = canvas.nodes.find((n) => n.id === hitId)
+        if (node?.type === 'text') {
+          applyResult(
+            reduceGesture(gestureState, canvas, {
+              type: 'start-text-edit',
+              nodeId: node.id,
+              text: node.text,
+            }),
+          )
+        }
+        return
+      }
       applyResult(
-        reduceGesture(gestureState, canvas, {
-          type: 'start-text-edit',
-          nodeId: selectedNode.id,
-          text: selectedNode.text,
-        }),
+        reduceGesture(gestureState, canvas, { type: 'dblclick-empty', point }, { createId }),
+      )
+    }
+
+    const createNodeAtViewportCenter = () => {
+      const root = rootRef.current
+      const centerScreen =
+        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+      const point = screenToCanvas(centerScreen, viewport)
+      applyResult(
+        reduceGesture(gestureState, canvas, { type: 'dblclick-empty', point }, { createId }),
       )
     }
 
@@ -417,6 +465,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}
       >
+        {/* Discoverability affordance: every canvas is empty until a node
+          exists, and double-click-empty-space has no visible cue at all —
+          this real, keyboard-reachable button is the one always-visible way
+          in. Positioned outside the pan/zoom transform so it stays fixed on
+          screen regardless of viewport. */}
+        <button
+          type="button"
+          data-testid="add-node-button"
+          onClick={createNodeAtViewportCenter}
+          style={{ position: 'absolute', top: 8, left: 8, zIndex: 1 }}
+        >
+          Add note
+        </button>
         <div
           style={{
             position: 'absolute',
@@ -519,7 +580,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                             point: { x: b.box.x, y: b.box.y },
                             targetNodeId: b.id,
                           },
-                          { createEdgeId: createId },
+                          { createId },
                         ),
                       )
                     }}

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -115,4 +115,59 @@ describe('applyCommand', () => {
     const next = applyCommand(canvas, { kind: 'move-node', id: 'a', x: 5, y: 5 })
     expect(spatialCanvasSchema.safeParse(next).success).toBe(true)
   })
+
+  it('create-node appends the node, leaving the input canvas untouched', () => {
+    const canvas = baseCanvas()
+    const snapshot = structuredClone(canvas)
+    const newNode = {
+      id: 'c',
+      type: 'text',
+      x: 400,
+      y: 0,
+      width: 100,
+      height: 50,
+      text: '',
+    } as const
+    const next = applyCommand(canvas, { kind: 'create-node', node: newNode })
+
+    expect(next).not.toBe(canvas)
+    expect(next.nodes).toEqual([...canvas.nodes, newNode])
+    expect(canvas).toEqual(snapshot)
+    expect(spatialCanvasSchema.safeParse(next).success).toBe(true)
+  })
+
+  it('create-node with an id already present is a no-op returning the input canvas', () => {
+    const canvas = baseCanvas()
+    const dup = { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'dup' } as const
+    const next = applyCommand(canvas, { kind: 'create-node', node: dup })
+    expect(next).toBe(canvas)
+  })
+
+  it('delete-node removes the node and every edge referencing it, leaving the rest untouched', () => {
+    const connected = applyCommand(baseCanvas(), {
+      kind: 'connect-nodes',
+      edgeId: 'e1',
+      fromNode: 'a',
+      toNode: 'b',
+    })
+    const next = applyCommand(connected, { kind: 'delete-node', id: 'a' })
+
+    expect(next.nodes).toEqual([connected.nodes[1]])
+    expect(next.edges).toEqual([])
+    expect(spatialCanvasSchema.safeParse(next).success).toBe(true)
+  })
+
+  it('delete-node with a missing id returns the input canvas unchanged', () => {
+    const canvas = baseCanvas()
+    const next = applyCommand(canvas, { kind: 'delete-node', id: 'missing' })
+    expect(next).toBe(canvas)
+  })
+
+  it('create then delete the same node is the identity (up to deep equality)', () => {
+    const canvas = baseCanvas()
+    const node = { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' } as const
+    const created = applyCommand(canvas, { kind: 'create-node', node })
+    const deleted = applyCommand(created, { kind: 'delete-node', id: node.id })
+    expect(deleted).toEqual(canvas)
+  })
 })

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -11,7 +11,12 @@
  *
  * `applyCommand` is total: a command whose target id is missing, or whose
  * kind does not apply to the target node's type, returns the INPUT canvas
- * unchanged rather than throwing.
+ * unchanged rather than throwing. `create-node` carries a full canvas-model
+ * `SpatialNode` (rather than a flattened x/y/w/h/text tuple) so a later node
+ * kind needs no command-shape change; a colliding id is likewise a no-op.
+ * `delete-node` cascades: it also removes every edge whose `fromNode`/
+ * `toNode` referenced the removed node, so no command sequence can ever
+ * produce a canvas with a dangling edge endpoint.
  */
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 
@@ -32,6 +37,8 @@ export type EditorCommand =
       readonly fromNode: string
       readonly toNode: string
     }
+  | { readonly kind: 'create-node'; readonly node: SpatialNode }
+  | { readonly kind: 'delete-node'; readonly id: string }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -106,6 +113,33 @@ function connectNodes(
   return { ...canvas, edges: [...canvas.edges, edge] }
 }
 
+/**
+ * Appends `node`. Rejects a colliding id as a no-op — mirroring
+ * `connectNodes`'s duplicate-edge-id guard — so a caller can never produce a
+ * canvas that fails `spatialCanvasSchema`'s implicit unique-id expectation.
+ */
+function createNode(canvas: SpatialCanvas, node: SpatialNode): SpatialCanvas {
+  const idExists = canvas.nodes.some((existing) => existing.id === node.id)
+  if (idExists) return canvas
+  return { ...canvas, nodes: [...canvas.nodes, node] }
+}
+
+/**
+ * Removes the node with `id` plus every edge that references it as
+ * `fromNode`/`toNode` — the command-layer half of the edge-referential-
+ * integrity invariant `deleteSpatialNode` (canvas-workspace) also enforces
+ * on the Loro side. A no-op (returns the input) when `id` is missing.
+ */
+function deleteNode(canvas: SpatialCanvas, id: string): SpatialCanvas {
+  const idExists = canvas.nodes.some((node) => node.id === id)
+  if (!idExists) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.filter((node) => node.id !== id),
+    edges: canvas.edges.filter((edge) => edge.fromNode !== id && edge.toNode !== id),
+  }
+}
+
 export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): SpatialCanvas {
   switch (command.kind) {
     case 'move-node':
@@ -116,5 +150,9 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setText(canvas, command.id, command.text)
     case 'connect-nodes':
       return connectNodes(canvas, command.edgeId, command.fromNode, command.toNode)
+    case 'create-node':
+      return createNode(canvas, command.node)
+    case 'delete-node':
+      return deleteNode(canvas, command.id)
   }
 }

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -27,4 +27,19 @@ describe('SPATIAL_EDITOR_UNSUPPORTED', () => {
     expect(docComment).toBeDefined()
     expect(docComment).toContain('SPATIAL_EDITOR_UNSUPPORTED')
   })
+
+  it('documents creation and deletion as SUPPORTED, and neither is listed as an unsupported gap', async () => {
+    const modules = import.meta.glob('./SpatialEditor.tsx', { query: '?raw', import: 'default' })
+    const entry = modules['./SpatialEditor.tsx']
+    const source = (await entry?.()) as string
+    const docComment = source.match(/^\/\*\*[\s\S]*?\*\//)?.[0]
+    expect(docComment).toBeDefined()
+    const supportedSection = docComment?.match(
+      /Supported:[\s\S]*?(?=\n \*\n| \* The component)/,
+    )?.[0]
+    expect(supportedSection).toBeDefined()
+    expect(supportedSection?.toLowerCase()).toContain('create')
+    expect(supportedSection?.toLowerCase()).toContain('delete')
+    expect(SPATIAL_EDITOR_UNSUPPORTED.some((item) => /create|delete/.test(item))).toBe(false)
+  })
 })

--- a/apps/web/src/components/spatial-editor/geometry.test.ts
+++ b/apps/web/src/components/spatial-editor/geometry.test.ts
@@ -2,6 +2,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
 import {
   boxContains,
+  findFreeSpot,
   hitTest,
   indexNodeBoxes,
   resizeBoxByDelta,
@@ -94,5 +95,45 @@ describe('resizeBoxByDelta', () => {
 
   it('e only affects width, not y/height', () => {
     expect(resizeBoxByDelta(box, 'e', 15, 999)).toEqual({ x: 0, y: 0, width: 115, height: 100 })
+  })
+})
+
+describe('findFreeSpot', () => {
+  const size = { width: 200, height: 100 }
+
+  it('returns the preferred point when nothing is occupied', () => {
+    expect(findFreeSpot({ x: 500, y: 300 }, size, [])).toEqual({ x: 500, y: 300 })
+  })
+
+  it('cascades to a non-overlapping point when the preferred box collides', () => {
+    const occupied = [{ x: 400, y: 250, width: 200, height: 100 }]
+    const spot = findFreeSpot({ x: 500, y: 300 }, size, occupied)
+    const box = { x: spot.x - size.width / 2, y: spot.y - size.height / 2, ...size }
+    const overlaps =
+      box.x < occupied[0].x + occupied[0].width &&
+      box.x + box.width > occupied[0].x &&
+      box.y < occupied[0].y + occupied[0].height &&
+      box.y + box.height > occupied[0].y
+    expect(overlaps).toBe(false)
+    expect(spot).not.toEqual({ x: 500, y: 300 })
+  })
+
+  it('is deterministic: same inputs produce the same output', () => {
+    const occupied = [{ x: 400, y: 250, width: 200, height: 100 }]
+    expect(findFreeSpot({ x: 500, y: 300 }, size, occupied)).toEqual(
+      findFreeSpot({ x: 500, y: 300 }, size, occupied),
+    )
+  })
+
+  it('is total: terminates and returns a finite point on a densely packed field', () => {
+    const occupied = Array.from({ length: 200 }, (_, i) => ({
+      x: i * 4,
+      y: i * 4,
+      width: 200,
+      height: 100,
+    }))
+    const spot = findFreeSpot({ x: 500, y: 300 }, size, occupied)
+    expect(Number.isFinite(spot.x)).toBe(true)
+    expect(Number.isFinite(spot.y)).toBe(true)
   })
 })

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -111,18 +111,22 @@ export function findFreeSpot(
   size: { readonly width: number; readonly height: number },
   occupied: readonly Box[],
 ): Point {
+  const candidateAt = (step: number): Point => ({
+    x: preferred.x + step * CASCADE_STEP_PX,
+    y: preferred.y + step * CASCADE_STEP_PX,
+  })
   const boxAt = (center: Point): Box => ({
     x: Math.round(center.x - size.width / 2),
     y: Math.round(center.y - size.height / 2),
     width: size.width,
     height: size.height,
   })
-  let candidate = preferred
-  for (let step = 0; step <= MAX_CASCADE_STEPS; step += 1) {
-    candidate = { x: preferred.x + step * CASCADE_STEP_PX, y: preferred.y + step * CASCADE_STEP_PX }
-    if (!occupied.some((box) => boxesIntersect(boxAt(candidate), box))) return candidate
+  for (let step = 0; step < MAX_CASCADE_STEPS; step += 1) {
+    const candidate = candidateAt(step)
+    const box = boxAt(candidate)
+    if (!occupied.some((other) => boxesIntersect(box, other))) return candidate
   }
-  return candidate
+  return candidateAt(MAX_CASCADE_STEPS)
 }
 
 /** Which axes a given handle moves, and in which direction, as a corner/edge is dragged. */

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -87,6 +87,44 @@ export function resizeHandleBoxes(box: Box, zoom: number): readonly ResizeHandle
   }))
 }
 
+/** Cascade step (canvas-space px) used by `findFreeSpot` between successive placement attempts. */
+const CASCADE_STEP_PX = 24
+/** Bounded search depth: `findFreeSpot` never loops forever on a densely occupied canvas. */
+const MAX_CASCADE_STEPS = 50
+
+function boxesIntersect(a: Box, b: Box): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+/**
+ * Finds a placement for a `size`-shaped box, centered on `preferred`, that
+ * does not overlap any box in `occupied`. Cascades diagonally in fixed
+ * `CASCADE_STEP_PX` steps from `preferred` until a non-colliding spot is
+ * found or the bounded search is exhausted, in which case it degrades to
+ * the last candidate rather than looping forever or throwing — an
+ * occasional overlap on a densely packed canvas is an accepted degradation,
+ * not a correctness bug. Deterministic: the same `preferred`/`size`/
+ * `occupied` always returns the same point.
+ */
+export function findFreeSpot(
+  preferred: Point,
+  size: { readonly width: number; readonly height: number },
+  occupied: readonly Box[],
+): Point {
+  const boxAt = (center: Point): Box => ({
+    x: Math.round(center.x - size.width / 2),
+    y: Math.round(center.y - size.height / 2),
+    width: size.width,
+    height: size.height,
+  })
+  let candidate = preferred
+  for (let step = 0; step <= MAX_CASCADE_STEPS; step += 1) {
+    candidate = { x: preferred.x + step * CASCADE_STEP_PX, y: preferred.y + step * CASCADE_STEP_PX }
+    if (!occupied.some((box) => boxesIntersect(boxAt(candidate), box))) return candidate
+  }
+  return candidate
+}
+
 /** Which axes a given handle moves, and in which direction, as a corner/edge is dragged. */
 export const HANDLE_SIGN: Record<ResizeHandleKind, { x: -1 | 0 | 1; y: -1 | 0 | 1 }> = {
   nw: { x: -1, y: -1 },

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -289,7 +289,7 @@ describe('connect gesture', () => {
       result.state,
       c,
       { type: 'pointerup', point: { x: 250, y: 30 }, targetNodeId: 'b' },
-      { createEdgeId: () => 'edge-1' },
+      { createId: () => 'edge-1' },
     )
     expect(result.command).toEqual({
       kind: 'connect-nodes',
@@ -431,5 +431,79 @@ describe('text-edit gesture', () => {
     const result = reduceGesture(editing.state, c, { type: 'canvas-replaced', canvas: replaced })
     expect(result.state.kind).toBe('idle')
     expect(result.command).toBeUndefined()
+  })
+})
+
+describe('dblclick-empty (create-node)', () => {
+  it('creates a text node centered on the point, selects it, and opens it for typing immediately', () => {
+    const c = canvas()
+    const result = reduceGesture(
+      createIdleState(),
+      c,
+      { type: 'dblclick-empty', point: { x: 300, y: 200 } },
+      { createId: () => 'new-node' },
+    )
+    expect(result.command).toMatchObject({
+      kind: 'create-node',
+      node: { id: 'new-node', type: 'text', text: '' },
+    })
+    expect(result.selectedId).toBe('new-node')
+    expect(result.state).toEqual({
+      kind: 'editing-text',
+      nodeId: 'new-node',
+      pendingText: '',
+    })
+  })
+
+  it('while a text edit is open, first commits the pending text, then creates the new node', () => {
+    const c = canvas()
+    const editing = reduceGesture(createIdleState(), c, {
+      type: 'start-text-edit',
+      nodeId: 'a',
+      text: 'hi',
+    })
+    const updated = reduceGesture(editing.state, c, { type: 'update-text-edit', text: 'edited' })
+    const result = reduceGesture(
+      updated.state,
+      c,
+      { type: 'dblclick-empty', point: { x: 300, y: 200 } },
+      { createId: () => 'new-node' },
+    )
+    // withPendingTextCommit's precedence: the emitted command is the pending
+    // set-text, matching every other pointerdown variant's click-away-commits
+    // policy — the create itself still lands (state advances to editing-text
+    // for the NEW node), it is simply not double-encoded into one command.
+    expect(result.command).toEqual({ kind: 'set-text', id: 'a', text: 'edited' })
+    expect(result.state).toEqual({
+      kind: 'editing-text',
+      nodeId: 'new-node',
+      pendingText: '',
+    })
+  })
+})
+
+describe('delete-selection', () => {
+  it('emits delete-node and clears selection while idle', () => {
+    const c = canvas()
+    const result = reduceGesture(createIdleState(), c, {
+      type: 'delete-selection',
+      nodeId: 'a',
+    })
+    expect(result.command).toEqual({ kind: 'delete-node', id: 'a' })
+    expect(result.selectedId).toBeNull()
+    expect(result.state.kind).toBe('idle')
+  })
+
+  it('emits NO command while a text edit is open, leaving state untouched (Backspace must not delete while typing)', () => {
+    const c = canvas()
+    const editing = reduceGesture(createIdleState(), c, {
+      type: 'start-text-edit',
+      nodeId: 'a',
+      text: 'hi',
+    })
+    const result = reduceGesture(editing.state, c, { type: 'delete-selection', nodeId: 'a' })
+    expect(result.command).toBeUndefined()
+    expect(result.state).toEqual(editing.state)
+    expect(result.selectedId).toBeUndefined()
   })
 })

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -20,7 +20,7 @@ describe('gesture reducer', () => {
     expect(down.selectedId).toBe('a')
     const up = reduceGesture(down.state, c, { type: 'pointerup', point: { x: 50, y: 30 } })
     expect(up.state.kind).toBe('idle')
-    expect(up.command).toBeUndefined()
+    expect(up.commands).toEqual([])
   })
 
   it('a drag on a selected node commits a move-node with the delta applied', () => {
@@ -35,7 +35,7 @@ describe('gesture reducer', () => {
       point: { x: 70, y: 45 },
     })
     result = reduceGesture(result.state, c, { type: 'pointerup', point: { x: 70, y: 45 } })
-    expect(result.command).toEqual({ kind: 'move-node', id: 'a', x: 30, y: 25 })
+    expect(result.commands).toEqual([{ kind: 'move-node', id: 'a', x: 30, y: 25 }])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -49,7 +49,7 @@ describe('gesture reducer', () => {
     result = reduceGesture(result.state, c, { type: 'pointermove', point: { x: 90, y: 90 } })
     result = reduceGesture(result.state, c, { type: 'pointercancel' })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('aborts cleanly when the target node vanishes mid-drag (canvas-replaced)', () => {
@@ -62,7 +62,7 @@ describe('gesture reducer', () => {
     const replaced: SpatialCanvas = { nodes: [], edges: [] }
     result = reduceGesture(result.state, c, { type: 'canvas-replaced', canvas: replaced })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('an externally-originated canvas-replaced (e.g. undo) cancels an in-flight move even when the target node still exists unchanged', () => {
@@ -82,7 +82,7 @@ describe('gesture reducer', () => {
       origin: 'external',
     })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('a locally-originated canvas-replaced leaves a valid in-flight move gesture unaffected', () => {
@@ -100,7 +100,7 @@ describe('gesture reducer', () => {
     })
     expect(result.state.kind).toBe('moving')
     result = reduceGesture(result.state, c, { type: 'pointerup', point: { x: 70, y: 45 } })
-    expect(result.command).toEqual({ kind: 'move-node', id: 'a', x: 30, y: 25 })
+    expect(result.commands).toEqual([{ kind: 'move-node', id: 'a', x: 30, y: 25 }])
   })
 
   it('aborts cleanly when the target node type changes mid-drag', () => {
@@ -116,7 +116,7 @@ describe('gesture reducer', () => {
     }
     result = reduceGesture(result.state, c, { type: 'canvas-replaced', canvas: replaced })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('commits from the gesture start snapshot when the node moved remotely mid-drag', () => {
@@ -134,7 +134,7 @@ describe('gesture reducer', () => {
     result = reduceGesture(result.state, remote, { type: 'canvas-replaced', canvas: remote })
     result = reduceGesture(result.state, remote, { type: 'pointerup', point: { x: 70, y: 45 } })
     // start node was at (10, 10); delta is (20, 15) -> commits 30, 25, NOT 999-based
-    expect(result.command).toEqual({ kind: 'move-node', id: 'a', x: 30, y: 25 })
+    expect(result.commands).toEqual([{ kind: 'move-node', id: 'a', x: 30, y: 25 }])
   })
 
   it('pointerdown on a missing node id is a no-op (no selection, stays idle)', () => {
@@ -146,7 +146,7 @@ describe('gesture reducer', () => {
     })
     expect(result.state.kind).toBe('idle')
     expect(result.selectedId).toBeUndefined()
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('is total over arbitrary pointerup/pointercancel without a prior pointerdown', () => {
@@ -174,14 +174,16 @@ describe('resize gesture', () => {
       point: { x: 130, y: 90 },
     })
     // se: width/height grow by the delta, x/y (the nw corner) stay fixed.
-    expect(result.command).toEqual({
-      kind: 'resize-node',
-      id: 'a',
-      x: 10,
-      y: 10,
-      width: 120,
-      height: 80,
-    })
+    expect(result.commands).toEqual([
+      {
+        kind: 'resize-node',
+        id: 'a',
+        x: 10,
+        y: 10,
+        width: 120,
+        height: 80,
+      },
+    ])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -200,14 +202,16 @@ describe('resize gesture', () => {
     })
     // nw: dragging inward shrinks width/height and moves x/y by the same
     // delta, so the se corner (x + width, y + height) stays fixed at (110, 60).
-    expect(result.command).toEqual({
-      kind: 'resize-node',
-      id: 'a',
-      x: 30,
-      y: 20,
-      width: 80,
-      height: 40,
-    })
+    expect(result.commands).toEqual([
+      {
+        kind: 'resize-node',
+        id: 'a',
+        x: 30,
+        y: 20,
+        width: 80,
+        height: 40,
+      },
+    ])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -224,7 +228,7 @@ describe('resize gesture', () => {
       type: 'pointerup',
       point: { x: 110, y: 60 },
     })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -244,14 +248,16 @@ describe('resize gesture', () => {
       type: 'pointerup',
       point: { x: 210, y: 210 },
     })
-    expect(result.command).toEqual({
-      kind: 'resize-node',
-      id: 'a',
-      x: 110,
-      y: 60,
-      width: 0,
-      height: 0,
-    })
+    expect(result.commands).toEqual([
+      {
+        kind: 'resize-node',
+        id: 'a',
+        x: 110,
+        y: 60,
+        width: 0,
+        height: 0,
+      },
+    ])
     expect(result.state.kind).toBe('idle')
   })
 })
@@ -267,7 +273,7 @@ describe('resize handle miss', () => {
       box: { x: 10, y: 10, width: 100, height: 50 },
     })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 })
 
@@ -291,12 +297,14 @@ describe('connect gesture', () => {
       { type: 'pointerup', point: { x: 250, y: 30 }, targetNodeId: 'b' },
       { createId: () => 'edge-1' },
     )
-    expect(result.command).toEqual({
-      kind: 'connect-nodes',
-      edgeId: 'edge-1',
-      fromNode: 'a',
-      toNode: 'b',
-    })
+    expect(result.commands).toEqual([
+      {
+        kind: 'connect-nodes',
+        edgeId: 'edge-1',
+        fromNode: 'a',
+        toNode: 'b',
+      },
+    ])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -307,7 +315,7 @@ describe('connect gesture', () => {
       nodeId: 'a',
     })
     result = reduceGesture(result.state, c, { type: 'pointerup', point: { x: 500, y: 500 } })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -322,7 +330,7 @@ describe('connect gesture', () => {
       point: { x: 50, y: 30 },
       targetNodeId: 'a',
     })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
     expect(result.state.kind).toBe('idle')
   })
 })
@@ -336,7 +344,7 @@ describe('text-edit gesture', () => {
       text: 'hi',
     })
     expect(result.state).toEqual({ kind: 'editing-text', nodeId: 'a', pendingText: 'hi' })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('commit-text-edit emits set-text and returns to idle', () => {
@@ -350,7 +358,7 @@ describe('text-edit gesture', () => {
       type: 'commit-text-edit',
       text: 'updated',
     })
-    expect(result.command).toEqual({ kind: 'set-text', id: 'a', text: 'updated' })
+    expect(result.commands).toEqual([{ kind: 'set-text', id: 'a', text: 'updated' }])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -373,9 +381,30 @@ describe('text-edit gesture', () => {
       nodeId: 'b',
       point: { x: 250, y: 30 },
     })
-    expect(result.command).toEqual({ kind: 'set-text', id: 'a', text: 'edited' })
+    expect(result.commands).toEqual([{ kind: 'set-text', id: 'a', text: 'edited' }])
     expect(result.state.kind).toBe('moving')
     expect(result.selectedId).toBe('b')
+  })
+
+  it('a pointerdown on empty canvas while a text edit is open commits the pending text (click-away commits)', () => {
+    const c = canvas()
+    const editing = reduceGesture(createIdleState(), c, {
+      type: 'start-text-edit',
+      nodeId: 'a',
+      text: 'hi',
+    })
+    const updated = reduceGesture(editing.state, c, { type: 'update-text-edit', text: 'edited' })
+    const result = reduceGesture(updated.state, c, { type: 'pointerdown-empty' })
+    expect(result.commands).toEqual([{ kind: 'set-text', id: 'a', text: 'edited' }])
+    expect(result.state.kind).toBe('idle')
+    expect(result.selectedId).toBeNull()
+  })
+
+  it('pointerdown-empty outside a text edit emits no command', () => {
+    const c = canvas()
+    const result = reduceGesture(createIdleState(), c, { type: 'pointerdown-empty' })
+    expect(result.commands).toEqual([])
+    expect(result.selectedId).toBeNull()
   })
 
   it('commit-text-edit outside editing-text state is a no-op', () => {
@@ -384,7 +413,7 @@ describe('text-edit gesture', () => {
       type: 'commit-text-edit',
       text: 'updated',
     })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
     expect(result.state.kind).toBe('idle')
   })
 
@@ -397,7 +426,7 @@ describe('text-edit gesture', () => {
     })
     const result = reduceGesture(editing.state, c, { type: 'cancel-text-edit' })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('an externally-originated canvas-replaced closes an open text edit without committing its pending text', () => {
@@ -414,7 +443,7 @@ describe('text-edit gesture', () => {
       origin: 'external',
     })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 
   it('aborts an in-flight text edit when the node type changes mid-edit (canvas-replaced)', () => {
@@ -430,7 +459,7 @@ describe('text-edit gesture', () => {
     }
     const result = reduceGesture(editing.state, c, { type: 'canvas-replaced', canvas: replaced })
     expect(result.state.kind).toBe('idle')
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
   })
 })
 
@@ -443,7 +472,7 @@ describe('dblclick-empty (create-node)', () => {
       { type: 'dblclick-empty', point: { x: 300, y: 200 } },
       { createId: () => 'new-node' },
     )
-    expect(result.command).toMatchObject({
+    expect(result.commands[0]).toMatchObject({
       kind: 'create-node',
       node: { id: 'new-node', type: 'text', text: '' },
     })
@@ -469,11 +498,13 @@ describe('dblclick-empty (create-node)', () => {
       { type: 'dblclick-empty', point: { x: 300, y: 200 } },
       { createId: () => 'new-node' },
     )
-    // withPendingTextCommit's precedence: the emitted command is the pending
-    // set-text, matching every other pointerdown variant's click-away-commits
-    // policy — the create itself still lands (state advances to editing-text
-    // for the NEW node), it is simply not double-encoded into one command.
-    expect(result.command).toEqual({ kind: 'set-text', id: 'a', text: 'edited' })
+    // withPendingTextCommit prepends the pending set-text ahead of the
+    // event's own commands (ordered commit-then-create) — neither command is
+    // dropped, and the old node's text is never lost.
+    expect(result.commands).toEqual([
+      { kind: 'set-text', id: 'a', text: 'edited' },
+      { kind: 'create-node', node: expect.objectContaining({ id: 'new-node', text: '' }) },
+    ])
     expect(result.state).toEqual({
       kind: 'editing-text',
       nodeId: 'new-node',
@@ -489,7 +520,7 @@ describe('delete-selection', () => {
       type: 'delete-selection',
       nodeId: 'a',
     })
-    expect(result.command).toEqual({ kind: 'delete-node', id: 'a' })
+    expect(result.commands).toEqual([{ kind: 'delete-node', id: 'a' }])
     expect(result.selectedId).toBeNull()
     expect(result.state.kind).toBe('idle')
   })
@@ -502,7 +533,7 @@ describe('delete-selection', () => {
       text: 'hi',
     })
     const result = reduceGesture(editing.state, c, { type: 'delete-selection', nodeId: 'a' })
-    expect(result.command).toBeUndefined()
+    expect(result.commands).toEqual([])
     expect(result.state).toEqual(editing.state)
     expect(result.selectedId).toBeUndefined()
   })

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -150,10 +150,14 @@ function targetsStillValid(state: GestureState, canvas: SpatialCanvas): boolean 
  * When `prevState` is an open text edit, PREPENDS a `set-text` command
  * carrying its `pendingText` ahead of `result`'s own commands — see the
  * open-text-edit-vs-other-gesture policy documented at the top of this
- * file. Prepending (never overwriting) is the fix for a real regression:
- * `dblclick-empty` already carries its own `create-node` command, and an
- * overwrite silently dropped it, leaving a node referenced by the new
- * gesture state that was never added to the canvas.
+ * file.
+ *
+ * It must PREPEND rather than overwrite, because the arms this wraps can
+ * already carry a command of their own — `dblclick-empty` carries
+ * `create-node`. Overwriting drops that one, leaving the returned gesture
+ * state referencing a node the canvas never received. Prepending also fixes
+ * the order: the text belongs to the node being left, so it has to commit
+ * before whatever the new gesture does.
  */
 function withPendingTextCommit(prevState: GestureState, result: GestureResult): GestureResult {
   if (prevState.kind !== 'editing-text') return result

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -1,6 +1,6 @@
 /**
  * Pure gesture state machine: pointer/text-edit events in, next state plus
- * an optional `EditorCommand` out. Keeps all drag math out of React so it
+ * zero or more `EditorCommand`s out. Keeps all drag math out of React so it
  * can be unit-tested without a DOM.
  *
  * Canvas-prop-change-during-gesture policy (this component is controlled,
@@ -19,12 +19,13 @@
  *
  * Open-text-edit-vs-other-gesture policy: `editing-text` carries the
  * in-progress `pendingText` (kept current via `update-text-edit`, one per
- * keystroke). A `pointerdown`/`pointerdown-handle`/`pointerdown-connect`
- * arriving while a text edit is open COMMITS that pending text — emits
- * `set-text` — and then transitions into the requested gesture, matching
- * every text editor's click-away-commits behavior (and this component's
- * own blur-commits convention in `TextNodeEditor`). Escape
- * (`cancel-text-edit`) remains the only explicit discard.
+ * keystroke). A `pointerdown`/`pointerdown-handle`/`pointerdown-connect`/
+ * `pointerdown-empty`/`dblclick-empty` arriving while a text edit is open
+ * COMMITS that pending text — emits `set-text` — and then proceeds with the
+ * requested gesture, matching every text editor's click-away-commits
+ * behavior (and this component's own blur-commits convention in
+ * `TextNodeEditor`). Escape (`cancel-text-edit`) remains the only explicit
+ * discard.
  */
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { EditorCommand } from './commands.js'
@@ -113,12 +114,13 @@ export type GestureEvent =
 
 export interface GestureResult {
   readonly state: GestureState
-  readonly command?: EditorCommand
+  /** Ordered — applied left-to-right by the caller. Empty when nothing mutates the canvas. */
+  readonly commands: readonly EditorCommand[]
   /** `string` selects a node, `null` clears selection, `undefined` = no change. */
   readonly selectedId?: string | null
 }
 
-const idle: GestureResult = { state: { kind: 'idle' } }
+const idle: GestureResult = { state: { kind: 'idle' }, commands: [] }
 
 function findNode(canvas: SpatialCanvas, id: string) {
   return canvas.nodes.find((node) => node.id === id)
@@ -140,18 +142,22 @@ function targetsStillValid(state: GestureState, canvas: SpatialCanvas): boolean 
 }
 
 /**
- * When `prevState` is an open text edit, folds its `pendingText` into
- * `result` as a `set-text` command — see the open-text-edit-vs-other-gesture
- * policy documented at the top of this file. `result.command` is always
- * `undefined` for the three pointerdown variants this is applied to, so
- * there is nothing to merge with, only to add.
+ * When `prevState` is an open text edit, PREPENDS a `set-text` command
+ * carrying its `pendingText` ahead of `result`'s own commands — see the
+ * open-text-edit-vs-other-gesture policy documented at the top of this
+ * file. Prepending (never overwriting) is the fix for a real regression:
+ * `dblclick-empty` already carries its own `create-node` command, and an
+ * overwrite silently dropped it, leaving a node referenced by the new
+ * gesture state that was never added to the canvas.
  */
 function withPendingTextCommit(prevState: GestureState, result: GestureResult): GestureResult {
   if (prevState.kind !== 'editing-text') return result
-  return {
-    ...result,
-    command: { kind: 'set-text', id: prevState.nodeId, text: prevState.pendingText },
+  const commit: EditorCommand = {
+    kind: 'set-text',
+    id: prevState.nodeId,
+    text: prevState.pendingText,
   }
+  return { ...result, commands: [commit, ...result.commands] }
 }
 
 function reduceCanvasReplaced(
@@ -163,7 +169,7 @@ function reduceCanvasReplaced(
   if (targetsStillValid(state, replacement)) {
     // Continue the gesture unchanged — the commit still uses the start
     // snapshot captured in `state`, never the replacement's coordinates.
-    return { state }
+    return { state, commands: [] }
   }
   return idle
 }
@@ -183,6 +189,7 @@ function reducePointerDown(
       startX: node.x,
       startY: node.y,
     },
+    commands: [],
     selectedId: event.nodeId,
   }
 }
@@ -202,6 +209,7 @@ function reducePointerDownHandle(
       startPoint: event.point,
       startBox: event.box,
     },
+    commands: [],
   }
 }
 
@@ -214,7 +222,7 @@ function reducePointerUpMoving(
   if (dx === 0 && dy === 0) return idle
   return {
     state: { kind: 'idle' },
-    command: { kind: 'move-node', id: state.nodeId, x: state.startX + dx, y: state.startY + dy },
+    commands: [{ kind: 'move-node', id: state.nodeId, x: state.startX + dx, y: state.startY + dy }],
   }
 }
 
@@ -234,14 +242,16 @@ function reducePointerUpResizing(
   if (isUnchanged) return idle
   return {
     state: { kind: 'idle' },
-    command: {
-      kind: 'resize-node',
-      id: state.nodeId,
-      x: nextBox.x,
-      y: nextBox.y,
-      width: nextBox.width,
-      height: nextBox.height,
-    },
+    commands: [
+      {
+        kind: 'resize-node',
+        id: state.nodeId,
+        x: nextBox.x,
+        y: nextBox.y,
+        width: nextBox.width,
+        height: nextBox.height,
+      },
+    ],
   }
 }
 
@@ -253,18 +263,20 @@ function reducePointerUpConnecting(
   if (event.targetNodeId === undefined || event.targetNodeId === state.fromNodeId) return idle
   return {
     state: { kind: 'idle' },
-    command: {
-      kind: 'connect-nodes',
-      edgeId: createId(),
-      fromNode: state.fromNodeId,
-      toNode: event.targetNodeId,
-    },
+    commands: [
+      {
+        kind: 'connect-nodes',
+        edgeId: createId(),
+        fromNode: state.fromNodeId,
+        toNode: event.targetNodeId,
+      },
+    ],
   }
 }
 
 /** Default geometry (canvas-space px) for a node created via dblclick-empty/Add-note. */
-const NEW_NODE_WIDTH = 200
-const NEW_NODE_HEIGHT = 100
+export const NEW_NODE_WIDTH = 200
+export const NEW_NODE_HEIGHT = 100
 
 /**
  * Builds the freshly-created text node, centered on `point`, plus the
@@ -285,7 +297,7 @@ function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureRe
   }
   return {
     state: { kind: 'editing-text', nodeId: id, pendingText: '' },
-    command: { kind: 'create-node', node },
+    commands: [{ kind: 'create-node', node }],
     selectedId: id,
   }
 }
@@ -315,14 +327,18 @@ export function reduceGesture(
     case 'cancel-text-edit':
       return idle
     case 'pointerdown-empty':
-      return { state: { kind: 'idle' }, selectedId: null }
+      return withPendingTextCommit(state, {
+        state: { kind: 'idle' },
+        commands: [],
+        selectedId: null,
+      })
     case 'dblclick-empty':
       return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))
     case 'delete-selection':
-      if (state.kind === 'editing-text') return { state }
+      if (state.kind === 'editing-text') return { state, commands: [] }
       return {
         state: { kind: 'idle' },
-        command: { kind: 'delete-node', id: event.nodeId },
+        commands: [{ kind: 'delete-node', id: event.nodeId }],
         selectedId: null,
       }
     case 'pointerdown':
@@ -332,17 +348,21 @@ export function reduceGesture(
     case 'pointerdown-connect':
       return withPendingTextCommit(state, {
         state: { kind: 'connecting', fromNodeId: event.nodeId },
+        commands: [],
       })
     case 'start-text-edit':
-      return { state: { kind: 'editing-text', nodeId: event.nodeId, pendingText: event.text } }
+      return {
+        state: { kind: 'editing-text', nodeId: event.nodeId, pendingText: event.text },
+        commands: [],
+      }
     case 'update-text-edit':
-      if (state.kind !== 'editing-text') return { state }
-      return { state: { ...state, pendingText: event.text } }
+      if (state.kind !== 'editing-text') return { state, commands: [] }
+      return { state: { ...state, pendingText: event.text }, commands: [] }
     case 'commit-text-edit':
       if (state.kind !== 'editing-text') return idle
       return {
         state: { kind: 'idle' },
-        command: { kind: 'set-text', id: state.nodeId, text: event.text },
+        commands: [{ kind: 'set-text', id: state.nodeId, text: event.text }],
       }
     case 'pointermove':
       // Pure state passthrough: the reducer recomputes the commit from
@@ -350,7 +370,7 @@ export function reduceGesture(
       // to be stored on the state for move/resize. Connecting has no other
       // state to update either (the in-flight line is component-rendered from
       // the raw pointer position, not reducer state).
-      return { state }
+      return { state, commands: [] }
     case 'pointerup':
       switch (state.kind) {
         case 'moving':

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -26,7 +26,7 @@
  * own blur-commits convention in `TextNodeEditor`). Escape
  * (`cancel-text-edit`) remains the only explicit discard.
  */
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { EditorCommand } from './commands.js'
 import { type ResizeHandleKind, resizeBoxByDelta } from './geometry.js'
 import type { Point } from './viewport.js'
@@ -86,6 +86,8 @@ export type GestureEvent =
     }
   | { readonly type: 'pointerdown-connect'; readonly nodeId: string }
   | { readonly type: 'pointerdown-empty' }
+  | { readonly type: 'dblclick-empty'; readonly point: Point }
+  | { readonly type: 'delete-selection'; readonly nodeId: string }
   | { readonly type: 'pointermove'; readonly point: Point }
   | { readonly type: 'pointerup'; readonly point: Point; readonly targetNodeId?: string }
   | { readonly type: 'pointercancel' }
@@ -246,26 +248,54 @@ function reducePointerUpResizing(
 function reducePointerUpConnecting(
   state: ConnectSnapshot,
   event: Extract<GestureEvent, { type: 'pointerup' }>,
-  createEdgeId: () => string,
+  createId: () => string,
 ): GestureResult {
   if (event.targetNodeId === undefined || event.targetNodeId === state.fromNodeId) return idle
   return {
     state: { kind: 'idle' },
     command: {
       kind: 'connect-nodes',
-      edgeId: createEdgeId(),
+      edgeId: createId(),
       fromNode: state.fromNodeId,
       toNode: event.targetNodeId,
     },
   }
 }
 
-export interface ReduceGestureOptions {
-  /** Injection seam for deterministic tests; defaults to crypto.randomUUID. */
-  readonly createEdgeId?: () => string
+/** Default geometry (canvas-space px) for a node created via dblclick-empty/Add-note. */
+const NEW_NODE_WIDTH = 200
+const NEW_NODE_HEIGHT = 100
+
+/**
+ * Builds the freshly-created text node, centered on `point`, plus the
+ * `create-node` command/state transition that opens it for typing
+ * immediately — a node you must double-click again to type into is a worse
+ * affordance than Excalidraw's.
+ */
+function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureResult {
+  const id = createId()
+  const node: SpatialNode = {
+    id,
+    type: 'text',
+    x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+    y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
+    width: NEW_NODE_WIDTH,
+    height: NEW_NODE_HEIGHT,
+    text: '',
+  }
+  return {
+    state: { kind: 'editing-text', nodeId: id, pendingText: '' },
+    command: { kind: 'create-node', node },
+    selectedId: id,
+  }
 }
 
-const defaultCreateEdgeId = () =>
+export interface ReduceGestureOptions {
+  /** Injection seam for deterministic tests; defaults to crypto.randomUUID. Used for both node and edge ids. */
+  readonly createId?: () => string
+}
+
+const defaultCreateId = () =>
   typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
     : String(Math.random())
@@ -276,7 +306,7 @@ export function reduceGesture(
   event: GestureEvent,
   options: ReduceGestureOptions = {},
 ): GestureResult {
-  const createEdgeId = options.createEdgeId ?? defaultCreateEdgeId
+  const createId = options.createId ?? defaultCreateId
 
   switch (event.type) {
     case 'canvas-replaced':
@@ -286,6 +316,15 @@ export function reduceGesture(
       return idle
     case 'pointerdown-empty':
       return { state: { kind: 'idle' }, selectedId: null }
+    case 'dblclick-empty':
+      return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))
+    case 'delete-selection':
+      if (state.kind === 'editing-text') return { state }
+      return {
+        state: { kind: 'idle' },
+        command: { kind: 'delete-node', id: event.nodeId },
+        selectedId: null,
+      }
     case 'pointerdown':
       return withPendingTextCommit(state, reducePointerDown(event, canvas))
     case 'pointerdown-handle':
@@ -319,7 +358,7 @@ export function reduceGesture(
         case 'resizing':
           return reducePointerUpResizing(state, event)
         case 'connecting':
-          return reducePointerUpConnecting(state, event, createEdgeId)
+          return reducePointerUpConnecting(state, event, createId)
         default:
           return idle
       }

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -122,6 +122,11 @@ export interface GestureResult {
 
 const idle: GestureResult = { state: { kind: 'idle' }, commands: [] }
 
+/** A result that only advances the gesture state: no canvas mutation, no selection change. */
+function stateOnly(state: GestureState): GestureResult {
+  return { state, commands: [] }
+}
+
 function findNode(canvas: SpatialCanvas, id: string) {
   return canvas.nodes.find((node) => node.id === id)
 }
@@ -169,7 +174,7 @@ function reduceCanvasReplaced(
   if (targetsStillValid(state, replacement)) {
     // Continue the gesture unchanged — the commit still uses the start
     // snapshot captured in `state`, never the replacement's coordinates.
-    return { state, commands: [] }
+    return stateOnly(state)
   }
   return idle
 }
@@ -200,17 +205,14 @@ function reducePointerDownHandle(
 ): GestureResult {
   const node = findNode(canvas, event.nodeId)
   if (node === undefined) return idle
-  return {
-    state: {
-      kind: 'resizing',
-      nodeId: event.nodeId,
-      startType: node.type,
-      handle: event.handle,
-      startPoint: event.point,
-      startBox: event.box,
-    },
-    commands: [],
-  }
+  return stateOnly({
+    kind: 'resizing',
+    nodeId: event.nodeId,
+    startType: node.type,
+    handle: event.handle,
+    startPoint: event.point,
+    startBox: event.box,
+  })
 }
 
 function reducePointerUpMoving(
@@ -335,7 +337,7 @@ export function reduceGesture(
     case 'dblclick-empty':
       return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))
     case 'delete-selection':
-      if (state.kind === 'editing-text') return { state, commands: [] }
+      if (state.kind === 'editing-text') return stateOnly(state)
       return {
         state: { kind: 'idle' },
         commands: [{ kind: 'delete-node', id: event.nodeId }],
@@ -346,18 +348,15 @@ export function reduceGesture(
     case 'pointerdown-handle':
       return withPendingTextCommit(state, reducePointerDownHandle(event, canvas))
     case 'pointerdown-connect':
-      return withPendingTextCommit(state, {
-        state: { kind: 'connecting', fromNodeId: event.nodeId },
-        commands: [],
-      })
+      return withPendingTextCommit(
+        state,
+        stateOnly({ kind: 'connecting', fromNodeId: event.nodeId }),
+      )
     case 'start-text-edit':
-      return {
-        state: { kind: 'editing-text', nodeId: event.nodeId, pendingText: event.text },
-        commands: [],
-      }
+      return stateOnly({ kind: 'editing-text', nodeId: event.nodeId, pendingText: event.text })
     case 'update-text-edit':
-      if (state.kind !== 'editing-text') return { state, commands: [] }
-      return { state: { ...state, pendingText: event.text }, commands: [] }
+      if (state.kind !== 'editing-text') return stateOnly(state)
+      return stateOnly({ ...state, pendingText: event.text })
     case 'commit-text-edit':
       if (state.kind !== 'editing-text') return idle
       return {
@@ -370,7 +369,7 @@ export function reduceGesture(
       // to be stored on the state for move/resize. Connecting has no other
       // state to update either (the in-flight line is component-rendered from
       // the raw pointer position, not reducer state).
-      return { state, commands: [] }
+      return stateOnly(state)
     case 'pointerup':
       switch (state.kind) {
         case 'moving':

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -17,6 +17,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { applyCommand } from '../components/spatial-editor/commands.js'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+
+// Spies on the module's logger so a fallback-to-full-resync (which always
+// logs a warning first, see commitToDoc's doc comment) is directly
+// observable rather than inferred from doc contents.
+const appLoggerSpies = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn() }))
+vi.mock('./app-logger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./app-logger.js')>()
+  return {
+    ...actual,
+    getAppLogger: (name: string) => ({
+      ...actual.getAppLogger(name),
+      warn: appLoggerSpies.warn,
+      error: appLoggerSpies.error,
+    }),
+  }
+})
+
 import {
   createCanvasSyncSession,
   createGenerationCounters,
@@ -115,6 +132,8 @@ function twoNodeCanvas(): SpatialCanvas {
 describe('createCanvasSyncSession', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    appLoggerSpies.warn.mockClear()
+    appLoggerSpies.error.mockClear()
   })
 
   afterEach(() => {
@@ -233,6 +252,119 @@ describe('createCanvasSyncSession', () => {
     expect(result.edges).toHaveLength(2)
     expect(result.edges.find((e) => e.id === 'e-existing')).toEqual(initial.edges[0])
     expect(result.edges.find((e) => e.id === 'e-new')).toEqual(next.edges[1])
+  })
+
+  it('onChange with create-node writes only the new node via writeSpatialNode, no fallback/log.warn', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(twoNodeCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const newNode: SpatialCanvas['nodes'][number] = {
+      id: 'n-c',
+      type: 'text',
+      x: 400,
+      y: 0,
+      width: 100,
+      height: 50,
+      text: '',
+    }
+    const command: EditorCommand = { kind: 'create-node', node: newNode }
+    const next = applyCommand(twoNodeCanvas(), command)
+    session.onChange(next, command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(appLoggerSpies.warn).not.toHaveBeenCalled()
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    for (const bytes of backend._ctrl.pushLocalUpdateCalls) doc.import(bytes)
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(['n-a', 'n-b', 'n-c'])
+  })
+
+  it('onChange with delete-node writes only that deletion via deleteSpatialNode (cascading edges), no fallback/log.warn', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    const initial: SpatialCanvas = {
+      nodes: [TEXT_NODE_A, TEXT_NODE_B],
+      edges: [{ id: 'e-1', fromNode: 'n-a', toNode: 'n-b' }],
+    }
+    session.connect()
+    const snapshotBytes = makeSnapshot(initial)
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const command: EditorCommand = { kind: 'delete-node', id: 'n-a' }
+    const next = applyCommand(initial, command)
+    session.onChange(next, command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(appLoggerSpies.warn).not.toHaveBeenCalled()
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    for (const bytes of backend._ctrl.pushLocalUpdateCalls) doc.import(bytes)
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id)).toEqual(['n-b'])
+    expect(result.edges).toEqual([])
+  })
+
+  it('debounce coalescing: create-node then move-node for the same id dedupes to a single write of the final node value', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(emptyCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const newNode: SpatialCanvas['nodes'][number] = {
+      id: 'n-c',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      text: '',
+    }
+    const createCmd: EditorCommand = { kind: 'create-node', node: newNode }
+    const afterCreate = applyCommand(emptyCanvas(), createCmd)
+    session.onChange(afterCreate, createCmd)
+
+    const moveCmd: EditorCommand = { kind: 'move-node', id: 'n-c', x: 50, y: 60 }
+    const afterMove = applyCommand(afterCreate, moveCmd)
+    session.onChange(afterMove, moveCmd)
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    doc.import(backend._ctrl.pushLocalUpdateCalls[0]!)
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0]).toMatchObject({ id: 'n-c', x: 50, y: 60 })
+  })
+
+  it('debounce coalescing: move-node then delete-node for the same id dedupes to the delete', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(twoNodeCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const moveCmd: EditorCommand = { kind: 'move-node', id: 'n-a', x: 1, y: 1 }
+    const afterMove = applyCommand(twoNodeCanvas(), moveCmd)
+    session.onChange(afterMove, moveCmd)
+
+    const deleteCmd: EditorCommand = { kind: 'delete-node', id: 'n-a' }
+    const afterDelete = applyCommand(afterMove, deleteCmd)
+    session.onChange(afterDelete, deleteCmd)
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    for (const bytes of backend._ctrl.pushLocalUpdateCalls) doc.import(bytes)
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id)).toEqual(['n-b'])
   })
 
   it('falls back to a full writeSpatialCanvas resync when the command target is missing from `next`, still converging on `next`', async () => {

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -1,5 +1,6 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import {
+  deleteSpatialNode,
   readSpatialCanvas,
   writeSpatialCanvas,
   writeSpatialEdge,
@@ -44,9 +45,12 @@ function commandTargetKey(command: EditorCommand): string {
     case 'move-node':
     case 'resize-node':
     case 'set-text':
+    case 'delete-node':
       return `node:${command.id}`
     case 'connect-nodes':
       return `edge:${command.edgeId}`
+    case 'create-node':
+      return `node:${command.node.id}`
     default:
       return `unmapped:${++unmappedCommandCounter}`
   }
@@ -148,6 +152,19 @@ function writeCommandTarget(doc: LoroDoc, next: SpatialCanvas, command: EditorCo
       writeSpatialEdge(doc, edge)
       return true
     }
+    case 'create-node': {
+      const node = next.nodes.find((n) => n.id === command.node.id)
+      if (!node) return false
+      writeSpatialNode(doc, node)
+      return true
+    }
+    case 'delete-node':
+      // Always "handled": deleteSpatialNode is a documented no-op for an
+      // already-absent id, so there is no missing-target case to fall back
+      // from here (unlike the other kinds, which need the target to still
+      // exist in `next` to know what to write).
+      deleteSpatialNode(doc, command.id)
+      return true
     default:
       return false
   }

--- a/apps/web/src/lib/loro-bridge-boundary.test.ts
+++ b/apps/web/src/lib/loro-bridge-boundary.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Source-scan guard: apps/web production code must mutate/inspect a spatial
+ * LoroDoc only through canvas-workspace's bridge functions
+ * (writeSpatialNode/writeSpatialEdge/deleteSpatialNode/deleteSpatialEdge/
+ * writeSpatialCanvas/readSpatialCanvas), never by calling
+ * `doc.getMap('nodes'|'edges')` directly — see package-canvas-workspace.md's
+ * "callers never manipulate the Loro layout directly" rule.
+ *
+ * The one documented exemption is `src/test-utils/` — browser-local-canvas.ts
+ * reads `doc.getMap('nodes')` to assert on the persisted doc from OUTSIDE the
+ * production code path, which is a legitimate test-assertion use, not a
+ * production call site.
+ */
+import { describe, expect, it } from 'vitest'
+
+const EXEMPT_PATH_PREFIXES = ['../test-utils/'] as const
+
+const modules = import.meta.glob('../**/*.{ts,tsx}', { query: '?raw', import: 'default' })
+
+const productionFiles = Object.keys(modules).filter((path) => {
+  if (path.includes('.test.')) return false
+  if (EXEMPT_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) return false
+  return true
+})
+
+const DIRECT_GET_MAP = /getMap\(\s*['"](nodes|edges)['"]\s*\)/
+
+describe('loro spatial-doc bridge boundary (apps/web)', () => {
+  it('scans a non-trivial floor of production files (guards a broken/empty glob)', () => {
+    expect(productionFiles.length).toBeGreaterThan(50)
+  })
+
+  it('the documented exemption is exactly src/test-utils/, nothing wider', () => {
+    expect([...EXEMPT_PATH_PREFIXES]).toEqual(['../test-utils/'])
+  })
+
+  for (const path of productionFiles) {
+    it(`${path} does not call doc.getMap('nodes'|'edges') directly`, async () => {
+      const loader = modules[path]
+      const source = (await loader?.()) as string
+      expect(source).not.toMatch(DIRECT_GET_MAP)
+    })
+  }
+})

--- a/apps/web/src/lib/loro-bridge-boundary.test.ts
+++ b/apps/web/src/lib/loro-bridge-boundary.test.ts
@@ -30,15 +30,13 @@ describe('loro spatial-doc bridge boundary (apps/web)', () => {
     expect(productionFiles.length).toBeGreaterThan(50)
   })
 
-  it('the documented exemption is exactly src/test-utils/, nothing wider', () => {
-    expect([...EXEMPT_PATH_PREFIXES]).toEqual(['../test-utils/'])
+  it("no production file calls doc.getMap('nodes'|'edges') directly", async () => {
+    const sources = await Promise.all(
+      productionFiles.map(async (path) => ({ path, source: (await modules[path]?.()) as string })),
+    )
+    const offenders = sources
+      .filter(({ source }) => DIRECT_GET_MAP.test(source))
+      .map(({ path }) => path)
+    expect(offenders).toEqual([])
   })
-
-  for (const path of productionFiles) {
-    it(`${path} does not call doc.getMap('nodes'|'edges') directly`, async () => {
-      const loader = modules[path]
-      const source = (await loader?.()) as string
-      expect(source).not.toMatch(DIRECT_GET_MAP)
-    })
-  }
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * create-node/delete-node reload persistence (real IndexedDB), the page-level
+ * complement to canvas-sync-session.test.ts's unit coverage: a node created
+ * through the dedicated `create-node` fine-grained write survives a remount,
+ * and a node removed through `delete-node` stays gone after another remount.
+ *
+ * SpatialEditor is mocked (see BrowserLocalCanvasPage.reload-elements.browser.test.tsx
+ * for why) so the test can drive `onChange` deterministically with the exact
+ * command shape a real create/delete gesture would report.
+ */
+
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EditorCommand } from '../components/spatial-editor/commands.js'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import {
+  clearWhiteboardDb,
+  createNodeCommand,
+  deleteNodeCommand,
+  loroCanvasesKeys,
+  persistedNodeIds,
+  textNodeCanvas,
+} from '../test-utils/browser-local-canvas.js'
+import '../index.css'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+type OnChange = (next: SpatialCanvas, command: EditorCommand) => void
+
+let latestOnChange: OnChange | null = null
+let latestMountedCanvases: SpatialCanvas[] = []
+
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: (props: { canvas: SpatialCanvas; onChange?: OnChange }) => {
+    latestOnChange = props.onChange ?? null
+    latestMountedCanvases.push(props.canvas)
+    return null
+  },
+}))
+
+const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
+
+describe('BrowserLocalCanvasPage create/delete-node reload persistence (browser — real IndexedDB)', () => {
+  let canvasId = ''
+
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+    latestOnChange = null
+    latestMountedCanvases = []
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('a node created via create-node survives remount; deleting it via delete-node stays gone after another remount', async () => {
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const created = textNodeCanvas('created-node', 20, 20)
+    const createCmd = createNodeCommand('created-node', 20, 20)
+
+    await waitFor(
+      async () => {
+        act(() => {
+          latestOnChange!(created, createCmd)
+        })
+        const keys = await loroCanvasesKeys()
+        expect(keys.length).toBeGreaterThan(0)
+      },
+      { timeout: 10000, interval: 600 },
+    )
+    const keys = await loroCanvasesKeys()
+    canvasId = keys.find((k) => k !== '__placeholder__')!
+    expect(canvasId).toBeDefined()
+    await waitFor(
+      async () => {
+        expect(await persistedNodeIds(canvasId)).toContain('created-node')
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    cleanup()
+    latestMountedCanvases = []
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    await waitFor(
+      () => {
+        const restoredIds = latestMountedCanvases.flatMap((canvas) => canvas.nodes.map((n) => n.id))
+        expect(restoredIds).toContain('created-node')
+      },
+      { timeout: 5000 },
+    )
+
+    // Now delete it and confirm it stays gone after a further remount.
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+    const afterDelete: SpatialCanvas = { nodes: [], edges: [] }
+    const deleteCmd = deleteNodeCommand('created-node')
+    await waitFor(
+      async () => {
+        act(() => {
+          latestOnChange!(afterDelete, deleteCmd)
+        })
+        expect(await persistedNodeIds(canvasId)).not.toContain('created-node')
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    cleanup()
+    latestMountedCanvases = []
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    await waitFor(
+      () => {
+        const restoredIds = latestMountedCanvases.flatMap((canvas) => canvas.nodes.map((n) => n.id))
+        expect(restoredIds).not.toContain('created-node')
+      },
+      { timeout: 5000 },
+    )
+  })
+})

--- a/apps/web/src/test-utils/browser-local-canvas.ts
+++ b/apps/web/src/test-utils/browser-local-canvas.ts
@@ -88,3 +88,13 @@ export function textNodeCanvas(id: string, x: number, y: number): SpatialCanvas 
 export function setTextCommand(id: string): EditorCommand {
   return { kind: 'set-text', id, text: 'x' }
 }
+
+/** The command a real SpatialEditor would report when creating `textNodeCanvas(id, x, y)`'s node. */
+export function createNodeCommand(id: string, x: number, y: number): EditorCommand {
+  return { kind: 'create-node', node: textNodeCanvas(id, x, y).nodes[0]! }
+}
+
+/** The command a real SpatialEditor would report when deleting the node with `id`. */
+export function deleteNodeCommand(id: string): EditorCommand {
+  return { kind: 'delete-node', id }
+}

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -15,11 +15,14 @@ pnpm --filter @kamiazya/whiteboard-web dev   # open http://localhost:5173
 ```
 
 The page mounts an OpenCanvas spatial editor. A fresh canvas starts empty —
-today the browser UI itself selects, moves, resizes, connects, and edits
-existing nodes; drawing brand-new nodes from the toolbar is not yet available
-in Browser-local mode. Reload the tab after moving a node or editing its text
-and the change is still there — that's your canvas persisting to IndexedDB in
-your own browser, with no server and no account.
+double-click empty canvas space, or click the "Add note" button in the
+top-left corner, to create a new note and start typing immediately. The
+browser UI also selects, moves, resizes, connects, and edits existing nodes,
+and deletes the selected node with Delete/Backspace (disabled while you're
+typing in its text editor, so Backspace edits text instead of deleting the
+note). Reload the tab after any of these edits and the change is still
+there — that's your canvas persisting to IndexedDB in your own browser, with
+no server and no account.
 
 **Where to go next:** want your AI agent (Claude Code, Codex, Gemini) to draw with
 you, or durable canvases as files on disk? That's the **Local daemon** — see

--- a/packages/canvas-workspace/src/index.ts
+++ b/packages/canvas-workspace/src/index.ts
@@ -10,6 +10,8 @@ export {
 } from './derive-index.js'
 export { extractBacklinks } from './extract-backlinks.js'
 export {
+  deleteSpatialEdge,
+  deleteSpatialNode,
   readFacets,
   readSpatialCanvas,
   writeFacets,

--- a/packages/canvas-workspace/src/loro-bridge.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.test.ts
@@ -7,6 +7,8 @@ import type {
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import {
+  deleteSpatialEdge,
+  deleteSpatialNode,
   readFacets,
   readSpatialCanvas,
   writeFacets,
@@ -297,6 +299,72 @@ describe('loro-bridge', () => {
     const result = readSpatialCanvas(doc1)
     const ids = result.nodes.map((n) => n.id).sort()
     expect(ids).toEqual([TEXT_NODE.id, LINK_NODE.id].sort())
+  })
+
+  test('deleteSpatialNode removes the node and cascades to its incident edges', () => {
+    const doc = makeDoc()
+    const otherEdge: CanvasEdge = { id: 'edge-2', fromNode: 'node-2', toNode: 'node-1' }
+    writeSpatialCanvas(doc, {
+      nodes: [TEXT_NODE, FILE_NODE, LINK_NODE],
+      edges: [EDGE, otherEdge],
+    })
+
+    deleteSpatialNode(doc, TEXT_NODE.id)
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id).sort()).toEqual([FILE_NODE.id, LINK_NODE.id].sort())
+    expect(result.edges).toEqual([])
+  })
+
+  test('deleteSpatialNode leaves unrelated nodes/edges untouched', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
+
+    deleteSpatialNode(doc, FILE_NODE.id)
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes).toEqual([TEXT_NODE])
+    // EDGE references node-1/node-2; node-2 (FILE_NODE) was removed so its
+    // incident edge must cascade too.
+    expect(result.edges).toEqual([])
+  })
+
+  test('deleteSpatialNode is idempotent and a no-op for a missing id', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [TEXT_NODE], edges: [] })
+
+    deleteSpatialNode(doc, 'missing-id')
+    deleteSpatialNode(doc, TEXT_NODE.id)
+    deleteSpatialNode(doc, TEXT_NODE.id)
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes).toEqual([])
+  })
+
+  test('deleteSpatialNode is a single commit: one UndoManager step restores node and edges together', async () => {
+    const { UndoManager } = await import('loro-crdt')
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
+    const undoManager = new UndoManager(doc, {})
+
+    deleteSpatialNode(doc, TEXT_NODE.id)
+    undoManager.undo()
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id).sort()).toEqual([TEXT_NODE.id, FILE_NODE.id].sort())
+    expect(result.edges).toEqual([EDGE])
+  })
+
+  test('deleteSpatialEdge removes exactly one edge, leaving nodes and other edges untouched', () => {
+    const doc = makeDoc()
+    const otherEdge: CanvasEdge = { id: 'edge-2', fromNode: 'node-2', toNode: 'node-1' }
+    writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE, otherEdge] })
+
+    deleteSpatialEdge(doc, EDGE.id)
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toEqual([otherEdge])
   })
 })
 

--- a/packages/canvas-workspace/src/loro-bridge.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.test.ts
@@ -316,7 +316,7 @@ describe('loro-bridge', () => {
     expect(result.edges).toEqual([])
   })
 
-  test('deleteSpatialNode leaves unrelated nodes/edges untouched', () => {
+  test('deleteSpatialNode keeps the other nodes and cascades only the incident edge', () => {
     const doc = makeDoc()
     writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
 
@@ -327,6 +327,27 @@ describe('loro-bridge', () => {
     // EDGE references node-1/node-2; node-2 (FILE_NODE) was removed so its
     // incident edge must cascade too.
     expect(result.edges).toEqual([])
+  })
+
+  test('deleteSpatialNode leaves an edge between two surviving nodes alone', () => {
+    // Every other edge in this suite joins node-1 and node-2, so every other
+    // deletion removes one of its endpoints. Without a third node, an
+    // implementation that simply cleared the whole edges map would satisfy
+    // the entire cascade suite — this is the case that separates "cascade
+    // the incident edges" from "drop them all".
+    const doc = makeDoc()
+    const thirdNode = { ...TEXT_NODE, id: 'node-3', x: 500 }
+    const survivingEdge: CanvasEdge = { id: 'edge-keep', fromNode: 'node-1', toNode: 'node-3' }
+    writeSpatialCanvas(doc, {
+      nodes: [TEXT_NODE, FILE_NODE, thirdNode],
+      edges: [EDGE, survivingEdge],
+    })
+
+    deleteSpatialNode(doc, FILE_NODE.id)
+
+    const result = readSpatialCanvas(doc)
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(['node-1', 'node-3'])
+    expect(result.edges).toEqual([survivingEdge])
   })
 
   test('deleteSpatialNode is idempotent and a no-op for a missing id', () => {

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -113,6 +113,42 @@ export function writeSpatialEdge(doc: LoroDoc, edge: CanvasEdge): void {
   doc.commit()
 }
 
+/**
+ * Deletes one node's LoroMap entry AND every edge whose fromNode/toNode
+ * referenced it, in a single `doc.commit()` — a cascading edge-integrity
+ * invariant this bridge enforces so `readSpatialCanvas` never returns an
+ * edge with a dangling endpoint. One commit (not one commit per removal)
+ * is what lets a single `UndoManager` step restore the node together with
+ * its edges, rather than leaving one half of the deletion undone.
+ * Idempotent and a no-op (no commit) for an id absent from the doc.
+ */
+export function deleteSpatialNode(doc: LoroDoc, nodeId: string): void {
+  const nodesMap = doc.getMap(NODES_KEY)
+  const edgesMap = doc.getMap(EDGES_KEY)
+  if (!nodesMap.keys().includes(nodeId)) return
+
+  nodesMap.delete(nodeId)
+  for (const edgeId of edgesMap.keys()) {
+    const raw = edgesMap.get(edgeId)
+    const parsed = canvasEdgeSchema.safeParse(raw)
+    if (parsed.success && (parsed.data.fromNode === nodeId || parsed.data.toNode === nodeId)) {
+      edgesMap.delete(edgeId)
+    }
+  }
+  doc.commit()
+}
+
+/**
+ * Edge counterpart to `deleteSpatialNode` — removes exactly one edge, no
+ * cascade needed since an edge has no dependents of its own.
+ */
+export function deleteSpatialEdge(doc: LoroDoc, edgeId: string): void {
+  const edgesMap = doc.getMap(EDGES_KEY)
+  if (!edgesMap.keys().includes(edgeId)) return
+  edgesMap.delete(edgeId)
+  doc.commit()
+}
+
 export function readSpatialCanvas(doc: LoroDoc): SpatialCanvas {
   const nodesMap = doc.getMap(NODES_KEY)
   const edgesMap = doc.getMap(EDGES_KEY)


### PR DESCRIPTION
Before this, a person could not put anything on a canvas. `EditorCommand` had exactly four kinds — `move-node`, `resize-node`, `set-text`, `connect-nodes` — with no create and no delete, and neither page had an add control. Nodes could only arrive through MCP, so the app was "an agent creates, a human arranges". Every canvas being empty after the Excalidraw cutover made that a blank, inert screen.

## Authoring

`create-node` and `delete-node` join the command union. Two ways in: double-click empty space (node lands at the pointer, opens for typing immediately — a node you must double-click again to type into would be worse than what Excalidraw gave you) and an `Add note` button, which is discoverable in a way a double-click affordance is not when the canvas is empty. Delete/Backspace removes the selection, and cannot fire while a text editor is open.

Deletion cascades to incident edges in the same command, so no canvas any sequence can produce contains an edge pointing at a missing node. `deleteSpatialNode`/`deleteSpatialEdge` land in `canvas-workspace` rather than reaching into the doc from `apps/web` — that package's rule is that callers never manipulate the Loro layout directly, and a new `loro-bridge-boundary.test.ts` source scan now enforces it instead of review catching it.

## Three defects found by driving it by hand

The first pass shipped green tests and an unusable screen, so it was dogfooded in a real browser before this PR. That found:

**Every `Add note` landed on the same coordinates.** Two clicks produced two rects at exactly `x=860 y=365 w=200 h=100`, perfectly stacked — to a person, one node, with the second unreachable underneath. Placement now cascades into free space. The double-click path deliberately keeps the raw pointer point: moving a node away from where someone clicked would be a worse bug.

**Typed text was discarded on click-away.** The `pointerdown-empty` arm of the gesture reducer returned to idle without the pending-text commit that the three node-targeted pointerdown arms run, so `TextNodeEditor` unmounted and its guarded blur-commit became a no-op. Losing what someone just typed is the worst thing this editor can do. Clicking away now commits; Escape remains the only path that discards.

**A latent bug found while in there, worse than the reported one.** `GestureResult` carried at most one command and the pending-text-commit helper *overwrote* it — so creating a node while a text edit was open silently dropped the creation, and the helper's own comment claimed the opposite. Fixed structurally: results carry an ordered command list, commit-then-create, so the whole silent-override class is gone rather than one call site patched.

The `Add note` control was also a bare element (`border: 0`, transparent background, `padding: 0`) — indistinguishable from a text label. It now uses the app's button idiom with a visible focus ring.

## What is verified, and how

Placement is confirmed in the running app: four `Add note` presses produce four non-overlapping nodes cascading by (120, 120), and the SVG viewBox grows to contain them.

![after-cascade-placement-real-chrome.jpg](https://github.com/user-attachments/assets/d34641c0-3c35-4f57-8355-074f98fa353e)

**The click-away commit fix is verified by the `web-browser` suite, not by a manual pass.** Synthetic pointer events from the available browser-automation tooling do not trigger the button's React handler in this environment (`elementFromPoint` returns the button, `btn.click()` works, a dispatched click does not), so hand-driving the type-then-click-away flow was not possible. Vitest browser mode does drive real pointer and keyboard input and those cases pass — which is the same reason the regression tests for both defects were required to drive real input rather than dispatch `commit-text-edit` directly. A test that injects the command cannot see this class of bug; that is precisely how it shipped.

## Deferred, not forgotten

Canvas chrome still renders a hardcoded `stroke="#333333"`, nearly invisible on the dark theme — visible in the screenshot above. It is tracked separately because `editor-appearance.ts`'s colors are shared with the **export** path: a dark stroke baked into a transparent PNG is invisible in most viewers, so the fix needs a light-locked default plus an export-byte-invariance guard, which is a different risk class from node authoring.

## Verification

`pnpm -r typecheck` clean, `web-browser` 27 files / 172 tests green, apps/web jsdom green, `knip` and `lint:noconsole` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create notes by double-clicking the canvas or using the “Add note” button.
  * Edit and delete selected notes with keyboard controls.
  * Automatically place new notes in available space to reduce overlap.
  * Save note creation and deletion reliably, including after reloads.
  * Remove connected edges automatically when deleting a note.

* **Bug Fixes**
  * Clicking away now commits text edits, while Escape discards them.
  * Improved handling of in-progress gestures and canvas replacement.

* **Documentation**
  * Updated the getting-started guide with note creation, editing, deletion, and persistence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->