### PR TITLE
feat(export): render real dark chrome when theme:'dark' is requested

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -211,12 +211,15 @@
    to delete. The editor's dark palette (contrast-tested against the WCAG
    1.4.11/1.4.3 floors) is the shared theme's dark palette; viewer and export
    both pin `mode: 'light'` at their call sites, preserving the invariant
-   that a user's UI theme can never change exported bytes. NOT fixed by this
-   decision: `mcp-server`'s `headless-renderer`'s `theme: 'dark'` export
-   option still only changes the document background, not node chrome —
-   giving export a real dark chrome variant is a behavior decision (export
-   gaining new visual output as a function of a request option), not a
-   convergence one, and is deliberately out of scope here.
+   that a user's UI theme can never change exported bytes. The dark-export
+   behavior decision was later taken (2026-08-08): `headless-renderer`'s
+   `theme: 'dark'` now builds the scene with `createSpatialTheme({ mode:
+   'dark' })` and sets `SvgDocumentOptions.textFill` (an inheritable root
+   `fill` — the document-level analogue of the editor host's inherited CSS
+   fill) so body runs stay legible on the dark background. `theme` is an
+   explicit per-request argument; the invariant that ambient UI theme never
+   changes exported bytes still holds, and light exports are byte-identical
+   to before.
    This decision also fixed a verified, separate defect: export's label
    appearance used to declare `fontFamily: 'sans-serif'` while its measurer
    (`measure-text.ts`) actually measured a vendored Roboto face, so the

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -503,6 +503,39 @@ describe('renderSceneToSvg — document envelope options', () => {
     )
   })
 
+  it('textFill emits an inheritable fill on the root svg, after viewBox', () => {
+    // The default text color for standalone consumers: markdown body runs
+    // carry no fill of their own (the editor supplies one via its host
+    // element), so a scene rendered outside the editor needs this seam to
+    // be self-describing on a non-white background.
+    const svg = renderSceneToSvg(scene, {
+      viewBox: { x: 0, y: 0, w: 100, h: 10 },
+      textFill: '#E6E8EB',
+    })
+    expect(
+      svg.startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="10" viewBox="0 0 100 10" fill="#E6E8EB">',
+      ),
+    ).toBe(true)
+  })
+
+  it('an absent or empty textFill leaves the envelope output byte-identical', () => {
+    const withEnvelope = renderSceneToSvg(scene, { padding: 5 })
+    expect(renderSceneToSvg(scene, { padding: 5, textFill: undefined })).toBe(withEnvelope)
+    expect(renderSceneToSvg(scene, { padding: 5, textFill: '' })).toBe(withEnvelope)
+  })
+
+  it('escapes a quote-bearing textFill and still never touches the legacy path', () => {
+    const svg = renderSceneToSvg(scene, { padding: 0, textFill: '"&' })
+    expect(svg).toContain('fill="&quot;&amp;"')
+    // textFill alone activates the envelope (it is a document option).
+    expect(
+      renderSceneToSvg(scene, { textFill: '#111111' }).startsWith(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="',
+      ),
+    ).toBe(true)
+  })
+
   it('escapes a quote/ampersand-bearing background color string', () => {
     const svg = renderSceneToSvg(scene, { background: '"&' })
     expect(svg).toContain('fill="&quot;&amp;"')

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -185,6 +185,13 @@ export interface SvgDocumentOptions {
   readonly viewBox?: BoundingBox
   readonly padding?: number
   readonly background?: string
+  /** Inheritable default text color, emitted as `fill` on the root `<svg>`.
+   *  Markdown body runs carry no fill of their own (inside the editor they
+   *  inherit the host element's CSS `fill`), so a scene rendered standalone
+   *  on a non-white background needs this to be self-describing. Elements
+   *  that carry their own fill are unaffected (nearest-ancestor wins). An
+   *  empty or non-string value is omitted, never defaulted. */
+  readonly textFill?: string
 }
 
 function hasEnvelopeOptions(
@@ -196,7 +203,8 @@ function hasEnvelopeOptions(
     options.height !== undefined ||
     options.viewBox !== undefined ||
     options.padding !== undefined ||
-    options.background !== undefined
+    options.background !== undefined ||
+    (typeof options.textFill === 'string' && options.textFill.length > 0)
   )
 }
 
@@ -244,7 +252,8 @@ function renderBackgroundRect(box: BoundingBox, background: string): string {
  * With no `options` (or an options object with no fields set), the root
  * element carries only `xmlns` — the exact string this function has always
  * produced. Passing any `SvgDocumentOptions` field activates the document
- * envelope: fixed root-attribute order `xmlns width height viewBox`, plus a
+ * envelope: fixed root-attribute order `xmlns width height viewBox fill`
+ * (`fill` only when `textFill` is set), plus a
  * leading `role="presentation"` background rect (document chrome, not a
  * per-node visual attribute — the one exemption to this package's
  * no-visual-attributes rule) when `background` is set.
@@ -262,6 +271,11 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
   const viewBoxAttr = `${formatCoord(viewBox.x)} ${formatCoord(viewBox.y)} ${formatCoord(viewBox.w)} ${formatCoord(viewBox.h)}`
   const background =
     options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : ''
+  // Fixed root-attribute order: xmlns width height viewBox fill.
+  const textFillAttr =
+    typeof options.textFill === 'string' && options.textFill.length > 0
+      ? ` fill="${escapeXmlAttr(options.textFill)}"`
+      : ''
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}">${background}${body}</svg>`
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}"${textFillAttr}>${background}${body}</svg>`
 }

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -42,10 +42,10 @@ export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
 // Seeded from the pre-theme editor's dark palette (EDITOR_DARK_PALETTE) — a
 // desaturated cool gray/near-white pair chosen to read against the app's
 // dark canvas surface (`oklch(0.145 0 0)`), not `#333333` inverted. Node
-// fill stays `none` in dark mode: export does not render a dark-mode
-// variant today (`headless-renderer`'s `theme: 'dark'` only changes the
-// document background), so there is no per-type dark fill to converge
-// against yet — filed as follow-up, not invented here.
+// fill stays `none` in dark mode: nodes read as outlined shapes on the
+// dark surface (the editor's behavior), and export's dark variant keeps
+// body text legible via the document-level root `fill` seam
+// (SvgDocumentOptions.textFill) rather than per-node fills.
 export const SPATIAL_DARK_PALETTE: SpatialPalette = {
   node: {
     text: { fill: 'none', stroke: '#9BA3AF' },

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -115,7 +115,7 @@ describe('headless-renderer', () => {
       edges: [{ id: 'e1', fromNode: 'a', toNode: 'b', label: 'flows' }],
     }
     const { renderSpatialCanvasToSvg } = await importRenderer()
-    const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
+    const darkSvg = (await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })).svg
     // Dark palette chrome (canvas-render SPATIAL_DARK_PALETTE).
     expect(darkSvg).toContain('stroke="#9BA3AF"')
     expect(darkSvg).toContain('fill="#E6E8EB"')
@@ -124,7 +124,7 @@ describe('headless-renderer', () => {
     expect(darkSvg).toMatch(/<svg [^>]*fill="#E6E8EB">/)
 
     // The light export is byte-stable: no root fill, light chrome only.
-    const lightSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'light' })
+    const lightSvg = (await renderSpatialCanvasToSvg(canvas, { theme: 'light' })).svg
     expect(lightSvg).toContain('stroke="#333333"')
     expect(lightSvg).not.toMatch(/<svg [^>]*fill=/)
   })

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -76,6 +76,7 @@ describe('headless-renderer', () => {
     // The background reaches the SVG as a leading background rect — assert
     // the fill color directly rather than decoding rendered PNG pixels.
     const lightSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'light' })
+    const { renderSpatialCanvasToSvg } = await importRenderer()
     const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
     expect(lightSvg.svg).toContain('fill="#ffffff"')
     expect(darkSvg.svg).toContain('fill="#121212"')
@@ -101,6 +102,31 @@ describe('headless-renderer', () => {
       expect(degenerate.width).toBe(base.width)
       expect(degenerate.height).toBe(base.height)
     }
+  })
+
+  it('theme="dark" renders real dark chrome: edge stroke, label fill, and a root text fill', async () => {
+    // A diagram whose meaning lives in its arrows must survive a dark
+    // export: light-theme edge chrome (#333333) on the dark background was
+    // effectively invisible.
+    const canvas = {
+      nodes: [
+        { id: 'a', type: 'text' as const, x: 0, y: 0, width: 120, height: 60, text: 'from' },
+        { id: 'b', type: 'text' as const, x: 300, y: 0, width: 120, height: 60, text: 'to' },
+      ],
+      edges: [{ id: 'e1', fromNode: 'a', toNode: 'b', label: 'flows' }],
+    }
+    const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
+    // Dark palette chrome (canvas-render SPATIAL_DARK_PALETTE).
+    expect(darkSvg).toContain('stroke="#9BA3AF"')
+    expect(darkSvg).toContain('fill="#E6E8EB"')
+    expect(darkSvg).not.toContain('stroke="#333333"')
+    // Root-level inheritable text fill so body runs are legible on dark.
+    expect(darkSvg).toMatch(/<svg [^>]*fill="#E6E8EB">/)
+
+    // The light export is byte-stable: no root fill, light chrome only.
+    const lightSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'light' })
+    expect(lightSvg).toContain('stroke="#333333"')
+    expect(lightSvg).not.toMatch(/<svg [^>]*fill=/)
   })
 
   it('renders a canvas to real SVG markup with the document envelope', async () => {

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -76,7 +76,6 @@ describe('headless-renderer', () => {
     // The background reaches the SVG as a leading background rect — assert
     // the fill color directly rather than decoding rendered PNG pixels.
     const lightSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'light' })
-    const { renderSpatialCanvasToSvg } = await importRenderer()
     const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
     expect(lightSvg.svg).toContain('fill="#ffffff"')
     expect(darkSvg.svg).toContain('fill="#121212"')
@@ -115,6 +114,7 @@ describe('headless-renderer', () => {
       ],
       edges: [{ id: 'e1', fromNode: 'a', toNode: 'b', label: 'flows' }],
     }
+    const { renderSpatialCanvasToSvg } = await importRenderer()
     const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
     // Dark palette chrome (canvas-render SPATIAL_DARK_PALETTE).
     expect(darkSvg).toContain('stroke="#9BA3AF"')

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -33,6 +33,7 @@ import {
   createSpatialTheme,
   layoutSpatialCanvas,
   renderSceneToSvg as renderSceneToSvgString,
+  SPATIAL_DARK_PALETTE,
 } from '@kamiazya/whiteboard-canvas-render'
 
 import { getLogger } from '../log.js'
@@ -42,7 +43,11 @@ import { createOpentypeMeasureText } from './measure-text.js'
 // Export never has its own theme switch (the composition root always
 // exports light, see package-canvas-render.md decision #8), so this
 // singleton is built once and reused across renders.
-const EXPORT_APPEARANCE = createSpatialTheme({ mode: 'light' })
+const EXPORT_APPEARANCE_BY_MODE = {
+  light: createSpatialTheme({ mode: 'light' }),
+  dark: createSpatialTheme({ mode: 'dark' }),
+} as const
+type ExportThemeMode = keyof typeof EXPORT_APPEARANCE_BY_MODE
 
 const log = getLogger('headless-renderer')
 
@@ -112,11 +117,15 @@ function onDegrade(event: SpatialLayoutDegradation): void {
  * opentype.js font load — see
  * `headless-renderer-geometry-conformance.test.ts`.
  */
-export function buildSpatialScene(canvas: SpatialCanvas, measure: MeasureText): Scene {
+export function buildSpatialScene(
+  canvas: SpatialCanvas,
+  measure: MeasureText,
+  mode: ExportThemeMode = 'light',
+): Scene {
   return layoutSpatialCanvas(canvas, {
     measure,
     parseBody: parseMarkdownBody,
-    appearance: EXPORT_APPEARANCE,
+    appearance: EXPORT_APPEARANCE_BY_MODE[mode],
     onDegrade,
   })
 }
@@ -126,10 +135,17 @@ function buildSvg(
   options: HeadlessExportOptions,
   measure: MeasureText,
 ): string {
-  const scene = buildSpatialScene(canvas, measure)
+  // `theme` is an explicit per-request argument — the invariant that a
+  // user's ambient UI theme never changes exported bytes is untouched.
+  const mode: ExportThemeMode = options.theme === 'dark' ? 'dark' : 'light'
+  const scene = buildSpatialScene(canvas, measure, mode)
   return renderSceneToSvgString(scene, {
     padding: options.padding ?? DEFAULT_PADDING_PX,
     background: themeBackground(options),
+    // Dark node chrome uses transparent fills, so body runs sit directly on
+    // the dark background — the root-level inheritable fill is what keeps
+    // them legible. Light stays byte-identical (no root fill).
+    ...(mode === 'dark' ? { textFill: SPATIAL_DARK_PALETTE.labelFill } : {}),
   })
 }
 


### PR DESCRIPTION
## Problem

`theme: 'dark'` swapped only the document background while the scene was always built light-themed — edge strokes and edge labels resolved to `#333333` and sat directly on the `#121212` background, effectively invisible. Nodes looked fine (light fills), which made the loss easy to miss: a diagram whose meaning lives in its arrows lost exactly that when exported dark. (Canvas `dark-export-loses-edge-labels`.)

## Decision

The canvas framed the choice: make the option honest, or remove it as half-implemented. **Made it honest** — the dark palette already exists and is WCAG-contrast-tested (theme layer, decision #8), so wiring it is small and the option is already documented API surface. The load-bearing invariant is preserved: `theme` is an explicit per-request argument; ambient UI theme still never influences exported bytes, and **light exports are byte-identical to before**.

## Implementation

- `headless-renderer`: the scene is built with `createSpatialTheme({ mode })` for the requested theme (dark node chrome: `#9BA3AF` outlines/edges, `#E6E8EB` labels, transparent fills — same as the editor's dark mode).
- Dark node fills are transparent, and markdown body runs carry no fill of their own (the canvas's "adjacent, worth checking" finding) — so `canvas-render` gains `SvgDocumentOptions.textFill`: an inheritable `fill` on the root `<svg>`, the document-level analogue of the editor host's inherited CSS fill. Additive by contract: absent/empty → byte-identical output; existing goldens untouched. Fixed root attribute order extends to `xmlns width height viewBox fill`.
- Palette comment + `package-canvas-render.md` decision #8 note updated to record the taken behavior decision.

## Verification

Real dark PNG rendered through the actual export pipeline (opentype measure + resvg raster):

![dark-export-check.png](https://github.com/user-attachments/assets/9f30f43d-6fc4-436c-86a8-a98e64518f7a)

Node outlines, body text, edge stroke, and the edge label are all legible on the dark background.

## Test plan

- [x] canvas-render: `textFill` emitted after `viewBox`; absent/empty byte-identical; escaping; envelope activation (red first)
- [x] headless-renderer: dark SVG contains dark edge stroke + label fill + root fill and no light chrome; light SVG unchanged with no root fill (red first)
- [x] Full mcp-node + canvas-render-node suites (3339+), typecheck, biome, knip
