### PR TITLE
fix(web): mark the connect source node the moment the connect arms

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1101,6 +1101,26 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }}
             >
               <title>Connection targets</title>
+              {/* Immediate acknowledgment that the connect ARMED: the
+                rubber-band line only appears once the pointer moves, so a
+                still hand needs the source node marked right away. */}
+              {(() => {
+                const source = boxes.find((b) => b.id === gestureState.fromNodeId)
+                if (source === undefined) return null
+                return (
+                  <rect
+                    data-testid="connect-source-indicator"
+                    x={source.box.x - 2}
+                    y={source.box.y - 2}
+                    width={source.box.width + 4}
+                    height={source.box.height + 4}
+                    fill="none"
+                    stroke="#2563eb"
+                    strokeWidth={2}
+                    strokeDasharray="6 3"
+                  />
+                )
+              })()}
               {/* Named rather than aria-hidden for the same reason as the
                 selection overlay: this subtree holds the focusable connection
                 targets, so hiding it would remove the keyboard path. */}

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -89,3 +89,18 @@ it('double-click creation survives while the Connect tool is armed (S6-2)', asyn
   await vi.waitFor(() => expect(latest.commands).toContain('create-node'))
   expect(latest.canvas.nodes.length).toBe(3)
 })
+
+it('arming a connect shows the source indicator immediately, before any pointer move', async () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(connectToolButton(container))
+  await userEvent.click(rootOf(container), { position: { x: 160, y: 130 } })
+
+  // A still hand must still see that the connect armed: the source node
+  // carries a visible indicator without waiting for the rubber-band line
+  // (which only appears on pointermove).
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="connect-source-indicator"]')).not.toBeNull(),
+  )
+})


### PR DESCRIPTION
Dogfood follow-up (canvas `connect-tool-first-move-feedback`): after clicking node A with the Connect tool, nothing changed on screen until the pointer moved (the rubber-band line is pointermove-driven), so a still hand couldn't tell the connect had armed.

The source node now carries a dashed accent outline for the whole `connecting` state, rendered inside the existing connection-targets overlay (no new layer; plain decorative rect). Escape-cancel already existed.

## Test plan
- [x] Red-first browser test: the indicator is visible immediately after click A, before any pointer move
- [x] All object-first-connect browser tests (4), full apps/web suite (1393), typecheck, biome, knip