### PR TITLE
feat(mcp): migrate to MCP SDK v2 and serve the 2026-07-28 revision

### DIFF
--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -11,20 +11,24 @@ References:
 
 ## Protocol Support
 
-This repo currently relies on the installed `@modelcontextprotocol/sdk` negotiation behavior rather than overriding protocol negotiation inside the app.
+This repo runs the MCP TypeScript SDK **v2 packages** (`@modelcontextprotocol/server` / `client`) and serves **both protocol eras** on every transport:
 
-- If the client asks for a supported protocol version, the server echoes that version in `initialize`.
-- If the client asks for an unsupported version, the server falls back to the SDK latest protocol version.
+- **2026-07-28 (modern)**: each request is self-contained (no `initialize` handshake, no `Mcp-Session-Id`; `_meta` carries `protocolVersion`/`clientCapabilities`). On HTTP `/mcp` this is served by `createMcpHandler` (per-request factory, `legacy: 'reject'`); the route classifies eras with `isLegacyRequest` — the exact predicate the handler itself uses. On stdio, `serveStdio` pins the connection's era at the opening exchange.
+- **2025-era (legacy)**: served by the pre-existing hand-wired stateless path (fresh per-request `WebStandardStreamableHTTPServerTransport` with `enableJsonResponse: true`) so legacy clients' response framing (plain JSON bodies) is byte-compatible with what the stdio proxy and the web app expect. Legacy `initialize` negotiation is unchanged:
+  - a supported protocol version is echoed back;
+  - an unsupported version falls back to the SDK latest legacy version.
 
-Current SDK-supported versions in this repo:
+Legacy versions accepted by the SDK's `initialize` negotiation:
 
-- `2025-11-25` (SDK latest fallback)
+- `2025-11-25` (SDK latest legacy fallback)
 - `2025-06-18`
 - `2025-03-26`
 - `2024-11-05`
 - `2024-10-07`
 
-When upgrading `@modelcontextprotocol/sdk`, re-check this matrix and the related initialize tests before shipping.
+Note: the deprecated core Logging capability (`logging/setLevel` + `notifications/message`) still works for legacy-era sessions; on modern-era requests the SDK only emits log notifications when the client opts in via the `io.modelcontextprotocol/logLevel` `_meta` key. Structured logs always reach stderr regardless.
+
+When upgrading the `@modelcontextprotocol/*` packages, re-check this matrix, the era tests (`app.test.ts` modern-pinned client, `serve-stdio-eras.test.ts`), and the related initialize tests before shipping.
 
 ## Recommended Flow
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -161,7 +161,6 @@
     "@libsql/client": "^0.17.3",
     "@libsql/kysely-libsql": "^0.4.1",
     "@modelcontextprotocol/ext-apps": "1.7.5",
-    "@modelcontextprotocol/sdk": "~1.30.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-zone": "^2.8.0",
     "@opentelemetry/core": "^2.8.0",
@@ -186,7 +185,9 @@
     "pino": "^10.3.1",
     "ws": "^8.21.0",
     "yaml": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0"
   },
   "devDependencies": {
     "@fast-check/vitest": "^0.4.1",

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1,8 +1,10 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js'
+import {
+  Client,
+  LATEST_PROTOCOL_VERSION,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client'
 import { Hono } from 'hono'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -460,6 +462,41 @@ describe('createApp daemon mutation auth', () => {
         text: JSON.stringify(createResult.structuredContent),
       },
     ])
+    await transport.close()
+  })
+
+  it('serves the 2026-07-28 revision on /mcp for a modern-pinned client', async () => {
+    // versionNegotiation pin means no legacy fallback: connect() succeeds only
+    // when the endpoint actually serves the modern (2026-07-28) era.
+    const app = createApp(createRuntimeOptions('secret'))
+    const client = new Client(
+      { name: 'app-modern-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    )
+    const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+      fetch: (input, init) => {
+        const headers = new Headers(init?.headers)
+        headers.set('Authorization', 'Bearer secret')
+        headers.set('Origin', 'http://127.0.0.1:6274')
+        return app.request(input instanceof URL ? input.toString() : String(input), {
+          ...init,
+          headers,
+        })
+      },
+    })
+
+    await client.connect(transport)
+    expect(client.getProtocolEra()).toBe('modern')
+    const tools = await client.listTools()
+    expect(tools.tools.some((tool) => tool.name === 'wb_canvas_create')).toBe(true)
+    const createResult = await client.callTool({
+      name: 'wb_canvas_create',
+      arguments: { workspaceId: 'default', segment: 'via-modern-mcp' },
+    })
+    expect(createResult.structuredContent).toMatchObject({
+      canvasId: expect.any(String),
+      segment: 'via-modern-mcp',
+    })
     await transport.close()
   })
 

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -3,7 +3,11 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { createServer as createOpenCanvasServer } from '@kamiazya/whiteboard-server-core'
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import {
+  createMcpHandler,
+  isLegacyRequest,
+  WebStandardStreamableHTTPServerTransport,
+} from '@modelcontextprotocol/server'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { encodeFrontiers, LoroDoc } from 'loro-crdt'
@@ -255,6 +259,20 @@ export function createApp(options: AppOptions) {
     }),
   )
 
+  // The modern (2026-07-28) serving entry: per-request factory, no protocol
+  // session — the same stateless idiom this endpoint has always used, now
+  // spec-level. `legacy: 'reject'` because 2025-era traffic is deliberately
+  // NOT served by this handler: the hand-wired legacy path below keeps
+  // `enableJsonResponse: true`, which the entry's built-in legacy fallback
+  // does not set, and changing legacy clients' response framing (JSON body →
+  // SSE) would break the stdio proxy and the web app's daemon client.
+  const modernMcpHandler = createMcpHandler(() => createMcpServer(), {
+    legacy: 'reject',
+    onerror: (error) => {
+      httpLog.warning({ err: error }, 'mcp-http:modern-error')
+    },
+  })
+
   app.all('/mcp', async (c) => {
     const startedAt = Date.now()
     const debug = shouldLogMcpHttpDebug()
@@ -274,6 +292,32 @@ export function createApp(options: AppOptions) {
       if (initializeDebug) {
         httpLog.info(initializeDebug, 'mcp-http:init')
       }
+    }
+    // Era routing runs the exact classification `createMcpHandler` itself
+    // uses, so this branch can never disagree with the entry. Modern
+    // requests never reach the legacy transport below.
+    const isLegacy =
+      parsedBody !== undefined
+        ? await isLegacyRequest(c.req.raw, parsedBody)
+        : await isLegacyRequest(c.req.raw)
+    if (!isLegacy) {
+      const response = await modernMcpHandler.fetch(c.req.raw, { parsedBody })
+      if (debug) {
+        const body = isJsonObject(parsedBody) ? parsedBody : {}
+        httpLog.info(
+          {
+            httpMethod: c.req.method.toUpperCase(),
+            path: c.req.path,
+            jsonrpcMethod: body.method ?? null,
+            requestId: body.id ?? null,
+            status: response.status,
+            durationMs: Date.now() - startedAt,
+            era: 'modern',
+          },
+          'mcp-http',
+        )
+      }
+      return response
     }
     // The MCP SDK throws 'Already connected' if a single Server is connected to
     // more than one transport, so build a fresh per-request server. The heavy

--- a/packages/mcp-server/src/server/mcp/index.test.ts
+++ b/packages/mcp-server/src/server/mcp/index.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../di/container.js', () => ({
     blobStore: {},
   })),
 }))
-vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+vi.mock('@modelcontextprotocol/server', () => ({
   McpServer: vi.fn(function FakeMcpServer(this: Record<string, unknown>) {
     this.server = { registerCapabilities: vi.fn() }
     this.registerResource = vi.fn()
@@ -59,8 +59,8 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
     this.close = vi.fn(async () => undefined)
   }),
 }))
-vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
-  StdioServerTransport: vi.fn(function FakeStdioServerTransport() {}),
+vi.mock('@modelcontextprotocol/server/stdio', () => ({
+  serveStdio: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
 }))
 
 describe('main()', () => {

--- a/packages/mcp-server/src/server/mcp/index.test.ts
+++ b/packages/mcp-server/src/server/mcp/index.test.ts
@@ -77,4 +77,18 @@ describe('main()', () => {
     expect(tracingCallOrder).toBeDefined()
     expect(installCallOrder).toBeLessThan(tracingCallOrder as number)
   })
+
+  it('serves stdio through serveStdio with a per-connection factory', async () => {
+    const { main } = await import('./index.js')
+    const { serveStdio } = await import('@modelcontextprotocol/server/stdio')
+
+    await main()
+
+    // serveStdio owns the connection's era decision; main() must hand it a
+    // FACTORY (not a pre-built server), so each opening exchange can pin a
+    // fresh instance for its era.
+    expect(serveStdio).toHaveBeenCalled()
+    const [factory] = vi.mocked(serveStdio).mock.calls.at(-1) ?? []
+    expect(typeof factory).toBe('function')
+  })
 })

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { McpServer } from '@modelcontextprotocol/server'
+import { serveStdio } from '@modelcontextprotocol/server/stdio'
 import { z } from 'zod'
 import { createContainer, resolveServerDeps } from '../../di/container.js'
 import { createStoreLocalModule } from '../../di/store-local.module.js'
@@ -78,7 +78,7 @@ export async function createMcpServer() {
     {
       title: 'Draw Diagram',
       description: 'Generate a starter prompt for drawing a new diagram with the whiteboard tools.',
-      argsSchema: {
+      argsSchema: z.object({
         goal: z.string().describe('What the diagram should explain or align on.'),
         diagramType: z
           .string()
@@ -86,7 +86,7 @@ export async function createMcpServer() {
           .describe(
             'Optional diagram type hint such as architecture, sequence, review, or comparison.',
           ),
-      },
+      }),
     },
     async ({ goal, diagramType }) => ({
       description: 'Starter instructions for creating a new whiteboard diagram.',
@@ -160,11 +160,18 @@ export async function main() {
   // hook here to keep schema and v0 import bootstrapping symmetric.
   const { prepareDataDir } = await import('../store/db/prepare.js')
   await prepareDataDir(getDataDir())
-  const server = await createMcpServer()
-  const transport = new StdioServerTransport()
-  await server.connect(transport)
+  // serveStdio owns the era decision for the connection: a 2025-era opening
+  // (`initialize`) is served exactly as the old hand-wired transport served
+  // it, and a 2026-07-28 opening pins a modern instance from the same
+  // factory. A direct `server.connect(new StdioServerTransport())` would
+  // speak only the 2025-era protocol.
+  const handle = serveStdio(() => createMcpServer(), {
+    onerror: (error) => {
+      process.stderr.write(`MCP stdio error: ${error}\n`)
+    },
+  })
 
-  closeServer = () => server.close()
+  closeServer = () => handle.close()
 }
 
 const isEntryPoint = isDirectEntryPoint(import.meta.url)

--- a/packages/mcp-server/src/server/mcp/logging.test.ts
+++ b/packages/mcp-server/src/server/mcp/logging.test.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer } from '@modelcontextprotocol/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type CapturedLogsHandle, captureLogsForTests, getLogger } from '../log.js'
 import { wireMcpLogging } from './logging.js'

--- a/packages/mcp-server/src/server/mcp/logging.ts
+++ b/packages/mcp-server/src/server/mcp/logging.ts
@@ -1,3 +1,5 @@
+import type { McpServer } from '@modelcontextprotocol/server'
+
 // Bridge our internal logger to the MCP `notifications/message` channel
 // described in https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging.
 //
@@ -11,8 +13,6 @@
 // The SDK applies its own per-session level filter on top of the project
 // logger's threshold, so `logging/setLevel` from a client only changes
 // what reaches that client.
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { addLogDestination, lineToLogRecord } from '../log.js'
 
 export interface WireMcpLoggingHandle {

--- a/packages/mcp-server/src/server/mcp/mcp-apps.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-apps.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { EXTENSION_ID, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { WHITEBOARD_ROOT } from '../config.js'
 import { getLogger } from '../log.js'
 

--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.test.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { describe, expect, it, vi } from 'vitest'
 import { captureLogsForTests } from '../log.js'
 import { InMemoryBlobStore } from '../store/inmemory/in-memory-blob-store.js'

--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
@@ -15,7 +15,7 @@ import {
   wbCanvasGet,
   wbCanvasList,
 } from '@kamiazya/whiteboard-server-core'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import type { z } from 'zod'
 import { getLogger } from '../log.js'
 import { registerToolWithAnnotations, structuredJsonResult } from './tool-support.js'

--- a/packages/mcp-server/src/server/mcp/serve-stdio-eras.test.ts
+++ b/packages/mcp-server/src/server/mcp/serve-stdio-eras.test.ts
@@ -1,0 +1,64 @@
+// The stdio entrypoint must serve BOTH protocol eras: a hand-constructed
+// `server.connect(StdioServerTransport)` speaks only the 2025-era protocol,
+// so main() goes through `serveStdio(factory)` — the opening exchange pins
+// the connection's era. These tests drive our real `createMcpServer`
+// factory through `serveStdio` over linked in-memory transports, one
+// connection per era.
+import { join } from 'node:path'
+import { Client } from '@modelcontextprotocol/client'
+import { InMemoryTransport } from '@modelcontextprotocol/server'
+import { serveStdio } from '@modelcontextprotocol/server/stdio'
+import { afterEach, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../routes/_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-serve-stdio-test-')
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return join(tmp.dir, 'data')
+  },
+  getDataDir: () => join(tmp.dir, 'data'),
+  get DIST_WEB_APP_DIR() {
+    return join(tmp.dir, 'web-app')
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+}))
+
+const { createMcpServer } = await import('./index.js')
+const { clearWorkspaceIdCache } = await import('./session-resolver.js')
+
+afterEach(() => {
+  clearWorkspaceIdCache()
+})
+
+it('serveStdio serves a legacy (2025) client from the createMcpServer factory', async () => {
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair()
+  const handle = serveStdio(() => createMcpServer(), { transport: serverSide })
+  const client = new Client({ name: 'legacy-stdio-client', version: '1.0.0' })
+  try {
+    await client.connect(clientSide)
+    const tools = await client.listTools()
+    expect(tools.tools.some((tool) => tool.name === 'wb_canvas_create')).toBe(true)
+  } finally {
+    await client.close().catch(() => {})
+    await handle.close().catch(() => {})
+  }
+})
+
+it('serveStdio serves a modern-pinned (2026-07-28) client from the same factory', async () => {
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair()
+  const handle = serveStdio(() => createMcpServer(), { transport: serverSide })
+  const client = new Client(
+    { name: 'modern-stdio-client', version: '1.0.0' },
+    { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+  )
+  try {
+    await client.connect(clientSide)
+    expect(client.getProtocolEra()).toBe('modern')
+    const tools = await client.listTools()
+    expect(tools.tools.some((tool) => tool.name === 'wb_canvas_create')).toBe(true)
+  } finally {
+    await client.close().catch(() => {})
+    await handle.close().catch(() => {})
+  }
+})

--- a/packages/mcp-server/src/server/mcp/tool-support.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-support.test.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { RESOURCE_URI_META_KEY } from './mcp-apps.js'

--- a/packages/mcp-server/src/server/mcp/tool-support.ts
+++ b/packages/mcp-server/src/server/mcp/tool-support.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import type { z } from 'zod'
 import { getLogger } from '../log.js'
 import { getTracer } from '../observability/tracing.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,12 +465,15 @@ importers:
       '@libsql/kysely-libsql':
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.17)
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.5
         version: 1.7.5(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
-      '@modelcontextprotocol/sdk':
-        specifier: ~1.30.0
-        version: 1.30.0(zod@4.4.3)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -2361,6 +2364,14 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/ext-apps@1.7.5':
     resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
     engines: {node: '>=20'}
@@ -2384,6 +2395,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -9174,6 +9189,20 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
   '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
@@ -9204,6 +9233,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@mswjs/interceptors@0.41.9':
     dependencies:


### PR DESCRIPTION
## What

Migrates the MCP server from `@modelcontextprotocol/sdk` (v1) to the **SDK v2 packages** and serves the **2026-07-28 protocol revision** on both transports, alongside unchanged 2025-era serving. User-requested (2026-08-08) after the spec's stateless redesign landed.

### Stage 1 — v1 → v2 package port (behavior-preserving)

- Ran the official `@modelcontextprotocol/codemod v1-to-v2`; imports now target `@modelcontextprotocol/server` / `client` (both published 2026-07-27, clear of the 7-day `minimumReleaseAge` window — **no policy exception needed**).
- All 3121 mcp-node tests pass unchanged; `ext-apps` 1.7.5 typechecks against the v2 `McpServer`.

### Stage 2 — dual-era serving (explicit opt-in per the SDK's migration guide)

- **HTTP `/mcp`**: modern (2026-07-28) requests — self-contained, no `initialize`, no `Mcp-Session-Id` — are served by `createMcpHandler` with our per-request `createMcpServer` factory: the same stateless idiom this endpoint has always used, now spec-level. Era routing uses `isLegacyRequest`, the exact classification the entry itself runs. The modern handler is `legacy: 'reject'` **deliberately**: 2025-era traffic keeps the pre-existing hand-wired path, whose `enableJsonResponse: true` preserves the plain-JSON response framing the stdio proxy and the web app's daemon client parse (the entry's built-in legacy fallback does not set it).
- **stdio**: `main()` now goes through `serveStdio(factory)` — the opening exchange pins the connection's era. A direct `server.connect(new StdioServerTransport())` would speak only 2025.

### Logging (deprecated capability)

The core Logging capability (`logging/setLevel` + `notifications/message`) keeps serving legacy-era sessions unchanged. On modern-era requests the SDK emits log notifications only when the client opts in via the `io.modelcontextprotocol/logLevel` `_meta` key; structured logs always reach stderr regardless. Documented in `docs/contributing/mcp-debugging.md`; the OTel-based successor is tracked in canvas `mcp-2026-07-28-spec-migration`.

## Verification

- **Red first (HTTP)**: a modern-pinned v2 `Client` (`versionNegotiation: { pin: '2026-07-28' }`, no legacy fallback) connects to `/mcp`, lists tools, and calls `wb_canvas_create` — fails on main, passes here.
- **stdio both eras**: `serve-stdio-eras.test.ts` drives the real `createMcpServer` factory through `serveStdio` over linked in-memory transports with a legacy client and a modern-pinned client.
- **Live daemon (real clients)**: legacy era via this repo's actual stdio-proxy MCP session (`wb_canvas_list` through the dev daemon); modern era via raw enveloped `tools/list` and `tools/call` (`MCP-Protocol-Version: 2026-07-28`, `Mcp-Method`/`Mcp-Name` headers, `_meta` protocolVersion/clientCapabilities) — returned all 16 tools, `structuredContent` with 149 canvases, `resultType: "complete"`, and `io.modelcontextprotocol/serverInfo` in result `_meta`.
- Full gates: 3121 mcp-node tests, `pnpm smoke:e2e` ALL OK, `pnpm build`, typecheck, biome, knip.

## Notes for review

- `registerToolWithAnnotations`' Zod `inputSchema`/`outputSchema` single-source-of-truth binding is untouched (v2 keeps the `registerTool` shape; the codemod wrapped one raw `argsSchema` object literal in `z.object()`).
- Legacy-response-framing compatibility is the one deliberate divergence from the SDK's "one entry, both eras" default — called out inline in `app.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modern MCP protocol connections, including protocol negotiation and version verification.
  * Preserved compatibility with legacy MCP clients.
  * Improved stdio-based MCP serving with clearer lifecycle handling and error reporting.
  * Modern MCP requests now receive enhanced debug logging and error handling.

* **Documentation**
  * Updated MCP debugging guidance with protocol-era behavior, transport handling, logging, negotiation, and verification details.

* **Tests**
  * Expanded coverage for modern and legacy connections, tool discovery, and canvas creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->