### PR TITLE
feat(web): quiet borders by default + DESIGN.md + chrome cleanup

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,0 +1,64 @@
+# apps/web design system
+
+Direction (approved brief `design-refactor-brief-2026-08-08`): **quiet tool**
+(Linear/Figma lineage). The canvas content is the only hero; chrome recedes.
+Hierarchy comes from surfaces and whitespace, not boxes. Accent color carries
+**state meaning only** — never decoration.
+
+## Tokens
+
+All tokens live in `src/index.css` as CSS custom properties (oklch), mapped
+into Tailwind v4 via `@theme inline`. Light values on `:root`, dark on
+`.dark`. Do not hardcode palette values in components; if a component needs a
+color the tokens cannot express, that is a token-system change, not an inline
+value.
+
+| Token | Role |
+| --- | --- |
+| `--background` / `--foreground` | page surface and its text |
+| `--card`, `--popover` (+`-foreground`) | raised surfaces (cards, menus, popovers) |
+| `--primary` (+`-foreground`) | the one emphasized action per view |
+| `--secondary`, `--muted`, `--accent` (+`-foreground`) | quiet fills, de-emphasized text, hover fills |
+| `--destructive` | irreversible actions and error text ONLY |
+| `--border`, `--input`, `--ring` | hairlines, input outlines, focus rings |
+| `--radius` (sm/md/lg/xl derived) | one radius scale — never ad-hoc radii |
+
+State colors outside the shadcn set (used by `ConnectionStatus`):
+`emerald-500` = live/synced, `amber-500` = needs attention,
+`muted-foreground` = neutral/local. These are the ONLY approved uses of raw
+Tailwind palette colors in chrome.
+
+## Rules
+
+- **Borders are quiet by default.** `src/index.css` restores the token
+  border color for every element (Tailwind v4 makes bare `border`
+  currentColor otherwise — the source of the pre-refactor "black box" look).
+  Use bare `border`; add `border-<color>` only when the border itself
+  carries state.
+- **One accent per view** (baseline-ui): destructive red on at most the one
+  destructive control; the connection chip is the only stateful color in a
+  header.
+- **Buttons**: use `components/ui/button.tsx` variants
+  (`default`/`outline`/`ghost`/`destructive`, sizes `sm`/`icon`) instead of
+  hand-rolled `rounded-md border px-*` buttons. Icon-only buttons MUST have
+  an `aria-label`.
+- **Sentence-length copy never sits in chrome.** Explanations live in
+  popovers/tooltips/dialogs (see `ConnectionStatus`); chrome carries words
+  only as short labels ("Saved", "Local").
+- **Dialogs**: `max-h` + `overflow-y-auto` when content can grow; page-width
+  cards must wrap (`min-w-0`, `break-all` for unbreakable strings) before
+  entering a dialog.
+- **Raw identifiers are not chrome.** Ids appear in detail surfaces only;
+  single-choice selectors (one workspace) render nothing at all.
+- **Both themes always.** Any new color must be defined for `:root` and
+  `.dark`, and respect the WCAG 1.4.3/1.4.11 floors the contrast tests pin.
+- **Motion**: compositor props only (`transform`, `opacity`), ≤200ms for
+  interaction feedback, `prefers-reduced-motion` respected. No entrance
+  animation without an explicit reason.
+
+## Canvas theme (D4 boundary)
+
+Canvas rendering (nodes/edges/selection) is themed by canvas-render's
+`createSpatialTheme` — a separate authority whose palette will join this
+token language in slice D4. The editor UI must not restyle scene SVG output
+directly; export bytes never depend on the app's ambient UI theme.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -82,4 +82,18 @@
     background-color: var(--background);
     color: var(--foreground);
   }
+
+  /*
+   * Tailwind v4 dropped v3's gray default border color: a bare `border`
+   * utility now inherits currentColor, which painted every bordered chrome
+   * element with near-black text color — the "everything is a black box"
+   * look the design refactor removes. Restoring the token here is what
+   * makes `border` quiet by default; reach for `border-<color>` only when
+   * a border must carry state (destructive, amber attention, etc.).
+   */
+  *,
+  ::before,
+  ::after {
+    border-color: var(--color-border);
+  }
 }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '../components/ui/alert-dialog.js'
+import { Button } from '../components/ui/button.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
@@ -397,24 +398,28 @@ export function BrowserLocalCanvasPage({
             {duplicateError}
           </div>
         )}
-        <button
+        <Button
           type="button"
           aria-label="Duplicate canvas"
           disabled={isDuplicating}
           onClick={() => void handleDuplicate()}
-          className="rounded-md border px-3 py-1 font-medium transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
         >
           Duplicate
-        </button>
+        </Button>
         <AlertDialog>
           <AlertDialogTrigger asChild>
-            <button
+            <Button
               type="button"
               aria-label="Delete canvas"
-              className="rounded-md border px-3 py-1 font-medium text-destructive transition-colors hover:bg-destructive/10"
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
             >
               Delete
-            </button>
+            </Button>
           </AlertDialogTrigger>
           <AlertDialogContent>
             <AlertDialogHeader>

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -594,6 +594,34 @@ describe('DaemonIndexPage', () => {
     expect(screen.getByTestId('daemon-index-canvas-card')).toBeTruthy()
   })
 
+  it('hides the workspace selector when there is only one workspace (raw id demoted, D3)', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'dTMMrBP3c5ah8_SXTRVvC' }],
+      canvasesByWorkspace: {
+        dTMMrBP3c5ah8_SXTRVvC: [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    // One workspace = nothing to choose; the raw id has no reason to be
+    // page chrome. Multi-workspace daemons keep the selector.
+    expect(screen.queryByLabelText('Workspace')).toBeNull()
+  })
+
+  it('labels the new-canvas input with a placeholder instead of floating unlabeled', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }] },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    expect(screen.getByPlaceholderText('New canvas name…')).toBeTruthy()
+  })
+
   it('offers Grid/Tree as a view toggle of the one canvas surface', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }],

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -6,6 +6,7 @@ import { CanvasThumb } from '../components/CanvasThumb.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
+import { Button } from '../components/ui/button.js'
 import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
@@ -276,7 +277,7 @@ export function DaemonIndexPage({
       <div className="flex h-dvh flex-col overflow-y-auto p-4">
         <h1 className="sr-only">Canvases</h1>
         <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
-          {workspaces.length > 0 && (
+          {workspaces.length > 1 && (
             <select
               aria-label="Workspace"
               value={selectedWorkspace ?? ''}
@@ -308,16 +309,14 @@ export function DaemonIndexPage({
               >
                 <input
                   aria-label="New canvas name"
+                  placeholder="New canvas name…"
                   value={newCanvasSlug}
                   onChange={(event) => setNewCanvasSlug(event.target.value)}
                   className="rounded-md border bg-background px-2 py-1 text-sm"
                 />
-                <button
-                  type="submit"
-                  className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
-                >
+                <Button type="submit" variant="outline" size="sm">
                   Create canvas
-                </button>
+                </Button>
               </form>
             </>
           )}


### PR DESCRIPTION
## What

**Design refactor D3** (approved brief `design-refactor-brief-2026-08-08`): design tokens + chrome.

- **Root cause of the "black box" look, fixed with one rule**: Tailwind v4 made a bare `border` utility inherit `currentColor` (near-black text color), and `index.css` lacked the shadcn compat rule restoring the token border color. A base-layer `* { border-color: var(--color-border) }` makes every border the quiet `--border` hairline again — border color is now opt-in for state (destructive, amber attention) only.
- **`apps/web/DESIGN.md`** documents the (already-existing, previously undocumented) oklch token set and the usage rules: one accent per view, sentence copy never in chrome, `Button` variants over hand-rolled buttons, dialogs scroll, raw ids are not chrome, both themes always. This is the reference all later slices (D4 canvas theme, D5 states) build on.
- **Raw workspace id demoted**: the selector hides when there is exactly one workspace (the common local case); multi-workspace daemons keep it. Server-side workspace *naming* needs an API and is a tracked follow-up, not invented here.
- The unlabeled new-canvas input gains a placeholder; Create canvas / Duplicate / Delete adopt `Button` variants.

## Visual repro (live dev app)

Index after — hairline borders, no raw id, labeled inputs:

![d3-after-index.jpg](https://github.com/user-attachments/assets/78d41ab2-9334-4edb-a253-118eabeb3a36)

Canvas header after — quiet chrome with the D1 chip carrying the page's only state color (a real rejected session, live):

![d3-after-canvas-syncoff.jpg](https://github.com/user-attachments/assets/ea00b2e2-4f74-4f35-98a3-5645c47308af)

## Test plan

- [x] Red first: single-workspace selector hidden; new-canvas placeholder present
- [x] Full apps/web: 1406 jsdom, typecheck, biome, knip
- [x] Live verification light theme (screenshots); dark theme relies on the token indirection (no hardcoded colors added)
