### PR TITLE
fix(web): make the soft-wrap browser test independent of typing throughput

### DIFF
--- a/apps/web/src/components/markdown-editor/source-pane-keymap.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/source-pane-keymap.browser.test.tsx
@@ -77,10 +77,16 @@ describe('SourcePane keymap (real browser)', () => {
   })
 
   it('long lines soft-wrap instead of scrolling horizontally', async () => {
-    const { editable } = mountEditor()
-    await userEvent.click(editable)
-    await userEvent.keyboard('word '.repeat(80).trim())
+    // The behavior under test is wrap LAYOUT, not typing: mount with the
+    // long line as the initial value instead of sending ~400 individual
+    // keystrokes through the real event pipeline — per-key CodeMirror
+    // update cycles made this test time out under full-suite load.
+    render(<MarkdownEditor value={'word '.repeat(80).trim()} onChange={vi.fn()} />)
+    // Wait for the long line to actually render first — asserting widths on a
+    // not-yet-measured (effectively empty) editor would pass vacuously.
+    const content = document.querySelector('.cm-content') as HTMLElement
+    await expect.poll(() => content.textContent?.includes('word word')).toBe(true)
     const scroller = document.querySelector('.cm-scroller') as HTMLElement
-    expect(scroller.scrollWidth).toBeLessThanOrEqual(scroller.clientWidth + 1)
+    await expect.poll(() => scroller.scrollWidth <= scroller.clientWidth + 1).toBe(true)
   })
 })


### PR DESCRIPTION
## What

`source-pane-keymap.browser.test.tsx` > "long lines soft-wrap instead of scrolling horizontally" timed out (15s) whenever the full `web-browser` project ran under machine load — observed three times in one day — while passing in isolation. Backlog issue `source-pane-softwrap-load-flake`; today's full-suite run reproduced it again, promoting it to a root-cause fix per the flake rubric.

**Root cause**: the test typed a ~400-character line via `userEvent.keyboard`, which drives one full CodeMirror update cycle per keystroke through the real event pipeline. The behavior under test is wrap **layout**, not typing throughput.

**Fix**: mount `MarkdownEditor` with the long line as its initial `value`, wait for the line to actually render (guarding against a vacuous pass on an unmeasured editor), then poll the scroll-width assertion deterministically. No timeout bump, no pinned timers.

## Verification

- Isolation: 6/6 green, the fixed test completes in well under a second of layout time.
- **Mutation check**: temporarily commenting out `EditorView.lineWrapping` in `SourcePane.tsx` makes exactly this test fail (trace artifact produced), so the assertion still catches a real wrap regression. Restored afterwards.

## Test plan

- [x] `pnpm vitest run --config vitest.browser.config.ts source-pane-keymap` — 6 passed
- [x] Mutation check above
