### PR TITLE
feat(render): quiet spatial light palette — mid-neutral strokes, softer labels

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,7 +1,7 @@
 # apps/web design system
 
-Direction (approved brief `design-refactor-brief-2026-08-08`): **quiet tool**
-(Linear/Figma lineage). The canvas content is the only hero; chrome recedes.
+Direction: **quiet tool** (Linear/Figma lineage). The canvas content is the
+only hero; chrome recedes.
 Hierarchy comes from surfaces and whitespace, not boxes. Accent color carries
 **state meaning only** — never decoration.
 
@@ -56,9 +56,9 @@ Tailwind palette colors in chrome.
   interaction feedback, `prefers-reduced-motion` respected. No entrance
   animation without an explicit reason.
 
-## Canvas theme (D4 boundary)
+## Canvas theme boundary
 
 Canvas rendering (nodes/edges/selection) is themed by canvas-render's
-`createSpatialTheme` — a separate authority whose palette will join this
-token language in slice D4. The editor UI must not restyle scene SVG output
-directly; export bytes never depend on the app's ambient UI theme.
+`createSpatialTheme` — a separate authority that shares this document's
+direction. The editor UI must not restyle scene SVG output directly; export
+bytes never depend on the app's ambient UI theme.

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -85,7 +85,7 @@ interface Props {
   onExport?: (format: SceneExportFormat) => Promise<Blob | null>
   onOpenSettings?: () => void
   // Right-side slot ahead of the secondary actions — the host page's
-  // connection-state chip (design refactor D1) mounts here so the one
+  // connection-state chip mounts here so the one
   // status affordance lives in the header instead of a banner row.
   statusSlot?: ReactNode
 }

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -1,5 +1,5 @@
 /**
- * The ONE connection-state affordance (design refactor D1). A small header
+ * The ONE connection-state affordance. A small header
  * chip signals the state; every sentence-shaped explanation and recovery
  * action lives in its popover — no standing banners.
  *

--- a/apps/web/src/components/settings/SettingsPanel.tsx
+++ b/apps/web/src/components/settings/SettingsPanel.tsx
@@ -18,7 +18,7 @@ interface SettingsPanelProps {
   onThemeChange: (next: ThemeMode) => void
   webMcpEnabled: boolean
   onWebMcpChange?: (enabled: boolean) => void
-  // Host-supplied operational sections (design refactor D2): the daemon
+  // Host-supplied operational sections: the daemon
   // index passes its Paired-web-apps and Storage cards here so those
   // surfaces live under Settings instead of a top-level tab. Browser-local
   // hosts omit it.

--- a/apps/web/src/components/spatial-editor/editor-appearance.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-appearance.test.ts
@@ -20,15 +20,15 @@ const edge = { id: 'e', fromNode: 'a', toNode: 'b' }
 describe('createEditorAppearance', () => {
   it('resolves the light theme with the shared per-type fill and the accessible stroke', () => {
     // The stroke value stays byte-identical to the pre-theme-layer editor
-    // (`#333333`); node FILL now differentiates per type (canvas-render's
+    // (`#737373`); node FILL now differentiates per type (canvas-render's
     // shared palette), which is the theme layer's intended convergence with
     // the viewer/export surfaces — see package-canvas-render.md decision #8.
     const appearance = createEditorAppearance('light')
     expect(appearance.resolveNode(textNode).appearance).toEqual({
       fill: '#ffffff',
-      stroke: '#333333',
+      stroke: '#737373',
     })
-    expect(appearance.resolveEdge(edge as never)).toEqual({ stroke: '#333333' })
+    expect(appearance.resolveEdge(edge as never)).toEqual({ stroke: '#737373' })
   })
 
   it('resolves a dark palette with real contrast against the dark canvas surface', () => {
@@ -40,7 +40,7 @@ describe('createEditorAppearance', () => {
     expect(appearance.resolveEdge(edge as never)).toEqual({
       stroke: EDITOR_DARK_PALETTE.chromeStroke,
     })
-    expect(EDITOR_DARK_PALETTE.chromeStroke).not.toBe('#333333')
+    expect(EDITOR_DARK_PALETTE.chromeStroke).not.toBe('#737373')
     expect(EDITOR_DARK_PALETTE.chromeStroke).not.toBe(EDITOR_LIGHT_PALETTE.chromeStroke)
   })
 

--- a/apps/web/src/components/spatial-editor/scene-render.test.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.test.ts
@@ -55,8 +55,8 @@ describe('renderCanvasToSvg', () => {
     const light = renderCanvasToSvg(c, { measure: fakeMeasure, theme: 'light' })
     const dark = renderCanvasToSvg(c, { measure: fakeMeasure, theme: 'dark' })
     expect(omitted.svg).toBe(light.svg)
-    expect(omitted.svg).toContain('#333333')
-    expect(dark.svg).not.toContain('#333333')
+    expect(omitted.svg).toContain('#737373')
+    expect(dark.svg).not.toContain('#737373')
     expect(dark.svg).toContain('#9BA3AF')
   })
 

--- a/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
@@ -62,7 +62,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     }
   })
 
-  it('renders light-mode chrome as #737373, proving the light path is untouched', () => {
+  it('renders light-mode chrome with the light palette stroke (#737373)', () => {
     const { container } = render(
       <SpatialEditor
         canvas={twoNodeCanvasWithEdge()}

--- a/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
@@ -2,7 +2,7 @@
  * jsdom cannot tell us whether dark-mode chrome is actually *visible* — this
  * mounts SpatialEditor in a real browser and reads the injected SVG's real
  * attribute values, pinning the exact intended hex per theme (never merely
- * "not #333333", which would pass for any wrong color too).
+ * "not #737373", which would pass for any wrong color too).
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, render } from '@testing-library/react'
@@ -38,7 +38,7 @@ afterEach(() => {
 })
 
 describe('SpatialEditor theme chrome (real browser)', () => {
-  it('renders dark-mode chrome and edge stroke as the intended dark hex, never #333333', () => {
+  it('renders dark-mode chrome and edge stroke as the intended dark hex, never #737373', () => {
     document.documentElement.classList.add('dark')
     const { container } = render(
       <SpatialEditor
@@ -62,7 +62,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     }
   })
 
-  it('renders light-mode chrome as #333333, proving the light path is untouched', () => {
+  it('renders light-mode chrome as #737373, proving the light path is untouched', () => {
     const { container } = render(
       <SpatialEditor
         canvas={twoNodeCanvasWithEdge()}

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -276,7 +276,7 @@ export function DaemonCanvasPage({
       </div>
     ) : null
 
-  // The ONE connection affordance (design refactor D1): a header chip whose
+  // The ONE connection affordance: a header chip whose
   // popover carries the explanation and both recovery paths. Re-pairing
   // navigates top-level to the daemon's own /pair consent page — the same
   // trust anchor first-time pairing uses.

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -276,10 +276,11 @@ export function DaemonCanvasPage({
       </div>
     ) : null
 
-  // The ONE connection affordance: a header chip whose
-  // popover carries the explanation and both recovery paths. Re-pairing
-  // navigates top-level to the daemon's own /pair consent page — the same
-  // trust anchor first-time pairing uses.
+  // The ONE connection affordance: a header chip whose popover carries
+  // the explanation and the available recovery paths — re-pairing always,
+  // plus continue-in-browser-local when the host page provides that
+  // escape. Re-pairing navigates top-level to the daemon's own /pair
+  // consent page, the same trust anchor first-time pairing uses.
   const connectionStatus = (
     <ConnectionStatus
       state={authError ? 'sync-off' : 'synced'}

--- a/packages/canvas-render/src/layout/spatial-geometry-parity.test.ts
+++ b/packages/canvas-render/src/layout/spatial-geometry-parity.test.ts
@@ -50,9 +50,9 @@ function fakeParseBody(text: string): MdastRoot {
 // (explicitly, or via layout's 'sans-serif' fallback) and why the measurer
 // above is family-sensitive.
 const editorShaped: SpatialAppearanceResolver = {
-  resolveNode: () => ({ appearance: { fill: 'none', stroke: '#333333' } }),
-  resolveEdge: () => ({ stroke: '#333333' }),
-  resolveLabel: () => ({ fill: '#333333' }),
+  resolveNode: () => ({ appearance: { fill: 'none', stroke: '#737373' } }),
+  resolveEdge: () => ({ stroke: '#737373' }),
+  resolveLabel: () => ({ fill: '#737373' }),
 }
 
 const viewerShaped: SpatialAppearanceResolver = {

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -19,16 +19,13 @@ export interface SpatialPalette {
   readonly cornerRadiusPx: number
 }
 
-// Seeded from the pre-theme export composition root's chrome (per-type
-// fill/stroke) plus the pre-theme editor's accessible `#333333` text/stroke
-// — this is what lets a single stroke/label value keep clearing the WCAG
-// floors the editor already tested for, while node fill still
-// differentiates by kind the way export's chrome did.
 // Quiet-tool direction (apps/web/DESIGN.md): node and edge strokes sit at
-// a mid neutral instead of near-black — chrome recedes so content reads
-// first — while still
-// clearing the WCAG 1.4.11 non-text floor (#737373 vs white = 4.74:1);
-// labels stay comfortably past the 1.4.3 text floor (#404040 = 10.4:1).
+// a mid neutral instead of near-black so chrome recedes and content reads
+// first, while clearing the WCAG 1.4.11 non-text floor (#737373 vs white =
+// 4.74:1); labels stay comfortably past the 1.4.3 text floor (#404040 =
+// 10.4:1). Node fill still differentiates by kind — a real semantic worth
+// keeping on every surface — and one stroke/label value per mode is what
+// keeps the WCAG guarantee testable as a single producer.
 export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
   node: {
     text: { fill: '#ffffff', stroke: '#737373' },

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -24,19 +24,24 @@ export interface SpatialPalette {
 // — this is what lets a single stroke/label value keep clearing the WCAG
 // floors the editor already tested for, while node fill still
 // differentiates by kind the way export's chrome did.
+// Quiet-tool direction (apps/web/DESIGN.md): node and edge strokes sit at
+// a mid neutral instead of near-black — chrome recedes so content reads
+// first — while still
+// clearing the WCAG 1.4.11 non-text floor (#737373 vs white = 4.74:1);
+// labels stay comfortably past the 1.4.3 text floor (#404040 = 10.4:1).
 export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
   node: {
-    text: { fill: '#ffffff', stroke: '#333333' },
-    file: { fill: '#f5f5f5', stroke: '#333333' },
-    link: { fill: '#eef4ff', stroke: '#333333' },
+    text: { fill: '#ffffff', stroke: '#737373' },
+    file: { fill: '#f5f5f5', stroke: '#737373' },
+    link: { fill: '#eef4ff', stroke: '#737373' },
     // Groups stay unfilled: a filled group rect emitted in document order
     // alongside a member node would otherwise risk painting over/under it
     // depending on emission order.
-    group: { fill: 'none', stroke: '#333333' },
+    group: { fill: 'none', stroke: '#737373' },
   },
-  edgeStroke: '#333333',
-  labelFill: '#333333',
-  cornerRadiusPx: 4,
+  edgeStroke: '#737373',
+  labelFill: '#404040',
+  cornerRadiusPx: 6,
 }
 
 // Seeded from the pre-theme editor's dark palette (EDITOR_DARK_PALETTE) — a

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -105,7 +105,7 @@ describe('headless-renderer', () => {
 
   it('theme="dark" renders real dark chrome: edge stroke, label fill, and a root text fill', async () => {
     // A diagram whose meaning lives in its arrows must survive a dark
-    // export: light-theme edge chrome (#333333) on the dark background was
+    // export: light-theme edge chrome (#737373) on the dark background was
     // effectively invisible.
     const canvas = {
       nodes: [
@@ -119,13 +119,13 @@ describe('headless-renderer', () => {
     // Dark palette chrome (canvas-render SPATIAL_DARK_PALETTE).
     expect(darkSvg).toContain('stroke="#9BA3AF"')
     expect(darkSvg).toContain('fill="#E6E8EB"')
-    expect(darkSvg).not.toContain('stroke="#333333"')
+    expect(darkSvg).not.toContain('stroke="#737373"')
     // Root-level inheritable text fill so body runs are legible on dark.
     expect(darkSvg).toMatch(/<svg [^>]*fill="#E6E8EB">/)
 
     // The light export is byte-stable: no root fill, light chrome only.
     const lightSvg = (await renderSpatialCanvasToSvg(canvas, { theme: 'light' })).svg
-    expect(lightSvg).toContain('stroke="#333333"')
+    expect(lightSvg).toContain('stroke="#737373"')
     expect(lightSvg).not.toMatch(/<svg [^>]*fill=/)
   })
 


### PR DESCRIPTION
## What

The canvas joins the quiet-tool direction (`apps/web/DESIGN.md`): the light spatial palette's `#333333` strokes were the canvas-side half of the black-box look the app chrome shed in #461.

- Node + edge strokes: `#333333` → `#737373` (WCAG 1.4.11 non-text floor: **4.74:1** on white)
- Label fill: `#333333` → `#404040` (WCAG 1.4.3 text floor: **10.4:1**)
- Node corner radius: 4 → 6 (sits with the UI radius scale)
- Node fills (per-kind semantic tints) and the **dark palette are unchanged**

The `createSpatialTheme` single-authority model means editor, viewer, and export all pick this up from one place. The invariant that the ambient UI theme never changes exported bytes is untouched — this is a **deliberate palette change**, applied by updating the pinned values in the editor-appearance, geometry-parity, scene-render, and headless-export tests (the floor-based WCAG contrast tests passed without modification, as designed).

Also removes internal design-process references from `DESIGN.md` and source comments (user feedback): durable files describe the direction, not the project chronology.

## Visual repro (live dev app)

Nodes, edge, and labels on the new palette — same visual language as the app chrome:

![d4-canvas-quiet.jpg](https://github.com/user-attachments/assets/fbdf099b-1c4e-4f5f-ada4-48e77b84ec15)

DOM-verified live: `rect stroke="#737373" rx="6"`, `polyline stroke="#737373"`.

## Test plan

- [x] canvas-render 237, export suite 59, apps/web 1406 jsdom, theme browser tests — all green with pinned values updated deliberately
- [x] WCAG floor tests pass unmodified (they assert floors, not values; the non-vacuity case keeps proving old `#333333` fails on dark)
- [x] Full `pnpm test` (5884; the one dist-presence failure was a stale build artifact, green after `pnpm build`), `pnpm -r typecheck`, knip
- [x] Live verification with real drawing (screenshot + DOM attribute check above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the light-theme canvas appearance with softer gray node and edge strokes.
  - Refined label contrast and introduced gently rounded node corners for a calmer visual presentation.

- **Documentation**
  - Clarified product design guidance and connection-status descriptions.

- **Tests**
  - Updated visual and rendering checks to reflect the refreshed canvas styling across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->