### PR TITLE
fix(daemon): harden the identity slice per review (no key material in logs, shared token contract)

### DIFF
--- a/packages/mcp-server/src/server/log.ts
+++ b/packages/mcp-server/src/server/log.ts
@@ -172,6 +172,8 @@ const REDACTED_PATHS = [
   'password',
   'secret',
   'apiKey',
+  'privateJwk',
+  'd',
   '*.token',
   '*.daemonToken',
   '*.bootstrapToken',
@@ -182,6 +184,8 @@ const REDACTED_PATHS = [
   '*.password',
   '*.secret',
   '*.apiKey',
+  '*.privateJwk',
+  '*.d',
 ]
 
 const root: Logger = pino(

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -34,6 +34,7 @@ describe('api-contracts barrel scope', () => {
       '@kamiazya/whiteboard-server-core',
       './branches.js',
       './canvas.js',
+      './pairing.js',
       './runtime.js',
     ])
   })

--- a/packages/mcp-server/src/server/routes/pairing.test.ts
+++ b/packages/mcp-server/src/server/routes/pairing.test.ts
@@ -202,6 +202,25 @@ describe('pairing token identity signatures', () => {
     ).toBe(false)
   })
 
+  it('rejects malformed and out-of-range nonces with 400', async () => {
+    const { app, grants } = makeApp()
+    grants.addGrant(HOSTED)
+    const bad = [
+      '!!!not-base64url!!!',
+      Buffer.alloc(15).toString('base64url'), // one byte short
+      Buffer.alloc(33).toString('base64url'), // one byte long
+    ]
+    for (const nonce of bad) {
+      const res = await post(
+        app,
+        '/api/pairing/token',
+        { grantType: 'origin', nonce },
+        { Origin: HOSTED },
+      )
+      expect(res.status).toBe(400)
+    }
+  })
+
   it('a request without a nonce gets no identity field (wire-compat)', async () => {
     const { app, grants } = makeApp()
     grants.addGrant(HOSTED)

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -28,6 +28,10 @@
 import { createHash } from 'node:crypto'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import {
+  type PairingTokenResponse,
+  pairingTokenRequestSchema,
+} from '../../shared/api-contracts/pairing.js'
 import type { DaemonIdentity } from '../security/daemon-identity.js'
 import type { PairingGrantStore } from '../security/pairing-grant-store.js'
 import type { PairingCodeStore, PairingTokenStore } from '../security/pairing-session.js'
@@ -57,51 +61,7 @@ const listGrantsResponseSchema = z
   .strict()
 type ListGrantsResponse = z.infer<typeof listGrantsResponseSchema>
 
-// A caller-random challenge nonce (base64url, 16-32 decoded bytes). When
-// present, the response carries an identity signature binding this nonce —
-// see the identity note on tokenResponseSchema.
-const tokenNonceSchema = z
-  .string()
-  .regex(/^[A-Za-z0-9_-]+$/, 'nonce must be base64url')
-  .refine((value) => {
-    const bytes = Buffer.from(value, 'base64url')
-    return bytes.length >= 16 && bytes.length <= 32
-  }, 'nonce must decode to 16-32 bytes')
-
-const tokenRequestSchema = z.discriminatedUnion('grantType', [
-  z
-    .object({
-      grantType: z.literal('code'),
-      code: z.string().min(1),
-      codeVerifier: z.string().min(1),
-      nonce: tokenNonceSchema.optional(),
-    })
-    .strict(),
-  z.object({ grantType: z.literal('origin'), nonce: tokenNonceSchema.optional() }).strict(),
-])
-
-const tokenResponseSchema = z
-  .object({
-    token: z.string(),
-    expiresAt: z.string(),
-    origin: z.string(),
-    // Present iff the request carried a nonce: the daemon's identity plus a
-    // signature over ["wb-token-v1", nonce, origin, sha256(token), expiresAt].
-    // Binding sha256(token) makes the signature vouch for the very credential
-    // being handed over — a squatter cannot splice a real daemon's signature
-    // onto its own fake token. Verified browser-side against the key pinned
-    // at /pair consent.
-    identity: z
-      .object({
-        alg: z.literal('Ed25519'),
-        publicKey: z.string(),
-        signature: z.string(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-type TokenResponse = z.infer<typeof tokenResponseSchema>
+type TokenResponse = PairingTokenResponse
 
 function signTokenResponse(
   identity: DaemonIdentity,
@@ -176,7 +136,7 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
     } catch {
       return c.json({ error: 'invalid JSON body' }, 400)
     }
-    const parsed = tokenRequestSchema.safeParse(body)
+    const parsed = pairingTokenRequestSchema.safeParse(body)
     if (!parsed.success) {
       return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
     }

--- a/packages/mcp-server/src/server/routes/runtime.test.ts
+++ b/packages/mcp-server/src/server/routes/runtime.test.ts
@@ -267,17 +267,19 @@ describe('daemon identity surfaces', () => {
     }
   })
 
-  it('verify rate-limits a tight loop with 429', async () => {
+  it('verify allows exactly the configured window then rate-limits with 429', async () => {
     const { app } = createApp()
-    let limited = 0
-    for (let i = 0; i < 70; i += 1) {
+    const statuses: number[] = []
+    for (let i = 0; i < 65; i += 1) {
       const res = await app.request('/api/runtime/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nonce: NONCE }),
       })
-      if (res.status === 429) limited += 1
+      statuses.push(res.status)
     }
-    expect(limited).toBeGreaterThan(0)
+    // First 60 succeed; everything after the boundary is throttled.
+    expect(statuses.slice(0, 60).every((status) => status === 200)).toBe(true)
+    expect(statuses.slice(60).every((status) => status === 429)).toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/security/daemon-identity.test.ts
+++ b/packages/mcp-server/src/server/security/daemon-identity.test.ts
@@ -77,6 +77,32 @@ describe('createDaemonIdentity', () => {
     }
   })
 
+  it('a wrong-shape identity file rotates without echoing its private key into logs', () => {
+    createDaemonIdentity({ dataDir: dir })
+    const plantedD = 'PLANTED-PRIVATE-KEY-MATERIAL-d'
+    writeFileSync(
+      join(dir, 'daemon-identity.json'),
+      JSON.stringify({
+        version: 999,
+        alg: 'Ed25519',
+        publicJwk: { kty: 'OKP', crv: 'Ed25519', x: 'x' },
+        privateJwk: { kty: 'OKP', crv: 'Ed25519', x: 'x', d: plantedD },
+      }),
+    )
+    const capture = captureLogsForTests('debug')
+    try {
+      const rotated = createDaemonIdentity({ dataDir: dir })
+      expect(Buffer.from(rotated.publicKey, 'base64url')).toHaveLength(32)
+      const record = capture.records.find(
+        (r) => r.scope === 'daemon-identity' && r.level === 'warning',
+      )
+      expect(record).toBeDefined()
+      expect(JSON.stringify(capture.records)).not.toContain(plantedD)
+    } finally {
+      capture.restore()
+    }
+  })
+
   it('never leaks the private key through the returned object or logs', () => {
     const capture = captureLogsForTests('debug')
     try {

--- a/packages/mcp-server/src/server/security/daemon-identity.test.ts
+++ b/packages/mcp-server/src/server/security/daemon-identity.test.ts
@@ -98,6 +98,12 @@ describe('createDaemonIdentity', () => {
       )
       expect(record).toBeDefined()
       expect(JSON.stringify(capture.records)).not.toContain(plantedD)
+      // Pin the sanitized-record contract itself: only a reason class, never
+      // the error object — ZodError happens not to echo input today, but the
+      // moment someone logs { err } this assertion fails rather than relying
+      // on that library behavior staying true.
+      expect(record).toMatchObject({ data: { reason: 'invalid-shape' } })
+      expect(record && 'err' in (record.data as Record<string, unknown>)).toBe(false)
     } finally {
       capture.restore()
     }

--- a/packages/mcp-server/src/server/security/daemon-identity.ts
+++ b/packages/mcp-server/src/server/security/daemon-identity.ts
@@ -83,7 +83,11 @@ function tryLoad(filepath: string): LoadedKeys | null {
       privateKey: createPrivateKey({ key: parsed.privateJwk, format: 'jwk' }),
     }
   } catch (err) {
-    log.warning({ err }, 'daemon identity file unreadable; generating a fresh keypair')
+    // Deliberately NOT logging the error object: the parsed JSON carries the
+    // private key (privateJwk.d), and a validation error could echo parts of
+    // its input. The reason class is enough to act on.
+    const reason = err instanceof SyntaxError ? 'invalid-json' : 'invalid-shape'
+    log.warning({ reason }, 'daemon identity file unreadable; generating a fresh keypair')
     return null
   }
 }

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -19,6 +19,12 @@ export {
 } from '@kamiazya/whiteboard-server-core'
 export * from './branches.js'
 export * from './canvas.js'
+export type { PairingTokenResponse } from './pairing.js'
+export {
+  pairingTokenNonceSchema,
+  pairingTokenRequestSchema,
+  pairingTokenResponseSchema,
+} from './pairing.js'
 export type { DaemonPingResponse } from './runtime.js'
 export { daemonPingResponseSchema } from './runtime.js'
 

--- a/packages/mcp-server/src/shared/api-contracts/pairing.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+// Pairing-token wire contract, shared between the daemon route
+// (server/routes/pairing.ts) and the browser-side verifier so the signed
+// response shape cannot drift between processes. Deliberately free of any
+// node:* import — the browser consumes these schemas directly.
+
+// A caller-random challenge nonce (base64url, 16-32 decoded bytes). When
+// present, the token response carries an identity signature binding it —
+// see pairingTokenResponseSchema.identity.
+export const pairingTokenNonceSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]+$/, 'nonce must be base64url')
+  .refine((value) => {
+    // Decoded base64url length without Buffer: 4 chars -> 3 bytes, minus padding.
+    const bytes = Math.floor((value.length * 3) / 4)
+    return bytes >= 16 && bytes <= 32
+  }, 'nonce must decode to 16-32 bytes')
+
+export const pairingTokenRequestSchema = z.discriminatedUnion('grantType', [
+  z
+    .object({
+      grantType: z.literal('code'),
+      code: z.string().min(1),
+      codeVerifier: z.string().min(1),
+      nonce: pairingTokenNonceSchema.optional(),
+    })
+    .strict(),
+  z.object({ grantType: z.literal('origin'), nonce: pairingTokenNonceSchema.optional() }).strict(),
+])
+
+export const pairingTokenResponseSchema = z
+  .object({
+    token: z.string(),
+    expiresAt: z.string(),
+    origin: z.string(),
+    // Present iff the request carried a nonce: the daemon's identity plus a
+    // signature over ["wb-token-v1", nonce, origin, sha256(token), expiresAt].
+    // Binding sha256(token) makes the signature vouch for the very credential
+    // being handed over — a squatter cannot splice a real daemon's signature
+    // onto its own fake token. Verified browser-side against the key pinned
+    // at /pair consent.
+    identity: z
+      .object({
+        alg: z.literal('Ed25519'),
+        publicKey: z.string(),
+        signature: z.string(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+export type PairingTokenResponse = z.infer<typeof pairingTokenResponseSchema>


### PR DESCRIPTION
## What

Applies the CodeRabbit review findings from #441 (triaged post-merge — all four were valid):

1. **Security (Major)**: the identity-file schema-failure branch logged the raw error object; Zod validation runs on JSON carrying `privateJwk.d`, so an error could echo private-key material. Now logs a sanitized reason class only, `privateJwk`/`d` (top-level + one-level-nested) are added to `REDACTED_PATHS`, and a pinned test plants a recognizable `d` value in a wrong-shape file and asserts it never reaches any log record (and rotation still happens).
2. **Contract drift (Major)**: pairing-token request/response schemas moved to `shared/api-contracts/pairing.ts` (no `node:*` imports) so the upcoming browser verifier imports the same contract instead of redeclaring it. Barrel test updated for the new module.
3. **Test boundary (Minor)**: malformed / 15-byte / 33-byte pairing nonces now have explicit 400 tests.
4. **Test boundary (Minor)**: the verify rate-limit test asserts the exact boundary — first 60 requests 200, everything after 429.

## Test plan

- [x] Full `mcp-node` suite (3114 passed), biome, knip, typecheck
- [x] New leak-regression test fails if the sanitized log line is reverted to `{ err }` (mutation-checked locally)

Backend-only hardening + test changes; no user-visible surface (preview verification N/A).
