### PR TITLE
feat(web): structural loading skeletons and a one-action empty state

### DIFF
--- a/apps/web/src/components/CanvasPageSkeleton.tsx
+++ b/apps/web/src/components/CanvasPageSkeleton.tsx
@@ -1,0 +1,20 @@
+/**
+ * Structural loading state for a full canvas page: header bar + canvas
+ * area placeholders instead of a lone sentence, so the page's shape is
+ * stable from first paint. Announced politely to assistive tech via the
+ * status role + label (the visible pulse carries no text).
+ */
+export function CanvasPageSkeleton({ label }: { label: string }) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label} className="flex h-dvh w-full flex-col">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
+        <div className="h-5 w-36 animate-pulse rounded bg-muted" />
+        <div className="ml-auto h-6 w-16 animate-pulse rounded-full bg-muted" />
+        <div className="size-6 animate-pulse rounded-md bg-muted" />
+      </div>
+      <div className="flex-1 p-6">
+        <div className="size-full animate-pulse rounded-lg bg-muted/50" />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
@@ -311,15 +312,7 @@ export function BrowserLocalCanvasPage({
   }
 
   if (pageState.kind === 'loading') {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="flex h-dvh items-center justify-center text-sm text-muted-foreground"
-      >
-        Loading…
-      </div>
-    )
+    return <CanvasPageSkeleton label="Loading canvas" />
   }
 
   return (

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -472,7 +472,7 @@ describe('DaemonCanvasPage', () => {
     expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
   })
 
-  it('shows the connecting status while workspace/canvas resolution is pending', async () => {
+  it('shows a structural skeleton while workspace/canvas resolution is pending', async () => {
     // Never resolves during this test, so the page stays in the loading state.
     mockListWorkspaces.mockReturnValue(new Promise(() => {}))
 
@@ -481,7 +481,7 @@ describe('DaemonCanvasPage', () => {
       { container: document.body },
     )
 
-    expect(screen.getByRole('status').textContent).toMatch(/connecting to daemon/i)
+    expect(screen.getByRole('status', { name: /connecting to daemon/i })).toBeTruthy()
   })
 
   it('shows a full-page alert when workspace/canvas resolution fails', async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -2,6 +2,7 @@ import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contract
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
@@ -226,15 +227,7 @@ export function DaemonCanvasPage({
   }
 
   if (controller.loading) {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="flex h-dvh items-center justify-center text-sm text-muted-foreground"
-      >
-        Connecting to daemon…
-      </div>
-    )
+    return <CanvasPageSkeleton label="Connecting to daemon" />
   }
 
   if (controller.loadError) {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -22,6 +22,8 @@ interface MockRoutes {
   snapshotByCanvas?: Record<string, Uint8Array>
   onUpdateCanvas?: (workspaceId: string, slug: string, bytes: Uint8Array) => void
   onSetCanvasName?: (workspaceId: string, slug: string, name: string) => void
+  /** When set, the canvases fetch resolves only after this promise settles. */
+  delayCanvases?: Promise<void>
 }
 
 function installFetchMock(routes: MockRoutes) {
@@ -35,7 +37,9 @@ function installFetchMock(routes: MockRoutes) {
       const workspaceId = decodeURIComponent(canvasesMatch[1])
       const canvases = routes.canvasesByWorkspace[workspaceId]
       if (!canvases) return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
-      return Promise.resolve(jsonResponse({ canvases }))
+      const respond = () => jsonResponse({ canvases })
+      if (routes.delayCanvases) return routes.delayCanvases.then(respond)
+      return Promise.resolve(respond())
     }
     if (canvasesMatch && init?.method === 'POST') {
       const workspaceId = decodeURIComponent(canvasesMatch[1])
@@ -620,6 +624,43 @@ describe('DaemonIndexPage', () => {
     await screen.findByText('alpha')
 
     expect(screen.getByPlaceholderText('New canvas name…')).toBeTruthy()
+  })
+
+  it('shows a loading skeleton before the first load resolves, never a false empty state', async () => {
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }] },
+      delayCanvases: gate,
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    // While the canvases fetch is in flight: structural skeleton, and no
+    // premature "No canvases" copy.
+    expect(await screen.findByRole('status', { name: /loading canvases/i })).toBeTruthy()
+    expect(screen.queryByText(/no canvases/i)).toBeNull()
+
+    release()
+    await screen.findByText('alpha')
+    expect(screen.queryByRole('status', { name: /loading canvases/i })).toBeNull()
+  })
+
+  it('empty workspace shows one clear next action that starts canvas creation', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: { 'ws-a': [] },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    expect(await screen.findByText('No canvases yet')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
+    // The action lands the user in the naming input, ready to type.
+    expect(document.activeElement).toBe(screen.getByLabelText('New canvas name'))
   })
 
   it('offers Grid/Tree as a view toggle of the one canvas surface', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -121,6 +121,12 @@ export function DaemonIndexPage({
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
   const [rows, setRows] = useState<CanvasRow[]>([])
+  // False from the moment a workspace switch clears rows until its canvases
+  // fetch settles — rows=[] alone cannot distinguish "still loading" from
+  // "genuinely empty", and rendering an empty state during the gap reads as
+  // data loss.
+  const [loaded, setLoaded] = useState(false)
+  const newCanvasInputRef = useRef<HTMLInputElement | null>(null)
   const [search, setSearch] = useState('')
   const [newCanvasSlug, setNewCanvasSlug] = useState('')
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -183,9 +189,11 @@ export function DaemonIndexPage({
           }
         })
         setRows(sortRows(nextRows))
+        setLoaded(true)
       } catch {
         if (isStale()) return
         setRows([])
+        setLoaded(true)
         setLoadError('Failed to load canvases for this workspace.')
       }
     },
@@ -199,6 +207,7 @@ export function DaemonIndexPage({
     // workspace's rows visible during the switch lets a click pair the new
     // workspace id with an old workspace's slug — a mismatched identity.
     setRows([])
+    setLoaded(false)
     setLoadError(null)
     void loadWorkspace(selectedWorkspace, () => cancelled)
     return () => {
@@ -308,6 +317,7 @@ export function DaemonIndexPage({
                 }}
               >
                 <input
+                  ref={newCanvasInputRef}
                   aria-label="New canvas name"
                   placeholder="New canvas name…"
                   value={newCanvasSlug}
@@ -380,8 +390,36 @@ export function DaemonIndexPage({
           <div role="alert" className="text-sm text-destructive">
             {loadError}
           </div>
-        ) : visible.length === 0 ? (
+        ) : !loaded ? (
+          <div
+            role="status"
+            aria-label="Loading canvases"
+            className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+          >
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="animate-pulse rounded-lg border p-2">
+                <div className="aspect-[4/3] rounded-md bg-muted" />
+                <div className="mt-2 h-4 w-2/3 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : visible.length === 0 && search !== '' ? (
           <p className="text-sm text-muted-foreground">No canvases match.</p>
+        ) : visible.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-16 text-center">
+            <p className="text-sm font-medium">No canvases yet</p>
+            <p className="text-sm text-muted-foreground">
+              Name your first canvas and it opens ready to draw.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => newCanvasInputRef.current?.focus()}
+            >
+              Create a canvas
+            </Button>
+          </div>
         ) : (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
             {visible.map((row) => {


### PR DESCRIPTION
## What

Final slice of the approved design refactor: **states**.

- The daemon index tracks loaded-ness: `rows=[]` alone cannot distinguish "still loading" from "genuinely empty", so the gap used to flash a false **"No canvases match."** It now renders a pulse-card skeleton (`role=status`, "Loading canvases"), then either the search-miss line, the real empty state, or the grid.
- The genuine empty state carries **one clear next action** — "Create a canvas" focuses the naming input — instead of a dead sentence.
- Full-page loading on both canvas pages becomes `CanvasPageSkeleton`: header + canvas placeholders so the page shape is stable from first paint. The old sentences ("Connecting to daemon", "Loading canvas") remain as the status labels for assistive tech.
- The unsupported-browser notice was verified to still surface through the connection chip popover (it lives inside the daemon-detection flow moved there in #459).

## Test plan

- [x] Red first: skeleton visible while the canvases fetch is gated (new `delayCanvases` mock hook) and no premature "No canvases" copy; empty workspace shows "No canvases yet" and the action focuses the naming input
- [x] Daemon page loading test updated to the skeleton contract (status role + label)
- [x] Full apps/web: 1409 jsdom, typecheck, biome, knip
- [x] Live sanity on the dev server