### PR TITLE
fix(web): keep the /pair consent route from being rewritten away

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -107,6 +107,35 @@ const INVALID_CONFIG_STATE: ProviderState = {
   message: 'Runtime configuration is invalid.',
 }
 
+describe('/pair consent route', () => {
+  it('renders the consent page and does NOT rewrite the URL away from /pair', async () => {
+    // Regression: the daemonView -> URL sync effect ran on mount, saw
+    // parseDaemonRoute('/pair') === null (so daemonView defaulted to the
+    // index), and navigated to '/' — dropping the origin/challenge/state
+    // query and dumping the user on the daemon gallery instead of the
+    // consent page. Observed live on the daemon origin, 2026-08-07.
+    const router = createMemoryRouter(
+      [
+        {
+          path: '*',
+          element: <App providerState={LOCAL_DAEMON_STATE} />,
+        },
+      ],
+      {
+        initialEntries: ['/pair?origin=https%3A%2F%2Fexample.com&challenge=chal&state=st'],
+      },
+    )
+    await act(async () => {
+      render(<RouterProvider router={router} />)
+    })
+
+    expect(router.state.location.pathname).toBe('/pair')
+    expect(router.state.location.search).toContain('challenge=chal')
+    await screen.findByText(/allow this web app to use your local daemon/i)
+    expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
+  })
+})
+
 describe('App backend configuration chip', () => {
   it('shows "Browser only" when configured for browser-local storage', () => {
     render(

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -130,7 +130,10 @@ describe('/pair consent route', () => {
     })
 
     expect(router.state.location.pathname).toBe('/pair')
-    expect(router.state.location.search).toContain('challenge=chal')
+    const search = new URLSearchParams(router.state.location.search)
+    expect(search.get('origin')).toBe('https://example.com')
+    expect(search.get('challenge')).toBe('chal')
+    expect(search.get('state')).toBe('st')
     await screen.findByText(/allow this web app to use your local daemon/i)
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
   })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -138,6 +138,13 @@ export function App({ providerState }: AppProps) {
   const location = useLocation()
   const navigate = useNavigate()
 
+  // The daemon-served consent page is its OWN surface, not a daemon view:
+  // parseDaemonRoute('/pair') is null, so without this guard the
+  // daemonView -> URL sync effect below immediately navigated to '/',
+  // dropping the origin/challenge/state query and dumping the user on the
+  // gallery instead of the consent prompt.
+  const isPairRoute = location.pathname === '/pair'
+
   // Pairing-grant return leg: a `#wb-grant=<code>&state=` fragment from the
   // daemon's /pair consent page. The exchange is async (a direct POST — the
   // token itself never rides the URL), so unlike the synchronous #wb= path
@@ -203,6 +210,7 @@ export function App({ providerState }: AppProps) {
   // subsequent sync pushes, so browser back/forward has real steps to walk.
   const isFirstUrlSyncRef = useRef(true)
   useEffect(() => {
+    if (isPairRoute) return
     const path = daemonRoutePath(daemonView)
     // Read-then-clear on the FIRST EFFECT RUN regardless of whether it ends
     // up navigating: a no-op first run (URL already matches the initial
@@ -216,7 +224,7 @@ export function App({ providerState }: AppProps) {
     // this effect on every navigation (including the one it just performed),
     // which is harmless but noisy. daemonView is the actual trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [daemonView, navigate])
+  }, [daemonView, navigate, isPairRoute])
 
   // URL -> state: handles the browser back/forward buttons (and, in
   // principle, any other code path that changes the route without going
@@ -225,6 +233,7 @@ export function App({ providerState }: AppProps) {
   // that hasn't caught up to the #wb= sync effect yet.
   const isFirstRouteSyncRef = useRef(true)
   useEffect(() => {
+    if (isPairRoute) return
     if (isFirstRouteSyncRef.current) {
       isFirstRouteSyncRef.current = false
       return
@@ -239,7 +248,7 @@ export function App({ providerState }: AppProps) {
       daemonRoutePath(current) === daemonRoutePath(parsed) ? current : parsed,
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname])
+  }, [location.pathname, isPairRoute])
 
   // Persists ONLY the reconnect target (baseUrl/workspaceId/slug), never the
   // bootstrapToken — the token stays in-memory via readDaemonTokenOnce's
@@ -285,7 +294,7 @@ export function App({ providerState }: AppProps) {
 
   // The daemon-served /pair consent page (pairing-grant flow) — rendered
   // in place of every other view; approving needs the R3-injected token.
-  if (location.pathname === '/pair') {
+  if (isPairRoute) {
     return (
       <Suspense fallback={<LazyPageFallback heightClass="h-dvh" message="Loading…" />}>
         <PairConsentPage daemonToken={daemonToken} />

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -383,9 +383,14 @@ describe('DaemonDetectedBanner', () => {
     // Each responder offers pairing IN PLACE (the hosted-app-first model);
     // leaving for the daemon's own origin stays available as a secondary
     // link, but must not be the only affordance.
-    const useHere = screen.getAllByRole('button', { name: /use here/i })
-    expect(useHere).toHaveLength(2)
-    const links = screen.getAllByRole('link', { name: /open/i })
+    // Unique accessible names per daemon: a control list must identify
+    // WHICH daemon each action targets.
+    const useHere = screen.getAllByRole('button', { name: /use http:\/\/127\.0\.0\.1:\d+ here/i })
+    expect(useHere.map((b) => b.getAttribute('aria-label'))).toEqual([
+      'Use http://127.0.0.1:3099 here',
+      'Use http://127.0.0.1:3102 here',
+    ])
+    const links = screen.getAllByRole('link', { name: /open http:\/\/127\.0\.0\.1:\d+/i })
     expect(links.map((l) => l.getAttribute('href'))).toEqual([
       'http://127.0.0.1:3099',
       'http://127.0.0.1:3102',

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -359,6 +359,7 @@ describe('DaemonDetectedBanner', () => {
   })
 
   it('shows a picker listing every daemon when several respond', async () => {
+    const beginGrantFn = vi.fn(async (_input: { daemonBaseUrl: string }) => {})
     const probeFn = vi.fn(async (baseUrl: string) => {
       if (baseUrl === 'http://127.0.0.1:3099')
         return { detected: true, instanceId: 'main' } as const
@@ -372,17 +373,29 @@ describe('DaemonDetectedBanner', () => {
         fetch={vi.fn()}
         locationProtocol="https:"
         probeFn={probeFn}
+        beginGrantFn={beginGrantFn}
       />,
     )
 
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
     await screen.findByText(/2 servers responded on local ports/i)
+    // Each responder offers pairing IN PLACE (the hosted-app-first model);
+    // leaving for the daemon's own origin stays available as a secondary
+    // link, but must not be the only affordance.
+    const useHere = screen.getAllByRole('button', { name: /use here/i })
+    expect(useHere).toHaveLength(2)
     const links = screen.getAllByRole('link', { name: /open/i })
     expect(links.map((l) => l.getAttribute('href'))).toEqual([
       'http://127.0.0.1:3099',
       'http://127.0.0.1:3102',
     ])
+
+    fireEvent.click(useHere[1] as HTMLElement)
+    await waitFor(() => expect(beginGrantFn).toHaveBeenCalledTimes(1))
+    expect(beginGrantFn.mock.calls[0]?.[0]).toMatchObject({
+      daemonBaseUrl: 'http://127.0.0.1:3102',
+    })
   })
 
   it('an unpaired swept responder is labelled UNVERIFIED, not "a whiteboard daemon is running"', async () => {

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -318,12 +318,14 @@ export function DaemonDetectedBanner({
               <button
                 type="button"
                 onClick={() => void beginGrantFn({ daemonBaseUrl: daemon.baseUrl })}
+                aria-label={`Use ${daemon.baseUrl} here`}
                 className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
               >
                 Use here
               </button>
               <a
                 href={daemon.baseUrl}
+                aria-label={`Open ${daemon.baseUrl}`}
                 className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
               >
                 Open

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -311,13 +311,24 @@ export function DaemonDetectedBanner({
         >
           <span>{found.length} servers responded on local ports (unverified).</span>
           {found.map((daemon) => (
-            <a
-              key={daemon.instanceId}
-              href={daemon.baseUrl}
-              className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"
-            >
-              Open {daemon.baseUrl.replace(/^https?:\/\//, '')}
-            </a>
+            // Pair IN PLACE first: leaving for the daemon's own origin is
+            // the fallback, not the only way through (hosted-app-first).
+            <span key={daemon.instanceId} className="flex items-center gap-1">
+              <span className="font-mono">{daemon.baseUrl.replace(/^https?:\/\//, '')}</span>
+              <button
+                type="button"
+                onClick={() => void beginGrantFn({ daemonBaseUrl: daemon.baseUrl })}
+                className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
+              >
+                Use here
+              </button>
+              <a
+                href={daemon.baseUrl}
+                className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
+              >
+                Open
+              </a>
+            </span>
           ))}
           <button
             type="button"


### PR DESCRIPTION
## Summary

Reported from real use: **"Use here" appeared to do nothing.** Driving Chrome against the deployed app and the real daemon found the cause, and the flow works end to end with this fix.

**The bug**: the daemon-served app rewrote `/pair` to `/` on mount — dropping the `origin`/`challenge`/`state` query and landing the user on the daemon's canvas gallery instead of the consent prompt. A grant could therefore never be created, so pairing silently never happened.

**Cause**: the consent page is not a daemon *view*, but the `daemonView → URL` sync effect still ran for it. `parseDaemonRoute('/pair')` is `null`, so the view defaulted to the index and the effect navigated to `/`. The `/pair` short-circuit in render never got a chance because the pathname had already changed. Both sync effects now exclude the route.

**Same dead end, second place**: the multi-responder picker only offered `Open <baseUrl>`, i.e. leave the hosted app — the very thing the hosted-app-first model exists to avoid. Each responder now offers **Use here** (pair in place) with `Open` kept as the fallback.

## Verification

- Regression test at the App level (this is where the defect lived): rendering App at `/pair?…` with local-daemon provider state must keep the pathname and query and render the consent page. It fails on the old code with `expected '/' to be '/pair'` — the exact observed symptom.
- Picker test asserts a `Use here` per responder and that it starts the grant for **that** daemon's baseUrl.
- apps/web jsdom 115 files / 1343 green, typecheck 0, knip clean, bundle gate OK.
- **Live in Chrome, real daemon**: hosted origin → *Use here* → consent page showing the requesting origin → *Approve* → back on `https://latest.kamiazya-whiteboard.pages.dev/` with the daemon's workspace list, then opened `/canvas/<ws>/opencanvas-mcp-server-plan` with the editor mounted. Daemon data operated in place from the hosted app.

## Note on how this escaped

`PairConsentPage.test.tsx` rendered the page component directly, so it never exercised the surrounding App effects; `App.test.tsx` had no `/pair` case. The new test closes exactly that seam.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Use here” action for each discovered daemon, allowing users to start pairing without leaving the page.
  * Kept a separate “Open” option for navigating directly to a daemon.

* **Bug Fixes**
  * Fixed pairing consent links so the `/pair` route and challenge parameters remain intact while the consent page is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->