### PR TITLE
feat(daemon)!: serve only the /pair consent page; the hosted app is the UI

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -108,7 +108,7 @@ describe('DaemonDetectedBanner', () => {
     expect(probeFn.mock.calls[1]?.[1]).toMatchObject({ forceRecheck: true })
   })
 
-  it('renders the detected banner with an "Open the local app" primary CTA linking to the daemon origin', async () => {
+  it('renders the detected banner with pairing as the only action (no daemon-origin link)', async () => {
     const probeFn = vi.fn().mockResolvedValue(DETECTED)
     render(
       <DaemonDetectedBanner
@@ -120,60 +120,11 @@ describe('DaemonDetectedBanner', () => {
     )
 
     await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
-    const openLink = screen.getByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099')
-    // The pairing-link ask is gone: since R3, navigating to the daemon
-    // origin needs no pairing at all.
+    // The daemon origin serves only /pair now — a bare-origin link would
+    // just bounce off its redirect, so the banner must not offer one.
+    expect(screen.queryByRole('link', { name: /open the local app|^open /i })).toBeNull()
+    expect(screen.getByRole('button', { name: /use .*here|use here/i })).not.toBeNull()
     expect(screen.queryByText(/ask your ai agent/i)).toBeNull()
-  })
-
-  it('deep-links "Open the local app" to the last-connected workspace/slug when known', async () => {
-    const probeFn = vi.fn().mockResolvedValue(DETECTED)
-    const store = makeStore()
-    store.update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        lastConnectedWorkspaceId: 'w1',
-        lastConnectedSlug: 'main',
-      },
-    }))
-    render(
-      <DaemonDetectedBanner
-        settingsStore={store}
-        fetch={vi.fn()}
-        locationProtocol="http:"
-        probeFn={probeFn}
-      />,
-    )
-
-    const openLink = await screen.findByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
-  })
-
-  it('does not emit a double slash when the stored base URL has a trailing slash', async () => {
-    const probeFn = vi.fn().mockResolvedValue(DETECTED)
-    const store = makeStore()
-    store.update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        localDaemonBaseUrl: 'http://127.0.0.1:3099/',
-        lastConnectedWorkspaceId: 'w1',
-        lastConnectedSlug: 'main',
-      },
-    }))
-    render(
-      <DaemonDetectedBanner
-        settingsStore={store}
-        fetch={vi.fn()}
-        locationProtocol="http:"
-        probeFn={probeFn}
-      />,
-    )
-
-    const openLink = await screen.findByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
   })
 
   it('still links to the how-to doc alongside the primary CTA', async () => {
@@ -277,36 +228,11 @@ describe('DaemonDetectedBanner', () => {
     await screen.findByText(UNSUPPORTED_BROWSER_NOTICE)
     expect(screen.queryByRole('button', { name: /check for local daemon/i })).toBeNull()
 
-    // The way out: a normal top-level navigation to the daemon's own origin
-    // is not subject to the fetch-level block that produced this notice.
-    const openLink = screen.getByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099')
-  })
-
-  it('deep-links the unsupported-notice escape hatch to the last-connected workspace when known', async () => {
-    const probeFn = vi.fn().mockResolvedValue({ detected: false, reason: 'blocked' })
-    const store = makeStore()
-    store.update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        lastConnectedWorkspaceId: 'w1',
-        lastConnectedSlug: 'main',
-      },
-    }))
-    render(
-      <DaemonDetectedBanner
-        settingsStore={store}
-        fetch={vi.fn()}
-        locationProtocol="https:"
-        probeFn={probeFn}
-      />,
-    )
-
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-
-    const openLink = await screen.findByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3099/canvas/w1/main')
+    // No daemon-origin escape hatch anymore (the daemon serves only /pair);
+    // the honest affordance is the docs link.
+    expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()
+    const learnMore = screen.getByRole('link', { name: /learn more/i })
+    expect(learnMore.getAttribute('href')).toContain('connect-to-local-daemon')
   })
 
   it('a manual check finds a daemon on a non-default port (server-side ports are dynamic)', async () => {
@@ -330,8 +256,7 @@ describe('DaemonDetectedBanner', () => {
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
     await screen.findByText(/A server responded at http:\/\/127\.0\.0\.1:3101/)
-    const openLink = screen.getByRole('link', { name: /open the local app/i })
-    expect(openLink.getAttribute('href')).toBe('http://127.0.0.1:3101')
+    expect(screen.getByRole('button', { name: /use here/i })).not.toBeNull()
   })
 
   it('remembers a found daemon and re-probes it first on the next mount', async () => {
@@ -391,21 +316,16 @@ describe('DaemonDetectedBanner', () => {
     fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
 
     await screen.findByText(/2 servers responded on local ports/i)
-    // Each responder offers pairing IN PLACE (the hosted-app-first model);
-    // leaving for the daemon's own origin stays available as a secondary
-    // link, but must not be the only affordance.
+    // Each responder offers pairing IN PLACE (the hosted-app-first model).
     // Unique accessible names per daemon: a control list must identify
-    // WHICH daemon each action targets.
+    // WHICH daemon each action targets. No daemon-origin links: the daemon
+    // serves only /pair now, so a bare-origin link would just redirect back.
     const useHere = screen.getAllByRole('button', { name: /use http:\/\/127\.0\.0\.1:\d+ here/i })
     expect(useHere.map((b) => b.getAttribute('aria-label'))).toEqual([
       'Use http://127.0.0.1:3099 here',
       'Use http://127.0.0.1:3102 here',
     ])
-    const links = screen.getAllByRole('link', { name: /open http:\/\/127\.0\.0\.1:\d+/i })
-    expect(links.map((l) => l.getAttribute('href'))).toEqual([
-      'http://127.0.0.1:3099',
-      'http://127.0.0.1:3102',
-    ])
+    expect(screen.queryAllByRole('link', { name: /open http/i })).toHaveLength(0)
 
     fireEvent.click(useHere[1] as HTMLElement)
     await waitFor(() => expect(beginGrantFn).toHaveBeenCalledTimes(1))

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -231,7 +231,7 @@ describe('DaemonDetectedBanner', () => {
     // No daemon-origin escape hatch anymore (the daemon serves only /pair);
     // the honest affordance is the docs link.
     expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()
-    const learnMore = screen.getByRole('link', { name: /learn more/i })
+    const learnMore = screen.getByRole('link', { name: /how to connect a local daemon/i })
     expect(learnMore.getAttribute('href')).toContain('connect-to-local-daemon')
   })
 

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -26,7 +26,7 @@ import { shouldShowDaemonCta } from './daemon-cta-visibility.js'
 // gate that produced this notice in the first place. The "Open the local
 // app" link below is the escape hatch.
 export const UNSUPPORTED_BROWSER_NOTICE =
-  'This browser blocks the hosted app from reaching a local daemon over the network, so canvases stay saved in this browser only.'
+  'This browser blocks the hosted app from reaching a local daemon over the network, so canvases stay saved in this browser only. Use a Chromium-based browser to connect a local daemon.'
 
 // Docs are not served from apps/web (no /docs route), so the banner links to
 // the source-of-truth GitHub blob rather than fabricating a local route.
@@ -135,16 +135,6 @@ export function DaemonDetectedBanner({
   // else is labelled unverified. This is presentation-level honesty, not a
   // security boundary: the durable fix is daemon->browser mutual auth.
   const isPairedTarget = detectedBaseUrl === storedTarget.localDaemonBaseUrl
-
-  const openLocalAppUrl = useMemo(() => {
-    const { lastConnectedWorkspaceId, lastConnectedSlug } = storedTarget
-    // The last-connected canvas belongs to the STORED daemon — deep-link
-    // only when the discovered daemon is that same base, else land on root.
-    if (detectedBaseUrl === baseUrl && lastConnectedWorkspaceId && lastConnectedSlug) {
-      return `${baseUrl}/canvas/${encodeURIComponent(lastConnectedWorkspaceId)}/${encodeURIComponent(lastConnectedSlug)}`
-    }
-    return detectedBaseUrl
-  }, [storedTarget, baseUrl, detectedBaseUrl])
 
   // 'http:'/'https:' -> 'http'/'https'; any other scheme (e.g. jsdom's
   // default 'about:' outside these injected-prop tests) falls back to
@@ -299,8 +289,13 @@ export function DaemonDetectedBanner({
         // its own line, away from the sentence that explains it.
         <span className="text-xs text-muted-foreground">
           {UNSUPPORTED_BROWSER_NOTICE}{' '}
-          <a href={openLocalAppUrl} className="font-medium underline">
-            Open the local app
+          <a
+            href={HOW_TO_CONNECT_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium underline"
+          >
+            Learn more
           </a>
         </span>
       )}
@@ -378,13 +373,6 @@ export function DaemonDetectedBanner({
               >
                 Use here
               </button>
-              <a
-                href={daemon.baseUrl}
-                aria-label={`Open ${daemon.baseUrl}`}
-                className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
-              >
-                Open
-              </a>
             </span>
           ))}
           <button
@@ -419,12 +407,6 @@ export function DaemonDetectedBanner({
           >
             Use here
           </button>
-          <a
-            href={openLocalAppUrl}
-            className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent"
-          >
-            Open the local app
-          </a>
           <a
             href={HOW_TO_CONNECT_URL}
             target="_blank"

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -295,7 +295,7 @@ export function DaemonDetectedBanner({
             rel="noreferrer"
             className="font-medium underline"
           >
-            Learn more
+            How to connect a local daemon
           </a>
         </span>
       )}

--- a/docs/contributing/adr/0001-apps-web-canonical-frontend.md
+++ b/docs/contributing/adr/0001-apps-web-canonical-frontend.md
@@ -38,3 +38,24 @@ The migration proceeds in stages so each stage ships as a working increment:
 **Keep daemon-served UI as canonical** — Continue treating `packages/mcp-server/src/app` as the primary frontend and treat `apps/web` as secondary. Rejected: contradicts the goal of a statically deployable frontend independent of the daemon process.
 
 **One-shot migration** — Replace both UIs in a single PR. Rejected: too wide a regression surface; staged approach keeps each increment verifiable.
+
+## Addendum (2026-08-08): the daemon serves /pair only
+
+The original decision left the daemon "optionally serving the static build
+of `apps/web`" as a convenience fallback. That option is now retired
+(maintainer decision, 2026-08-08): the local daemon serves exactly one page —
+`/pair`, the pairing consent trust anchor that must come from the daemon's
+own origin (see ADR-0005 and the daemon identity keypair design) — plus the
+static assets it needs. Every other UI path answers a 302 to the official
+hosted app, and daemon startup auto-open targets the hosted app as well.
+
+Rationale: with the official hosted origin admitted by the daemon by
+default and pairing grants persisting across restarts, the hosted PWA is
+the canonical entry for every flow, and a second fully-functional origin
+was a source of divergence (duplicate SW/PWA behavior, split user state,
+double security surface). Accepted tradeoff, explicitly: a fully-offline
+FIRST run (PWA never installed) has no canvas UI — the installed PWA is
+the offline path.
+
+The `dist/web-app` copy step and its packaging checks remain: `/pair` is
+rendered by the same built bundle.

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -31,10 +31,9 @@ this project can fix by itself.
 
 The practical consequence: **connecting the hosted web app to a local daemon
 now requires a fresh `#wb=` link every session.** This applies to pairing
-from a hosted origin. Opening the daemon's own origin directly is a separate
-path — there the daemon serves the page and supplies the token same-origin,
-so no pairing link is involved; the `DaemonDetectedBanner` one-click
-reconnect navigates there.
+from a hosted origin. (The daemon itself serves only the `/pair` consent
+page at its own origin; every other UI path redirects to the official
+hosted app.)
 
 An earlier "silent reconnect" feature stored a possession credential (a
 WebCrypto keypair, with a plaintext localStorage secret as a fallback for

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -11,37 +11,27 @@ underlying MCP tools your AI agent calls (`create_branch`, `merge`, and so
 on) intentionally keep their git-derived names — the UI vocabulary is a
 presentation-layer choice and does not change the tool contract.
 
-## Opening the daemon's own UI directly
+## The daemon serves only the pairing page
 
-The local daemon serves the canonical `apps/web` build at its own origin —
-open `http://127.0.0.1:<port>/` (default port `3099`) in a browser and it
-renders the same canvas gallery and editor as a standalone `apps/web` deploy,
-already same-origin with the daemon's `/api/*`, `/mcp`, and WebSocket routes.
-No pairing link or Local Network Access prompt is needed for this path.
+The local daemon is a backend: the one page it serves is `/pair`, the
+pairing consent page (which must come from the daemon's own origin — it is
+the trust anchor that pins the daemon's identity key). Opening
+`http://127.0.0.1:<port>/` (default port `3099`) in a browser redirects to
+the official hosted app, which connects back to the daemon through its
+default origin admission and a pairing grant.
 
-Running `whiteboard daemon run` interactively opens this URL in your default
-browser automatically once the daemon is listening, so there is no separate
-step even for a human with no AI agent in the loop. Pass `--no-open` (or set
-`openBrowser: false` in a [config file](../reference/configuration.md#config-file-local-daemon))
+Running `whiteboard daemon run` interactively opens the hosted app in your
+default browser automatically once the daemon is listening. Pass `--no-open`
+(or set `openBrowser: false` in a
+[config file](../reference/configuration.md#config-file-local-daemon))
 to disable this. See
 [Auto-opening the browser](../reference/configuration.md#auto-opening-the-browser-whiteboard-daemon-run)
 for the full list of conditions under which it is suppressed (CI, containers,
 non-interactive shells, non-loopback binds).
 
-- **No service worker on this origin.** The daemon injects a per-request
-  `__WHITEBOARD_RUNTIME_CONFIG__` and `__WHITEBOARD_DAEMON_TOKEN__` into every
-  response; a Workbox-precached shell would pin a stale token across daemon
-  restarts, so the daemon-served build ships without the offline service
-  worker that a standalone `apps/web` deploy installs.
-- **Loopback-only live sync.** The injected daemon base URL for the
-  WebSocket connection is always `http://127.0.0.1:<port>` — a fixed loopback
-  address, not whatever host or IP the browser used to reach the page. If you
-  bind the daemon beyond loopback (for example `--host 0.0.0.0`) and open its
-  UI from another device on the LAN, the page loads but its live-sync
-  WebSocket still tries to reach `127.0.0.1` on *that device*, which is not
-  the daemon — sync silently fails. This same-origin UI is intended for
-  local, same-machine use; reach a daemon from another device through the
-  pairing flow below instead.
+Note the tradeoff this design accepts: with no network access and no
+previously-installed PWA, there is no canvas UI on a first run — install the
+hosted app as a PWA while online to keep an offline-capable editor.
 
 ## How detection works
 
@@ -77,22 +67,19 @@ depends on capability, not a fixed version list:
   WebKit blocks the request as mixed content with no override. On this
   browser, canvases stay in this browser (IndexedDB) — the app shows an
   explicit notice instead of a silently missing "connect" option, with a
-  link to open the local app directly (see below).
+  link to this page.
 
 This is determined by probing the daemon, not by inspecting your browser's
 identity string: the app only shows the "not supported" notice once a probe
 has actually proven the browser blocked the request.
 
-**The way out on an unsupported browser: open the daemon's own origin.** The
-mixed-content/private-network block above applies only to the background
-`fetch` the app uses to detect a daemon — it does not apply to a normal
-top-level navigation. So on Safari (or any future engine with the same
-restriction), click the "Open the local app" link in the notice, or type the
-daemon's address directly into the address bar (`http://127.0.0.1:3099` by
-default). That loads the same `apps/web` build served same-origin by the
-daemon, described in
-[Opening the daemon's own UI directly](#opening-the-daemons-own-ui-directly)
-above, where every feature — including live daemon sync — works normally.
+**On an unsupported browser, daemon connectivity is currently unavailable.**
+The daemon no longer serves a full UI at its own origin (it serves only the
+`/pair` consent page), so the previous escape hatch — opening
+`http://127.0.0.1:3099` directly — no longer applies. Use a Chromium-based
+browser (Chrome, Edge, Brave, Arc) to connect the hosted app to a local
+daemon; on other engines the hosted app keeps working with browser-local
+storage only.
 
 ## How pairing works
 

--- a/packages/mcp-server/scripts/smoke/mcp-daemon-origin-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-daemon-origin-smoke.mjs
@@ -1,19 +1,16 @@
-#!/usr/bin/env node
-// Real-browser proof for R3 of the MCP-UI retirement (ADR 0001) AND for the
-// daemon-auto-open-browser feature: a real Chromium tab loading the local
-// daemon's own origin lands directly in a CONNECTED, working app — same
-// origin, no `#wb=` fragment, no pairing step — because the daemon injects
-// the token server-side into the HTML it serves. Requires a real prior
-// `pnpm build` so it exercises the actual built dist/web-app, not a
-// fixture.
+// Real-browser proof of the daemon's hosted-first UI end state (ADR-0001
+// addendum): the daemon serves exactly ONE page — /pair, the pairing consent
+// trust anchor — and redirects every other UI path to the official hosted
+// app. Requires a real prior `pnpm build` so it exercises the actual built
+// dist/web-app, not a fixture.
 //
-// The auto-open feature's whole reason to exist is that a human opening
-// this URL manually (or via the OS auto-launching a browser tab) must NOT
-// need to run through the pairing flow. This script is the proof: it seeds
-// a real canvas through the daemon's own HTTP API (not a fixture write),
-// then drives a real browser to the bare origin and asserts the canvas
-// gallery shows it, the "Check for local daemon" pairing CTA is absent, and
-// opening the canvas actually renders it.
+// What this pins:
+// 1. The bare origin (and any other UI path) answers 302 to the official
+//    hosted app URL, and the redirect leaks no token.
+// 2. /pair renders the real consent page from the built bundle, with the
+//    daemon's identity fingerprint (proves the daemon-served page, its
+//    asset serving, AND the identity ping end-to-end in one shot).
+// 3. Reserved paths keep their non-UI semantics (/token stays 404).
 //
 // Direct invocation requires tsx:
 //   node --import tsx/esm scripts/smoke/mcp-daemon-origin-smoke.mjs
@@ -36,50 +33,46 @@ if (!existsSync(webAppIndexHtml)) {
 
 // `server/config.ts`'s DATA_DIR is a module-level constant captured from
 // WHITEBOARD_DATA_DIR at import time — it MUST be set before the dynamic
-// import below, or this smoke silently reuses whatever data dir the
-// developer's own daemon uses (and a re-run collides with the canvas slug
-// this script seeds on every invocation).
+// import below.
 const dataDir = mkdtempSync(join(tmpdir(), 'whiteboard-daemon-origin-smoke-'))
 process.env.WHITEBOARD_DATA_DIR = dataDir
 
 const { startHttpServer } = await import(resolve(root, 'src/server/http-server.ts'))
 const { findAvailablePort } = await import(resolve(root, 'src/cli/daemon-run.ts'))
 
-const TOKEN = 'smoke-daemon-origin-token-connected-app'
-const WORKSPACE_ID = 'sess-daemon-origin-smoke'
-const CANVAS_SLUG = 'daemon-origin-smoke-canvas'
+const TOKEN = 'smoke-daemon-origin-token-pair-only'
+const OFFICIAL_HOSTED_APP_URL = 'https://kamiazya-whiteboard.pages.dev/'
 
 const port = await findAvailablePort(4300)
 const running = await startHttpServer({ port, host: '127.0.0.1', token: TOKEN })
-
 const daemonBaseUrl = `http://127.0.0.1:${port}`
 
-async function authedFetch(path, init = {}) {
-  const headers = new Headers(init.headers)
-  headers.set('Authorization', `Bearer ${TOKEN}`)
-  return fetch(`${daemonBaseUrl}${path}`, { ...init, headers })
+let failed = false
+
+// --- 1. Redirect contract (plain fetch, redirects not followed) ---
+for (const path of ['/', '/local/some-canvas', '/w/ws/c/alias']) {
+  const res = await fetch(`${daemonBaseUrl}${path}`, { redirect: 'manual' })
+  const location = res.headers.get('location')
+  if (res.status === 302 && location === OFFICIAL_HOSTED_APP_URL && !location.includes(TOKEN)) {
+    console.log(`  pass  ${path} redirects to the official hosted app`)
+  } else {
+    console.error(
+      `  FAIL  ${path} expected 302 -> ${OFFICIAL_HOSTED_APP_URL}, got ${res.status} -> ${location}`,
+    )
+    failed = true
+  }
 }
 
-// Seed a real canvas through the live daemon's own HTTP API — same route
-// the apps/web gallery itself calls — so this proves the served app is
-// actually reading daemon-backed state, not a coincidental empty gallery.
-const createRes = await authedFetch(
-  `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases`,
-  {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ slug: CANVAS_SLUG }),
-  },
-)
-if (!createRes.ok) {
-  const body = await createRes.text().catch(() => '')
-  console.error(
-    `[mcp-daemon-origin-smoke] FAIL: seed canvas POST failed: ${createRes.status} ${body}`,
-  )
-  await running.close()
-  process.exit(1)
+// Reserved path semantics survive the catch-all change.
+const tokenRes = await fetch(`${daemonBaseUrl}/token`, { redirect: 'manual' })
+if (tokenRes.status === 404) {
+  console.log('  pass  /token stays 404 (reserved, never redirected)')
+} else {
+  console.error(`  FAIL  /token expected 404, got ${tokenRes.status}`)
+  failed = true
 }
 
+// --- 2. /pair renders the real consent page in a real browser ---
 const browser = await chromium.launch({
   headless: true,
   ...(process.env.WHITEBOARD_CHROME_PATH && {
@@ -87,9 +80,7 @@ const browser = await chromium.launch({
   }),
 })
 
-let failed = false
 const consoleErrors = []
-
 try {
   const page = await browser.newPage()
   page.on('console', (msg) => {
@@ -99,175 +90,59 @@ try {
     consoleErrors.push(`uncaught: ${err.message}`)
   })
 
-  // The daemon origin itself — no #wb= fragment. This is the "open the
-  // daemon and get the canonical UI, already connected" scenario the
-  // auto-open feature (and the retirement) are pinning.
-  await page.goto(`${daemonBaseUrl}/`, { waitUntil: 'networkidle' })
+  const pairUrl = `${daemonBaseUrl}/pair?origin=${encodeURIComponent(
+    'https://app.example',
+  )}&challenge=smoke-challenge&state=smoke-state`
+  await page.goto(pairUrl, { waitUntil: 'networkidle' })
 
-  if (page.url().includes('#wb=')) {
-    console.error(`  FAIL  daemon origin URL carries a #wb= pairing fragment: ${page.url()}`)
-    failed = true
+  const consentHeading = page.getByRole('heading', {
+    name: /allow this web app to use your local daemon/i,
+  })
+  if (await consentHeading.isVisible({ timeout: 10_000 }).catch(() => false)) {
+    console.log('  pass  /pair renders the consent page from the built bundle')
   } else {
-    console.log('  pass  no #wb= pairing fragment on the daemon origin URL')
-  }
-
-  const galleryHeading = page.getByRole('heading', { name: /canvases|whiteboard/i }).first()
-  const galleryVisible = await galleryHeading
-    .waitFor({ state: 'visible', timeout: 15_000 })
-    .then(() => true)
-    .catch(() => false)
-  if (galleryVisible) {
-    console.log('  pass  the daemon origin renders the apps/web canvas gallery')
-  } else {
-    console.error('  FAIL  no recognizable gallery heading rendered at the daemon origin')
+    console.error('  FAIL  /pair did not render the consent heading')
     failed = true
   }
 
-  // Connected-to-daemon proof: the gallery must show the canvas seeded
-  // through the live daemon's own API above. A stale/disconnected app would
-  // render an empty gallery instead (browser-local mode has no daemon data
-  // to read from).
-  const seededSlug = page.getByTestId('canvas-slug').filter({ hasText: CANVAS_SLUG })
-  const seededVisible = await seededSlug
-    .waitFor({ state: 'visible', timeout: 15_000 })
-    .then(() => true)
-    .catch(() => false)
-  if (seededVisible) {
-    console.log('  pass  gallery shows the canvas seeded through the live daemon API')
+  // The fingerprint proves the identity ping worked end-to-end from the
+  // daemon-served page (daemon identity keypair -> ping -> WebCrypto
+  // fingerprint render).
+  const fingerprint = page.getByTestId('daemon-fingerprint')
+  const fingerprintText = await fingerprint.textContent({ timeout: 10_000 }).catch(() => null)
+  if (fingerprintText !== null && /^[A-Z2-7]{4}-[A-Z2-7]{4}$/.test(fingerprintText.trim())) {
+    console.log(`  pass  /pair shows the daemon identity fingerprint (${fingerprintText.trim()})`)
   } else {
-    console.error(
-      '  FAIL  seeded canvas slug not visible in the gallery — app may not be reading daemon data',
-    )
+    console.error(`  FAIL  no daemon identity fingerprint rendered (got: ${fingerprintText})`)
     failed = true
   }
 
-  // Not-connected proof: the "Check for local daemon" CTA only renders in
-  // the browser-local (disconnected) provider path — its presence here
-  // would mean the daemon token injection failed and the app fell back to
-  // browser-local storage instead of talking to this daemon.
-  const pairingCta = await page
-    .getByText('Check for local daemon', { exact: false })
-    .first()
-    .isVisible()
-    .catch(() => false)
-  if (pairingCta) {
-    console.error(
-      '  FAIL  the browser-local "Check for local daemon" CTA is visible — not connected',
-    )
-    failed = true
+  // A browser navigation to the bare origin must land on the hosted app URL
+  // (it will fail to LOAD offline/in CI — the assertion is the URL, so stop
+  // at 'commit' and tolerate a network error for the external origin).
+  await page.goto(`${daemonBaseUrl}/`, { waitUntil: 'commit' }).catch(() => {})
+  const landedUrl = page.url()
+  if (landedUrl.startsWith(OFFICIAL_HOSTED_APP_URL)) {
+    console.log('  pass  navigating the bare origin follows the redirect to the hosted app')
   } else {
-    console.log('  pass  no "Check for local daemon" CTA (already connected, no pairing needed)')
-  }
-
-  // Opening the seeded canvas must actually render it, not just list it.
-  // Match the editor's OWN root (its `role="application"` + accessible name)
-  // rather than the page's wrapping `data-testid`: a wrapper can mount while
-  // the editor inside it fails, which is exactly the case this check exists
-  // to catch. Page-agnostic, so both canvas pages are covered by one signal.
-  if (seededVisible) {
-    await seededSlug.click()
-    const editorVisible = await page
-      .locator('[role="application"][aria-label="Spatial canvas editor"]')
-      .first()
-      .waitFor({ state: 'visible', timeout: 20_000 })
-      .then(() => true)
-      .catch(() => false)
-    if (editorVisible) {
-      console.log('  pass  opening the seeded canvas renders the spatial editor surface')
-    } else {
-      console.error('  FAIL  opening the seeded canvas did not render the spatial editor surface')
-      failed = true
-    }
-  }
-
-  // Token-injection proof: `/api/*` only gates MUTATION methods (POST/PUT/
-  // DELETE/PATCH — see routes/auth.ts createDaemonMutationAuthMiddleware),
-  // so an unauthenticated GET-only check (gallery listing, opening a
-  // canvas) would pass even if the server had stopped injecting
-  // `__WHITEBOARD_DAEMON_TOKEN__`. Driving a real WRITE through the UI
-  // (creating a canvas) is what actually depends on the injected token
-  // reaching `readDaemonTokenOnce()` and riding along on the browser's own
-  // fetch — this is the assertion the token-injection mutation-check pins.
-  // A fresh navigation back to `/` (not `page.goBack()`) deliberately, so
-  // this step doesn't inherit the canvas page's live WS reconnect loop —
-  // that loop keeps the network "busy" forever once connected, so a
-  // history-back navigation never reaches a quiet state to interact from.
-  await page.goto(`${daemonBaseUrl}/`, { waitUntil: 'domcontentloaded' })
-  const newCanvasSlug = 'daemon-origin-smoke-new-canvas'
-  const newCanvasNameInput = page.getByLabel('New canvas name')
-  // handleCreate in DaemonIndexPage.tsx navigates straight into the newly
-  // created canvas on success (onOpenCanvas), rather than staying on the
-  // gallery — so success is "the URL now names the new canvas", and
-  // failure (401 from a missing token) is "a createError alert appears and
-  // the gallery URL is unchanged". Race both outcomes instead of waiting
-  // for only one, so an auth failure resolves promptly instead of only
-  // being caught by the outer timeout.
-  const created = await newCanvasNameInput
-    .waitFor({ state: 'visible', timeout: 15_000 })
-    .then(() => newCanvasNameInput.fill(newCanvasSlug))
-    .then(() => page.getByRole('button', { name: 'Create canvas' }).click())
-    .then(() =>
-      Promise.race([
-        page
-          .waitForURL((url) => url.pathname.includes(newCanvasSlug), { timeout: 15_000 })
-          .then(() => true),
-        page
-          .getByRole('alert')
-          .waitFor({ state: 'visible', timeout: 15_000 })
-          .then(() => false),
-      ]),
-    )
-    .catch(() => false)
-  if (created) {
-    console.log(
-      '  pass  creating a canvas through the UI succeeds (token reached the mutation gate)',
-    )
-  } else {
-    console.error(
-      '  FAIL  creating a canvas through the UI did not succeed — the injected token may be missing',
-    )
+    console.error(`  FAIL  bare-origin navigation landed on ${landedUrl}`)
     failed = true
-  }
-
-  // R3 pins no service worker on the daemon origin (see
-  // apps/web/scripts/copy-into-mcp-dist.mjs) — a stale precached shell would
-  // pin an old injected daemon token across restarts.
-  const swController = await page.evaluate(() => navigator.serviceWorker?.controller ?? null)
-  if (swController === null) {
-    console.log('  pass  no service worker controls the daemon-origin page')
-  } else {
-    console.error('  FAIL  a service worker is controlling the daemon-origin page')
-    failed = true
-  }
-
-  const swRegistrationErrors = consoleErrors.filter((line) => /sw\.js|service.?worker/i.test(line))
-  const uncaughtErrors = consoleErrors.filter((line) => line.startsWith('uncaught:'))
-  if (uncaughtErrors.length === 0) {
-    console.log('  pass  no uncaught page errors (absent sw.js is caught and logged, not thrown)')
-  } else {
-    console.error(`  FAIL  uncaught page errors: ${uncaughtErrors.join('; ')}`)
-    failed = true
-  }
-  if (swRegistrationErrors.length > 0) {
-    console.log(
-      `  note  ${swRegistrationErrors.length} console error(s) mention the service worker (expected: registration is attempted and its rejection is caught+logged) — ${swRegistrationErrors.join('; ')}`,
-    )
   }
 } finally {
-  // Both must be attempted even if one throws — otherwise a browser.close()
-  // failure would leave the daemon's listening port open for the rest of
-  // the process's lifetime.
-  const [browserResult, serverResult] = await Promise.allSettled([browser.close(), running.close()])
-  for (const result of [browserResult, serverResult]) {
-    if (result.status === 'rejected') {
-      console.error('[mcp-daemon-origin-smoke] cleanup error:', result.reason)
-    }
-  }
+  await browser.close()
+  await running.close()
   rmSync(dataDir, { recursive: true, force: true })
+}
+
+if (consoleErrors.length > 0) {
+  // Console errors on /pair are diagnostic only for the external-origin
+  // navigation (expected to fail to load in an offline CI sandbox) — but a
+  // consent-page error is a real failure signal worth surfacing.
+  console.log(`  note  browser console errors observed:\n    ${consoleErrors.join('\n    ')}`)
 }
 
 if (failed) {
   console.error('[mcp-daemon-origin-smoke] FAIL')
   process.exit(1)
 }
-console.log('[mcp-daemon-origin-smoke] passed')
+console.log('[mcp-daemon-origin-smoke] PASS')

--- a/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
@@ -181,7 +181,7 @@ afterEach(async () => {
 
 describe.skipIf(!hasWorkingPty)('daemon run auto-open: real process launch', () => {
   it(
-    'invokes the fake opener with the daemon origin URL exactly once when every guard passes',
+    'invokes the fake opener with the hosted app URL exactly once when every guard passes',
     async () => {
       const port = await findAvailablePort(4310)
       const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
@@ -215,7 +215,7 @@ describe.skipIf(!hasWorkingPty)('daemon run auto-open: real process launch', () 
       await killAndWait(pid, closed)
       liveChildren.splice(0, liveChildren.length)
 
-      expect(lines).toEqual([`http://127.0.0.1:${port}`])
+      expect(lines).toEqual(['https://kamiazya-whiteboard.pages.dev/'])
     },
     READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
   )

--- a/packages/mcp-server/src/cli/daemon-run-auto-open.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run-auto-open.test.ts
@@ -16,10 +16,10 @@ function baseInput(overrides: Partial<Parameters<typeof maybeOpenDaemonBrowser>[
 }
 
 describe('maybeOpenDaemonBrowser', () => {
-  it('opens the daemon origin URL when every guard passes', async () => {
+  it('opens the official hosted app URL when every guard passes', async () => {
     const input = baseInput()
     await maybeOpenDaemonBrowser(input)
-    expect(input.openFn).toHaveBeenCalledWith('http://127.0.0.1:3099')
+    expect(input.openFn).toHaveBeenCalledWith('https://kamiazya-whiteboard.pages.dev/')
   })
 
   it('does not open when --no-open was passed', async () => {

--- a/packages/mcp-server/src/cli/daemon-run-auto-open.ts
+++ b/packages/mcp-server/src/cli/daemon-run-auto-open.ts
@@ -15,6 +15,7 @@ import {
   isRunningInContainer,
 } from '../daemon/container-detection.js'
 import { getLogger } from '../server/log.js'
+import { OFFICIAL_HOSTED_APP_URL } from '../server/security/web-origin-allowlist.js'
 
 const log = getLogger('daemon-run-auto-open')
 
@@ -47,7 +48,10 @@ export async function maybeOpenDaemonBrowser(input: MaybeOpenDaemonBrowserInput)
   // propagate: the caller does not — and must not have to — wrap this call
   // in its own try/catch. The URL is computed up front so every failure
   // path below can tell the user what to open manually.
-  const url = `http://${input.host}:${input.port}`
+  // Hosted-first: the browser opens the official hosted app, which reaches
+  // this daemon via its default origin admission + a pairing grant. The
+  // daemon's own origin now serves only the /pair consent page.
+  const url = OFFICIAL_HOSTED_APP_URL
   try {
     const env = input.env ?? process.env
     const decision = decideAutoOpenBrowser({

--- a/packages/mcp-server/src/server/app.oauth-authz.test.ts
+++ b/packages/mcp-server/src/server/app.oauth-authz.test.ts
@@ -150,7 +150,9 @@ describe('createApp oauth-authz wiring', () => {
         allowedWebOrigins: ['https://whiteboard.pages.dev'],
       }),
     )
-    const res = await app.request('http://127.0.0.1:3099/', { headers: { Host: '127.0.0.1:3099' } })
+    const res = await app.request('http://127.0.0.1:3099/pair', {
+      headers: { Host: '127.0.0.1:3099' },
+    })
     const html = await res.text()
     // The daemon-served app must stay entirely out of the OAuth state,
     // storage, callback, and client_id path — it authenticates same-origin

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -148,7 +148,7 @@ describe('createApp daemon mutation auth', () => {
 
   it('injects the daemon token into its own dedicated global, not the runtime-config object', async () => {
     const app = createApp(createRuntimeOptions('secret'))
-    const res = await app.request('/canvas/session1/demo')
+    const res = await app.request('/pair')
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
@@ -156,9 +156,32 @@ describe('createApp daemon mutation auth', () => {
     expect(html).toContain('window.__WHITEBOARD_DAEMON_TOKEN__ = "secret"')
   })
 
+  it('redirects every non-/pair UI path to the official hosted app', async () => {
+    const app = createApp(createRuntimeOptions('secret'))
+    for (const path of ['/', '/canvas/session1/demo', '/local/abc', '/w/ws/c/alias']) {
+      const res = await app.request(path)
+      expect(res.status).toBe(302)
+      expect(res.headers.get('location')).toBe('https://kamiazya-whiteboard.pages.dev/')
+      // The redirect must never leak the daemon token anywhere.
+      expect(res.headers.get('location')).not.toContain('secret')
+    }
+    // Reserved paths keep their existing semantics (404, not redirect).
+    const reserved = await app.request('/token')
+    expect(reserved.status).toBe(404)
+  })
+
+  it('still serves the injected app shell on /pair (the consent trust anchor)', async () => {
+    const app = createApp(createRuntimeOptions('secret'))
+    const res = await app.request('/pair?origin=https%3A%2F%2Fapp.example&challenge=c&state=s')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
+    expect(html).toContain('window.__WHITEBOARD_DAEMON_TOKEN__ = "secret"')
+  })
+
   it('omits the token script entirely when no daemon token is configured', async () => {
     const app = createApp(createRuntimeOptions(undefined))
-    const res = await app.request('/canvas/session1/demo')
+    const res = await app.request('/pair')
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.__WHITEBOARD_RUNTIME_CONFIG__')
@@ -168,7 +191,7 @@ describe('createApp daemon mutation auth', () => {
   it('adds baseline security headers to HTML responses', async () => {
     const app = createApp(createRuntimeOptions('secret'))
 
-    const res = await app.request('/canvas/session1/demo')
+    const res = await app.request('/pair')
 
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Security-Policy')).toBe("frame-ancestors 'none'")
@@ -1087,7 +1110,7 @@ describe('createApp daemon mutation auth', () => {
   describe('runtime config injection', () => {
     it('injects daemonBaseUrl composed from 127.0.0.1 and port into served HTML, with no daemonToken key', async () => {
       const app = createApp(createRuntimeOptions('secret'))
-      const res = await app.request('/canvas/session1/demo')
+      const res = await app.request('/pair')
       expect(res.status).toBe(200)
       const html = await res.text()
       expect(html).toContain('"daemonBaseUrl":"http://127.0.0.1:3099"')
@@ -1145,8 +1168,8 @@ describe('createApp daemon mutation auth', () => {
     })
   })
 
-  describe('local-daemon root serves the built apps/web (R3/R5 UI retirement)', () => {
-    it('serves dist/web-app/index.html with runtime config injected when present', async () => {
+  describe('local-daemon serves /pair only (hosted-first UI end state)', () => {
+    it('serves dist/web-app/index.html on /pair with runtime config injected', async () => {
       await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
       await writeFile(
         join(tmp.dir, 'web-app', 'index.html'),
@@ -1154,7 +1177,7 @@ describe('createApp daemon mutation auth', () => {
       )
 
       const app = createApp(createRuntimeOptions('secret'))
-      const res = await app.request('/')
+      const res = await app.request('/pair')
       expect(res.status).toBe(200)
       const html = await res.text()
       expect(html).toContain('apps-web-marker')
@@ -1162,10 +1185,19 @@ describe('createApp daemon mutation auth', () => {
       expect(html).toContain('window.__WHITEBOARD_DAEMON_TOKEN__ = "secret"')
     })
 
-    it('returns the clean 404 (not a fallback UI) when dist/web-app is absent', async () => {
-      await rm(join(tmp.dir, 'web-app', 'index.html'), { force: true })
+    it('the root redirects to the hosted app even when the build is present', async () => {
+      await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
+      await writeFile(join(tmp.dir, 'web-app', 'index.html'), '<!DOCTYPE html><html></html>')
       const app = createApp(createRuntimeOptions('secret'))
       const res = await app.request('/')
+      expect(res.status).toBe(302)
+      expect(res.headers.get('location')).toBe('https://kamiazya-whiteboard.pages.dev/')
+    })
+
+    it('returns the clean 404 on /pair when dist/web-app is absent', async () => {
+      await rm(join(tmp.dir, 'web-app', 'index.html'), { force: true })
+      const app = createApp(createRuntimeOptions('secret'))
+      const res = await app.request('/pair')
       expect(res.status).toBe(404)
       const body = await res.text()
       expect(body).toBe('Not found. Run `pnpm build` first.')
@@ -1207,7 +1239,7 @@ describe('createApp daemon mutation auth', () => {
       )
 
       const app = createApp(createRuntimeOptions('secret'))
-      const res = await app.request('/canvas/session1/demo')
+      const res = await app.request('/pair')
       expect(res.status).toBe(200)
       expect(await res.text()).toContain('apps-web-marker')
     })

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -59,6 +59,7 @@ import {
   createServerModeOriginMiddleware,
   sanitizeServerModeStatus,
 } from './security/server-mode-middleware.js'
+import { OFFICIAL_HOSTED_APP_URL } from './security/web-origin-allowlist.js'
 import { createWsTicketStore } from './security/ws-ticket-store.js'
 import {
   BranchNotFoundError,
@@ -709,9 +710,19 @@ export function createApp(options: AppOptions) {
   // SPA page load.
   const daemonPort = options.getStatus().port
 
+  // Hosted-first end state (supersedes ADR-0001's optional full-UI serving,
+  // see the ADR addendum): the daemon serves exactly ONE page — /pair, the
+  // pairing consent trust anchor that must come from the daemon's own
+  // origin — plus the assets it needs. Every other UI path redirects to the
+  // official hosted app, which reaches this daemon through its default
+  // origin admission + a pairing grant. Accepted tradeoff: a fully-offline
+  // FIRST run has no canvas UI; the installed PWA is the offline path.
   app.get('*', async (c) => {
     if (isReservedUiPath(c.req.path)) {
       return c.notFound()
+    }
+    if (c.req.path !== '/pair') {
+      return c.redirect(OFFICIAL_HOSTED_APP_URL, 302)
     }
     try {
       const html = await readFile(join(DIST_WEB_APP_DIR, 'index.html'), 'utf-8')

--- a/packages/mcp-server/src/server/http-server.status.test.ts
+++ b/packages/mcp-server/src/server/http-server.status.test.ts
@@ -54,7 +54,7 @@ describe('startHttpServer runtime status app.ui / app.buildPresent', () => {
     await rm(tmpRoot, { recursive: true, force: true })
   })
 
-  it('reports ui: "web-app" and buildPresent from dist/web-app', async () => {
+  it('reports ui: "pair-only" and buildPresent from dist/web-app', async () => {
     await writeFile(join(distWebAppDir, 'index.html'), '<html></html>')
 
     const port = await findAvailablePort(4200)
@@ -62,7 +62,7 @@ describe('startHttpServer runtime status app.ui / app.buildPresent', () => {
     await waitUntilListening(port)
 
     const status = running.getRuntimeStatus()
-    expect(status.app.ui).toBe('web-app')
+    expect(status.app.ui).toBe('pair-only')
     expect(status.app.buildPresent).toBe(true)
   })
 
@@ -72,7 +72,7 @@ describe('startHttpServer runtime status app.ui / app.buildPresent', () => {
     await waitUntilListening(port)
 
     const status = running.getRuntimeStatus()
-    expect(status.app.ui).toBe('web-app')
+    expect(status.app.ui).toBe('pair-only')
     expect(status.app.buildPresent).toBe(false)
   })
 })

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -122,7 +122,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
       app: {
         served: true,
         buildPresent: existsSync(join(DIST_WEB_APP_DIR, 'index.html')),
-        ui: 'web-app',
+        ui: 'pair-only',
       },
       mcp: { httpEnabled: true, endpoint: `http://${host}:${options.port}/mcp` },
       clients: { connected: stats.connectedClients, ready: stats.readyClients },

--- a/packages/mcp-server/src/server/security/web-origin-allowlist.ts
+++ b/packages/mcp-server/src/server/security/web-origin-allowlist.ts
@@ -102,6 +102,11 @@ export const DEFAULT_ALLOWED_WEB_ORIGINS: readonly string[] = [
   'https://kamiazya-whiteboard.pages.dev',
 ]
 
+// The canonical entry URL of the official hosted app — the daemon's
+// non-/pair UI redirect target and the auto-open destination. Kept next to
+// the CORS default above so the two can never drift apart.
+export const OFFICIAL_HOSTED_APP_URL = `${DEFAULT_ALLOWED_WEB_ORIGINS[0]}/`
+
 // Startup-time wiring helper shared by both entrypoints (cli/daemon-run.ts,
 // server/index.ts): parses the env once and logs a structured failure record
 // (never echoing the raw offending value) instead of each entrypoint

--- a/packages/mcp-server/src/shared/api-contracts/runtime.ts
+++ b/packages/mcp-server/src/shared/api-contracts/runtime.ts
@@ -65,14 +65,17 @@ export const runtimeStatusResponseSchema = z.object({
   idleForMs: z.number(),
   auth: z.object({ mode: z.string(), hasToken: z.boolean() }),
   storage: z.object({ dataDir: z.string(), dataDirWritable: z.boolean() }),
-  // 'web-app' is the canonical apps/web build (dist/web-app), served by the
-  // local daemon. 'server-placeholder' is the minimal static page served at
-  // server-mode's root (apps/web is not served there — server-mode has no
-  // token/session-acquisition flow apps/web's provider model can use).
+  // 'pair-only' is the local daemon's hosted-first end state: it serves the
+  // apps/web build only on /pair (the consent trust anchor) and redirects
+  // every other UI path to the official hosted app. 'web-app' is retained
+  // for wire-compat with older daemons that served the full build.
+  // 'server-placeholder' is the minimal static page served at server-mode's
+  // root (apps/web is not served there — server-mode has no token/session-
+  // acquisition flow apps/web's provider model can use).
   app: z.object({
     served: z.boolean(),
     buildPresent: z.boolean(),
-    ui: z.enum(['web-app', 'server-placeholder']),
+    ui: z.enum(['pair-only', 'web-app', 'server-placeholder']),
   }),
   mcp: z.object({ httpEnabled: z.boolean(), endpoint: z.string() }),
   clients: z.object({ connected: z.number(), ready: z.number() }),


### PR DESCRIPTION
## What

Executes the decided hosted-first end state (canvas `daemon-ui-pair-only`, 2026-08-08; ADR-0001 addendum included): **the local daemon stops serving a UI of its own.**

- The SPA catch-all now serves only `/pair` (the pairing consent trust anchor, which must come from the daemon's own origin per ADR-0005 and the identity-pinning design) plus `/assets/*`/`/fonts/*`. Every other UI path answers **302 to the official hosted app** — the same constant as the default CORS admission (#440), so the two can never drift. Reserved paths (`/api`, `/mcp`, `/ws`, `/token`, `/.well-known/`) keep their semantics.
- `whiteboard daemon run` auto-open now opens the **hosted app**.
- Runtime status reports `app.ui: 'pair-only'` (additive enum value; `web-app` retained for wire-compat).
- The web app's daemon banner drops its daemon-origin links ("Open the local app" / per-daemon "Open") — they would only bounce off the redirect. Pairing in place ("Use here") is the sole affordance.
- **Honest regression, documented + tracked**: on engines that block loopback fetches from hosted https origins (Safari, Firefox), the old escape hatch was the daemon's full UI; with it gone there is currently no daemon path there. The unsupported-browser notice and docs now say Chromium-based browsers are required; follow-up directions live in canvas `non-chromium-daemon-connectivity-gap`.
- Accepted tradeoff (explicit in the ADR addendum): a fully-offline FIRST run (PWA never installed) has no canvas UI; the installed PWA is the offline path.
- The `daemon-origin` CI smoke is repurposed to pin the new contract instead of the old one.

## Test plan

- [x] Route tests: non-/pair paths 302 to the hosted app with no token leak; `/pair` serves the injected shell; `/token` stays 404; missing-dist 404 on /pair
- [x] Status contract + http-server tests updated to `pair-only`; auto-open unit + real-launch tests target the hosted URL
- [x] Banner tests updated: no daemon-origin links anywhere; picker keeps per-daemon "Use here" accessible names; unsupported notice links to the docs
- [x] Full suites green: mcp-node 3117, apps/web 1385; knip, biome, `-r typecheck`
- [x] Repurposed `smoke:daemon-origin` run locally against the real built `dist/web-app`: all redirect assertions pass and a real Chromium renders `/pair` with the daemon identity fingerprint
- [ ] Preview verification on the live daemon after CI (redirect + /pair + auto-open target), evidence to follow

## Docs

`docs/how-to/connect-to-local-daemon.md` (section rewritten + unsupported-browser guidance), `docs/explanation/security-model.md`, ADR-0001 addendum.
