### PR TITLE
fix(web): make the spatial editor's core interactions survive real pointer input

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -408,12 +408,19 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 30 }),
       )
     await editor.element().dispatchEvent(
-      new MouseEvent('dblclick', {
+      new PointerEvent('pointerdown', {
         bubbles: true,
         clientX: 40,
         clientY: 40,
+        pointerId: 90,
+        button: 0,
       }),
     )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 90 }),
+      )
 
     const textEditor = page.getByTestId('text-node-editor')
     await textEditor.fill('edited')
@@ -447,12 +454,19 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 40 }),
       )
     await editor.element().dispatchEvent(
-      new MouseEvent('dblclick', {
+      new PointerEvent('pointerdown', {
         bubbles: true,
         clientX: 40,
         clientY: 40,
+        pointerId: 90,
+        button: 0,
       }),
     )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 90 }),
+      )
 
     const textEditor = page.getByTestId('text-node-editor')
     await textEditor.fill('edited')
@@ -1073,12 +1087,33 @@ describe('SpatialEditor (browser)', () => {
     const editor = page.getByTestId('spatial-editor')
     // Empty space: far from both node "a" (20,20-120,80) and node "b" (250,20-330,60).
     await editor.element().dispatchEvent(
-      new MouseEvent('dblclick', {
+      new PointerEvent('pointerdown', {
         bubbles: true,
         clientX: 500,
         clientY: 300,
+        pointerId: 91,
+        button: 0,
       }),
     )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 500, clientY: 300, pointerId: 91 }),
+      )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 500,
+        clientY: 300,
+        pointerId: 91,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 500, clientY: 300, pointerId: 91 }),
+      )
 
     const textEditor = page.getByTestId('text-node-editor')
     expect(textEditor.element()).toBeTruthy()
@@ -1235,12 +1270,19 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 62 }),
       )
     await editor.element().dispatchEvent(
-      new MouseEvent('dblclick', {
+      new PointerEvent('pointerdown', {
         bubbles: true,
         clientX: 40,
         clientY: 40,
+        pointerId: 90,
+        button: 0,
       }),
     )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 90 }),
+      )
 
     const textEditor = page.getByTestId('text-node-editor')
     await textEditor.fill('hell')
@@ -1275,16 +1317,41 @@ describe('SpatialEditor (browser)', () => {
     const editor = page.getByTestId('spatial-editor')
 
     // Create node 1 at (100, 100), commit empty text via blur.
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 100,
+        pointerId: 92,
+        button: 0,
+      }),
+    )
     await editor
       .element()
-      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 100, clientY: 100 }))
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 100, clientY: 100, pointerId: 92 }),
+      )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 100,
+        pointerId: 92,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 100, clientY: 100, pointerId: 92 }),
+      )
     let textEditor = page.getByTestId('text-node-editor')
     ;(textEditor.element() as HTMLTextAreaElement).blur()
     let canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
     expect(canvas.nodes).toHaveLength(1)
     // Wait for ControlledEditor's setCanvas to actually flush and re-render
     // SpatialEditor with the updated `canvas` prop (evidenced by the
-    // TextNodeEditor unmounting) — otherwise the next dblclick's handler
+    // TextNodeEditor unmounting) — otherwise the next double-press's handler
     // closure still sees the PRE-create (empty) canvas, and the next create
     // silently overwrites node 1 instead of adding node 2.
     await waitFor(() => {
@@ -1292,9 +1359,34 @@ describe('SpatialEditor (browser)', () => {
     })
 
     // Create node 2 at (400, 100), commit.
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 400,
+        clientY: 100,
+        pointerId: 93,
+        button: 0,
+      }),
+    )
     await editor
       .element()
-      .dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 400, clientY: 100 }))
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 400, clientY: 100, pointerId: 93 }),
+      )
+    await editor.element().dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 400,
+        clientY: 100,
+        pointerId: 93,
+        button: 0,
+      }),
+    )
+    await editor
+      .element()
+      .dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 400, clientY: 100, pointerId: 93 }),
+      )
     textEditor = page.getByTestId('text-node-editor')
     ;(textEditor.element() as HTMLTextAreaElement).blur()
     canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
@@ -1345,6 +1437,12 @@ describe('SpatialEditor (browser)', () => {
     expect(canvas.edges).toHaveLength(1)
     const edgeId = canvas.edges[0]!.id
     expect(canvas.edges[0]).toEqual({ id: edgeId, fromNode: node1Box.id, toNode: node2Box.id })
+
+    // Give the double-press window time to lapse: the press that started
+    // the connect gesture was also on node 1's chrome, and a same-node press
+    // inside DOUBLE_PRESS_WINDOW_MS correctly opens the text editor instead
+    // of selecting. A human pauses here; synthetic dispatch does not.
+    await new Promise((resolve) => setTimeout(resolve, 450))
 
     // Select node 1 again, delete it.
     await editor.element().dispatchEvent(

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -1107,10 +1107,12 @@ describe('SpatialEditor (browser)', () => {
         />
       </div>,
     )
-    const button = page.getByTestId('add-node-button')
-    await button
-      .element()
-      .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    // A REAL pointer sequence (pointerdown -> pointerup -> click), not a
+    // synthetic MouseEvent: the synthetic form skips pointerdown and so
+    // cannot detect the root capturing the pointer and swallowing the
+    // button's click — the bug that made this button do nothing in the
+    // running app while this test stayed green.
+    await userEvent.click(page.getByTestId('add-node-button'))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -117,6 +117,11 @@ export interface SpatialEditorHandle {
 }
 
 const DEFAULT_TEST_ID = 'spatial-editor'
+/**
+ * Window for OUR double-press detection (see handlePointerDown). Matches the
+ * common OS double-click interval; not user-configurable today.
+ */
+const DOUBLE_PRESS_WINDOW_MS = 400
 const ZOOM_WHEEL_FACTOR = 1.1
 /** Canvas-space px per arrow-key nudge on a focused resize handle; Shift multiplies by 4. */
 const RESIZE_KEYBOARD_STEP = 8
@@ -180,6 +185,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const [livePoint, setLivePoint] = useState<Point | null>(null)
     const isPanningRef = useRef(false)
+    /** Last primary press for double-press detection: logical target + time. */
+    const lastPressRef = useRef<{ key: string; at: number } | null>(null)
     const lastPanPointRef = useRef({ x: 0, y: 0 })
     /**
      * The pointerId this component currently holds capture for, or `null`.
@@ -339,15 +346,63 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
-      capturePointer(root, e.pointerId)
+      // Deliberately NO pointer capture here. Capturing on the press
+      // retargets the subsequent clicks to the capturing root, so a control
+      // the press bubbled from never receives its click. Capture is taken
+      // on the first real pointermove instead (see handlePointerMove): a
+      // press that turns into a drag still gets capture before it can
+      // escape the element. Overlay handle/connect gestures are the
+      // exception (beginOverlayGesture) — they want capture immediately.
       const screenPoint = clientPointToRootLocal(e, root)
       const point = screenToCanvas(screenPoint, viewport)
       const hitId = hitTest(boxes, point)
+
+      // Double-press detection is OURS, not the browser's `dblclick`: the
+      // first press selects the node, which re-renders the DOM under the
+      // pointer (selection overlay, gesture state), so the second click can
+      // land on a different element instance and Chromium then never
+      // synthesises a dblclick at all. Detecting two presses on the same
+      // logical target within the OS-conventional window is stable against
+      // re-renders because it compares node ids, not DOM identity.
+      const pressKey = hitId ?? 'empty'
+      const now = e.timeStamp
+      const isDoublePress =
+        lastPressRef.current !== null &&
+        lastPressRef.current.key === pressKey &&
+        now - lastPressRef.current.at <= DOUBLE_PRESS_WINDOW_MS
+      lastPressRef.current = isDoublePress ? null : { key: pressKey, at: now }
+
       if (hitId === undefined) {
+        if (isDoublePress) {
+          // Suppress the press's default focus action: React flushes the
+          // editor mount (with autofocus) synchronously inside this
+          // discrete event, and the browser would otherwise apply
+          // mousedown's default focus AFTER our handler — yanking focus off
+          // the just-mounted textarea, whose blur instantly commits and
+          // closes it again.
+          e.preventDefault()
+          createNodeAt(point)
+          return
+        }
         isPanningRef.current = true
         lastPanPointRef.current = screenPoint
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
         return
+      }
+      if (isDoublePress) {
+        const node = canvas.nodes.find((n) => n.id === hitId)
+        if (node?.type === 'text') {
+          // Same focus-default suppression as the empty-space branch above.
+          e.preventDefault()
+          applyResult(
+            reduceGesture(gestureState, canvas, {
+              type: 'start-text-edit',
+              nodeId: node.id,
+              text: node.text,
+            }),
+          )
+          return
+        }
       }
       applyResult(
         reduceGesture(gestureState, canvas, { type: 'pointerdown', nodeId: hitId, point }),
@@ -357,6 +412,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
+      // First movement of an in-flight gesture: take capture now (see the
+      // handlePointerDown comment for why not at the press). Idempotent —
+      // re-capturing the same pointer is a no-op.
+      if (
+        activePointerIdRef.current === null &&
+        (isPanningRef.current || gestureState.kind !== 'idle')
+      ) {
+        capturePointer(root, e.pointerId)
+      }
       const screenPoint = clientPointToRootLocal(e, root)
       if (isPanningRef.current) {
         const screenDelta = {
@@ -533,34 +597,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       )
     }
 
-    const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-      if (isOverlayEvent(e)) return
-      const root = rootRef.current
-      if (root === null) return
-      const screenPoint = clientPointToRootLocal(e, root)
-      const point = screenToCanvas(screenPoint, viewport)
-      // Hit-test the ACTUAL double-click point rather than trusting whatever
-      // happens to be selected: a text-edit commit does not clear selection
-      // (see gestures.ts's commit-text-edit), so a later double-click
-      // elsewhere on empty space would otherwise reopen the previously
-      // selected node's editor instead of creating a new node.
-      const hitId = hitTest(boxes, point)
-      if (hitId !== undefined) {
-        const node = canvas.nodes.find((n) => n.id === hitId)
-        if (node?.type === 'text') {
-          applyResult(
-            reduceGesture(gestureState, canvas, {
-              type: 'start-text-edit',
-              nodeId: node.id,
-              text: node.text,
-            }),
-          )
-        }
-        return
-      }
-      createNodeAt(point)
-    }
-
     /**
      * The button path (unlike double-click, whose point comes straight from
      * the pointer) always resolves to the same viewport-center point, so
@@ -607,7 +643,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
         onLostPointerCapture={handlePointerCancel}
-        onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}
       >
         {/* Discoverability affordance: every canvas is empty until a node

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -320,8 +320,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return root
     }
 
+    /**
+     * True when the event originated inside an overlay control (the Add
+     * note button, the text editor, a future tool palette) rather than the
+     * canvas surface. The root's gesture handlers must ignore those:
+     * capturing the pointer on such a press retargets the subsequent
+     * `click` to the capturing root, so the control's own onClick never
+     * fires — a press on "Add note" silently did nothing. Overlay controls
+     * opt in via `data-editor-overlay`; a per-control stopPropagation is
+     * exactly the thing someone forgets (this bug), so the guard lives here
+     * where forgetting is impossible.
+     */
+    const isOverlayEvent = (e: React.SyntheticEvent) =>
+      e.target instanceof Element && e.target.closest('[data-editor-overlay]') !== null
+
     const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return
+      if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
       capturePointer(root, e.pointerId)
@@ -519,6 +534,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
       const screenPoint = clientPointToRootLocal(e, root)
@@ -603,6 +619,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           type="button"
           data-testid="add-node-button"
           onClick={createNodeAtViewportCenter}
+          data-editor-overlay
           className="absolute z-10 rounded-md border bg-background px-3 py-1.5 text-sm shadow-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
           style={{ top: 8, left: 8 }}
         >

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -78,6 +78,7 @@ export function TextNodeEditor({
         setValue(e.target.value)
         onChange?.(e.target.value)
       }}
+      data-editor-overlay
       onPointerDown={(e) => e.stopPropagation()}
       onBlur={commit}
       onKeyDown={(e) => {

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -1,0 +1,57 @@
+// Regression: pressing "Add note" with a REAL pointer sequence must create
+// a node. The root gesture handler used to capture the pointer on the
+// button's own pointerdown (it hit-tests as empty canvas space), and an
+// active capture retargets the subsequent `click` to the capturing element —
+// so the button's onClick never fired and the press silently did nothing.
+// A synthetic MouseEvent('click') skips pointerdown entirely and cannot see
+// this, which is why the older test missed it: only a real pointer sequence
+// (userEvent) exercises the capture path.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function Host({ onCommand }: { onCommand: (kind: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>({ nodes: [], edges: [] })
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        canvas={canvas}
+        onChange={(next, command) => {
+          onCommand(command.kind)
+          setCanvas(next)
+        }}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+it('a real pointer click on "Add note" creates a node and opens its editor', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+
+  await userEvent.click(page.getByRole('button', { name: 'Add note' }))
+
+  expect(commands).toEqual(['create-node'])
+  expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
+  expect(container.querySelectorAll('textarea').length).toBe(1)
+})
+
+it('committing the new note untouched keeps a visible empty node, not a blank canvas', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+
+  await userEvent.click(page.getByRole('button', { name: 'Add note' }))
+  // Click empty canvas space without typing — the editor commits the (empty)
+  // pending text and the node must survive as a visible box.
+  await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element)
+
+  expect(commands[0]).toBe('create-node')
+  expect(container.querySelectorAll('textarea').length).toBe(0)
+  expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
+})

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -49,7 +49,12 @@ it('committing the new note untouched keeps a visible empty node, not a blank ca
   await userEvent.click(page.getByRole('button', { name: 'Add note' }))
   // Click empty canvas space without typing — the editor commits the (empty)
   // pending text and the node must survive as a visible box.
-  await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element)
+  await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element, {
+    // A far corner: the new note (and its editor) sit at the viewport
+    // centre, and clicking INSIDE the open textarea correctly keeps the
+    // editor open — the commit only happens when the press lands outside.
+    position: { x: 770, y: 570 },
+  })
 
   expect(commands[0]).toBe('create-node')
   expect(container.querySelectorAll('textarea').length).toBe(0)

--- a/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
@@ -1,0 +1,84 @@
+// Regression: double-click text editing must survive REAL pointer sequences.
+// The first press selects the node and re-renders the DOM under the pointer
+// (selection overlay, gesture state), so the browser can see the two clicks
+// landing on different element instances and never synthesise a `dblclick`
+// at all — double-click-to-edit silently did nothing in the running app
+// while synthetic-event tests stayed green. The editor therefore detects a
+// double press itself, by node id and time window, which is stable against
+// re-renders. These tests drive real pointer input end to end.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'hello world' }],
+  edges: [],
+}
+
+function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        canvas={canvas}
+        onChange={(next, command) => {
+          onCommand?.(command.kind)
+          setCanvas(next)
+        }}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+it('a real double-click on a text node opens its editor with the existing text', async () => {
+  const { container } = render(<Host />)
+  await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 150 } })
+
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  expect(container.querySelector('textarea')?.value).toBe('hello world')
+})
+
+it('a real double-click on an already-selected node still opens the editor', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await userEvent.click(root, { position: { x: 200, y: 150 } })
+  expect(container.querySelectorAll('[data-testid="selection-overlay"]').length).toBe(1)
+
+  await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+})
+
+it('a real double-click on empty space creates exactly one node and opens it', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  await userEvent.dblClick(rootOf(container), { position: { x: 600, y: 450 } })
+
+  expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+})
+
+it('typing into the opened editor and committing persists the text', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = rootOf(container)
+  await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  const textarea = container.querySelector('textarea')
+
+  await userEvent.fill(textarea as HTMLTextAreaElement, 'edited body')
+  // Click far outside the node to blur-commit.
+  await userEvent.click(root, { position: { x: 700, y: 500 } })
+
+  expect(commands).toContain('set-text')
+  expect(container.querySelector('textarea')).toBeNull()
+})

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -385,6 +385,11 @@ export function reduceGesture(
           return reducePointerUpResizing(state, event)
         case 'connecting':
           return reducePointerUpConnecting(state, event, createId)
+        case 'editing-text':
+          // A double-press opens the editor on the SECOND pointerdown; that
+          // press's own pointerup arrives afterwards and must not tear the
+          // editor down again.
+          return stateOnly(state)
         default:
           return idle
       }


### PR DESCRIPTION
Two first-touch interactions silently did nothing in the running app while every synthetic-event test stayed green: pressing **Add note**, and **double-clicking a text node to edit it**. Both are fixed here, with real-pointer browser tests that fail on the old code.

## Add note (commit 1)

The button's press bubbled to the canvas root, which hit-tests the point (the button overlays empty canvas space), captured the pointer, and an active capture retargets the subsequent click to the capturing element — the button's onClick never fired. Verified by instrumentation: zero onChange calls, no textarea, degenerate empty-scene SVG.

Overlay controls now opt in via `data-editor-overlay` and the root's gesture handlers ignore events originating inside one. A guard at the root rather than per-control stopPropagation: a forgotten stopPropagation is exactly this bug — TextNodeEditor had one, the button did not, and the coming tool palette would have needed a third.

## Double-click to edit (commit 2)

Two independent causes, diagnosed by tracing real event sequences:

1. **The browser never synthesised a dblclick.** The first press selects the node, which re-renders the DOM under the pointer, so the second click can land on a different element instance — and dblclick requires both clicks on the same target. The editor now detects a double press itself (same node id within 400ms), stable against re-renders; the native dblclick handler is removed so the two mechanisms cannot both fire.

2. **Opening on the second pointerdown lost a focus fight.** React flushes the editor mount (autofocus included) synchronously inside the discrete event; the browser then applies mousedown's default focus action AFTER the handler, yanking focus off the just-mounted textarea, whose blur instantly committed and closed it. The double-press branches call `preventDefault()` to suppress that default. Mutation-checked: removing the suppression fails all four new tests.

Supporting changes: `pointerup` preserves an `editing-text` state (the second press's own release arrives after the editor opens); pointer capture moves from pointerdown to the first pointermove of an in-flight gesture, so a press that stays a click keeps native click semantics while a drag still captures before escaping.

## Tests

Legacy tests dispatched bare `MouseEvent('dblclick')` — an event no real browser produces in isolation — and one was named "via a real click" while dispatching a synthetic click. All rewritten to real pointer sequences. One test's "click away" turned out to land inside the open textarea; keeping the editor open there is correct behaviour, and the test now clicks genuinely outside.

Full suite: 514 files / 5648 passed, browser 30 files / 187 passed, typecheck 0 errors, lint clean.

## CI note

Failure bursts on this PR (and on main) during 2026-08-06 carry the GitHub Actions "Service Unavailable / Failed to resolve action download info" signature — infrastructure, not code. Checks will be re-run once the outage clears.