### PR TITLE
feat(web): feedback micro-motion — chip pulse, save-dot entrance, toast rise

### DIFF
--- a/apps/web/src/components/HeaderSaveDot.tsx
+++ b/apps/web/src/components/HeaderSaveDot.tsx
@@ -47,6 +47,9 @@ export function HeaderSaveDot({
           data-testid="header-save-dot"
           className={cn(
             'relative inline-flex size-4 shrink-0 items-center justify-center rounded-full',
+            // Appears only when there is something to save — a soft
+            // fade+scale entrance keeps the dot from popping into the header.
+            'animate-in fade-in-0 zoom-in-75 duration-(--motion-duration-fast) ease-(--motion-ease-out)',
             'transition-transform hover:scale-110 focus-visible:outline-none',
             'focus-visible:ring-2 focus-visible:ring-primary/50',
             saving ? 'cursor-progress' : 'cursor-pointer',

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -64,10 +64,22 @@ export function ConnectionStatus({
           data-testid="connection-chip"
           className={cn(
             'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
+            'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
             state === 'sync-off' && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
           )}
         >
-          <span aria-hidden="true" className={cn('size-2 rounded-full', DOT_CLASS[state])} />
+          <span aria-hidden="true" className="relative inline-flex size-2">
+            {state === 'sync-off' && (
+              // One-shot attention echo behind the dot: mounts exactly when
+              // the chip enters sync-off, pulses twice, then rests. Finite
+              // by design — a standing ping would be noise, not guidance.
+              <span
+                data-testid="connection-chip-pulse"
+                className="absolute inset-0 rounded-full bg-amber-500 animate-[attention-pulse_900ms_var(--motion-ease-out)_2]"
+              />
+            )}
+            <span className={cn('absolute inset-0 rounded-full', DOT_CLASS[state])} />
+          </span>
           {CHIP_LABEL[state]}
         </button>
       </PopoverTrigger>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -108,6 +108,23 @@
   }
 
   /*
+   * One-shot attention echo (ConnectionStatus sync-off entry): an
+   * expanding, fading ring behind the chip dot. Compositor props only;
+   * a FINITE iteration count at the use site keeps it a pulse that
+   * guides attention on entry, never a standing ping.
+   */
+  @keyframes attention-pulse {
+    from {
+      transform: scale(1);
+      opacity: 0.7;
+    }
+    to {
+      transform: scale(2.4);
+      opacity: 0;
+    }
+  }
+
+  /*
    * Reduced-motion floor: neutralize every animation and transition —
    * including tw-animate-css's data-state entrances — for users who asked
    * the OS for less motion. 0.01ms instead of 0 so `animationend` /

--- a/apps/web/src/motion-feedback.browser.test.tsx
+++ b/apps/web/src/motion-feedback.browser.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * M2 feedback micro-motion contract (real browser, real compiled CSS):
+ * state-change feedback surfaces animate on the shared motion tokens.
+ *
+ * - The update toast enters with a real animation (not an instant pop).
+ * - The connection chip transitions its colors on the token duration.
+ * - Entering sync-off pulses a finite attention echo on the chip dot —
+ *   finite, so the chip guides attention once instead of pinging forever.
+ */
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { ConnectionStatus } from './components/connection/ConnectionStatus.js'
+import './index.css'
+import { UpdateToast } from './pwa/UpdateToast.js'
+
+beforeAll(async () => {
+  await vi.waitFor(() => {
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue('--motion-duration-normal')
+      .trim()
+    if (v === '') throw new Error('index.css not applied yet')
+  })
+})
+
+afterEach(cleanup)
+
+describe('feedback micro-motion', () => {
+  it('update toast enters with an animation on the token duration', () => {
+    render(<UpdateToast onReload={vi.fn()} onDismiss={vi.fn()} />)
+    const toast = document.querySelector('[role="status"]') as HTMLElement
+    const cs = getComputedStyle(toast)
+    expect(cs.animationName).not.toBe('none')
+    expect(cs.animationDuration).toBe('0.22s')
+  })
+
+  it('connection chip transitions colors on the token duration', () => {
+    render(<ConnectionStatus state="synced" />)
+    const chip = document.querySelector('[data-testid="connection-chip"]') as HTMLElement
+    const cs = getComputedStyle(chip)
+    expect(cs.transitionProperty).toContain('color')
+    expect(cs.transitionDuration).toContain('0.22s')
+  })
+
+  it('sync-off shows a finite attention pulse on the chip dot', () => {
+    render(<ConnectionStatus state="sync-off" onRepair={vi.fn()} />)
+    const echo = document.querySelector('[data-testid="connection-chip-pulse"]') as HTMLElement
+    expect(echo).not.toBeNull()
+    const cs = getComputedStyle(echo)
+    expect(cs.animationName).toBe('attention-pulse')
+    // Finite: guides attention on entry, never pings forever.
+    expect(Number(cs.animationIterationCount)).toBeGreaterThan(0)
+    expect(cs.animationIterationCount).not.toBe('infinite')
+  })
+
+  it('synced chip has no attention pulse', () => {
+    render(<ConnectionStatus state="synced" />)
+    expect(document.querySelector('[data-testid="connection-chip-pulse"]')).toBeNull()
+  })
+})

--- a/apps/web/src/pwa/UpdateToast.test.tsx
+++ b/apps/web/src/pwa/UpdateToast.test.tsx
@@ -28,9 +28,14 @@ describe('UpdateToast', () => {
     // positioning with a stacking z-index is what keeps it visible.
     render(<UpdateToast onReload={vi.fn()} onDismiss={vi.fn()} />)
 
+    // The centering/positioning wrapper and the animated surface are
+    // separate elements (the enter keyframe owns `transform`), so the
+    // fixed+z contract holds on the status element or an ancestor.
     const toast = screen.getByRole('status')
-    expect(toast.className).toMatch(/\bfixed\b/)
-    expect(toast.className).toMatch(/\bz-\d+\b/)
+    const overlay = toast.closest('[class*="fixed"]') as HTMLElement | null
+    expect(overlay).not.toBeNull()
+    expect(overlay?.className).toMatch(/\bfixed\b/)
+    expect(overlay?.className).toMatch(/\bz-\d+\b/)
   })
 
   it('hides the toast and calls onDismiss when Dismiss is clicked', () => {

--- a/apps/web/src/pwa/UpdateToast.tsx
+++ b/apps/web/src/pwa/UpdateToast.tsx
@@ -15,30 +15,36 @@ export function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
   // Fixed + z-index, not document flow: the app shell fills 100dvh, so a
   // static element appended to <body> sits below the viewport and the
   // update prompt is never actually seen.
+  // The centering translate lives on the outer wrapper and the entrance
+  // animation on the inner surface: tw-animate's enter keyframe owns
+  // `transform`, so putting both on one element would drop the -50% x
+  // centering for the duration of the entrance.
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg border bg-background px-4 py-2 text-sm shadow-lg"
-    >
-      <span>Update available</span>
-      <button
-        type="button"
-        onClick={onReload}
-        className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-lg border bg-background px-4 py-2 text-sm shadow-lg animate-in fade-in-0 slide-in-from-bottom-2 duration-(--motion-duration-normal) ease-(--motion-ease-out)"
       >
-        Reload
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          setDismissed(true)
-          onDismiss()
-        }}
-        className="rounded-md px-2 py-0.5 text-muted-foreground transition-colors hover:bg-accent"
-      >
-        Dismiss
-      </button>
+        <span>Update available</span>
+        <button
+          type="button"
+          onClick={onReload}
+          className="rounded-md border px-2 py-0.5 font-medium transition-colors hover:bg-accent"
+        >
+          Reload
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setDismissed(true)
+            onDismiss()
+          }}
+          className="rounded-md px-2 py-0.5 text-muted-foreground transition-colors hover:bg-accent"
+        >
+          Dismiss
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What

Second slice (M2) of the motion loop, built on the M1 tokens (#467): the state-feedback surfaces that used to flip instantly now animate — motion serving feedback and attention, per DESIGN.md's Motion rules.

- **Connection chip**: color state change crossfades on `--motion-duration-normal`. Entering **sync-off** pulses a finite attention echo behind the dot (new `attention-pulse` keyframe, `transform`/`opacity` only, two beats then rest). Sync-off is the one state a user must notice; a finite pulse guides attention once — a standing ping would be noise.
- **Header save dot**: fast fade+scale entrance instead of popping into the header.
- **Update toast**: rises in from the bottom edge. The centering translate moved to a wrapper element because tw-animate's enter keyframe owns `transform` — both on one element would drop the `-50%` x-centering during the entrance. The fixed+z overlay regression test now asserts on the status element or its ancestor.

All compositor props on the shared tokens; reduced motion is covered by the M1 global guard.

## Verification (live dev app)

Real sync-off session, computed styles at runtime:

- chip: `transitionDuration: 0.22s`, `transitionTimingFunction: cubic-bezier(0.16, 1, 0.3, 1)`
- pulse echo: `animationName: attention-pulse`, `0.9s`, `iterationCount: 2`

## Test plan

- [x] Red first (`motion-feedback.browser.test.tsx`, real compiled CSS): toast animates on the token duration; chip transitions colors on the token duration; sync-off pulse exists, is finite, and is absent for synced
- [x] apps/web jsdom 1409 passed; web-browser project 43 files / 233 passed
- [x] lint / typecheck / knip clean
