### PR TITLE
feat(web): motion foundation — tokens, reduced-motion floor, popover entrance

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -52,9 +52,17 @@ Tailwind palette colors in chrome.
   single-choice selectors (one workspace) render nothing at all.
 - **Both themes always.** Any new color must be defined for `:root` and
   `.dark`, and respect the WCAG 1.4.3/1.4.11 floors the contrast tests pin.
-- **Motion**: compositor props only (`transform`, `opacity`), ≤200ms for
-  interaction feedback, `prefers-reduced-motion` respected. No entrance
-  animation without an explicit reason.
+- **Motion**: every animation must serve hierarchy, feedback, or
+  continuity — if it serves none, delete it. Compositor props only
+  (`transform`, `opacity`). Use the motion tokens from `src/index.css`
+  instead of ad-hoc numbers: `--motion-duration-fast` (150ms,
+  hover/press feedback), `--motion-duration-normal` (220ms, state
+  changes and small surfaces like popovers/toasts),
+  `--motion-ease-out` (soft ease-out — never bouncy in chrome).
+  Entrances are fade + small rise/scale (0.98→1); no entrance animation
+  without an explicit reason. `prefers-reduced-motion` is enforced
+  globally by the base-layer guard in `src/index.css` — component code
+  must not assume an animation ran (never gate logic on motion).
 
 ## Canvas theme boundary
 

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -25,6 +25,12 @@ function PopoverContent({
         sideOffset={sideOffset}
         className={cn(
           'z-50 w-80 rounded-lg border bg-popover p-3 text-popover-foreground shadow-md outline-none',
+          // Entrance/exit: scale+fade micro emphasis (DESIGN.md Motion) via
+          // the shared motion tokens; reduced-motion is neutralized by the
+          // global guard in index.css.
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-[0.98]',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-[0.98]',
+          'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
           className,
         )}
         {...props}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -30,6 +30,16 @@
 
 :root {
   --radius: 0.625rem;
+  /*
+   * Motion tokens (see DESIGN.md "Motion"): every transition/animation in
+   * chrome uses these instead of ad-hoc numbers. fast = hover/press
+   * feedback, normal = state changes and small surfaces (popover, toast).
+   * The easing is a soft ease-out — human acceleration, gentle settle,
+   * never bouncy.
+   */
+  --motion-duration-fast: 150ms;
+  --motion-duration-normal: 220ms;
+  --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -95,5 +105,23 @@
   ::before,
   ::after {
     border-color: var(--color-border);
+  }
+
+  /*
+   * Reduced-motion floor: neutralize every animation and transition —
+   * including tw-animate-css's data-state entrances — for users who asked
+   * the OS for less motion. 0.01ms instead of 0 so `animationend` /
+   * `transitionend` listeners still fire and state machines that wait on
+   * them cannot deadlock.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }

--- a/apps/web/src/motion-foundation.browser.test.tsx
+++ b/apps/web/src/motion-foundation.browser.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Motion foundation contract (real browser, real compiled CSS):
+ *
+ * 1. The motion tokens exist on :root so components can consume
+ *    `var(--motion-*)` instead of ad-hoc numbers.
+ * 2. The base layer ships a `prefers-reduced-motion: reduce` guard that
+ *    neutralizes animations AND transitions. Browser test runners cannot
+ *    flip the OS media preference per test, so the guard is pinned by
+ *    walking the compiled stylesheet for the media rule and its
+ *    neutralizing declarations — a real parse through the Tailwind
+ *    pipeline, not a source-text grep.
+ */
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import './index.css'
+
+function collectCssText(): string {
+  let out = ''
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList
+    try {
+      rules = sheet.cssRules
+    } catch {
+      continue
+    }
+    for (const rule of Array.from(rules)) {
+      out += `${rule.cssText}\n`
+    }
+  }
+  return out
+}
+
+describe('motion foundation', () => {
+  beforeAll(async () => {
+    // Wait until the imported stylesheet is actually applied.
+    await vi.waitFor(() => {
+      const v = getComputedStyle(document.documentElement)
+        .getPropertyValue('--motion-duration-fast')
+        .trim()
+      if (v === '') throw new Error('index.css not applied yet')
+    })
+  })
+
+  it('defines the motion tokens on :root', () => {
+    const styles = getComputedStyle(document.documentElement)
+    expect(styles.getPropertyValue('--motion-duration-fast').trim()).toBe('150ms')
+    expect(styles.getPropertyValue('--motion-duration-normal').trim()).toBe('220ms')
+    expect(styles.getPropertyValue('--motion-ease-out').trim()).toContain('cubic-bezier')
+  })
+
+  it('ships a prefers-reduced-motion guard neutralizing animations and transitions', () => {
+    const css = collectCssText()
+    const mediaIdx = css.indexOf('prefers-reduced-motion: reduce')
+    expect(mediaIdx).toBeGreaterThan(-1)
+    const afterMedia = css.slice(mediaIdx)
+    expect(afterMedia).toContain('animation-duration: 0.01ms')
+    expect(afterMedia).toContain('transition-duration: 0.01ms')
+  })
+})


### PR DESCRIPTION
## What

First slice (M1) of the motion loop — see the audit summary below. The goal is a motion **system**, not one-off tweaks: tokens, an enforced reduced-motion floor, and one consumer proving the pipeline.

**Audit findings this slice addresses**
- No `prefers-reduced-motion` handling existed anywhere in apps/web, while DESIGN.md required it — a paper rule.
- Durations/easings were ad-hoc per component; no motion tokens.
- Only dialogs animated (shadcn defaults); popovers and state changes were instant.

**Changes**
- `src/index.css`: motion tokens — `--motion-duration-fast` (150ms, hover/press), `--motion-duration-normal` (220ms, popovers/toasts/state changes), `--motion-ease-out` (soft ease-out, never bouncy in chrome).
- Base-layer `prefers-reduced-motion: reduce` guard neutralizing every animation AND transition, including tw-animate-css data-state entrances. `0.01ms` instead of `0` so `animationend`/`transitionend` listeners still fire.
- Popover entrance/exit: scale+fade (0.98→1) on the token duration/easing — the first consumer proving the tokens compose with tw-animate-css through the Tailwind v4 var shorthand.
- DESIGN.md Motion section now states the concrete system.

## Visual repro (live dev app)

Connection chip popover before/after open (real dev session):

![m1-popover-motion.gif](https://github.com/user-attachments/assets/45bda28e-a136-4765-aed0-a177d6c90e61)

Live computed style on the open popover: `animationName: enter`, `animationDuration: 0.22s`, `animationTimingFunction: cubic-bezier(0.16, 1, 0.3, 1)` — the tokens resolving end-to-end.

## Test plan

- [x] New `motion-foundation.browser.test.tsx` (real compiled CSS): tokens on `:root`, reduced-motion media rule present with both neutralizing declarations
- [x] Mutation-checked both directions (guard removed → guard test fails; tokens removed → token test fails)
- [x] apps/web jsdom 1409 passed; web-browser project 42 files / 229 passed
- [x] lint / typecheck / knip clean
