### PR TITLE
test(mcp-server): guard the dev-daemon hook ready-wait that nothing was testing

### DIFF
--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -199,3 +199,12 @@ can vanish silently, since the `SessionStart` hook only fires once per session a
 mid-session. If two processes race to bind the same port, the loser now logs one classified
 `{ port, code: 'EADDRINUSE' }` record via `getLogger('http-server')` and exits, instead of the raw
 unhandled-`'error'`-event stack trace `tmp/logs/mcp-http-dev.log` used to accumulate.
+
+If the hook itself times out waiting for the spawned daemon to answer an authenticated `/mcp`
+probe, it prints `MCP tools will be unavailable for this session` and exits non-zero — the session
+starts anyway, just without whiteboard MCP tools; check `tmp/logs/mcp-http-dev.log` for what the
+daemon was doing, then start it manually (`pnpm mcp:http:dev`) and reconnect. The wait bound
+defaults to 30s (cold `tsx` + `happy-dom` + canvas + resvg startup) and is overridable via
+`WHITEBOARD_DEV_READY_TIMEOUT_MS` (milliseconds; a non-numeric, non-integer, zero, or negative
+value falls back to the 30s default) — mainly useful for shortening the wait when scripting or
+testing the hook itself, not something a normal dev session needs to set.

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
@@ -16,9 +16,9 @@ export const DEFAULT_READY_TIMEOUT_MS = 30_000
  * @returns {number}
  */
 export function resolveReadyTimeoutMs(env) {
-  const raw = env.WHITEBOARD_DEV_READY_TIMEOUT_MS
-  if (raw === undefined || raw === '') return DEFAULT_READY_TIMEOUT_MS
-  const parsed = Number(raw)
+  // Number(undefined) is NaN and Number('') is 0, so an absent or empty
+  // override falls through the same guard as a malformed one.
+  const parsed = Number(env.WHITEBOARD_DEV_READY_TIMEOUT_MS)
   if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_READY_TIMEOUT_MS
   return parsed
 }

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.mjs
@@ -1,3 +1,28 @@
+// Upper bound on how long ensure-http-dev-daemon.mjs waits for a spawned
+// daemon to answer. tsx + happy-dom + canvas + resvg cold start + node_modules
+// linking can take ~10-15s on slow machines, so leave generous headroom —
+// the hook only runs once per session start, so this isn't on a hot path.
+export const DEFAULT_READY_TIMEOUT_MS = 30_000
+
+/**
+ * Resolves the ready-wait bound from WHITEBOARD_DEV_READY_TIMEOUT_MS,
+ * falling back to DEFAULT_READY_TIMEOUT_MS whenever the override is absent
+ * or malformed (non-numeric, non-integer, zero, or negative). Total and
+ * never throws — a SessionStart hook must not die over a stray dev env var,
+ * it should just behave as if the override were never set. Kept as a
+ * seam mainly so tests can exercise the timeout path in well under 30s.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {number}
+ */
+export function resolveReadyTimeoutMs(env) {
+  const raw = env.WHITEBOARD_DEV_READY_TIMEOUT_MS
+  if (raw === undefined || raw === '') return DEFAULT_READY_TIMEOUT_MS
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_READY_TIMEOUT_MS
+  return parsed
+}
+
 export async function waitForAuthenticatedMcp({
   probe,
   sleep,

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon-lib.test.ts
@@ -3,8 +3,10 @@ import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   buildMcpHttpDevSpawnArgs,
+  DEFAULT_READY_TIMEOUT_MS,
   isSelfHealableIdentity,
   resolveDevBearerToken,
+  resolveReadyTimeoutMs,
   verifyDevDaemonIdentity,
   waitForAuthenticatedMcp,
 } from './ensure-http-dev-daemon-lib.mjs'
@@ -152,6 +154,36 @@ describe('verifyDevDaemonIdentity', () => {
     })
 
     expect(verdict).toBe('ours')
+  })
+})
+
+describe('resolveReadyTimeoutMs', () => {
+  it('defaults to DEFAULT_READY_TIMEOUT_MS when the override is absent', () => {
+    expect(resolveReadyTimeoutMs({})).toBe(DEFAULT_READY_TIMEOUT_MS)
+  })
+
+  it('defaults when the override is undefined', () => {
+    expect(resolveReadyTimeoutMs({ WHITEBOARD_DEV_READY_TIMEOUT_MS: undefined })).toBe(
+      DEFAULT_READY_TIMEOUT_MS,
+    )
+  })
+
+  it('uses a valid positive integer override', () => {
+    expect(resolveReadyTimeoutMs({ WHITEBOARD_DEV_READY_TIMEOUT_MS: '5000' })).toBe(5000)
+  })
+
+  it.each([
+    '',
+    'abc',
+    '0',
+    '-1',
+    '1.5',
+    'Infinity',
+    'NaN',
+  ])('falls back to the default for a malformed override %j (never throws)', (raw) => {
+    expect(resolveReadyTimeoutMs({ WHITEBOARD_DEV_READY_TIMEOUT_MS: raw })).toBe(
+      DEFAULT_READY_TIMEOUT_MS,
+    )
   })
 })
 

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs
@@ -17,6 +17,7 @@ import {
   buildMcpHttpDevSpawnArgs,
   isSelfHealableIdentity,
   resolveDevBearerToken,
+  resolveReadyTimeoutMs,
   verifyDevDaemonIdentity,
   waitForAuthenticatedMcp,
 } from './ensure-http-dev-daemon-lib.mjs'
@@ -34,11 +35,13 @@ const PORT = deriveDevPort({
 })
 const EXPECTED_DATA_DIR = resolveDevDataDirEnv(process.env, REPO_ROOT).WHITEBOARD_DATA_DIR
 const HOST = '127.0.0.1'
-// Upper bound on how long we'll wait for `pnpm mcp:http:dev` to bind. tsx
-// + happy-dom + canvas + resvg cold start + node_modules linking can take
-// ~10-15s on slow machines, so leave generous headroom. The hook is only
-// invoked once per session start, so this isn't on a hot path.
-const READY_TIMEOUT_MS = 30_000
+// Upper bound on how long we'll wait for `pnpm mcp:http:dev` to bind.
+// Defaults to 30s (tsx + happy-dom + canvas + resvg cold start +
+// node_modules linking can take ~10-15s on slow machines, so leave generous
+// headroom — the hook is only invoked once per session start, so this isn't
+// on a hot path). Overridable via WHITEBOARD_DEV_READY_TIMEOUT_MS, mainly so
+// tests can exercise the timeout path without waiting 30s.
+const READY_TIMEOUT_MS = resolveReadyTimeoutMs(process.env)
 const READY_POLL_INTERVAL_MS = 200
 // Bearer token expected by `/mcp`. Must match the value the local clients
 // (.claude/settings.json, .codex/config.toml) send. If a different daemon
@@ -229,7 +232,8 @@ const ready = await waitForAuthenticatedMcp({
 if (!ready) {
   const detail = exitedEarly ? `; spawned process exited with code ${exitCode}` : ''
   console.error(
-    `[ensure-http-dev-daemon] timed out waiting for authenticated MCP at http://${HOST}:${PORT} after ${READY_TIMEOUT_MS}ms${detail} — see ${LOG_PATH}`,
+    `[ensure-http-dev-daemon] timed out waiting for authenticated MCP at http://${HOST}:${PORT} after ${READY_TIMEOUT_MS}ms${detail} — see ${LOG_PATH}. ` +
+      'MCP tools will be unavailable for this session.',
   )
   process.exit(1)
 }

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
@@ -1,0 +1,212 @@
+// Subprocess-level tests of the SessionStart hook entrypoint. Runs the real
+// ensure-http-dev-daemon.mjs as a child process against a PATH-shimmed
+// `pnpm` (never a real build) plus a fake authenticated MCP responder, so
+// the wait-for-ready behavior is exercised the same way a client's session
+// start actually does: wait for the hook process to exit, not for a unit
+// under test to return a promise.
+//
+// No .cmd counterpart exists for the shim, so this suite only runs on POSIX.
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startFakeMcpResponder } from './test-utils/fake-mcp-daemon.mjs'
+import { resolveRepoRootFromGit } from './with-dev-data-dir-lib.mjs'
+
+const REPO_ROOT = resolveRepoRootFromGit(resolve(import.meta.dirname))
+const HOOK_SCRIPT_PATH = resolve(import.meta.dirname, 'ensure-http-dev-daemon.mjs')
+const SHIM_ENTRY_PATH = resolve(import.meta.dirname, 'test-utils/fake-pnpm-shim.mjs')
+const HOST = '127.0.0.1'
+const LOG_PATH_SUFFIX = 'tmp/logs/mcp-http-dev.log'
+
+async function reserveFreePort(): Promise<number> {
+  return new Promise((resolvePort, rejectPort) => {
+    const tester = createServer()
+    tester.once('error', rejectPort)
+    tester.listen(0, HOST, () => {
+      const address = tester.address()
+      const port = typeof address === 'object' && address ? address.port : undefined
+      tester.close(() => {
+        if (port === undefined) {
+          rejectPort(new Error('failed to reserve a free port'))
+          return
+        }
+        resolvePort(port)
+      })
+    })
+  })
+}
+
+/**
+ * Writes a POSIX `pnpm` wrapper into a fresh temp dir that execs node
+ * directly against fake-pnpm-shim.mjs, and returns that dir for prepending
+ * onto the spawned hook's PATH.
+ */
+function writePnpmShimDir(): string {
+  const shimDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-shim-'))
+  const shimPath = join(shimDir, 'pnpm')
+  writeFileSync(shimPath, `#!/bin/sh\nexec node "${SHIM_ENTRY_PATH}" "$@"\n`)
+  chmodSync(shimPath, 0o755)
+  return shimDir
+}
+
+function runHook(env: NodeJS.ProcessEnv): Promise<{
+  exitCode: number | null
+  exitedAt: number
+  stderr: string
+}> {
+  return new Promise((resolveRun) => {
+    const child: ChildProcessWithoutNullStreams = spawn(
+      process.execPath,
+      [HOOK_SCRIPT_PATH, '--quiet'],
+      { cwd: REPO_ROOT, env },
+    )
+    let stderr = ''
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.once('exit', (exitCode) => {
+      resolveRun({ exitCode, exitedAt: Date.now(), stderr })
+    })
+  })
+}
+
+function killQuietly(pid: number | undefined) {
+  if (pid === undefined) return
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    /* already dead */
+  }
+}
+
+describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
+  const cleanupPids: number[] = []
+  const cleanupDirs: string[] = []
+  let cleanupResponder: (() => Promise<void>) | undefined
+
+  afterEach(async () => {
+    for (const pid of cleanupPids.splice(0)) killQuietly(pid)
+    if (cleanupResponder) {
+      await cleanupResponder()
+      cleanupResponder = undefined
+    }
+    for (const dir of cleanupDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'does not exit until the daemon it spawned actually answers MCP (happens-before, not a timing threshold)',
+    async () => {
+      const port = await reserveFreePort()
+      const token = randomUUID()
+      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
+      const shimDir = writePnpmShimDir()
+      const bindSentinelPath = join(dataDir, 'bind-sentinel.json')
+      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
+      cleanupDirs.push(dataDir, shimDir)
+
+      const { exitCode, exitedAt, stderr } = await runHook({
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH ?? ''}`,
+        WHITEBOARD_DEV_PORT: String(port),
+        WHITEBOARD_TOKEN: token,
+        // No marker is ever written by the fake daemon here (unlike the
+        // real one) — this deliberately exercises the no-marker self-heal
+        // path (verifyDevDaemonIdentity -> 'no-marker' -> isSelfHealableIdentity)
+        // rather than depending on marker-writing behavior the fake lacks.
+        WHITEBOARD_DATA_DIR: dataDir,
+        WHITEBOARD_DEV_READY_TIMEOUT_MS: '8000',
+        FAKE_PNPM_BIND_DELAY_MS: '1200',
+        FAKE_PNPM_BIND_SENTINEL: bindSentinelPath,
+        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
+      })
+
+      expect(exitCode, `hook stderr:\n${stderr}`).toBe(0)
+      const { boundAt } = JSON.parse(readFileSync(bindSentinelPath, 'utf8')) as { boundAt: number }
+      // The headline invariant: the hook's exit is never earlier than the
+      // daemon's bind. A fire-and-forget hook would exit long before the
+      // 1.2s bind delay elapses and this would fail.
+      expect(exitedAt).toBeGreaterThanOrEqual(boundAt)
+
+      // The hook unref's the spawned daemon rather than killing it — clean
+      // up the still-running fake daemon so it doesn't leak past the test.
+      const { pid } = JSON.parse(readFileSync(invokedSentinelPath, 'utf8')) as { pid: number }
+      cleanupPids.push(pid)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'terminates within the bound and fails loudly when the daemon never answers',
+    async () => {
+      const port = await reserveFreePort()
+      const token = randomUUID()
+      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
+      const shimDir = writePnpmShimDir()
+      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
+      cleanupDirs.push(dataDir, shimDir)
+
+      const startedAt = Date.now()
+      const { exitCode, stderr } = await runHook({
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH ?? ''}`,
+        WHITEBOARD_DEV_PORT: String(port),
+        WHITEBOARD_TOKEN: token,
+        WHITEBOARD_DATA_DIR: dataDir,
+        WHITEBOARD_DEV_READY_TIMEOUT_MS: '800',
+        FAKE_PNPM_NEVER_BIND: '1',
+        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
+      })
+      const elapsedMs = Date.now() - startedAt
+
+      // Well under the mcp-node project's 10s testTimeout — proves the
+      // hook terminates on its own instead of hanging.
+      expect(elapsedMs).toBeLessThan(6_000)
+      expect(exitCode).not.toBe(0)
+      expect(stderr).toContain(String(port))
+      expect(stderr).toContain(LOG_PATH_SUFFIX)
+      expect(stderr).toContain('MCP tools will be unavailable')
+
+      const { pid } = JSON.parse(readFileSync(invokedSentinelPath, 'utf8')) as { pid: number }
+      cleanupPids.push(pid)
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'is a no-op when our authenticated daemon is already up with a matching identity marker (fast path preserved)',
+    async () => {
+      const port = await reserveFreePort()
+      const token = randomUUID()
+      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
+      const shimDir = writePnpmShimDir()
+      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
+      cleanupDirs.push(dataDir, shimDir)
+
+      const responder = await startFakeMcpResponder({ port, token, host: HOST })
+      cleanupResponder = responder.close
+      writeFileSync(
+        join(dataDir, 'dev-daemon.json'),
+        JSON.stringify({
+          port,
+          repoRoot: REPO_ROOT,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        }),
+      )
+
+      const { exitCode, stderr } = await runHook({
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH ?? ''}`,
+        WHITEBOARD_DEV_PORT: String(port),
+        WHITEBOARD_TOKEN: token,
+        WHITEBOARD_DATA_DIR: dataDir,
+        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
+      })
+
+      expect(exitCode, `hook stderr:\n${stderr}`).toBe(0)
+      expect(() => readFileSync(invokedSentinelPath, 'utf8')).toThrow()
+    },
+  )
+})

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
@@ -83,6 +83,12 @@ function killQuietly(pid: number | undefined) {
   }
 }
 
+const itPosix = it.skipIf(process.platform === 'win32')
+
+function readSentinel<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T
+}
+
 describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
   const cleanupPids: number[] = []
   const cleanupDirs: string[] = []
@@ -97,35 +103,61 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
     for (const dir of cleanupDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'does not exit until the daemon it spawned actually answers MCP (happens-before, not a timing threshold)',
-    async () => {
-      const port = await reserveFreePort()
-      const token = randomUUID()
-      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
-      const shimDir = writePnpmShimDir()
-      const bindSentinelPath = join(dataDir, 'bind-sentinel.json')
-      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
-      cleanupDirs.push(dataDir, shimDir)
+  /**
+   * Reserves a free port, a temp data dir and a PATH shim dir (both
+   * registered for cleanup), and returns the env every hook run shares.
+   * Per-case behavior is layered on by spreading extra FAKE_PNPM_* /
+   * WHITEBOARD_DEV_READY_TIMEOUT_MS entries over `env`.
+   *
+   * The fake daemon never writes an identity marker (unlike the real one),
+   * so a fresh data dir also exercises the no-marker self-heal path
+   * (verifyDevDaemonIdentity -> 'no-marker' -> isSelfHealableIdentity).
+   */
+  async function prepareHookRun(): Promise<{
+    port: number
+    token: string
+    dataDir: string
+    invokedSentinelPath: string
+    env: NodeJS.ProcessEnv
+  }> {
+    const port = await reserveFreePort()
+    const token = randomUUID()
+    const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
+    const shimDir = writePnpmShimDir()
+    cleanupDirs.push(dataDir, shimDir)
+    const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
 
-      const { exitCode, exitedAt, stderr } = await runHook({
+    return {
+      port,
+      token,
+      dataDir,
+      invokedSentinelPath,
+      env: {
         ...process.env,
         PATH: `${shimDir}:${process.env.PATH ?? ''}`,
         WHITEBOARD_DEV_PORT: String(port),
         WHITEBOARD_TOKEN: token,
-        // No marker is ever written by the fake daemon here (unlike the
-        // real one) — this deliberately exercises the no-marker self-heal
-        // path (verifyDevDaemonIdentity -> 'no-marker' -> isSelfHealableIdentity)
-        // rather than depending on marker-writing behavior the fake lacks.
         WHITEBOARD_DATA_DIR: dataDir,
+        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
+      },
+    }
+  }
+
+  itPosix(
+    'does not exit until the daemon it spawned actually answers MCP (happens-before, not a timing threshold)',
+    async () => {
+      const { dataDir, invokedSentinelPath, env } = await prepareHookRun()
+      const bindSentinelPath = join(dataDir, 'bind-sentinel.json')
+
+      const { exitCode, exitedAt, stderr } = await runHook({
+        ...env,
         WHITEBOARD_DEV_READY_TIMEOUT_MS: '8000',
         FAKE_PNPM_BIND_DELAY_MS: '1200',
         FAKE_PNPM_BIND_SENTINEL: bindSentinelPath,
-        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
       })
 
       expect(exitCode, `hook stderr:\n${stderr}`).toBe(0)
-      const { boundAt } = JSON.parse(readFileSync(bindSentinelPath, 'utf8')) as { boundAt: number }
+      const { boundAt } = readSentinel<{ boundAt: number }>(bindSentinelPath)
       // The headline invariant: the hook's exit is never earlier than the
       // daemon's bind. A fire-and-forget hook would exit long before the
       // 1.2s bind delay elapses and this would fail.
@@ -133,31 +165,20 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
 
       // The hook unref's the spawned daemon rather than killing it — clean
       // up the still-running fake daemon so it doesn't leak past the test.
-      const { pid } = JSON.parse(readFileSync(invokedSentinelPath, 'utf8')) as { pid: number }
-      cleanupPids.push(pid)
+      cleanupPids.push(readSentinel<{ pid: number }>(invokedSentinelPath).pid)
     },
   )
 
-  it.skipIf(process.platform === 'win32')(
+  itPosix(
     'terminates within the bound and fails loudly when the daemon never answers',
     async () => {
-      const port = await reserveFreePort()
-      const token = randomUUID()
-      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
-      const shimDir = writePnpmShimDir()
-      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
-      cleanupDirs.push(dataDir, shimDir)
+      const { port, invokedSentinelPath, env } = await prepareHookRun()
 
       const startedAt = Date.now()
       const { exitCode, stderr } = await runHook({
-        ...process.env,
-        PATH: `${shimDir}:${process.env.PATH ?? ''}`,
-        WHITEBOARD_DEV_PORT: String(port),
-        WHITEBOARD_TOKEN: token,
-        WHITEBOARD_DATA_DIR: dataDir,
+        ...env,
         WHITEBOARD_DEV_READY_TIMEOUT_MS: '800',
         FAKE_PNPM_NEVER_BIND: '1',
-        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
       })
       const elapsedMs = Date.now() - startedAt
 
@@ -169,20 +190,14 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
       expect(stderr).toContain(LOG_PATH_SUFFIX)
       expect(stderr).toContain('MCP tools will be unavailable')
 
-      const { pid } = JSON.parse(readFileSync(invokedSentinelPath, 'utf8')) as { pid: number }
-      cleanupPids.push(pid)
+      cleanupPids.push(readSentinel<{ pid: number }>(invokedSentinelPath).pid)
     },
   )
 
-  it.skipIf(process.platform === 'win32')(
+  itPosix(
     'is a no-op when our authenticated daemon is already up with a matching identity marker (fast path preserved)',
     async () => {
-      const port = await reserveFreePort()
-      const token = randomUUID()
-      const dataDir = mkdtempSync(join(tmpdir(), 'ensure-http-dev-daemon-data-'))
-      const shimDir = writePnpmShimDir()
-      const invokedSentinelPath = join(dataDir, 'invoked-sentinel.json')
-      cleanupDirs.push(dataDir, shimDir)
+      const { port, token, dataDir, invokedSentinelPath, env } = await prepareHookRun()
 
       const responder = await startFakeMcpResponder({ port, token, host: HOST })
       cleanupResponder = responder.close
@@ -196,14 +211,7 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
         }),
       )
 
-      const { exitCode, stderr } = await runHook({
-        ...process.env,
-        PATH: `${shimDir}:${process.env.PATH ?? ''}`,
-        WHITEBOARD_DEV_PORT: String(port),
-        WHITEBOARD_TOKEN: token,
-        WHITEBOARD_DATA_DIR: dataDir,
-        FAKE_PNPM_INVOKED_SENTINEL: invokedSentinelPath,
-      })
+      const { exitCode, stderr } = await runHook(env)
 
       expect(exitCode, `hook stderr:\n${stderr}`).toBe(0)
       expect(() => readFileSync(invokedSentinelPath, 'utf8')).toThrow()

--- a/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.mjs
@@ -1,0 +1,40 @@
+// Test-only helper shared between ensure-http-dev-daemon.script.test.ts
+// (which starts a responder directly, in-process, for the fast-path case)
+// and fake-pnpm-shim.mjs (which starts one from a spawned subprocess, for
+// the wait-path/timeout-path cases). Kept minimal: it only has to satisfy
+// probeAuthenticatedMcpDaemon()'s three checks (reachable, correct bearer,
+// json/event-stream content-type).
+
+import { createServer } from 'node:http'
+
+/**
+ * Starts a minimal HTTP responder that answers POST /mcp like the real
+ * daemon's authenticated MCP endpoint, for exactly the fields
+ * probeAuthenticatedMcpDaemon() inspects.
+ *
+ * @param {{ port: number, token: string, host?: string }} args
+ * @returns {Promise<{ server: import('node:http').Server, close: () => Promise<void> }>}
+ */
+export function startFakeMcpResponder({ port, token, host = '127.0.0.1' }) {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      if (req.method !== 'POST' || req.url !== '/mcp') {
+        res.writeHead(404).end()
+        return
+      }
+      if (req.headers.authorization !== `Bearer ${token}`) {
+        res.writeHead(401).end()
+        return
+      }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: 'fake-mcp-daemon', result: {} }))
+    })
+    server.once('error', reject)
+    server.listen(port, host, () => {
+      resolve({
+        server,
+        close: () => new Promise((resolveClose) => server.close(() => resolveClose())),
+      })
+    })
+  })
+}

--- a/packages/mcp-server/scripts/dev/test-utils/fake-pnpm-shim.mjs
+++ b/packages/mcp-server/scripts/dev/test-utils/fake-pnpm-shim.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Test double for `pnpm mcp:http:dev`, invoked by ensure-http-dev-daemon.mjs
+// via a PATH-shimmed `pnpm` wrapper (see ensure-http-dev-daemon.script.test.ts).
+// Simulates a dev daemon's build-then-bind startup shape without paying for
+// a real tsx/canvas/resvg cold start, so the wait-path and timeout-path
+// tests run in well under the mcp-node project's 10s testTimeout.
+//
+// Behavior is entirely env-driven so the test controls timing without
+// touching argv (which the real pnpm script also receives --port=/--token=
+// for):
+//   FAKE_PNPM_INVOKED_SENTINEL - path written immediately on invocation, so
+//     a test can assert this process was (or was not) ever spawned.
+//   FAKE_PNPM_BIND_DELAY_MS    - ms to sleep before binding (default 0).
+//   FAKE_PNPM_NEVER_BIND       - when set, sleeps indefinitely instead of
+//     ever calling startFakeMcpResponder, simulating a daemon stuck before
+//     its listen() call.
+//   FAKE_PNPM_BIND_SENTINEL    - path written the moment the responder
+//     starts listening, carrying a boundAt timestamp the test compares
+//     against the hook's own exit time (happens-before assertion).
+
+import { writeFileSync } from 'node:fs'
+import { startFakeMcpResponder } from './fake-mcp-daemon.mjs'
+
+const PORT_FLAG = '--port='
+const TOKEN_FLAG = '--token='
+const args = process.argv.slice(2)
+const port = Number(args.find((arg) => arg.startsWith(PORT_FLAG))?.slice(PORT_FLAG.length))
+const token =
+  args.find((arg) => arg.startsWith(TOKEN_FLAG))?.slice(TOKEN_FLAG.length) ?? 'whiteboard-dev'
+
+const invokedSentinel = process.env.FAKE_PNPM_INVOKED_SENTINEL
+if (invokedSentinel) {
+  writeFileSync(invokedSentinel, JSON.stringify({ pid: process.pid, invokedAt: Date.now() }))
+}
+
+const bindDelayMs = Number(process.env.FAKE_PNPM_BIND_DELAY_MS ?? '0')
+await new Promise((resolveSleep) => setTimeout(resolveSleep, bindDelayMs))
+
+if (process.env.FAKE_PNPM_NEVER_BIND === '1') {
+  // Never resolves: this process just sits here, like a dev server stuck
+  // before its listen() call. The test kills it directly during cleanup.
+  await new Promise(() => {})
+}
+
+await startFakeMcpResponder({ port, token })
+
+const bindSentinel = process.env.FAKE_PNPM_BIND_SENTINEL
+if (bindSentinel) {
+  writeFileSync(bindSentinel, JSON.stringify({ boundAt: Date.now() }))
+}
+
+// Stay alive like a real `tsx watch` dev process; the test kills this pid
+// directly during cleanup instead of expecting a graceful shutdown path.
+await new Promise(() => {})


### PR DESCRIPTION
The SessionStart hook already waits for the daemon to answer before it exits — `await waitForAuthenticatedMcp(...)` with a 30s bound and a 200ms poll. Nothing tested that. Deleting the entire wait block left the whole suite green, which means the invariant the hook exists to uphold was resting on nobody editing that file carelessly.

This adds the guard, not the behavior.

## Why this invariant is worth a subprocess test

If the hook exits before the daemon is listening, the MCP client connects to a refused port at session start and registers **zero tools for the entire session**, with no retry. The failure is silent and total, and it is invisible from inside the process the hook spawns — so the test drives the real script as a subprocess.

## What the test asserts

Three cases in `ensure-http-dev-daemon.script.test.ts`, all against a PATH-shimmed fake `pnpm` so no real build runs:

- **Wait path** — the fake daemon writes a bind timestamp to a sentinel file; the test asserts the hook process exited strictly *after* that bind. This is a happens-before assertion, deliberately not an elapsed-time threshold: a timing bound would be the flake shape this repo keeps rejecting, and it would pass for a hook that merely sleeps.
- **Timeout path** — with a daemon that never binds, the hook must terminate within the bound, exit non-zero, and name the port and log path. A hook that hangs is worse than one that fails, so "does not hang" is the assertion, not "eventually errors".
- **Fast path** — with a healthy authenticated daemon already on the port, the hook exits 0 and never invokes the shim. The pre-existing no-op behavior stays a no-op; the wait applies only to the branch where this process did the spawning.

## Mutation check

Replacing the `waitForAuthenticatedMcp` block with a constant `true` fails exactly the wait-path and timeout-path tests (2 failed / 29 passed). Restoring it returns 31/31. Verified by hand, not only reported by the implementation.

## Production changes, kept minimal

- `READY_TIMEOUT_MS` now comes from `resolveReadyTimeoutMs(env)`, a total resolver defaulting to the named `DEFAULT_READY_TIMEOUT_MS = 30_000`. This exists so the timeout test can run in ~1s instead of blowing the 10s test timeout. It is total by design — a malformed dev env var must never kill a hook — and when the variable is absent the resolved value is byte-identical to today's, so no developer who ignores it sees any change.
- The timeout message gains the clause naming the consequence ("MCP tools will be unavailable for this session"). Port and log path were already there.

Nothing else moves: the probe, the spawn, the identity check, and the fast path are untouched.
