### PR TITLE
feat(web): pin the daemon identity at consent and verify renewals against it

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -493,6 +493,30 @@ export function App({ providerState }: AppProps) {
           message="Beta preview — your data is stored only in this browser."
         />
         <BackendConfigChip state={effectiveState} />
+        {grantConnection?.status === 'identity-mismatch' && !grantErrorDismissed && (
+          // Fail-closed renewal refusal: a PINNED daemon answered with a
+          // wrong or missing identity signature. Either the daemon rotated
+          // its key (delete + regenerate) or something else is on its port —
+          // both need a fresh human approval on the daemon's consent page.
+          <div
+            role="alert"
+            className="flex shrink-0 items-center justify-between gap-2 bg-destructive/10 px-3 py-1.5 text-xs text-destructive"
+          >
+            <span>
+              This daemon's identity changed — automatic reconnection was refused. If you rotated or
+              reinstalled the daemon, re-approve it from "Check for local daemon"; otherwise treat
+              this as a warning that something else may be answering on its port.
+            </span>
+            <button
+              type="button"
+              onClick={() => setGrantErrorDismissed(true)}
+              aria-label="Dismiss identity warning"
+              className="shrink-0 rounded px-1.5 py-0.5 font-medium hover:bg-background/60"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
         {grantConnection?.status === 'error' && !grantErrorDismissed && (
           // The user just clicked Approve on the daemon's consent page —
           // landing back here on browser-local with no explanation was a

--- a/apps/web/src/components/PairedOriginsCard.tsx
+++ b/apps/web/src/components/PairedOriginsCard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { z } from 'zod'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
+import { fingerprintPublicKey } from '@/lib/daemon-identity-pin'
 
 // Mirrors the daemon's GET /api/pairing/grants response (see
 // packages/mcp-server/src/server/routes/pairing.ts) — hydrated through the
@@ -33,6 +34,32 @@ export function PairedOriginsCard() {
   // daemon can never overwrite the active one's grants — its grantIds
   // belong to the other daemon entirely.
   const generationRef = useRef(0)
+  const [fingerprint, setFingerprint] = useState<string | null>(null)
+
+  // The daemon's identity fingerprint, so a user can cross-check the value
+  // shown on the /pair consent page out-of-band. Best-effort: absent on
+  // legacy daemons or while unreachable.
+  useEffect(() => {
+    const generation = generationRef.current
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetchApi('/api/runtime/ping')
+        if (!res.ok) return
+        const body = (await res.json()) as { identity?: { publicKey?: unknown } }
+        const publicKey = body.identity?.publicKey
+        if (typeof publicKey !== 'string' || publicKey.length === 0) return
+        const value = await fingerprintPublicKey(publicKey)
+        if (!cancelled && generation === generationRef.current) setFingerprint(value)
+      } catch {
+        // Leave the fingerprint absent.
+      }
+    })()
+    return () => {
+      cancelled = true
+      setFingerprint(null)
+    }
+  }, [fetchApi])
 
   const load = useCallback(async () => {
     const generation = ++generationRef.current
@@ -91,6 +118,16 @@ export function PairedOriginsCard() {
       <p className="mb-3 text-xs text-muted-foreground">
         Web apps you approved on this daemon's consent page. Revoking cuts their access immediately,
         including any active session.
+        {fingerprint !== null && (
+          <>
+            {' '}
+            This daemon's identity:{' '}
+            <span data-testid="daemon-fingerprint" className="font-mono">
+              {fingerprint}
+            </span>
+            .
+          </>
+        )}
       </p>
       {revokeError && (
         <p role="alert" className="mb-2 text-xs text-destructive">

--- a/apps/web/src/lib/daemon-identity-pin.test.ts
+++ b/apps/web/src/lib/daemon-identity-pin.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createChallengeNonce,
+  fingerprintPublicKey,
+  getPinnedIdentity,
+  pinIdentity,
+  sha256Base64Url,
+  verifyIdentitySignature,
+} from './daemon-identity-pin.js'
+
+function fakeStorage() {
+  const map = new Map<string, string>()
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    map,
+  }
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+}
+
+async function generateSigningPair() {
+  const pair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair
+  const jwk = await crypto.subtle.exportKey('jwk', pair.publicKey)
+  return { pair, publicKey: jwk.x as string }
+}
+
+async function signParts(pair: CryptoKeyPair, parts: readonly string[]): Promise<string> {
+  const payload = new TextEncoder().encode(JSON.stringify(parts))
+  const signature = await crypto.subtle.sign({ name: 'Ed25519' }, pair.privateKey, payload)
+  return bytesToBase64Url(new Uint8Array(signature))
+}
+
+describe('daemon identity pin store', () => {
+  it('round-trips a pin per daemon baseUrl (trailing slash normalized)', () => {
+    const storage = fakeStorage()
+    pinIdentity('http://127.0.0.1:3099/', { alg: 'Ed25519', publicKey: 'key-a' }, storage)
+    expect(getPinnedIdentity('http://127.0.0.1:3099', storage)).toMatchObject({
+      alg: 'Ed25519',
+      publicKey: 'key-a',
+    })
+    expect(getPinnedIdentity('http://127.0.0.1:3100', storage)).toBeNull()
+  })
+
+  it('a corrupt pin store degrades to no pins instead of throwing', () => {
+    const storage = fakeStorage()
+    storage.setItem('whiteboard:daemon-identity-pins', '{broken')
+    expect(getPinnedIdentity('http://127.0.0.1:3099', storage)).toBeNull()
+    // And re-pinning over the corrupt store works.
+    pinIdentity('http://127.0.0.1:3099', { alg: 'Ed25519', publicKey: 'key-b' }, storage)
+    expect(getPinnedIdentity('http://127.0.0.1:3099', storage)?.publicKey).toBe('key-b')
+  })
+})
+
+describe('verifyIdentitySignature', () => {
+  it('accepts a genuine signature and rejects a tampered message', async () => {
+    const { pair, publicKey } = await generateSigningPair()
+    const parts = ['wb-token-v1', createChallengeNonce(), 'https://app.example', 'hash', 'exp']
+    const signature = await signParts(pair, parts)
+
+    await expect(verifyIdentitySignature({ publicKey, parts, signature })).resolves.toBe(true)
+    await expect(
+      verifyIdentitySignature({ publicKey, parts: [...parts.slice(0, -1), 'other'], signature }),
+    ).resolves.toBe(false)
+  })
+
+  it('rejects a signature from a DIFFERENT key (the squatter case)', async () => {
+    const real = await generateSigningPair()
+    const squatter = await generateSigningPair()
+    const parts = ['wb-verify-v1', createChallengeNonce(), 'https://app.example']
+    const forged = await signParts(squatter.pair, parts)
+    await expect(
+      verifyIdentitySignature({ publicKey: real.publicKey, parts, signature: forged }),
+    ).resolves.toBe(false)
+  })
+
+  it('returns false (never throws) on malformed key material', async () => {
+    await expect(
+      verifyIdentitySignature({ publicKey: '!!!', parts: ['a'], signature: 'sig' }),
+    ).resolves.toBe(false)
+  })
+})
+
+describe('fingerprintPublicKey', () => {
+  it('is deterministic, grouped XXXX-XXXX, and key-sensitive', async () => {
+    const a = await generateSigningPair()
+    const b = await generateSigningPair()
+    const fpA = await fingerprintPublicKey(a.publicKey)
+    expect(fpA).toMatch(/^[A-Z2-7]{4}-[A-Z2-7]{4}$/)
+    expect(await fingerprintPublicKey(a.publicKey)).toBe(fpA)
+    expect(await fingerprintPublicKey(b.publicKey)).not.toBe(fpA)
+  })
+})
+
+describe('sha256Base64Url', () => {
+  it('matches the daemon-side sha256 base64url encoding', async () => {
+    // Known vector: sha256("abc") = ba7816bf... (base64url of raw digest)
+    await expect(sha256Base64Url('abc')).resolves.toBe(
+      'ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0',
+    )
+  })
+})

--- a/apps/web/src/lib/daemon-identity-pin.ts
+++ b/apps/web/src/lib/daemon-identity-pin.ts
@@ -1,0 +1,149 @@
+/**
+ * Browser half of daemon mutual authentication: pin the daemon's Ed25519
+ * public key at /pair consent time, then verify every later signed response
+ * against the PIN — never against whatever key a responder advertises. A
+ * port-squatting local process serving its own key fails the pinned
+ * verification and is refused (fail closed; the pin is kept so the
+ * key-changed warning has its evidence, per the approved design).
+ */
+import { z } from 'zod'
+
+const PINS_KEY = 'whiteboard:daemon-identity-pins'
+
+const pinSchema = z
+  .object({
+    alg: z.literal('Ed25519'),
+    publicKey: z.string().min(1),
+    pinnedAt: z.string(),
+  })
+  .strict()
+
+const pinsFileSchema = z.record(z.string(), pinSchema)
+
+export type DaemonIdentityPin = z.infer<typeof pinSchema>
+
+interface StorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+function loadPins(storage: StorageLike): Record<string, DaemonIdentityPin> {
+  const raw = storage.getItem(PINS_KEY)
+  if (raw === null) return {}
+  try {
+    return pinsFileSchema.parse(JSON.parse(raw))
+  } catch {
+    // A corrupt pin store must not brick pairing: treated as no pins, and
+    // the next successful consent re-pins.
+    return {}
+  }
+}
+
+export function getPinnedIdentity(
+  daemonBaseUrl: string,
+  storage: StorageLike = globalThis.localStorage,
+): DaemonIdentityPin | null {
+  return loadPins(storage)[daemonBaseUrl.replace(/\/+$/, '')] ?? null
+}
+
+export function pinIdentity(
+  daemonBaseUrl: string,
+  identity: { alg: 'Ed25519'; publicKey: string },
+  storage: StorageLike = globalThis.localStorage,
+): void {
+  const pins = loadPins(storage)
+  storage.setItem(
+    PINS_KEY,
+    JSON.stringify({
+      ...pins,
+      [daemonBaseUrl.replace(/\/+$/, '')]: { ...identity, pinnedAt: new Date().toISOString() },
+    }),
+  )
+}
+
+export function createChallengeNonce(): string {
+  const buffer = new Uint8Array(24)
+  crypto.getRandomValues(buffer)
+  return btoa(String.fromCharCode(...buffer))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const padded = value.replaceAll('-', '+').replaceAll('_', '/')
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='))
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0))
+}
+
+// Must byte-match the daemon's buildSignedPayload (JSON-array encoding gives
+// unambiguous part boundaries; first part is the domain-separation tag).
+function buildSignedPayload(parts: readonly string[]): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(parts))
+}
+
+export async function verifyIdentitySignature({
+  publicKey,
+  parts,
+  signature,
+}: {
+  publicKey: string
+  parts: readonly string[]
+  signature: string
+}): Promise<boolean> {
+  try {
+    const key = await crypto.subtle.importKey(
+      'jwk',
+      { kty: 'OKP', crv: 'Ed25519', x: publicKey },
+      { name: 'Ed25519' },
+      false,
+      ['verify'],
+    )
+    // Uint8Array views satisfy BufferSource at runtime; TS lib DOM typing of
+    // verify() is stricter than the spec here.
+    return await crypto.subtle.verify(
+      { name: 'Ed25519' },
+      key,
+      base64UrlToBytes(signature) as BufferSource,
+      buildSignedPayload(parts) as BufferSource,
+    )
+  } catch {
+    // Unsupported algorithm or malformed key material: verification failed,
+    // never a throw — callers treat this exactly like a bad signature.
+    return false
+  }
+}
+
+export async function sha256Base64Url(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')
+}
+
+const FINGERPRINT_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+
+/**
+ * Short human-checkable fingerprint of a daemon public key: first 40 bits of
+ * sha256(raw key), base32, grouped as XXXX-XXXX. Shown on the /pair consent
+ * page and the Storage tab so a user can cross-check out-of-band.
+ */
+export async function fingerprintPublicKey(publicKey: string): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', base64UrlToBytes(publicKey) as BufferSource),
+  )
+  let bits = 0
+  let acc = 0
+  let out = ''
+  for (const byte of digest) {
+    acc = (acc << 8) | byte
+    bits += 8
+    while (bits >= 5 && out.length < 8) {
+      bits -= 5
+      out += FINGERPRINT_ALPHABET[(acc >> bits) & 31]
+    }
+    if (out.length >= 8) break
+  }
+  return `${out.slice(0, 4)}-${out.slice(4, 8)}`
+}

--- a/apps/web/src/lib/pairing-grant.test.ts
+++ b/apps/web/src/lib/pairing-grant.test.ts
@@ -22,7 +22,16 @@ describe('PKCE pair', () => {
 
 describe('grant fragment', () => {
   it('parses #wb-grant=<code>&state=<state>', () => {
-    expect(parseGrantFragment('#wb-grant=abc&state=xyz')).toEqual({ code: 'abc', state: 'xyz' })
+    expect(parseGrantFragment('#wb-grant=abc&state=xyz')).toEqual({
+      code: 'abc',
+      state: 'xyz',
+      identity: null,
+    })
+    expect(parseGrantFragment('#wb-grant=abc&state=xyz&identity=pk')).toEqual({
+      code: 'abc',
+      state: 'xyz',
+      identity: 'pk',
+    })
   })
 
   it('returns null for an absent or incomplete fragment', () => {
@@ -134,11 +143,13 @@ describe('consumeGrantFragment', () => {
     expect(map.has('whiteboard:pairing-transaction')).toBe(false)
     const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
     expect(url).toBe(`${DAEMON}/api/pairing/token`)
-    expect(JSON.parse(String(init.body))).toEqual({
+    expect(JSON.parse(String(init.body))).toMatchObject({
       grantType: 'code',
       code: 'the-code',
       codeVerifier: 'verifier',
     })
+    // The exchange always challenges with a fresh nonce.
+    expect(JSON.parse(String(init.body)).nonce).toMatch(/^[A-Za-z0-9_-]{20,}$/)
   })
 
   it('rejects a state mismatch without exchanging anything', async () => {
@@ -184,5 +195,178 @@ describe('consumeGrantFragment', () => {
       fetch: fetchFn as unknown as typeof globalThis.fetch,
     })
     expect(result.status).toBe('error')
+  })
+})
+
+describe('mutual authentication (identity pinning)', () => {
+  function makeStorage(initial: Record<string, string> = {}) {
+    const map = new Map(Object.entries(initial))
+    return {
+      map,
+      storage: {
+        getItem: (k: string) => map.get(k) ?? null,
+        setItem: (k: string, v: string) => void map.set(k, v),
+        removeItem: (k: string) => void map.delete(k),
+      },
+    }
+  }
+
+  function bytesToBase64Url(bytes: Uint8Array): string {
+    return btoa(String.fromCharCode(...bytes))
+      .replaceAll('+', '-')
+      .replaceAll('/', '_')
+      .replaceAll('=', '')
+  }
+
+  async function makeDaemonSigner() {
+    const pair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair
+    const jwk = await crypto.subtle.exportKey('jwk', pair.publicKey)
+    const publicKey = jwk.x as string
+    const sign = async (parts: readonly string[]) =>
+      bytesToBase64Url(
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: 'Ed25519' },
+            pair.privateKey,
+            new TextEncoder().encode(JSON.stringify(parts)),
+          ),
+        ),
+      )
+    return { publicKey, sign }
+  }
+
+  async function sha256b64u(value: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+    return bytesToBase64Url(new Uint8Array(digest))
+  }
+
+  // A fetch stub that behaves like the real daemon: signs whatever nonce
+  // the request carries, with the given signer.
+  function daemonFetch(signer: Awaited<ReturnType<typeof makeDaemonSigner>>, token = 'tok') {
+    return vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { nonce?: string }
+      const expiresAt = '2099-01-01T00:00:00.000Z'
+      const identity =
+        body.nonce !== undefined
+          ? {
+              alg: 'Ed25519',
+              publicKey: signer.publicKey,
+              signature: await signer.sign([
+                'wb-token-v1',
+                body.nonce,
+                HOSTED,
+                await sha256b64u(token),
+                expiresAt,
+              ]),
+            }
+          : undefined
+      return Response.json({ token, expiresAt, origin: HOSTED, identity })
+    })
+  }
+
+  it('exchange with a fragment identity verifies the signature and pins the key', async () => {
+    const signer = await makeDaemonSigner()
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st-1',
+        codeVerifier: 'verifier',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const pins = makeStorage()
+
+    const result = await consumeGrantFragment({
+      hash: `#wb-grant=code&state=st-1&identity=${encodeURIComponent(signer.publicKey)}`,
+      sessionStorage: storage,
+      fetch: daemonFetch(signer) as unknown as typeof globalThis.fetch,
+      hostedOrigin: HOSTED,
+      pinStorage: pins.storage,
+    })
+
+    expect(result.status).toBe('paired')
+    const stored = JSON.parse(pins.map.get('whiteboard:daemon-identity-pins') ?? '{}')
+    expect(stored[DAEMON]?.publicKey).toBe(signer.publicKey)
+  })
+
+  it("exchange refuses a response signed by a DIFFERENT key than the approved fragment's", async () => {
+    const approved = await makeDaemonSigner()
+    const squatter = await makeDaemonSigner()
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st-1',
+        codeVerifier: 'verifier',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const pins = makeStorage()
+
+    const result = await consumeGrantFragment({
+      hash: `#wb-grant=code&state=st-1&identity=${encodeURIComponent(approved.publicKey)}`,
+      sessionStorage: storage,
+      fetch: daemonFetch(squatter) as unknown as typeof globalThis.fetch,
+      hostedOrigin: HOSTED,
+      pinStorage: pins.storage,
+    })
+
+    expect(result).toEqual({ status: 'error', detail: 'daemon identity verification failed' })
+    expect(pins.map.has('whiteboard:daemon-identity-pins')).toBe(false)
+  })
+
+  it('renewal against a pinned daemon verifies and stays paired', async () => {
+    const signer = await makeDaemonSigner()
+    const pins = makeStorage({
+      'whiteboard:daemon-identity-pins': JSON.stringify({
+        [DAEMON]: { alg: 'Ed25519', publicKey: signer.publicKey, pinnedAt: 'then' },
+      }),
+    })
+
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: daemonFetch(signer) as unknown as typeof globalThis.fetch,
+      hostedOrigin: HOSTED,
+      pinStorage: pins.storage,
+    })
+    expect(result.status).toBe('paired')
+  })
+
+  it('renewal fails CLOSED with identity-mismatch when a pinned daemon answers with another key', async () => {
+    const pinnedKey = await makeDaemonSigner()
+    const squatter = await makeDaemonSigner()
+    const pins = makeStorage({
+      'whiteboard:daemon-identity-pins': JSON.stringify({
+        [DAEMON]: { alg: 'Ed25519', publicKey: pinnedKey.publicKey, pinnedAt: 'then' },
+      }),
+    })
+
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: daemonFetch(squatter) as unknown as typeof globalThis.fetch,
+      hostedOrigin: HOSTED,
+      pinStorage: pins.storage,
+    })
+    expect(result).toEqual({ status: 'identity-mismatch', daemonBaseUrl: DAEMON })
+    // The pin survives (evidence for the warning UI), per the approved design.
+    expect(pins.map.get('whiteboard:daemon-identity-pins')).toContain(pinnedKey.publicKey)
+  })
+
+  it('renewal against an UNPINNED daemon sends no nonce and stays on the legacy path', async () => {
+    const signer = await makeDaemonSigner()
+    const pins = makeStorage()
+    const fetchFn = daemonFetch(signer)
+
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+      hostedOrigin: HOSTED,
+      pinStorage: pins.storage,
+    })
+    expect(result.status).toBe('paired')
+    const body = JSON.parse(
+      String((fetchFn.mock.calls[0] as unknown as [string, RequestInit])[1].body),
+    )
+    expect(body.nonce).toBeUndefined()
   })
 })

--- a/apps/web/src/lib/pairing-grant.ts
+++ b/apps/web/src/lib/pairing-grant.ts
@@ -17,6 +17,14 @@
  * the caller).
  */
 
+import {
+  createChallengeNonce,
+  getPinnedIdentity,
+  pinIdentity,
+  sha256Base64Url,
+  verifyIdentitySignature,
+} from './daemon-identity-pin.js'
+
 const TRANSACTION_KEY = 'whiteboard:pairing-transaction'
 const GRANT_FRAGMENT_PREFIX = '#wb-grant='
 
@@ -69,28 +77,42 @@ export async function beginPairingGrant({
   navigate(url.toString())
 }
 
-export function parseGrantFragment(hash: string): { code: string; state: string } | null {
+export function parseGrantFragment(
+  hash: string,
+): { code: string; state: string; identity: string | null } | null {
   if (!hash.startsWith(GRANT_FRAGMENT_PREFIX)) return null
   const params = new URLSearchParams(hash.slice(1))
   const code = params.get('wb-grant')
   const state = params.get('state')
   if (!code || !state) return null
-  return { code, state }
+  // The daemon-served consent page embeds the daemon's public key here —
+  // learned over the SAME top-level navigation the user just approved on,
+  // which is the trust anchor the pin inherits. Absent on legacy daemons.
+  return { code, state, identity: params.get('identity') }
 }
 
 export type GrantConsumeResult =
   | { status: 'paired'; daemonBaseUrl: string; token: string }
   | { status: 'none' }
   | { status: 'error'; detail: string }
+  /** A PINNED daemon answered with a wrong/missing identity signature.
+   *  Renewal is refused (fail closed) but the pin is kept so the
+   *  key-changed warning UI has its evidence; re-approving on /pair
+   *  re-pins. */
+  | { status: 'identity-mismatch'; daemonBaseUrl: string }
 
 export async function consumeGrantFragment({
   hash,
   sessionStorage,
   fetch,
+  hostedOrigin = globalThis.location.origin,
+  pinStorage = globalThis.localStorage,
 }: {
   hash: string
   sessionStorage: StorageLike
   fetch: typeof globalThis.fetch
+  hostedOrigin?: string
+  pinStorage?: StorageLike
 }): Promise<GrantConsumeResult> {
   const fragment = parseGrantFragment(hash)
   if (fragment === null) return { status: 'none' }
@@ -119,6 +141,7 @@ export async function consumeGrantFragment({
     return { status: 'error', detail: 'pairing state mismatch' }
   }
 
+  const nonce = createChallengeNonce()
   try {
     const response = await fetch(`${transaction.daemonBaseUrl}/api/pairing/token`, {
       method: 'POST',
@@ -127,14 +150,46 @@ export async function consumeGrantFragment({
         grantType: 'code',
         code: fragment.code,
         codeVerifier: transaction.codeVerifier,
+        nonce,
       }),
     })
     if (!response.ok) {
       return { status: 'error', detail: `token exchange rejected (${response.status})` }
     }
-    const body = (await response.json()) as { token?: unknown }
+    const body = (await response.json()) as {
+      token?: unknown
+      expiresAt?: unknown
+      identity?: { publicKey?: unknown; signature?: unknown }
+    }
     if (typeof body.token !== 'string' || body.token.length === 0) {
       return { status: 'error', detail: 'token exchange returned no token' }
+    }
+    if (fragment.identity !== null) {
+      // The key the user just approved (fragment) must be the key that
+      // signs the credential handed over — anything else is refused.
+      const verified =
+        typeof body.expiresAt === 'string' &&
+        body.identity?.publicKey === fragment.identity &&
+        typeof body.identity?.signature === 'string' &&
+        (await verifyIdentitySignature({
+          publicKey: fragment.identity,
+          parts: [
+            'wb-token-v1',
+            nonce,
+            hostedOrigin,
+            await sha256Base64Url(body.token),
+            body.expiresAt,
+          ],
+          signature: body.identity.signature,
+        }))
+      if (!verified) {
+        return { status: 'error', detail: 'daemon identity verification failed' }
+      }
+      pinIdentity(
+        transaction.daemonBaseUrl,
+        { alg: 'Ed25519', publicKey: fragment.identity },
+        pinStorage,
+      )
     }
     return { status: 'paired', daemonBaseUrl: transaction.daemonBaseUrl, token: body.token }
   } catch (error) {
@@ -154,20 +209,51 @@ export async function consumeGrantFragment({
 export async function renewPairingToken({
   daemonBaseUrl,
   fetch,
+  hostedOrigin = globalThis.location.origin,
+  pinStorage = globalThis.localStorage,
 }: {
   daemonBaseUrl: string
   fetch: typeof globalThis.fetch
+  hostedOrigin?: string
+  pinStorage?: StorageLike
 }): Promise<GrantConsumeResult> {
   const base = daemonBaseUrl.replace(/\/+$/, '')
+  const pinned = getPinnedIdentity(base, pinStorage)
+  const nonce = pinned !== null ? createChallengeNonce() : undefined
   try {
     const response = await fetch(`${base}/api/pairing/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ grantType: 'origin' }),
+      body: JSON.stringify({ grantType: 'origin', ...(nonce !== undefined ? { nonce } : {}) }),
     })
     if (!response.ok) return { status: 'none' }
-    const body = (await response.json()) as { token?: unknown }
+    const body = (await response.json()) as {
+      token?: unknown
+      expiresAt?: unknown
+      identity?: { publicKey?: unknown; signature?: unknown }
+    }
     if (typeof body.token !== 'string' || body.token.length === 0) return { status: 'none' }
+    if (pinned !== null && nonce !== undefined) {
+      // Verified against the PIN, never the advertised key: a squatter (or
+      // a rotated daemon) fails closed here and the user re-approves on
+      // /pair, which re-pins.
+      const verified =
+        typeof body.expiresAt === 'string' &&
+        body.identity?.publicKey === pinned.publicKey &&
+        typeof body.identity?.signature === 'string' &&
+        (await verifyIdentitySignature({
+          publicKey: pinned.publicKey,
+          parts: [
+            'wb-token-v1',
+            nonce,
+            hostedOrigin,
+            await sha256Base64Url(body.token),
+            body.expiresAt,
+          ],
+          signature: body.identity.signature,
+        }))
+      if (!verified) return { status: 'identity-mismatch', daemonBaseUrl: base }
+    }
     return { status: 'paired', daemonBaseUrl: base, token: body.token }
   } catch {
     return { status: 'none' }

--- a/apps/web/src/pages/PairConsentPage.test.tsx
+++ b/apps/web/src/pages/PairConsentPage.test.tsx
@@ -40,8 +40,13 @@ describe('PairConsentPage', () => {
 
     await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1))
     expect(navigate.mock.calls[0]?.[0]).toBe(`${HOSTED}/#wb-grant=the-code&state=st-1`)
-    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
-    expect(url).toBe('/api/pairing/grants')
+    // The page also pings its own origin for the identity fingerprint;
+    // find the grant call by URL rather than by index.
+    const grantCall = fetchFn.mock.calls.find(
+      (call) => (call as unknown as [string])[0] === '/api/pairing/grants',
+    ) as unknown as [string, RequestInit]
+    expect(grantCall).toBeDefined()
+    const [, init] = grantCall
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer daemon-secret')
     expect(JSON.parse(String(init.body))).toEqual({ origin: HOSTED, codeChallenge: 'chal' })
   })
@@ -54,7 +59,13 @@ describe('PairConsentPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /deny/i }))
 
     await screen.findByText(/denied/i)
-    expect(fetchFn).not.toHaveBeenCalled()
+    // The identity-fingerprint ping is a harmless same-origin read; what
+    // Deny must never do is touch the pairing API.
+    expect(
+      fetchFn.mock.calls.filter((call) =>
+        String((call as unknown as [string])[0]).startsWith('/api/pairing'),
+      ),
+    ).toHaveLength(0)
     expect(navigate).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/pages/PairConsentPage.tsx
+++ b/apps/web/src/pages/PairConsentPage.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { createPairingGrant } from '../lib/daemon-api-client.js'
+import { fingerprintPublicKey } from '../lib/daemon-identity-pin.js'
 
 /**
  * The daemon-served /pair consent page (pairing-grant flow). A hosted web
@@ -55,6 +56,30 @@ export function PairConsentPage({
   const location = useLocation()
   const request = useMemo(() => parsePairRequest(location.search), [location.search])
   const [consent, setConsent] = useState<ConsentState>({ kind: 'prompt' })
+  // This page is daemon-served, so a same-origin ping is the daemon
+  // introducing ITSELF — the trust anchor the requesting origin's pin
+  // inherits via the return fragment. Failure keeps identity null (legacy
+  // daemon posture): pairing still works, just unpinned.
+  const [identity, setIdentity] = useState<{ publicKey: string; fingerprint: string } | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetchFn('/api/runtime/ping')
+        if (!res.ok) return
+        const body = (await res.json()) as { identity?: { publicKey?: unknown } }
+        const publicKey = body.identity?.publicKey
+        if (typeof publicKey !== 'string' || publicKey.length === 0) return
+        const fingerprint = await fingerprintPublicKey(publicKey)
+        if (!cancelled) setIdentity({ publicKey, fingerprint })
+      } catch {
+        // Legacy daemon or transient failure: proceed unpinned.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [fetchFn])
 
   if (request === null) {
     return (
@@ -82,7 +107,11 @@ export function PairConsentPage({
       // The fragment carries only the single-use code + the caller's own
       // state nonce — never a token.
       const stateParam = encodeURIComponent(request?.state ?? '')
-      onNavigate(`${request?.origin}/#wb-grant=${encodeURIComponent(code)}&state=${stateParam}`)
+      const identityParam =
+        identity !== null ? `&identity=${encodeURIComponent(identity.publicKey)}` : ''
+      onNavigate(
+        `${request?.origin}/#wb-grant=${encodeURIComponent(code)}&state=${stateParam}${identityParam}`,
+      )
     } catch (error) {
       setConsent({
         kind: 'failed',
@@ -102,6 +131,14 @@ export function PairConsentPage({
         is asking to read and edit the canvases stored by this daemon. Only approve origins you
         recognize.
       </p>
+      {identity !== null && (
+        <p className="mb-4 text-xs text-muted-foreground">
+          This daemon's identity:{' '}
+          <span data-testid="daemon-fingerprint" className="font-mono">
+            {identity.fingerprint}
+          </span>
+        </p>
+      )}
       {consent.kind === 'denied' ? (
         <p className="text-sm font-medium">Denied — nothing was granted. You can close this tab.</p>
       ) : consent.kind === 'failed' ? (


### PR DESCRIPTION
## What

Browser half of the approved mutual-auth design (canvas `daemon-mutual-auth-design`; server half landed in #441/#442). The web app now **pins the daemon's Ed25519 public key at /pair consent time and verifies every later signed response against the pin** — a port-squatting local process advertising its own key gains nothing.

- **`lib/daemon-identity-pin.ts`** (new): localStorage pin store keyed by daemon baseUrl (corrupt store degrades to unpinned, re-pins on next consent), WebCrypto Ed25519 verification byte-matching the daemon's JSON-array payload encoding, challenge nonces, and an `XXXX-XXXX` base32 fingerprint (first 40 bits of sha256(key)).
- **/pair consent page**: fetches its own origin's ping (daemon-served → the daemon introducing itself over the approved top-level navigation), shows the fingerprint to the user, and embeds the key in the `#wb-grant` return fragment.
- **Token exchange** (`consumeGrantFragment`): challenges with a nonce; the response must be signed by the approved fragment key over `["wb-token-v1", nonce, origin, sha256(token), expiresAt]` — otherwise `daemon identity verification failed` and no pin. Success pins.
- **Silent renewal** (`renewPairingToken`): verifies against the **pin**, never the advertised key. Mismatch → new `identity-mismatch` result: renewal refused (fail closed), pin kept as evidence, and App shows a "daemon's identity changed — re-approve" warning alert.
- **Storage tab**: the Paired web apps card shows the daemon's fingerprint for out-of-band cross-checking against the consent page.
- Legacy daemons without an identity keep working unpinned (no behavior change).

## Test plan

- [x] Pin store round-trip/normalization/corrupt-degrade; WebCrypto verify accepts genuine + rejects tampered message, different-key (squatter) signature, malformed key; fingerprint determinism/format; sha256 vector matches the daemon encoding
- [x] Exchange: nonce always sent; fragment-key verification pins on success; different-signer response refused with no pin
- [x] Renewal: pinned+valid → paired; pinned+wrong-key → `identity-mismatch` with pin retained; unpinned → no nonce (legacy path)
- [x] Consent page: fingerprint rendered; grant call unaffected; Deny still touches no pairing API
- [x] Full apps/web suite 1388 passed; `-r typecheck`, biome, knip green
- [ ] Preview verification: full pair → pin → renewal loop against a local daemon running the #441 server code (evidence to follow)
