### PR TITLE
fix(web): actually surface the identity-mismatch renewal warning

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -175,6 +175,31 @@ describe('silent renewal on a hosted origin', () => {
     expect(screen.queryByTestId('daemon-index-page')).toBeNull()
   })
 
+  it('surfaces the identity-mismatch warning when renewal fails closed', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        migration: {},
+        capabilities: {},
+      }),
+    )
+    mockRenewResult = { status: 'identity-mismatch', daemonBaseUrl: 'http://127.0.0.1:3099' }
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <App providerState={BROWSER_LOCAL_STATE} />
+        </MemoryRouter>,
+      )
+    })
+
+    // Fail closed: stays on browser-local AND tells the user why.
+    await screen.findByTestId('browser-local-canvas-page')
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/identity changed/i)
+  })
+
   it('does not attempt renewal when no daemon was ever stored', async () => {
     await act(async () => {
       render(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -195,7 +195,12 @@ export function App({ providerState }: AppProps) {
       daemonBaseUrl: storedBaseUrl,
       fetch: globalThis.fetch.bind(globalThis),
     }).then((result) => {
-      if (result.status === 'paired') setGrantConnection(result)
+      // 'paired' connects; 'identity-mismatch' must ALSO land in state — it
+      // is the fail-closed warning ("this daemon's identity changed"), and
+      // dropping it here would silently swallow the whole verification.
+      if (result.status === 'paired' || result.status === 'identity-mismatch') {
+        setGrantConnection(result)
+      }
     })
     // Cold-load decision over mount-time facts; the ref guards StrictMode.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## What

Live verification of #443 on the deployed hosted app (planted a wrong pin for the dev daemon, reloaded) found the silent-renewal callback in `App.tsx` only committed `'paired'` results to state — an `identity-mismatch` outcome was computed by `renewPairingToken`, then **dropped**, so the fail-closed "daemon's identity changed" warning could never render. The alert JSX and the lib-level fail-closed path were both unit-covered; the one un-covered wiring line between them was the bug.

- `App.tsx`: commit both `'paired'` and `'identity-mismatch'` renewal outcomes to `grantConnection`.
- `App.test.tsx`: new scenario test — renewal returns `identity-mismatch` → stays on browser-local AND shows the warning alert.

## Test plan

- [x] New App-level test red on the old code, green now; full App suite 43 passed
- [ ] Post-merge: re-run the planted-wrong-pin scenario on the deployed `latest` and confirm the warning renders (evidence to follow on this thread)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silent pairing renewal handling when an identity mismatch occurs.
  * The app now remains in browser-local mode and displays a warning when a connected identity changes.
  * Successful renewals continue to be saved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->