### PR TITLE
fix(web): label unverified loopback responders instead of claiming they are your daemon

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -108,7 +108,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    await screen.findByText(/A local whiteboard daemon is running at/)
+    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
     const openLink = screen.getByRole('link', { name: /open the local app/i })
     expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099')
     // The pairing-link ask is gone: since R3, navigating to the daemon
@@ -194,7 +194,9 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /dismiss/i }))
 
-    expect(screen.queryByText(/A local whiteboard daemon is running at/)).toBeNull()
+    expect(
+      screen.queryByText(/(A local whiteboard daemon is running at|A server responded at)/),
+    ).toBeNull()
 
     const saved = store.load()
     expect(saved.storage.dismissedDaemonCtaInstanceId).toBe('inst-1')
@@ -224,7 +226,9 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /forget this daemon/i }))
 
-    expect(screen.queryByText(/A local whiteboard daemon is running at/)).toBeNull()
+    expect(
+      screen.queryByText(/(A local whiteboard daemon is running at|A server responded at)/),
+    ).toBeNull()
     const saved = store.load()
     expect(saved.storage.localDaemonBaseUrl).toBeUndefined()
     expect(saved.storage.lastConnectedWorkspaceId).toBeUndefined()
@@ -242,7 +246,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    await screen.findByText(/A local whiteboard daemon is running at/)
+    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
     expect(screen.queryByRole('button', { name: /forget this daemon/i })).toBeNull()
   })
 
@@ -314,7 +318,7 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
-    await screen.findByText(/A local whiteboard daemon is running at http:\/\/127\.0\.0\.1:3101/)
+    await screen.findByText(/A server responded at http:\/\/127\.0\.0\.1:3101/)
     const openLink = screen.getByRole('link', { name: /open the local app/i })
     expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3101')
   })
@@ -335,7 +339,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-    await screen.findByText(/running at http:\/\/127\.0\.0\.1:3104/)
+    await screen.findByText(/responded at http:\/\/127\.0\.0\.1:3104/)
     expect(store.load().storage.knownDaemonBaseUrls).toEqual(['http://127.0.0.1:3104'])
     first.unmount()
 
@@ -350,7 +354,7 @@ describe('DaemonDetectedBanner', () => {
         probeFn={probeFn}
       />,
     )
-    await screen.findByText(/running at http:\/\/127\.0\.0\.1:3104/)
+    await screen.findByText(/responded at http:\/\/127\.0\.0\.1:3104/)
     expect(probeFn.mock.calls.map((c) => c[0])).toContain('http://127.0.0.1:3104')
   })
 
@@ -373,12 +377,56 @@ describe('DaemonDetectedBanner', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
-    await screen.findByText(/2 local daemons are running/i)
+    await screen.findByText(/2 servers responded on local ports/i)
     const links = screen.getAllByRole('link', { name: /open/i })
     expect(links.map((l) => l.getAttribute('href'))).toEqual([
       'http://127.0.0.1:3099',
       'http://127.0.0.1:3102',
     ])
+  })
+
+  it('an unpaired swept responder is labelled UNVERIFIED, not "a whiteboard daemon is running"', async () => {
+    // Any local process can bind a loopback port and answer /api/runtime/
+    // ping with a self-asserted instanceId, so a swept hit is an unproven
+    // claim. The app must not lend it its own trust label until the user
+    // has actually granted this origin on that daemon's own consent page.
+    const probeFn = vi.fn().mockResolvedValue(DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/responded at/i)
+    expect(screen.getByText(/unverified/i)).not.toBeNull()
+    expect(screen.queryByText(/a local whiteboard daemon is running/i)).toBeNull()
+  })
+
+  it('a previously paired daemon keeps the plain trusted label', async () => {
+    const store = makeStore()
+    store.update((current) => ({
+      ...current,
+      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+    }))
+    const probeFn = vi.fn().mockResolvedValue(DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+
+    await screen.findByText(/a local whiteboard daemon is running/i)
+    expect(screen.queryByText(/unverified/i)).toBeNull()
   })
 
   it('a detected daemon offers connect-in-place, which starts the pairing-grant redirect', async () => {
@@ -487,7 +535,7 @@ describe('DaemonDetectedBanner', () => {
 
     daemonUp = true
     fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
-    await screen.findByText(/A local whiteboard daemon is running at/)
+    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
     expect(screen.queryByText(/no local daemon found/i)).toBeNull()
   })
 

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -106,6 +106,15 @@ export function DaemonDetectedBanner({
   // the stored/default target while nothing is confirmed.
   const detectedBaseUrl = found?.[0]?.baseUrl ?? baseUrl
 
+  // A responder on a loopback port is an UNPROVEN claim: any local process
+  // can bind a free port and answer /api/runtime/ping with a self-asserted
+  // instanceId (see the daemon-impersonation-port-squatting issue). Only a
+  // baseUrl this browser has actually paired with — the user approved it on
+  // that daemon's own consent page — earns the app's trust label. Everything
+  // else is labelled unverified. This is presentation-level honesty, not a
+  // security boundary: the durable fix is daemon->browser mutual auth.
+  const isPairedTarget = detectedBaseUrl === storedTarget.localDaemonBaseUrl
+
   const openLocalAppUrl = useMemo(() => {
     const { lastConnectedWorkspaceId, lastConnectedSlug } = storedTarget
     // The last-connected canvas belongs to the STORED daemon — deep-link
@@ -279,7 +288,7 @@ export function DaemonDetectedBanner({
               >
                 connect anyway
               </button>
-              , or see{' '}
+              . Only approve a daemon you started yourself, or see{' '}
               <a
                 href={HOW_TO_CONNECT_URL}
                 target="_blank"
@@ -300,7 +309,7 @@ export function DaemonDetectedBanner({
           data-testid="daemon-picker"
           className="flex shrink-0 flex-wrap items-center gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
         >
-          <span>{found.length} local daemons are running.</span>
+          <span>{found.length} servers responded on local ports (unverified).</span>
           {found.map((daemon) => (
             <a
               key={daemon.instanceId}
@@ -325,7 +334,16 @@ export function DaemonDetectedBanner({
           data-testid="daemon-detected-banner"
           className="flex shrink-0 items-center justify-between gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
         >
-          <span>A local whiteboard daemon is running at {detectedBaseUrl}.</span>
+          <span>
+            {isPairedTarget ? (
+              <>A local whiteboard daemon is running at {detectedBaseUrl}.</>
+            ) : (
+              <>
+                A server responded at {detectedBaseUrl} (unverified — approve it on its own page to
+                confirm it is your daemon).
+              </>
+            )}
+          </span>
           <button
             type="button"
             onClick={() => void beginGrantFn({ daemonBaseUrl: detectedBaseUrl })}

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -60,6 +60,42 @@ frequently-reused development port accordingly, and prefer the local
 daemon (loopback-bound, its own token) over browser-local storage for
 anything you would not want a future occupant of that port to read.
 
+## Daemon impersonation (loopback port squatting, the other direction)
+
+The section above concerns a process inheriting a browser ORIGIN. The
+mirror case is a process impersonating the DAEMON: the hosted app can
+sweep loopback ports to find one, and `/api/runtime/ping` is public and
+its instance id is self-asserted, so any local process that binds a free
+loopback port can answer it.
+
+Pairing therefore authenticates one direction only — browser origin to
+daemon, via a grant the user approves. The reverse (is this responder
+really your daemon?) is **not** authenticated today. A squatter that wins
+a swept port cannot touch the real daemon's data — grants, tokens, and the
+data directory are per-daemon and separated by OS permissions — but it can
+present itself for pairing and capture content the user creates afterward.
+
+What the UI does about it:
+
+- A responder this browser has never paired with is labelled
+  "responded … (unverified)", never "your daemon is running". The app does
+  not lend its own trust to an unproven claim.
+- Approving a grant is always an explicit click on the responding daemon's
+  own consent page, which shows the requesting origin.
+- The trusted-direction bootstraps — the `create_pairing_link` MCP tool, or
+  opening the hosted app from the daemon itself — carry the base URL and
+  credential from the real daemon, so they avoid this exposure entirely.
+  Prefer them when available.
+
+Scope: this is about a local process that can bind a port but is not the
+daemon. A full-privilege local attacker is outside this threat model (the
+daemon already trusts the loopback interface and the OS user boundary) and
+would read the daemon's data directory directly instead.
+
+The durable fix is daemon-to-browser authentication: a daemon keypair
+whose public half the ping advertises, with a signed challenge during
+token exchange. Until that lands, discovery is convenience, not proof.
+
 ## HTTP protections
 
 - **Bearer token**: local HTTP clients must send `Authorization: Bearer <token>` when token auth is enabled. The token is written to `daemon.json` in the data directory (`~/.whiteboard` by default) so the stdio MCP server can locate the running daemon. The file is created with mode `0o600` (owner-read/write only) and is re-chmod'd after write on non-Windows platforms to counteract a permissive umask. Treat `daemon.json` as a credential file and ensure the data directory itself is not world-readable.


### PR DESCRIPTION
## Summary

Raised in review of the port-sweep discovery (#432): does sweeping loopback ports widen the impersonation surface, and shouldn't a trusted direction (MCP/CLI opening the browser) be preferred? **Both points are correct**, and this PR applies the immediately-available mitigation while recording the durable fix.

**The gap**: pairing grants authenticate exactly one direction — browser origin → daemon. The reverse is unauthenticated: `/api/runtime/ping` is public and its `instanceId` is self-asserted, so any local process that binds a free loopback port can answer it. The banner then said *"A local whiteboard daemon is running at …"* for **any** responder, lending the app's own credibility to a possible impostor and making the phishing step of a port-squatting attack materially easier. (The attack class pre-dates the sweep — `findAvailablePort` already let a squatter hold 3099 while the real daemon moved to 3100 — but 10 ports plus a trust-labelled picker raised both probability and persuasiveness.)

**What changed**:
- Only a baseUrl this browser has actually paired with keeps the plain trusted label. Everything else reads *"A server responded at … (unverified — approve it on its own page to confirm it is your daemon)"*.
- The multi-responder picker says *"N servers responded on local ports (unverified)"* instead of *"N local daemons are running"*.
- "connect anyway" now warns: only approve a daemon you started yourself.
- `docs/explanation/security-model.md` gains a **Daemon impersonation** section, deliberately adjacent to the existing loopback-origin-squatting section (they are mirror cases), covering scope limits, why the real daemon is unharmed, and the preference for trusted-direction bootstraps (`create_pairing_link`, daemon-side handoff).

This is presentation-level honesty, not a security boundary. The durable fix — a daemon keypair advertised via ping plus a signed challenge during token exchange — is tracked on the `daemon-impersonation-port-squatting` canvas along with the proposal to make daemon-originated handoff the primary path.

## Verification

New tests pin both directions (an unpaired responder must be labelled unverified; a paired one must not be), existing assertions updated to the new copy. apps/web jsdom 115 files / 1342 green, typecheck 0, knip clean.
