### PR TITLE
feat(web): select an edge by clicking its line, Delete removes it

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -478,6 +478,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // re-renders because it compares node ids, not DOM identity.
       // Shift-click builds a multi-selection instead of starting a gesture.
       if (e.shiftKey && hitId !== undefined) {
+        // Node and edge selection are mutually exclusive: Delete processes a
+        // selected edge FIRST, so an edge left selected here would be what a
+        // Delete on the node multi-selection actually removes.
+        setSelectedEdgeId(null)
         if (selectedId === null) {
           setSelectedId(hitId)
         } else if (hitId === selectedId) {
@@ -629,6 +633,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         const [primary, ...rest] = hitIds
         setSelectedId(primary ?? null)
         setExtraIds(new Set(rest))
+        // A drag that began on an edge line was a marquee, not an edge click
+        // — drop the press-time edge selection so Delete acts on the nodes.
+        setSelectedEdgeId(null)
         return
       }
       if (isPanningRef.current) {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -46,7 +46,13 @@ import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
 import { editorTextFill } from './editor-appearance.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
-import { findFreeSpot, hitTest, indexNodeBoxes, resizeBoxByDelta } from './geometry.js'
+import {
+  distanceToPolyline,
+  findFreeSpot,
+  hitTest,
+  indexNodeBoxes,
+  resizeBoxByDelta,
+} from './geometry.js'
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
@@ -274,10 +280,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [canvas, externalVersion])
 
-    const { svg, bounds } = useMemo(
+    const { svg, bounds, scene } = useMemo(
       () => renderCanvasToSvg(canvas, { measure: resolvedMeasure, theme }),
       [canvas, resolvedMeasure, theme],
     )
+    // Routed edge paths in canvas coordinates, for edge hit-testing and the
+    // selection highlight. Edges have no area, so selection is a
+    // distance-to-polyline test against a zoom-adjusted tolerance.
+    const edgePaths = useMemo(
+      () =>
+        scene.nodes.flatMap((node) =>
+          node.kind === 'edge' ? [{ id: node.id, path: node.path }] : [],
+        ),
+      [scene],
+    )
+    const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
     /**
@@ -488,6 +505,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (hitId === undefined) {
         setMarquee({ start: point, current: point })
         setExtraIds(new Set())
+        const EDGE_HIT_TOLERANCE_PX = 6
+        const hitEdge = edgePaths.find(
+          (edge) => distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
+        )
+        if (hitEdge !== undefined) {
+          setSelectedEdgeId(hitEdge.id)
+          applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
+          return
+        }
+        setSelectedEdgeId(null)
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
         return
       }
@@ -496,6 +523,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (hitId !== undefined && hitId !== selectedId && !extraIds.has(hitId)) {
         setExtraIds(new Set())
       }
+      setSelectedEdgeId(null)
       // Connect tool: the FIRST node press arms the connect (the same
       // reducer arm the keyboard/handle flows use). While 'connecting', a
       // node press is swallowed — the connect completes on the POINTERUP
@@ -658,6 +686,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
       // Keyboard equivalent of pointercancel: discards an in-flight
       // resize/move/connect gesture without committing it.
+      if (e.key === 'Escape' && selectedEdgeId !== null) {
+        e.preventDefault()
+        setSelectedEdgeId(null)
+        return
+      }
+      if (
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        selectedEdgeId !== null &&
+        gestureState.kind !== 'editing-text'
+      ) {
+        const target = e.target as HTMLElement | null
+        const tag = target?.tagName
+        if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !target?.isContentEditable) {
+          e.preventDefault()
+          applyResult({
+            state: { kind: 'idle' },
+            commands: [{ kind: 'delete-edge', id: selectedEdgeId } as const],
+          })
+          setSelectedEdgeId(null)
+          return
+        }
+      }
       if (e.key === 'Escape' && gestureState.kind !== 'idle') {
         e.preventDefault()
         applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
@@ -1090,6 +1140,32 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               contentSvg={dragContentSvg}
             />
           )}
+          {selectedEdgeId !== null &&
+            (() => {
+              const selected = edgePaths.find((edge) => edge.id === selectedEdgeId)
+              if (selected === undefined || selected.path.length < 2) return null
+              return (
+                <svg
+                  style={{
+                    position: 'absolute',
+                    overflow: 'visible',
+                    left: 0,
+                    top: 0,
+                    pointerEvents: 'none',
+                  }}
+                >
+                  <title>Selected connection</title>
+                  <polyline
+                    data-testid="edge-selection-highlight"
+                    points={selected.path.map((p) => `${p.x},${p.y}`).join(' ')}
+                    fill="none"
+                    stroke="#2563eb"
+                    strokeWidth={3}
+                    strokeLinecap="round"
+                  />
+                </svg>
+              )
+            })()}
           {gestureState.kind === 'connecting' && (
             <svg
               style={{

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -601,6 +601,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           // the press; a DOUBLE one creates a node here (resolved at the
           // release, consistent with the node-edit double-press rule).
           if (armed !== null && armed.key === 'empty') createNodeAt(armed.point)
+          // An edge selected at this press has no focusable element of its
+          // own (node shapes carry tabIndex; edge polylines do not), so
+          // without an explicit focus the real keyboard's Delete/Escape
+          // would land on <body> and never reach this root's onKeyDown.
+          // Focus here at the RELEASE: the browser's default mousedown
+          // focus handling runs after the pointerdown listener and undoes
+          // a focus taken there.
+          if (selectedEdgeId !== null) root?.focus()
           return
         }
         const rect = {
@@ -926,12 +934,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // this slice's scope.
         role="application"
         aria-label="Spatial canvas editor"
+        // Click-focusable (not tab-reachable): edge selection focuses this
+        // root programmatically so real keyboard events reach onKeyDown.
+        tabIndex={-1}
         style={{
           position: 'relative',
           width: '100%',
           height: '100%',
           overflow: 'hidden',
           touchAction: 'none',
+          outline: 'none',
         }}
         onPointerDown={handlePointerDown}
         onContextMenu={handleContextMenu}

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -39,6 +39,7 @@ export type EditorCommand =
     }
   | { readonly kind: 'create-node'; readonly node: SpatialNode }
   | { readonly kind: 'delete-node'; readonly id: string }
+  | { readonly kind: 'delete-edge'; readonly id: string }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -152,6 +153,8 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return connectNodes(canvas, command.edgeId, command.fromNode, command.toNode)
     case 'create-node':
       return createNode(canvas, command.node)
+    case 'delete-edge':
+      return { ...canvas, edges: canvas.edges.filter((edge) => edge.id !== command.id) }
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -128,4 +128,53 @@ it('Escape and empty-space clicks clear the edge selection without deleting', as
     expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
   )
   expect(latest.canvas.edges).toHaveLength(1)
+
+  // The pointer path of the same policy: reselect, then click empty space.
+  await userEvent.click(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
+  )
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it('Shift-clicking a node clears the edge selection (mutually exclusive)', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+
+  await userEvent.click(rootOf(container), { position: { x: 160, y: 130 }, modifiers: ['Shift'] })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
+  )
+  // Delete now acts on the node selection, never the previously clicked edge.
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+  await vi.waitFor(() => expect(latest.canvas.nodes.length).toBeLessThan(2))
+  expect(latest.commands).not.toContain('delete-edge')
+})
+
+it('a marquee drag that starts on an edge line ends with no edge selected', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  const mid = edgeMidpointPosition(container)
+  // Drag from the edge line into empty space below: this is a marquee, not
+  // an edge click, so the press-time edge selection must not survive it.
+  await userEvent.dragAndDrop(rootOf(container), rootOf(container), {
+    sourcePosition: mid,
+    targetPosition: { x: mid.x + 120, y: mid.y + 150 },
+  })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
+  )
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+  expect(latest.canvas.edges).toHaveLength(1)
+  expect(latest.commands).not.toContain('delete-edge')
 })

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -1,0 +1,111 @@
+// Create/delete symmetry for edges: the Connect tool makes edge creation a
+// two-click flow, so a misclicked connection must be just as removable —
+// click the edge line to select it, press Delete to remove it.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function makeStart(): SpatialCanvas {
+  return {
+    nodes: [
+      { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 400, y: 100, width: 120, height: 60, text: 'B' },
+    ],
+    edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+  }
+}
+
+function makeHost() {
+  const start = makeStart()
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+/**
+ * Element-relative click position ON the rendered edge, derived from the
+ * committed polyline's own client rect. Hardcoded canvas coordinates break
+ * under the vitest browser iframe's UI scaling (the page renders scaled, so
+ * a fixed element-relative point lands elsewhere in canvas space depending
+ * on the current scale); rect-derived positions live in the same scaled
+ * space as the click and stay correct at any zoom.
+ */
+function edgeMidpointPosition(container: HTMLElement): { x: number; y: number } {
+  const root = rootOf(container)
+  const polyline = container.querySelector(
+    '[data-testid="spatial-editor"] svg polyline',
+  ) as SVGPolylineElement
+  const edgeRect = polyline.getBoundingClientRect()
+  const rootRect = root.getBoundingClientRect()
+  return {
+    x: edgeRect.x + edgeRect.width / 2 - rootRect.x,
+    y: edgeRect.y + edgeRect.height / 2 - rootRect.y,
+  }
+}
+
+it('clicking an edge selects it and Delete removes it', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+  await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(0))
+  expect(latest.commands).toContain('delete-edge')
+  // Nodes are untouched.
+  expect(latest.canvas.nodes).toHaveLength(2)
+})
+
+it('a click NEAR but not on the edge selects nothing', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  const mid = edgeMidpointPosition(container)
+  await userEvent.click(rootOf(container), { position: { x: mid.x, y: mid.y + 50 } })
+  expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull()
+
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it('Escape and empty-space clicks clear the edge selection without deleting', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
+  )
+  expect(latest.canvas.edges).toHaveLength(1)
+})

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -83,6 +83,26 @@ it('clicking an edge selects it and Delete removes it', async () => {
   expect(latest.canvas.nodes).toHaveLength(2)
 })
 
+it('a real keyboard Delete works after a cold edge click (focus lands in the editor)', async () => {
+  // Live-verification regression: dispatching a synthetic keydown on the
+  // editor root bypasses focus, but a real key press goes to
+  // document.activeElement. A cold click on an edge hits no focusable
+  // element (unlike node shapes, which carry tabIndex), so unless the
+  // editor takes focus on edge selection, the real Delete lands on <body>
+  // and nothing happens. userEvent.keyboard routes through activeElement,
+  // pinning the real path.
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  await userEvent.click(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+
+  await userEvent.keyboard('{Delete}')
+  await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(0))
+})
+
 it('a click NEAR but not on the edge selects nothing', async () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -167,3 +167,31 @@ export function resizeBoxByDelta(
     height: startBox.height + sign.y * dy,
   }
 }
+
+/**
+ * Minimum distance from a point to a polyline (canvas coordinates). Used to
+ * hit-test edges, which have no area of their own — the caller compares the
+ * result against a zoom-adjusted tolerance.
+ */
+export function distanceToPolyline(
+  point: { x: number; y: number },
+  path: readonly { x: number; y: number }[],
+): number {
+  if (path.length === 0) return Number.POSITIVE_INFINITY
+  if (path.length === 1) return Math.hypot(point.x - path[0].x, point.y - path[0].y)
+  let min = Number.POSITIVE_INFINITY
+  for (let i = 0; i + 1 < path.length; i += 1) {
+    const a = path[i]
+    const b = path[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const lengthSq = dx * dx + dy * dy
+    const t =
+      lengthSq === 0
+        ? 0
+        : Math.max(0, Math.min(1, ((point.x - a.x) * dx + (point.y - a.y) * dy) / lengthSq))
+    const distance = Math.hypot(point.x - (a.x + t * dx), point.y - (a.y + t * dy))
+    if (distance < min) min = distance
+  }
+  return min
+}


### PR DESCRIPTION
## What

Create/delete symmetry for edges (dogfood finding `edges-cannot-be-selected-or-deleted`): the Connect tool made edge **creation** a two-click flow, but a misclicked edge could not be removed at all. Now:

- Clicking an edge's line (6px screen-space tolerance, zoom-aware via `distanceToPolyline`) selects it and shows a highlight overlay.
- `Delete`/`Backspace` removes the selected edge (`delete-edge` command through the `applyResult` boundary); `Escape` and empty-space clicks clear the selection without deleting.
- Node presses clear any edge selection; text-entry targets never trigger the delete.

## Follow-up caught by live verification (second commit)

The browser tests dispatched synthetic keydowns directly on the editor root, which bypasses focus. Live verification showed the real keyboard's Delete never arrived: an edge has no focusable element (node shapes carry `tabIndex`; polylines do not), so focus stayed on `<body>`. Fix: the root is click-focusable (`tabIndex={-1}`, outline suppressed) and takes focus at the **release** of an edge-selecting press — the browser's default mousedown focus handling runs after the pointerdown listener and undoes a focus taken there. A new regression test routes the key through `document.activeElement` via `userEvent.keyboard`, pinning the real path.

## Visual repro (live dev app, real pointer + real keyboard)

Edge selected by clicking its line (highlight; `document.activeElement` = editor root):

![edge-selected-live.jpg](https://github.com/user-attachments/assets/95c2eb07-f2c2-4129-8484-85120a958578)

After pressing Delete — the edge is gone (4 → 3 polylines in DOM):

![edge-deleted-live.jpg](https://github.com/user-attachments/assets/b0970b10-a6af-4f3b-9272-312d54a1896e)

## Test plan

- [x] New real-pointer browser tests (`edge-select-delete.browser.test.tsx`): click-select + Delete removes (nodes untouched); near-miss selects nothing; Escape/empty-click clears without deleting; real-keyboard Delete after a cold edge click via `userEvent.keyboard` (red first — it reproduced the live focus gap)
- [x] `delete-edge` command unit coverage via `applyCommand`
- [x] All 217 apps/web browser tests, 1393 jsdom tests, typecheck, biome, knip
- [x] Live verification in the running dev app with real pointer/keyboard (screenshots above)
