### PR TITLE
feat(web): OOUI interaction surfaces for the spatial editor

### DIFF
--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -1,0 +1,83 @@
+/**
+ * Right-click menu — the OOUI object-action surface.
+ *
+ * Per the recorded decision (palette owns creation; objects own their
+ * actions): a node's full action set lives here, reached from the object
+ * itself. Empty canvas space gets its own creation entry, since "here" is
+ * position information the bottom palette cannot express.
+ *
+ * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
+ * presses inside the menu. Item actions fire on CLICK (not pointerdown) for
+ * the same reason as the selection Edit control: an editor opened inside a
+ * discrete pointerdown loses the focus fight with mousedown's default
+ * action, while click fires after those defaults.
+ */
+import { useEffect, useRef } from 'react'
+
+export interface ContextMenuItem {
+  readonly label: string
+  readonly onSelect: () => void
+  /** Visually separates destructive entries (Delete). */
+  readonly danger?: boolean
+}
+
+export interface ContextMenuProps {
+  /** Screen position relative to the editor root. */
+  readonly x: number
+  readonly y: number
+  readonly items: readonly ContextMenuItem[]
+  readonly onClose: () => void
+}
+
+export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  // Focus the menu on open so Escape works without an extra click, and close
+  // on any pointerdown outside — both standard menu dismissal paths.
+  useEffect(() => {
+    menuRef.current?.focus()
+    const onPointerDownAnywhere = (e: PointerEvent) => {
+      if (e.target instanceof Element && e.target.closest('[data-context-menu]') !== null) return
+      onClose()
+    }
+    window.addEventListener('pointerdown', onPointerDownAnywhere, true)
+    return () => window.removeEventListener('pointerdown', onPointerDownAnywhere, true)
+  }, [onClose])
+
+  return (
+    <div
+      ref={menuRef}
+      data-editor-overlay
+      data-context-menu
+      data-testid="context-menu"
+      role="menu"
+      aria-label="Canvas actions"
+      tabIndex={-1}
+      className="absolute z-20 min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none"
+      style={{ left: x, top: y }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          onClose()
+        }
+      }}
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          role="menuitem"
+          className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
+            item.danger ? 'text-red-600' : ''
+          }`}
+          onClick={() => {
+            onClose()
+            item.onSelect()
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
+++ b/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
@@ -47,7 +47,6 @@ export function DragPreviewLayer({ preview, zoom, contentSvg }: DragPreviewLayer
         // Same trusted producer as the committed scene: canvas-render's
         // serializer is the sole source of this string (see CanvasViewer's
         // documented reasoning for dangerouslySetInnerHTML).
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: string comes exclusively from renderSceneToSvg's escaping serializer
         dangerouslySetInnerHTML={{ __html: contentSvg.svg }}
       />
     )

--- a/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
+++ b/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
@@ -10,11 +10,48 @@ export interface DragPreviewLayerProps {
   readonly preview: DragPreview
   /** Current viewport zoom, so stroke width/dash stay a constant on-screen size. */
   readonly zoom: number
+  /**
+   * The dragged node's own content, rendered ONCE at drag start (a
+   * single-node renderCanvasToSvg is ~0.4ms; per-frame motion is a pure
+   * CSS transform of this fragment). When present the box preview shows
+   * the real node travelling with the pointer instead of a dashed
+   * outline — the outline remains as the fallback and for resize.
+   */
+  readonly contentSvg?: { readonly svg: string; readonly originX: number; readonly originY: number }
 }
 
-export function DragPreviewLayer({ preview, zoom }: DragPreviewLayerProps) {
+export function DragPreviewLayer({ preview, zoom, contentSvg }: DragPreviewLayerProps) {
   const strokeWidth = 2 / zoom
   const dashArray = `${6 / zoom} ${4 / zoom}`
+  if (preview.kind === 'box' && contentSvg !== undefined) {
+    return (
+      <div
+        data-testid="drag-preview"
+        aria-hidden="true"
+        // The preview's canvas-space box, exposed for tests: the visual
+        // motion is a transform of a pre-rendered fragment, so the box is
+        // otherwise not recoverable from the DOM.
+        data-box-x={preview.box.x}
+        data-box-y={preview.box.y}
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          pointerEvents: 'none',
+          // The fragment was rendered with the node at its ORIGINAL x/y, so
+          // the travel is expressed as a pure translate by the drag delta —
+          // the only per-frame cost.
+          transform: `translate(${preview.box.x - contentSvg.originX}px, ${preview.box.y - contentSvg.originY}px)`,
+          opacity: 0.85,
+        }}
+        // Same trusted producer as the committed scene: canvas-render's
+        // serializer is the sole source of this string (see CanvasViewer's
+        // documented reasoning for dangerouslySetInnerHTML).
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: string comes exclusively from renderSceneToSvg's escaping serializer
+        dangerouslySetInnerHTML={{ __html: contentSvg.svg }}
+      />
+    )
+  }
   return (
     <svg
       data-testid="drag-preview"

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -117,6 +117,9 @@ export function SelectionOverlay({
           }}
           onKeyDown={(e) => {
             if (onHandleKeyDown === undefined || !ARROW_KEYS.has(e.key)) return
+            // Fully handled here — without this the root's own arrow handler
+            // would ALSO nudge the node, double-applying every keypress.
+            e.stopPropagation()
             onHandleKeyDown(handle.kind, handle.box, e)
           }}
         />

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -15,6 +15,16 @@ export interface SelectionOverlayProps {
   readonly onHandleKeyDown?: (handle: ResizeHandleKind, box: Box, e: React.KeyboardEvent) => void
   /** Enter/Space on the focused connect handle — the keyboard equivalent of a pointer connect-drag. */
   readonly onConnectKeyDown?: (e: React.KeyboardEvent) => void
+  /**
+   * Opens the selected node's text editor. Rendered only when provided
+   * (non-text nodes have no text to edit). Fired on CLICK, not pointerdown:
+   * the editor mount (autofocus included) flushes synchronously inside a
+   * discrete event, and mousedown's default focus action would then blur
+   * the just-mounted textarea and instantly close it — the same fight the
+   * double-press path suppresses with preventDefault. Click fires after
+   * those defaults, so it needs no suppression at all.
+   */
+  readonly onEditRequest?: () => void
 }
 
 const SELECTION_STROKE = '#2563eb'
@@ -37,6 +47,7 @@ export function SelectionOverlay({
   onConnectPointerDown,
   onHandleKeyDown,
   onConnectKeyDown,
+  onEditRequest,
 }: SelectionOverlayProps) {
   const handles = resizeHandleBoxes(box, zoom)
   const connectHandleSize = 10 / zoom
@@ -112,6 +123,46 @@ export function SelectionOverlay({
           onConnectKeyDown(e)
         }}
       />
+      {onEditRequest !== undefined && (
+        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+        <g
+          data-testid="edit-handle"
+          role="button"
+          tabIndex={0}
+          aria-label="Edit text"
+          style={{ pointerEvents: 'auto', cursor: 'pointer' }}
+          onPointerDown={(e) => {
+            // Keep the press away from the root's node/empty hit-test; the
+            // action itself fires on click (see onEditRequest's doc).
+            e.stopPropagation()
+          }}
+          onClick={() => onEditRequest()}
+          onKeyDown={(e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return
+            e.preventDefault()
+            onEditRequest()
+          }}
+        >
+          <rect
+            x={box.x + box.width - 22 / zoom}
+            y={box.y - 26 / zoom}
+            width={22 / zoom}
+            height={20 / zoom}
+            rx={4 / zoom}
+            fill={SELECTION_STROKE}
+          />
+          <text
+            x={box.x + box.width - 11 / zoom}
+            y={box.y - 12 / zoom}
+            textAnchor="middle"
+            fontSize={12 / zoom}
+            fill="#ffffff"
+            style={{ userSelect: 'none' }}
+          >
+            ✎
+          </text>
+        </g>
+      )}
     </svg>
   )
 }

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -40,6 +40,25 @@ const HANDLE_LABEL: Record<ResizeHandleKind, string> = {
 }
 const ARROW_KEYS = new Set(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'])
 
+/**
+ * One connect handle per side. Every handle starts the SAME connecting
+ * gesture — the committed edge's path is routed from geometry at layout
+ * time, so the chosen side is ergonomic freedom, not persisted data. The
+ * right handle keeps the historical un-suffixed testid.
+ */
+type SideSpec = {
+  readonly kind: 'n' | 'e' | 's' | 'w'
+  readonly label: string
+  readonly cx: (box: Box, size: number) => number
+  readonly cy: (box: Box, size: number) => number
+}
+const CONNECT_SIDES: readonly SideSpec[] = [
+  { kind: 'n', label: 'top', cx: (b) => b.x + b.width / 2, cy: (b, s) => b.y - s },
+  { kind: 'e', label: 'right', cx: (b, s) => b.x + b.width + s, cy: (b) => b.y + b.height / 2 },
+  { kind: 's', label: 'bottom', cx: (b) => b.x + b.width / 2, cy: (b, s) => b.y + b.height + s },
+  { kind: 'w', label: 'left', cx: (b, s) => b.x - s, cy: (b) => b.y + b.height / 2 },
+]
+
 export function SelectionOverlay({
   box,
   zoom,
@@ -102,27 +121,30 @@ export function SelectionOverlay({
           }}
         />
       ))}
-      {/* biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand. */}
-      <circle
-        data-testid="connect-handle"
-        role="button"
-        tabIndex={0}
-        aria-label="Connect to another node"
-        cx={box.x + box.width + connectHandleSize}
-        cy={box.y + box.height / 2}
-        r={connectHandleSize / 2}
-        fill={SELECTION_STROKE}
-        style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
-        onPointerDown={(e) => {
-          if (e.button !== 0) return
-          e.stopPropagation()
-          onConnectPointerDown(e)
-        }}
-        onKeyDown={(e) => {
-          if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
-          onConnectKeyDown(e)
-        }}
-      />
+      {CONNECT_SIDES.map((side) => (
+        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+        <circle
+          key={side.kind}
+          data-testid={side.kind === 'e' ? 'connect-handle' : `connect-handle-${side.kind}`}
+          role="button"
+          tabIndex={0}
+          aria-label={`Connect to another node (from the ${side.label} side)`}
+          cx={side.cx(box, connectHandleSize)}
+          cy={side.cy(box, connectHandleSize)}
+          r={connectHandleSize / 2}
+          fill={SELECTION_STROKE}
+          style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
+          onPointerDown={(e) => {
+            if (e.button !== 0) return
+            e.stopPropagation()
+            onConnectPointerDown(e)
+          }}
+          onKeyDown={(e) => {
+            if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
+            onConnectKeyDown(e)
+          }}
+        />
+      ))}
       {onEditRequest !== undefined && (
         // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
         <g

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -501,7 +501,7 @@ describe('SpatialEditor (browser)', () => {
     )
     const editor = page.getByTestId('spatial-editor')
     const transformed = container.querySelector<HTMLDivElement>(
-      '[data-testid="spatial-editor"] > div',
+      '[data-testid="viewport-transform"]',
     )
     expect(transformed).not.toBeNull()
     expect(transformed?.style.transform).toBe('scale(1) translate(0px, 0px)')
@@ -579,7 +579,7 @@ describe('SpatialEditor (browser)', () => {
     )
     const editor = page.getByTestId('spatial-editor')
     const transformed = container.querySelector<HTMLDivElement>(
-      '[data-testid="spatial-editor"] > div',
+      '[data-testid="viewport-transform"]',
     )
     expect(transformed).not.toBeNull()
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -675,14 +675,13 @@ describe('SpatialEditor (browser)', () => {
       // `dispatchEvent` returns (continuous-priority updates), unlike the
       // discrete pointerup commit other tests in this file assert on.
       await waitFor(() => {
-        const rect = page.getByTestId('drag-preview').element().querySelector('rect')
-        expect(rect).toBeTruthy()
-        expect(Number(rect?.getAttribute('x'))).toBe(expectedX)
-        expect(Number(rect?.getAttribute('y'))).toBe(expectedY)
+        const el = page.getByTestId('drag-preview').element()
+        expect(Number(el.getAttribute('data-box-x'))).toBe(expectedX)
+        expect(Number(el.getAttribute('data-box-y'))).toBe(expectedY)
       })
-      const rect = page.getByTestId('drag-preview').element().querySelector('rect')
-      const x = Number(rect?.getAttribute('x'))
-      const y = Number(rect?.getAttribute('y'))
+      const el = page.getByTestId('drag-preview').element()
+      const x = Number(el.getAttribute('data-box-x'))
+      const y = Number(el.getAttribute('data-box-y'))
       if (previousRectX !== undefined && previousRectY !== undefined) {
         // Identity-viewport, so canvas-space offset equals screen-space offset.
         expect(x - previousRectX).toBe(delta.x - deltas[deltas.indexOf(delta) - 1]!.x)
@@ -896,8 +895,21 @@ describe('SpatialEditor (browser)', () => {
       )
     }
     // No layout/measure work happened: `canvas` never changed mid-gesture, so
-    // the `useMemo` keyed on it never re-ran renderCanvasToSvg.
-    expect(measure).not.toHaveBeenCalled()
+    // the `useMemo` keyed on it never re-ran renderCanvasToSvg. The ONE
+    // allowed cost is the single-node drag-start render feeding the content
+    // preview; the invariant is that further moves add ZERO calls.
+    const afterFirstMove = measure.mock.calls.length
+    for (const dx of [12, 24, 36]) {
+      await editor.element().dispatchEvent(
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          clientX: 40 + dx,
+          clientY: 40,
+          pointerId: 204,
+        }),
+      )
+    }
+    expect(measure.mock.calls.length).toBe(afterFirstMove)
     // The committed shape rect for node "a" is exactly where it started —
     // only the overlay preview tracked the pointer, not the real scene.
     const committedRectAfter = container.querySelector('svg:not([data-testid="drag-preview"]) rect')
@@ -944,8 +956,10 @@ describe('SpatialEditor (browser)', () => {
         button: 0,
       }),
     )
-    const rectAt = () =>
-      page.getByTestId('drag-preview').element().querySelector('rect') as SVGRectElement
+    const boxAt = () => {
+      const el = page.getByTestId('drag-preview').element()
+      return { x: Number(el.getAttribute('data-box-x')), y: Number(el.getAttribute('data-box-y')) }
+    }
     await editor.element().dispatchEvent(
       new PointerEvent('pointermove', {
         bubbles: true,
@@ -954,8 +968,8 @@ describe('SpatialEditor (browser)', () => {
         pointerId: 206,
       }),
     )
-    await waitFor(() => expect(rectAt()).toBeTruthy())
-    const first = { x: Number(rectAt().getAttribute('x')), y: Number(rectAt().getAttribute('y')) }
+    await waitFor(() => expect(Number.isFinite(boxAt().x)).toBe(true))
+    const first = boxAt()
     await editor.element().dispatchEvent(
       new PointerEvent('pointermove', {
         bubbles: true,
@@ -965,10 +979,9 @@ describe('SpatialEditor (browser)', () => {
       }),
     )
     await waitFor(() => {
-      const rect = rectAt()
-      expect(Number(rect.getAttribute('x')) - first.x).toBeCloseTo(20, 5)
+      expect(boxAt().x - first.x).toBeCloseTo(20, 5)
     })
-    const second = { x: Number(rectAt().getAttribute('x')), y: Number(rectAt().getAttribute('y')) }
+    const second = boxAt()
     // Screen-space delta (40, 20) at zoom 2 is canvas-space delta (20, 10) —
     // the preview must move by the CANVAS-space amount, not the raw
     // screen-space pointer delta, since it draws inside the zoomed content.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -884,7 +884,13 @@ describe('SpatialEditor (browser)', () => {
         button: 0,
       }),
     )
+    // A real drag delivers each move on its own frame; back-to-back
+    // dispatches in one tick all see the pre-down handler closure, so
+    // livePoint never updates and no live-drag frame ever happens — the
+    // exact blind spot that let a per-frame-render mutation pass unseen.
+    await new Promise((resolve) => requestAnimationFrame(resolve))
     for (const delta of [10, 20, 30, 40, 50]) {
+      await new Promise((resolve) => requestAnimationFrame(resolve))
       await editor.element().dispatchEvent(
         new PointerEvent('pointermove', {
           bubbles: true,
@@ -900,6 +906,7 @@ describe('SpatialEditor (browser)', () => {
     // preview; the invariant is that further moves add ZERO calls.
     const afterFirstMove = measure.mock.calls.length
     for (const dx of [12, 24, 36]) {
+      await new Promise((resolve) => requestAnimationFrame(resolve))
       await editor.element().dispatchEvent(
         new PointerEvent('pointermove', {
           bubbles: true,
@@ -909,6 +916,11 @@ describe('SpatialEditor (browser)', () => {
         }),
       )
     }
+    // Continuous-priority updates flush asynchronously — without this wait
+    // the assertion runs before React processes the moves, and a per-frame
+    // re-render mutation slips through unseen (observed; this line is what
+    // gives the guard teeth).
+    await new Promise((resolve) => requestAnimationFrame(resolve))
     expect(measure.mock.calls.length).toBe(afterFirstMove)
     // The committed shape rect for node "a" is exactly where it started —
     // only the overlay preview tracked the pointer, not the real scene.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -25,7 +25,7 @@ function twoNodeCanvas(): SpatialCanvas {
 }
 
 function transformOf(container: HTMLElement) {
-  return container.querySelector<HTMLDivElement>('[data-testid="spatial-editor"] > div')?.style
+  return container.querySelector<HTMLDivElement>('[data-testid="viewport-transform"]')?.style
     .transform
 }
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -247,6 +247,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     )
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
+    /**
+     * The dragged node's own content, rendered ONCE per drag (the reducer's
+     * pointermove passthrough returns the same state reference, so this memo
+     * holds for the whole gesture; a single-node render costs ~0.4ms).
+     * Per-frame motion is then a pure CSS transform in DragPreviewLayer —
+     * the full-canvas render stays untouched during the drag.
+     */
+    const dragContentSvg = useMemo(() => {
+      if (gestureState.kind !== 'moving') return undefined
+      const node = canvas.nodes.find((n) => n.id === gestureState.nodeId)
+      if (node === undefined) return undefined
+      const rendered = renderCanvasToSvg(
+        { nodes: [node], edges: [] },
+        { measure: resolvedMeasure, theme },
+      )
+      return {
+        svg: rendered.svg,
+        originX: gestureState.startX - rendered.bounds.x,
+        originY: gestureState.startY - rendered.bounds.y,
+      }
+    }, [gestureState, canvas, resolvedMeasure, theme])
+
     useImperativeHandle(
       forwardedRef,
       () => ({
@@ -735,7 +757,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             layout+stringify+innerHTML path runs once per gesture (at
             pointerup) instead of once per frame. */}
           {dragPreview !== undefined && (
-            <DragPreviewLayer preview={dragPreview} zoom={viewport.zoom} />
+            <DragPreviewLayer
+              preview={dragPreview}
+              zoom={viewport.zoom}
+              contentSvg={dragContentSvg}
+            />
           )}
           {gestureState.kind === 'connecting' && (
             <svg

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -209,6 +209,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * used to blur the just-mounted textarea when we opened at the press.
      */
     const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
+    /** In-flight marquee selection rect, in canvas space (Excalidraw
+     * semantics: plain drag on empty space selects; pan is Space+drag,
+     * middle-button drag, or wheel). */
+    const [marquee, setMarquee] = useState<{ start: Point; current: Point } | null>(null)
+    const spaceDownRef = useRef(false)
     const isPanningRef = useRef(false)
     /** Last primary press for double-press detection: logical target + time. */
     const lastPressRef = useRef<{ key: string; at: number } | null>(null)
@@ -394,10 +399,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       e.target instanceof Element && e.target.closest('[data-editor-overlay]') !== null
 
     const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (e.button !== 0) return
       if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
+      const screenPointForPan = clientPointToRootLocal(e, root)
+      // Middle-button (or Space-held) drag pans from ANYWHERE — Excalidraw
+      // semantics; a plain left drag on empty space marquee-selects instead.
+      if (e.button === 1 || (e.button === 0 && spaceDownRef.current)) {
+        e.preventDefault()
+        isPanningRef.current = true
+        lastPanPointRef.current = screenPointForPan
+        return
+      }
+      if (e.button !== 0) return
       // Deliberately NO pointer capture here. Capturing on the press
       // retargets the subsequent clicks to the capturing root, so a control
       // the press bubbled from never receives its click. Capture is taken
@@ -443,8 +457,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       doublePressRef.current = isDoublePress ? { key: pressKey, point } : null
 
       if (hitId === undefined) {
-        isPanningRef.current = true
-        lastPanPointRef.current = screenPoint
+        setMarquee({ start: point, current: point })
         setExtraIds(new Set())
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
         return
@@ -485,6 +498,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         capturePointer(root, e.pointerId)
       }
       const screenPoint = clientPointToRootLocal(e, root)
+      if (marquee !== null) {
+        setMarquee({ start: marquee.start, current: screenToCanvas(screenPoint, viewport) })
+        return
+      }
       if (isPanningRef.current) {
         const screenDelta = {
           x: screenPoint.x - lastPanPointRef.current.x,
@@ -505,17 +522,39 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       activePointerIdRef.current = null
       const armed = doublePressRef.current
       doublePressRef.current = null
+      if (marquee !== null) {
+        setMarquee(null)
+        const zeroMove =
+          marquee.start.x === marquee.current.x && marquee.start.y === marquee.current.y
+        if (zeroMove) {
+          // A stationary empty press: a plain one just cleared selection at
+          // the press; a DOUBLE one creates a node here (resolved at the
+          // release, consistent with the node-edit double-press rule).
+          if (armed !== null && armed.key === 'empty') createNodeAt(armed.point)
+          return
+        }
+        const rect = {
+          x: Math.min(marquee.start.x, marquee.current.x),
+          y: Math.min(marquee.start.y, marquee.current.y),
+          w: Math.abs(marquee.current.x - marquee.start.x),
+          h: Math.abs(marquee.current.y - marquee.start.y),
+        }
+        const hitIds = boxes
+          .filter(
+            (entry) =>
+              entry.box.x < rect.x + rect.w &&
+              entry.box.x + entry.box.width > rect.x &&
+              entry.box.y < rect.y + rect.h &&
+              entry.box.y + entry.box.height > rect.y,
+          )
+          .map((entry) => entry.id)
+        const [primary, ...rest] = hitIds
+        setSelectedId(primary ?? null)
+        setExtraIds(new Set(rest))
+        return
+      }
       if (isPanningRef.current) {
         isPanningRef.current = false
-        // A double press on empty space that never panned creates a node
-        // at the pressed point (double-click-to-create).
-        if (armed !== null && armed.key === 'empty' && root !== null) {
-          const screenPoint = clientPointToRootLocal(e, root)
-          const point = screenToCanvas(screenPoint, viewport)
-          if (point.x === armed.point.x && point.y === armed.point.y) {
-            createNodeAt(armed.point)
-          }
-        }
         return
       }
       if (root === null) return
@@ -592,6 +631,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // Shift multiplies the step. A focused resize handle handles arrows
       // itself and stops propagation there, so an arrow reaching THIS
       // handler is never a resize.
+      if (e.key === ' ' && gestureState.kind === 'idle') {
+        // Held Space turns the next left-drag into a pan (Excalidraw
+        // semantics). preventDefault stops the page scrolling on Space.
+        e.preventDefault()
+        spaceDownRef.current = true
+        return
+      }
       const nudge = ARROW_KEY_DELTA[e.key]
       if (
         nudge !== undefined &&
@@ -797,6 +843,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }}
         onPointerDown={handlePointerDown}
         onContextMenu={handleContextMenu}
+        onKeyUp={(e) => {
+          if (e.key === ' ') spaceDownRef.current = false
+        }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
@@ -882,6 +931,31 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             // already-reviewed reasoning as CanvasViewer.tsx's identical sink.
             dangerouslySetInnerHTML={{ __html: svg }}
           />
+          {marquee !== null && (
+            <svg
+              data-testid="marquee-rect"
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                overflow: 'visible',
+                left: 0,
+                top: 0,
+                pointerEvents: 'none',
+              }}
+            >
+              <rect
+                x={Math.min(marquee.start.x, marquee.current.x)}
+                y={Math.min(marquee.start.y, marquee.current.y)}
+                width={Math.abs(marquee.current.x - marquee.start.x)}
+                height={Math.abs(marquee.current.y - marquee.start.y)}
+                fill="#2563eb"
+                fillOpacity={0.08}
+                stroke="#2563eb"
+                strokeWidth={1 / viewport.zoom}
+                strokeDasharray={`${4 / viewport.zoom} ${3 / viewport.zoom}`}
+              />
+            </svg>
+          )}
           {extraIds.size > 0 && (
             <svg
               data-testid="extra-selection-outlines"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -51,6 +51,7 @@ import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from 
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
+import { ToolPalette } from './ToolPalette.js'
 import {
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
@@ -645,22 +646,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         onLostPointerCapture={handlePointerCancel}
         onKeyDown={handleKeyDown}
       >
-        {/* Discoverability affordance: every canvas is empty until a node
-          exists, and double-click-empty-space has no visible cue at all —
-          this real, keyboard-reachable button is the one always-visible way
-          in. Positioned outside the pan/zoom transform so it stays fixed on
-          screen regardless of viewport. */}
-        <button
-          type="button"
-          data-testid="add-node-button"
-          onClick={createNodeAtViewportCenter}
-          data-editor-overlay
-          className="absolute z-10 rounded-md border bg-background px-3 py-1.5 text-sm shadow-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-          style={{ top: 8, left: 8 }}
-        >
-          Add note
-        </button>
+        {/* The OOUI creation surface: every canvas is empty until a node
+          exists and double-click-empty-space has no visible cue, so the
+          palette is the always-visible, keyboard-reachable way in. Fixed to
+          the bottom edge outside the pan/zoom transform. */}
+        <ToolPalette onCreateNode={createNodeAtViewportCenter} />
         <div
+          data-testid="viewport-transform"
           style={{
             position: 'absolute',
             left: 0,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -193,6 +193,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       nodeId: string | undefined
       point: Point
     } | null>(null)
+    /**
+     * Additional selected node ids beyond the reducer's single primary
+     * selection. Multi-select lives at the component layer on purpose: the
+     * gesture reducer keeps its single-node contract, and group operations
+     * expand into per-member commands at commit time (see the pointerup and
+     * delete paths). Cleared whenever the primary selection clears.
+     */
+    const [extraIds, setExtraIds] = useState<ReadonlySet<string>>(new Set())
+    /**
+     * Armed by a second same-target press inside the double-press window;
+     * RESOLVED at pointerup: zero movement opens the editor (node) or
+     * creates (empty), any movement means it was a drag all along. Firing
+     * at the release also sidesteps mousedown's default focus action, which
+     * used to blur the just-mounted textarea when we opened at the press.
+     */
+    const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
     const isPanningRef = useRef(false)
     /** Last primary press for double-press detection: logical target + time. */
     const lastPressRef = useRef<{ key: string; at: number } | null>(null)
@@ -400,6 +416,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // synthesises a dblclick at all. Detecting two presses on the same
       // logical target within the OS-conventional window is stable against
       // re-renders because it compares node ids, not DOM identity.
+      // Shift-click builds a multi-selection instead of starting a gesture.
+      if (e.shiftKey && hitId !== undefined) {
+        if (selectedId === null) {
+          setSelectedId(hitId)
+        } else if (hitId === selectedId) {
+          // Deselecting the primary promotes an extra, if any.
+          const [next, ...rest] = [...extraIds]
+          setSelectedId(next ?? null)
+          setExtraIds(new Set(rest))
+        } else {
+          const next = new Set(extraIds)
+          if (next.has(hitId)) next.delete(hitId)
+          else next.add(hitId)
+          setExtraIds(next)
+        }
+        return
+      }
       const pressKey = hitId ?? 'empty'
       const now = e.timeStamp
       const isDoublePress =
@@ -407,38 +440,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         lastPressRef.current.key === pressKey &&
         now - lastPressRef.current.at <= DOUBLE_PRESS_WINDOW_MS
       lastPressRef.current = isDoublePress ? null : { key: pressKey, at: now }
+      doublePressRef.current = isDoublePress ? { key: pressKey, point } : null
 
       if (hitId === undefined) {
-        if (isDoublePress) {
-          // Suppress the press's default focus action: React flushes the
-          // editor mount (with autofocus) synchronously inside this
-          // discrete event, and the browser would otherwise apply
-          // mousedown's default focus AFTER our handler — yanking focus off
-          // the just-mounted textarea, whose blur instantly commits and
-          // closes it again.
-          e.preventDefault()
-          createNodeAt(point)
-          return
-        }
         isPanningRef.current = true
         lastPanPointRef.current = screenPoint
+        setExtraIds(new Set())
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
         return
       }
-      if (isDoublePress) {
-        const node = canvas.nodes.find((n) => n.id === hitId)
-        if (node?.type === 'text') {
-          // Same focus-default suppression as the empty-space branch above.
-          e.preventDefault()
-          applyResult(
-            reduceGesture(gestureState, canvas, {
-              type: 'start-text-edit',
-              nodeId: node.id,
-              text: node.text,
-            }),
-          )
-          return
-        }
+      // A plain press on a NON-member collapses the multi-selection; a press
+      // on a member keeps it (that press starts a group move).
+      if (hitId !== undefined && hitId !== selectedId && !extraIds.has(hitId)) {
+        setExtraIds(new Set())
       }
       applyResult(
         reduceGesture(gestureState, canvas, { type: 'pointerdown', nodeId: hitId, point }),
@@ -489,22 +503,69 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       activePointerIdRef.current = null
+      const armed = doublePressRef.current
+      doublePressRef.current = null
       if (isPanningRef.current) {
         isPanningRef.current = false
+        // A double press on empty space that never panned creates a node
+        // at the pressed point (double-click-to-create).
+        if (armed !== null && armed.key === 'empty' && root !== null) {
+          const screenPoint = clientPointToRootLocal(e, root)
+          const point = screenToCanvas(screenPoint, viewport)
+          if (point.x === armed.point.x && point.y === armed.point.y) {
+            createNodeAt(armed.point)
+          }
+        }
         return
       }
       if (root === null) return
       const screenPoint = clientPointToRootLocal(e, root)
       const point = screenToCanvas(screenPoint, viewport)
       const targetNodeId = gestureState.kind === 'connecting' ? hitTest(boxes, point) : undefined
-      applyResult(
-        reduceGesture(
-          gestureState,
-          canvas,
-          { type: 'pointerup', point, targetNodeId },
-          { createId },
-        ),
+      const result = reduceGesture(
+        gestureState,
+        canvas,
+        { type: 'pointerup', point, targetNodeId },
+        { createId },
       )
+      // A move commit on a multi-selection member applies the SAME delta to
+      // every other member — expanded here at commit time so the reducer
+      // keeps its single-node contract.
+      // A double press on a node that never moved is double-click-to-edit.
+      if (
+        armed !== null &&
+        gestureState.kind === 'moving' &&
+        armed.key === gestureState.nodeId &&
+        result.commands.length === 0
+      ) {
+        const node = canvasRef.current.nodes.find((n) => n.id === gestureState.nodeId)
+        if (node?.type === 'text') {
+          applyResult(
+            reduceGesture(result.state, canvas, {
+              type: 'start-text-edit',
+              nodeId: node.id,
+              text: node.text,
+            }),
+          )
+          return
+        }
+      }
+      const moved = result.commands.find((c) => c.kind === 'move-node')
+      if (moved !== undefined && extraIds.size > 0 && gestureState.kind === 'moving') {
+        const dx = moved.x - gestureState.startX
+        const dy = moved.y - gestureState.startY
+        const extras = [...extraIds]
+          .filter((id) => id !== moved.id)
+          .flatMap((id) => {
+            const node = canvasRef.current.nodes.find((n) => n.id === id)
+            return node === undefined
+              ? []
+              : [{ kind: 'move-node' as const, id, x: node.x + dx, y: node.y + dy }]
+          })
+        applyResult({ ...result, commands: [...result.commands, ...extras] })
+        return
+      }
+      applyResult(result)
     }
 
     const handlePointerCancel = () => {
@@ -556,6 +617,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             },
           ],
         })
+        return
+      }
+      if (
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        selection !== undefined &&
+        extraIds.size > 0 &&
+        gestureState.kind !== 'editing-text'
+      ) {
+        e.preventDefault()
+        const ids = [selection.id, ...extraIds]
+        applyResult({
+          state: { kind: 'idle' },
+          commands: ids.map((id) => ({ kind: 'delete-node' as const, id })),
+          selectedId: null,
+        })
+        setExtraIds(new Set())
         return
       }
       if ((e.key === 'Delete' || e.key === 'Backspace') && selection !== undefined) {
@@ -805,6 +882,38 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             // already-reviewed reasoning as CanvasViewer.tsx's identical sink.
             dangerouslySetInnerHTML={{ __html: svg }}
           />
+          {extraIds.size > 0 && (
+            <svg
+              data-testid="extra-selection-outlines"
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                overflow: 'visible',
+                left: 0,
+                top: 0,
+                pointerEvents: 'none',
+              }}
+            >
+              {[...extraIds].flatMap((id) => {
+                const b = boxes.find((entry) => entry.id === id)
+                return b === undefined ? (
+                  []
+                ) : (
+                  <rect
+                    key={id}
+                    x={b.box.x}
+                    y={b.box.y}
+                    width={b.box.width}
+                    height={b.box.height}
+                    fill="none"
+                    stroke="#2563eb"
+                    strokeWidth={1.5 / viewport.zoom}
+                    opacity={0.7}
+                  />
+                )
+              })}
+            </svg>
+          )}
           {selection !== undefined && (
             <SelectionOverlay
               box={selection.box}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -335,6 +335,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         running = applyCommand(running, command)
         onChange(running, command)
       }
+      // Written back HERE, not only from the canvas prop at re-render: two
+      // commits landing in one tick (key auto-repeat, batched events) would
+      // otherwise both compute from the pre-commit ref and the second would
+      // clobber the first.
+      canvasRef.current = running
     }
 
     /**
@@ -522,6 +527,37 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // while typing would delete the node instead of a character. The
       // reducer's own editing-text guard is the second, machine-checkable
       // layer of that same policy (see gestures.ts's delete-selection arm).
+      // Arrow keys nudge the SELECTED node (standard canvas-tool parity);
+      // Shift multiplies the step. A focused resize handle handles arrows
+      // itself and stops propagation there, so an arrow reaching THIS
+      // handler is never a resize.
+      const nudge = ARROW_KEY_DELTA[e.key]
+      if (
+        nudge !== undefined &&
+        selection !== undefined &&
+        selectedNode !== undefined &&
+        gestureState.kind === 'idle'
+      ) {
+        e.preventDefault()
+        const step = e.shiftKey ? RESIZE_KEYBOARD_STEP_LARGE : RESIZE_KEYBOARD_STEP
+        // Read the node's position from canvasRef, not the render closure:
+        // key auto-repeat delivers keydowns faster than commits re-render,
+        // and a stale base makes each repeat clobber the previous nudge.
+        const current = canvasRef.current.nodes.find((n) => n.id === selectedNode.id)
+        if (current === undefined) return
+        applyResult({
+          state: gestureState,
+          commands: [
+            {
+              kind: 'move-node',
+              id: current.id,
+              x: current.x + nudge.dx * step,
+              y: current.y + nudge.dy * step,
+            },
+          ],
+        })
+        return
+      }
       if ((e.key === 'Delete' || e.key === 'Backspace') && selection !== undefined) {
         const target = e.target as HTMLElement | null
         const tag = target?.tagName

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -39,6 +39,7 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { ContextMenu } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
@@ -185,6 +186,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * ~30ms on an 80-node canvas — far past a frame budget).
      */
     const [livePoint, setLivePoint] = useState<Point | null>(null)
+    /** Open right-click menu: screen position (root-relative) + hit target. */
+    const [contextMenu, setContextMenu] = useState<{
+      x: number
+      y: number
+      nodeId: string | undefined
+      point: Point
+    } | null>(null)
     const isPanningRef = useRef(false)
     /** Last primary press for double-press detection: logical target + time. */
     const lastPressRef = useRef<{ key: string; at: number } | null>(null)
@@ -432,6 +440,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       )
     }
 
+    const handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isOverlayEvent(e)) return
+      // Replace the browser menu with the object's own action menu.
+      e.preventDefault()
+      const root = rootRef.current
+      if (root === null) return
+      const screenPoint = clientPointToRootLocal(e, root)
+      const point = screenToCanvas(screenPoint, viewport)
+      const hitId = hitTest(boxes, point)
+      if (hitId !== undefined) setSelectedId(hitId)
+      setContextMenu({ x: screenPoint.x, y: screenPoint.y, nodeId: hitId, point })
+    }
+
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
@@ -662,6 +683,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           touchAction: 'none',
         }}
         onPointerDown={handlePointerDown}
+        onContextMenu={handleContextMenu}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
@@ -673,6 +695,50 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
         <ToolPalette onCreateNode={createNodeAtViewportCenter} />
+        {contextMenu !== null && (
+          <ContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            onClose={() => setContextMenu(null)}
+            items={(() => {
+              const node =
+                contextMenu.nodeId === undefined
+                  ? undefined
+                  : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
+              if (node === undefined) {
+                return [{ label: 'Add note here', onSelect: () => createNodeAt(contextMenu.point) }]
+              }
+              const items = []
+              if (node.type === 'text') {
+                items.push({
+                  label: 'Edit text',
+                  onSelect: () => {
+                    applyResult(
+                      reduceGesture(gestureState, canvas, {
+                        type: 'start-text-edit',
+                        nodeId: node.id,
+                        text: node.text,
+                      }),
+                    )
+                  },
+                })
+              }
+              items.push({
+                label: 'Delete',
+                danger: true,
+                onSelect: () => {
+                  applyResult(
+                    reduceGesture(gestureState, canvas, {
+                      type: 'delete-selection',
+                      nodeId: node.id,
+                    }),
+                  )
+                },
+              })
+              return items
+            })()}
+          />
+        )}
         <div
           data-testid="viewport-transform"
           style={{

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -715,6 +715,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }}
               onHandleKeyDown={handleResizeHandleKeyDown}
               onConnectKeyDown={handleConnectKeyDown}
+              onEditRequest={
+                selectedNode?.type === 'text'
+                  ? () => {
+                      applyResult(
+                        reduceGesture(gestureState, canvas, {
+                          type: 'start-text-edit',
+                          nodeId: selectedNode.id,
+                          text: selectedNode.text,
+                        }),
+                      )
+                    }
+                  : undefined
+              }
             />
           )}
           {/* In-flight gesture preview. Drawn from component-local pointer

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -1,0 +1,38 @@
+/**
+ * Bottom tool palette — the OOUI creation surface.
+ *
+ * Design rule (recorded in the ooui-palette-vs-object-actions decision):
+ * what does NOT exist yet comes from the palette; what already exists is
+ * acted on from the object itself (selection affordances, and later a
+ * context menu). So this strip carries creation and interaction-mode
+ * controls only — it must never grow per-object actions like delete or
+ * color, which belong on the selected object.
+ *
+ * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
+ * presses originating here (see SpatialEditor's isOverlayEvent): without
+ * that, the root would capture the pointer and swallow the buttons' clicks.
+ */
+interface ToolPaletteProps {
+  readonly onCreateNode: () => void
+}
+
+export function ToolPalette({ onCreateNode }: ToolPaletteProps) {
+  return (
+    <div
+      data-editor-overlay
+      data-testid="tool-palette"
+      role="toolbar"
+      aria-label="Canvas tools"
+      className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background p-1 shadow-md"
+    >
+      <button
+        type="button"
+        data-testid="add-node-button"
+        onClick={onCreateNode}
+        className="rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+      >
+        Add note
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/connect-sides.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/connect-sides.browser.test.tsx
@@ -1,0 +1,79 @@
+// Edge creation from every side, not only the right — reported as friction
+// after real use. Each handle starts the same connecting gesture; the edge's
+// path is routed from geometry at layout time, so no side is persisted.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 300, y: 250, width: 160, height: 80, text: 'from' },
+    { id: 'b', type: 'text', x: 60, y: 250, width: 120, height: 80, text: 'to-left' },
+  ],
+  edges: [],
+}
+
+function Host({ onCommand }: { onCommand: (kind: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        canvas={canvas}
+        onChange={(next, command) => {
+          onCommand(command.kind)
+          setCanvas(next)
+        }}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+it('renders a connect handle on every side of the selection', async () => {
+  const { container } = render(<Host onCommand={() => {}} />)
+  await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element, {
+    position: { x: 380, y: 290 },
+  })
+  await expect.element(page.getByTestId('connect-handle')).toBeInTheDocument()
+  for (const side of ['n', 's', 'w']) {
+    await expect.element(page.getByTestId(`connect-handle-${side}`)).toBeInTheDocument()
+  }
+})
+
+it('dragging from the LEFT handle onto another node creates an edge', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  // Select node "a", then drag from its west handle to node "b".
+  await userEvent.click(root, { position: { x: 380, y: 290 } })
+  const west = page.getByTestId('connect-handle-w')
+  await expect.element(west).toBeInTheDocument()
+
+  const westEl = west.element() as SVGCircleElement
+  const rootRect = root.getBoundingClientRect()
+  await westEl.dispatchEvent(
+    new PointerEvent('pointerdown', {
+      bubbles: true,
+      clientX: rootRect.left + 295,
+      clientY: rootRect.top + 290,
+      pointerId: 80,
+      button: 0,
+    }),
+  )
+  await root.dispatchEvent(
+    new PointerEvent('pointerup', {
+      bubbles: true,
+      clientX: rootRect.left + 120,
+      clientY: rootRect.top + 290,
+      pointerId: 80,
+    }),
+  )
+
+  expect(commands).toContain('connect-nodes')
+})

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -1,0 +1,99 @@
+// The OOUI object-action surface: right-click a node for its actions,
+// right-click empty space to create "here". Real pointer input throughout —
+// synthetic-event-only coverage is how this editor's first-touch bugs
+// survived unnoticed.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'hello' }],
+  edges: [],
+}
+
+function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        canvas={canvas}
+        onChange={(next, command) => {
+          onCommand?.(command.kind)
+          setCanvas(next)
+        }}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function rightClick(el: HTMLElement, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      button: 2,
+    }),
+  )
+}
+
+it('right-clicking a text node opens its action menu; Edit text opens the editor', async () => {
+  const { container } = render(<Host />)
+  rightClick(rootOf(container), 200, 150)
+
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await userEvent.click(page.getByRole('menuitem', { name: 'Edit text' }))
+
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+})
+
+it('Delete from the menu removes the node and its edges', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  rightClick(rootOf(container), 200, 150)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Delete' }))
+
+  expect(commands).toContain('delete-node')
+  await vi.waitFor(() =>
+    expect(container.querySelectorAll('svg rect[fill="#ffffff"]').length).toBe(0),
+  )
+})
+
+it('right-clicking empty space offers creation at that point', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  rightClick(rootOf(container), 600, 450)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add note here' }))
+
+  expect(commands).toContain('create-node')
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+})
+
+it('Escape closes the menu without acting', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  rightClick(rootOf(container), 200, 150)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  await userEvent.keyboard('{Escape}')
+
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  expect(commands).toHaveLength(0)
+})

--- a/apps/web/src/components/spatial-editor/drag-content-preview.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-content-preview.browser.test.tsx
@@ -1,0 +1,66 @@
+// The drag preview must carry the node's REAL content, not just a dashed
+// outline — user verdict on the outline-only version: still stressful,
+// "the drawing does not travel". The content is rendered once at drag
+// start (single-node render, ~0.4ms) and travels via a per-frame CSS
+// transform; the committed full-canvas render stays untouched during the
+// drag, which is the property that keeps this smooth on large canvases.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'travelling text' },
+  ],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+    </div>
+  )
+}
+
+function press(el: HTMLElement, type: string, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  return el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId: 7,
+      button: 0,
+    }),
+  )
+}
+
+it('the drag preview shows the node content itself, translated with the pointer', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  press(root, 'pointerdown', 200, 150)
+  // Let React commit the 'moving' state before the move event: the move
+  // handler reads gestureState from its render closure, so a move dispatched
+  // in the same tick as the down still sees 'idle' and bails.
+  await new Promise((r) => requestAnimationFrame(r))
+  press(root, 'pointermove', 260, 190)
+  await vi.waitFor(() => {
+    const preview = container.querySelector('[data-testid="drag-preview"]')
+    expect(preview).not.toBeNull()
+    // Real content, not an outline: the node's text travels with the preview.
+    expect(preview?.textContent).toContain('travelling text')
+    // Motion is a pure transform of the once-rendered fragment.
+    expect((preview as HTMLElement).style.transform).toContain('translate')
+  })
+
+  press(root, 'pointerup', 260, 190)
+  // Preview gone after commit; the node itself moved by the delta.
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="drag-preview"]')).toBeNull())
+})

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -50,3 +50,21 @@ it('the Edit control is keyboard-operable (Enter opens the editor)', async () =>
 
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
 })
+
+it('arrow keys nudge the selected node; Shift enlarges the step', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await userEvent.click(root, { position: { x: 200, y: 150 } })
+
+  root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+  root.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'ArrowDown', shiftKey: true, bubbles: true }),
+  )
+
+  // Start (100,100); +8 right, +32 down.
+  await vi.waitFor(() => {
+    const rect = container.querySelector('svg rect[fill="#ffffff"]')
+    expect(rect?.getAttribute('x')).toBe('108')
+    expect(rect?.getAttribute('y')).toBe('132')
+  })
+})

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -1,0 +1,52 @@
+// The visible path into text editing (OOUI: actions live on the object).
+// Double-click works but announces nothing; this control is the discoverable
+// route. Fired on click, not pointerdown — opening the editor inside a
+// discrete pointerdown loses the focus fight with mousedown's default
+// action (see SelectionOverlay's onEditRequest doc).
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'hello world' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+it('selecting a text node shows an Edit control; clicking it opens the editor', async () => {
+  const { container } = render(<Host />)
+  await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
+
+  const editHandle = page.getByTestId('edit-handle')
+  await expect.element(editHandle).toBeInTheDocument()
+
+  await userEvent.click(editHandle)
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  expect(container.querySelector('textarea')?.value).toBe('hello world')
+})
+
+it('the Edit control is keyboard-operable (Enter opens the editor)', async () => {
+  const { container } = render(<Host />)
+  await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
+  ;(page.getByTestId('edit-handle').element() as SVGElement & { focus(): void }).focus()
+  await userEvent.keyboard('{Enter}')
+
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+})

--- a/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
@@ -1,0 +1,113 @@
+// Excalidraw gesture semantics (user decision): plain left-drag on empty
+// space marquee-selects intersecting nodes; panning moves to Space+drag or
+// middle-button drag (wheel pan unchanged). The stationary empty double
+// press still creates a node, resolved at the release.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 300, y: 100, width: 120, height: 60, text: 'B' },
+    { id: 'c', type: 'text', x: 600, y: 400, width: 120, height: 60, text: 'C' },
+  ],
+  edges: [],
+}
+
+let latest: SpatialCanvas = start
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  latest = canvas
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function ev(el: HTMLElement, type: string, x: number, y: number, extra: PointerEventInit = {}) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId: 9,
+      button: type === 'pointerdown' ? (extra.button ?? 0) : undefined,
+      ...extra,
+    }),
+  )
+}
+
+async function frame() {
+  await new Promise((r) => requestAnimationFrame(r))
+}
+
+it('plain drag on empty space marquee-selects the intersecting nodes', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  // Sweep (50,50) → (460,200): covers a and b, not c.
+  ev(root, 'pointerdown', 50, 50)
+  await frame()
+  ev(root, 'pointermove', 260, 130)
+  await frame()
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="marquee-rect"]')).not.toBeNull()
+  })
+  ev(root, 'pointermove', 460, 200)
+  await frame()
+  ev(root, 'pointerup', 460, 200)
+
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
+    // a is primary (selection overlay), b is an extra outline.
+    expect(container.querySelectorAll('[data-testid="selection-overlay"]').length).toBe(1)
+    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
+      1,
+    )
+  })
+})
+
+it('middle-button drag pans instead of selecting', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  ev(root, 'pointerdown', 400, 300, { button: 1 })
+  await frame()
+  ev(root, 'pointermove', 440, 320)
+  await frame()
+  ev(root, 'pointerup', 440, 320)
+
+  await vi.waitFor(() => {
+    const wrapper = container.querySelector<HTMLElement>('[data-testid="viewport-transform"]')
+    expect(wrapper?.style.transform).toBe('scale(1) translate(40px, 20px)')
+  })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+})
+
+it('a stationary empty double press still creates a node at the point', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  ev(root, 'pointerdown', 500, 500)
+  ev(root, 'pointerup', 500, 500)
+  await frame()
+  ev(root, 'pointerdown', 500, 500)
+  ev(root, 'pointerup', 500, 500)
+
+  await vi.waitFor(() => {
+    expect(latest.nodes.length).toBe(4)
+    expect(container.querySelector('textarea')).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
@@ -1,0 +1,140 @@
+// Multi-select slice (a): shift-click membership, group move, batch delete.
+// Marquee selection is deliberately deferred — it needs the pan-gesture
+// decision recorded on the task. Real pointer input throughout.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 300, y: 100, width: 120, height: 60, text: 'B' },
+    { id: 'c', type: 'text', x: 500, y: 100, width: 120, height: 60, text: 'C' },
+  ],
+  edges: [],
+}
+
+let latest: SpatialCanvas = start
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  latest = canvas
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function press(el: HTMLElement, x: number, y: number, opts: { shift?: boolean; id?: number } = {}) {
+  const r = el.getBoundingClientRect()
+  const base = {
+    bubbles: true,
+    clientX: r.left + x,
+    clientY: r.top + y,
+    pointerId: opts.id ?? 5,
+    shiftKey: opts.shift ?? false,
+  }
+  el.dispatchEvent(new PointerEvent('pointerdown', { ...base, button: 0 }))
+  el.dispatchEvent(new PointerEvent('pointerup', base))
+}
+
+async function frame() {
+  await new Promise((r) => requestAnimationFrame(r))
+}
+
+it('shift-click adds members; outlines mark them; shift-click again removes', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  press(root, 150, 130)
+  await frame()
+  press(root, 350, 130, { shift: true })
+  await frame()
+
+  await vi.waitFor(() => {
+    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
+      1,
+    )
+  })
+
+  press(root, 350, 130, { shift: true })
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="extra-selection-outlines"]')).toBeNull()
+  })
+})
+
+it('dragging one member moves every member by the same delta', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  press(root, 150, 130)
+  await frame()
+  press(root, 350, 130, { shift: true })
+  await frame()
+
+  // Drag the PRIMARY (a) by (+40, +20).
+  const r = root.getBoundingClientRect()
+  root.dispatchEvent(
+    new PointerEvent('pointerdown', {
+      bubbles: true,
+      clientX: r.left + 150,
+      clientY: r.top + 130,
+      pointerId: 6,
+      button: 0,
+    }),
+  )
+  await frame()
+  root.dispatchEvent(
+    new PointerEvent('pointermove', {
+      bubbles: true,
+      clientX: r.left + 190,
+      clientY: r.top + 150,
+      pointerId: 6,
+    }),
+  )
+  await frame()
+  root.dispatchEvent(
+    new PointerEvent('pointerup', {
+      bubbles: true,
+      clientX: r.left + 190,
+      clientY: r.top + 150,
+      pointerId: 6,
+    }),
+  )
+
+  await vi.waitFor(() => {
+    const a = latest.nodes.find((n) => n.id === 'a')
+    const b = latest.nodes.find((n) => n.id === 'b')
+    const c = latest.nodes.find((n) => n.id === 'c')
+    expect({ a: [a?.x, a?.y], b: [b?.x, b?.y], c: [c?.x, c?.y] }).toEqual({
+      a: [140, 120],
+      b: [340, 120],
+      c: [500, 100],
+    })
+  })
+})
+
+it('Delete removes every member of the multi-selection', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  press(root, 150, 130)
+  await frame()
+  press(root, 350, 130, { shift: true })
+  await frame()
+
+  root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+
+  await vi.waitFor(() => {
+    expect(latest.nodes.map((n) => n.id)).toEqual(['c'])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,14 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.4: ^3.1.4
+  fast-uri@<3.1.5: ^3.1.5
   kysely@<0.28.17: ^0.28.17
   '@grpc/grpc-js@<1.14.4': ^1.14.4
   shell-quote@<1.9.0: ^1.9.0
   uuid@<11.1.1: ^11.1.1
   qs@>=6.11.1 <6.15.2: ^6.15.2
+  ip-address@<=10.3.0: '>=10.3.1'
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   ip-address@<=10.1.0: ^10.1.1
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12
@@ -4800,8 +4802,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -5088,8 +5090,8 @@ packages:
   inversify@8.2.1:
     resolution: {integrity: sha512-uqPy3dGPx5R5lSW3Aa8eTUc85zBkJVwW6FaJnE4Z3byz+QixDpo/86jMxcrh0qAWmymzOBoBBLzBcEk+6LHJnw==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5318,8 +5320,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -10562,7 +10564,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -10829,14 +10831,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11160,7 +11162,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -11539,7 +11541,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -11592,7 +11594,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -11920,7 +11922,7 @@ snapshots:
     transitivePeerDependencies:
       - reflect-metadata
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -12126,7 +12128,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13292,7 +13294,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -13780,7 +13782,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
     optional: true
 
@@ -14726,7 +14728,7 @@ snapshots:
       '@oozcitak/dom': 2.0.2
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   xmlchars@2.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,14 @@ catalog:
 # minimumReleaseAgeExclude when one is needed before the window elapses.
 # Requires pnpm >= 10.16 (see packageManager in package.json).
 minimumReleaseAge: 10080
+
+# Security-patch escape hatch (see the comment above): versions listed here
+# may be installed before the 7-day window elapses because they close a
+# published advisory. Prune entries once they age past the window.
+minimumReleaseAgeExclude:
+  - js-yaml
+  - fast-uri
+  - ip-address
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeStrict: true
 
@@ -51,12 +59,14 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.4: ^3.1.4
+  fast-uri@<3.1.5: ^3.1.5
   kysely@<0.28.17: ^0.28.17
   "@grpc/grpc-js@<1.14.4": ^1.14.4
   shell-quote@<1.9.0: ^1.9.0
   uuid@<11.1.1: ^11.1.1
   qs@>=6.11.1 <6.15.2: ^6.15.2
+  ip-address@<=10.3.0: '>=10.3.1'
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   ip-address@<=10.1.0: ^10.1.1
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12


### PR DESCRIPTION
**Stacked on #423** (base: `fix-add-note-capture`) — merge #423 first. Stacked while the GitHub Actions outage blocks CI.

Ten increments raising the editor to standard-canvas-tool UX, each with real-pointer browser tests and mutation-checked guards:

1. **Bottom tool palette** — creation moves into a bottom toolbar (OOUI: palette owns what does not exist yet).
2. **Visible Edit control** on the selected text node.
3. **Connect handles on all four sides** (was right-only).
4. **Drag preview carries the real node content** — one single-node render at drag start, pure CSS transform per frame.
5. **Right-click context menu** — Edit/Delete on nodes, "Add note here" on empty space.
6. **Drag perf guard given real teeth** — a per-frame-render mutation now fails (18 vs 10 measure calls).
7. **Arrow-key nudge** (8px / Shift 32px) — exposing and fixing the `applyResult` canvasRef write-back gap and the handles' missing arrow stopPropagation.
8. **Multi-select** — shift-click membership, group move, batch delete, outlines on extras.
9. **Double-press resolved at RELEASE** — zero movement = edit/create, movement = drag; removes the mousedown focus-default fight entirely.
10. **Marquee selection, Excalidraw semantics** (user decision) — plain drag on empty space sweeps a marquee selecting intersecting nodes; pan moves to Space+drag / middle-button; the stationary empty double press still creates.

Suite: full 520 files / 5668 passed, spatial-editor browser 61/61, typecheck 0, lint clean, bundle-size gate OK.