### PR TITLE
feat(web): continuity motion — loaded-grid fade, view-toggle crossfade, dialog tokens

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -43,7 +43,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-(--motion-duration-normal) ease-(--motion-ease-out) sm:max-w-lg',
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-(--motion-duration-normal) ease-(--motion-ease-out) sm:max-w-lg',
           className,
         )}
         {...props}

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -117,6 +117,22 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByText('beta')).toBeNull()
   })
 
+  it('fades the loaded grid in for skeleton-to-content continuity', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />)
+
+    const card = await screen.findByTestId('daemon-index-canvas-card')
+    const grid = card.parentElement as HTMLElement
+    expect(grid.className).toMatch(/\banimate-in\b/)
+    expect(grid.className).toMatch(/\bfade-in-0\b/)
+  })
+
   it('honors initialWorkspaceId over the daemon-listed first workspace', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -378,11 +378,16 @@ export function DaemonIndexPage({
 
         {view === 'tree' ? (
           selectedWorkspace ? (
-            <WorkspaceFilesPanel
-              daemonFetch={daemonFetch}
-              daemonBaseUrl={daemonBaseUrl}
-              workspaceId={selectedWorkspace}
-            />
+            // The wrapper remounts on every grid/tree toggle, so the fade
+            // re-runs and the view switch reads as one continuous surface
+            // changing shape rather than an instant swap.
+            <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
+              <WorkspaceFilesPanel
+                daemonFetch={daemonFetch}
+                daemonBaseUrl={daemonBaseUrl}
+                workspaceId={selectedWorkspace}
+              />
+            </div>
           ) : (
             <p className="text-sm text-muted-foreground">No workspace selected.</p>
           )
@@ -406,7 +411,7 @@ export function DaemonIndexPage({
         ) : visible.length === 0 && search !== '' ? (
           <p className="text-sm text-muted-foreground">No canvases match.</p>
         ) : visible.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="flex flex-col items-center gap-3 py-16 text-center animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
             <p className="text-sm font-medium">No canvases yet</p>
             <p className="text-sm text-muted-foreground">
               Name your first canvas and it opens ready to draw.
@@ -421,7 +426,9 @@ export function DaemonIndexPage({
             </Button>
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          // Mounts when the skeleton unmounts: the fade carries the
+          // skeleton-to-content handoff instead of an instant swap.
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
             {visible.map((row) => {
               const hasDisplayName = row.displayName !== row.slug
               return (


### PR DESCRIPTION
## What

Third slice (M3) of the motion loop, on the shared tokens (#467): the index page's loading and view-state handoffs used to swap instantly.

- **Skeleton → content**: the loaded canvas grid (and the post-load empty state) fades in when the skeleton unmounts, so loading resolves as one continuous surface instead of two unrelated frames.
- **Grid / Tree toggle**: each view remounts inside a fading wrapper, so the switch reads as the same surface changing shape.
- **Dialogs**: `dialog.tsx` / `alert-dialog.tsx` drop the hardcoded `duration-200` for the token duration + easing.

All entrances are opacity-only; each carries an explicit continuity reason per DESIGN.md's "no entrance animation without a reason" rule. Reduced motion stays covered by the global guard.

## Verification (live dev app)

Computed styles at runtime: loaded grid `animationName: enter, 0.22s, cubic-bezier(0.16, 1, 0.3, 1)`; tree-view wrapper `enter, 0.22s` after clicking the toggle.

## Test plan

- [x] Red first: loaded grid carries the fade-in entrance (DaemonIndexPage jsdom)
- [x] apps/web jsdom 1410 passed; web-browser project 42 files / 229 passed
- [x] lint / typecheck clean
