### PR TITLE
fix(tooling): make lint reachable before CI

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
       "!**/dist/**",
       "!**/node_modules/**",
       "!**/.playwright-mcp/**",
-      "!**/.claude/**",
+      "!.claude/**",
       "!packages/mcp-server/dist/**",
       "!packages/mcp-server/coverage/**",
       "!packages/mcp-server/tmp/**",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,3 +27,5 @@ pre-push:
       run: pnpm test --project mcp-node
     noconsole:
       run: pnpm lint:noconsole
+    lint:
+      run: pnpm lint


### PR DESCRIPTION
A lint-only CI failure on the theme-layer PR (an import ordering violation in a file a dev-loop lane wrote) exposed two independent gaps. Neither was a one-off mistake.

## Gap 1 — `pnpm lint` could not run inside a worktree

`biome.json` excluded `"**/.claude/**"`. Worktrees live at `.claude/worktrees/<name>/`, so that pattern matched through the ancestor directory in the absolute path, and every file in every worktree was excluded from traversal.

Measured from inside a worktree, before:

| invocation | result |
|---|---|
| `pnpm lint` (`biome check .`) | `Checked 0 files`, `No files were processed`, exit 1 |
| `biome check <explicit file>` | `Checked 1 file` — worked |

So biome was not broken there; the traversal from `.` was. The consequence is what matters: the repo's own standard lint command was unusable in exactly the place every dev-loop lane works, so a lane could not self-check and reported green.

Anchoring the pattern to the config root fixes it. After: `Checked 1092 files`, exit 0. The main checkout still skips `.claude/worktrees/`, because there that path really is under its own `.claude/` — the file count is unchanged there, so nothing new was pulled in.

## Gap 2 — no hook ran `biome check` at all

Not worktree-specific.

- pre-commit runs `pnpm biome format --write {staged_files}`. Format only. Import organisation is an assist rule rather than formatting, so this hook would not have caught the failure even in the main checkout.
- pre-push ran typecheck + `test --project mcp-node` + `lint:noconsole`, the last being a single scoped rule rather than `biome check`.

`lefthook.yml`'s own comment calls pre-push "the real gate … it mirrors CI", and lint is in CI's `check` job, so its absence read as an inconsistency with the stated intent rather than a deliberate omission. It costs about one second.

## Verified end-to-end, not assumed

A deliberate lint violation was committed and pushed on a scratch branch. The gate ran and rejected the push:

```
✔️ noconsole (0.82s)   ✔️ test-node (18.16s)   ✔️ typecheck (20.32s)
🥊 lint (1.33s)
error: failed to push some refs
```

Worth recording because an intermediate reading was wrong: `lefthook run pre-push` invoked by hand reports every command as `(skip) no matching push files`, which looks like the gate never runs. That is an artifact of there being no push range outside a real push. The probe above is what settles it.

## No new guard

The "0 files processed" failure mode needs none: biome already errors and exits non-zero on it, so pre-push and CI both fail loudly by themselves. Adding a test asserting the config pattern shape would restate what the tool already enforces.
