### PR TITLE
feat(web): Select/Connect tool modes with object-first connect

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -23,7 +23,7 @@
  *
  * NOT yet supported (see `SPATIAL_EDITOR_UNSUPPORTED`): freehand drawing
  * and shape tools (`x-whiteboard` extension authoring — its own slice),
- * multi-select, grouping, undo/redo, arrow-side pinning, snapping,
+ * grouping, undo/redo, arrow-side pinning, snapping,
  * persistence, and sync. Those are later phases.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
@@ -52,7 +52,7 @@ import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from 
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
-import { ToolPalette } from './ToolPalette.js'
+import { type EditorTool, ToolPalette } from './ToolPalette.js'
 import {
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
@@ -71,7 +71,6 @@ import {
 export const SPATIAL_EDITOR_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
-  'multi-select',
   'grouping',
   'undo-redo',
   'arrow-side-pinning',
@@ -186,6 +185,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * ~30ms on an 80-node canvas — far past a frame budget).
      */
     const [livePoint, setLivePoint] = useState<Point | null>(null)
+    // OOUI interaction mode (S6/S7): Select is the default and matches the
+    // pre-tool behavior byte-for-byte; Connect arms object-first click-A,
+    // click-B edge creation. Creation is deliberately NOT a mode — the
+    // palette's Add note and double-click-anywhere both work in every mode.
+    const [tool, setTool] = useState<EditorTool>('select')
     /** Open right-click menu: screen position (root-relative) + hit target. */
     const [contextMenu, setContextMenu] = useState<{
       x: number
@@ -491,6 +495,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // on a member keeps it (that press starts a group move).
       if (hitId !== undefined && hitId !== selectedId && !extraIds.has(hitId)) {
         setExtraIds(new Set())
+      }
+      // Connect tool: the FIRST node press arms the connect (the same
+      // reducer arm the keyboard/handle flows use). While 'connecting', a
+      // node press is swallowed — the connect completes on the POINTERUP
+      // over the target (the reducer's completion arm), so dispatching a
+      // plain pointerdown here would tear the in-flight connect down first.
+      if (tool === 'connect' && hitId !== undefined) {
+        if (gestureState.kind !== 'connecting') {
+          applyResult(
+            reduceGesture(gestureState, canvas, { type: 'pointerdown-connect', nodeId: hitId }),
+          )
+        }
+        return
       }
       applyResult(
         reduceGesture(gestureState, canvas, { type: 'pointerdown', nodeId: hitId, point }),
@@ -881,7 +898,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
-        <ToolPalette onCreateNode={createNodeAtViewportCenter} />
+        <ToolPalette onCreateNode={createNodeAtViewportCenter} tool={tool} onToolChange={setTool} />
         {contextMenu !== null && (
           <ContextMenu
             x={contextMenu.x}

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -12,11 +12,18 @@
  * presses originating here (see SpatialEditor's isOverlayEvent): without
  * that, the root would capture the pointer and swallow the buttons' clicks.
  */
+export type EditorTool = 'select' | 'connect'
+
 interface ToolPaletteProps {
   readonly onCreateNode: () => void
+  readonly tool: EditorTool
+  readonly onToolChange: (tool: EditorTool) => void
 }
 
-export function ToolPalette({ onCreateNode }: ToolPaletteProps) {
+const TOOL_BUTTON_CLASS =
+  'rounded-md border px-3 py-1.5 text-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:font-medium'
+
+export function ToolPalette({ onCreateNode, tool, onToolChange }: ToolPaletteProps) {
   return (
     <div
       data-editor-overlay
@@ -25,6 +32,24 @@ export function ToolPalette({ onCreateNode }: ToolPaletteProps) {
       aria-label="Canvas tools"
       className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background p-1 shadow-md"
     >
+      <button
+        type="button"
+        data-testid="select-tool-button"
+        aria-pressed={tool === 'select'}
+        onClick={() => onToolChange('select')}
+        className={TOOL_BUTTON_CLASS}
+      >
+        Select
+      </button>
+      <button
+        type="button"
+        data-testid="connect-tool-button"
+        aria-pressed={tool === 'connect'}
+        onClick={() => onToolChange('connect')}
+        className={TOOL_BUTTON_CLASS}
+      >
+        Connect
+      </button>
       <button
         type="button"
         data-testid="add-node-button"

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -4,7 +4,6 @@ import { SPATIAL_EDITOR_UNSUPPORTED } from './SpatialEditor.js'
 const REQUIRED_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
-  'multi-select',
   'grouping',
   'undo-redo',
   'arrow-side-pinning',

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -319,7 +319,11 @@ describe('connect gesture', () => {
     expect(result.state.kind).toBe('idle')
   })
 
-  it('dropping a connect drag back onto its own source node is a no-op (self-connection guard)', () => {
+  it('releasing over the source node creates no edge and KEEPS the connect armed (click-A-click-B)', () => {
+    // Self-connection stays guarded (no command), but the state survives:
+    // the object-first Connect tool's first click presses AND releases on
+    // the source node, so an idle reset here would make click-click
+    // connecting impossible. Cancel is releasing over empty space.
     const c = canvas()
     let result = reduceGesture(createIdleState(), c, {
       type: 'pointerdown-connect',
@@ -331,7 +335,7 @@ describe('connect gesture', () => {
       targetNodeId: 'a',
     })
     expect(result.commands).toEqual([])
-    expect(result.state.kind).toBe('idle')
+    expect(result.state.kind).toBe('connecting')
   })
 })
 

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -266,7 +266,12 @@ function reducePointerUpConnecting(
   event: Extract<GestureEvent, { type: 'pointerup' }>,
   createId: () => string,
 ): GestureResult {
-  if (event.targetNodeId === undefined || event.targetNodeId === state.fromNodeId) return idle
+  // Releasing over empty space cancels. Releasing over the SOURCE node
+  // keeps the connect armed: that is the first click of the object-first
+  // click-A-click-B flow (the press and its own release both land on A),
+  // and in the drag flow it just means "still choosing a target".
+  if (event.targetNodeId === undefined) return idle
+  if (event.targetNodeId === state.fromNodeId) return stateOnly(state)
   return {
     state: { kind: 'idle' },
     commands: [

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -1,0 +1,91 @@
+// OOUI Connect tool (S7/S9): with the Connect tool armed, connecting two
+// nodes is click A, then click B — no drag, no keyboard, no handle hunting.
+// The tool is additive: Select stays the default and double-click creation
+// survives in every mode (S6 decisions, 2026-08-08).
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 400, y: 300, width: 120, height: 60, text: 'B' },
+  ],
+  edges: [],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function connectToolButton(container: HTMLElement): HTMLButtonElement {
+  return container.querySelector('[data-testid="connect-tool-button"]') as HTMLButtonElement
+}
+
+it('Connect tool: click A then click B creates the edge', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(connectToolButton(container))
+  expect(connectToolButton(container).getAttribute('aria-pressed')).toBe('true')
+
+  const root = rootOf(container)
+  await userEvent.click(root, { position: { x: 160, y: 130 } }) // node A
+  await userEvent.click(root, { position: { x: 460, y: 330 } }) // node B
+
+  await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(1))
+  expect(latest.canvas.edges[0]).toMatchObject({ fromNode: 'a', toNode: 'b' })
+  expect(latest.commands).toContain('connect-nodes')
+})
+
+it('the Select tool stays the default and node presses do not start a connect', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  const selectButton = container.querySelector(
+    '[data-testid="select-tool-button"]',
+  ) as HTMLButtonElement
+  expect(selectButton.getAttribute('aria-pressed')).toBe('true')
+
+  const root = rootOf(container)
+  await userEvent.click(root, { position: { x: 160, y: 130 } })
+  await userEvent.click(root, { position: { x: 460, y: 330 } })
+  expect(latest.canvas.edges).toHaveLength(0)
+})
+
+it('double-click creation survives while the Connect tool is armed (S6-2)', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(connectToolButton(container))
+  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 480 } })
+
+  await vi.waitFor(() => expect(latest.commands).toContain('create-node'))
+  expect(latest.canvas.nodes.length).toBe(3)
+})


### PR DESCRIPTION
## What

Executes the closed **S6 decision gate** (user decisions, 2026-08-08) and ships slices **S7 + S9** of the OOUI editor redesign (plan canvas `ooui-editor-redesign`):

- **Strict v1 tool inventory (S6-1)**: the palette is now `Select | Connect | Add note`. Select is the default and is byte-for-byte the previous interaction model; no reserved disabled slots; Pan stays gestural.
- **Object-first connect (S9)**: with the Connect tool armed, creating an edge is *click A, then click B* — no drag, no handle hunting. Routing is an additive arm: the existing drag/keyboard connect flows are untouched.
- **Double-click creation survives in every mode (S6-2)** — creation is deliberately not a mode.
- **Multi-select graduated from `SPATIAL_EDITOR_UNSUPPORTED` (S6-3)**: the user asked for it in scope, and it turned out to be already shipped (shift-click membership, group move/delete, marquee — all real-pointer browser-tested). Only the contract list was stale; both sides of the doc-contract updated.

One deliberate reducer semantics change: releasing a connect over its **source node now keeps the connect armed** instead of resetting to idle — the first click of click-A-click-B presses and releases on A, so the old reset made click-click connecting impossible. Self-connection stays guarded (no command ever emitted) and empty-space release still cancels. The pinned unit test was updated to the new contract with the rationale inline.

## Verification

Live in the running editor: Connect tool armed (pressed state visible), clicked the left note then "Meeting notes" — the new edge appears between them:

![pr-connect-tool.jpg](https://github.com/user-attachments/assets/ff1f2285-d38f-4896-b20c-f41f4c93c84d)

## Test plan

- [x] New real-pointer browser tests (`object-first-connect.browser.test.tsx`): click-A-click-B creates the edge with the tool armed; Select default never connects on plain clicks; double-click creation works while Connect is armed (red first)
- [x] Reducer unit test updated: self-release keeps `connecting`, emits no command
- [x] All 66 spatial-editor browser tests, full apps/web suite (1391), typecheck, biome, knip
- [x] Doc-contract test green on the graduated list (both directions)
