### PR TITLE
feat(daemon): durable Ed25519 identity with challenge-response verification

### DIFF
--- a/packages/mcp-server/src/server/app-types.ts
+++ b/packages/mcp-server/src/server/app-types.ts
@@ -1,5 +1,6 @@
 import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
+import type { DaemonIdentity } from './security/daemon-identity.js'
 import type { McpHttpAuthStrategy } from './security/mcp-auth.js'
 import type { OAuthClientRegistry } from './security/oauth-authz-registry.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
@@ -52,10 +53,15 @@ interface LocalDaemonAppOptions {
     codes: PairingCodeStore
     tokens: PairingTokenStore
   }
+  /** Daemon signing identity (security/daemon-identity.ts). Injectable for
+   *  tests; when omitted, createApp loads-or-creates it from the data dir. */
+  identity?: DaemonIdentity
 }
 
 export interface ServerModeAppOptions {
   authMode: 'server-mode'
+  /** See LocalDaemonAppOptions.identity. */
+  identity?: DaemonIdentity
   /** OpenCanvas store/sync ports. When present, server-core's /api/v1
    *  HTTP surface (createServer(deps).app) is mounted behind the same
    *  /api/* auth as every other API route; when absent, /api/v1 stays

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -22,7 +22,7 @@ import {
   toInlineScriptJson,
 } from './app-helpers.js'
 import type { AppOptions } from './app-types.js'
-import { DIST_WEB_APP_DIR } from './config.js'
+import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { getLogger, getLogLevel, setLogLevel } from './log.js'
 import { createMcpServer } from './mcp/index.js'
 import { tracingMiddleware } from './observability/http-tracing.js'
@@ -45,6 +45,7 @@ import { broadcastLoroUpdate, sendHeadChanged, setResolveViewportFn } from './ro
 import { createWsTicketRouter } from './routes/ws-ticket.js'
 import { createApiHostGuardMiddleware } from './security/api-host-guard.js'
 import { createApiLoopbackCorsMiddleware } from './security/cors-loopback.js'
+import { createDaemonIdentity } from './security/daemon-identity.js'
 import {
   buildMcpProtectedResourceMetadata,
   createLocalTokenMcpHttpAuthStrategy,
@@ -99,6 +100,9 @@ export function createApp(options: AppOptions) {
   const app = new Hono()
 
   const instanceId = options.instanceId ?? randomUUID()
+  // The signing identity behind /api/runtime/ping's `identity`,
+  // /api/runtime/verify, and pairing-token response signatures.
+  const identity = options.identity ?? createDaemonIdentity({ dataDir: getDataDir() })
   const token = options.authMode === 'local-daemon' ? options.token : undefined
   const mcpAuth =
     options.authMode === 'local-daemon'
@@ -337,7 +341,7 @@ export function createApp(options: AppOptions) {
   if (options.authMode === 'local-daemon' && options.pairing !== undefined) {
     // Pairing-grant routes are local-daemon only by design (the consent
     // model assumes the daemon's own served UI and loopback reachability).
-    app.route('/', createPairingRouter(options.pairing))
+    app.route('/', createPairingRouter({ ...options.pairing, identity }))
   }
 
   // server-core's OpenCanvas /api/v1 surface (workspace tree, canvasId +
@@ -395,6 +399,7 @@ export function createApp(options: AppOptions) {
       token,
       mcpAuth: mcpAuth ?? undefined,
       instanceId,
+      identity,
       touch: options.touch,
       getStatus: options.authMode === 'server-mode' ? serverModeGetStatus! : options.getStatus,
       shutdown: options.shutdown,

--- a/packages/mcp-server/src/server/routes/pairing.test.ts
+++ b/packages/mcp-server/src/server/routes/pairing.test.ts
@@ -1,7 +1,9 @@
+import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { buildSignedPayload, createDaemonIdentity } from '../security/daemon-identity.js'
 import { createPairingGrantStore } from '../security/pairing-grant-store.js'
 import {
   computeS256Challenge,
@@ -19,7 +21,8 @@ function makeApp() {
   const grants = createPairingGrantStore(dir)
   const codes = createPairingCodeStore()
   const tokens = createPairingTokenStore()
-  return { app: createPairingRouter({ grants, codes, tokens }), grants, tokens }
+  const identity = createDaemonIdentity({ dataDir: dir })
+  return { app: createPairingRouter({ grants, codes, tokens, identity }), grants, tokens, identity }
 }
 
 afterEach(() => {
@@ -139,5 +142,102 @@ describe('pairing routes', () => {
       codeChallenge: 'x',
     })
     expect(res.status).toBe(400)
+  })
+})
+
+describe('pairing token identity signatures', () => {
+  const NONCE = Buffer.from('fedcba9876543210').toString('base64url')
+
+  function verifies(
+    identity: { publicKey: string },
+    parts: readonly string[],
+    signatureB64u: string,
+  ) {
+    const key = createPublicKey({
+      key: { kty: 'OKP', crv: 'Ed25519', x: identity.publicKey },
+      format: 'jwk',
+    })
+    return cryptoVerify(
+      null,
+      buildSignedPayload(parts),
+      key,
+      Buffer.from(signatureB64u, 'base64url'),
+    )
+  }
+
+  it('a renewal carrying a nonce gets a signature vouching for the minted token', async () => {
+    const { app, grants, identity } = makeApp()
+    grants.addGrant(HOSTED)
+
+    const res = await post(
+      app,
+      '/api/pairing/token',
+      { grantType: 'origin', nonce: NONCE },
+      { Origin: HOSTED },
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      token: string
+      expiresAt: string
+      origin: string
+      identity?: { alg: string; publicKey: string; signature: string }
+    }
+    expect(body.identity?.publicKey).toBe(identity.publicKey)
+    const tokenHash = createHash('sha256').update(body.token, 'utf8').digest('base64url')
+    expect(
+      verifies(
+        identity,
+        ['wb-token-v1', NONCE, body.origin, tokenHash, body.expiresAt],
+        body.identity?.signature ?? '',
+      ),
+    ).toBe(true)
+    // The signature must NOT verify for a different token (splice attempt).
+    const otherHash = createHash('sha256').update('forged-token', 'utf8').digest('base64url')
+    expect(
+      verifies(
+        identity,
+        ['wb-token-v1', NONCE, body.origin, otherHash, body.expiresAt],
+        body.identity?.signature ?? '',
+      ),
+    ).toBe(false)
+  })
+
+  it('a request without a nonce gets no identity field (wire-compat)', async () => {
+    const { app, grants } = makeApp()
+    grants.addGrant(HOSTED)
+    const res = await post(app, '/api/pairing/token', { grantType: 'origin' }, { Origin: HOSTED })
+    const body = (await res.json()) as { identity?: unknown }
+    expect(res.status).toBe(200)
+    expect(body.identity).toBeUndefined()
+  })
+
+  it('the code-exchange leg also signs when a nonce is present', async () => {
+    const { app, identity } = makeApp()
+    const codeVerifier = 'exchange-verifier'
+    const codeChallenge = await computeS256Challenge(codeVerifier)
+    const grantRes = await post(app, '/api/pairing/grants', { origin: HOSTED, codeChallenge })
+    const { code } = (await grantRes.json()) as { code: string }
+
+    const res = await post(app, '/api/pairing/token', {
+      grantType: 'code',
+      code,
+      codeVerifier,
+      nonce: NONCE,
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      token: string
+      expiresAt: string
+      origin: string
+      identity?: { signature: string }
+    }
+    const tokenHash = createHash('sha256').update(body.token, 'utf8').digest('base64url')
+    expect(
+      verifies(
+        identity,
+        ['wb-token-v1', NONCE, body.origin, tokenHash, body.expiresAt],
+        body.identity?.signature ?? '',
+      ),
+    ).toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -25,8 +25,10 @@
 //   CSRF shape: the endpoint mints a token only FOR the requesting origin;
 //   it never mutates daemon data and never widens any other origin's
 //   access, so a forged cross-site POST yields the attacker nothing.
+import { createHash } from 'node:crypto'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import type { DaemonIdentity } from '../security/daemon-identity.js'
 import type { PairingGrantStore } from '../security/pairing-grant-store.js'
 import type { PairingCodeStore, PairingTokenStore } from '../security/pairing-session.js'
 
@@ -55,15 +57,27 @@ const listGrantsResponseSchema = z
   .strict()
 type ListGrantsResponse = z.infer<typeof listGrantsResponseSchema>
 
+// A caller-random challenge nonce (base64url, 16-32 decoded bytes). When
+// present, the response carries an identity signature binding this nonce —
+// see the identity note on tokenResponseSchema.
+const tokenNonceSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]+$/, 'nonce must be base64url')
+  .refine((value) => {
+    const bytes = Buffer.from(value, 'base64url')
+    return bytes.length >= 16 && bytes.length <= 32
+  }, 'nonce must decode to 16-32 bytes')
+
 const tokenRequestSchema = z.discriminatedUnion('grantType', [
   z
     .object({
       grantType: z.literal('code'),
       code: z.string().min(1),
       codeVerifier: z.string().min(1),
+      nonce: tokenNonceSchema.optional(),
     })
     .strict(),
-  z.object({ grantType: z.literal('origin') }).strict(),
+  z.object({ grantType: z.literal('origin'), nonce: tokenNonceSchema.optional() }).strict(),
 ])
 
 const tokenResponseSchema = z
@@ -71,17 +85,46 @@ const tokenResponseSchema = z
     token: z.string(),
     expiresAt: z.string(),
     origin: z.string(),
+    // Present iff the request carried a nonce: the daemon's identity plus a
+    // signature over ["wb-token-v1", nonce, origin, sha256(token), expiresAt].
+    // Binding sha256(token) makes the signature vouch for the very credential
+    // being handed over — a squatter cannot splice a real daemon's signature
+    // onto its own fake token. Verified browser-side against the key pinned
+    // at /pair consent.
+    identity: z
+      .object({
+        alg: z.literal('Ed25519'),
+        publicKey: z.string(),
+        signature: z.string(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
 type TokenResponse = z.infer<typeof tokenResponseSchema>
+
+function signTokenResponse(
+  identity: DaemonIdentity,
+  nonce: string,
+  minted: { token: string; expiresAt: string },
+  origin: string,
+): NonNullable<TokenResponse['identity']> {
+  const tokenHash = createHash('sha256').update(minted.token, 'utf8').digest('base64url')
+  return {
+    alg: identity.alg,
+    publicKey: identity.publicKey,
+    signature: identity.sign(['wb-token-v1', nonce, origin, tokenHash, minted.expiresAt]),
+  }
+}
 
 export interface PairingRouterOptions {
   grants: PairingGrantStore
   codes: PairingCodeStore
   tokens: PairingTokenStore
+  identity: DaemonIdentity
 }
 
-export function createPairingRouter({ grants, codes, tokens }: PairingRouterOptions) {
+export function createPairingRouter({ grants, codes, tokens, identity }: PairingRouterOptions) {
   const app = new Hono()
 
   app.post('/api/pairing/grants', async (c) => {
@@ -144,7 +187,13 @@ export function createPairingRouter({ grants, codes, tokens }: PairingRouterOpti
         return c.json({ error: 'invalid or expired code' }, 403)
       }
       const minted = tokens.mint(redeemed.origin)
-      const response: TokenResponse = { ...minted, origin: redeemed.origin }
+      const response: TokenResponse = {
+        ...minted,
+        origin: redeemed.origin,
+        ...(parsed.data.nonce !== undefined
+          ? { identity: signTokenResponse(identity, parsed.data.nonce, minted, redeemed.origin) }
+          : {}),
+      }
       return c.json(response, 200)
     }
 
@@ -163,7 +212,13 @@ export function createPairingRouter({ grants, codes, tokens }: PairingRouterOpti
       return c.json({ error: 'origin has no pairing grant' }, 403)
     }
     const minted = tokens.mint(origin)
-    const response: TokenResponse = { ...minted, origin }
+    const response: TokenResponse = {
+      ...minted,
+      origin,
+      ...(parsed.data.nonce !== undefined
+        ? { identity: signTokenResponse(identity, parsed.data.nonce, minted, origin) }
+        : {}),
+    }
     return c.json(response, 200)
   })
 

--- a/packages/mcp-server/src/server/routes/runtime.test.ts
+++ b/packages/mcp-server/src/server/routes/runtime.test.ts
@@ -1,3 +1,7 @@
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Hermetic harness — these tests must NEVER touch the developer's real
@@ -38,6 +42,21 @@ vi.mock('../../daemon/log-rotation.js', () => ({
 }))
 
 const { createRuntimeRouter } = await import('./runtime.js')
+const { buildSignedPayload, createDaemonIdentity } = await import('../security/daemon-identity.js')
+
+// Real identity in an isolated temp dir (injected — the router never touches
+// the mocked config seam for it).
+const identityDir = mkdtempSync(join(tmpdir(), 'wb-runtime-identity-'))
+const testIdentity = createDaemonIdentity({ dataDir: identityDir })
+process.once('exit', () => rmSync(identityDir, { recursive: true, force: true }))
+
+function verifyIdentitySignature(parts: readonly string[], signatureB64u: string) {
+  const key = createPublicKey({
+    key: { kty: 'OKP', crv: 'Ed25519', x: testIdentity.publicKey },
+    format: 'jwk',
+  })
+  return cryptoVerify(null, buildSignedPayload(parts), key, Buffer.from(signatureB64u, 'base64url'))
+}
 
 function createApp() {
   const touch = vi.fn()
@@ -45,6 +64,7 @@ function createApp() {
   const app = createRuntimeRouter({
     token: 'secret',
     instanceId: 'test-instance-id',
+    identity: testIdentity,
     touch,
     shutdown,
     getStatus: () => ({
@@ -76,7 +96,11 @@ describe('runtime routes', () => {
     const { app } = createApp()
     const res = await app.request('/api/runtime/ping')
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ ok: true, instanceId: 'test-instance-id' })
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      instanceId: 'test-instance-id',
+      identity: { alg: 'Ed25519', publicKey: testIdentity.publicKey },
+    })
   })
 
   it('rejects status without a bearer token', async () => {
@@ -182,5 +206,78 @@ describe('runtime routes', () => {
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toMatchObject({ removed: 2, retained: 5 })
     expect(mockPurgeOldDaemonLogs).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('daemon identity surfaces', () => {
+  const NONCE = Buffer.from('0123456789abcdef').toString('base64url')
+
+  it('ping advertises the identity public key', async () => {
+    const { app } = createApp()
+    const res = await app.request('/api/runtime/ping')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { identity?: { alg: string; publicKey: string } }
+    expect(body.identity).toEqual({ alg: 'Ed25519', publicKey: testIdentity.publicKey })
+  })
+
+  it('verify answers an unauthenticated challenge with a signature binding nonce + origin', async () => {
+    const { app } = createApp()
+    const res = await app.request('/api/runtime/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'https://caller.example' },
+      body: JSON.stringify({ nonce: NONCE }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { alg: string; publicKey: string; signature: string }
+    expect(body.publicKey).toBe(testIdentity.publicKey)
+    expect(
+      verifyIdentitySignature(['wb-verify-v1', NONCE, 'https://caller.example'], body.signature),
+    ).toBe(true)
+    // A different origin's challenge must not verify with this signature.
+    expect(
+      verifyIdentitySignature(['wb-verify-v1', NONCE, 'https://other.example'], body.signature),
+    ).toBe(false)
+  })
+
+  it('verify binds an ABSENT Origin header as the empty string', async () => {
+    const { app } = createApp()
+    const res = await app.request('/api/runtime/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce: NONCE }),
+    })
+    const body = (await res.json()) as { signature: string }
+    expect(verifyIdentitySignature(['wb-verify-v1', NONCE, ''], body.signature)).toBe(true)
+  })
+
+  it('verify rejects a malformed nonce', async () => {
+    const { app } = createApp()
+    for (const nonce of [
+      '',
+      'short',
+      '!!!not-base64url!!!',
+      Buffer.alloc(64).toString('base64url'),
+    ]) {
+      const res = await app.request('/api/runtime/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce }),
+      })
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it('verify rate-limits a tight loop with 429', async () => {
+    const { app } = createApp()
+    let limited = 0
+    for (let i = 0; i < 70; i += 1) {
+      const res = await app.request('/api/runtime/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce: NONCE }),
+      })
+      if (res.status === 429) limited += 1
+    }
+    expect(limited).toBeGreaterThan(0)
   })
 })

--- a/packages/mcp-server/src/server/routes/runtime.ts
+++ b/packages/mcp-server/src/server/routes/runtime.ts
@@ -1,17 +1,29 @@
 import { Hono } from 'hono'
 import { purgeOldDaemonLogs } from '../../daemon/log-rotation.js'
-import { daemonPingResponseSchema } from '../../shared/api-contracts/runtime.js'
+import {
+  daemonPingResponseSchema,
+  runtimeVerifyRequestSchema,
+  runtimeVerifyResponseSchema,
+} from '../../shared/api-contracts/runtime.js'
 import { getDataDir } from '../config.js'
 import type { RuntimeStatus } from '../http-server.js'
+import type { DaemonIdentity } from '../security/daemon-identity.js'
 import type { McpHttpAuthStrategy } from '../security/mcp-auth.js'
 import { readLatestCompactedAt } from '../store/canvas-store.js'
 import { isAuthorized } from './auth.js'
 import { computeStorageReport } from './runtime-storage.js'
 
+// /api/runtime/verify is public and does an Ed25519 sign per call, so cap
+// the rate. Loopback traffic makes per-IP buckets meaningless — one global
+// sliding window is enough to stop a tight local loop from burning CPU.
+const VERIFY_RATE_LIMIT = 60
+const VERIFY_RATE_WINDOW_MS = 60_000
+
 export interface RuntimeRouterOptions {
   token?: string
   mcpAuth?: McpHttpAuthStrategy
   instanceId: string
+  identity: DaemonIdentity
   touch: () => void
   getStatus: () => RuntimeStatus
   shutdown: () => Promise<void>
@@ -21,11 +33,58 @@ export function createRuntimeRouter(options: RuntimeRouterOptions) {
   const app = new Hono()
 
   app.get('/api/runtime/ping', (c) => {
-    return c.json(daemonPingResponseSchema.parse({ ok: true, instanceId: options.instanceId }))
+    return c.json(
+      daemonPingResponseSchema.parse({
+        ok: true,
+        instanceId: options.instanceId,
+        identity: { alg: options.identity.alg, publicKey: options.identity.publicKey },
+      }),
+    )
+  })
+
+  // Challenge-response proof of identity (see security/daemon-identity.ts).
+  // Public like ping: the response is only useful to a caller that has the
+  // real daemon's key PINNED — a squatter answering with its own key fails
+  // the browser-side verification.
+  let verifyWindowStartMs = 0
+  let verifyWindowCount = 0
+  app.post('/api/runtime/verify', async (c) => {
+    const now = Date.now()
+    if (now - verifyWindowStartMs >= VERIFY_RATE_WINDOW_MS) {
+      verifyWindowStartMs = now
+      verifyWindowCount = 0
+    }
+    verifyWindowCount += 1
+    if (verifyWindowCount > VERIFY_RATE_LIMIT) {
+      return c.json({ error: 'rate limited' }, 429)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400)
+    }
+    const parsed = runtimeVerifyRequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
+    }
+    // Binding the Origin header stops a relay from farming signatures that
+    // verify for a different origin's challenge; a missing header binds "".
+    const origin = c.req.header('origin') ?? ''
+    const signature = options.identity.sign(['wb-verify-v1', parsed.data.nonce, origin])
+    return c.json(
+      runtimeVerifyResponseSchema.parse({
+        alg: options.identity.alg,
+        publicKey: options.identity.publicKey,
+        signature,
+      }),
+    )
   })
 
   app.use('/api/runtime/*', async (c, next) => {
     if (c.req.path === '/api/runtime/ping') return next()
+    if (c.req.path === '/api/runtime/verify') return next()
     if (!isAuthorized(c.req.header('authorization'), options.token)) {
       return c.json({ error: 'unauthorized' }, 401)
     }

--- a/packages/mcp-server/src/server/security/daemon-identity.test.ts
+++ b/packages/mcp-server/src/server/security/daemon-identity.test.ts
@@ -1,0 +1,93 @@
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../log.js'
+import { buildSignedPayload, createDaemonIdentity } from './daemon-identity.js'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wb-daemon-identity-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function verifySignature(publicKeyB64u: string, parts: readonly string[], signatureB64u: string) {
+  const key = createPublicKey({
+    key: { kty: 'OKP', crv: 'Ed25519', x: publicKeyB64u },
+    format: 'jwk',
+  })
+  return cryptoVerify(null, buildSignedPayload(parts), key, Buffer.from(signatureB64u, 'base64url'))
+}
+
+describe('createDaemonIdentity', () => {
+  it('generates a persisted Ed25519 identity on first start', () => {
+    const identity = createDaemonIdentity({ dataDir: dir })
+
+    expect(identity.alg).toBe('Ed25519')
+    // Raw Ed25519 public key: 32 bytes, base64url.
+    expect(Buffer.from(identity.publicKey, 'base64url')).toHaveLength(32)
+    const stat = statSync(join(dir, 'daemon-identity.json'))
+    expect(stat.mode & 0o777).toBe(0o600)
+  })
+
+  it('reloads the SAME identity across restarts', () => {
+    const first = createDaemonIdentity({ dataDir: dir })
+    const second = createDaemonIdentity({ dataDir: dir })
+    expect(second.publicKey).toBe(first.publicKey)
+  })
+
+  it('signatures verify against the advertised public key', () => {
+    const identity = createDaemonIdentity({ dataDir: dir })
+    const parts = ['wb-verify-v1', 'nonce-abc', 'https://example.com'] as const
+    const signature = identity.sign(parts)
+    expect(verifySignature(identity.publicKey, parts, signature)).toBe(true)
+    // A different message must not verify.
+    expect(verifySignature(identity.publicKey, ['wb-verify-v1', 'other', ''], signature)).toBe(
+      false,
+    )
+  })
+
+  it('part boundaries are unambiguous (["ab","c"] never collides with ["a","bc"])', () => {
+    expect(buildSignedPayload(['ab', 'c'])).not.toEqual(buildSignedPayload(['a', 'bc']))
+  })
+
+  it('a corrupt identity file regenerates (rotation semantics) with a warning', () => {
+    const first = createDaemonIdentity({ dataDir: dir })
+    writeFileSync(join(dir, 'daemon-identity.json'), '{not json')
+    chmodSync(join(dir, 'daemon-identity.json'), 0o600)
+
+    const capture = captureLogsForTests('debug')
+    try {
+      const second = createDaemonIdentity({ dataDir: dir })
+      expect(second.publicKey).not.toBe(first.publicKey)
+      const record = capture.records.find(
+        (r) => r.scope === 'daemon-identity' && r.level === 'warning',
+      )
+      expect(record).toBeDefined()
+      // The regenerated identity must persist and reload stably.
+      const third = createDaemonIdentity({ dataDir: dir })
+      expect(third.publicKey).toBe(second.publicKey)
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('never leaks the private key through the returned object or logs', () => {
+    const capture = captureLogsForTests('debug')
+    try {
+      const identity = createDaemonIdentity({ dataDir: dir })
+      expect(Object.keys(identity).sort()).toEqual(['alg', 'publicKey', 'sign'])
+      const raw = readFileSync(join(dir, 'daemon-identity.json'), 'utf8')
+      const privateD = JSON.parse(raw).privateJwk.d
+      expect(typeof privateD).toBe('string')
+      expect(JSON.stringify(capture.records)).not.toContain(privateD)
+    } finally {
+      capture.restore()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/security/daemon-identity.ts
+++ b/packages/mcp-server/src/server/security/daemon-identity.ts
@@ -1,0 +1,129 @@
+/**
+ * The daemon's durable identity keypair — the trust anchor that lets a
+ * browser verify a loopback responder is the real daemon (and not a
+ * port-squatting local process). The public key is pinned by the web app at
+ * /pair consent time; every later signature is verified against that pin,
+ * so a squatter advertising its own key gains nothing.
+ *
+ * Threat boundary: defends against a process that can bind a loopback port
+ * but cannot read this data dir. A full-privilege local attacker can read
+ * the private key and is out of scope — the daemon already trusts the OS
+ * user boundary.
+ *
+ * A corrupt or unreadable file regenerates a fresh keypair (rotation
+ * semantics): paired browsers fail closed on the key mismatch and require a
+ * fresh /pair approval, which re-pins. Losing the file costs re-approval
+ * clicks, never a dead daemon.
+ */
+import {
+  createPrivateKey,
+  createPublicKey,
+  sign as cryptoSign,
+  generateKeyPairSync,
+  type KeyObject,
+} from 'node:crypto'
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { z } from 'zod'
+import { getLogger } from '../log.js'
+
+const log = getLogger('daemon-identity')
+
+const DAEMON_IDENTITY_FILENAME = 'daemon-identity.json'
+
+const ed25519JwkSchema = z
+  .object({
+    kty: z.literal('OKP'),
+    crv: z.literal('Ed25519'),
+    x: z.string().min(1),
+    d: z.string().min(1).optional(),
+  })
+  .loose()
+
+const identityFileSchema = z
+  .object({
+    version: z.literal(1),
+    alg: z.literal('Ed25519'),
+    publicJwk: ed25519JwkSchema,
+    privateJwk: ed25519JwkSchema.refine((jwk) => jwk.d !== undefined, 'private JWK must carry d'),
+  })
+  .loose()
+
+export interface DaemonIdentity {
+  readonly alg: 'Ed25519'
+  /** Raw 32-byte Ed25519 public key, base64url. */
+  readonly publicKey: string
+  /** Signs a domain-separated message; returns the signature base64url. */
+  readonly sign: (parts: readonly string[]) => string
+}
+
+// JSON-array encoding gives unambiguous part boundaries: ["ab","c"] and
+// ["a","bc"] serialize differently, so no length-prefixing scheme is needed.
+// The first part is always a domain-separation tag ("wb-verify-v1", ...).
+export function buildSignedPayload(parts: readonly string[]): Buffer {
+  return Buffer.from(JSON.stringify(parts), 'utf8')
+}
+
+interface LoadedKeys {
+  publicKey: KeyObject
+  privateKey: KeyObject
+}
+
+function tryLoad(filepath: string): LoadedKeys | null {
+  let raw: string
+  try {
+    raw = readFileSync(filepath, 'utf8')
+  } catch {
+    return null
+  }
+  try {
+    const parsed = identityFileSchema.parse(JSON.parse(raw))
+    return {
+      publicKey: createPublicKey({ key: parsed.publicJwk, format: 'jwk' }),
+      privateKey: createPrivateKey({ key: parsed.privateJwk, format: 'jwk' }),
+    }
+  } catch (err) {
+    log.warning({ err }, 'daemon identity file unreadable; generating a fresh keypair')
+    return null
+  }
+}
+
+function generateAndPersist(filepath: string): LoadedKeys {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const record = {
+    version: 1,
+    alg: 'Ed25519',
+    publicJwk: publicKey.export({ format: 'jwk' }),
+    privateJwk: privateKey.export({ format: 'jwk' }),
+  }
+  // Write-then-rename with owner-only perms, same posture as the pairing
+  // grants file: a half-written identity must never be observed, and the
+  // private key is never group/world readable.
+  // The data dir may not exist yet on a first start (identity generation can
+  // precede any store write); owner-only like the rest of the data dir.
+  mkdirSync(dirname(filepath), { recursive: true, mode: 0o700 })
+  const tmpPath = `${filepath}.tmp`
+  writeFileSync(tmpPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+  renameSync(tmpPath, filepath)
+  return { publicKey, privateKey }
+}
+
+export function createDaemonIdentity({ dataDir }: { dataDir: string }): DaemonIdentity {
+  const filepath = join(dataDir, DAEMON_IDENTITY_FILENAME)
+  const keys = tryLoad(filepath) ?? generateAndPersist(filepath)
+
+  const publicJwk = keys.publicKey.export({ format: 'jwk' }) as { x?: string }
+  const publicKeyB64u = publicJwk.x
+  if (publicKeyB64u === undefined) {
+    // Unreachable for a well-formed Ed25519 key; guard so a broken export
+    // fails loudly at startup instead of advertising an empty identity.
+    throw new Error('daemon identity public key export produced no key material')
+  }
+
+  return {
+    alg: 'Ed25519',
+    publicKey: publicKeyB64u,
+    sign: (parts) =>
+      cryptoSign(null, buildSignedPayload(parts), keys.privateKey).toString('base64url'),
+  }
+}

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -161,8 +161,12 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
     })
   })
 
-  it('GET /api/runtime/ping is the sole declared public route', () => {
+  it('GET /api/runtime/ping is a declared public route', () => {
     expect(resolveApiRouteScope('GET', '/api/runtime/ping')).toEqual({ kind: 'public' })
+  })
+
+  it('POST /api/runtime/verify is public — the identity challenge must precede any pairing', () => {
+    expect(resolveApiRouteScope('POST', '/api/runtime/verify')).toEqual({ kind: 'public' })
   })
 
   it('a non-/api path is out of scope for this registry (null, not silently public)', () => {

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -53,6 +53,11 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
   // other /api/runtime/* path requires a scope below.
   if (path === '/api/runtime/ping') return { kind: 'public' }
 
+  // Same carve-out class as ping: the identity challenge (POST-only) must be
+  // answerable BEFORE any pairing exists — it is how a browser decides
+  // whether a responder is trustworthy at all. Rate-limited in the router.
+  if (path === '/api/runtime/verify') return { kind: 'public' }
+
   const isWrite = isWriteMethod(method)
 
   // File routes: reading/writing a canvas's attached binary file.

--- a/packages/mcp-server/src/shared/api-contracts/runtime.ts
+++ b/packages/mcp-server/src/shared/api-contracts/runtime.ts
@@ -5,12 +5,53 @@ import { z } from 'zod'
 // alone can misidentify an unrelated process as "our" daemon; instanceId is
 // unique per start and never reused, closing that identity-confusion window
 // for the CLI's stop/status/doctor checks that read this endpoint.
+// The daemon's durable signing identity (see server/security/daemon-identity.ts).
+// publicKey is the raw Ed25519 public key, base64url. Advertising it is safe:
+// trust comes from the web app PINNING the key at /pair consent time and
+// verifying signatures against the pin, never from the advertisement itself.
+export const daemonIdentitySchema = z.object({
+  alg: z.literal('Ed25519'),
+  publicKey: z.string().min(1),
+})
+
+export type DaemonIdentityInfo = z.infer<typeof daemonIdentitySchema>
+
 export const daemonPingResponseSchema = z.object({
   ok: z.literal(true),
   instanceId: z.string(),
+  // Optional for wire-compat with daemons predating the identity keypair;
+  // current daemons always include it.
+  identity: daemonIdentitySchema.optional(),
 })
 
 export type DaemonPingResponse = z.infer<typeof daemonPingResponseSchema>
+
+// POST /api/runtime/verify: a caller-random nonce (base64url, 16-32 decoded
+// bytes) is answered with a signature over ["wb-verify-v1", nonce, origin]
+// so a browser can challenge a loopback responder to prove it holds the
+// pinned daemon's private key. Public (like ping) and unreplayable (fresh
+// nonce per challenge).
+export const runtimeVerifyRequestSchema = z
+  .object({
+    nonce: z
+      .string()
+      .regex(/^[A-Za-z0-9_-]+$/, 'nonce must be base64url')
+      .refine((value) => {
+        const bytes = Buffer.from(value, 'base64url')
+        return bytes.length >= 16 && bytes.length <= 32
+      }, 'nonce must decode to 16-32 bytes'),
+  })
+  .strict()
+
+export const runtimeVerifyResponseSchema = z
+  .object({
+    alg: z.literal('Ed25519'),
+    publicKey: z.string().min(1),
+    signature: z.string().min(1),
+  })
+  .strict()
+
+export type RuntimeVerifyResponse = z.infer<typeof runtimeVerifyResponseSchema>
 
 export const runtimeStatusResponseSchema = z.object({
   ok: z.boolean(),


### PR DESCRIPTION
## What

Server half of the approved mutual-auth design (canvas `daemon-mutual-auth-design`, decided 2026-08-08): the daemon gains a durable Ed25519 signing identity so a browser can prove a loopback responder is the real daemon — closing the port-squatting impersonation gap where any local process binding 3099-3108 could answer the (self-asserted) ping.

- **`security/daemon-identity.ts`**: keypair generated on first start, persisted at `<dataDir>/daemon-identity.json` (0600, write-then-rename). Corrupt file regenerates — rotation semantics; browsers fail closed on mismatch and re-approve on /pair. Signed payloads are JSON-array encoded (unambiguous part boundaries) with domain-separation tags.
- **`GET /api/runtime/ping`**: additive `identity: { alg, publicKey }` (optional in the shared Zod contract for wire-compat).
- **NEW public `POST /api/runtime/verify`**: caller-random nonce (base64url, 16-32 bytes) → signature over `["wb-verify-v1", nonce, origin]`. Origin-bound so signatures can't be farmed for another origin's challenge; globally rate-limited (loopback makes per-IP buckets meaningless). Registered as the third public route in the scope registry with tests.
- **`POST /api/pairing/token`** (code exchange + silent renewal): optional `nonce` → response `identity` with a signature over `["wb-token-v1", nonce, origin, sha256(token), expiresAt]` — the signature vouches for the exact credential handed over, so a squatter can't splice a real signature onto a fake token.

Threat boundary unchanged: defends a port-bind-only local attacker; a full-privilege attacker can read the key and is out of scope.

The web-app half (pin at /pair consent, verify against the pin, key-mismatch UI, fingerprint display) is the next slice.

## Test plan

- [x] Identity store: persistence/reload, 0600 perms, corrupt-file rotation + warning, sign/verify round-trip, part-boundary unambiguity, no private-key leak via API or logs
- [x] Runtime routes: ping identity; verify signature validates (and fails for a wrong origin); absent Origin binds ""; malformed nonces 400; rate limit 429; unauthenticated access preserved
- [x] Pairing routes: renewal + code-exchange signatures verify against the identity and fail for a spliced token hash; nonce-less requests get no identity field
- [x] Registry: `/api/runtime/verify` public + existing exhaustiveness tests
- [x] Full `mcp-node` suite (3112 passed), knip, biome, typecheck
- [x] Live verification: branch-built daemon; verified `ping` → `verify` end-to-end using **WebCrypto Ed25519** (the browser-side verification path): signature verifies for the challenged origin, rejects a different origin, identity file mode 600

Note: no `smoke:e2e` change — this adds HTTP routes, not MCP tools (the smoke covers the MCP tool surface); route tests + the live WebCrypto check above are the runtime guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable Ed25519 daemon identities for signing and verifying runtime interactions.
  - Runtime ping responses can now include the daemon’s signing algorithm and public key.
  - Added a public verification challenge endpoint with origin-bound nonce signatures and rate limiting.
  - Pairing exchanges and origin renewals can now return signatures tied to the request, token, and expiration.
- **Security**
  - Added validation for malformed or reused nonces and token-mismatch signatures.
  - Identity credentials are securely stored and automatically regenerated if damaged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->