### PR TITLE
fix(web): re-check for a new service worker on interval and tab focus

### DIFF
--- a/apps/web/src/pwa/UpdateToast.test.tsx
+++ b/apps/web/src/pwa/UpdateToast.test.tsx
@@ -21,6 +21,18 @@ describe('UpdateToast', () => {
     expect(onReload).toHaveBeenCalledTimes(1)
   })
 
+  it('renders overlaid on the viewport, not in document flow', () => {
+    // The app shell fills 100dvh, so a static toast appended to <body> lands
+    // BELOW the viewport and is never seen — the exact failure observed on
+    // the deployed preview (toast at y === viewport height). Fixed
+    // positioning with a stacking z-index is what keeps it visible.
+    render(<UpdateToast onReload={vi.fn()} onDismiss={vi.fn()} />)
+
+    const toast = screen.getByRole('status')
+    expect(toast.className).toMatch(/\bfixed\b/)
+    expect(toast.className).toMatch(/\bz-\d+\b/)
+  })
+
   it('hides the toast and calls onDismiss when Dismiss is clicked', () => {
     const onDismiss = vi.fn()
     render(<UpdateToast onReload={vi.fn()} onDismiss={onDismiss} />)

--- a/apps/web/src/pwa/UpdateToast.tsx
+++ b/apps/web/src/pwa/UpdateToast.tsx
@@ -12,10 +12,21 @@ export function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
   const [dismissed, setDismissed] = useState(false)
   if (dismissed) return null
 
+  // Fixed + z-index, not document flow: the app shell fills 100dvh, so a
+  // static element appended to <body> sits below the viewport and the
+  // update prompt is never actually seen.
   return (
-    <div role="status" aria-live="polite" className="pwa-update-toast">
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg border bg-background px-4 py-2 text-sm shadow-lg"
+    >
       <span>Update available</span>
-      <button type="button" onClick={onReload}>
+      <button
+        type="button"
+        onClick={onReload}
+        className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
+      >
         Reload
       </button>
       <button
@@ -24,6 +35,7 @@ export function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
           setDismissed(true)
           onDismiss()
         }}
+        className="rounded-md px-2 py-0.5 text-muted-foreground transition-colors hover:bg-accent"
       >
         Dismiss
       </button>

--- a/apps/web/src/pwa/register-sw.test.ts
+++ b/apps/web/src/pwa/register-sw.test.ts
@@ -105,4 +105,59 @@ describe('setupSwRegistration', () => {
       window.removeEventListener('unhandledrejection', onUnhandledRejection)
     }
   })
+
+  it('passes both onNeedRefresh and onRegisteredSW to registerSW', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
+    const registerSW = vi.fn()
+    const importRegister = vi.fn().mockResolvedValue({ registerSW })
+
+    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(registerSW).toHaveBeenCalledTimes(1)
+    expect(registerSW.mock.calls[0][0]).toHaveProperty('onNeedRefresh')
+    expect(registerSW.mock.calls[0][0]).toHaveProperty('onRegisteredSW')
+    expect(typeof registerSW.mock.calls[0][0].onRegisteredSW).toBe('function')
+  })
+
+  it('starts the update scheduler when onRegisteredSW is invoked with a registration', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
+    const registerSW = vi.fn()
+    const importRegister = vi.fn().mockResolvedValue({ registerSW })
+
+    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const { onRegisteredSW } = registerSW.mock.calls[0][0]
+    const update = vi.fn().mockResolvedValue(undefined)
+    const fakeRegistration = { update } as unknown as ServiceWorkerRegistration
+
+    vi.useFakeTimers()
+    try {
+      onRegisteredSW('/sw.js', fakeRegistration)
+      // dynamic import of the scheduler module needs microtask flushes
+      await vi.waitFor(() => {
+        vi.advanceTimersByTime(60 * 60 * 1000)
+        expect(update).toHaveBeenCalled()
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not throw and schedules nothing when onRegisteredSW is invoked with no registration', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
+    const registerSW = vi.fn()
+    const importRegister = vi.fn().mockResolvedValue({ registerSW })
+
+    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const { onRegisteredSW } = registerSW.mock.calls[0][0]
+
+    expect(() => onRegisteredSW('/sw.js', undefined)).not.toThrow()
+  })
 })

--- a/apps/web/src/pwa/register-sw.test.ts
+++ b/apps/web/src/pwa/register-sw.test.ts
@@ -147,6 +147,42 @@ describe('setupSwRegistration', () => {
     }
   })
 
+  it('does not leave an unhandled rejection when the update-scheduler dynamic import fails', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
+    const registerSW = vi.fn()
+    const importRegister = vi.fn().mockResolvedValue({ registerSW })
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      unhandledRejections.push(event.reason)
+    }
+    window.addEventListener('unhandledrejection', onUnhandledRejection)
+
+    try {
+      setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      const { onRegisteredSW } = registerSW.mock.calls[0][0]
+      const fakeRegistration = {
+        update: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ServiceWorkerRegistration
+
+      vi.doMock('./sw-update-scheduler.js', () => {
+        throw new Error('chunk load failed')
+      })
+
+      expect(() => onRegisteredSW('/sw.js', fakeRegistration)).not.toThrow()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandledRejection)
+      vi.doUnmock('./sw-update-scheduler.js')
+    }
+  })
+
   it('does not throw and schedules nothing when onRegisteredSW is invoked with no registration', async () => {
     Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
     const registerSW = vi.fn()

--- a/apps/web/src/pwa/register-sw.ts
+++ b/apps/web/src/pwa/register-sw.ts
@@ -43,6 +43,27 @@ export function setupSwRegistration({
                 log.error('failed to load the update toast module', err)
               })
           },
+          onRegisteredSW: (_swScriptUrl, registration) => {
+            // A long-open or quickly-reloaded tab may never re-check sw.js on
+            // its own cadence, so a deploy can go unnoticed indefinitely.
+            // Scheduling periodic + focus-triggered `registration.update()`
+            // calls is what turns a deploy into an onNeedRefresh toast within
+            // one interval tick or tab refocus. The scheduler module stays
+            // out of the entry chunk via this dynamic import, matching the
+            // update-toast module above.
+            if (!registration) return
+            void import('./sw-update-scheduler.js')
+              .then(({ startSwUpdateScheduler }) => {
+                startSwUpdateScheduler({
+                  update: async () => {
+                    await registration.update()
+                  },
+                })
+              })
+              .catch((err: unknown) => {
+                log.error('failed to load the service worker update scheduler', err)
+              })
+          },
         })
       })
       .catch((err: unknown) => {

--- a/apps/web/src/pwa/register-sw.ts
+++ b/apps/web/src/pwa/register-sw.ts
@@ -54,11 +54,7 @@ export function setupSwRegistration({
             if (!registration) return
             void import('./sw-update-scheduler.js')
               .then(({ startSwUpdateScheduler }) => {
-                startSwUpdateScheduler({
-                  update: async () => {
-                    await registration.update()
-                  },
-                })
+                startSwUpdateScheduler({ update: () => registration.update() })
               })
               .catch((err: unknown) => {
                 log.error('failed to load the service worker update scheduler', err)

--- a/apps/web/src/pwa/sw-update-scheduler.test.ts
+++ b/apps/web/src/pwa/sw-update-scheduler.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startSwUpdateScheduler, SW_UPDATE_CHECK_INTERVAL_MS } from './sw-update-scheduler.js'
+
+// Minimal fake Document surface: startSwUpdateScheduler only needs
+// visibilitychange add/remove + a mutable visibilityState.
+function createFakeDoc(): {
+  doc: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
+    visibilityState: DocumentVisibilityState
+  }
+  fireVisibilityChange: (state: DocumentVisibilityState) => void
+  listenerCount: () => number
+} {
+  const listeners = new Set<() => void>()
+  const doc = {
+    visibilityState: 'visible' as DocumentVisibilityState,
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      if (event === 'visibilitychange') listeners.add(handler)
+    }),
+    removeEventListener: vi.fn((event: string, handler: () => void) => {
+      if (event === 'visibilitychange') listeners.delete(handler)
+    }),
+  }
+  return {
+    doc,
+    fireVisibilityChange: (state: DocumentVisibilityState) => {
+      doc.visibilityState = state
+      for (const listener of listeners) listener()
+    },
+    listenerCount: () => listeners.size,
+  }
+}
+
+describe('startSwUpdateScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('calls update() once per interval tick', () => {
+    const { doc } = createFakeDoc()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const stop = startSwUpdateScheduler({ update, doc })
+
+    vi.advanceTimersByTime(SW_UPDATE_CHECK_INTERVAL_MS)
+    expect(update).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(SW_UPDATE_CHECK_INTERVAL_MS)
+    expect(update).toHaveBeenCalledTimes(2)
+
+    stop()
+  })
+
+  it('calls update() once when the document becomes visible', () => {
+    const { doc, fireVisibilityChange } = createFakeDoc()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const stop = startSwUpdateScheduler({ update, doc })
+
+    fireVisibilityChange('visible')
+    expect(update).toHaveBeenCalledTimes(1)
+
+    stop()
+  })
+
+  it('does not call update() when visibilitychange fires while hidden', () => {
+    const { doc, fireVisibilityChange } = createFakeDoc()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const stop = startSwUpdateScheduler({ update, doc })
+
+    fireVisibilityChange('hidden')
+    expect(update).not.toHaveBeenCalled()
+
+    stop()
+  })
+
+  it('swallows a rejecting update() without an unhandled rejection, and keeps scheduling', async () => {
+    const { doc } = createFakeDoc()
+    const update = vi.fn().mockRejectedValue(new Error('offline'))
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      unhandledRejections.push(event.reason)
+    }
+    window.addEventListener('unhandledrejection', onUnhandledRejection)
+
+    try {
+      const stop = startSwUpdateScheduler({ update, doc })
+
+      vi.advanceTimersByTime(SW_UPDATE_CHECK_INTERVAL_MS)
+      // let the rejected promise's .catch() microtask settle under fake timers
+      await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+
+      vi.advanceTimersByTime(SW_UPDATE_CHECK_INTERVAL_MS)
+      await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+
+      expect(unhandledRejections).toEqual([])
+      stop()
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandledRejection)
+    }
+  })
+
+  it('dispose() clears the interval and removes the visibilitychange listener', () => {
+    const { doc, fireVisibilityChange, listenerCount } = createFakeDoc()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const stop = startSwUpdateScheduler({ update, doc })
+
+    expect(listenerCount()).toBe(1)
+    stop()
+    expect(listenerCount()).toBe(0)
+
+    vi.advanceTimersByTime(SW_UPDATE_CHECK_INTERVAL_MS * 2)
+    fireVisibilityChange('visible')
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('accepts a custom intervalMs', () => {
+    const { doc } = createFakeDoc()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const stop = startSwUpdateScheduler({ update, doc, intervalMs: 1000 })
+
+    vi.advanceTimersByTime(1000)
+    expect(update).toHaveBeenCalledTimes(1)
+
+    stop()
+  })
+})

--- a/apps/web/src/pwa/sw-update-scheduler.test.ts
+++ b/apps/web/src/pwa/sw-update-scheduler.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { startSwUpdateScheduler, SW_UPDATE_CHECK_INTERVAL_MS } from './sw-update-scheduler.js'
+import {
+  type SchedulerDocument,
+  startSwUpdateScheduler,
+  SW_UPDATE_CHECK_INTERVAL_MS,
+} from './sw-update-scheduler.js'
 
-// Minimal fake Document surface: startSwUpdateScheduler only needs
-// visibilitychange add/remove + a mutable visibilityState.
 function createFakeDoc(): {
-  doc: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
-    visibilityState: DocumentVisibilityState
-  }
+  doc: SchedulerDocument
   fireVisibilityChange: (state: DocumentVisibilityState) => void
   listenerCount: () => number
 } {

--- a/apps/web/src/pwa/sw-update-scheduler.test.ts
+++ b/apps/web/src/pwa/sw-update-scheduler.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   type SchedulerDocument,
-  startSwUpdateScheduler,
   SW_UPDATE_CHECK_INTERVAL_MS,
+  startSwUpdateScheduler,
 } from './sw-update-scheduler.js'
 
 function createFakeDoc(): {

--- a/apps/web/src/pwa/sw-update-scheduler.ts
+++ b/apps/web/src/pwa/sw-update-scheduler.ts
@@ -1,0 +1,64 @@
+import { getAppLogger } from '../lib/app-logger.js'
+
+const log = getAppLogger('sw-update-scheduler')
+
+// Browsers only byte-check sw.js on their own cadence (typically once per
+// navigation), so a long-open or quickly-reloaded tab can go a full deploy
+// cycle without ever noticing a new service worker exists. An hourly poll
+// plus a check on tab refocus is what turns a deploy into a visible update
+// toast without requiring a hard reload or manual unregister.
+export const SW_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+type FakeableDocument = Pick<Document, 'addEventListener' | 'removeEventListener'> & {
+  visibilityState: DocumentVisibilityState
+}
+
+export interface StartSwUpdateSchedulerOptions {
+  /** Triggers one service worker update check, e.g. `() => registration.update()`. */
+  update: () => Promise<void>
+  intervalMs?: number
+  doc?: FakeableDocument
+  setIntervalFn?: typeof setInterval
+  clearIntervalFn?: typeof clearInterval
+}
+
+export type StopSwUpdateScheduler = () => void
+
+/**
+ * Schedules periodic + focus-triggered `update()` checks against a live
+ * service worker registration. This module only ever CHECKS for an update —
+ * it never swaps the active worker itself. Actually applying an update stays
+ * strictly user-initiated via the onNeedRefresh -> UpdateToast flow, per the
+ * `registerType: 'prompt'` design intent (never silently swap under a
+ * mid-draw user).
+ */
+export function startSwUpdateScheduler({
+  update,
+  intervalMs = SW_UPDATE_CHECK_INTERVAL_MS,
+  doc = document,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+}: StartSwUpdateSchedulerOptions): StopSwUpdateScheduler {
+  const checkForUpdate = (): void => {
+    // A rejection here (offline, transient network failure) must never
+    // become an unhandled rejection or stop future checks — one failed
+    // byte-check is not a reason to give up on ever detecting a deploy.
+    void update().catch((err: unknown) => {
+      log.debug('service worker update check failed', err)
+    })
+  }
+
+  const intervalId = setIntervalFn(checkForUpdate, intervalMs)
+
+  const onVisibilityChange = (): void => {
+    if (doc.visibilityState === 'visible') {
+      checkForUpdate()
+    }
+  }
+  doc.addEventListener('visibilitychange', onVisibilityChange)
+
+  return () => {
+    clearIntervalFn(intervalId)
+    doc.removeEventListener('visibilitychange', onVisibilityChange)
+  }
+}

--- a/apps/web/src/pwa/sw-update-scheduler.ts
+++ b/apps/web/src/pwa/sw-update-scheduler.ts
@@ -9,17 +9,19 @@ const log = getAppLogger('sw-update-scheduler')
 // toast without requiring a hard reload or manual unregister.
 export const SW_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
 
-type FakeableDocument = Pick<Document, 'addEventListener' | 'removeEventListener'> & {
+/** Minimal Document surface this scheduler needs, so tests can pass a fake. */
+export type SchedulerDocument = Pick<Document, 'addEventListener' | 'removeEventListener'> & {
   visibilityState: DocumentVisibilityState
 }
 
 export interface StartSwUpdateSchedulerOptions {
-  /** Triggers one service worker update check, e.g. `() => registration.update()`. */
-  update: () => Promise<void>
+  /**
+   * Triggers one service worker update check, e.g. `() => registration.update()`.
+   * Whatever it resolves to is ignored — only rejection is meaningful here.
+   */
+  update: () => Promise<unknown>
   intervalMs?: number
-  doc?: FakeableDocument
-  setIntervalFn?: typeof setInterval
-  clearIntervalFn?: typeof clearInterval
+  doc?: SchedulerDocument
 }
 
 export type StopSwUpdateScheduler = () => void
@@ -36,8 +38,6 @@ export function startSwUpdateScheduler({
   update,
   intervalMs = SW_UPDATE_CHECK_INTERVAL_MS,
   doc = document,
-  setIntervalFn = setInterval,
-  clearIntervalFn = clearInterval,
 }: StartSwUpdateSchedulerOptions): StopSwUpdateScheduler {
   const checkForUpdate = (): void => {
     // A rejection here (offline, transient network failure) must never
@@ -48,7 +48,7 @@ export function startSwUpdateScheduler({
     })
   }
 
-  const intervalId = setIntervalFn(checkForUpdate, intervalMs)
+  const intervalId = setInterval(checkForUpdate, intervalMs)
 
   const onVisibilityChange = (): void => {
     if (doc.visibilityState === 'visible') {
@@ -58,7 +58,7 @@ export function startSwUpdateScheduler({
   doc.addEventListener('visibilitychange', onVisibilityChange)
 
   return () => {
-    clearIntervalFn(intervalId)
+    clearInterval(intervalId)
     doc.removeEventListener('visibilitychange', onVisibilityChange)
   }
 }


### PR DESCRIPTION
## Problem

After a Cloudflare Pages deploy, an already-visited browser keeps loading the old app shell: the registered service worker serves the cached bundle, and nothing ever re-checks `sw.js`, so the update toast never gets a chance to appear. Observed 2026-08-07 on `latest`: reloads stayed on the old entry bundle while a cache-busted fetch of `/` returned the new one; only unregistering the SW picked up the deploy.

## Fix

The prompt-mode toast infrastructure already existed — the missing piece was the update *check*. `register-sw.ts` now passes `onRegisteredSW` and starts a small scheduler (`sw-update-scheduler.ts`, dynamically imported, 0.42 kB chunk) that calls `registration.update()`:

- every 60 minutes, and
- on `visibilitychange` → visible (tab refocus),

so a deploy becomes an UpdateToast within one focus event or one interval tick. `update()` rejections (offline etc.) are caught and logged; one failure never kills the schedule. `registerType: 'prompt'`, the toast wiring, and `vite-pwa-options.ts` are untouched, and the scheduler stays out of the eager entry chunk (bundle-size smoke passes).

## Test plan

- [x] Unit (jsdom): interval ticks call `update()`; visible-transition triggers a check; hidden does not; rejection is caught + logged and the schedule survives; dispose clears interval + listener; dynamic-import failure path logged
- [x] `register-sw.test.ts`: `onRegisteredSW` wired; undefined registration schedules nothing; all pre-existing cases unmodified
- [x] `pnpm build` green incl. PWA generation; bundle smoke passes
- [ ] Preview verification: two deploys on this PR's preview URL — confirm the toast appears on tab refocus without unregistering the SW (evidence to follow in a comment)

No browser-mode/E2E layer: vitest browser mode cannot install a real production SW, so the unit layer plus the manual two-deploy preview check is the nearest honest coverage.
