### PR TITLE
feat(web): two-finger touch pan and pinch zoom on the spatial canvas

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -486,7 +486,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           if (gestureState.kind !== 'idle') {
             applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
           }
-          capturePointer(root, e.pointerId)
+          // Capture BOTH fingers, not just the one that arrived second: an
+          // uncaptured first finger crossing outside the root would stop
+          // delivering its move/up events here, leaving a stale entry in
+          // touchPointsRef that would misread a later one-finger press as
+          // a pinch participant.
+          for (const pointerId of touchPointsRef.current.keys()) {
+            trySetPointerCapture(root, pointerId)
+          }
+          activePointerIdRef.current = e.pointerId
           return
         }
       }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -4,7 +4,9 @@
  * canvas-viewer's read-only `CanvasViewer` uses — this is NOT a fourth
  * scene builder).
  *
- * Supported: display, pan, zoom, select (click / click-empty-to-clear),
+ * Supported: display, pan, zoom (wheel / Space-drag / middle-drag on
+ * desktop; two-finger drag pans and pinch zooms on touch — one finger
+ * keeps the select/move semantics), select (click / click-empty-to-clear),
  * move (drag a selected node), resize (drag a corner/edge handle,
  * anchor-preserving, OR arrow-key nudge a focused resize handle), edit
  * text (double-click a text node; commits on blur/Cmd+Enter, Escape
@@ -64,6 +66,7 @@ import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, ToolPalette } from './ToolPalette.js'
+import { computePinchUpdate } from './touch-pinch.js'
 import {
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
@@ -236,6 +239,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const [marquee, setMarquee] = useState<{ start: Point; current: Point } | null>(null)
     const spaceDownRef = useRef(false)
     const isPanningRef = useRef(false)
+    // Two-finger touch navigation (`touch-action: none` disables the
+    // browser's own scrolling/zooming, so the editor must supply it):
+    // root-local positions per active touch pointer, and whether a pinch
+    // owns the touch sequence. The flag stays up until EVERY finger lifts,
+    // so the lone finger left behind after a pinch cannot fall through to
+    // the marquee/move path mid-air.
+    const touchPointsRef = useRef<Map<number, Point>>(new Map())
+    const pinchActiveRef = useRef(false)
     /** Last primary press for double-press detection: logical target + time. */
     const lastPressRef = useRef<{ key: string; at: number } | null>(null)
     const lastPanPointRef = useRef({ x: 0, y: 0 })
@@ -460,6 +471,25 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
+      if (e.pointerType === 'touch') {
+        touchPointsRef.current.set(e.pointerId, clientPointToRootLocal(e, root))
+        if (pinchActiveRef.current) return
+        if (touchPointsRef.current.size === 2) {
+          // The second finger converts whatever the first finger started
+          // (marquee, node move, double-press arming) into navigation:
+          // cancel it all, then pan/zoom until every finger lifts.
+          pinchActiveRef.current = true
+          setMarquee(null)
+          isPanningRef.current = false
+          lastPressRef.current = null
+          doublePressRef.current = null
+          if (gestureState.kind !== 'idle') {
+            applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+          }
+          capturePointer(root, e.pointerId)
+          return
+        }
+      }
       const screenPointForPan = clientPointToRootLocal(e, root)
       // Middle-button (or Space-held) drag pans from ANYWHERE — Excalidraw
       // semantics; a plain left drag on empty space marquee-selects instead.
@@ -607,6 +637,29 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
+      if (e.pointerType === 'touch' && touchPointsRef.current.has(e.pointerId)) {
+        const points = touchPointsRef.current
+        const nextPoint = clientPointToRootLocal(e, root)
+        if (pinchActiveRef.current && points.size >= 2) {
+          // The pinch pair is the two longest-lived fingers (Map preserves
+          // insertion order); later fingers are tracked but inert.
+          const [idA, idB] = points.keys()
+          if (e.pointerId === idA || e.pointerId === idB) {
+            const prev = { a: points.get(idA)!, b: points.get(idB)! }
+            const next = {
+              a: e.pointerId === idA ? nextPoint : prev.a,
+              b: e.pointerId === idB ? nextPoint : prev.b,
+            }
+            const { panDelta, zoomFactor, anchor } = computePinchUpdate(prev, next)
+            setViewport((vp) => zoomAt(panBy(vp, panDelta), anchor, zoomFactor))
+          }
+          points.set(e.pointerId, nextPoint)
+          return
+        }
+        points.set(e.pointerId, nextPoint)
+        // A lone finger left behind by a pinch stays inert until it lifts.
+        if (pinchActiveRef.current) return
+      }
       // First movement of an in-flight gesture: take capture now (see the
       // handlePointerDown comment for why not at the press). Idempotent —
       // re-capturing the same pointer is a no-op.
@@ -638,6 +691,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
+      if (e.pointerType === 'touch') {
+        touchPointsRef.current.delete(e.pointerId)
+        if (pinchActiveRef.current) {
+          if (touchPointsRef.current.size === 0) pinchActiveRef.current = false
+          // Fingers lifting out of a pinch never run the click/marquee
+          // release logic — the sequence was navigation, not a gesture.
+          return
+        }
+      }
       activePointerIdRef.current = null
       const armed = doublePressRef.current
       doublePressRef.current = null
@@ -743,7 +805,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       applyResult(result)
     }
 
-    const handlePointerCancel = () => {
+    const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.pointerType === 'touch') {
+        touchPointsRef.current.delete(e.pointerId)
+        if (touchPointsRef.current.size === 0) pinchActiveRef.current = false
+      }
       isPanningRef.current = false
       activePointerIdRef.current = null
       applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))

--- a/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Mobile navigation contract: with `touch-action: none` on the editor root
+ * the browser's own touch scrolling/zooming is disabled, so WE must supply
+ * it — two fingers pan and pinch-zoom the viewport (one finger keeps the
+ * select/move/marquee semantics). Real PointerEvents with
+ * pointerType='touch' exercise the actual root handlers.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>({
+    nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'hello' }],
+    edges: [],
+  })
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+    </div>
+  )
+}
+
+function touch(
+  target: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  pointerId: number,
+  x: number,
+  y: number,
+) {
+  const init = {
+    pointerId,
+    pointerType: 'touch',
+    clientX: x,
+    clientY: y,
+    isPrimary: pointerId === 1,
+  }
+  if (type === 'pointerdown') fireEvent.pointerDown(target, init)
+  else if (type === 'pointermove') fireEvent.pointerMove(target, init)
+  else fireEvent.pointerUp(target, init)
+}
+
+function getTransform(container: HTMLElement): string {
+  const layer = container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+  return layer.style.transform
+}
+
+function parseTransform(css: string): { zoom: number; x: number; y: number } {
+  const m = css.match(/scale\(([-\d.]+)\) translate\(([-\d.]+)px, ([-\d.]+)px\)/)
+  if (!m) throw new Error(`unexpected transform: ${css}`)
+  return { zoom: Number(m[1]), x: -Number(m[2]), y: -Number(m[3]) }
+}
+
+it('two-finger drag pans the viewport', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const before = parseTransform(getTransform(container))
+
+  touch(root, 'pointerdown', 1, 300, 300)
+  touch(root, 'pointerdown', 2, 400, 300)
+  touch(root, 'pointermove', 1, 340, 330)
+  touch(root, 'pointermove', 2, 440, 330)
+  touch(root, 'pointerup', 1, 340, 330)
+  touch(root, 'pointerup', 2, 440, 330)
+
+  const after = parseTransform(getTransform(container))
+  // Fingers moved +40/+30 screen px; content follows, so the viewport
+  // origin moves the opposite way in canvas units.
+  expect(after.x).toBeCloseTo(before.x - 40 / before.zoom, 4)
+  expect(after.y).toBeCloseTo(before.y - 30 / before.zoom, 4)
+  expect(after.zoom).toBeCloseTo(before.zoom, 4)
+})
+
+it('spreading two fingers zooms the viewport in', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const before = parseTransform(getTransform(container))
+
+  touch(root, 'pointerdown', 1, 350, 300)
+  touch(root, 'pointerdown', 2, 450, 300)
+  touch(root, 'pointermove', 1, 300, 300)
+  touch(root, 'pointermove', 2, 500, 300)
+  touch(root, 'pointerup', 1, 300, 300)
+  touch(root, 'pointerup', 2, 500, 300)
+
+  const after = parseTransform(getTransform(container))
+  expect(after.zoom).toBeCloseTo(before.zoom * 2, 4)
+})
+
+it('a second finger cancels an in-flight one-finger marquee instead of leaving it armed', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  // One finger down on empty space arms a marquee; the second finger must
+  // convert the gesture to pan/zoom, and releasing must leave no marquee.
+  touch(root, 'pointerdown', 1, 500, 400)
+  touch(root, 'pointerdown', 2, 600, 400)
+  touch(root, 'pointermove', 1, 520, 420)
+  touch(root, 'pointermove', 2, 620, 420)
+  touch(root, 'pointerup', 1, 520, 420)
+  touch(root, 'pointerup', 2, 620, 420)
+
+  expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
+})
+
+it('after a pinch ends, the remaining finger does not keep panning the viewport', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  touch(root, 'pointerdown', 1, 300, 300)
+  touch(root, 'pointerdown', 2, 400, 300)
+  touch(root, 'pointermove', 1, 320, 300)
+  touch(root, 'pointermove', 2, 420, 300)
+  touch(root, 'pointerup', 2, 420, 300)
+  const atPinchEnd = getTransform(container)
+
+  // Lone finger keeps moving — must not pan (nor start a marquee drag).
+  touch(root, 'pointermove', 1, 420, 400)
+  touch(root, 'pointerup', 1, 420, 400)
+
+  expect(getTransform(container)).toBe(atPinchEnd)
+})

--- a/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
@@ -107,6 +107,26 @@ it('a second finger cancels an in-flight one-finger marquee instead of leaving i
   expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
 })
 
+it('activating a pinch captures BOTH fingers, not just the second', async () => {
+  // An uncaptured first finger crossing outside the root stops delivering
+  // its move/up events, leaving a stale touch entry that would misread a
+  // later one-finger press as a pinch participant.
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const captured: number[] = []
+  root.setPointerCapture = (id: number) => {
+    captured.push(id)
+  }
+
+  touch(root, 'pointerdown', 1, 300, 300)
+  touch(root, 'pointerdown', 2, 400, 300)
+  touch(root, 'pointerup', 1, 300, 300)
+  touch(root, 'pointerup', 2, 400, 300)
+
+  expect(captured).toContain(1)
+  expect(captured).toContain(2)
+})
+
 it('after a pinch ends, the remaining finger does not keep panning the viewport', async () => {
   const { container } = render(<Host />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement

--- a/apps/web/src/components/spatial-editor/touch-pinch.test.ts
+++ b/apps/web/src/components/spatial-editor/touch-pinch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { computePinchUpdate } from './touch-pinch.js'
+import { panBy, zoomAt } from './viewport.js'
+
+describe('computePinchUpdate', () => {
+  it('two fingers translating together pan without zooming', () => {
+    const update = computePinchUpdate(
+      { a: { x: 100, y: 100 }, b: { x: 200, y: 100 } },
+      { a: { x: 130, y: 120 }, b: { x: 230, y: 120 } },
+    )
+    expect(update.panDelta).toEqual({ x: 30, y: 20 })
+    expect(update.zoomFactor).toBe(1)
+  })
+
+  it('spreading fingers zooms in around the (unmoved) centroid', () => {
+    const update = computePinchUpdate(
+      { a: { x: 140, y: 100 }, b: { x: 160, y: 100 } },
+      { a: { x: 130, y: 100 }, b: { x: 170, y: 100 } },
+    )
+    expect(update.panDelta).toEqual({ x: 0, y: 0 })
+    expect(update.zoomFactor).toBe(2)
+    expect(update.anchor).toEqual({ x: 150, y: 100 })
+  })
+
+  it('pinching fingers together zooms out', () => {
+    const update = computePinchUpdate(
+      { a: { x: 100, y: 100 }, b: { x: 200, y: 100 } },
+      { a: { x: 125, y: 100 }, b: { x: 175, y: 100 } },
+    )
+    expect(update.zoomFactor).toBe(0.5)
+  })
+
+  it('a degenerate (near-zero) finger distance degrades to pan-only', () => {
+    const update = computePinchUpdate(
+      { a: { x: 100, y: 100 }, b: { x: 100.2, y: 100 } },
+      { a: { x: 150, y: 100 }, b: { x: 170, y: 100 } },
+    )
+    expect(update.zoomFactor).toBe(1)
+  })
+
+  it('keeps the canvas point under the centroid fixed when applied pan-then-zoom', () => {
+    // The invariant that makes a pinch feel physical: whatever content sat
+    // under the fingers' midpoint stays under it across the frame.
+    const vp = { x: 40, y: 60, zoom: 1.5 }
+    const prev = { a: { x: 100, y: 200 }, b: { x: 300, y: 200 } }
+    const next = { a: { x: 120, y: 240 }, b: { x: 360, y: 240 } }
+    const update = computePinchUpdate(prev, next)
+
+    const prevCentroid = { x: 200, y: 200 }
+    const canvasUnderCentroid = {
+      x: prevCentroid.x / vp.zoom + vp.x,
+      y: prevCentroid.y / vp.zoom + vp.y,
+    }
+
+    const applied = zoomAt(panBy(vp, update.panDelta), update.anchor, update.zoomFactor)
+    const screenAfter = {
+      x: (canvasUnderCentroid.x - applied.x) * applied.zoom,
+      y: (canvasUnderCentroid.y - applied.y) * applied.zoom,
+    }
+    expect(screenAfter.x).toBeCloseTo(update.anchor.x, 6)
+    expect(screenAfter.y).toBeCloseTo(update.anchor.y, 6)
+  })
+})

--- a/apps/web/src/components/spatial-editor/touch-pinch.ts
+++ b/apps/web/src/components/spatial-editor/touch-pinch.ts
@@ -1,0 +1,49 @@
+import type { Point } from './viewport.js'
+
+/**
+ * Pure math for the two-finger touch gesture: given the previous and next
+ * root-local positions of both fingers, produce the viewport update — pan
+ * by the centroid's movement, zoom by the finger-distance ratio, anchored
+ * at the next centroid so the content under the fingers stays under them.
+ *
+ * The caller applies it as `zoomAt(panBy(vp, panDelta), anchor, zoomFactor)`
+ * (pan first, then zoom around the post-pan anchor).
+ */
+export interface PinchPair {
+  readonly a: Point
+  readonly b: Point
+}
+
+export interface PinchUpdate {
+  readonly panDelta: Point
+  readonly zoomFactor: number
+  readonly anchor: Point
+}
+
+// Below this finger distance (px) the ratio becomes numerically wild —
+// treat the pinch as pan-only for that frame.
+const MIN_PINCH_DISTANCE_PX = 1
+
+function centroid(pair: PinchPair): Point {
+  return { x: (pair.a.x + pair.b.x) / 2, y: (pair.a.y + pair.b.y) / 2 }
+}
+
+function distance(pair: PinchPair): number {
+  return Math.hypot(pair.a.x - pair.b.x, pair.a.y - pair.b.y)
+}
+
+export function computePinchUpdate(prev: PinchPair, next: PinchPair): PinchUpdate {
+  const prevCentroid = centroid(prev)
+  const nextCentroid = centroid(next)
+  const prevDistance = distance(prev)
+  const nextDistance = distance(next)
+  const zoomFactor =
+    prevDistance < MIN_PINCH_DISTANCE_PX || nextDistance < MIN_PINCH_DISTANCE_PX
+      ? 1
+      : nextDistance / prevDistance
+  return {
+    panDelta: { x: nextCentroid.x - prevCentroid.x, y: nextCentroid.y - prevCentroid.y },
+    zoomFactor,
+    anchor: nextCentroid,
+  }
+}


### PR DESCRIPTION
## What

User report: on a phone the canvas could not be panned or zoomed at all. Root cause: the editor root sets `touch-action: none` (disabling the browser's own touch scrolling/zooming — necessary so one-finger gestures reach the editor) but supplied **no touch navigation of its own**; pan/zoom existed only as wheel, Space-drag, and middle-button drag, none of which exist on a phone.

**Fix — the standard whiteboard convention:**

- **One finger** keeps the existing semantics: tap to select, drag a node to move it, drag empty space for marquee select, double-tap to create/edit.
- **Two fingers** navigate: dragging both pans by the centroid's movement; pinching zooms by the finger-distance ratio, anchored at the centroid so the content under your fingers stays under them.
- A second finger landing mid-gesture cancels whatever the first finger started (marquee, node move) and converts the sequence to navigation; the lone finger left after a pinch stays inert until it lifts — no accidental marquee or pan tail.

`touch-pinch.ts` is the pure per-frame math (`computePinchUpdate`: pan delta + zoom factor + anchor); `SpatialEditor` wires it through the existing pointer handlers keyed on `pointerType === 'touch'`. Mouse/pen paths are untouched.

## Verification

- Live dev app: dispatched real touch PointerEvent sequences against the running editor — pinch spread took the viewport from `scale(1) translate(0px, 0px)` to `scale(2) translate(-275px, -113px)` (anchored at the finger centroid), and a two-finger +40/+30px drag panned exactly +20/+15 canvas units at zoom 2.
- The **Cloudflare Pages preview URL** below (browser-local mode) can be opened directly on a phone to feel the real gesture.

## Test plan

- [x] Red first: pure-math unit tests (pan-only, spread ×2, pinch ×0.5, degenerate distance, and the pinned invariant that the canvas point under the centroid stays fixed when applied pan-then-zoom against the real viewport math)
- [x] Red first: real-PointerEvent browser tests — two-finger pan, pinch zoom, second-finger cancels an in-flight marquee, lone finger after pinch does not keep panning
- [x] Full web-browser project 43 files / 233 passed (all existing mouse-path suites green); jsdom 1416 passed
- [x] typecheck / lint / knip clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-finger touch navigation to the spatial editor, including panning and pinch-to-zoom.
  * Automatically switches from one-finger selection or manipulation to touch navigation when a second finger is detected.
  * Improved handling of touch releases and cancellations to prevent unintended editor movement.

* **Tests**
  * Added coverage for panning, zooming, gesture cancellation, and edge-case pinch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->