### PR TITLE
feat(web): label a pinned daemon 'identity verified' after a live challenge

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -334,6 +334,51 @@ describe('DaemonDetectedBanner', () => {
     })
   })
 
+  it('a pinned, challenge-verified daemon earns the "identity verified" label', async () => {
+    const probeFn = vi.fn().mockResolvedValue(DETECTED)
+    const store = makeStore()
+    store.update((current) => ({
+      ...current,
+      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+    }))
+    const challengeFn = vi.fn(async () => 'verified' as const)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+        challengeFn={challengeFn}
+      />,
+    )
+
+    await screen.findByText(/identity verified/)
+    expect(challengeFn).toHaveBeenCalledWith('http://127.0.0.1:3099')
+  })
+
+  it('a pinned daemon FAILING its challenge is downgraded to the cautious copy', async () => {
+    const probeFn = vi.fn().mockResolvedValue(DETECTED)
+    const store = makeStore()
+    store.update((current) => ({
+      ...current,
+      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+    }))
+    const challengeFn = vi.fn(async () => 'failed' as const)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={store}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+        challengeFn={challengeFn}
+      />,
+    )
+
+    // The paired-target trust copy must NOT survive a failed challenge.
+    await screen.findByText(/A server responded at/)
+    expect(screen.queryByText(/identity verified/)).toBeNull()
+  })
+
   it('an unpaired swept responder is labelled UNVERIFIED, not "a whiteboard daemon is running"', async () => {
     // Any local process can bind a loopback port and answer /api/runtime/
     // ping with a self-asserted instanceId, so a swept hit is an unproven

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -7,6 +7,10 @@ import {
   rememberKnownDaemon,
 } from '../../lib/daemon-discovery.js'
 import {
+  challengeDaemonIdentity,
+  type IdentityChallengeResult,
+} from '../../lib/daemon-identity-pin.js'
+import {
   type DaemonProbeResult,
   DEFAULT_DAEMON_BASE_URL,
   type ProbeDaemonOptions,
@@ -57,6 +61,9 @@ interface DaemonDetectedBannerProps {
   // Injectable for tests; production default starts the pairing-grant
   // redirect (see lib/pairing-grant.ts).
   beginGrantFn?: (input: { daemonBaseUrl: string }) => Promise<void>
+  // Injectable for tests; production default challenges the responder's
+  // identity against the pinned key (see lib/daemon-identity-pin.ts).
+  challengeFn?: (baseUrl: string) => Promise<IdentityChallengeResult>
 }
 
 /**
@@ -78,12 +85,20 @@ export function DaemonDetectedBanner({
       sessionStorage: window.sessionStorage,
       navigate: (url) => window.location.assign(url),
     }),
+  challengeFn = (baseUrl) =>
+    challengeDaemonIdentity({ daemonBaseUrl: baseUrl, fetch: globalThis.fetch.bind(globalThis) }),
 }: DaemonDetectedBannerProps) {
   const [result, setResult] = useState<DaemonProbeResult | null>(null)
   // Every daemon the last sweep confirmed (dynamic ports mean there can be
   // several — one per dev worktree is the local norm). `result` above stays
   // the representative single answer the dismissal/tier logic reads.
   const [found, setFound] = useState<DiscoveredDaemon[] | null>(null)
+  // Cryptographic upgrade of the trust label: when the single detected
+  // responder's baseUrl carries a PIN (approved on /pair before), challenge
+  // it and only then say "identity verified". 'failed' downgrades the copy
+  // to the cautious form even for the paired target — a daemon we once
+  // pinned must be able to answer its own challenge.
+  const [identityStatus, setIdentityStatus] = useState<IdentityChallengeResult | null>(null)
   // Set only when the USER clicked the check and it came back empty — the
   // silent auto-probe on loopback mounts must not spawn failure copy the
   // user never asked for.
@@ -135,6 +150,25 @@ export function DaemonDetectedBanner({
   // else is labelled unverified. This is presentation-level honesty, not a
   // security boundary: the durable fix is daemon->browser mutual auth.
   const isPairedTarget = detectedBaseUrl === storedTarget.localDaemonBaseUrl
+
+  const detectedCount = found?.length ?? 0
+  useEffect(() => {
+    if (detectedCount !== 1) {
+      setIdentityStatus(null)
+      return
+    }
+    let cancelled = false
+    setIdentityStatus(null)
+    void challengeFn(detectedBaseUrl).then((status) => {
+      if (!cancelled) setIdentityStatus(status)
+    })
+    return () => {
+      cancelled = true
+    }
+    // challengeFn is an injected seam with a stable default; re-challenging
+    // is keyed on WHICH daemon was detected, not the callback identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detectedCount, detectedBaseUrl])
 
   // 'http:'/'https:' -> 'http'/'https'; any other scheme (e.g. jsdom's
   // default 'about:' outside these injected-prop tests) falls back to
@@ -391,7 +425,9 @@ export function DaemonDetectedBanner({
           className="flex shrink-0 items-center justify-between gap-2 bg-muted px-3 py-1.5 text-xs text-muted-foreground"
         >
           <span>
-            {isPairedTarget ? (
+            {isPairedTarget && identityStatus === 'verified' ? (
+              <>A local whiteboard daemon is running at {detectedBaseUrl} (identity verified).</>
+            ) : isPairedTarget && identityStatus !== 'failed' ? (
               <>A local whiteboard daemon is running at {detectedBaseUrl}.</>
             ) : (
               <>

--- a/apps/web/src/lib/daemon-identity-pin.test.ts
+++ b/apps/web/src/lib/daemon-identity-pin.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  challengeDaemonIdentity,
   createChallengeNonce,
   fingerprintPublicKey,
   getPinnedIdentity,
@@ -106,5 +107,105 @@ describe('sha256Base64Url', () => {
     await expect(sha256Base64Url('abc')).resolves.toBe(
       'ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0',
     )
+  })
+})
+
+describe('challengeDaemonIdentity', () => {
+  const BASE = 'http://127.0.0.1:3099'
+
+  function pinsWith(publicKey: string) {
+    const storage = fakeStorage()
+    storage.setItem(
+      'whiteboard:daemon-identity-pins',
+      JSON.stringify({ [BASE]: { alg: 'Ed25519', publicKey, pinnedAt: 'then' } }),
+    )
+    return storage
+  }
+
+  it('resolves unpinned without ever fetching when no pin exists', async () => {
+    const fetchFn = vi.fn()
+    await expect(
+      challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage: fakeStorage(),
+      }),
+    ).resolves.toBe('unpinned')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('verifies a genuine challenge answer against the pin', async () => {
+    const pair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair
+    const jwk = await crypto.subtle.exportKey('jwk', pair.publicKey)
+    const publicKey = jwk.x as string
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      const { nonce } = JSON.parse(String(init?.body)) as { nonce: string }
+      const payload = new TextEncoder().encode(
+        JSON.stringify(['wb-verify-v1', nonce, 'https://app.example']),
+      )
+      const sig = new Uint8Array(
+        await crypto.subtle.sign({ name: 'Ed25519' }, pair.privateKey, payload),
+      )
+      const signature = btoa(String.fromCharCode(...sig))
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replaceAll('=', '')
+      return Response.json({ alg: 'Ed25519', publicKey, signature })
+    })
+    await expect(
+      challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage: pinsWith(publicKey),
+      }),
+    ).resolves.toBe('verified')
+  })
+
+  it('fails a pinned responder answering with another key, an error, or nothing', async () => {
+    const squatter = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair
+    const squatterJwk = await crypto.subtle.exportKey('jwk', squatter.publicKey)
+    const storage = pinsWith('PINNED-REAL-KEY')
+
+    const wrongKey = vi.fn(async () =>
+      Response.json({ alg: 'Ed25519', publicKey: squatterJwk.x, signature: 'sig' }),
+    )
+    await expect(
+      challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: wrongKey as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage,
+      }),
+    ).resolves.toBe('failed')
+
+    const notFound = vi.fn(async () => new Response('nope', { status: 404 }))
+    await expect(
+      challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: notFound as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage,
+      }),
+    ).resolves.toBe('failed')
+
+    const network = vi.fn(async () => {
+      throw new TypeError('unreachable')
+    })
+    await expect(
+      challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: network as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage,
+      }),
+    ).resolves.toBe('failed')
   })
 })

--- a/apps/web/src/lib/daemon-identity-pin.ts
+++ b/apps/web/src/lib/daemon-identity-pin.ts
@@ -147,3 +147,51 @@ export async function fingerprintPublicKey(publicKey: string): Promise<string> {
   }
   return `${out.slice(0, 4)}-${out.slice(4, 8)}`
 }
+
+export type IdentityChallengeResult = 'verified' | 'failed' | 'unpinned'
+
+/**
+ * Challenges a loopback responder to prove it holds the PINNED daemon's
+ * private key (POST /api/runtime/verify with a fresh nonce, signature over
+ * ["wb-verify-v1", nonce, origin]). 'unpinned' when this browser never
+ * pinned that baseUrl (nothing to verify against — the caller keeps its
+ * cautious copy). Any non-verifying answer from a pinned responder —
+ * wrong key, bad signature, missing route, network failure — is 'failed':
+ * a daemon we once pinned MUST be able to answer its own challenge, so
+ * the absence of proof is treated as no proof.
+ */
+export async function challengeDaemonIdentity({
+  daemonBaseUrl,
+  fetch,
+  hostedOrigin = globalThis.location.origin,
+  storage = globalThis.localStorage,
+}: {
+  daemonBaseUrl: string
+  fetch: typeof globalThis.fetch
+  hostedOrigin?: string
+  storage?: StorageLike
+}): Promise<IdentityChallengeResult> {
+  const pinned = getPinnedIdentity(daemonBaseUrl, storage)
+  if (pinned === null) return 'unpinned'
+  const nonce = createChallengeNonce()
+  try {
+    const response = await fetch(`${daemonBaseUrl.replace(/\/+$/, '')}/api/runtime/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce }),
+    })
+    if (!response.ok) return 'failed'
+    const body = (await response.json()) as { publicKey?: unknown; signature?: unknown }
+    const verified =
+      body.publicKey === pinned.publicKey &&
+      typeof body.signature === 'string' &&
+      (await verifyIdentitySignature({
+        publicKey: pinned.publicKey,
+        parts: ['wb-verify-v1', nonce, hostedOrigin],
+        signature: body.signature,
+      }))
+    return verified ? 'verified' : 'failed'
+  } catch {
+    return 'failed'
+  }
+}


### PR DESCRIPTION
## What

Completes the mutual-auth design's discovery-labeling leg (canvas `daemon-impersonation-port-squatting`, the last remaining item): when the single detected responder's baseUrl carries a **pinned identity** (approved on /pair before), the banner challenges it live via `POST /api/runtime/verify` — fresh nonce, signature over `["wb-verify-v1", nonce, origin]` — and verifies against the **pin**, never the advertised key. Only a passing challenge earns "(identity verified)" in the copy.

Fail-cautious by design: a pinned responder that cannot answer its own challenge (wrong key, missing route, network failure) is **downgraded to the cautious unverified copy even when it matches the stored paired target** — a daemon we once pinned must be able to prove itself, so absence of proof is treated as no proof. Unpinned responders keep the existing unverified behavior byte-for-byte.

- `lib/daemon-identity-pin.ts`: `challengeDaemonIdentity` → `'verified' | 'failed' | 'unpinned'` ('unpinned' never fetches).
- `DaemonDetectedBanner`: injectable `challengeFn` seam (same pattern as `probeFn`), challenge keyed on the detected baseUrl, three-way label.

## Test plan

- [x] Lib: unpinned short-circuits with no fetch; genuine WebCrypto-signed answer verifies; wrong key / 404 / network failure all fail (red first)
- [x] Banner: pinned+verified renders the verified label and challenges the right baseUrl; pinned+failed drops the trust copy; all 60 pre-existing banner tests unchanged
- [x] Full apps/web suite 1391, typecheck, biome, knip
- [ ] Live check on latest after merge (pin the dev daemon via /pair, observe the verified label) — will report on this thread

Backend routes are #441's, already live-verified with WebCrypto end-to-end.