### PR TITLE
feat(web): one connection chip replaces the standing connection banners

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-popover": "^1.1.23",
     "@radix-ui/react-scroll-area": "^1.2.18",
     "@radix-ui/react-separator": "^1.1.15",
     "@radix-ui/react-slot": "^1.3.3",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -275,22 +275,24 @@ describe('/pair consent route', () => {
 })
 
 describe('App backend configuration chip', () => {
-  it('shows "Browser only" when configured for browser-local storage', () => {
+  it('renders no fixed backend-config overlay (D1: the header connection chip owns this)', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <App providerState={BROWSER_LOCAL_STATE} />
       </MemoryRouter>,
     )
-    expect(screen.getByText('Browser only')).toBeTruthy()
+    expect(screen.queryByTestId('backend-config-chip')).toBeNull()
+    expect(screen.queryByText('Browser only')).toBeNull()
   })
 
-  it('shows the daemon URL when configured for a local daemon', () => {
+  it('renders no daemon-URL overlay when configured for a local daemon', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <App providerState={LOCAL_DAEMON_STATE} />
       </MemoryRouter>,
     )
-    expect(screen.getByText('Configured for local daemon at http://127.0.0.1:3000')).toBeTruthy()
+    expect(screen.queryByTestId('backend-config-chip')).toBeNull()
+    expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
   })
 
   it('does not render the chip on the invalid-config error page', () => {
@@ -684,7 +686,7 @@ describe('App local-daemon provider state', () => {
     expect(receivedDaemonPageProps?.slug).toBe('canvas-b')
   })
 
-  it('escapes to browser-local with BROWSER_LOCAL_CAPABILITIES and neutral chip/banner copy', async () => {
+  it('escapes to browser-local with BROWSER_LOCAL_CAPABILITIES and neutral banner copy', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <App providerState={LOCAL_DAEMON_STATE} />
@@ -706,7 +708,6 @@ describe('App local-daemon provider state', () => {
     expect(screen.getByTestId('browser-local-canvas-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-canvas-page')).toBeNull()
     expect(receivedCapabilities).toEqual(BROWSER_LOCAL_CAPABILITIES)
-    expect(screen.getByText('Browser only')).toBeTruthy()
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
     expect(
       screen.getByText('Beta preview — your data is stored only in this browser.'),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,13 +70,6 @@ interface AppProps {
   providerState?: ProviderState
 }
 
-interface BackendConfigChipProps {
-  // invalid-config renders its own error page and never shows the chip;
-  // excluding it here lets the compiler prove that instead of a silent
-  // 'Browser only' fallback.
-  state: Exclude<ProviderState, { kind: 'invalid-config' }>
-}
-
 // Suspense fallback shared by every lazy page chunk (DaemonCanvasPage and
 // BrowserLocalCanvasPage). The height class differs by mount site (root
 // fills the viewport; the in-banner branches fill the flex row under it), so
@@ -91,27 +84,6 @@ function LazyPageFallback({ heightClass, message }: { heightClass: string; messa
       className={`flex ${heightClass} items-center justify-center text-sm text-muted-foreground`}
     >
       {message}
-    </div>
-  )
-}
-
-// Reports the configured storage backend only — this reflects runtime
-// config, not a live connection/detection probe. Do not claim 'Connected'
-// or 'Daemon unavailable' here; that needs an actual live probe.
-// Fixed-positioned overlay: the canvas page owns the full viewport (h-dvh),
-// so an in-flow sibling would push it down and create a page scrollbar.
-function BackendConfigChip({ state }: BackendConfigChipProps) {
-  const label =
-    state.kind === 'local-daemon'
-      ? `Configured for local daemon at ${state.daemonBaseUrl}`
-      : 'Browser only'
-
-  return (
-    <div
-      data-testid="backend-config-chip"
-      className="fixed right-2 bottom-2 z-50 flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs font-medium text-muted-foreground shadow-sm"
-    >
-      {label}
     </div>
   )
 }
@@ -450,7 +422,6 @@ export function App({ providerState }: AppProps) {
             store={userSettingsStore}
             message="Beta preview — features may be incomplete."
           />
-          <BackendConfigChip state={effectiveState} />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Suspense
               fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
@@ -497,7 +468,6 @@ export function App({ providerState }: AppProps) {
           store={userSettingsStore}
           message="Beta preview — your data is stored only in this browser."
         />
-        <BackendConfigChip state={effectiveState} />
         {grantConnection?.status === 'identity-mismatch' && !grantErrorDismissed && (
           // Fail-closed renewal refusal: a PINNED daemon answered with a
           // wrong or missing identity signature. Either the daemon rotated

--- a/apps/web/src/components/BetaBanner.tsx
+++ b/apps/web/src/components/BetaBanner.tsx
@@ -9,7 +9,7 @@ interface BetaBannerProps {
 }
 
 // Thin top banner, not fixed-positioned, so it stays clear of
-// BackendConfigChip's bottom-right fixed overlay in App.tsx.
+// the connection chip in the page header (ConnectionStatus).
 export function BetaBanner({ store, message }: BetaBannerProps) {
   const [dismissedAt, setDismissedAt] = useState(() => store.load().storage.dismissedBetaBannerAt)
 

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -84,6 +84,10 @@ interface Props {
   // app's or Excalidraw's own) produces one.
   onExport?: (format: SceneExportFormat) => Promise<Blob | null>
   onOpenSettings?: () => void
+  // Right-side slot ahead of the secondary actions — the host page's
+  // connection-state chip (design refactor D1) mounts here so the one
+  // status affordance lives in the header instead of a banner row.
+  statusSlot?: ReactNode
 }
 
 // Give the canvas visual priority and keep the surrounding chrome lightweight.
@@ -115,6 +119,7 @@ export default function WorkspaceTopBar({
   versionPanelExtra,
   onExport,
   onOpenSettings,
+  statusSlot,
 }: Props) {
   const isLocalMode = dataMode === 'local'
   const versionsEnabled = capabilities?.versions ?? true
@@ -376,6 +381,7 @@ export default function WorkspaceTopBar({
         )}
       </div>
 
+      {statusSlot}
       <TopBarSecondaryActions
         versionsEnabled={versionsEnabled}
         onToggleVersionOpen={() => setVersionOpen((v) => !v)}

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -14,8 +14,10 @@ describe('ConnectionStatus chip', () => {
 
     const chip = screen.getByRole('button', { name: /synced/i })
     expect(chip).toBeTruthy()
-    // No standing sentence copy outside the popover.
-    expect(screen.queryByText(/data lives/i)).toBeNull()
+    // No standing sentence copy outside the popover: the actual popover
+    // explanation must not be rendered until the chip is opened.
+    expect(screen.queryByText(/changes are saved to your local daemon/i)).toBeNull()
+    expect(screen.queryByText(/live sync is on/i)).toBeNull()
 
     fireEvent.click(chip)
     expect(await screen.findByText(/live sync is on/i)).toBeTruthy()

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -1,0 +1,66 @@
+// D1 of the design refactor (brief: design-refactor-brief-2026-08-08): the
+// connection story collapses from standing banners into ONE header chip.
+// The chip is the always-visible state signal; everything sentence-shaped
+// (explanation, data location, recovery actions) lives in its popover.
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ConnectionStatus } from './ConnectionStatus.js'
+
+afterEach(cleanup)
+
+describe('ConnectionStatus chip', () => {
+  it('synced state shows a quiet chip and explains where data lives in the popover', async () => {
+    render(<ConnectionStatus state="synced" daemonBaseUrl="http://127.0.0.1:3099" />)
+
+    const chip = screen.getByRole('button', { name: /synced/i })
+    expect(chip).toBeTruthy()
+    // No standing sentence copy outside the popover.
+    expect(screen.queryByText(/data lives/i)).toBeNull()
+
+    fireEvent.click(chip)
+    expect(await screen.findByText(/live sync is on/i)).toBeTruthy()
+    expect(screen.getByText(/127\.0\.0\.1:3099/)).toBeTruthy()
+  })
+
+  it('local state explains browser-only storage and hosts extra content (daemon detection)', async () => {
+    render(
+      <ConnectionStatus state="local">
+        <button type="button">Use here</button>
+      </ConnectionStatus>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /local/i }))
+    expect(await screen.findByText(/only in this browser/i)).toBeTruthy()
+    // The slot for daemon-detection / capability content renders inside.
+    expect(screen.getByRole('button', { name: 'Use here' })).toBeTruthy()
+  })
+
+  it('sync-off state carries attention styling and BOTH recovery actions', async () => {
+    const onRepair = vi.fn()
+    const onContinueBrowserLocal = vi.fn()
+    render(
+      <ConnectionStatus
+        state="sync-off"
+        onRepair={onRepair}
+        onContinueBrowserLocal={onContinueBrowserLocal}
+      />,
+    )
+
+    const chip = screen.getByRole('button', { name: /sync off/i })
+    fireEvent.click(chip)
+    expect(await screen.findByText(/rejected this session/i)).toBeTruthy()
+    // The dead-end fix: the popover states where edits are going...
+    expect(screen.getByText(/edits stay in this browser/i)).toBeTruthy()
+    // ...and offers both ways forward.
+    fireEvent.click(screen.getByRole('button', { name: /re-pair/i }))
+    expect(onRepair).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: /continue in browser-local/i }))
+    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+  })
+
+  it('sync-off announces itself to assistive tech without a visual banner', () => {
+    render(<ConnectionStatus state="sync-off" onRepair={vi.fn()} />)
+    // A polite live region replaces the old role="alert" banner.
+    expect(screen.getByRole('status', { name: /live sync off/i })).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -1,0 +1,130 @@
+/**
+ * The ONE connection-state affordance (design refactor D1). A small header
+ * chip signals the state; every sentence-shaped explanation and recovery
+ * action lives in its popover — no standing banners.
+ *
+ * States:
+ * - `synced`   — daemon-backed page with live sync running.
+ * - `local`    — browser-local page; data exists only in this browser.
+ *                `children` hosts page-supplied extras (daemon detection,
+ *                capability hint) inside the popover.
+ * - `sync-off` — daemon-backed page whose session was rejected. The chip
+ *                turns attention-colored and the popover carries the two
+ *                ways forward (re-pair / continue browser-local). A polite
+ *                sr-only live region announces the transition so dropping
+ *                the old role="alert" banner loses no assistive-tech signal.
+ */
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
+
+export type ConnectionState = 'synced' | 'local' | 'sync-off'
+
+export interface ConnectionStatusProps {
+  readonly state: ConnectionState
+  /** Shown in the synced popover so the user knows which daemon holds the data. */
+  readonly daemonBaseUrl?: string
+  /** sync-off only: starts the pairing grant flow on the daemon's /pair page. */
+  readonly onRepair?: () => void
+  /** sync-off only: switches this canvas to the browser-local flow. */
+  readonly onContinueBrowserLocal?: () => void
+  /** local only: page-supplied popover extras (daemon detection, capability hint). */
+  readonly children?: ReactNode
+}
+
+const CHIP_LABEL: Record<ConnectionState, string> = {
+  synced: 'Synced',
+  local: 'Local',
+  'sync-off': 'Sync off',
+}
+
+const DOT_CLASS: Record<ConnectionState, string> = {
+  synced: 'bg-emerald-500',
+  local: 'bg-muted-foreground/60',
+  'sync-off': 'bg-amber-500',
+}
+
+export function ConnectionStatus({
+  state,
+  daemonBaseUrl,
+  onRepair,
+  onContinueBrowserLocal,
+  children,
+}: ConnectionStatusProps) {
+  return (
+    <Popover>
+      {state === 'sync-off' && (
+        <span role="status" aria-label="Live sync off" className="sr-only">
+          Live sync off
+        </span>
+      )}
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="connection-chip"
+          className={cn(
+            'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
+            state === 'sync-off' && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
+          )}
+        >
+          <span aria-hidden="true" className={cn('size-2 rounded-full', DOT_CLASS[state])} />
+          {CHIP_LABEL[state]}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent data-testid="connection-popover">
+        {state === 'synced' && (
+          <div className="flex flex-col gap-1 text-sm">
+            <p className="font-medium">Live sync is on</p>
+            <p className="text-muted-foreground">
+              Changes are saved to your local daemon
+              {daemonBaseUrl ? (
+                <>
+                  {' at '}
+                  <span className="font-mono text-xs">
+                    {daemonBaseUrl.replace(/^https?:\/\//, '')}
+                  </span>
+                </>
+              ) : null}
+              .
+            </p>
+          </div>
+        )}
+        {state === 'local' && (
+          <div className="flex flex-col gap-2 text-sm">
+            <p className="font-medium">Browser-local canvas</p>
+            <p className="text-muted-foreground">Your data is stored only in this browser.</p>
+            {children}
+          </div>
+        )}
+        {state === 'sync-off' && (
+          <div className="flex flex-col gap-2 text-sm">
+            <p className="font-medium">Live sync is off</p>
+            <p className="text-muted-foreground">
+              The daemon rejected this session, so edits stay in this browser until you re-pair.
+            </p>
+            <div className="mt-1 flex flex-col gap-1.5">
+              {onRepair && (
+                <button
+                  type="button"
+                  onClick={onRepair}
+                  className="rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent"
+                >
+                  Re-pair with the daemon
+                </button>
+              )}
+              {onContinueBrowserLocal && (
+                <button
+                  type="button"
+                  onClick={onContinueBrowserLocal}
+                  className="rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent"
+                >
+                  Continue in browser-local
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,36 @@
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import type * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = 'end',
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-80 rounded-lg border bg-popover p-3 text-popover-foreground shadow-md outline-none',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverContent, PopoverTrigger }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -738,17 +738,26 @@ describe('BrowserLocalCanvasPage', () => {
     const CTA_TEXT =
       'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
 
-    it('shows a single compact CTA line instead of the four daemon-only teaser buttons', async () => {
+    it('moves the capability CTA into the Local connection chip popover (D1: no standing copy)', async () => {
       const store = new MemoryStore()
       await store.setDefaultCanvasId('c1')
       await store.save(snap)
       await act(async () => {
         render(<BrowserLocalCanvasPage store={store} />)
       })
-      expect(screen.getAllByText(CTA_TEXT)).toHaveLength(1)
+      // No sentence-length CTA sits in the page chrome anymore...
+      expect(screen.queryByText(CTA_TEXT)).toBeNull()
       for (const label of ['Version history', 'Workspaces', 'Branches', 'Merge']) {
         expect(screen.queryByRole('button', { name: label })).toBeNull()
       }
+      // ...it lives in the Local chip's popover, next to the storage note.
+      // (Synchronous assertions: this file runs under fake timers, so
+      // findBy*'s real-timer polling would hang.)
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('connection-chip'))
+      })
+      expect(screen.getByText(/only in this browser/i)).toBeTruthy()
+      expect(screen.getByText(CTA_TEXT)).toBeTruthy()
     })
 
     it('does not render any mode-switch control — mode stays a read-only status', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
@@ -334,6 +335,20 @@ export function BrowserLocalCanvasPage({
         }
       >
         <WorkspaceTopBar
+          statusSlot={
+            <ConnectionStatus state="local">
+              <p className="text-muted-foreground">
+                Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
+                combining changes
+              </p>
+              <Suspense fallback={null}>
+                <DaemonDetectedBanner
+                  settingsStore={settingsStore}
+                  fetch={window.fetch.bind(window)}
+                />
+              </Suspense>
+            </ConnectionStatus>
+          }
           dataMode="local"
           workspaceId="local"
           slug={pageState.snapshot.id}
@@ -372,9 +387,6 @@ export function BrowserLocalCanvasPage({
           since <main> does not scope them the way sectioning content does. */}
       <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-1 text-xs">
         <span className="text-muted-foreground">{persistenceLabel(pageState.persistence)}</span>
-        <Suspense fallback={null}>
-          <DaemonDetectedBanner settingsStore={settingsStore} fetch={window.fetch.bind(window)} />
-        </Suspense>
         {cleanupError && (
           <div role="alert" aria-live="assertive" className="text-destructive">
             {cleanupError}
@@ -385,10 +397,6 @@ export function BrowserLocalCanvasPage({
             {duplicateError}
           </div>
         )}
-        <span className="ml-auto text-muted-foreground">
-          Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
-          combining changes
-        </span>
         <button
           type="button"
           aria-label="Duplicate canvas"

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -323,7 +323,7 @@ describe('DaemonCanvasPage', () => {
     expect(createdBackends[1]?.disconnectCount).toBe(0)
   })
 
-  it('shows a role=alert banner on WS auth failure (close 1008 -> onAuthError)', async () => {
+  it('flips the connection chip to "Sync off" on WS auth failure (close 1008 -> onAuthError)', async () => {
     await act(async () => {
       render(
         <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -331,22 +331,29 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Healthy session: the chip reads Synced.
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
 
     const backend = createdBackends[0]!
     await act(async () => {
       backend.handlers?.onAuthError?.()
     })
 
-    const alert = screen.getByRole('alert')
-    expect(alert.textContent).toMatch(/daemon rejected/i)
-    // Strengthened banner: an explicit "Live sync off" label, not just the
-    // re-pairing sentence, so the degraded state reads at a glance.
-    expect(alert.textContent).toMatch(/live sync off/i)
-    // Editor chrome stays mounted — auth error is a banner, not a full-page replacement.
+    // D1: no standing role=alert banner — the chip carries the state and a
+    // polite live region announces it to assistive tech.
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
+    expect(screen.getByRole('status', { name: /live sync off/i })).toBeTruthy()
+    // Editor chrome stays mounted — auth error never replaces the page.
     expect(screen.getByTestId('spatial-editor-container')).toBeTruthy()
+
+    // The popover is the recovery surface: both ways forward are offered.
+    fireEvent.click(screen.getByTestId('connection-chip'))
+    await waitFor(() => expect(screen.getByRole('button', { name: /re-pair/i })).toBeTruthy())
+    expect(screen.getByText(/edits stay in this browser/i)).toBeTruthy()
   })
 
-  it('shows a persistent "Sync off" indicator distinct from the alert banner while authError is true', async () => {
+  it('keeps the sr-only live region quiet until authError is true', async () => {
     await act(async () => {
       render(
         <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -361,12 +368,9 @@ describe('DaemonCanvasPage', () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
 
-    // Deliberately not role=alert — there must be exactly one alert on the
-    // page (the banner) so existing screen.getByRole('alert') calls stay
-    // unambiguous; the chip is a secondary, persistent status indicator.
-    const chip = screen.getByLabelText(/live sync off/i)
-    expect(chip.getAttribute('role')).not.toBe('alert')
-    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    const region = screen.getByLabelText(/live sync off/i)
+    expect(region.getAttribute('role')).toBe('status')
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('renders the "Sync off" indicator even when no canvas is selected', async () => {
@@ -424,7 +428,7 @@ describe('DaemonCanvasPage', () => {
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
-    expect(screen.getByRole('alert').textContent).toMatch(/daemon rejected/i)
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
     expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
 
     await act(async () => {
@@ -432,12 +436,12 @@ describe('DaemonCanvasPage', () => {
       await selectCanvasFromSwitcher('second')
     })
 
-    // The stale banner (and chip) must not outlive the backend that produced it.
-    expect(screen.queryByRole('alert')).toBeNull()
+    // The stale sync-off state must not outlive the backend that produced it.
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
     expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
   })
 
-  it('renders a browser-local escape button in the auth banner and invokes the callback', async () => {
+  it('offers the browser-local escape inside the chip popover and invokes the callback', async () => {
     const onContinueBrowserLocal = vi.fn()
     await act(async () => {
       render(
@@ -455,7 +459,13 @@ describe('DaemonCanvasPage', () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
 
-    const escapeButton = screen.getByRole('button', { name: /continue in browser-local/i })
+    // D1: the escape lives in the chip's popover, not a banner.
+    await act(async () => {
+      screen.getByTestId('connection-chip').click()
+    })
+    const escapeButton = await screen.findByRole('button', {
+      name: /continue in browser-local/i,
+    })
     await act(async () => {
       escapeButton.click()
     })

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -3,6 +3,7 @@ import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
+import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { MergeToast } from '../components/MergeToast.js'
@@ -17,6 +18,7 @@ import { getAppLogger } from '../lib/app-logger.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
+import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
@@ -274,6 +276,26 @@ export function DaemonCanvasPage({
       </div>
     ) : null
 
+  // The ONE connection affordance (design refactor D1): a header chip whose
+  // popover carries the explanation and both recovery paths. Re-pairing
+  // navigates top-level to the daemon's own /pair consent page — the same
+  // trust anchor first-time pairing uses.
+  const connectionStatus = (
+    <ConnectionStatus
+      state={authError ? 'sync-off' : 'synced'}
+      daemonBaseUrl={daemonBaseUrl}
+      onRepair={() => {
+        void beginPairingGrant({
+          daemonBaseUrl,
+          hostedOrigin: window.location.origin,
+          sessionStorage: window.sessionStorage,
+          navigate: (url) => window.location.assign(url),
+        })
+      }}
+      onContinueBrowserLocal={onContinueBrowserLocal}
+    />
+  )
+
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       <main className="relative flex h-dvh w-full flex-col">
@@ -287,48 +309,17 @@ export function DaemonCanvasPage({
             <span className="text-xs text-destructive">{controller.switchError}</span>
           </div>
         )}
-        {authError && (
-          <>
-            <div
-              role="alert"
-              aria-live="assertive"
-              className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-1"
-            >
-              <span aria-hidden="true" className="text-sm text-destructive">
-                ⚠
-              </span>
-              <span className="text-xs font-semibold text-destructive">Live sync off:</span>
-              <span className="text-xs text-destructive">
-                The daemon rejected this session. Try re-pairing.
-              </span>
-              {onContinueBrowserLocal && (
-                <button
-                  type="button"
-                  onClick={onContinueBrowserLocal}
-                  className="rounded-md border px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent"
-                >
-                  Continue in browser-local
-                </button>
-              )}
-            </div>
-            {/* Rendered at the page level (not inside `{canvas && ...}`) so the
-                degraded state stays visible even in the no-canvas/empty-workspace
-                view where WorkspaceTopBar itself doesn't mount. Deliberately
-                role="status" rather than role="alert": the page must keep exactly
-                one alert (the banner above) so existing screen.getByRole('alert')
-                assertions stay unambiguous, while this chip persists as a compact
-                reminder once attention moves past it. */}
-            <div
-              role="status"
-              aria-label="Live sync off"
-              className="flex w-fit items-center gap-1 self-start rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] font-medium text-destructive"
-            >
-              Sync off
-            </div>
-          </>
+        {/* Rendered at the page level when WorkspaceTopBar has nowhere to
+            mount (no-canvas/empty-workspace view) so the degraded state
+            never disappears with the canvas-gated chrome. */}
+        {authError && !canvas && (
+          <div className="flex items-center border-b bg-background px-4 py-1.5">
+            {connectionStatus}
+          </div>
         )}
         {canvas && (
           <WorkspaceTopBar
+            statusSlot={connectionStatus}
             workspaceId={canvas.workspaceId}
             slug={canvas.slug}
             canvases={controller.canvases}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.24
         version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.18
         version: 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3114,6 +3117,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.24':
     resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.23':
+    resolution: {integrity: sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -9963,6 +9979,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.5)
       aria-hidden: 1.2.6
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## What

**Design refactor D1** (user-approved brief `design-refactor-brief-2026-08-08`, method: ui-skills improve-ui audit + shape interview): the connection story collapses from standing banners into **one header chip** — Synced 🟢 / Local ⚪ / Sync off 🟠 — whose popover carries everything sentence-shaped.

- **DaemonCanvasPage**: the red "Live sync off" alert banner and its twin status pill are gone. On a rejected session the chip flips to Sync off; the popover states where edits are going ("edits stay in this browser") and offers **both** ways forward — *Re-pair with the daemon* (top-level `/pair` grant, the same trust anchor as first-time pairing) and *Continue in browser-local*. A polite sr-only live region preserves the assistive-tech announcement the alert used to provide. The chip renders standalone when no canvas is selected so the degraded state never disappears with the canvas-gated chrome.
- **BrowserLocalCanvasPage**: the standing capability CTA sentence and the inline daemon-detected banner move into the Local chip's popover; the sub-row shrinks to save status + Duplicate/Delete.
- **App**: the fixed bottom-right `BackendConfigChip` overlay ("Browser only" / "Configured for local daemon at …") is deleted — a second visual voice for the same story.
- New `ui/popover` primitive (`@radix-ui/react-popover` 1.1.23, same Radix family, clears the 7-day release-age window); `WorkspaceTopBar` gains a `statusSlot`.

## Visual repro

Before — three layers of standing text (probe banner, capability CTA, config pill) crowd a whiteboard:

![d1-before-banners.jpg](https://github.com/user-attachments/assets/03da79b6-dc30-4f88-b30a-159f20acea7e)

After — one Local chip; the chrome recedes and the canvas is the page:

![d1-after-clean.jpg](https://github.com/user-attachments/assets/3d24c2c3-1a92-4655-8f60-b1e04049d583)

The chip's popover carries the explanation, the capability hint, and the daemon-detection flow (Check for local daemon):

![d1-after-popover.jpg](https://github.com/user-attachments/assets/1744156c-1991-4d5f-9878-efce680c99c8)

## Test plan

- [x] `ConnectionStatus` unit tests (4): per-state chip + popover content; sync-off popover carries BOTH recovery actions; sr-only status region (red first)
- [x] DaemonCanvasPage tests rewritten to the chip contract: Synced→Sync off flip on `onAuthError`, no `role="alert"`, editor stays mounted, popover recovery actions, state clears on canvas switch, standalone chip with no canvas
- [x] BrowserLocalCanvasPage: CTA sentence absent from chrome, present in popover; save-status/duplicate/delete row unchanged
- [x] App: no fixed backend-config overlay in any provider state
- [x] Full apps/web: 1403 jsdom, 226/227 browser (1 = known `source-pane-softwrap-load-flake`), typecheck, biome, knip
- [x] Live verification on the dev server (screenshots above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a connection-status chip for synced, local, and sync-off states.
  - Added popover details, recovery actions, browser-local continuation, and accessible sync-loss announcements.
  - Added connection status to the workspace header for consistent visibility.
  - Added support for deferred daemon notifications within the header.
- **UX Improvements**
  - Moved daemon configuration and recovery information from page banners into the connection chip.
  - Removed duplicate connection messaging from canvas toolbars.
  - Preserved editor access during authentication failures while providing recovery options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->