### PR TITLE
feat(web): daemon discovery across dynamic ports, remembered daemons, and failure guidance

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -290,6 +290,71 @@ describe('DaemonDetectedBanner', () => {
     expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
   })
 
+  it('a failed manual check on a hosted origin explains the allowlist requirement instead of silence', async () => {
+    // The real shape of the 2026-08-07 report: daemon running, hosted origin
+    // not in WHITEBOARD_ALLOWED_WEB_ORIGINS -> CORS rejection surfaces as an
+    // opaque 'network' failure, indistinguishable from daemon-absent. The
+    // banner must say SOMETHING actionable either way.
+    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'network' })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/no daemon reachable from this origin/i)
+    const docsLink = screen.getByRole('link', { name: /how to connect/i })
+    expect(docsLink.getAttribute('href')).toBe(HOW_TO_CONNECT_URL)
+    // Retry stays available.
+    expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
+  })
+
+  it('a failed manual check on a loopback origin reports plainly that nothing was found', async () => {
+    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'refused' })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/no local daemon found/i)
+    // No hosted-origin allowlist lecture on loopback — it does not apply.
+    expect(screen.queryByText(/no daemon reachable from this origin/i)).toBeNull()
+  })
+
+  it('the failure message clears once a re-check succeeds', async () => {
+    const probeFn = vi
+      .fn()
+      .mockResolvedValueOnce(NOT_DETECTED)
+      .mockResolvedValueOnce(NOT_DETECTED)
+      .mockResolvedValue(DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    await screen.findByText(/no local daemon found/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
+    await screen.findByText(/A local whiteboard daemon is running at/)
+    expect(screen.queryByText(/no local daemon found/i)).toBeNull()
+  })
+
   it('keeps the CTA affordance when the probe fails inconclusively (not proven blocked)', async () => {
     const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'network' })
     render(

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -69,11 +69,13 @@ describe('DaemonDetectedBanner', () => {
     )
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-    await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
-    expect(probeFn.mock.calls[0]?.[1]).toMatchObject({
-      forceRecheck: true,
-      pageOriginScheme: 'https',
-    })
+    // A manual check sweeps the default port range in parallel (dynamic
+    // server-side ports); every probe in the sweep is a forced recheck.
+    await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(2))
+    expect(probeFn.mock.calls[0]?.[0]).toBe('http://127.0.0.1:3099')
+    for (const call of probeFn.mock.calls) {
+      expect(call[1]).toMatchObject({ forceRecheck: true, pageOriginScheme: 'https' })
+    }
   })
 
   it('renders the manual affordance on http: too when the result is not-detected', async () => {
@@ -87,9 +89,11 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
+    // The silent auto-probe stays narrow: exactly the one stored/default
+    // baseUrl, no port sweep.
     await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-    await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(2))
     expect(probeFn.mock.calls[1]?.[1]).toMatchObject({ forceRecheck: true })
   })
 
@@ -290,6 +294,93 @@ describe('DaemonDetectedBanner', () => {
     expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
   })
 
+  it('a manual check finds a daemon on a non-default port (server-side ports are dynamic)', async () => {
+    // ensure-daemon binds findAvailablePort(3099): when 3099 is taken by
+    // something else, the daemon lives on 3100+ — the check must scan, not
+    // assume.
+    const probeFn = vi.fn(async (baseUrl: string) =>
+      baseUrl === 'http://127.0.0.1:3101'
+        ? ({ detected: true, instanceId: 'moved' } as const)
+        : ({ detected: false, reason: 'refused' } as const),
+    )
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/A local whiteboard daemon is running at http:\/\/127\.0\.0\.1:3101/)
+    const openLink = screen.getByRole('link', { name: /open the local app/i })
+    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3101')
+  })
+
+  it('remembers a found daemon and re-probes it first on the next mount', async () => {
+    const store = makeStore()
+    const probeFn = vi.fn(async (baseUrl: string) =>
+      baseUrl === 'http://127.0.0.1:3104'
+        ? ({ detected: true, instanceId: 'wt' } as const)
+        : ({ detected: false, reason: 'refused' } as const),
+    )
+    const first = render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    await screen.findByText(/running at http:\/\/127\.0\.0\.1:3104/)
+    expect(store.load().storage.knownDaemonBaseUrls).toEqual(['http://127.0.0.1:3104'])
+    first.unmount()
+
+    // Next visit on a loopback origin: the auto-probe includes the
+    // remembered baseUrl, so the moved daemon is found without a click.
+    probeFn.mockClear()
+    render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+      />,
+    )
+    await screen.findByText(/running at http:\/\/127\.0\.0\.1:3104/)
+    expect(probeFn.mock.calls.map((c) => c[0])).toContain('http://127.0.0.1:3104')
+  })
+
+  it('shows a picker listing every daemon when several respond', async () => {
+    const probeFn = vi.fn(async (baseUrl: string) => {
+      if (baseUrl === 'http://127.0.0.1:3099')
+        return { detected: true, instanceId: 'main' } as const
+      if (baseUrl === 'http://127.0.0.1:3102')
+        return { detected: true, instanceId: 'worktree' } as const
+      return { detected: false, reason: 'refused' } as const
+    })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/2 local daemons are running/i)
+    const links = screen.getAllByRole('link', { name: /open/i })
+    expect(links.map((l) => l.getAttribute('href'))).toEqual([
+      'http://127.0.0.1:3099',
+      'http://127.0.0.1:3102',
+    ])
+  })
+
   it('a failed manual check on a hosted origin explains the allowlist requirement instead of silence', async () => {
     // The real shape of the 2026-08-07 report: daemon running, hosted origin
     // not in WHITEBOARD_ALLOWED_WEB_ORIGINS -> CORS rejection surfaces as an
@@ -333,11 +424,10 @@ describe('DaemonDetectedBanner', () => {
   })
 
   it('the failure message clears once a re-check succeeds', async () => {
-    const probeFn = vi
-      .fn()
-      .mockResolvedValueOnce(NOT_DETECTED)
-      .mockResolvedValueOnce(NOT_DETECTED)
-      .mockResolvedValue(DETECTED)
+    // Sweep-aware fake: a mutable flag instead of call-count sequencing,
+    // because one manual check now issues several probes.
+    let daemonUp = false
+    const probeFn = vi.fn(async () => (daemonUp ? DETECTED : NOT_DETECTED))
     render(
       <DaemonDetectedBanner
         settingsStore={makeStore()}
@@ -350,6 +440,7 @@ describe('DaemonDetectedBanner', () => {
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
     await screen.findByText(/no local daemon found/i)
 
+    daemonUp = true
     fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
     await screen.findByText(/A local whiteboard daemon is running at/)
     expect(screen.queryByText(/no local daemon found/i)).toBeNull()
@@ -368,7 +459,7 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
-    await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(1))
     expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
     expect(screen.queryByText(UNSUPPORTED_BROWSER_NOTICE)).toBeNull()
     expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { deriveCapabilityTier } from '../../lib/capability-tier.js'
 import {
+  candidateBaseUrls,
+  type DiscoveredDaemon,
+  discoverDaemons,
+  rememberKnownDaemon,
+} from '../../lib/daemon-discovery.js'
+import {
   type DaemonProbeResult,
   DEFAULT_DAEMON_BASE_URL,
   type ProbeDaemonOptions,
@@ -49,6 +55,10 @@ export function DaemonDetectedBanner({
   probeFn = probeDaemon,
 }: DaemonDetectedBannerProps) {
   const [result, setResult] = useState<DaemonProbeResult | null>(null)
+  // Every daemon the last sweep confirmed (dynamic ports mean there can be
+  // several — one per dev worktree is the local norm). `result` above stays
+  // the representative single answer the dismissal/tier logic reads.
+  const [found, setFound] = useState<DiscoveredDaemon[] | null>(null)
   // Set only when the USER clicked the check and it came back empty — the
   // silent auto-probe on loopback mounts must not spawn failure copy the
   // user never asked for.
@@ -81,13 +91,19 @@ export function DaemonDetectedBanner({
   // top-level link rather than a pairing instruction. Deep-link to the
   // last-connected canvas when known so the link lands the user back where
   // they were instead of just the daemon's root.
+  // Where the sweep actually found a daemon (dynamic ports); falls back to
+  // the stored/default target while nothing is confirmed.
+  const detectedBaseUrl = found?.[0]?.baseUrl ?? baseUrl
+
   const openLocalAppUrl = useMemo(() => {
     const { lastConnectedWorkspaceId, lastConnectedSlug } = storedTarget
-    if (lastConnectedWorkspaceId && lastConnectedSlug) {
+    // The last-connected canvas belongs to the STORED daemon — deep-link
+    // only when the discovered daemon is that same base, else land on root.
+    if (detectedBaseUrl === baseUrl && lastConnectedWorkspaceId && lastConnectedSlug) {
       return `${baseUrl}/canvas/${encodeURIComponent(lastConnectedWorkspaceId)}/${encodeURIComponent(lastConnectedSlug)}`
     }
-    return baseUrl
-  }, [storedTarget, baseUrl])
+    return detectedBaseUrl
+  }, [storedTarget, baseUrl, detectedBaseUrl])
 
   // 'http:'/'https:' -> 'http'/'https'; any other scheme (e.g. jsdom's
   // default 'about:' outside these injected-prop tests) falls back to
@@ -99,15 +115,48 @@ export function DaemonDetectedBanner({
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
-    probeFn(baseUrl, {
+    const known = settingsStore.load().storage.knownDaemonBaseUrls ?? []
+    // The server side binds dynamically (findAvailablePort from 3099; dev
+    // worktrees use derived ports), so a single fixed-port ping misses
+    // moved daemons. Remembered baseUrls are always re-checked; the wider
+    // port scan runs only on explicit user intent — the silent loopback
+    // auto-probe stays narrow.
+    const candidates = candidateBaseUrls({
+      remembered: [...known, baseUrl],
+      ...(forceRecheck ? {} : { portRangeCount: 0 }),
+    })
+    discoverDaemons({
+      candidates,
       fetch,
+      pageOriginScheme,
+      probeFn,
       forceRecheck,
       signal: controller.signal,
-      pageOriginScheme,
-    }).then((next) => {
+    }).then(({ found: nextFound, failures }) => {
       if (controller.signal.aborted) return
-      setResult(next)
-      setManualCheckFailed(Boolean(forceRecheck) && !next.detected)
+      setFound(nextFound)
+      const first = nextFound[0]
+      setResult(
+        first
+          ? { detected: true, instanceId: first.instanceId }
+          : // Prefer a proven-blocked failure so the capability tier stays
+            // honest even when another candidate merely timed out.
+            (failures.find((f) => !f.detected && f.reason === 'blocked') ??
+              failures[0] ??
+              ({ detected: false, reason: 'network' } as const)),
+      )
+      setManualCheckFailed(Boolean(forceRecheck) && nextFound.length === 0)
+      if (nextFound.length > 0) {
+        // Persist every confirmed daemon, first-found ending most recent,
+        // so the next visit's narrow auto-probe reaches them directly.
+        settingsStore.update((current) => {
+          let list = current.storage.knownDaemonBaseUrls ?? []
+          for (const daemon of [...nextFound].reverse()) {
+            list = rememberKnownDaemon(list, daemon.baseUrl)
+          }
+          return { ...current, storage: { ...current.storage, knownDaemonBaseUrls: list } }
+        })
+      }
     })
   }
 
@@ -226,12 +275,37 @@ export function DaemonDetectedBanner({
           )}
         </span>
       )}
-      {showBanner && (
+      {showBanner && found !== null && found.length > 1 && (
+        <div
+          data-testid="daemon-picker"
+          className="flex shrink-0 flex-wrap items-center gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
+        >
+          <span>{found.length} local daemons are running.</span>
+          {found.map((daemon) => (
+            <a
+              key={daemon.instanceId}
+              href={daemon.baseUrl}
+              className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"
+            >
+              Open {daemon.baseUrl.replace(/^https?:\/\//, '')}
+            </a>
+          ))}
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss"
+            className="shrink-0 rounded px-1.5 py-0.5 font-medium hover:bg-background/60"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+      {showBanner && (found === null || found.length <= 1) && (
         <div
           data-testid="daemon-detected-banner"
           className="flex shrink-0 items-center justify-between gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
         >
-          <span>A local whiteboard daemon is running at {baseUrl}.</span>
+          <span>A local whiteboard daemon is running at {detectedBaseUrl}.</span>
           <a
             href={openLocalAppUrl}
             className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -49,6 +49,10 @@ export function DaemonDetectedBanner({
   probeFn = probeDaemon,
 }: DaemonDetectedBannerProps) {
   const [result, setResult] = useState<DaemonProbeResult | null>(null)
+  // Set only when the USER clicked the check and it came back empty — the
+  // silent auto-probe on loopback mounts must not spawn failure copy the
+  // user never asked for.
+  const [manualCheckFailed, setManualCheckFailed] = useState(false)
   const [dismissedAt, setDismissedAt] = useState(
     () => settingsStore.load().storage.dismissedDaemonCtaAt,
   )
@@ -103,6 +107,7 @@ export function DaemonDetectedBanner({
     }).then((next) => {
       if (controller.signal.aborted) return
       setResult(next)
+      setManualCheckFailed(Boolean(forceRecheck) && !next.detected)
     })
   }
 
@@ -193,6 +198,33 @@ export function DaemonDetectedBanner({
         >
           Check for local daemon
         </button>
+      )}
+      {showManualAffordance && manualCheckFailed && (
+        // A CORS rejection (daemon running but this origin not in its
+        // WHITEBOARD_ALLOWED_WEB_ORIGINS) is indistinguishable from
+        // daemon-absent at the fetch layer, so the hosted-origin copy stays
+        // conditional ("if yours is running…") per the honesty discipline
+        // above. Loopback origins need no allowlist entry, so they get the
+        // plain not-found message.
+        <span data-testid="daemon-check-failed-notice" className="text-xs text-muted-foreground">
+          {pageOriginScheme === 'https' ? (
+            <>
+              No daemon reachable from this origin. If yours is running, it must allow this origin
+              via <code>WHITEBOARD_ALLOWED_WEB_ORIGINS</code> —{' '}
+              <a
+                href={HOW_TO_CONNECT_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium underline"
+              >
+                how to connect
+              </a>
+              .
+            </>
+          ) : (
+            <>No local daemon found at {baseUrl}.</>
+          )}
+        </span>
       )}
       {showBanner && (
         <div

--- a/apps/web/src/lib/daemon-discovery.test.ts
+++ b/apps/web/src/lib/daemon-discovery.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { candidateBaseUrls, discoverDaemons, rememberKnownDaemon } from './daemon-discovery.js'
+import type { DaemonProbeResult, ProbeDaemonOptions } from './daemon-probe.js'
+
+const DETECTED = (id: string): DaemonProbeResult => ({ detected: true, instanceId: id })
+const MISS: DaemonProbeResult = { detected: false, reason: 'refused' }
+
+function probeMap(map: Record<string, DaemonProbeResult>) {
+  return vi.fn(
+    async (baseUrl: string, _options: ProbeDaemonOptions): Promise<DaemonProbeResult> => {
+      return map[baseUrl] ?? MISS
+    },
+  )
+}
+
+describe('candidateBaseUrls', () => {
+  it('puts remembered daemons first, then the port range, deduplicated', () => {
+    const candidates = candidateBaseUrls({
+      remembered: ['http://127.0.0.1:3105', 'http://127.0.0.1:3099'],
+      portRangeStart: 3099,
+      portRangeCount: 3,
+    })
+    expect(candidates).toEqual([
+      'http://127.0.0.1:3105',
+      'http://127.0.0.1:3099',
+      'http://127.0.0.1:3100',
+      'http://127.0.0.1:3101',
+    ])
+  })
+
+  it('normalizes trailing slashes on remembered entries before deduplicating', () => {
+    const candidates = candidateBaseUrls({
+      remembered: ['http://127.0.0.1:3099/'],
+      portRangeStart: 3099,
+      portRangeCount: 1,
+    })
+    expect(candidates).toEqual(['http://127.0.0.1:3099'])
+  })
+})
+
+describe('discoverDaemons', () => {
+  it('returns every responding daemon with its baseUrl, in candidate order', async () => {
+    const probeFn = probeMap({
+      'http://127.0.0.1:3099': DETECTED('a'),
+      'http://127.0.0.1:3101': DETECTED('b'),
+    })
+    const { found, failures } = await discoverDaemons({
+      candidates: candidateBaseUrls({ remembered: [], portRangeStart: 3099, portRangeCount: 4 }),
+      probeFn,
+      fetch: vi.fn() as unknown as typeof globalThis.fetch,
+      pageOriginScheme: 'http',
+    })
+    expect(found.map((f) => f.baseUrl)).toEqual(['http://127.0.0.1:3099', 'http://127.0.0.1:3101'])
+    expect(found.map((f) => f.instanceId)).toEqual(['a', 'b'])
+    expect(failures).toHaveLength(2)
+  })
+
+  it('deduplicates two baseUrls answered by the same daemon instance', async () => {
+    // A remembered URL and a scanned port can name the same daemon.
+    const probeFn = probeMap({
+      'http://localhost:3099': DETECTED('same'),
+      'http://127.0.0.1:3099': DETECTED('same'),
+    })
+    const { found } = await discoverDaemons({
+      candidates: ['http://localhost:3099', 'http://127.0.0.1:3099'],
+      probeFn,
+      fetch: vi.fn() as unknown as typeof globalThis.fetch,
+      pageOriginScheme: 'http',
+    })
+    expect(found).toHaveLength(1)
+    expect(found[0]?.baseUrl).toBe('http://localhost:3099')
+  })
+
+  it('returns empty when nothing responds', async () => {
+    const { found } = await discoverDaemons({
+      candidates: candidateBaseUrls({ remembered: [], portRangeStart: 3099, portRangeCount: 2 }),
+      probeFn: probeMap({}),
+      fetch: vi.fn() as unknown as typeof globalThis.fetch,
+      pageOriginScheme: 'http',
+    })
+    expect(found).toEqual([])
+  })
+})
+
+describe('rememberKnownDaemon', () => {
+  it('prepends the baseUrl, most recent first, deduplicated and capped', () => {
+    expect(rememberKnownDaemon(['http://a', 'http://b'], 'http://b')).toEqual([
+      'http://b',
+      'http://a',
+    ])
+    const many = ['1', '2', '3', '4', '5'].map((n) => `http://127.0.0.1:310${n}`)
+    const next = rememberKnownDaemon(many, 'http://127.0.0.1:3199')
+    expect(next).toHaveLength(5)
+    expect(next[0]).toBe('http://127.0.0.1:3199')
+  })
+})

--- a/apps/web/src/lib/daemon-discovery.ts
+++ b/apps/web/src/lib/daemon-discovery.ts
@@ -1,0 +1,116 @@
+/**
+ * Local-daemon discovery over a bounded candidate set.
+ *
+ * The server side already binds dynamically: the packaged daemon takes the
+ * first free port from 3099 upward (ensure-daemon's findAvailablePort) and
+ * dev worktree daemons run on hash-derived ports. The browser cannot read
+ * the daemon registry file, so discovery is limited to two channels:
+ * previously remembered baseUrls (localStorage, most recent first) and a
+ * small scan of the default port range. Everything is probed in parallel
+ * with the same timeboxed ping used by the single-probe path.
+ *
+ * A baseUrl is a HINT, not an identity: a port can be re-bound by a
+ * different daemon between visits, so results carry the ping's instanceId
+ * and callers must treat that (plus pairing, where it applies) as the
+ * actual identity.
+ */
+import type { DaemonProbeResult, ProbeDaemonOptions } from './daemon-probe.js'
+import { probeDaemon } from './daemon-probe.js'
+
+const DEFAULT_PORT_RANGE_START = 3099
+// findAvailablePort drift rarely goes far; a bounded scan keeps a manual
+// check under ~1s worst-case (probes run in parallel, each timeboxed).
+const DEFAULT_PORT_RANGE_COUNT = 10
+const MAX_REMEMBERED_DAEMONS = 5
+
+export interface DiscoveredDaemon {
+  readonly baseUrl: string
+  readonly instanceId: string
+}
+
+export interface DiscoveryOutcome {
+  readonly found: DiscoveredDaemon[]
+  /** Failure results for candidates that answered nothing usable — kept so
+   *  callers can still derive the proven-blocked capability tier. */
+  readonly failures: DaemonProbeResult[]
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '')
+}
+
+export function candidateBaseUrls({
+  remembered,
+  portRangeStart = DEFAULT_PORT_RANGE_START,
+  portRangeCount = DEFAULT_PORT_RANGE_COUNT,
+}: {
+  remembered: readonly string[]
+  portRangeStart?: number
+  portRangeCount?: number
+}): string[] {
+  const seen = new Set<string>()
+  const candidates: string[] = []
+  const push = (baseUrl: string) => {
+    const normalized = normalizeBaseUrl(baseUrl)
+    if (seen.has(normalized)) return
+    seen.add(normalized)
+    candidates.push(normalized)
+  }
+  for (const baseUrl of remembered) push(baseUrl)
+  for (let i = 0; i < portRangeCount; i++) push(`http://127.0.0.1:${portRangeStart + i}`)
+  return candidates
+}
+
+export async function discoverDaemons({
+  candidates,
+  fetch,
+  pageOriginScheme,
+  probeFn = probeDaemon,
+  forceRecheck,
+  signal,
+}: {
+  candidates: readonly string[]
+  fetch: typeof globalThis.fetch
+  pageOriginScheme: 'http' | 'https'
+  probeFn?: (baseUrl: string, options: ProbeDaemonOptions) => Promise<DaemonProbeResult>
+  forceRecheck?: boolean
+  signal?: AbortSignal
+}): Promise<DiscoveryOutcome> {
+  const results = await Promise.all(
+    candidates.map(async (baseUrl) => {
+      try {
+        const result = await probeFn(baseUrl, {
+          fetch,
+          pageOriginScheme,
+          forceRecheck,
+          signal,
+        })
+        return { baseUrl, result }
+      } catch {
+        // A single candidate failing hard must not sink the whole sweep.
+        return { baseUrl, result: null }
+      }
+    }),
+  )
+  const byInstance = new Map<string, DiscoveredDaemon>()
+  const failures: DaemonProbeResult[] = []
+  for (const { baseUrl, result } of results) {
+    if (!result?.detected) {
+      if (result) failures.push(result)
+      continue
+    }
+    // First candidate wins per instance: remembered URLs precede the scan,
+    // so a daemon reachable under both keeps its remembered spelling.
+    if (!byInstance.has(result.instanceId)) {
+      byInstance.set(result.instanceId, { baseUrl, instanceId: result.instanceId })
+    }
+  }
+  return { found: [...byInstance.values()], failures }
+}
+
+/** MRU update for the persisted known-daemon list. */
+export function rememberKnownDaemon(known: readonly string[], baseUrl: string): string[] {
+  const normalized = normalizeBaseUrl(baseUrl)
+  const rest = known.map(normalizeBaseUrl).filter((entry) => entry !== normalized)
+  return [normalized, ...rest].slice(0, MAX_REMEMBERED_DAEMONS)
+}

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -1,6 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createUserSettingsStore, defaultUserSettings, STORAGE_KEY } from './user-settings-store.js'
 
+describe('knownDaemonBaseUrls bound', () => {
+  it('an oversized stored array fails validation and load falls back to defaults', () => {
+    localStorage.clear()
+    const oversized = Array.from({ length: 6 }, (_, i) => `http://127.0.0.1:${3099 + i}`)
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, storage: { knownDaemonBaseUrls: oversized } }),
+    )
+    const store = createUserSettingsStore()
+    // Consistent with the store's existing invalid-value semantics (e.g. a
+    // non-http localDaemonBaseUrl): safeParse fails and defaults win, so
+    // discovery can never fan out over an unbounded tampered list.
+    expect(store.load().storage.knownDaemonBaseUrls).toBeUndefined()
+  })
+})
+
 describe('createUserSettingsStore', () => {
   beforeEach(() => {
     localStorage.clear()

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -82,6 +82,10 @@ const storageSettingsSchema = z
           }
         }, 'must be an http(s) URL'),
       )
+      // The writer keeps this MRU-capped (daemon-discovery's helper), and
+      // every stored entry is re-probed on the next check — an oversized
+      // tampered array must not turn discovery into an unbounded fan-out.
+      .max(5, 'must contain at most 5 daemon URLs')
       .optional(),
     dismissedPersistenceWarningAt: z.string().optional(),
     dismissedBetaBannerAt: z.string().optional(),

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -67,6 +67,22 @@ const storageSettingsSchema = z
     // by a cross-field refine the way daemonConnectionPayloadSchema does.
     lastConnectedWorkspaceId: z.string().optional(),
     lastConnectedSlug: z.string().optional(),
+    // Every daemon baseUrl a probe has actually confirmed, most recent
+    // first (see daemon-discovery.ts's MRU helper). Same http(s)-only
+    // constraint as localDaemonBaseUrl above and for the same reason:
+    // these values are rendered into hrefs and fetched.
+    knownDaemonBaseUrls: z
+      .array(
+        z.string().refine((value) => {
+          try {
+            const { protocol } = new URL(value)
+            return protocol === 'http:' || protocol === 'https:'
+          } catch {
+            return false
+          }
+        }, 'must be an http(s) URL'),
+      )
+      .optional(),
     dismissedPersistenceWarningAt: z.string().optional(),
     dismissedBetaBannerAt: z.string().optional(),
     dismissedDaemonCtaAt: z.string().optional(),

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -117,6 +117,13 @@ bootstrap token, so anyone who has the link can pair with your daemon until
 the token is rotated. Share it only with the intended recipient, and prefer
 loopback (`http://127.0.0.1:...`) origins for purely local use.
 
+The hosted app's "Check for local daemon" does not assume the default
+port: it re-checks daemons it has successfully found before (remembered in
+the browser, most recent first) and scans a small range above the default
+(3099–3108) in parallel, because the daemon binds the first free port from
+3099 upward. When several daemons respond — one per dev worktree is
+common — the banner lists each of them.
+
 For hosted (non-loopback) `webOrigin` values, the daemon must also be
 configured to accept that origin via `WHITEBOARD_ALLOWED_WEB_ORIGINS` — either
 as an exact match or via a `https://*.example.com` wildcard subdomain pattern

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.mjs
@@ -68,6 +68,27 @@ export function resolveRepoRootFromGit(cwd) {
  * .dev-data, which is intentional: it keeps parallel dev-loop lanes from
  * sharing (and corrupting) one another's canvas data.
  */
+// The project's own hosted-app origins (production + preview deployments).
+// Dev-only default: the hosted app pairing with a local dev daemon is this
+// repo's primary dogfood loop, and a hook-respawned daemon silently losing
+// the allowance was a real dead end (2026-08-07). The published daemon keeps
+// its loopback-only default — widening THAT is a product decision
+// (see the default-allow-official-hosted-origins canvas).
+const DEV_DEFAULT_ALLOWED_WEB_ORIGINS =
+  'https://kamiazya-whiteboard.pages.dev,https://*.kamiazya-whiteboard.pages.dev'
+
+/**
+ * Returns a new env object with WHITEBOARD_ALLOWED_WEB_ORIGINS defaulted to
+ * the project's own pages.dev origins. Any explicit caller value wins —
+ * including the empty string, which deliberately restores loopback-only.
+ */
+export function resolveDevAllowedWebOriginsEnv(env) {
+  if (env.WHITEBOARD_ALLOWED_WEB_ORIGINS !== undefined) {
+    return { ...env }
+  }
+  return { ...env, WHITEBOARD_ALLOWED_WEB_ORIGINS: DEV_DEFAULT_ALLOWED_WEB_ORIGINS }
+}
+
 export function resolveDevDataDirEnv(env, repoRoot) {
   if (env.WHITEBOARD_DATA_DIR) {
     return { ...env }

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir-lib.test.ts
@@ -16,12 +16,34 @@ import {
   readDevDaemonMarker,
   removeDevDaemonMarker,
   reraiseSignalOrExit,
+  resolveDevAllowedWebOriginsEnv,
   resolveDevDataDirEnv,
   resolveEffectivePort,
   resolveRepoRootFromScriptDir,
   resolveTsxWatchSpawn,
   writeDevDaemonMarker,
 } from './with-dev-data-dir-lib.mjs'
+
+describe('resolveDevAllowedWebOriginsEnv', () => {
+  it('defaults to the project pages.dev origins when unset', () => {
+    const result = resolveDevAllowedWebOriginsEnv({})
+    expect(result.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe(
+      'https://kamiazya-whiteboard.pages.dev,https://*.kamiazya-whiteboard.pages.dev',
+    )
+  })
+
+  it('an explicit env value wins over the dev default', () => {
+    const result = resolveDevAllowedWebOriginsEnv({
+      WHITEBOARD_ALLOWED_WEB_ORIGINS: 'https://example.com',
+    })
+    expect(result.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe('https://example.com')
+  })
+
+  it('an explicit empty string disables the default (deliberate loopback-only)', () => {
+    const result = resolveDevAllowedWebOriginsEnv({ WHITEBOARD_ALLOWED_WEB_ORIGINS: '' })
+    expect(result.WHITEBOARD_ALLOWED_WEB_ORIGINS).toBe('')
+  })
+})
 
 describe('resolveDevDataDirEnv', () => {
   const repoRoot = '/repo'

--- a/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
+++ b/packages/mcp-server/scripts/dev/with-dev-data-dir.mjs
@@ -8,6 +8,7 @@ import {
   injectDerivedPortArg,
   removeDevDaemonMarker,
   reraiseSignalOrExit,
+  resolveDevAllowedWebOriginsEnv,
   resolveDevDataDirEnv,
   resolveEffectivePort,
   resolveRepoRootFromGit,
@@ -22,7 +23,7 @@ import {
 const repoRoot = resolveRepoRootFromGit(process.cwd())
 const packageRoot = resolve(repoRoot, 'packages/mcp-server')
 const hadExplicitDataDirOverride = Boolean(process.env.WHITEBOARD_DATA_DIR)
-const env = resolveDevDataDirEnv(process.env, repoRoot)
+const env = resolveDevAllowedWebOriginsEnv(resolveDevDataDirEnv(process.env, repoRoot))
 
 // resolveDataDir() (shared/data-dir-secure.ts) only hardens permissions on
 // its own home-directory default; an explicit WHITEBOARD_DATA_DIR — which is


### PR DESCRIPTION
## Summary

Three fixes from today's live report (hosted app could not reach the local daemon), per the filed canvases `daemon-check-silent-cors-dead-end` and `daemon-discovery-dynamic-port-memory-multi`:

1. **Dev daemon default-allows the project's hosted origins** (`with-dev-data-dir` env resolution): `WHITEBOARD_ALLOWED_WEB_ORIGINS` defaults to `https://kamiazya-whiteboard.pages.dev` + wildcard previews so hosted-app pairing survives hook-driven daemon restarts. Any explicit value wins — including the empty string (deliberate loopback-only). The **published** daemon's loopback-only default is untouched; widening that is the recorded product decision (`default-allow-official-hosted-origins`).
2. **A failed daemon check explains itself** instead of silent nothing: a user-initiated check that comes back empty now shows the conditional allowlist hint (hosted origins) or a plain not-found line (loopback). CORS-rejected and daemon-absent are indistinguishable at the fetch layer, so the copy stays honest ("if yours is running…"). The silent loopback auto-probe stays silent.
3. **Daemon discovery** (`daemon-discovery.ts`): the server side already binds dynamically (`findAvailablePort` from 3099; dev worktrees on derived ports) while the app pinged exactly `http://127.0.0.1:3099`. A manual check now sweeps remembered baseUrls + a bounded port range (3099–3108) in parallel; found daemons persist MRU (capped 5, http(s)-validated in the settings schema) so the next visit's narrow auto-probe reaches them directly; several responders render a picker listing each daemon. Dedupe is by ping `instanceId` — a baseUrl is a hint, not an identity — and the last-connected deep link applies only when the found daemon is the stored one.

## Verification

- New module tests (candidate ordering/dedup, discovery, instanceId dedupe, MRU) 6/6; banner suite 21/21 including the three new behaviors (non-default-port find, remember-and-re-probe on next mount, multi picker); apps/web jsdom 113 files / 1321 green; typecheck 0; knip clean.
- Live (real Chromium against the running dev daemon): manual check sweeps 3099–3108 and shows the banner with the found base; failure notice renders on empty sweeps.
- Observed pre-existing, out of scope: with React StrictMode's dev double-mount, the loopback auto-probe's abort can poison the probe memo so the banner needs a manual click in `pnpm dev` (production builds unaffected; same abort/memo structure exists on main).

## Docs

`docs/how-to/connect-to-local-daemon.md` documents the scan range and remembered-daemon behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically discovers local daemons across remembered and nearby ports.
  - Displays multiple available daemons for easy selection.
  - Remembers detected daemon connections for faster future access.
  - Shows the detected connection address and preserves relevant deep links.
- **Bug Fixes**
  - Provides clearer guidance for connection failures and supports successful retry recovery.
  - Improves handling of multiple daemon instances and network errors.
- **Documentation**
  - Updated local daemon connection instructions to explain expanded discovery and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->