### PR TITLE
fix(web): grow a text node's box to fit its committed body

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,7 +50,7 @@ import { findFreeSpot, hitTest, indexNodeBoxes, resizeBoxByDelta } from './geome
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
-import { renderCanvasToSvg } from './scene-render.js'
+import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { ToolPalette } from './ToolPalette.js'
 import {
@@ -355,6 +355,31 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       for (const command of result.commands) {
         running = applyCommand(running, command)
         onChange(running, command)
+        // Grow-only auto-fit: a committed body that lays out taller than the
+        // stored box gets a follow-up resize so content never overflows the
+        // border. Never shrinks — an authored roomy box (or manual enlarge)
+        // is respected. Stored geometry stays truthful, so export (the same
+        // layout over the same canvas) renders exactly what the editor shows.
+        if (command.kind === 'set-text') {
+          const node = running.nodes.find((n) => n.id === command.id)
+          if (node !== undefined && node.type === 'text') {
+            const required = Math.ceil(
+              requiredTextNodeHeight(node, { measure: resolvedMeasure, theme }),
+            )
+            if (required > node.height) {
+              const grow = {
+                kind: 'resize-node',
+                id: node.id,
+                x: node.x,
+                y: node.y,
+                width: node.width,
+                height: required,
+              } as const
+              running = applyCommand(running, grow)
+              onChange(running, grow)
+            }
+          }
+        }
       }
       // Written back HERE, not only from the canvas prop at re-render: two
       // commits landing in one tick (key auto-repeat, batched events) would

--- a/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
@@ -1,0 +1,85 @@
+// Regression for the top authoring defect: a node's stored height was
+// authored at creation and never reconciled with the height the layout
+// actually produces for the committed body, so normal short notes overflowed
+// their border and overlapped neighbours. Contract pinned here: committing
+// text GROWS the node to fit its laid-out content (grow-only — a roomy box
+// stays at its authored size, and manual enlargement is never fought).
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const TALL_BODY = [
+  '# Heading',
+  '',
+  '- first bullet point with some words',
+  '- second bullet point with more words',
+  '- third bullet point',
+  '',
+  'A closing paragraph line.',
+].join('\n')
+
+function makeHost(initial: SpatialCanvas) {
+  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+async function editNodeText(container: HTMLElement, text: string) {
+  const root = rootOf(container)
+  await userEvent.dblClick(root, { position: { x: 200, y: 130 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await userEvent.fill(container.querySelector('textarea') as HTMLTextAreaElement, text)
+  // Click far outside the node to blur-commit.
+  await userEvent.click(root, { position: { x: 700, y: 500 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).toBeNull())
+}
+
+it('committing a tall body grows the node height to contain it', async () => {
+  const { Host, latest } = makeHost({
+    nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 60, text: 'hi' }],
+    edges: [],
+  })
+  const { container } = render(<Host />)
+
+  await editNodeText(container, TALL_BODY)
+
+  const node = latest.canvas.nodes.find((n) => n.id === 'n1')
+  expect(node?.type === 'text' ? node.text : undefined).toBe(TALL_BODY)
+  // Seven laid-out lines cannot fit 60px; the box must have grown. The exact
+  // value is measurement-dependent — the contract is containment, so assert
+  // a clear lower bound rather than a golden number.
+  expect(node?.height ?? 0).toBeGreaterThan(120)
+  // Position and width are untouched by the grow.
+  expect(node).toMatchObject({ x: 100, y: 100, width: 200 })
+})
+
+it('committing a short body into a roomy box leaves its height alone (grow-only)', async () => {
+  const { Host, latest } = makeHost({
+    nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 180, text: 'hello' }],
+    edges: [],
+  })
+  const { container } = render(<Host />)
+
+  await editNodeText(container, 'ok')
+
+  const node = latest.canvas.nodes.find((n) => n.id === 'n1')
+  expect(node?.type === 'text' ? node.text : undefined).toBe('ok')
+  expect(node?.height).toBe(180)
+})

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -5,11 +5,12 @@
  * `renderSceneToSvg`, exactly as `CanvasViewer` does in canvas-viewer.
  */
 import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { BoundingBox, MeasureText, Scene } from '@kamiazya/whiteboard-canvas-render'
 import {
   layoutSpatialCanvas,
   renderSceneToSvg,
+  SPATIAL_THEME_GEOMETRY,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
@@ -25,6 +26,27 @@ export interface RenderedCanvas {
   readonly svg: string
   readonly bounds: BoundingBox
   readonly scene: Scene
+}
+
+/**
+ * The height a text node needs for its laid-out body, in canvas px.
+ *
+ * Measured by laying out the node ALONE with height 1: the shape chrome
+ * always spans the stored height, so measuring at the real height could
+ * never report "content is shorter than the box" — collapsing the box to
+ * 1px makes the scene's bottom edge the CONTENT's bottom edge. Bottom
+ * padding is added back so a grown box keeps the same breathing room the
+ * layout gives the top.
+ */
+export function requiredTextNodeHeight(node: SpatialNode, options: RenderCanvasOptions): number {
+  const probe: SpatialCanvas = { nodes: [{ ...node, height: 1 }], edges: [] }
+  const scene = layoutSpatialCanvas(probe, {
+    measure: options.measure,
+    parseBody: parseMarkdownBody,
+    appearance: createEditorAppearance(options.theme ?? 'light'),
+  })
+  const bounds = sceneBounds(scene)
+  return bounds.y + bounds.h - node.y + SPATIAL_THEME_GEOMETRY.paddingPx
 }
 
 export function renderCanvasToSvg(


### PR DESCRIPTION
## Problem

A spatial node's stored height was authored at creation and never reconciled with the height `layoutSpatialCanvas` actually produces for its parsed body — a normal short note (heading + a few bullets) immediately overflowed its border and overlapped neighbours, with no affordance to fix it. Canvas `node-box-does-not-fit-content` called this the most visible authoring defect; `box-with-label-autofit-height-overflow` is the same root from the MCP annotate side.

## Decision (settling the trade-off the canvas flagged)

**The editor reconciles geometry, grow-only.** On text commit, stored `height` rises to the laid-out content height; it never shrinks, so authored roomy boxes and manual enlargement are respected. Export parity holds by construction — export runs the same `layoutSpatialCanvas` over the same, now-truthful stored geometry, so nothing renders differently between editor and SVG. The alternative (clipping in the shared layer) was rejected: it visually hides content and would silently change existing exports.

## Implementation

- `scene-render.ts`: `requiredTextNodeHeight` lays the node out **alone at height 1** — the shape chrome always spans the stored height, so measuring at the real height could never report "content shorter than box"; collapsing to 1px makes the scene's bottom edge the content's bottom edge (+ the theme's padding for symmetric breathing room).
- `SpatialEditor.tsx` `applyResult`: after a `set-text` command, if the required height exceeds the stored height, a follow-up `resize-node` command grows the box (x/y/width untouched). Both commands flow through the normal `onChange`, so sync layers see ordinary commands.
- `commands.ts`/`gestures.ts` stay pure (purity guard untouched); measurement happens at the React layer where the injected `MeasureText` lives.

## Verification

Live in the running editor (vite dev, browser-local): committing a heading + three bullets + a paragraph into a small note grows the box to contain everything:

![pr-autogrow-after.jpg](https://github.com/user-attachments/assets/85a531b4-1326-4349-b42d-a53ef9e4412f)

Legacy nodes keep their stored size until their next text commit (grow-only, commit-triggered) — no bulk rewrite of existing canvases.

## Test plan

- [x] New real-pointer browser test `auto-grow-height.browser.test.tsx`: tall body grows the box (containment lower-bound, x/y/width untouched); short body into a roomy box leaves height alone (grow-only). Red on the old code.
- [x] All 63 spatial-editor browser tests, full apps/web jsdom suite (1386), typecheck, biome, knip
- [x] Manual verification above

Follow-up (tracked on the annotate canvas): return the laid-out bbox from the `annotate` MCP tool so programmatic layouts can flow elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spatial text nodes now automatically grow in height when entered content requires more space.
  * Node position and width remain unchanged during resizing.

* **Bug Fixes**
  * Prevented existing text-node heights from shrinking when shorter content is entered.

* **Tests**
  * Added regression coverage for text expansion, preserved dimensions, and non-shrinking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->