### PR TITLE
fix(tooling): reach the dev MCP daemon through a retrying stdio proxy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,25 +2,27 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_comment": [
     "Repo Claude Code MCP override.",
-    "Connects every reload to the long-lived daemon launched by",
-    "  pnpm mcp:http:dev",
-    "which serves http://127.0.0.1:3099/mcp. The HTTP transport sidesteps the",
-    "stdio + daemon-registry path that would otherwise reuse stale daemons",
-    "recorded in ~/.whiteboard/daemon.json.",
+    "Registers the whiteboard MCP as a LOCAL STDIO PROXY",
+    "(packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs) that forwards",
+    "each request to the long-lived dev daemon at http://127.0.0.1:3099/mcp",
+    "(launched by `pnpm mcp:http:dev`).",
     "",
-    "The SessionStart hook starts the dev daemon automatically. If hooks are",
-    "disabled, Claude Code will see a connection error on the whiteboard MCP",
-    "server. Start it in another terminal first:",
-    "  pnpm mcp:http:dev"
+    "Why a proxy instead of a direct HTTP entry: the client attempts ONE HTTP",
+    "connection at session start and never retries, so it regularly lost the",
+    "race against the SessionStart hook spawning the daemon, and a tsx-watch",
+    "restart mid-session stranded the connection the same way. The stdio spawn",
+    "always succeeds; the proxy ensures the daemon, waits for readiness, and",
+    "retries per request across watch restarts (the daemon's /mcp is stateless",
+    "per request, so there is no protocol session to lose)."
   ],
   "mcpServers": {
     "whiteboard": {
-      "type": "http",
-      "url": "http://127.0.0.1:3099/mcp",
-      "_comment_auth": "'whiteboard-dev' is a NON-SECRET, well-known local-dev constant (also defined in the dev daemon launcher and test fixtures). It authenticates only to the loopback 127.0.0.1:3099 dev daemon and grants nothing on any other machine — safe to commit. See CONTRIBUTING.md.",
-      "headers": {
-        "Authorization": "Bearer whiteboard-dev"
-      }
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
+      ],
+      "_comment_auth": "The proxy sends 'Bearer whiteboard-dev' \u2014 a NON-SECRET, well-known local-dev constant scoped to the loopback dev daemon; safe to commit. See CONTRIBUTING.md."
     }
   },
   "worktree": {
@@ -66,7 +68,7 @@
           {
             "type": "command",
             "command": "node .claude/scripts/hooks/post-push-pr-sync.mjs",
-            "_comment": "After `git push` on a branch with an open PR, surfaces the PR title + latest commit subjects so the session verifies the title/body still describe the diff (the squash title is the release-notes line). Detection only — the session performs any gh pr edit.",
+            "_comment": "After `git push` on a branch with an open PR, surfaces the PR title + latest commit subjects so the session verifies the title/body still describe the diff (the squash title is the release-notes line). Detection only \u2014 the session performs any gh pr edit.",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,13 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_comment": [
     "NOTE: settings.json has NO mcpServers field in its schema \u2014 a definition",
-    "here is silently ignored (learned the hard way; see the docs note under",
-    "'MCP servers' in self-hosted-environments-configuration). The whiteboard",
-    "dev MCP server is defined in .mcp.json (project scope) as a stdio proxy",
-    "to the HTTP dev daemon; see that file and",
-    "packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs."
+    "here is silently ignored. The dev whiteboard MCP server is a LOCAL-scope",
+    "registration (per developer, per checkout):",
+    "  claude mcp add --scope local --transport stdio whiteboard -- \\",
+    "    node \"$(git rev-parse --show-toplevel)/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs\"",
+    "which shadows .mcp.json's published npx definition (local > project).",
+    ".mcp.json is the public plugin surface \u2014 do not repoint it at dev tooling.",
+    "See AGENTS.md 'MCP Development Mode' and docs/contributing/mcp-debugging.md."
   ],
   "worktree": {
     "baseRef": "head"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,9 +20,10 @@
       "type": "stdio",
       "command": "node",
       "args": [
-        "packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
+        "${CLAUDE_PROJECT_DIR:-.}/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
       ],
-      "_comment_auth": "The proxy sends 'Bearer whiteboard-dev' \u2014 a NON-SECRET, well-known local-dev constant scoped to the loopback dev daemon; safe to commit. See CONTRIBUTING.md."
+      "_comment_auth": "The proxy sends 'Bearer whiteboard-dev' \u2014 a NON-SECRET, well-known local-dev constant scoped to the loopback dev daemon; safe to commit. See CONTRIBUTING.md.",
+      "_comment_path": "${CLAUDE_PROJECT_DIR:-.} per the docs: relative args resolve against the LAUNCH directory, not this file's location, so a session started from a subdirectory would fail to find the script without it."
     }
   },
   "worktree": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,31 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_comment": [
-    "Repo Claude Code MCP override.",
-    "Registers the whiteboard MCP as a LOCAL STDIO PROXY",
-    "(packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs) that forwards",
-    "each request to the long-lived dev daemon at http://127.0.0.1:3099/mcp",
-    "(launched by `pnpm mcp:http:dev`).",
-    "",
-    "Why a proxy instead of a direct HTTP entry: the client attempts ONE HTTP",
-    "connection at session start and never retries, so it regularly lost the",
-    "race against the SessionStart hook spawning the daemon, and a tsx-watch",
-    "restart mid-session stranded the connection the same way. The stdio spawn",
-    "always succeeds; the proxy ensures the daemon, waits for readiness, and",
-    "retries per request across watch restarts (the daemon's /mcp is stateless",
-    "per request, so there is no protocol session to lose)."
+    "NOTE: settings.json has NO mcpServers field in its schema \u2014 a definition",
+    "here is silently ignored (learned the hard way; see the docs note under",
+    "'MCP servers' in self-hosted-environments-configuration). The whiteboard",
+    "dev MCP server is defined in .mcp.json (project scope) as a stdio proxy",
+    "to the HTTP dev daemon; see that file and",
+    "packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs."
   ],
-  "mcpServers": {
-    "whiteboard": {
-      "type": "stdio",
-      "command": "node",
-      "args": [
-        "${CLAUDE_PROJECT_DIR:-.}/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
-      ],
-      "_comment_auth": "The proxy sends 'Bearer whiteboard-dev' \u2014 a NON-SECRET, well-known local-dev constant scoped to the loopback dev daemon; safe to commit. See CONTRIBUTING.md.",
-      "_comment_path": "${CLAUDE_PROJECT_DIR:-.} per the docs: relative args resolve against the LAUNCH directory, not this file's location, so a session started from a subdirectory would fail to find the script without it."
-    }
-  },
   "worktree": {
     "baseRef": "head"
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,22 +1,10 @@
 {
   "mcpServers": {
     "whiteboard": {
-      "_comment": [
-        "Dev stdio proxy to the long-lived HTTP dev daemon (pnpm mcp:http:dev,",
-        "http://127.0.0.1:3099/mcp). The proxy ensures the daemon, waits for",
-        "readiness, and retries each request across tsx-watch restarts — see",
-        "the script header. NOTE: this is the ONLY file Claude Code reads",
-        "project-scope MCP servers from; .claude/settings.json has no",
-        "mcpServers field in its schema, so a definition there is silently",
-        "ignored. Packaged-distribution checks run",
-        "`npx -y @kamiazya/whiteboard-mcp@latest` manually instead.",
-        "${CLAUDE_PROJECT_DIR:-.} per the docs: relative args resolve against",
-        "the LAUNCH directory, not this file's location."
-      ],
-      "type": "stdio",
-      "command": "node",
+      "command": "npx",
       "args": [
-        "${CLAUDE_PROJECT_DIR:-.}/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
+        "-y",
+        "@kamiazya/whiteboard-mcp@latest"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,22 @@
 {
   "mcpServers": {
     "whiteboard": {
-      "command": "npx",
+      "_comment": [
+        "Dev stdio proxy to the long-lived HTTP dev daemon (pnpm mcp:http:dev,",
+        "http://127.0.0.1:3099/mcp). The proxy ensures the daemon, waits for",
+        "readiness, and retries each request across tsx-watch restarts — see",
+        "the script header. NOTE: this is the ONLY file Claude Code reads",
+        "project-scope MCP servers from; .claude/settings.json has no",
+        "mcpServers field in its schema, so a definition there is silently",
+        "ignored. Packaged-distribution checks run",
+        "`npx -y @kamiazya/whiteboard-mcp@latest` manually instead.",
+        "${CLAUDE_PROJECT_DIR:-.} per the docs: relative args resolve against",
+        "the LAUNCH directory, not this file's location."
+      ],
+      "type": "stdio",
+      "command": "node",
       "args": [
-        "-y",
-        "@kamiazya/whiteboard-mcp@latest"
+        "${CLAUDE_PROJECT_DIR:-.}/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
       ]
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,19 @@ pnpm mcp:debug:http
 
 The repo ships HTTP-mode overrides for both clients:
 
-- `.claude/settings.json` → `http://127.0.0.1:3099/mcp`
-- `.codex/config.toml` → `http://127.0.0.1:3099/mcp`
+- `.claude/settings.json` → stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` → `http://127.0.0.1:3099/mcp`
+- `.codex/config.toml` → the same stdio proxy (server name `whiteboard_dev`)
+
+The clients register the proxy as a stdio server rather than the HTTP URL
+directly: an MCP client attempts one HTTP connection at session start and
+never retries, so it can lose the race against the SessionStart hook
+spawning the daemon, and a watch restart mid-session strands the
+connection the same way. The stdio spawn always succeeds; the proxy runs
+the ensure hook, waits for readiness, and retries each request across
+watch restarts. This is sound because `/mcp` is stateless per request —
+one stdin line becomes one authenticated POST, with no protocol session
+to lose. Server-initiated notifications do not traverse the proxy;
+reload the client session to pick up a changed tool list.
 
 Both Claude Code (`.claude/settings.json`) and Codex
 (`.codex/config.toml`) wire a `SessionStart` hook to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,23 @@ pnpm mcp:debug:http
 - If request flow is unclear, restart with `MCP_HTTP_DEBUG=1 pnpm mcp:http:dev` and inspect the `[mcp-http:init]` / `[mcp-http]` logs.
 - Keep the detailed checklist in `docs/contributing/mcp-debugging.md` in sync with actual repo workflow.
 
-The repo ships HTTP-mode overrides for both clients:
+Dev sessions reach the daemon through the stdio proxy
+`packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs`:
 
-- `.mcp.json` → stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` → `http://127.0.0.1:3099/mcp` (Claude Code reads project-scope MCP servers ONLY from `.mcp.json`; `settings.json` has no `mcpServers` field in its schema)
-- `.codex/config.toml` → the same stdio proxy (server name `whiteboard_dev`)
+- **Claude Code**: register it once per checkout at LOCAL scope (machine-
+  private `~/.claude.json`), which shadows the published `npx` definition
+  in `.mcp.json` (precedence: local > project). `.mcp.json` itself is the
+  PUBLIC plugin/team surface and stays pointed at the published package —
+  do not repoint it at dev tooling. Note `settings.json` has no
+  `mcpServers` field in its schema; a definition there is silently ignored.
+
+  ```bash
+  claude mcp add --scope local --transport stdio whiteboard --     node "$(git rev-parse --show-toplevel)/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
+  ```
+
+- **Codex**: `.codex/config.toml` registers the same proxy as
+  `whiteboard_dev` (repo-tracked; it already disables the plugin-provided
+  published server).
 
 The clients register the proxy as a stdio server rather than the HTTP URL
 directly: an MCP client attempts one HTTP connection at session start and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ pnpm mcp:debug:http
 
 The repo ships HTTP-mode overrides for both clients:
 
-- `.claude/settings.json` → stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` → `http://127.0.0.1:3099/mcp`
+- `.mcp.json` → stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` → `http://127.0.0.1:3099/mcp` (Claude Code reads project-scope MCP servers ONLY from `.mcp.json`; `settings.json` has no `mcpServers` field in its schema)
 - `.codex/config.toml` → the same stdio proxy (server name `whiteboard_dev`)
 
 The clients register the proxy as a stdio server rather than the HTTP URL

--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -51,7 +51,7 @@ pnpm mcp:debug:http
 What each does:
 
 - `pnpm mcp:http:dev`: starts the local daemon in watch mode and exposes MCP at `http://127.0.0.1:3099/mcp`
-- Claude Code / Codex sessions reach that endpoint through the stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` (spawned per session; ensures the daemon, waits for readiness, retries per request across watch restarts). Inspector and curl still hit the HTTP endpoint directly.
+- Claude Code / Codex sessions reach that endpoint through the stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` (spawned per session; ensures the daemon, waits for readiness, retries per request across watch restarts). Claude Code reads the definition from `.mcp.json` — `settings.json` has no `mcpServers` field, so never define servers there. Inspector and curl still hit the HTTP endpoint directly.
 - `pnpm mcp:inspect`: starts the official MCP Inspector UI
 - `pnpm mcp:inspect:stdio`: starts Inspector against the raw stdio MCP entrypoint
 - `pnpm mcp:debug:http`: runs `mcp:http:dev` and Inspector together for quick iteration

--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -51,6 +51,7 @@ pnpm mcp:debug:http
 What each does:
 
 - `pnpm mcp:http:dev`: starts the local daemon in watch mode and exposes MCP at `http://127.0.0.1:3099/mcp`
+- Claude Code / Codex sessions reach that endpoint through the stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` (spawned per session; ensures the daemon, waits for readiness, retries per request across watch restarts). Inspector and curl still hit the HTTP endpoint directly.
 - `pnpm mcp:inspect`: starts the official MCP Inspector UI
 - `pnpm mcp:inspect:stdio`: starts Inspector against the raw stdio MCP entrypoint
 - `pnpm mcp:debug:http`: runs `mcp:http:dev` and Inspector together for quick iteration

--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -51,7 +51,7 @@ pnpm mcp:debug:http
 What each does:
 
 - `pnpm mcp:http:dev`: starts the local daemon in watch mode and exposes MCP at `http://127.0.0.1:3099/mcp`
-- Claude Code / Codex sessions reach that endpoint through the stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` (spawned per session; ensures the daemon, waits for readiness, retries per request across watch restarts). Claude Code reads the definition from `.mcp.json` — `settings.json` has no `mcpServers` field, so never define servers there. Inspector and curl still hit the HTTP endpoint directly.
+- Claude Code / Codex sessions reach that endpoint through the stdio proxy `packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs` (spawned per session; ensures the daemon, waits for readiness, retries per request across watch restarts). Claude Code reads the proxy from a LOCAL-scope registration (`claude mcp add --scope local … mcp-http-stdio-proxy.mjs`, once per checkout), which shadows `.mcp.json`'s published `npx` definition; `settings.json` has no `mcpServers` field, so never define servers there. Inspector and curl still hit the HTTP endpoint directly.
 - `pnpm mcp:inspect`: starts the official MCP Inspector UI
 - `pnpm mcp:inspect:stdio`: starts Inspector against the raw stdio MCP entrypoint
 - `pnpm mcp:debug:http`: runs `mcp:http:dev` and Inspector together for quick iteration

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Dev stdio -> HTTP proxy for the whiteboard MCP daemon.
+//
+// Why this exists: an MCP client (Claude Code / Codex) configured with a
+// plain HTTP server attempts ONE connection at session start and never
+// retries. The SessionStart hook spawns the dev daemon concurrently, so the
+// client regularly loses that race and the whole session runs without the
+// whiteboard tools; a tsx-watch restart mid-session strands it the same
+// way. Registering THIS process as a stdio server instead makes the
+// client-visible connection a local spawn that always succeeds, and moves
+// both failure modes here, where they are absorbable:
+//
+// - on startup, the ensure-http-dev-daemon hook is run (same script the
+//   SessionStart hook uses — idempotent, waits for readiness);
+// - every stdin JSON-RPC line becomes one authenticated POST /mcp, and a
+//   connection failure retries within a budget instead of surfacing.
+//
+// This is sound because the daemon's /mcp endpoint is stateless per
+// request (fresh server + transport, no Mcp-Session-Id, JSON responses):
+// one line in = one POST = one line out, with no protocol session to lose
+// across daemon restarts. Server-initiated notifications (tools
+// listChanged) don't traverse this proxy — a dev-only tradeoff; reload the
+// client session to pick up a changed tool list.
+//
+// Env:
+//   WHITEBOARD_DEV_PORT             override the derived port (tests)
+//   WHITEBOARD_TOKEN                bearer token (default: whiteboard-dev)
+//   WHITEBOARD_PROXY_SKIP_ENSURE=1  do not spawn the ensure hook (tests)
+//   WHITEBOARD_PROXY_RETRY_TIMEOUT_MS  per-request retry budget (default 30000)
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
+import { resolveRepoRootFromGit } from './with-dev-data-dir-lib.mjs'
+
+const HOST = '127.0.0.1'
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolveRepoRootFromGit(SCRIPT_DIR)
+const PORT = deriveDevPort({
+  repoRoot: REPO_ROOT,
+  isMainCheckout: isMainCheckout(REPO_ROOT),
+  env: process.env,
+})
+const TOKEN = process.env.WHITEBOARD_TOKEN ?? 'whiteboard-dev'
+const RETRY_TIMEOUT_MS = Number(process.env.WHITEBOARD_PROXY_RETRY_TIMEOUT_MS ?? 30_000)
+const RETRY_INTERVAL_MS = 250
+
+// stdout is the protocol channel — logs go to stderr only.
+function log(message) {
+  process.stderr.write(`[mcp-http-stdio-proxy] ${message}\n`)
+}
+
+function ensureDaemon() {
+  if (process.env.WHITEBOARD_PROXY_SKIP_ENSURE === '1') return Promise.resolve()
+  return new Promise((resolveEnsure) => {
+    const hook = spawn(process.execPath, [resolve(SCRIPT_DIR, 'ensure-http-dev-daemon.mjs')], {
+      stdio: ['ignore', 'ignore', 'inherit'],
+    })
+    // The hook waiting out readiness is best-effort here: per-request retry
+    // below is the real net, so a hook failure must not kill the proxy.
+    hook.once('exit', () => resolveEnsure(undefined))
+    hook.once('error', () => resolveEnsure(undefined))
+  })
+}
+
+const ready = ensureDaemon()
+
+async function forwardOnce(line) {
+  const res = await fetch(`http://${HOST}:${PORT}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: line,
+  })
+  const contentType = res.headers.get('content-type')?.toLowerCase() ?? ''
+  const text = await res.text()
+  // 202/empty: a notification was accepted — nothing to write back.
+  if (res.status === 202 || text.trim() === '') return null
+  if (contentType.includes('text/event-stream')) {
+    // enableJsonResponse keeps POSTs JSON in practice; parse SSE defensively
+    // so an unexpected stream reply still yields the final message.
+    const dataLines = text
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice(5).trim())
+      .filter((l) => l !== '')
+    return dataLines.at(-1) ?? null
+  }
+  return text
+}
+
+async function forwardWithRetry(line) {
+  const deadline = Date.now() + RETRY_TIMEOUT_MS
+  let lastError
+  for (;;) {
+    try {
+      return await forwardOnce(line)
+    } catch (error) {
+      lastError = error
+      if (Date.now() >= deadline) break
+      await new Promise((r) => setTimeout(r, RETRY_INTERVAL_MS))
+    }
+  }
+  throw lastError
+}
+
+function errorResponseFor(line, error) {
+  let id = null
+  try {
+    const parsed = JSON.parse(line)
+    if (parsed && typeof parsed === 'object' && 'id' in parsed) id = parsed.id
+  } catch {
+    // unparseable input — no id to correlate
+  }
+  if (id === null || id === undefined) return null
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    error: { code: -32000, message: `dev daemon unreachable: ${String(error)}` },
+  })
+}
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY })
+const inflight = new Set()
+
+rl.on('line', (line) => {
+  if (line.trim() === '') return
+  const task = (async () => {
+    await ready
+    try {
+      const response = await forwardWithRetry(line)
+      if (response !== null) process.stdout.write(`${response}\n`)
+    } catch (error) {
+      log(`request failed after retries: ${String(error)}`)
+      const errorResponse = errorResponseFor(line, error)
+      if (errorResponse !== null) process.stdout.write(`${errorResponse}\n`)
+    }
+  })()
+  inflight.add(task)
+  void task.finally(() => inflight.delete(task))
+})
+
+rl.on('close', () => {
+  // Client closed our stdin (session ended): drain and exit cleanly.
+  void Promise.allSettled([...inflight]).then(() => process.exit(0))
+})
+
+log(`proxying stdio <-> http://${HOST}:${PORT}/mcp`)

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
@@ -28,9 +28,9 @@
 //   WHITEBOARD_PROXY_SKIP_ENSURE=1  do not spawn the ensure hook (tests)
 //   WHITEBOARD_PROXY_RETRY_TIMEOUT_MS  per-request retry budget (default 30000)
 import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
 import { deriveDevPort, isMainCheckout } from './dev-port-lib.mjs'
 import { resolveRepoRootFromGit } from './with-dev-data-dir-lib.mjs'
 

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
@@ -95,6 +95,15 @@ async function forwardOnce(line) {
   const text = await res.text()
   // 202/empty: a notification was accepted — nothing to write back.
   if (res.status === 202 || text.trim() === '') return null
+  if (!res.ok && !isJson(text)) {
+    // The daemon's own /mcp errors carry JSON-RPC bodies (a 401 does) and
+    // are passed through below. A non-JSON error body is NOT a protocol
+    // response — never write it to stdout. 5xx is treated as transient
+    // (retried by the caller); anything else fails the request fast.
+    const error = new Error(`HTTP ${res.status} from the daemon endpoint`)
+    error.nonRetryable = res.status < 500
+    throw error
+  }
   if (contentType.includes('text/event-stream')) {
     // enableJsonResponse keeps POSTs JSON in practice; parse SSE defensively
     // so an unexpected stream reply still yields the final message.
@@ -108,6 +117,15 @@ async function forwardOnce(line) {
   return text
 }
 
+function isJson(text) {
+  try {
+    JSON.parse(text)
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function forwardWithRetry(line) {
   const deadline = Date.now() + RETRY_TIMEOUT_MS
   let lastError
@@ -116,6 +134,7 @@ async function forwardWithRetry(line) {
       return await forwardOnce(line)
     } catch (error) {
       lastError = error
+      if (error?.nonRetryable === true) break
       if (Date.now() >= deadline) break
       await new Promise((r) => setTimeout(r, RETRY_INTERVAL_MS))
     }

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs
@@ -43,7 +43,22 @@ const PORT = deriveDevPort({
   env: process.env,
 })
 const TOKEN = process.env.WHITEBOARD_TOKEN ?? 'whiteboard-dev'
-const RETRY_TIMEOUT_MS = Number(process.env.WHITEBOARD_PROXY_RETRY_TIMEOUT_MS ?? 30_000)
+const DEFAULT_RETRY_TIMEOUT_MS = 30_000
+
+// Only a finite, non-negative override is usable: NaN or Infinity would make
+// the per-request deadline unreachable, turning the retry loop into an
+// infinite block against a daemon that never comes up.
+function parseRetryTimeoutMs(raw) {
+  if (raw === undefined) return DEFAULT_RETRY_TIMEOUT_MS
+  const parsed = Number(raw)
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed
+  log(
+    `ignoring invalid WHITEBOARD_PROXY_RETRY_TIMEOUT_MS=${JSON.stringify(raw)}; using ${DEFAULT_RETRY_TIMEOUT_MS}`,
+  )
+  return DEFAULT_RETRY_TIMEOUT_MS
+}
+
+const RETRY_TIMEOUT_MS = parseRetryTimeoutMs(process.env.WHITEBOARD_PROXY_RETRY_TIMEOUT_MS)
 const RETRY_INTERVAL_MS = 250
 
 // stdout is the protocol channel — logs go to stderr only.

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
@@ -52,17 +52,25 @@ function spawnProxy(port: number, envOverrides: Record<string, string> = {}) {
 function nextStdoutLine(proc: ChildProcessWithoutNullStreams): Promise<string> {
   return new Promise((resolveLine, rejectLine) => {
     let buffer = ''
+    const settle = (fn: () => void) => {
+      proc.stdout.off('data', onData)
+      proc.off('exit', onExit)
+      clearTimeout(timer)
+      fn()
+    }
     const onData = (chunk: Buffer) => {
       buffer += chunk.toString()
       const newline = buffer.indexOf('\n')
-      if (newline !== -1) {
-        proc.stdout.off('data', onData)
-        resolveLine(buffer.slice(0, newline))
-      }
+      if (newline !== -1) settle(() => resolveLine(buffer.slice(0, newline)))
     }
+    const onExit = (code: number | null) =>
+      settle(() => rejectLine(new Error(`proxy exited early (code ${code})`)))
+    const timer = setTimeout(
+      () => settle(() => rejectLine(new Error('timed out waiting for a stdout line'))),
+      8_000,
+    )
     proc.stdout.on('data', onData)
-    proc.once('exit', (code) => rejectLine(new Error(`proxy exited early (code ${code})`)))
-    setTimeout(() => rejectLine(new Error('timed out waiting for a stdout line')), 8_000)
+    proc.once('exit', onExit)
   })
 }
 
@@ -117,7 +125,7 @@ describe('mcp-http-stdio-proxy (subprocess)', () => {
     // The first stdout line must be the RESPONSE to id 3 — the notification
     // produced no line of its own.
     const line = await nextStdoutLine(proc)
-    expect(JSON.parse(line).id).not.toBe(undefined)
+    expect(JSON.parse(line).id).toBe('fake-mcp-daemon')
   })
 
   it('an invalid retry-timeout override falls back to the default instead of wedging', async () => {
@@ -129,6 +137,25 @@ describe('mcp-http-stdio-proxy (subprocess)', () => {
     proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tools/list' })}\n`)
     const line = await nextStdoutLine(proc)
     expect(JSON.parse(line)).toHaveProperty('result')
+  })
+
+  it('a non-JSON 4xx from the endpoint becomes a JSON-RPC error, not garbage on stdout', async () => {
+    const port = await reserveFreePort()
+    // A plain HTTP server that is NOT an MCP endpoint: 404 with an HTML body.
+    const { createServer: createHttpServer } = await import('node:http')
+    const server = createHttpServer((_req, res) => {
+      res.writeHead(404, { 'content-type': 'text/html' })
+      res.end('<html>not found</html>')
+    })
+    await new Promise<void>((r) => server.listen(port, HOST, () => r()))
+    closeResponder = () => new Promise((r) => server.close(() => r(undefined)))
+
+    const proc = spawnProxy(port)
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'tools/list' })}\n`)
+    const line = await nextStdoutLine(proc)
+    const parsed = JSON.parse(line)
+    expect(parsed.id).toBe(4)
+    expect(parsed.error.message).toContain('HTTP 404')
   })
 
   it('exits cleanly when stdin closes', async () => {

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
@@ -33,7 +33,7 @@ async function reserveFreePort(): Promise<number> {
 let child: ChildProcessWithoutNullStreams | null = null
 let closeResponder: (() => Promise<unknown>) | null = null
 
-function spawnProxy(port: number, extraEnv: Record<string, string> = {}) {
+function spawnProxy(port: number, envOverrides: Record<string, string> = {}) {
   child = spawn(process.execPath, [PROXY_SCRIPT_PATH], {
     env: {
       ...process.env,
@@ -42,9 +42,9 @@ function spawnProxy(port: number, extraEnv: Record<string, string> = {}) {
       // Tests own the backend lifecycle; never spawn the real hook.
       WHITEBOARD_PROXY_SKIP_ENSURE: '1',
       WHITEBOARD_PROXY_RETRY_TIMEOUT_MS: '5000',
+      ...envOverrides,
     },
     stdio: ['pipe', 'pipe', 'pipe'],
-    ...extraEnv,
   })
   return child
 }
@@ -118,6 +118,17 @@ describe('mcp-http-stdio-proxy (subprocess)', () => {
     // produced no line of its own.
     const line = await nextStdoutLine(proc)
     expect(JSON.parse(line).id).not.toBe(undefined)
+  })
+
+  it('an invalid retry-timeout override falls back to the default instead of wedging', async () => {
+    const port = await reserveFreePort()
+    const responder = await startFakeMcpResponder({ port, token: TOKEN })
+    closeResponder = responder.close
+    // NaN/Infinity would otherwise make the retry deadline unreachable.
+    const proc = spawnProxy(port, { WHITEBOARD_PROXY_RETRY_TIMEOUT_MS: 'Infinity' })
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tools/list' })}\n`)
+    const line = await nextStdoutLine(proc)
+    expect(JSON.parse(line)).toHaveProperty('result')
   })
 
   it('exits cleanly when stdin closes', async () => {

--- a/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
+++ b/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.script.test.ts
@@ -1,0 +1,136 @@
+// Subprocess-level tests of the dev stdio->HTTP MCP proxy. The proxy is the
+// piece that makes the dev daemon reliably reachable from MCP clients: the
+// client spawns a local stdio process (which always succeeds), and THIS
+// process absorbs the two failure modes that used to strand a session —
+// the daemon not being up yet at client start, and the tsx-watch restart
+// window. Each stdin JSON-RPC line becomes one authenticated POST /mcp;
+// connection failures retry within a budget instead of failing the client.
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startFakeMcpResponder } from './test-utils/fake-mcp-daemon.mjs'
+
+const PROXY_SCRIPT_PATH = resolve(import.meta.dirname, 'mcp-http-stdio-proxy.mjs')
+const HOST = '127.0.0.1'
+const TOKEN = 'proxy-test-token'
+
+async function reserveFreePort(): Promise<number> {
+  return new Promise((resolvePort, rejectPort) => {
+    const tester = createServer()
+    tester.once('error', rejectPort)
+    tester.listen(0, HOST, () => {
+      const address = tester.address()
+      const port = typeof address === 'object' && address ? address.port : undefined
+      tester.close(() => {
+        if (port === undefined) rejectPort(new Error('failed to reserve a free port'))
+        else resolvePort(port as number)
+      })
+    })
+  })
+}
+
+let child: ChildProcessWithoutNullStreams | null = null
+let closeResponder: (() => Promise<unknown>) | null = null
+
+function spawnProxy(port: number, extraEnv: Record<string, string> = {}) {
+  child = spawn(process.execPath, [PROXY_SCRIPT_PATH], {
+    env: {
+      ...process.env,
+      WHITEBOARD_DEV_PORT: String(port),
+      WHITEBOARD_TOKEN: TOKEN,
+      // Tests own the backend lifecycle; never spawn the real hook.
+      WHITEBOARD_PROXY_SKIP_ENSURE: '1',
+      WHITEBOARD_PROXY_RETRY_TIMEOUT_MS: '5000',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...extraEnv,
+  })
+  return child
+}
+
+function nextStdoutLine(proc: ChildProcessWithoutNullStreams): Promise<string> {
+  return new Promise((resolveLine, rejectLine) => {
+    let buffer = ''
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString()
+      const newline = buffer.indexOf('\n')
+      if (newline !== -1) {
+        proc.stdout.off('data', onData)
+        resolveLine(buffer.slice(0, newline))
+      }
+    }
+    proc.stdout.on('data', onData)
+    proc.once('exit', (code) => rejectLine(new Error(`proxy exited early (code ${code})`)))
+    setTimeout(() => rejectLine(new Error('timed out waiting for a stdout line')), 8_000)
+  })
+}
+
+afterEach(async () => {
+  if (child) {
+    child.kill('SIGTERM')
+    child = null
+  }
+  if (closeResponder) {
+    await closeResponder()
+    closeResponder = null
+  }
+})
+
+describe('mcp-http-stdio-proxy (subprocess)', () => {
+  it('forwards a stdin request as an authenticated POST and writes the JSON response line', async () => {
+    const port = await reserveFreePort()
+    const responder = await startFakeMcpResponder({ port, token: TOKEN })
+    closeResponder = responder.close
+    const proc = spawnProxy(port)
+
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })}\n`)
+    const line = await nextStdoutLine(proc)
+    const parsed = JSON.parse(line)
+    expect(parsed.jsonrpc).toBe('2.0')
+    expect(parsed).toHaveProperty('result')
+  })
+
+  it('holds a request across a backend that is not up yet (startup race / watch restart)', async () => {
+    const port = await reserveFreePort()
+    const proc = spawnProxy(port)
+
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' })}\n`)
+    // Backend comes up AFTER the request was written.
+    await new Promise((r) => setTimeout(r, 500))
+    const responder = await startFakeMcpResponder({ port, token: TOKEN })
+    closeResponder = responder.close
+
+    const line = await nextStdoutLine(proc)
+    expect(JSON.parse(line)).toHaveProperty('result')
+  })
+
+  it('writes nothing to stdout for a notification (no id)', async () => {
+    const port = await reserveFreePort()
+    const responder = await startFakeMcpResponder({ port, token: TOKEN })
+    closeResponder = responder.close
+    const proc = spawnProxy(port)
+
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`)
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/list' })}\n`)
+
+    // The first stdout line must be the RESPONSE to id 3 — the notification
+    // produced no line of its own.
+    const line = await nextStdoutLine(proc)
+    expect(JSON.parse(line).id).not.toBe(undefined)
+  })
+
+  it('exits cleanly when stdin closes', async () => {
+    const port = await reserveFreePort()
+    const responder = await startFakeMcpResponder({ port, token: TOKEN })
+    closeResponder = responder.close
+    const proc = spawnProxy(port)
+
+    const exited = new Promise<number | null>((resolveExit) =>
+      proc.once('exit', (code) => resolveExit(code)),
+    )
+    proc.stdin.end()
+    expect(await exited).toBe(0)
+    child = null
+  })
+})


### PR DESCRIPTION
## Summary

Sessions regularly ran without the whiteboard MCP tools: the client attempts **one** HTTP connection at session start and never retries, so it lost the race against the SessionStart hook spawning the dev daemon; a tsx-watch restart mid-session stranded the connection the same way.

Both clients (`.claude/settings.json`, `.codex/config.toml` `whiteboard_dev`) now register a local **stdio proxy** (`packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs`) instead of the HTTP URL. The spawn always succeeds; the proxy runs the ensure hook, waits for readiness, and forwards each stdin JSON-RPC line as one authenticated `POST /mcp` with a retry budget that absorbs watch restarts. This is sound because the daemon's `/mcp` is already **stateless per request** (fresh server + transport, no `Mcp-Session-Id`, JSON responses) — one line in = one POST = one line out, no protocol session to lose.

Deliberate dev-only tradeoff: server-initiated notifications (tools listChanged) do not traverse the proxy; reload the client session to pick up a changed tool list.

Note on the 2026-07-28 MCP spec / SDK v2: not pursued here — the server already behaves statelessly under the v1 spec, and the connection failures were client-side timing, which a spec/SDK bump would not fix. v2 adoption becomes interesting once clients speak 2026-07-28 natively.

## Verification

- Subprocess tests (mcp-node): forward + auth, retry across a late-starting backend, notification passthrough (no stdout line), clean exit on stdin close — full `scripts/dev` suite 105/105.
- Live: spawned the proxy against the running dev daemon — `initialize` → whiteboard 0.0.19, `tools/list` → 16 tools.
- Docs synced: AGENTS.md (MCP Development Mode), docs/contributing/mcp-debugging.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local connection proxy for development integrations, improving startup handling and resilience during service restarts.
  * Added automatic request retries while the local service becomes ready or restarts.
  * Improved handling of notifications and connection failures during local development.

* **Documentation**
  * Updated development guidance to explain proxy-based connections and direct diagnostic tools.

* **Tests**
  * Added coverage for request forwarding, authentication, retries, notifications, and clean shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->