### PR TITLE
feat(web): edge context menu with Edit label and Delete

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -130,6 +130,9 @@ export interface SpatialEditorHandle {
 
 const EDGE_LABEL_EDITOR_WIDTH_PX = 160
 const EDGE_LABEL_EDITOR_HEIGHT_PX = 28
+/** Screen-space px within which a press/right-click counts as hitting an
+ * edge line; divided by the zoom for the canvas-space comparison. */
+const EDGE_HIT_TOLERANCE_PX = 6
 const DEFAULT_TEST_ID = 'spatial-editor'
 /**
  * Window for OUR double-press detection (see handlePointerDown). Matches the
@@ -208,6 +211,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       x: number
       y: number
       nodeId: string | undefined
+      edgeId: string | undefined
       point: Point
     } | null>(null)
     /**
@@ -509,7 +513,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // distinguish "double-click on an edge" (open its label editor) from
       // "double-click on empty space" (create a node) — both have
       // hitId === undefined.
-      const EDGE_HIT_TOLERANCE_PX = 6
       const hitEdge =
         hitId === undefined
           ? edgePaths.find(
@@ -572,7 +575,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const point = screenToCanvas(screenPoint, viewport)
       const hitId = hitTest(boxes, point)
       if (hitId !== undefined) setSelectedId(hitId)
-      setContextMenu({ x: screenPoint.x, y: screenPoint.y, nodeId: hitId, point })
+      // Same edge tolerance as the click path: the object under the pointer
+      // gets ITS menu, so an edge line must not read as empty space.
+      const hitEdge =
+        hitId === undefined
+          ? edgePaths.find(
+              (edge) =>
+                distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
+            )
+          : undefined
+      if (hitEdge !== undefined) setSelectedEdgeId(hitEdge.id)
+      setContextMenu({
+        x: screenPoint.x,
+        y: screenPoint.y,
+        nodeId: hitId,
+        edgeId: hitEdge?.id,
+        point,
+      })
     }
 
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -1008,6 +1027,26 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 contextMenu.nodeId === undefined
                   ? undefined
                   : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
+              const edge =
+                contextMenu.edgeId === undefined
+                  ? undefined
+                  : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
+              if (node === undefined && edge !== undefined) {
+                return [
+                  { label: 'Edit label', onSelect: () => setEdgeLabelEditId(edge.id) },
+                  {
+                    label: 'Delete',
+                    danger: true,
+                    onSelect: () => {
+                      applyResult({
+                        state: { kind: 'idle' },
+                        commands: [{ kind: 'delete-edge', id: edge.id } as const],
+                      })
+                      setSelectedEdgeId(null)
+                    },
+                  },
+                ]
+              }
               if (node === undefined) {
                 return [{ label: 'Add note here', onSelect: () => createNodeAt(contextMenu.point) }]
               }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -574,7 +574,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const screenPoint = clientPointToRootLocal(e, root)
       const point = screenToCanvas(screenPoint, viewport)
       const hitId = hitTest(boxes, point)
-      if (hitId !== undefined) setSelectedId(hitId)
+      // Node and edge selection stay mutually exclusive here too (see the
+      // pointerdown path): Delete acts on a selected edge FIRST, so leaving
+      // the other object type selected makes Delete remove the wrong thing.
+      if (hitId !== undefined) {
+        setSelectedId(hitId)
+        setSelectedEdgeId(null)
+      }
       // Same edge tolerance as the click path: the object under the pointer
       // gets ITS menu, so an edge line must not read as empty space.
       const hitEdge =
@@ -584,7 +590,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
             )
           : undefined
-      if (hitEdge !== undefined) setSelectedEdgeId(hitEdge.id)
+      if (hitEdge !== undefined) {
+        setSelectedEdgeId(hitEdge.id)
+        setSelectedId(null)
+        setExtraIds(new Set())
+      }
       setContextMenu({
         x: screenPoint.x,
         y: screenPoint.y,

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -97,3 +97,81 @@ it('Escape closes the menu without acting', async () => {
   await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
   expect(commands).toHaveLength(0)
 })
+
+// --- Edge context menu: the object under the pointer gets ITS actions ---
+
+const edgeStart: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 400, y: 100, width: 120, height: 60, text: 'B' },
+  ],
+  edges: [{ id: 'e1', fromNode: 'a', toNode: 'b', label: 'link' }],
+}
+
+function makeEdgeHost() {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: edgeStart, commands: [] }
+  function EdgeHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(edgeStart)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { EdgeHost, latest }
+}
+
+function edgeMidpoint(container: HTMLElement): { x: number; y: number } {
+  const root = rootOf(container)
+  const polyline = container.querySelector(
+    '[data-testid="spatial-editor"] svg polyline',
+  ) as SVGPolylineElement
+  const edgeRect = polyline.getBoundingClientRect()
+  const rootRect = root.getBoundingClientRect()
+  return {
+    x: edgeRect.x + edgeRect.width / 2 - rootRect.x,
+    y: edgeRect.y + edgeRect.height / 2 - rootRect.y,
+  }
+}
+
+it('right-clicking an edge offers Edit label and Delete, not node creation', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).not.toContain('Add note here')
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Edit label' }))
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-label-editor"]')).not.toBeNull(),
+  )
+  expect(
+    (container.querySelector('[data-testid="edge-label-editor"]') as HTMLTextAreaElement).value,
+  ).toBe('link')
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it('Delete from the edge menu removes the edge and leaves the nodes', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Delete' }))
+
+  await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(0))
+  expect(latest.commands).toContain('delete-edge')
+  expect(latest.canvas.nodes).toHaveLength(2)
+})

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -175,3 +175,37 @@ it('Delete from the edge menu removes the edge and leaves the nodes', async () =
   expect(latest.commands).toContain('delete-edge')
   expect(latest.canvas.nodes).toHaveLength(2)
 })
+
+it('context-menu targeting keeps node and edge selection mutually exclusive', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  // Select the edge first (click its line), then right-click a NODE: the
+  // edge selection must clear, or a later Delete removes the edge the user
+  // is no longer pointing at. Positions are recomputed at each use: the
+  // vitest browser iframe's UI scale can settle between renders, so a
+  // cached rect-derived point goes stale (this test caught that live).
+  await userEvent.click(rootOf(container), { position: edgeMidpoint(container) })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
+  )
+  rightClick(rootOf(container), 160, 130)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
+  )
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+
+  // And the reverse: node selected, then right-click the edge.
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByRole('menuitem', { name: 'Edit label' })).toBeInTheDocument()
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  rootOf(container).dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }))
+  // The node right-clicked earlier is no longer selected; Delete acts on
+  // the edge selection made by the second right-click only.
+  await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(0))
+  expect(latest.canvas.nodes).toHaveLength(2)
+})


### PR DESCRIPTION
## What

Dogfood finding, following #453/#454: right-clicking an edge's line fell through to the **empty-space** menu ("Add note here") — the object under the pointer got no actions, unlike nodes, which offer Edit text / Delete. The context-menu hit-test now includes edges at the same zoom-aware tolerance as the click path (`EDGE_HIT_TOLERANCE_PX`, hoisted to module scope now that two paths share it), selects the edge for visual feedback, and offers:

- **Edit label** — opens the inline label editor from #454
- **Delete** (danger) — `delete-edge` through the `applyResult` boundary

Node and empty-space menus are unchanged.

## Visual repro (live dev app)

Right-click on the edge line — the edge highlights and gets its own menu instead of "Add note here":

![edge-context-menu.jpg](https://github.com/user-attachments/assets/b5ee15a0-4280-4555-88f8-bde819c29ebd)

After choosing Delete, the edge is gone (3 → 2 polylines in DOM), nodes untouched:

![edge-context-deleted.jpg](https://github.com/user-attachments/assets/83ccc1b0-ce2b-4186-9dd2-9bd86b81ea20)

## Test plan

- [x] Real-pointer browser tests (`context-menu.browser.test.tsx`, red first): edge right-click offers Edit label + Delete and NOT "Add note here"; Edit label opens the editor prefilled; Delete removes the edge, emits `delete-edge`, leaves both nodes
- [x] Existing node / empty-space context-menu tests unchanged and green (6/6 in file)
- [x] Full apps/web browser suite (225 passed; the 1 failure is the known unrelated `source-pane-keymap` load-flake — passes in isolation and in CI, now tracked as canvas `source-pane-softwrap-load-flake`), 1397 jsdom, typecheck, biome, knip
- [x] Live verification in the running dev app (screenshots above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-menu actions for editing edge labels and deleting edges.
  * Right-clicking an edge now selects it and displays relevant actions without offering node creation.

* **Bug Fixes**
  * Improved edge detection for click and context-menu interactions.
  * Edge labels and connected nodes are preserved correctly during context-menu operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->