### PR TITLE
test(web): pin the editor's single content path and command boundary (S10)

### DIFF
--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -37,3 +37,38 @@ describe('theme resolver purity (no ambient DOM read)', () => {
     expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
   })
 })
+
+describe('single content path (S10 guardrail)', () => {
+  it('raw HTML injection exists ONLY at the two documented scene-svg sinks', async () => {
+    // Every user-visible string in the editor renders either as plain React
+    // text (palette labels, notices) or through canvas-render's escaping
+    // serializer injected at exactly these two places. A third
+    // dangerouslySetInnerHTML/innerHTML would be a new, unguarded XSS
+    // surface — add it here only with the same serializer-only guarantee.
+    const allowed = new Map([
+      ['./SpatialEditor.tsx', 1],
+      ['./DragPreviewLayer.tsx', 1],
+    ])
+    for (const [path, loader] of Object.entries(modules)) {
+      if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) continue
+      const source = (await loader()) as string
+      const injections = (source.match(/dangerouslySetInnerHTML=/g) ?? []).length
+      expect({ path, injections }).toEqual({ path, injections: allowed.get(path) ?? 0 })
+    }
+  })
+
+  it('canvas mutations construct typed EditorCommands (no setter bypasses applyCommand)', async () => {
+    // The palette and every tool mode mutate the canvas exclusively by
+    // dispatching an EditorCommand through applyCommand — a hand-rolled
+    // canvas object spread reaching onChange directly would bypass the
+    // command layer sync consumers replay.
+    const loader = modules['./SpatialEditor.tsx']
+    const source = (await loader?.()) as string
+    // The doc comment's `onChange(next, command)` mention is prose, not a
+    // call — match call sites by their argument shape: every real call
+    // passes a canvas produced by applyCommand (directly or via `running`).
+    const callSites = (source.match(/onChange\((running|applyCommand\()/g) ?? []).length
+    const allCalls = (source.match(/onChange\(/g) ?? []).length - 1 // minus the doc-comment mention
+    expect(allCalls).toBe(callSites)
+  })
+})

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -40,19 +40,22 @@ describe('theme resolver purity (no ambient DOM read)', () => {
 
 describe('single content path (S10 guardrail)', () => {
   it('raw HTML injection exists ONLY at the two documented scene-svg sinks', async () => {
-    // Every user-visible string in the editor renders either as plain React
-    // text (palette labels, notices) or through canvas-render's escaping
-    // serializer injected at exactly these two places. A third
-    // dangerouslySetInnerHTML/innerHTML would be a new, unguarded XSS
-    // surface — add it here only with the same serializer-only guarantee.
+    // String-level TRIPWIRE, not a syntax-aware proof: it catches the ways
+    // raw markup realistically enters a React/DOM codebase
+    // (dangerouslySetInnerHTML, innerHTML/outerHTML assignment,
+    // insertAdjacentHTML). The escaping guarantee itself lives in
+    // canvas-render's serializer tests — this test only pins that nothing
+    // BUT that serializer's two documented injection points exists here.
     const allowed = new Map([
       ['./SpatialEditor.tsx', 1],
       ['./DragPreviewLayer.tsx', 1],
     ])
+    const sinkPattern =
+      /dangerouslySetInnerHTML=|\.innerHTML\s*=|\.outerHTML\s*=|insertAdjacentHTML\(/g
     for (const [path, loader] of Object.entries(modules)) {
-      if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) continue
+      if (/\.(test|spec)\.(ts|tsx)$/.test(path)) continue
       const source = (await loader()) as string
-      const injections = (source.match(/dangerouslySetInnerHTML=/g) ?? []).length
+      const injections = (source.match(sinkPattern) ?? []).length
       expect({ path, injections }).toEqual({ path, injections: allowed.get(path) ?? 0 })
     }
   })
@@ -64,11 +67,17 @@ describe('single content path (S10 guardrail)', () => {
     // command layer sync consumers replay.
     const loader = modules['./SpatialEditor.tsx']
     const source = (await loader?.()) as string
-    // The doc comment's `onChange(next, command)` mention is prose, not a
-    // call — match call sites by their argument shape: every real call
-    // passes a canvas produced by applyCommand (directly or via `running`).
-    const callSites = (source.match(/onChange\((running|applyCommand\()/g) ?? []).length
-    const allCalls = (source.match(/onChange\(/g) ?? []).length - 1 // minus the doc-comment mention
+    // String-level TRIPWIRE for the command boundary: every statement-level
+    // onChange call must hand over a canvas spelled `running` (the
+    // applyCommand accumulator) or an inline `applyCommand(...)` result.
+    // This is deliberately formatting-sensitive and NOT data-flow analysis —
+    // a rename or a bypass shows up as a diff in this file, and the
+    // behavioral guarantee (sync consumers can replay commands) is carried
+    // by the browser-tier tests that assert commands reconstruct the
+    // canvas. Prose mentions inside comments don't match: only call sites
+    // preceded by code punctuation/whitespace count.
+    const callSites = (source.match(/[^`\w]onChange\((running\b|applyCommand\()/g) ?? []).length
+    const allCalls = (source.match(/[^`\w]onChange\(/g) ?? []).length
     expect(allCalls).toBe(callSites)
   })
 })


### PR DESCRIPTION
Closes the OOUI initiative's opportunistic S10 audit slice (test-only):

- **Single content path**: `dangerouslySetInnerHTML=` may appear only at the two documented scene-svg sinks (`SpatialEditor.tsx`, `DragPreviewLayer.tsx`), both fed exclusively by canvas-render's escaping serializer. Any third injection point fails the directory-wide source scan.
- **Command boundary**: every `onChange` call site in the editor hands over a canvas produced by `applyCommand` (directly or via the running accumulator) — a hand-rolled canvas mutation bypassing the typed `EditorCommand` layer fails the scan.

Audited the shipped palette/tool code against both properties first (clean); the tests pin them. Test-only change — no user-visible surface (preview verification N/A). Full spatial-editor suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that raw HTML injection is limited to approved components.
  * Added checks ensuring canvas changes use the supported command pathway rather than bypassing it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->