### PR TITLE
fix(server-core): require createWorkspace opt-in before materializing a new workspace

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -73,7 +73,10 @@ Every tool above operates on the persisted document and never requires a
 connected browser tab — canvas rendering and export are headless. `wb_canvas_create`
 is the only tool that lazily creates a canvas on first touch; the patch/render/export/
 version tools all fail with an explicit error if `canvasId` does not resolve to an
-existing canvas, instead of silently creating a new, empty one.
+existing canvas, instead of silently creating a new, empty one. The same discipline
+applies one level up: an unknown `workspaceId` is an error, never an implicit new
+workspace — bootstrapping a genuinely new workspace requires passing
+`createWorkspace: true` to `wb_canvas_create`.
 
 ## Why Loro
 

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -94,6 +94,14 @@ async function callTool(name, args) {
   return JSON.parse(text)
 }
 
+async function expectToolError(name, args) {
+  const res = await rpc('tools/call', { name, arguments: args })
+  if (!res?.isError) {
+    throw new Error(`expected ${name} to fail, got: ${JSON.stringify(res)}`)
+  }
+  console.log(`[e2e] ${name} without createWorkspace → isError (expected)`)
+}
+
 function cleanup(exitCode) {
   try {
     child.kill('SIGTERM')
@@ -158,10 +166,18 @@ async function main() {
   }
   console.log(`[e2e] tools/list → ${names.length} tools match expected set`)
 
+  // Unknown-workspace guard: without createWorkspace the create must fail
+  // (workspaces never materialize implicitly from a typo'd workspaceId).
+  await expectToolError('wb_canvas_create', {
+    workspaceId: WORKSPACE_ID,
+    segment: 'e2e-src',
+  })
+
   // wb_canvas_create: first daemon-dependent RPC (cold-start latency).
   const created = await callTool('wb_canvas_create', {
     workspaceId: WORKSPACE_ID,
     segment: 'e2e-src',
+    createWorkspace: true,
   })
   if (typeof created.canvasId !== 'string' || created.segment !== 'e2e-src') {
     throw new Error(`wb_canvas_create returned unexpected shape: ${JSON.stringify(created)}`)

--- a/packages/mcp-server/src/server/app.opencanvas-v1.test.ts
+++ b/packages/mcp-server/src/server/app.opencanvas-v1.test.ts
@@ -88,7 +88,7 @@ describe('createApp /api/v1 OpenCanvas mount', () => {
     const createRes = await app.request('/api/v1/workspaces/default/canvases', {
       method: 'POST',
       headers: { Authorization: 'Bearer secret', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ segment: 'notes' }),
+      body: JSON.stringify({ segment: 'notes', createWorkspace: true }),
     })
     expect(createRes.status).toBe(201)
 

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -447,7 +447,7 @@ describe('createApp daemon mutation auth', () => {
     const canvasCreateTool = tools.tools.find((tool) => tool.name === 'wb_canvas_create')
     const createResult = await client.callTool({
       name: 'wb_canvas_create',
-      arguments: { workspaceId: 'default', segment: 'via-mcp' },
+      arguments: { workspaceId: 'default', segment: 'via-mcp', createWorkspace: true },
     })
 
     expect(canvasCreateTool).toBeDefined()
@@ -491,7 +491,7 @@ describe('createApp daemon mutation auth', () => {
     expect(tools.tools.some((tool) => tool.name === 'wb_canvas_create')).toBe(true)
     const createResult = await client.callTool({
       name: 'wb_canvas_create',
-      arguments: { workspaceId: 'default', segment: 'via-modern-mcp' },
+      arguments: { workspaceId: 'default', segment: 'via-modern-mcp', createWorkspace: true },
     })
     expect(createResult.structuredContent).toMatchObject({
       canvasId: expect.any(String),

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -60,7 +60,11 @@ export function triggerDaemonCanvasCreate(
   options: { retryDaemonStartup: boolean; maxDaemonStartupRetries: number },
 ): Promise<Record<string, unknown>> {
   const attempt = () =>
-    callTool('wb_canvas_create', { workspaceId: WORKSPACE_ID, segment: 'e2e-src' })
+    callTool('wb_canvas_create', {
+      workspaceId: WORKSPACE_ID,
+      segment: 'e2e-src',
+      createWorkspace: true,
+    })
   return options.retryDaemonStartup
     ? retryDaemonStartup({ attempt, maxRetries: options.maxDaemonStartupRetries })
     : attempt()

--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.test.ts
@@ -53,7 +53,7 @@ describe('registerOpenCanvasTools', () => {
     }
 
     const created = await findHandler('wb_canvas_create')(
-      { workspaceId: 'ws-1', segment: 'canvas-a' },
+      { workspaceId: 'ws-1', segment: 'canvas-a', createWorkspace: true },
       { requestId: 'req-0' },
     )
     const canvasId = created.structuredContent.canvasId as string

--- a/packages/server-core/src/canvas-routes.test.ts
+++ b/packages/server-core/src/canvas-routes.test.ts
@@ -22,7 +22,7 @@ describe('canvas CRUD routes', () => {
     const res = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     expect(res.status).toBe(201)
     const body = createCanvasOutputSchema.parse(await res.json())
@@ -45,9 +45,19 @@ describe('canvas CRUD routes', () => {
     const res = await app.request('/api/v1/workspaces/..%2Ftraversal/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     expect(res.status).toBe(400)
+  })
+
+  it('POST into an unknown workspace without createWorkspace returns 404', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/v1/workspaces/typo-probe-ws/canvases', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ segment: 'doc-a' }),
+    })
+    expect(res.status).toBe(404)
   })
 
   it('POST creating a duplicate sibling segment returns 409', async () => {
@@ -55,12 +65,12 @@ describe('canvas CRUD routes', () => {
     await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const res = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     expect(res.status).toBe(409)
   })
@@ -70,7 +80,7 @@ describe('canvas CRUD routes', () => {
     await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const res = await app.request('/api/v1/workspaces/ws-1/canvases')
     expect(res.status).toBe(200)
@@ -83,7 +93,7 @@ describe('canvas CRUD routes', () => {
     const createRes = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const { canvasId } = createCanvasOutputSchema.parse(await createRes.json())
 
@@ -101,7 +111,7 @@ describe('canvas CRUD routes', () => {
     const createRes = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const { canvasId } = createCanvasOutputSchema.parse(await createRes.json())
 
@@ -123,7 +133,7 @@ describe('canvas OKF read route', () => {
     const createRes = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const created = createCanvasOutputSchema.parse(await createRes.json())
     await tools.canvasImportOkf.execute({
@@ -143,7 +153,7 @@ describe('canvas OKF read route', () => {
     const createRes = await app.request('/api/v1/workspaces/ws-1/canvases', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ segment: 'doc-a' }),
+      body: JSON.stringify({ segment: 'doc-a', createWorkspace: true }),
     })
     const created = createCanvasOutputSchema.parse(await createRes.json())
     const res = await app.request(`/api/v1/workspaces/ws-1/canvases/${created.canvasId}/okf`)

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -7,6 +7,7 @@ import {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
   CanvasSegmentConflictError,
+  WorkspaceNotFoundError,
 } from './tools/canvas-crud.errors.js'
 import { wbCanvasCreate, wbCanvasDelete, wbCanvasGet, wbCanvasList } from './tools/canvas-crud.js'
 import {
@@ -137,6 +138,9 @@ export function createServer(deps: ServerDeps) {
 
 function mapCanvasError(c: Context, err: unknown) {
   if (err instanceof CanvasNotFoundError) {
+    return c.json({ error: err.message }, 404)
+  }
+  if (err instanceof WorkspaceNotFoundError) {
     return c.json({ error: err.message }, 404)
   }
   if (err instanceof CanvasSegmentConflictError) {

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -13,6 +13,7 @@ export {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
   CanvasSegmentConflictError,
+  WorkspaceNotFoundError,
 } from './tools/canvas-crud.errors.js'
 export { wbCanvasCreate, wbCanvasDelete, wbCanvasGet, wbCanvasList } from './tools/canvas-crud.js'
 export {

--- a/packages/server-core/src/tools/canvas-crud.errors.ts
+++ b/packages/server-core/src/tools/canvas-crud.errors.ts
@@ -15,6 +15,16 @@ export class CanvasNotFoundError extends Error {
   }
 }
 
+export class WorkspaceNotFoundError extends Error {
+  constructor(readonly workspaceId: string) {
+    super(
+      `Workspace not found: "${workspaceId}". ` +
+        'Pass createWorkspace: true to create it along with the canvas.',
+    )
+    this.name = 'WorkspaceNotFoundError'
+  }
+}
+
 export class CanvasSegmentConflictError extends Error {
   constructor(readonly segment: string) {
     super(`Segment conflict: "${segment}" already exists under this parent`)

--- a/packages/server-core/src/tools/canvas-crud.schemas.ts
+++ b/packages/server-core/src/tools/canvas-crud.schemas.ts
@@ -19,6 +19,14 @@ export const createCanvasInputSchema = z
     workspaceId: workspaceIdSchema,
     segment: segmentSchema,
     parentId: treeIdSchema.optional(),
+    // Workspaces are never materialized implicitly: a typo'd or hallucinated
+    // workspaceId must fail loudly instead of silently writing data into a
+    // workspace nobody asked for. Creating a genuinely new workspace is an
+    // explicit opt-in via this flag.
+    createWorkspace: z
+      .boolean()
+      .optional()
+      .describe('Set true to create the workspace if it does not exist yet.'),
   })
   .strict()
 

--- a/packages/server-core/src/tools/canvas-crud.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.test.ts
@@ -7,6 +7,7 @@ import {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
   CanvasSegmentConflictError,
+  WorkspaceNotFoundError,
 } from './canvas-crud.errors.js'
 import { wbCanvasCreate, wbCanvasDelete, wbCanvasGet, wbCanvasList } from './canvas-crud.js'
 
@@ -21,14 +22,22 @@ function makeDeps(): ServerDeps {
 describe('wbCanvasCreate', () => {
   it('creates a canvas and returns canvasId + segment', async () => {
     const deps = makeDeps()
-    const result = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const result = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     expect(result.segment).toBe('doc-a')
     expect(() => canvasIdSchema.parse(result.canvasId)).not.toThrow()
   })
 
   it('creates a nested canvas under an existing parent and the alias reflects nesting', async () => {
     const deps = makeDeps()
-    const parent = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'folder' })
+    const parent = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'folder',
+      createWorkspace: true,
+    })
     const parentNode = await wbCanvasGet(deps, {
       workspaceId: 'ws-1',
       canvasId: parent.canvasId,
@@ -48,7 +57,7 @@ describe('wbCanvasCreate', () => {
 
   it('throws CanvasSegmentConflictError when a sibling with the same segment already exists', async () => {
     const deps = makeDeps()
-    await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a', createWorkspace: true })
     await expect(wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })).rejects.toThrow(
       CanvasSegmentConflictError,
     )
@@ -57,13 +66,50 @@ describe('wbCanvasCreate', () => {
   it('throws CanvasParentNotFoundError when parentId does not exist', async () => {
     const deps = makeDeps()
     await expect(
-      wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a', parentId: 'does-not-exist' }),
+      wbCanvasCreate(deps, {
+        workspaceId: 'ws-1',
+        segment: 'doc-a',
+        parentId: 'does-not-exist',
+        createWorkspace: true,
+      }),
     ).rejects.toThrow(CanvasParentNotFoundError)
+  })
+
+  it('throws WorkspaceNotFoundError for an unknown workspaceId without createWorkspace', async () => {
+    const deps = makeDeps()
+    await expect(
+      wbCanvasCreate(deps, { workspaceId: 'typo-probe-ws', segment: 'doc-a' }),
+    ).rejects.toThrow(WorkspaceNotFoundError)
+    const listed = await wbCanvasList(deps, { workspaceId: 'typo-probe-ws' })
+    expect(listed.canvases).toEqual([])
+  })
+
+  it('materializes the workspace when createWorkspace: true is passed', async () => {
+    const deps = makeDeps()
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'brand-new-ws',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
+    expect(created.segment).toBe('doc-a')
+    const listed = await wbCanvasList(deps, { workspaceId: 'brand-new-ws' })
+    expect(listed.canvases.map((c) => c.canvasId)).toContain(created.canvasId)
+  })
+
+  it('succeeds without the flag when the workspace already exists', async () => {
+    const deps = makeDeps()
+    await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a', createWorkspace: true })
+    const second = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-b' })
+    expect(second.segment).toBe('doc-b')
   })
 
   it('reindexes the workspace so the new canvas is visible via WorkspaceIndex', async () => {
     const deps = makeDeps()
-    const created = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     const listed = await deps.workspaceIndex.listCanvases({ workspaceId: 'ws-1' })
     expect(listed.rows.map((row) => row.canvasId)).toContain(created.canvasId)
   })
@@ -72,7 +118,11 @@ describe('wbCanvasCreate', () => {
 describe('wbCanvasGet', () => {
   it('returns the canvas with its resolved alias after create', async () => {
     const deps = makeDeps()
-    const created = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     const result = await wbCanvasGet(deps, { workspaceId: 'ws-1', canvasId: created.canvasId })
     expect(result).toEqual({ canvasId: created.canvasId, segment: 'doc-a', alias: 'doc-a' })
   })
@@ -94,7 +144,7 @@ describe('wbCanvasList', () => {
 
   it('returns all created canvases with resolved aliases', async () => {
     const deps = makeDeps()
-    await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a', createWorkspace: true })
     await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-b' })
     const result = await wbCanvasList(deps, { workspaceId: 'ws-1' })
     expect(result.canvases).toHaveLength(2)
@@ -103,7 +153,11 @@ describe('wbCanvasList', () => {
 
   it('excludes a deleted canvas', async () => {
     const deps = makeDeps()
-    const created = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     await wbCanvasDelete(deps, { workspaceId: 'ws-1', canvasId: created.canvasId })
     const result = await wbCanvasList(deps, { workspaceId: 'ws-1' })
     expect(result.canvases).toEqual([])
@@ -113,7 +167,11 @@ describe('wbCanvasList', () => {
 describe('wbCanvasDelete', () => {
   it('deletes a canvas so a later get throws CanvasNotFoundError', async () => {
     const deps = makeDeps()
-    const created = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     const result = await wbCanvasDelete(deps, { workspaceId: 'ws-1', canvasId: created.canvasId })
     expect(result).toEqual({ deleted: true })
     await expect(
@@ -130,7 +188,11 @@ describe('wbCanvasDelete', () => {
 
   it('reindexes the workspace so the deleted canvas no longer appears via WorkspaceIndex', async () => {
     const deps = makeDeps()
-    const created = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     await wbCanvasDelete(deps, { workspaceId: 'ws-1', canvasId: created.canvasId })
     const listed = await deps.workspaceIndex.listCanvases({ workspaceId: 'ws-1' })
     expect(listed.rows.map((row) => row.canvasId)).not.toContain(created.canvasId)
@@ -138,7 +200,11 @@ describe('wbCanvasDelete', () => {
 
   it('deletes a canvas that has children without throwing, and the child no longer resolves', async () => {
     const deps = makeDeps()
-    const parent = await wbCanvasCreate(deps, { workspaceId: 'ws-1', segment: 'folder' })
+    const parent = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'folder',
+      createWorkspace: true,
+    })
     const tree = await loadTreeForAssertions(deps)
     const parentTreeNode = tree.snapshot().nodes.find((n) => n.canvasId === parent.canvasId)
     const child = await wbCanvasCreate(deps, {

--- a/packages/server-core/src/tools/canvas-crud.ts
+++ b/packages/server-core/src/tools/canvas-crud.ts
@@ -1,11 +1,12 @@
-import type { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
-import type { TreeID } from 'loro-crdt'
+import { WorkspaceTree } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc, type TreeID } from 'loro-crdt'
 import type { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
   CanvasSegmentConflictError,
+  WorkspaceNotFoundError,
 } from './canvas-crud.errors.js'
 import type {
   createCanvasInputSchema,
@@ -19,7 +20,11 @@ import type {
 } from './canvas-crud.schemas.js'
 import { generateCanvasId } from './generate-canvas-id.js'
 import { withReindex } from './with-reindex.js'
-import { loadWorkspaceTree, saveWorkspaceTree } from './workspace-tree-io.js'
+import {
+  loadWorkspaceTree,
+  loadWorkspaceTreeIfExists,
+  saveWorkspaceTree,
+} from './workspace-tree-io.js'
 
 /**
  * Finds the tree node whose `canvasId` matches, or throws
@@ -38,7 +43,15 @@ export async function wbCanvasCreate(
   input: z.infer<typeof createCanvasInputSchema>,
 ): Promise<z.infer<typeof createCanvasOutputSchema>> {
   return withReindex(deps, async (input: z.infer<typeof createCanvasInputSchema>) => {
-    const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
+    // Workspaces never materialize implicitly: a typo'd or hallucinated
+    // workspaceId must fail loudly rather than silently writing data into a
+    // workspace nobody asked for. `createWorkspace: true` is the explicit
+    // opt-in that bootstraps a genuinely new workspace.
+    const existingTree = await loadWorkspaceTreeIfExists(deps.canvasDocStore, input.workspaceId)
+    if (existingTree === null && input.createWorkspace !== true) {
+      throw new WorkspaceNotFoundError(input.workspaceId)
+    }
+    const tree = existingTree ?? new WorkspaceTree(new LoroDoc())
 
     const parentId = input.parentId as TreeID | undefined
     if (parentId !== undefined && tree.getNode(parentId) === undefined) {

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -125,7 +125,11 @@ describe('facet_set tool', () => {
 
   test('reindexes the workspace so queryFacet reflects the newly-set facet', async () => {
     const deps = makeDeps(new FakeCanvasDocStore())
-    const created = await wbCanvasCreate(deps, { workspaceId: WORKSPACE_ID, segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: WORKSPACE_ID,
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     const tool = createFacetSetTool(deps)
 
     await tool.execute({

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -172,7 +172,11 @@ describe('version_restore tool', () => {
     const store = new FakeCanvasDocStore()
     const deps = makeDeps(store)
     const { wbCanvasCreate } = await import('./canvas-crud.js')
-    const created = await wbCanvasCreate(deps, { workspaceId: WORKSPACE_ID, segment: 'doc-a' })
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: WORKSPACE_ID,
+      segment: 'doc-a',
+      createWorkspace: true,
+    })
     const saveTool = createVersionSaveTool(deps)
     const restoreTool = createVersionRestoreTool(deps)
 

--- a/packages/server-core/src/tools/workspace-tree-io.ts
+++ b/packages/server-core/src/tools/workspace-tree-io.ts
@@ -21,12 +21,25 @@ export async function loadWorkspaceTree(
   canvasDocStore: CanvasDocStore,
   workspaceId: WorkspaceId,
 ): Promise<WorkspaceTree> {
+  return (
+    (await loadWorkspaceTreeIfExists(canvasDocStore, workspaceId)) ??
+    new WorkspaceTree(new LoroDoc())
+  )
+}
+
+/**
+ * Like `loadWorkspaceTree`, but resolves to `null` for a workspace with no
+ * persisted tree — the existence signal `wbCanvasCreate` uses to refuse
+ * materializing a workspace nobody explicitly asked for.
+ */
+export async function loadWorkspaceTreeIfExists(
+  canvasDocStore: CanvasDocStore,
+  workspaceId: WorkspaceId,
+): Promise<WorkspaceTree | null> {
   const result = await canvasDocStore.loadSnapshot({
     docRef: { kind: 'workspace-tree', workspaceId },
   })
-  if (result === null) {
-    return new WorkspaceTree(new LoroDoc())
-  }
+  if (result === null) return null
   const bytes = reassembleSnapshot(result.manifest, result.chunks)
   return WorkspaceTree.fromSnapshot(bytes)
 }


### PR DESCRIPTION
## What

`wb_canvas_create` (and the `/api/v1` create route behind the same handler) silently **materialized a brand-new workspace for any unknown `workspaceId`** — a typo'd or agent-hallucinated id succeeded and wrote data "somewhere else" instead of erroring, losing exactly the signal that would catch the mistake. Backlog issue `annotate-typo-creates-workspace`, re-verified live against the current tool surface before this fix.

Since implicit creation was also the *only* way a workspace could come into existence over MCP, a plain "unknown → error" would have removed a capability. The contract is now an explicit opt-in:

- `createCanvasInputSchema` gains an optional **`createWorkspace: boolean`** (documented in the tool schema).
- Unknown `workspaceId` **without** the flag → new typed `WorkspaceNotFoundError` whose message points at the flag (`404` on the HTTP route, `isError` over MCP).
- With `createWorkspace: true` → the workspace bootstraps exactly as before.
- An existing workspace never needs the flag — nothing changes for the common case.

`loadWorkspaceTreeIfExists` is the new existence seam in `workspace-tree-io.ts`; `loadWorkspaceTree` keeps its total behavior for read paths. The web app is unaffected (it creates canvases via the daemon's legacy `/api/workspaces/...` route, which manages its own workspace lifecycle).

## Verification (live dev daemon over MCP)

- `wb_canvas_create {workspaceId: "typo-probe-live", segment: "probe"}` → error: `Workspace not found: "typo-probe-live". Pass createWorkspace: true to create it along with the canvas.`
- `wb_canvas_create {workspaceId: "default", segment: "live-guard-probe"}` (existing workspace, no flag) → created normally (probe deleted afterwards).
- `pnpm smoke:e2e` now exercises **both directions** against a real stdio child: the flagless create must return `isError`, then the flagged create bootstraps the `e2e` workspace and the rest of the round-trip runs. Pre-fix this smoke step is what failed — the runtime guard, not just the unit layer, is regression-covered.

## Test plan

- [x] Red first (`canvas-crud.test.ts`): unknown ws without flag → `WorkspaceNotFoundError` and nothing persisted; `createWorkspace: true` → materializes; existing ws without flag → succeeds
- [x] Route-level: POST into an unknown workspace without the flag → `404`
- [x] server-core-node 225 passed; mcp-node 3347 passed (existing first-create call sites updated to the new contract)
- [x] `pnpm smoke:e2e` green including the new negative step
- [x] `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`, `pnpm build` clean
- [x] Docs: `docs/explanation/architecture.md` records the no-implicit-workspace rule
