### PR TITLE
fix(web): show an in-flight state and a local-network hint on daemon check

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -754,5 +754,38 @@ describe('DaemonDetectedBanner', () => {
 
       expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
     })
+
+    it('clears the stale failure notice once a retry sweep starts', async () => {
+      const { promise: firstProbe, resolve: resolveFirst } = deferred<DaemonProbeResult>()
+      const probeFn = vi.fn().mockReturnValueOnce(firstProbe)
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="https:"
+          probeFn={probeFn}
+        />,
+      )
+
+      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      act(() => {
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        resolveFirst({ detected: false, reason: 'network' })
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(screen.getByTestId('daemon-check-failed-notice')).not.toBeNull()
+
+      // Retry: leave the second sweep in flight so we can see whether the
+      // stale failure notice from the first sweep is still rendered.
+      probeFn.mockReturnValueOnce(new Promise<DaemonProbeResult>(() => {}))
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
+      })
+
+      expect(screen.getByRole('status').textContent).toMatch(/checking/i)
+      expect(screen.queryByTestId('daemon-check-failed-notice')).toBeNull()
+    })
   })
 })

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -1,12 +1,23 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonProbeResult, ProbeDaemonOptions } from '../../lib/daemon-probe.js'
 import { createUserSettingsStore, type UserSettingsStore } from '../../lib/user-settings-store.js'
 import {
   DaemonDetectedBanner,
   HOW_TO_CONNECT_URL,
+  LNA_HINT_TEXT,
   UNSUPPORTED_BROWSER_NOTICE,
 } from './DaemonDetectedBanner.js'
+
+/** A promise plus its resolver, for tests that need to control exactly
+ *  when a probe sweep settles relative to fake-timer advances. */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
 
 function makeStore(): UserSettingsStore {
   localStorage.clear()
@@ -598,5 +609,150 @@ describe('DaemonDetectedBanner', () => {
     unmount()
 
     expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  describe('in-flight state and the Local Network Access hint', () => {
+    // These cases drive the ~1s hint timer with fake timers. Real-timer
+    // testing-library helpers (waitFor/findBy*) poll on a real setTimeout
+    // and would hang once fake timers are installed, so every assertion in
+    // this block uses the synchronous get*/query* queries instead, and
+    // `act`/`vi.advanceTimersByTimeAsync` drive time forward explicitly.
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('disables the button and renders a "Checking…" status while a sweep is outstanding on https:', () => {
+      const probeFn = vi.fn().mockImplementation(() => new Promise<DaemonProbeResult>(() => {}))
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="https:"
+          probeFn={probeFn}
+        />,
+      )
+
+      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      act(() => {
+        fireEvent.click(button)
+      })
+
+      expect(button.hasAttribute('disabled')).toBe(true)
+      expect(button.getAttribute('aria-busy')).toBe('true')
+      expect(screen.getByRole('status').textContent).toMatch(/checking/i)
+    })
+
+    it('shows the LNA hint on https: after the sweep has been outstanding for ~1s', async () => {
+      const { promise } = deferred<DaemonProbeResult>()
+      const probeFn = vi.fn().mockReturnValue(promise)
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="https:"
+          probeFn={probeFn}
+        />,
+      )
+
+      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
+      act(() => {
+        fireEvent.click(button)
+      })
+
+      expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
+      expect(screen.getByText(LNA_HINT_TEXT)).not.toBeNull()
+    })
+
+    it('never shows the LNA hint on http:, even during the auto-probe well past the delay', async () => {
+      const { promise } = deferred<DaemonProbeResult>()
+      const probeFn = vi.fn().mockReturnValue(promise)
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="http:"
+          probeFn={probeFn}
+        />,
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
+      // The in-flight state is still visible though — the sweep never
+      // settles because `promise` is never resolved.
+      expect(screen.getByRole('status').textContent).toMatch(/checking/i)
+    })
+
+    it('resets checking, the hint, and re-enables the button once the sweep settles', async () => {
+      const { promise, resolve } = deferred<void>()
+      // Every candidate in the sweep awaits the same deferred, so resolving
+      // it once settles the whole sweep at a controlled moment.
+      const resolvingProbeFn = vi
+        .fn()
+        .mockReturnValue(promise.then(() => ({ detected: false, reason: 'refused' }) as const))
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="https:"
+          probeFn={resolvingProbeFn}
+        />,
+      )
+
+      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      act(() => {
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
+      expect(screen.getByText(LNA_HINT_TEXT)).not.toBeNull()
+
+      await act(async () => {
+        resolve()
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
+      expect(screen.queryByRole('status')).toBeNull()
+      const rechecked = screen.getByRole('button', { name: /check for local daemon/i })
+      expect(rechecked.hasAttribute('disabled')).toBe(false)
+    })
+
+    it('never flashes the hint when the sweep settles before the ~1s delay', async () => {
+      const { promise, resolve } = deferred<DaemonProbeResult>()
+      const probeFn = vi.fn().mockReturnValue(promise)
+      render(
+        <DaemonDetectedBanner
+          settingsStore={makeStore()}
+          fetch={vi.fn()}
+          locationProtocol="https:"
+          probeFn={probeFn}
+        />,
+      )
+
+      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      act(() => {
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200)
+        resolve({ detected: false, reason: 'refused' })
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
+
+      expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
+    })
   })
 })

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -33,6 +33,20 @@ export const UNSUPPORTED_BROWSER_NOTICE =
 export const HOW_TO_CONNECT_URL =
   'https://github.com/kamiazya/whiteboard/blob/main/docs/how-to/connect-to-local-daemon.md'
 
+// Chrome's Local Network Access prompt lives in browser chrome, not the
+// page, so a probe sweep that is merely waiting on that decision looks
+// identical (from script) to one still timing out. This delay is a
+// judgment call, not a measured threshold: long enough that a fast sweep
+// never flashes the hint, short enough that a stalled one gets a hint
+// before the user gives up and clicks again.
+const LNA_HINT_DELAY_MS = 1000
+
+// Phrased as a possibility, not a claim: the same stall also happens from
+// a plain network timeout with no permission prompt involved, and this
+// component has no way to distinguish the two from script.
+export const LNA_HINT_TEXT =
+  'This is taking a while — your browser may be asking for permission to reach local devices. Check for a permission prompt.'
+
 interface DaemonDetectedBannerProps {
   settingsStore: UserSettingsStore
   fetch: typeof globalThis.fetch
@@ -78,6 +92,13 @@ export function DaemonDetectedBanner({
     () => settingsStore.load().storage.dismissedDaemonCtaAt,
   )
   const abortRef = useRef<AbortController | null>(null)
+  // True for the whole window between a sweep starting and it settling
+  // (found, failed, or blocked) — drives the disabled/"Checking…" button
+  // state so a second click during the sweep is impossible instead of
+  // silently deduped by the in-flight map one layer down.
+  const [checking, setChecking] = useState(false)
+  const [showLnaHint, setShowLnaHint] = useState(false)
+  const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // The store object identity never changes, so anything derived from it has
   // to be recomputed explicitly when we write to it — a useMemo keyed on the
@@ -135,6 +156,16 @@ export function DaemonDetectedBanner({
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
+    setChecking(true)
+    setShowLnaHint(false)
+    if (hintTimerRef.current !== null) clearTimeout(hintTimerRef.current)
+    hintTimerRef.current =
+      pageOriginScheme === 'https'
+        ? setTimeout(() => {
+            if (controller.signal.aborted) return
+            setShowLnaHint(true)
+          }, LNA_HINT_DELAY_MS)
+        : null
     const known = settingsStore.load().storage.knownDaemonBaseUrls ?? []
     // The server side binds dynamically (findAvailablePort from 3099; dev
     // worktrees use derived ports), so a single fixed-port ping misses
@@ -154,6 +185,12 @@ export function DaemonDetectedBanner({
       signal: controller.signal,
     }).then(({ found: nextFound, failures }) => {
       if (controller.signal.aborted) return
+      if (hintTimerRef.current !== null) {
+        clearTimeout(hintTimerRef.current)
+        hintTimerRef.current = null
+      }
+      setChecking(false)
+      setShowLnaHint(false)
       setFound(nextFound)
       const first = nextFound[0]
       setResult(
@@ -182,7 +219,10 @@ export function DaemonDetectedBanner({
 
   useEffect(() => {
     if (locationProtocol === 'http:') runProbe()
-    return () => abortRef.current?.abort()
+    return () => {
+      abortRef.current?.abort()
+      if (hintTimerRef.current !== null) clearTimeout(hintTimerRef.current)
+    }
     // Auto-probe once on mount for the http: (loopback) path only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locationProtocol])
@@ -263,10 +303,20 @@ export function DaemonDetectedBanner({
         <button
           type="button"
           onClick={() => runProbe(true)}
-          className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent"
+          disabled={checking}
+          aria-busy={checking}
+          className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
         >
           Check for local daemon
         </button>
+      )}
+      {showManualAffordance && checking && (
+        <span role="status" className="text-xs text-muted-foreground">
+          Checking…
+        </span>
+      )}
+      {showManualAffordance && checking && showLnaHint && (
+        <span className="text-xs text-muted-foreground">{LNA_HINT_TEXT}</span>
       )}
       {showManualAffordance && manualCheckFailed && (
         // A CORS rejection (daemon running but this origin not in its

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -152,20 +152,27 @@ export function DaemonDetectedBanner({
   // path is open without evidence.
   const pageOriginScheme = locationProtocol === 'http:' ? 'http' : 'https'
 
+  // Always paired with aborting/settling the sweep the timer belongs to, so
+  // a pending hint can never outlive its own probe.
+  function clearHintTimer() {
+    if (hintTimerRef.current !== null) {
+      clearTimeout(hintTimerRef.current)
+      hintTimerRef.current = null
+    }
+  }
+
   function runProbe(forceRecheck?: boolean) {
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
     setChecking(true)
     setShowLnaHint(false)
-    if (hintTimerRef.current !== null) clearTimeout(hintTimerRef.current)
-    hintTimerRef.current =
-      pageOriginScheme === 'https'
-        ? setTimeout(() => {
-            if (controller.signal.aborted) return
-            setShowLnaHint(true)
-          }, LNA_HINT_DELAY_MS)
-        : null
+    clearHintTimer()
+    // Only an https: origin can hit the Local Network Access prompt; a
+    // loopback origin reaches the daemon same-origin with no permission gate.
+    if (pageOriginScheme === 'https') {
+      hintTimerRef.current = setTimeout(() => setShowLnaHint(true), LNA_HINT_DELAY_MS)
+    }
     const known = settingsStore.load().storage.knownDaemonBaseUrls ?? []
     // The server side binds dynamically (findAvailablePort from 3099; dev
     // worktrees use derived ports), so a single fixed-port ping misses
@@ -185,10 +192,7 @@ export function DaemonDetectedBanner({
       signal: controller.signal,
     }).then(({ found: nextFound, failures }) => {
       if (controller.signal.aborted) return
-      if (hintTimerRef.current !== null) {
-        clearTimeout(hintTimerRef.current)
-        hintTimerRef.current = null
-      }
+      clearHintTimer()
       setChecking(false)
       setShowLnaHint(false)
       setFound(nextFound)
@@ -221,7 +225,7 @@ export function DaemonDetectedBanner({
     if (locationProtocol === 'http:') runProbe()
     return () => {
       abortRef.current?.abort()
-      if (hintTimerRef.current !== null) clearTimeout(hintTimerRef.current)
+      clearHintTimer()
     }
     // Auto-probe once on mount for the http: (loopback) path only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -311,12 +315,12 @@ export function DaemonDetectedBanner({
         </button>
       )}
       {showManualAffordance && checking && (
-        <span role="status" className="text-xs text-muted-foreground">
-          Checking…
-        </span>
-      )}
-      {showManualAffordance && checking && showLnaHint && (
-        <span className="text-xs text-muted-foreground">{LNA_HINT_TEXT}</span>
+        <>
+          <span role="status" className="text-xs text-muted-foreground">
+            Checking…
+          </span>
+          {showLnaHint && <span className="text-xs text-muted-foreground">{LNA_HINT_TEXT}</span>}
+        </>
       )}
       {showManualAffordance && manualCheckFailed && (
         // A CORS rejection (daemon running but this origin not in its

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -167,6 +167,7 @@ export function DaemonDetectedBanner({
     abortRef.current = controller
     setChecking(true)
     setShowLnaHint(false)
+    setManualCheckFailed(false)
     clearHintTimer()
     // Only an https: origin can hit the Local Network Access prompt; a
     // loopback origin reaches the daemon same-origin with no permission gate.


### PR DESCRIPTION
## Problem

Clicking "Check for local daemon" on the hosted origin sometimes appears to do nothing. Two compounding cases:

1. Chrome's Local Network Access permission prompt lives in browser chrome, not the page — while it is pending, every loopback probe is parked on the user's decision and the page shows zero feedback.
2. Even without the prompt, the probe sweep runs up to its timeout with the button static, inviting a useless second click (the in-flight map dedupes silently).

## Fix

In `DaemonDetectedBanner.tsx`:

- While a sweep is outstanding, the trigger button is disabled and a "Checking…" indicator renders (announced via `role="status"`).
- On https: origins only, if the check has been outstanding for more than ~1s, a hint appears: the browser *may* be asking for permission to reach local devices (phrased as a possibility — the same stall also happens from plain probe timeouts). The hint clears the moment the sweep settles, and the timer is cleaned up on settle/unmount.
- A stale failure notice is now cleared when a retry starts.

The discovery-layer dedupe is unchanged; this is purely presentation of the already-existing in-flight window. No files outside `components/migration/**` are touched.

## Test plan

- [x] jsdom component tests: disabled button + Checking… during an unresolved sweep; hint after ~1s on https:; hint never on http: (auto-probe and manual); everything resets on settle; early settle never flashes the hint; unmount with an armed timer is clean; all pre-existing cases pass
- [x] `pnpm test` green in the worktree
- [ ] Preview verification: on the PR preview origin with no daemon running, click the check and observe Checking… + hint (screenshot to follow)

No browser-mode layer: the real LNA prompt cannot be automated, and jsdom + the injected probe seam fully models the in-flight window.
