### PR TITLE
fix(render): draw headings at their measured size and emit list markers

### DIFF
--- a/packages/canvas-render/src/layout/__snapshots__/mdast-blocks.test.ts.snap
+++ b/packages/canvas-render/src/layout/__snapshots__/mdast-blocks.test.ts.snap
@@ -16,6 +16,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
         {
           "appearance": {
             "fontFamily": "sans-serif",
+            "fontSize": 32,
           },
           "baseline": 25.6,
           "bbox": {
@@ -41,6 +42,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
         {
           "appearance": {
             "fontFamily": "sans-serif",
+            "fontSize": 16,
           },
           "baseline": 12.8,
           "bbox": {
@@ -72,6 +74,21 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
           },
           "children": [
             {
+              "appearance": {
+                "fontFamily": "sans-serif",
+                "fontSize": 16,
+              },
+              "baseline": 12.8,
+              "bbox": {
+                "h": 16,
+                "w": 19.2,
+                "x": -24,
+                "y": 64,
+              },
+              "kind": "textRun",
+              "text": "1.",
+            },
+            {
               "bbox": {
                 "h": 16,
                 "w": 576,
@@ -83,6 +100,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                 {
                   "appearance": {
                     "fontFamily": "sans-serif",
+                    "fontSize": 16,
                   },
                   "baseline": 12.8,
                   "bbox": {
@@ -114,6 +132,21 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                   },
                   "children": [
                     {
+                      "appearance": {
+                        "fontFamily": "sans-serif",
+                        "fontSize": 16,
+                      },
+                      "baseline": 12.8,
+                      "bbox": {
+                        "h": 16,
+                        "w": 9.6,
+                        "x": -24,
+                        "y": 88,
+                      },
+                      "kind": "textRun",
+                      "text": "•",
+                    },
+                    {
                       "bbox": {
                         "h": 16,
                         "w": 552,
@@ -125,6 +158,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                         {
                           "appearance": {
                             "fontFamily": "sans-serif",
+                            "fontSize": 16,
                           },
                           "baseline": 12.8,
                           "bbox": {
@@ -182,6 +216,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                 {
                   "appearance": {
                     "fontFamily": "sans-serif",
+                    "fontSize": 16,
                   },
                   "baseline": 12.8,
                   "bbox": {
@@ -207,6 +242,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
                 {
                   "appearance": {
                     "fontFamily": "sans-serif",
+                    "fontSize": 16,
                   },
                   "baseline": 12.8,
                   "bbox": {
@@ -256,6 +292,7 @@ exports[`layoutMdastBlocks — golden block layout > matches the committed golde
             {
               "appearance": {
                 "fontFamily": "sans-serif",
+                "fontSize": 16,
               },
               "baseline": 12.8,
               "bbox": {

--- a/packages/canvas-render/src/layout/mdast-blocks-font.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks-font.test.ts
@@ -109,3 +109,69 @@ describe('layoutMdastBlocks — declared font family matches the measured one', 
     expect([...families]).toEqual(['OneFamily'])
   })
 })
+
+describe('measured-vs-declared font SIZE on markdown runs', () => {
+  it('a heading run declares the size it was measured at, not the inherited default', () => {
+    // Headings are measured at HEADING_FONT_SIZE_PX[depth]; a run that then
+    // draws at the host's inherited size renders every wrap width and block
+    // height wrong AND flattens the visual hierarchy (h1 == body). Same
+    // invariant class as the fontFamily guard above, for size.
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        { type: 'heading', depth: 1, children: [{ type: 'text', value: 'Title' }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'body' }] },
+      ],
+    }
+    const runs = collectRuns(
+      layoutMdastBlocks(root, { measure, maxWidth: 400, fontFamily: 'Roboto' }),
+    )
+    const heading = runs.find((run) => run.text === 'Title')
+    const body = runs.find((run) => run.text === 'body')
+    expect(heading?.appearance?.fontSize).toBe(32)
+    expect(body?.appearance?.fontSize).toBe(16)
+  })
+
+  it('list items draw their marker glyph (bullet / ordinal) as a measured run', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [{ type: 'paragraph', children: [{ type: 'text', value: 'alpha' }] }],
+            },
+          ],
+        },
+        {
+          type: 'list',
+          ordered: true,
+          children: [
+            {
+              type: 'listItem',
+              children: [{ type: 'paragraph', children: [{ type: 'text', value: 'first' }] }],
+            },
+            {
+              type: 'listItem',
+              children: [{ type: 'paragraph', children: [{ type: 'text', value: 'second' }] }],
+            },
+          ],
+        },
+      ],
+    }
+    const runs = collectRuns(
+      layoutMdastBlocks(root, { measure, maxWidth: 400, fontFamily: 'Roboto' }),
+    )
+    const texts = runs.map((run) => run.text)
+    expect(texts).toContain('\u2022')
+    expect(texts).toContain('1.')
+    expect(texts).toContain('2.')
+    // Markers sit in the indent gutter, left of the content (wrapper-relative
+    // negative x, since the listItem wrapper translates by its own bbox.x).
+    const bullet = runs.find((run) => run.text === '\u2022')
+    expect((bullet?.bbox.x ?? 0) < 0).toBe(true)
+  })
+})

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -155,9 +155,12 @@ function layoutPhrasing(
       text,
       ...runStyle,
       ...extra,
-      // Stamped last so nothing can emit a run declaring a family other than
-      // the one it was measured with (see MdastLayoutOptions.fontFamily).
-      appearance: { ...extra.appearance, fontFamily: options.fontFamily },
+      // Stamped last so nothing can emit a run declaring a family OR SIZE
+      // other than the ones it was measured with (see
+      // MdastLayoutOptions.fontFamily) — a run drawn at the host's inherited
+      // size would render every measured wrap width wrong and flatten the
+      // heading hierarchy.
+      appearance: { ...extra.appearance, fontFamily: options.fontFamily, fontSize: fontSizePx },
     })
     line.x += width
   }
@@ -465,7 +468,30 @@ function layoutListItem(
 ): ListItemNode {
   const startY = cursor.y
   const indented: MdastLayoutOptions = { ...options, maxWidth: options.maxWidth - LIST_INDENT_PX }
-  const children = item.children.map((child) => layoutBlock(child, cursor, indented, depth))
+  const children: (ListItemNode['children'][number] | TextRunNode)[] = item.children.map((child) =>
+    layoutBlock(child, cursor, indented, depth),
+  )
+  // The marker glyph (bullet or ordinal). Wrapper-RELATIVE like every other
+  // child (the listItem renderer translates by its own bbox.x), so the
+  // gutter to the left of the content is negative x. Checked task items
+  // keep provenance only — a checkbox affordance is a separate feature,
+  // and drawing a bullet next to it would double the glyphs.
+  if (item.checked === null || item.checked === undefined) {
+    const markerText = ordinal !== undefined ? `${ordinal}.` : '\u2022'
+    const metrics = options.measure(markerText, bodyFont(options.fontFamily, BODY_FONT_SIZE_PX))
+    children.unshift({
+      kind: 'textRun',
+      bbox: {
+        x: -LIST_INDENT_PX,
+        y: startY,
+        w: clampAdvance(metrics.advanceWidth),
+        h: BODY_FONT_SIZE_PX,
+      },
+      baseline: clampAdvance(metrics.ascent),
+      text: markerText,
+      appearance: { fontFamily: options.fontFamily, fontSize: BODY_FONT_SIZE_PX },
+    })
+  }
   return {
     kind: 'listItem',
     bbox: {


### PR DESCRIPTION
## Problem (dogfooding find, canvas `node-markdown-fidelity-headings-list-markers`)

Every markdown surface (editor, viewer, export) rendered flat:

- Heading runs were **measured** at `HEADING_FONT_SIZE_PX[depth]` (h1 = 32px) but carried no `appearance.fontSize`, so they **drew** at the host's inherited size — the same measured-vs-declared mismatch class the `fontFamily` stamp already guards, meaning wrap widths and heading block heights were computed for a size that never rendered, and h1 looked identical to body text.
- List items indented but drew **no marker glyph at all** — no bullet, no ordinal.

## Fix

- `pushRun` stamps `fontSize` alongside `fontFamily` (stamped last — nothing can emit a run declaring a size other than the one it was measured with). The backend already emits `font-size` from appearance (decision #6); no serializer change.
- `layoutListItem` emits a measured marker run (`•`, or `n.` for ordered) in the indent gutter at wrapper-relative negative x (the listItem renderer translates by its own `bbox.x`). Checked task items keep provenance only — a checkbox affordance is a separate feature, noted inline.

## Result (real export pipeline)

![md-fidelity-after.png](https://github.com/user-attachments/assets/e6968ab5-7a8a-456c-b040-ee553e31f1e5)

## Test plan

- [x] Red-first in `mdast-blocks-font.test.ts` (the measured-vs-declared guard file): heading declares 32 / body declares 16; `•`, `1.`, `2.` markers exist as runs with gutter-negative x
- [x] Layout golden snapshot regenerated — diff is purely additive (fontSize fields + marker runs); hand-built SVG determinism goldens untouched
- [x] Full canvas-render (237), mcp-node + apps/web (4511) suites, typecheck, biome, knip
- [x] Doc snapshots regenerated twice: no real image drift (plain-label diagrams inherit 16px either way)