### PR TITLE
feat(web): canvas-only top level — Storage and pairing move into Settings

### DIFF
--- a/apps/web/src/components/PairedOriginsCard.tsx
+++ b/apps/web/src/components/PairedOriginsCard.tsx
@@ -145,7 +145,7 @@ export function PairedOriginsCard() {
           <ul className="space-y-1.5">
             {state.grants.map((grant) => (
               <li key={grant.grantId} className="flex items-center justify-between gap-2 text-xs">
-                <span className="truncate font-mono">{grant.origin}</span>
+                <span className="min-w-0 break-all font-mono">{grant.origin}</span>
                 <button
                   type="button"
                   aria-label={`Revoke ${grant.origin}`}

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -71,7 +71,7 @@ const CATEGORIES: CategoryDescriptor[] = [
   {
     key: 'libraries',
     label: 'User libraries',
-    description: 'Excalidraw library packs you installed',
+    description: 'Library packs you installed',
     softCapBytes: USER_LIBRARIES_SOFT_CAP_BYTES,
   },
 ]
@@ -483,7 +483,9 @@ export function StorageReportCard() {
         </Button>
       </div>
 
-      {error && <div className="text-xs text-destructive">Error: {error}</div>}
+      {error && (
+        <div className="text-xs text-destructive">Couldn't load storage usage ({error}).</div>
+      )}
 
       <ul className="rounded-lg border divide-y">
         {CATEGORIES.map(({ key, label, description, softCapBytes }) => {
@@ -635,9 +637,9 @@ export function StorageReportCard() {
           <DialogHeader>
             <DialogTitle>User libraries</DialogTitle>
             <DialogDescription>
-              Installed Excalidraw library packs. Removing a pack deletes its{' '}
-              <code>.excalidrawlib</code> file from disk and drops the registry row — canvases that
-              referenced it keep their embedded copies of any item already inserted.
+              Installed library packs. Removing a pack deletes its <code>.excalidrawlib</code> file
+              from disk and drops the registry row — canvases that referenced it keep their embedded
+              copies of any item already inserted.
             </DialogDescription>
           </DialogHeader>
           {libsLoading ? (

--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { Monitor, Moon, Palette, Sun } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useCallback, useId } from 'react'
 import {
   Dialog,
@@ -17,6 +18,11 @@ interface SettingsPanelProps {
   onThemeChange: (next: ThemeMode) => void
   webMcpEnabled: boolean
   onWebMcpChange?: (enabled: boolean) => void
+  // Host-supplied operational sections (design refactor D2): the daemon
+  // index passes its Paired-web-apps and Storage cards here so those
+  // surfaces live under Settings instead of a top-level tab. Browser-local
+  // hosts omit it.
+  extraSections?: ReactNode
 }
 
 const THEME_OPTIONS: Array<{ value: ThemeMode; label: string; icon: typeof Sun }> = [
@@ -34,6 +40,7 @@ export function SettingsPanel({
   onThemeChange,
   webMcpEnabled,
   onWebMcpChange,
+  extraSections,
 }: SettingsPanelProps) {
   const themeGroupId = useId()
   const webMcpLabelId = useId()
@@ -120,6 +127,8 @@ export function SettingsPanel({
               </button>
             </div>
           </section>
+
+          {extraSections}
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -57,7 +57,11 @@ export function SettingsPanel({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+      <DialogContent
+        className="max-h-[85dvh] overflow-y-auto sm:max-w-md data-[has-extra=true]:sm:max-w-xl"
+        data-has-extra={extraSections != null}
+        aria-describedby={undefined}
+      >
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription className="sr-only">Application settings</DialogDescription>

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -56,14 +56,14 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('DaemonIndexPage Files tab', () => {
+describe('DaemonIndexPage tree view', () => {
   it('shows the alias tree and previews a canvas OKF on click', async () => {
     installFetchMock()
     render(
       <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenCanvas={() => {}} />,
     )
 
-    fireEvent.click(await screen.findByRole('tab', { name: 'Files' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('workspace-files-panel')).not.toBeNull()

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -573,7 +573,7 @@ describe('DaemonIndexPage', () => {
     expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 
-  it('mounts StorageReportCard when the Storage tab is selected', async () => {
+  it('has no Storage tab — storage and pairing live in Settings (design refactor D2)', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }],
       canvasesByWorkspace: { 'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }] },
@@ -582,9 +582,30 @@ describe('DaemonIndexPage', () => {
     render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
     await screen.findByText('alpha')
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Storage' }))
+    // The top level is the canvas surface only: no tablist at all.
+    expect(screen.queryByRole('tab')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Storage' })).toBeNull()
 
+    // The operational surfaces open from Settings instead.
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
     expect(await screen.findByText('Storage usage')).toBeTruthy()
-    expect(screen.queryByTestId('daemon-index-canvas-card')).toBeNull()
+    expect(screen.getByText('Paired web apps')).toBeTruthy()
+    // The canvas grid stays mounted behind the dialog.
+    expect(screen.getByTestId('daemon-index-canvas-card')).toBeTruthy()
+  })
+
+  it('offers Grid/Tree as a view toggle of the one canvas surface', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }] },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    const grid = screen.getByRole('button', { name: 'Grid view' })
+    const tree = screen.getByRole('button', { name: 'Tree view' })
+    expect(grid.getAttribute('aria-pressed')).toBe('true')
+    expect(tree.getAttribute('aria-pressed')).toBe('false')
   })
 })

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -1,11 +1,14 @@
 import { workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { LayoutGrid, ListTree, Settings } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { z } from 'zod'
 import { CanvasThumb } from '../components/CanvasThumb.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
+import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import { useThemeMode } from '../hooks/useThemeMode.js'
 import {
   createCanvas,
   createDaemonFetch,
@@ -18,6 +21,7 @@ import {
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import { deriveCopySlug } from '../lib/derive-copy-slug.js'
 import type { WhiteboardCapabilities } from '../lib/provider.js'
+import { createUserSettingsStore } from '../lib/user-settings-store.js'
 
 // A gallery for a connected daemon, scoped to ONE workspace at a time — the
 // workspace selector picks which workspace's canvases populate the grid.
@@ -96,7 +100,7 @@ function formatRelative(iso: string): string {
   return `${Math.floor(diff / 86400)}d ago`
 }
 
-type TabKey = 'canvases' | 'files' | 'storage'
+type ViewKey = 'grid' | 'tree'
 
 export function DaemonIndexPage({
   daemonBaseUrl,
@@ -106,7 +110,13 @@ export function DaemonIndexPage({
 }: DaemonIndexPageProps) {
   const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
 
-  const [tab, setTab] = useState<TabKey>('canvases')
+  const [view, setView] = useState<ViewKey>('grid')
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const { theme, setTheme } = useThemeMode()
+  const [settingsStore] = useState(() => createUserSettingsStore())
+  const [webMcpEnabled, setWebMcpEnabled] = useState(
+    () => settingsStore.load().capabilities.webMcpEnabled !== false,
+  )
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
   const [rows, setRows] = useState<CanvasRow[]>([])
@@ -266,43 +276,7 @@ export function DaemonIndexPage({
       <div className="flex h-dvh flex-col overflow-y-auto p-4">
         <h1 className="sr-only">Canvases</h1>
         <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
-          <div
-            role="tablist"
-            aria-label="Daemon index tabs"
-            className="flex items-center gap-1 rounded-md border p-0.5"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'canvases'}
-              onClick={() => setTab('canvases')}
-              className="rounded px-3 py-1 text-sm font-medium data-[selected=true]:bg-accent"
-              data-selected={tab === 'canvases'}
-            >
-              Canvases
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'files'}
-              onClick={() => setTab('files')}
-              className="rounded px-3 py-1 text-sm font-medium data-[selected=true]:bg-accent"
-              data-selected={tab === 'files'}
-            >
-              Files
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'storage'}
-              onClick={() => setTab('storage')}
-              className="rounded px-3 py-1 text-sm font-medium data-[selected=true]:bg-accent"
-              data-selected={tab === 'storage'}
-            >
-              Storage
-            </button>
-          </div>
-          {(tab === 'canvases' || tab === 'files') && workspaces.length > 0 && (
+          {workspaces.length > 0 && (
             <select
               aria-label="Workspace"
               value={selectedWorkspace ?? ''}
@@ -316,7 +290,7 @@ export function DaemonIndexPage({
               ))}
             </select>
           )}
-          {tab === 'canvases' && (
+          {view === 'grid' && (
             <>
               <input
                 aria-label="Search canvases"
@@ -347,6 +321,39 @@ export function DaemonIndexPage({
               </form>
             </>
           )}
+          <div className="ml-auto flex items-center gap-1">
+            {/* One canvas surface, two projections: the toggle switches how
+                the SAME list renders (thumbnail grid / alias tree+preview)
+                instead of the former Canvases-vs-Files tab split. */}
+            <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+              <button
+                type="button"
+                aria-label="Grid view"
+                aria-pressed={view === 'grid'}
+                onClick={() => setView('grid')}
+                className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+              >
+                <LayoutGrid className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label="Tree view"
+                aria-pressed={view === 'tree'}
+                onClick={() => setView('tree')}
+                className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+              >
+                <ListTree className="size-4" />
+              </button>
+            </div>
+            <button
+              type="button"
+              aria-label="Settings"
+              onClick={() => setSettingsOpen(true)}
+              className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <Settings className="size-4" />
+            </button>
+          </div>
         </div>
 
         {createError && (
@@ -360,12 +367,7 @@ export function DaemonIndexPage({
           </div>
         )}
 
-        {tab === 'storage' ? (
-          <div className="space-y-4">
-            <PairedOriginsCard />
-            <StorageReportCard />
-          </div>
-        ) : tab === 'files' ? (
+        {view === 'tree' ? (
           selectedWorkspace ? (
             <WorkspaceFilesPanel
               daemonFetch={daemonFetch}
@@ -441,6 +443,24 @@ export function DaemonIndexPage({
             })}
           </div>
         )}
+        <SettingsPanel
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          theme={theme}
+          onThemeChange={setTheme}
+          webMcpEnabled={webMcpEnabled}
+          onWebMcpChange={setWebMcpEnabled}
+          extraSections={
+            <>
+              <section aria-label="Paired web apps">
+                <PairedOriginsCard />
+              </section>
+              <section aria-label="Storage">
+                <StorageReportCard />
+              </section>
+            </>
+          }
+        />
       </div>
     </DaemonApiContext.Provider>
   )


### PR DESCRIPTION
## What

**Design refactor D2** (approved brief `design-refactor-brief-2026-08-08`): the top level becomes **one canvas surface**.

- The daemon index's Canvases / Files / Storage tablist is gone. **Files was never a different place** — it showed the same canvases as an alias tree + preview — so it becomes a **view toggle** (Grid ⧉ / Tree ☰) of the one surface instead of a sibling tab whose name contradicted its content.
- The Storage tab's operational surfaces (**Paired web apps**, **Storage usage**) move under **Settings** (new gear on the index toolbar), via a new `extraSections` slot on `SettingsPanel`. Security/ops management is a different audience at a different frequency; it no longer occupies top-level navigation.
- Legacy copy purged: "Excalidraw library packs" → "Library packs" (the feature survives; the era branding doesn't), and the raw `Error: HTTP 401` line is now a sentence ("Couldn't load storage usage (…)").

## Visual repro (live dev app, paired via the D1 chip popover flow)

Before — three parallel tabs, Files claiming to be a place, Storage top-level:

![d2-before-tabs.jpg](https://github.com/user-attachments/assets/89ae80d8-5eef-4ce5-ab3e-3396529ff127)

After — one canvas surface; Grid/Tree toggle + Settings gear on the right:

![d2-after-grid.jpg](https://github.com/user-attachments/assets/5218acce-0c92-4018-98f1-d48df8ea1ced)

Settings hosts Capabilities + Paired web apps + Storage usage (with the new error copy):

![d2-after-settings.jpg](https://github.com/user-attachments/assets/db229319-0061-43ab-8d71-e38a0a3229cb)

## Test plan

- [x] Red first: index has **no tab roles at all**; Storage reachable via the Settings dialog (canvas grid stays mounted behind it); Grid/Tree buttons carry `aria-pressed`
- [x] Former Files-tab test rewritten to the Tree-view toggle (alias tree + OKF preview unchanged underneath)
- [x] StorageReportCard tests green under the copy changes (19/19)
- [x] Full apps/web: 1404 jsdom, typecheck, biome, knip
- [x] Live verification: paired localhost:5199 through the D1 chip → grid, tree, and Settings all exercised (screenshots above)

## Notes

- The `HTTP 401` from the storage report endpoint visible in the screenshot is pre-existing (also present on the old Storage tab) and out of D2's scope — tracked separately.
- Chrome styling (button shapes, raw workspace id in the select) is D3 (design tokens), deliberately untouched here.
