### PR TITLE
feat(web): edit an edge's label by double-clicking its line

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -13,9 +13,12 @@
  * target node's connect-target control and Enter/Space it; Escape cancels
  * an in-flight gesture from the keyboard too), create a node (double-click
  * empty canvas space, or the keyboard-reachable "Add note" button — both
- * open the new node for typing immediately), and delete the current
+ * open the new node for typing immediately), delete the current
  * selection (Delete/Backspace, disabled while its text editor is open so
- * Backspace-while-typing edits text instead of deleting the node).
+ * Backspace-while-typing edits text instead of deleting the node), select
+ * an edge (click its line) and delete it (Delete/Backspace), and edit an
+ * edge's label (double-click its line; commits on blur, empty removes,
+ * Escape cancels).
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -51,8 +54,10 @@ import {
   findFreeSpot,
   hitTest,
   indexNodeBoxes,
+  polylineMidpoint,
   resizeBoxByDelta,
 } from './geometry.js'
+
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
@@ -123,6 +128,8 @@ export interface SpatialEditorHandle {
   fitToContent(nodeIds?: readonly string[]): void
 }
 
+const EDGE_LABEL_EDITOR_WIDTH_PX = 160
+const EDGE_LABEL_EDITOR_HEIGHT_PX = 28
 const DEFAULT_TEST_ID = 'spatial-editor'
 /**
  * Window for OUR double-press detection (see handlePointerDown). Matches the
@@ -295,6 +302,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       [scene],
     )
     const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
+    const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
     /**
@@ -497,7 +505,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }
         return
       }
-      const pressKey = hitId ?? 'empty'
+      // Edge hit-test runs at the press so the double-press pairing can
+      // distinguish "double-click on an edge" (open its label editor) from
+      // "double-click on empty space" (create a node) — both have
+      // hitId === undefined.
+      const EDGE_HIT_TOLERANCE_PX = 6
+      const hitEdge =
+        hitId === undefined
+          ? edgePaths.find(
+              (edge) =>
+                distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
+            )
+          : undefined
+      const pressKey = hitId ?? (hitEdge !== undefined ? `edge:${hitEdge.id}` : 'empty')
       const now = e.timeStamp
       const isDoublePress =
         lastPressRef.current !== null &&
@@ -509,10 +529,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (hitId === undefined) {
         setMarquee({ start: point, current: point })
         setExtraIds(new Set())
-        const EDGE_HIT_TOLERANCE_PX = 6
-        const hitEdge = edgePaths.find(
-          (edge) => distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
-        )
         if (hitEdge !== undefined) {
           setSelectedEdgeId(hitEdge.id)
           applyResult(reduceGesture(gestureState, canvas, { type: 'pointerdown-empty' }))
@@ -605,6 +621,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           // the press; a DOUBLE one creates a node here (resolved at the
           // release, consistent with the node-edit double-press rule).
           if (armed !== null && armed.key === 'empty') createNodeAt(armed.point)
+          // Double press ON an edge line edits the OBJECT under the pointer
+          // (the label), mirroring the node double-press-edits rule; node
+          // creation stays the empty-space double press above.
+          if (armed?.key.startsWith('edge:')) {
+            setEdgeLabelEditId(armed.key.slice('edge:'.length))
+          }
           // An edge selected at this press has no focusable element of its
           // own (node shapes carry tabIndex; edge polylines do not), so
           // without an explicit focus the real keyboard's Delete/Escape
@@ -740,9 +762,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // handler is never a resize.
       if (e.key === ' ' && gestureState.kind === 'idle') {
         // Held Space turns the next left-drag into a pan (Excalidraw
-        // semantics). preventDefault stops the page scrolling on Space.
-        e.preventDefault()
-        spaceDownRef.current = true
+        // semantics). preventDefault stops the page scrolling on Space —
+        // but never while the key originates in a text-entry surface. Node
+        // text editing is covered by the gesture-state check (editing-text
+        // is not idle); the edge label editor keeps the gesture idle, so a
+        // typed space would otherwise be swallowed here.
+        const target = e.target as HTMLElement | null
+        const tag = target?.tagName
+        if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !target?.isContentEditable) {
+          e.preventDefault()
+          spaceDownRef.current = true
+        }
         return
       }
       const nudge = ARROW_KEY_DELTA[e.key]
@@ -1263,6 +1293,35 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ))}
             </svg>
           )}
+          {edgeLabelEditId !== null &&
+            (() => {
+              const edge = canvas.edges.find((entry) => entry.id === edgeLabelEditId)
+              const path = edgePaths.find((entry) => entry.id === edgeLabelEditId)?.path
+              if (edge === undefined || path === undefined || path.length < 2) return null
+              const mid = polylineMidpoint(path)
+              return (
+                <TextNodeEditor
+                  box={{
+                    x: mid.x - EDGE_LABEL_EDITOR_WIDTH_PX / 2,
+                    y: mid.y - EDGE_LABEL_EDITOR_HEIGHT_PX / 2,
+                    width: EDGE_LABEL_EDITOR_WIDTH_PX,
+                    height: EDGE_LABEL_EDITOR_HEIGHT_PX,
+                  }}
+                  initialText={edge.label ?? ''}
+                  testId="edge-label-editor"
+                  onCommit={(label) => {
+                    applyResult({
+                      state: { kind: 'idle' },
+                      commands: [
+                        { kind: 'set-edge-label', id: edge.id, label: label.trim() } as const,
+                      ],
+                    })
+                    setEdgeLabelEditId(null)
+                  }}
+                  onCancel={() => setEdgeLabelEditId(null)}
+                />
+              )
+            })()}
           {gestureState.kind === 'editing-text' &&
             selectedNode?.type === 'text' &&
             selection !== undefined && (

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -22,6 +22,8 @@ import type { Box } from './geometry.js'
 export interface TextNodeEditorProps {
   readonly box: Box
   readonly initialText: string
+  /** Overrides the testid for non-node uses (e.g. the edge label editor). */
+  readonly testId?: string
   readonly onCommit: (text: string) => void
   readonly onCancel: () => void
   /** Fires on every keystroke so a caller can track the in-progress value (e.g. to commit it if a gesture interrupts the edit). */
@@ -31,6 +33,7 @@ export interface TextNodeEditorProps {
 export function TextNodeEditor({
   box,
   initialText,
+  testId = 'text-node-editor',
   onCommit,
   onCancel,
   onChange,
@@ -63,7 +66,7 @@ export function TextNodeEditor({
   return (
     <textarea
       ref={textareaRef}
-      data-testid="text-node-editor"
+      data-testid={testId}
       value={value}
       style={{
         position: 'absolute',

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -163,6 +163,33 @@ describe('applyCommand', () => {
     expect(next).toBe(canvas)
   })
 
+  it('set-edge-label sets, updates, and (with an empty string) removes the label', () => {
+    const connected = applyCommand(baseCanvas(), {
+      kind: 'connect-nodes',
+      edgeId: 'e1',
+      fromNode: 'a',
+      toNode: 'b',
+    })
+
+    const labeled = applyCommand(connected, { kind: 'set-edge-label', id: 'e1', label: 'yes' })
+    expect(labeled.edges[0]).toMatchObject({ id: 'e1', label: 'yes' })
+    expect(labeled.nodes).toBe(connected.nodes)
+    expect(spatialCanvasSchema.safeParse(labeled).success).toBe(true)
+
+    const relabeled = applyCommand(labeled, { kind: 'set-edge-label', id: 'e1', label: 'no' })
+    expect(relabeled.edges[0]).toMatchObject({ id: 'e1', label: 'no' })
+
+    const cleared = applyCommand(relabeled, { kind: 'set-edge-label', id: 'e1', label: '' })
+    expect(cleared.edges[0]).not.toHaveProperty('label')
+    expect(spatialCanvasSchema.safeParse(cleared).success).toBe(true)
+  })
+
+  it('set-edge-label with a missing id returns the input canvas unchanged', () => {
+    const canvas = baseCanvas()
+    const next = applyCommand(canvas, { kind: 'set-edge-label', id: 'missing', label: 'x' })
+    expect(next).toBe(canvas)
+  })
+
   it('create then delete the same node is the identity (up to deep equality)', () => {
     const canvas = baseCanvas()
     const node = { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' } as const

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -40,6 +40,7 @@ export type EditorCommand =
   | { readonly kind: 'create-node'; readonly node: SpatialNode }
   | { readonly kind: 'delete-node'; readonly id: string }
   | { readonly kind: 'delete-edge'; readonly id: string }
+  | { readonly kind: 'set-edge-label'; readonly id: string; readonly label: string }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -141,6 +142,23 @@ function deleteNode(canvas: SpatialCanvas, id: string): SpatialCanvas {
   }
 }
 
+/** An empty label removes the field: the model's `label` is optional and an
+ * empty string would serialize as an authored-but-blank label. */
+function setEdgeLabel(canvas: SpatialCanvas, id: string, label: string): SpatialCanvas {
+  if (!canvas.edges.some((edge) => edge.id === id)) return canvas
+  return {
+    ...canvas,
+    edges: canvas.edges.map((edge) => {
+      if (edge.id !== id) return edge
+      if (label === '') {
+        const { label: _removed, ...rest } = edge
+        return rest
+      }
+      return { ...edge, label }
+    }),
+  }
+}
+
 export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): SpatialCanvas {
   switch (command.kind) {
     case 'move-node':
@@ -155,6 +173,8 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return createNode(canvas, command.node)
     case 'delete-edge':
       return { ...canvas, edges: canvas.edges.filter((edge) => edge.id !== command.id) }
+    case 'set-edge-label':
+      return setEdgeLabel(canvas, command.id, command.label)
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
@@ -1,0 +1,148 @@
+// OOUI edit affordance for edges: double-clicking an edge's line opens an
+// inline label editor (the object-double-click-edits rule nodes already
+// follow), instead of falling through to double-click node creation. The
+// canvas model's edges carry an optional `label`; before this, the editor
+// had no way to author one.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function makeStart(label?: string): SpatialCanvas {
+  return {
+    nodes: [
+      { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 400, y: 100, width: 120, height: 60, text: 'B' },
+    ],
+    edges: [
+      label === undefined
+        ? { id: 'e1', fromNode: 'a', toNode: 'b' }
+        : { id: 'e1', fromNode: 'a', toNode: 'b', label },
+    ],
+  }
+}
+
+function makeHost(start: SpatialCanvas) {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+/** Element-relative position ON the edge polyline (see edge-select-delete). */
+function edgeMidpointPosition(container: HTMLElement): { x: number; y: number } {
+  const root = rootOf(container)
+  const polyline = container.querySelector(
+    '[data-testid="spatial-editor"] svg polyline',
+  ) as SVGPolylineElement
+  const edgeRect = polyline.getBoundingClientRect()
+  const rootRect = root.getBoundingClientRect()
+  return {
+    x: edgeRect.x + edgeRect.width / 2 - rootRect.x,
+    y: edgeRect.y + edgeRect.height / 2 - rootRect.y,
+  }
+}
+
+function labelEditor(container: HTMLElement): HTMLTextAreaElement | null {
+  return container.querySelector('[data-testid="edge-label-editor"]')
+}
+
+it('double-clicking an edge opens the label editor; committing sets the label', async () => {
+  const { Host, latest } = makeHost(makeStart())
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() => expect(labelEditor(container)).not.toBeNull())
+  // The double press on an edge must NOT create a node.
+  expect(latest.canvas.nodes).toHaveLength(2)
+
+  await userEvent.fill(labelEditor(container) as HTMLTextAreaElement, 'yes')
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await vi.waitFor(() => expect(labelEditor(container)).toBeNull())
+
+  expect(latest.commands).toContain('set-edge-label')
+  expect(latest.canvas.edges[0]).toMatchObject({ id: 'e1', label: 'yes' })
+  // The committed label is rendered into the scene.
+  await vi.waitFor(() =>
+    expect(rootOf(container).querySelector('svg')?.textContent ?? '').toContain('yes'),
+  )
+})
+
+it('the editor opens pre-filled with the existing label and Escape cancels without a command', async () => {
+  const { Host, latest } = makeHost(makeStart('before'))
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() => expect(labelEditor(container)).not.toBeNull())
+  expect((labelEditor(container) as HTMLTextAreaElement).value).toBe('before')
+
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(labelEditor(container)).toBeNull())
+  expect(latest.commands).not.toContain('set-edge-label')
+  expect(latest.canvas.edges[0]).toMatchObject({ label: 'before' })
+})
+
+it('committing an empty value removes the label', async () => {
+  const { Host, latest } = makeHost(makeStart('old'))
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() => expect(labelEditor(container)).not.toBeNull())
+
+  await userEvent.fill(labelEditor(container) as HTMLTextAreaElement, '')
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await vi.waitFor(() => expect(labelEditor(container)).toBeNull())
+
+  expect(latest.canvas.edges[0]).not.toHaveProperty('label')
+})
+
+it('typed spaces reach the label editor instead of arming the Space-pan', async () => {
+  // Live-verification regression: the root's held-Space pan arm
+  // preventDefault()s Space while the gesture state is idle — and edge
+  // label editing keeps the gesture idle (unlike node text editing), so a
+  // typed space never reached the textarea. Type through real keydowns,
+  // not fill(), to exercise the bubbling path.
+  const { Host, latest } = makeHost(makeStart())
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: edgeMidpointPosition(container) })
+  await vi.waitFor(() => expect(labelEditor(container)).not.toBeNull())
+
+  await userEvent.type(labelEditor(container) as HTMLTextAreaElement, 'depends on')
+  expect((labelEditor(container) as HTMLTextAreaElement).value).toBe('depends on')
+
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await vi.waitFor(() => expect(latest.canvas.edges[0]).toMatchObject({ label: 'depends on' }))
+})
+
+it('double-clicking empty space still creates a node (S6-2 unaffected)', async () => {
+  const { Host, latest } = makeHost(makeStart())
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 480 } })
+  await vi.waitFor(() => expect(latest.commands).toContain('create-node'))
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(labelEditor(container)).toBeNull()
+})

--- a/apps/web/src/components/spatial-editor/geometry.test.ts
+++ b/apps/web/src/components/spatial-editor/geometry.test.ts
@@ -5,6 +5,7 @@ import {
   findFreeSpot,
   hitTest,
   indexNodeBoxes,
+  polylineMidpoint,
   resizeBoxByDelta,
   resizeHandleBoxes,
 } from './geometry.js'
@@ -135,5 +136,28 @@ describe('findFreeSpot', () => {
     const spot = findFreeSpot({ x: 500, y: 300 }, size, occupied)
     expect(Number.isFinite(spot.x)).toBe(true)
     expect(Number.isFinite(spot.y)).toBe(true)
+  })
+})
+
+describe('polylineMidpoint', () => {
+  it('returns the arc-length midpoint of a two-segment path', () => {
+    // Segments of length 10 then 30: midpoint is 20 along, i.e. 10 into segment 2.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 30 },
+    ]
+    expect(polylineMidpoint(path)).toEqual({ x: 10, y: 10 })
+  })
+
+  it('degrades on degenerate paths instead of throwing', () => {
+    expect(polylineMidpoint([])).toEqual({ x: 0, y: 0 })
+    expect(polylineMidpoint([{ x: 3, y: 4 }])).toEqual({ x: 3, y: 4 })
+    expect(
+      polylineMidpoint([
+        { x: 5, y: 5 },
+        { x: 5, y: 5 },
+      ]),
+    ).toEqual({ x: 5, y: 5 })
   })
 })

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -195,3 +195,36 @@ export function distanceToPolyline(
   }
   return min
 }
+
+/**
+ * The point at half the polyline's arc length — where an edge's inline
+ * label editor anchors. Degenerate paths degrade instead of throwing:
+ * empty → origin, single point → that point.
+ */
+export function polylineMidpoint(path: readonly { x: number; y: number }[]): {
+  x: number
+  y: number
+} {
+  if (path.length === 0) return { x: 0, y: 0 }
+  if (path.length === 1) return { x: path[0].x, y: path[0].y }
+  const segmentLengths: number[] = []
+  let total = 0
+  for (let i = 0; i + 1 < path.length; i += 1) {
+    const length = Math.hypot(path[i + 1].x - path[i].x, path[i + 1].y - path[i].y)
+    segmentLengths.push(length)
+    total += length
+  }
+  if (total === 0) return { x: path[0].x, y: path[0].y }
+  let remaining = total / 2
+  for (let i = 0; i < segmentLengths.length; i += 1) {
+    if (remaining <= segmentLengths[i]) {
+      const t = segmentLengths[i] === 0 ? 0 : remaining / segmentLengths[i]
+      return {
+        x: path[i].x + t * (path[i + 1].x - path[i].x),
+        y: path[i].y + t * (path[i + 1].y - path[i].y),
+      }
+    }
+    remaining -= segmentLengths[i]
+  }
+  return { x: path[path.length - 1].x, y: path[path.length - 1].y }
+}


### PR DESCRIPTION
## What

Dogfood finding: the canvas model's edges carry an optional `label` (export and dark-export already render it), but the editor had **no way to author one**. Double-clicking an edge's line now opens an inline label editor — the object-double-click-edits rule text nodes already follow:

- Opens at the polyline's arc-length midpoint, prefilled with the existing label.
- Commit on blur; an empty value **removes** the label; Escape cancels.
- Node creation stays the empty-space double press (S6-2): the double-press pairing keys edge presses as `edge:<id>`, so double-clicking an edge no longer falls through to "create a node on top of the edge".

New `set-edge-label` command goes through the `applyResult` boundary; `polylineMidpoint` is a total geometry helper (degenerate paths degrade to a point).

## Bug caught by live verification

Typing a label with a space produced `dependson`: the root's held-Space pan arm `preventDefault()`s Space while the gesture is idle, and edge label editing keeps the gesture idle (unlike node text editing, whose `editing-text` state dodges the branch). The pan arm now ignores key events originating in text-entry surfaces; the regression types through real keydowns (`userEvent.type`), not `fill()`, to pin the bubbling path.

## Visual repro (live dev app, real pointer + keyboard)

Double-click on the edge opens the inline editor on the line:

![edge-label-editor-open.jpg](https://github.com/user-attachments/assets/a2dc23e3-4c91-4ffa-924a-caf9f6f6ddc6)

After committing, "depends on" (space intact) renders on the edge; it survives reload and re-opens prefilled for editing:

![edge-label-committed.jpg](https://github.com/user-attachments/assets/efb4d6f0-0802-4e50-aac4-148c0acd5300)

## Test plan

- [x] Unit: `set-edge-label` sets/updates/removes (empty string), missing id is identity, nodes stay reference-equal (red first)
- [x] Unit: `polylineMidpoint` arc-length midpoint + degenerate-path degradation
- [x] Real-pointer browser tests (`edge-label-edit.browser.test.tsx`): open-and-commit renders the label into the scene; prefilled + Escape cancels without a command; empty commit removes; typed spaces reach the editor (red first — reproduced the live bug); empty-space double-click still creates a node (S6-2)
- [x] Full apps/web browser suite (223; 1 unrelated known load-flake in markdown-editor passes in isolation), 1397 jsdom, typecheck, biome, knip
- [x] Live verification in the running dev app (screenshots above)
