### PR TITLE
feat(web): grid page shell and icon chrome for the canvas pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -335,33 +335,38 @@ export function App({ providerState }: AppProps) {
         // propagates through Suspense's own error path to the nearest
         // boundary, which must be here to catch it.
         <ErrorBoundary>
-          <Suspense
-            fallback={<LazyPageFallback heightClass="h-dvh" message="Connecting to daemon…" />}
-          >
-            {daemonView.kind === 'index' ? (
-              <DaemonIndexPage
-                daemonBaseUrl={payload.baseUrl}
-                token={pairedToken}
-                initialWorkspaceId={daemonView.workspaceId}
-                onOpenCanvas={(workspaceId, slug) =>
-                  setDaemonView({ kind: 'canvas', workspaceId, slug })
-                }
-              />
-            ) : (
-              <DaemonCanvasPage
-                key={`${daemonView.workspaceId}:${daemonView.slug}`}
-                daemonBaseUrl={payload.baseUrl}
-                workspaceId={daemonView.workspaceId}
-                slug={daemonView.slug}
-                token={pairedToken}
-                onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-                browserLocalStore={browserLocalStore}
-                onNavigateBack={() =>
-                  setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
-                }
-              />
-            )}
-          </Suspense>
+          {/* Pages size to their allotted height (h-full) so app-level rows
+              like the beta banner can never clip them — this bannerless
+              branch supplies the viewport height itself. */}
+          <div className="h-dvh">
+            <Suspense
+              fallback={<LazyPageFallback heightClass="h-dvh" message="Connecting to daemon…" />}
+            >
+              {daemonView.kind === 'index' ? (
+                <DaemonIndexPage
+                  daemonBaseUrl={payload.baseUrl}
+                  token={pairedToken}
+                  initialWorkspaceId={daemonView.workspaceId}
+                  onOpenCanvas={(workspaceId, slug) =>
+                    setDaemonView({ kind: 'canvas', workspaceId, slug })
+                  }
+                />
+              ) : (
+                <DaemonCanvasPage
+                  key={`${daemonView.workspaceId}:${daemonView.slug}`}
+                  daemonBaseUrl={payload.baseUrl}
+                  workspaceId={daemonView.workspaceId}
+                  slug={daemonView.slug}
+                  token={pairedToken}
+                  onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+                  browserLocalStore={browserLocalStore}
+                  onNavigateBack={() =>
+                    setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
+                  }
+                />
+              )}
+            </Suspense>
+          </div>
         </ErrorBoundary>
       )
     }
@@ -458,9 +463,10 @@ export function App({ providerState }: AppProps) {
   }
 
   // Own the viewport as a flex column so the in-flow banner sits ABOVE the
-  // canvas instead of pushing the h-dvh canvas page past the viewport (which
-  // would add a page scrollbar). The canvas fills the remaining height; the
-  // wrapper clips the canvas page's own h-dvh to that remaining space.
+  // canvas. Pages size to the height this shell allots them (h-full), so
+  // the banner displaces the canvas instead of clipping its bottom edge —
+  // the tool palette used to vanish behind the viewport on phones exactly
+  // because the page claimed h-dvh underneath an in-flow banner.
   return (
     <ErrorBoundary>
       <div className="flex h-dvh flex-col">

--- a/apps/web/src/components/CanvasPageSkeleton.tsx
+++ b/apps/web/src/components/CanvasPageSkeleton.tsx
@@ -6,7 +6,12 @@
  */
 export function CanvasPageSkeleton({ label }: { label: string }) {
   return (
-    <div role="status" aria-live="polite" aria-label={label} className="flex h-dvh w-full flex-col">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+      className="flex h-full w-full flex-col"
+    >
       <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
         <div className="h-5 w-36 animate-pulse rounded bg-muted" />
         <div className="ml-auto h-6 w-16 animate-pulse rounded-full bg-muted" />

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -132,7 +132,7 @@ describe('WorkspaceTopBar browser mode', () => {
   it('opens History from the real top bar and keeps the popover list scrollable', async () => {
     const { container } = renderTopBar()
 
-    await page.getByRole('button', { name: 'History' }).click()
+    await page.getByRole('button', { name: 'Version history' }).click()
 
     await waitFor(() => {
       expect(container.textContent).toContain('Version history')
@@ -167,7 +167,7 @@ describe('WorkspaceTopBar browser mode', () => {
   it('keeps the version popover open when a mousedown lands inside the restore confirmation dialog (RED-first)', async () => {
     renderTopBar()
 
-    await page.getByRole('button', { name: 'History' }).click()
+    await page.getByRole('button', { name: 'Version history' }).click()
     await waitFor(() => {
       expect(screen.getByText('Version history')).toBeTruthy()
     })
@@ -228,7 +228,7 @@ describe('WorkspaceTopBar browser mode', () => {
     const onRestored = vi.fn()
     renderTopBar({ onRestored })
 
-    await page.getByRole('button', { name: 'History' }).click()
+    await page.getByRole('button', { name: 'Version history' }).click()
     await page.getByText(/^Version 1$/).click()
 
     await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
@@ -503,9 +503,9 @@ describe('WorkspaceTopBar browser mode', () => {
 
     // Exposed right-side actions are hidden at this width.
     await waitFor(() => {
-      expect(isDisplayNone(screen.getByRole('button', { name: 'History', hidden: true }))).toBe(
-        true,
-      )
+      expect(
+        isDisplayNone(screen.getByRole('button', { name: 'Version history', hidden: true })),
+      ).toBe(true)
       expect(
         isDisplayNone(screen.getByRole('button', { name: /Theme: light/i, hidden: true })),
       ).toBe(true)
@@ -556,7 +556,7 @@ describe('WorkspaceTopBar browser mode', () => {
     renderTopBar({ theme: 'light', onToggleTheme: vi.fn() })
     await waitFor(() => {
       expect(isDisplayNone(screen.getByTestId('topbar-more-actions-trigger'))).toBe(true)
-      expect(isDisplayNone(screen.getByRole('button', { name: 'History' }))).toBe(false)
+      expect(isDisplayNone(screen.getByRole('button', { name: 'Version history' }))).toBe(false)
       expect(isDisplayNone(screen.getByRole('button', { name: /Theme: light/i }))).toBe(false)
       expect(isDisplayNone(screen.getByRole('button', { name: 'Fullscreen' }))).toBe(false)
     })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -1830,20 +1830,22 @@ describe('node placement and affordances', () => {
     expect(node?.type === 'text' ? node.text : undefined).toBe('')
   })
 
-  it('the Add note button has real, visible button affordance (not a bare, transparent element)', async () => {
+  it('the Add note button has real, visible button affordance (icon + accessible name)', async () => {
+    // Icon-only since the chrome iconification: the affordance is a
+    // rendered icon inside the bordered palette container, and the full
+    // name lives on aria-label (what assistive tech and tooltips read).
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor canvas={{ nodes: [], edges: [] }} onChange={vi.fn()} measure={fakeMeasure} />
       </div>,
     )
     const button = page.getByTestId('add-node-button').element() as HTMLButtonElement
-    const style = getComputedStyle(button)
-    const hasVisibleBackground = style.backgroundColor !== 'rgba(0, 0, 0, 0)'
-    const hasVisibleBorder = Number.parseFloat(style.borderWidth) > 0
-    expect(hasVisibleBackground || hasVisibleBorder).toBe(true)
-    expect(
-      Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingLeft),
-    ).toBeGreaterThan(0)
+    const icon = button.querySelector('svg')
+    expect(icon).not.toBeNull()
+    expect((icon as SVGElement).getBoundingClientRect().width).toBeGreaterThan(0)
+    expect(button.getAttribute('aria-label')).toBe('Add note')
+    const palette = button.closest('[data-testid="tool-palette"]') as HTMLElement
+    expect(Number.parseFloat(getComputedStyle(palette).borderWidth)).toBeGreaterThan(0)
     button.focus()
     expect(document.activeElement).toBe(button)
   })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -40,7 +40,9 @@ describe('Add note button', () => {
     )
     const button = getByTestId('add-node-button') as HTMLButtonElement
     expect(button.tagName).toBe('BUTTON')
-    expect(button.textContent).toBe('Add note')
+    // Icon-only since the chrome iconification: the accessible name lives
+    // on aria-label, which is what assistive tech (and getByRole) resolve.
+    expect(button.getAttribute('aria-label')).toBe('Add note')
     expect(button.disabled).toBe(false)
   })
 })

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -8,10 +8,18 @@
  * controls only — it must never grow per-object actions like delete or
  * color, which belong on the selected object.
  *
+ * Icon-only buttons (chrome carries no sentence-shaped copy): every button
+ * keeps its full accessible name via aria-label — which is also what the
+ * existing getByRole('button', { name: ... }) tests and screen readers
+ * resolve — and a tooltip supplies the sighted-hover equivalent.
+ *
  * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
  * presses originating here (see SpatialEditor's isOverlayEvent): without
  * that, the root would capture the pointer and swallow the buttons' clicks.
  */
+import { MousePointer2, Spline, StickyNote } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
 export type EditorTool = 'select' | 'connect'
 
 interface ToolPaletteProps {
@@ -21,7 +29,7 @@ interface ToolPaletteProps {
 }
 
 const TOOL_BUTTON_CLASS =
-  'rounded-md border px-3 py-1.5 text-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:font-medium'
+  'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
 
 export function ToolPalette({ onCreateNode, tool, onToolChange }: ToolPaletteProps) {
   return (
@@ -30,34 +38,53 @@ export function ToolPalette({ onCreateNode, tool, onToolChange }: ToolPalettePro
       data-testid="tool-palette"
       role="toolbar"
       aria-label="Canvas tools"
-      className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background p-1 shadow-md"
+      className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
     >
-      <button
-        type="button"
-        data-testid="select-tool-button"
-        aria-pressed={tool === 'select'}
-        onClick={() => onToolChange('select')}
-        className={TOOL_BUTTON_CLASS}
-      >
-        Select
-      </button>
-      <button
-        type="button"
-        data-testid="connect-tool-button"
-        aria-pressed={tool === 'connect'}
-        onClick={() => onToolChange('connect')}
-        className={TOOL_BUTTON_CLASS}
-      >
-        Connect
-      </button>
-      <button
-        type="button"
-        data-testid="add-node-button"
-        onClick={onCreateNode}
-        className="rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-      >
-        Add note
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="select-tool-button"
+            aria-pressed={tool === 'select'}
+            aria-label="Select"
+            onClick={() => onToolChange('select')}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <MousePointer2 aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Select</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="connect-tool-button"
+            aria-pressed={tool === 'connect'}
+            aria-label="Connect"
+            onClick={() => onToolChange('connect')}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <Spline aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Connect nodes</TooltipContent>
+      </Tooltip>
+      <div aria-hidden="true" className="mx-0.5 h-5 w-px bg-border" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="add-node-button"
+            aria-label="Add note"
+            onClick={onCreateNode}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <StickyNote aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Add note</TooltipContent>
+      </Tooltip>
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
@@ -86,7 +86,9 @@ it('double-clicking an edge opens the label editor; committing sets the label', 
   expect(latest.canvas.edges[0]).toMatchObject({ id: 'e1', label: 'yes' })
   // The committed label is rendered into the scene.
   await vi.waitFor(() =>
-    expect(rootOf(container).querySelector('svg')?.textContent ?? '').toContain('yes'),
+    expect(
+      rootOf(container).querySelector('[data-testid="viewport-transform"] svg')?.textContent ?? '',
+    ).toContain('yes'),
   )
 })
 

--- a/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
@@ -50,12 +50,14 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     )
     document.documentElement.classList.remove('dark')
 
-    const rects = container.querySelectorAll('svg rect')
+    const rects = container.querySelectorAll('[data-testid="viewport-transform"] svg rect')
     expect(rects.length).toBeGreaterThan(0)
     for (const rect of rects) {
       expect(rect.getAttribute('stroke')).toBe(EDITOR_DARK_PALETTE.chromeStroke)
     }
-    const edgePaths = container.querySelectorAll('svg path, svg polyline, svg line')
+    const edgePaths = container.querySelectorAll(
+      '[data-testid="viewport-transform"] :is(svg path, svg polyline, svg line)',
+    )
     expect(edgePaths.length).toBeGreaterThan(0)
     for (const edgeEl of edgePaths) {
       expect(edgeEl.getAttribute('stroke')).toBe(EDITOR_DARK_PALETTE.chromeStroke)
@@ -71,7 +73,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
         theme="light"
       />,
     )
-    const rects = container.querySelectorAll('svg rect')
+    const rects = container.querySelectorAll('[data-testid="viewport-transform"] svg rect')
     expect(rects.length).toBeGreaterThan(0)
     for (const rect of rects) {
       expect(rect.getAttribute('stroke')).toBe(EDITOR_LIGHT_PALETTE.chromeStroke)
@@ -87,7 +89,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
         theme="dark"
       />,
     )
-    const svg = container.querySelector('svg')
+    const svg = container.querySelector('[data-testid="viewport-transform"] svg')
     const host = svg?.parentElement
     expect(host?.style.fill).toBe(hexToRgb(EDITOR_DARK_PALETTE.textFill))
   })
@@ -101,7 +103,9 @@ describe('SpatialEditor theme chrome (real browser)', () => {
         theme="light"
       />,
     )
-    const lightViewBox = light.container.querySelector('svg')?.getAttribute('viewBox')
+    const lightViewBox = light.container
+      .querySelector('[data-testid="viewport-transform"] svg')
+      ?.getAttribute('viewBox')
     cleanup()
     const dark = render(
       <SpatialEditor
@@ -111,7 +115,9 @@ describe('SpatialEditor theme chrome (real browser)', () => {
         theme="dark"
       />,
     )
-    const darkViewBox = dark.container.querySelector('svg')?.getAttribute('viewBox')
+    const darkViewBox = dark.container
+      .querySelector('[data-testid="viewport-transform"] svg')
+      ?.getAttribute('viewBox')
     expect(darkViewBox).toBe(lightViewBox)
   })
 })

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -53,11 +53,11 @@ export function TopBarSecondaryActions({
                 data-version-trigger
                 variant="ghost"
                 size="sm"
-                className="h-8 gap-1.5"
+                className="size-8 p-0"
                 onClick={onToggleVersionOpen}
+                aria-label="Version history"
               >
                 <History className="size-3.5" />
-                <span className="text-xs">History</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>Version history</TooltipContent>

--- a/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
@@ -10,7 +10,13 @@ import '../index.css'
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 async function clearDb(): Promise<void> {
@@ -87,6 +93,35 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
     } finally {
       filler.remove()
     }
+  })
+
+  it('layout: respects the height its parent allots (app-level banner scenario)', async () => {
+    // The phone bug: the app shell stacks a beta banner ABOVE the page, so
+    // the page must size to the remaining height (h-full). A page that
+    // claims the whole viewport (h-dvh) under an in-flow banner slides its
+    // bottom — the tool palette — past the viewport edge.
+    const BANNER_PX = 40
+    rtlRender(
+      <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ height: BANNER_PX, flexShrink: 0 }} />
+        <div style={{ minHeight: 0, flex: 1, overflow: 'hidden' }}>
+          <MemoryRouter initialEntries={['/']}>
+            <BrowserLocalCanvasPage store={new IndexedDBStore()} />
+          </MemoryRouter>
+        </div>
+      </div>,
+    )
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    const container = screen.getByTestId('spatial-editor-container')
+    const rect = container.getBoundingClientRect()
+    expect(rect.bottom).toBeLessThanOrEqual(window.innerHeight + 1)
+    const main = container.closest('main') as HTMLElement
+    expect(main.getBoundingClientRect().height).toBeLessThanOrEqual(
+      window.innerHeight - BANNER_PX + 1,
+    )
   })
 
   it('cleanup: delete canvas shows cleanup-completed', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
@@ -57,6 +57,38 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
     expect(container.clientWidth).toBeGreaterThan(600)
   })
 
+  it('layout: the editor area is never clipped below the viewport, whatever the header stacks', async () => {
+    // Regression: the old flex column let a growing/wrapping header push the
+    // editor's bottom edge past the viewport. The grid shell gives the
+    // header stack an auto row and the editor minmax(0,1fr) — the editor's
+    // bottom must sit exactly at the viewport's bottom edge.
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    const container = screen.getByTestId('spatial-editor-container')
+    const rect = container.getBoundingClientRect()
+    expect(rect.bottom).toBeLessThanOrEqual(window.innerHeight + 1)
+    // And it truly fills the remainder — no dead strip above the fold.
+    expect(rect.bottom).toBeGreaterThan(window.innerHeight - 2)
+
+    // The actual regression: GROW the header stack (as a wrapping row or an
+    // appearing banner would) and the editor must give up exactly that
+    // height instead of sliding its bottom edge below the viewport.
+    const headerStack = container.closest('main')?.firstElementChild as HTMLElement
+    const filler = document.createElement('div')
+    filler.style.height = '120px'
+    headerStack.appendChild(filler)
+    try {
+      const grown = container.getBoundingClientRect()
+      expect(grown.bottom).toBeLessThanOrEqual(window.innerHeight + 1)
+      expect(grown.height).toBeLessThan(rect.height)
+    } finally {
+      filler.remove()
+    }
+  })
+
   it('cleanup: delete canvas shows cleanup-completed', async () => {
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
     await waitFor(

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -27,7 +27,13 @@ import {
 import '../index.css'
 
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 type OnChange = (next: SpatialCanvas, command: EditorCommand) => void

--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -17,7 +17,13 @@ import '../index.css'
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 async function clearDb(): Promise<void> {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -7,7 +7,13 @@ import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import '../index.css'
 
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 async function clearDb(): Promise<void> {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.history-nav.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.history-nav.browser.test.tsx
@@ -70,7 +70,11 @@ describe('BrowserLocalCanvasPage browser Back/Forward (browser — real IndexedD
       [{ path: '*', element: <BrowserLocalCanvasPage store={store} /> }],
       { initialEntries: ['/'] },
     )
-    rtlRender(<RouterProvider router={router} />)
+    rtlRender(
+      <div style={{ height: '100vh' }}>
+        <RouterProvider router={router} />
+      </div>,
+    )
 
     await waitFor(
       () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -20,7 +20,13 @@ import { clearWhiteboardDb } from '../test-utils/browser-local-canvas.js'
 import '../index.css'
 
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 let spatialMounts = 0

--- a/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.multi-canvas.browser.test.tsx
@@ -36,7 +36,13 @@ import '../index.css'
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 type OnChange = (next: SpatialCanvas, command: EditorCommand) => void

--- a/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.reload-elements.browser.test.tsx
@@ -33,7 +33,13 @@ import '../index.css'
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 type OnChange = (next: SpatialCanvas, command: EditorCommand) => void

--- a/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
@@ -10,7 +10,13 @@ import '../index.css'
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
 function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+  return rtlRender(
+    // Pages fill their allotted height (h-full) — the app shell owns the
+    // viewport in production, so tests supply the equivalent sized parent.
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
 }
 
 async function clearDb(): Promise<void> {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -281,7 +281,7 @@ export function BrowserLocalCanvasPage({
       <div
         role="alert"
         aria-live="assertive"
-        className="flex h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+        className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center"
       >
         <p className="max-w-md text-sm text-destructive">{pageState.message}</p>
         <button
@@ -299,7 +299,7 @@ export function BrowserLocalCanvasPage({
     return (
       <div
         data-testid="cleanup-completed"
-        className="flex h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+        className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center"
       >
         <p className="text-sm text-muted-foreground">Canvas removed.</p>
         <button
@@ -322,7 +322,7 @@ export function BrowserLocalCanvasPage({
     // every header-shaped row stacks inside the auto row, and the editor
     // owns minmax(0,1fr) — however many rows appear or however tall they
     // wrap, the editor row is always exactly the remaining viewport height.
-    <main ref={mainRef} className="grid h-dvh w-full grid-rows-[auto_minmax(0,1fr)]">
+    <main ref={mainRef} className="grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
       <div className="min-w-0">
         {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
           is the visible title control, but the page keeps a real <h1> for

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,3 +1,4 @@
+import { Copy, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
@@ -17,6 +18,7 @@ import {
   AlertDialogTrigger,
 } from '../components/ui/alert-dialog.js'
 import { Button } from '../components/ui/button.js'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
@@ -316,129 +318,138 @@ export function BrowserLocalCanvasPage({
   }
 
   return (
-    // h-dvh makes the page own its viewport height: without it the flex chain
-    // has no sized ancestor and the editor area collapses to 0px.
-    <main ref={mainRef} className="flex h-dvh w-full flex-col">
-      {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
+    // Two-row grid shell (h-dvh makes the page own its viewport height):
+    // every header-shaped row stacks inside the auto row, and the editor
+    // owns minmax(0,1fr) — however many rows appear or however tall they
+    // wrap, the editor row is always exactly the remaining viewport height.
+    <main ref={mainRef} className="grid h-dvh w-full grid-rows-[auto_minmax(0,1fr)]">
+      <div className="min-w-0">
+        {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
           is the visible title control, but the page keeps a real <h1> for
           accessibility trees. */}
-      <h1 className="sr-only">{pageState.snapshot.name}</h1>
-      <Suspense
-        fallback={
-          <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
-        }
-      >
-        <WorkspaceTopBar
-          statusSlot={
-            <ConnectionStatus state="local">
-              <p className="text-muted-foreground">
-                Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
-                combining changes
-              </p>
-              <Suspense fallback={null}>
-                <DaemonDetectedBanner
-                  settingsStore={settingsStore}
-                  fetch={window.fetch.bind(window)}
-                />
-              </Suspense>
-            </ConnectionStatus>
+        <h1 className="sr-only">{pageState.snapshot.name}</h1>
+        <Suspense
+          fallback={
+            <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
           }
-          dataMode="local"
-          workspaceId="local"
-          slug={pageState.snapshot.id}
-          canvases={switcherOptions.map((c) => ({
-            slug: c.id,
-            name: c.name,
-            updatedAt: c.updatedAt,
-          }))}
-          onNavigateToCanvas={(id) => void switchCanvas(id)}
-          onRenameCanvas={renameCanvas}
-          onCreateCanvas={async () => {
-            const created = await createCanvas()
-            await switchCanvas(created.id)
-          }}
-          onCreateMarkdownCanvas={async () => {
-            const created = await createCanvas(undefined, 'markdown')
-            await switchCanvas(created.id)
-          }}
-          theme={theme}
-          onToggleTheme={setTheme}
-          onEnterFullscreen={() => {
-            void mainRef.current?.requestFullscreen()
-          }}
-          capabilities={{
-            versions: capabilities.versions,
-            branches: capabilities.branches,
-            merge: capabilities.merge,
-          }}
-          onExport={exportScene}
-          onOpenSettings={handleOpenSettings}
-        />
-      </Suspense>
-      {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain
+        >
+          <WorkspaceTopBar
+            statusSlot={
+              <ConnectionStatus state="local">
+                <p className="text-muted-foreground">
+                  Connect a local daemon (MCP) to unlock version history, workspaces, variations,
+                  and combining changes
+                </p>
+                <Suspense fallback={null}>
+                  <DaemonDetectedBanner
+                    settingsStore={settingsStore}
+                    fetch={window.fetch.bind(window)}
+                  />
+                </Suspense>
+              </ConnectionStatus>
+            }
+            dataMode="local"
+            workspaceId="local"
+            slug={pageState.snapshot.id}
+            canvases={switcherOptions.map((c) => ({
+              slug: c.id,
+              name: c.name,
+              updatedAt: c.updatedAt,
+            }))}
+            onNavigateToCanvas={(id) => void switchCanvas(id)}
+            onRenameCanvas={renameCanvas}
+            onCreateCanvas={async () => {
+              const created = await createCanvas()
+              await switchCanvas(created.id)
+            }}
+            onCreateMarkdownCanvas={async () => {
+              const created = await createCanvas(undefined, 'markdown')
+              await switchCanvas(created.id)
+            }}
+            theme={theme}
+            onToggleTheme={setTheme}
+            onEnterFullscreen={() => {
+              void mainRef.current?.requestFullscreen()
+            }}
+            capabilities={{
+              versions: capabilities.versions,
+              branches: capabilities.branches,
+              merge: capabilities.merge,
+            }}
+            onExport={exportScene}
+            onOpenSettings={handleOpenSettings}
+          />
+        </Suspense>
+        {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain
           div, not a second <header>: two sibling <header> landmarks under
           <main> would both register as "banner" in accessibility trees
           since <main> does not scope them the way sectioning content does. */}
-      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-1 text-xs">
-        <span className="text-muted-foreground">{persistenceLabel(pageState.persistence)}</span>
-        {cleanupError && (
-          <div role="alert" aria-live="assertive" className="text-destructive">
-            {cleanupError}
-          </div>
-        )}
-        {duplicateError && (
-          <div role="alert" aria-live="assertive" className="text-destructive">
-            {duplicateError}
-          </div>
-        )}
-        <Button
-          type="button"
-          aria-label="Duplicate canvas"
-          disabled={isDuplicating}
-          onClick={() => void handleDuplicate()}
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs"
-        >
-          Duplicate
-        </Button>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              type="button"
-              aria-label="Delete canvas"
-              variant="outline"
-              size="sm"
-              className="h-7 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
-            >
-              Delete
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This permanently removes the canvas and its drawing data from this browser. This
-                action cannot be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => void triggerCleanup()}
-                className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+        <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-1 text-xs">
+          <span className="text-muted-foreground">{persistenceLabel(pageState.persistence)}</span>
+          {cleanupError && (
+            <div role="alert" aria-live="assertive" className="text-destructive">
+              {cleanupError}
+            </div>
+          )}
+          {duplicateError && (
+            <div role="alert" aria-live="assertive" className="text-destructive">
+              {duplicateError}
+            </div>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                aria-label="Duplicate canvas"
+                disabled={isDuplicating}
+                onClick={() => void handleDuplicate()}
+                variant="ghost"
+                size="sm"
+                className="size-7 p-0"
               >
-                Delete
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+                <Copy aria-hidden="true" className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Duplicate canvas</TooltipContent>
+          </Tooltip>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                type="button"
+                aria-label="Delete canvas"
+                variant="ghost"
+                size="sm"
+                className="size-7 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 aria-hidden="true" className="size-3.5" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently removes the canvas and its drawing data from this browser. This
+                  action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => void triggerCleanup()}
+                  className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+                >
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </div>
       {/* The snapshot's kind picks the editor: markdown canvases open the
           markdown editor (body persisted as a Loro 'body' text container
           through the same store — see use-markdown-body.ts), everything
           else the spatial editor. */}
-      <div data-testid="spatial-editor-container" className="min-h-0 flex-1">
+      <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
         {canvasKind === 'markdown' ? (
           markdownBody.body !== null && (
             <MarkdownEditor

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -136,9 +136,9 @@ describe('DaemonCanvasPage', () => {
     // The bar's History button is the real versions-capability affordance
     // now that WorkspaceTopBar owns it (see WorkspaceTopBar.tsx).
     expect(screen.getByRole('button', { name: /history/i })).toBeTruthy()
-    // Workspaces is now a real switcher (not a static teaser) once
-    // capabilities.workspaces is true and the daemon has workspaces to list.
-    expect(screen.getByLabelText('Workspaces')).toBeTruthy()
+    // A single-workspace daemon renders no workspace selector at all —
+    // one raw id is not a choice, and every header row costs canvas height.
+    expect(screen.queryByLabelText('Workspaces')).toBeNull()
   })
 
   describe('workspace switcher', () => {
@@ -898,7 +898,7 @@ describe('DaemonCanvasPage', () => {
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
 
-      const toggle = screen.getByRole('button', { name: 'History' })
+      const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
         toggle.click()
       })
@@ -950,7 +950,7 @@ describe('DaemonCanvasPage', () => {
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
 
-      const toggle = screen.getByRole('button', { name: 'History' })
+      const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
         toggle.click()
       })
@@ -1041,7 +1041,7 @@ describe('DaemonCanvasPage', () => {
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
 
-      const toggle = screen.getByRole('button', { name: 'History' })
+      const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
         toggle.click()
       })

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -292,115 +292,134 @@ export function DaemonCanvasPage({
 
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
-      <main className="relative flex h-dvh w-full flex-col">
-        <h1 className="sr-only">Whiteboard (daemon)</h1>
-        {controller.switchError && (
-          <div
-            role="alert"
-            aria-live="assertive"
-            className="flex items-center gap-2 border-b bg-background px-4 py-1"
-          >
-            <span className="text-xs text-destructive">{controller.switchError}</span>
-          </div>
-        )}
-        {/* Rendered at the page level when WorkspaceTopBar has nowhere to
+      {/* Two-row grid shell: everything header-shaped stacks inside the
+          auto row, and the canvas owns minmax(0,1fr) — however many banner
+          rows appear (or however tall they wrap), the canvas row is always
+          exactly the remaining viewport height, never clipped below it. */}
+      <main className="relative grid h-dvh w-full grid-rows-[auto_minmax(0,1fr)]">
+        <div className="min-w-0">
+          <h1 className="sr-only">Whiteboard (daemon)</h1>
+          {controller.switchError && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="flex items-center gap-2 border-b bg-background px-4 py-1"
+            >
+              <span className="text-xs text-destructive">{controller.switchError}</span>
+            </div>
+          )}
+          {/* Rendered at the page level when WorkspaceTopBar has nowhere to
             mount (no-canvas/empty-workspace view) so the degraded state
             never disappears with the canvas-gated chrome. */}
-        {authError && !canvas && (
-          <div className="flex items-center border-b bg-background px-4 py-1.5">
-            {connectionStatus}
-          </div>
-        )}
-        {canvas && (
-          <WorkspaceTopBar
-            statusSlot={connectionStatus}
-            workspaceId={canvas.workspaceId}
-            slug={canvas.slug}
-            canvases={controller.canvases}
-            onNavigateToCanvas={controller.switchCanvas}
-            capabilities={{
-              versions: capabilities.versions,
-              branches: capabilities.branches,
-              merge: capabilities.merge,
-            }}
-            branchRefreshSignal={branchRefreshSignal}
-            versionRefreshSignal={versionRefreshSignal}
-            onRestored={clearLocalUndo}
-            versionPanelExtra={versionPanelExtra}
-            onNavigateBack={onNavigateBack}
-            onExport={exportScene}
-            onOpenSettings={handleOpenSettings}
-          />
-        )}
-        {capabilities.branches && canvas && (
-          <HeaderBranchBanner workspaceId={canvas.workspaceId} slug={canvas.slug} />
-        )}
-        <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
-          {capabilities.workspaces && controller.workspaces.length > 0 ? (
-            <select
-              aria-label="Workspaces"
-              value={controller.workspaceId ?? ''}
-              onChange={(event) => void controller.switchWorkspace(event.target.value)}
-              className="min-w-0 max-w-40 truncate rounded-md border bg-background px-2 py-1 text-xs"
-            >
-              {controller.workspaces.map((w) => (
-                <option key={w.workspaceId} value={w.workspaceId}>
-                  {w.workspaceId}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <CapabilityTeaser label="Workspaces" enabled={capabilities.workspaces} />
+          {authError && !canvas && (
+            <div className="flex items-center border-b bg-background px-4 py-1.5">
+              {connectionStatus}
+            </div>
           )}
-          {/* WorkspaceTopBar owns the real History/HeaderSaveDot/HeaderBranchChip
+          {canvas && (
+            <WorkspaceTopBar
+              statusSlot={connectionStatus}
+              workspaceId={canvas.workspaceId}
+              slug={canvas.slug}
+              canvases={controller.canvases}
+              onNavigateToCanvas={controller.switchCanvas}
+              capabilities={{
+                versions: capabilities.versions,
+                branches: capabilities.branches,
+                merge: capabilities.merge,
+              }}
+              branchRefreshSignal={branchRefreshSignal}
+              versionRefreshSignal={versionRefreshSignal}
+              onRestored={clearLocalUndo}
+              versionPanelExtra={versionPanelExtra}
+              onNavigateBack={onNavigateBack}
+              onExport={exportScene}
+              onOpenSettings={handleOpenSettings}
+            />
+          )}
+          {capabilities.branches && canvas && (
+            <HeaderBranchBanner workspaceId={canvas.workspaceId} slug={canvas.slug} />
+          )}
+          {/* This row only exists when it carries something meaningful: a
+            real workspace CHOICE (two or more), or capability teasers. A
+            single-workspace daemon with full capabilities — the common
+            local case — gets no extra header row at all (raw ids are not
+            chrome, and every header row costs canvas height on a phone). */}
+          {(!capabilities.workspaces ||
+            controller.workspaces.length > 1 ||
+            !capabilities.versions ||
+            !capabilities.branches ||
+            !capabilities.merge) && (
+            <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
+              {capabilities.workspaces ? (
+                controller.workspaces.length > 1 && (
+                  <select
+                    aria-label="Workspaces"
+                    value={controller.workspaceId ?? ''}
+                    onChange={(event) => void controller.switchWorkspace(event.target.value)}
+                    className="min-w-0 max-w-40 truncate rounded-md border bg-background px-2 py-1 text-xs"
+                  >
+                    {controller.workspaces.map((w) => (
+                      <option key={w.workspaceId} value={w.workspaceId}>
+                        {w.workspaceId}
+                      </option>
+                    ))}
+                  </select>
+                )
+              ) : (
+                <CapabilityTeaser label="Workspaces" enabled={capabilities.workspaces} />
+              )}
+              {/* WorkspaceTopBar owns the real History/HeaderSaveDot/HeaderBranchChip
               affordances once a canvas is selected; these page-level teasers only
               surface guidance while the capability itself is unavailable. */}
-          {!capabilities.versions && (
-            <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
+              {!capabilities.versions && (
+                <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
+              )}
+              {!capabilities.branches && (
+                <CapabilityTeaser label="Variations" enabled={capabilities.branches} />
+              )}
+              {!capabilities.merge && <CapabilityTeaser label="Combine" enabled={false} />}
+            </div>
           )}
-          {!capabilities.branches && (
-            <CapabilityTeaser label="Variations" enabled={capabilities.branches} />
-          )}
-          {!capabilities.merge && <CapabilityTeaser label="Combine" enabled={false} />}
-        </div>
-        {canvas && browserLocalStore && (
-          <details
-            className="border-b bg-background px-4 py-2 text-sm"
-            onToggle={(event) => setImportSectionOpen(event.currentTarget.open)}
-          >
-            <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
-              Import from this browser
-            </summary>
-            {/* <details> only hides collapsed children visually — React still
+          {canvas && browserLocalStore && (
+            <details
+              className="border-b bg-background px-4 py-2 text-sm"
+              onToggle={(event) => setImportSectionOpen(event.currentTarget.open)}
+            >
+              <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+                Import from this browser
+              </summary>
+              {/* <details> only hides collapsed children visually — React still
                 mounts them. Gate on the open state so the lazy chunk and its
                 IndexedDB read are deferred until the user expands the section. */}
-            {importSectionOpen && (
-              <div className="pt-2">
-                {/* Local boundary: a chunk-load or render failure in this
+              {importSectionOpen && (
+                <div className="pt-2">
+                  {/* Local boundary: a chunk-load or render failure in this
                     optional disclosure must degrade the section alone, not
                     take the whole editor to the app-level boundary. */}
-                <ErrorBoundary
-                  fallback={() => (
-                    <p role="alert" className="text-xs text-destructive">
-                      Import is unavailable right now. Reopen this section to retry.
-                    </p>
-                  )}
-                >
-                  <Suspense fallback={null}>
-                    <LazyImportSection
-                      workspaceId={canvas.workspaceId}
-                      daemonFetch={daemonFetch}
-                      daemonBaseUrl={daemonBaseUrl}
-                      browserLocalStore={browserLocalStore}
-                    />
-                  </Suspense>
-                </ErrorBoundary>
-              </div>
-            )}
-          </details>
-        )}
+                  <ErrorBoundary
+                    fallback={() => (
+                      <p role="alert" className="text-xs text-destructive">
+                        Import is unavailable right now. Reopen this section to retry.
+                      </p>
+                    )}
+                  >
+                    <Suspense fallback={null}>
+                      <LazyImportSection
+                        workspaceId={canvas.workspaceId}
+                        daemonFetch={daemonFetch}
+                        daemonBaseUrl={daemonBaseUrl}
+                        browserLocalStore={browserLocalStore}
+                      />
+                    </Suspense>
+                  </ErrorBoundary>
+                </div>
+              )}
+            </details>
+          )}
+        </div>
         {controller.canvases.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+          <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 p-6 text-center">
             {/* WorkspaceTopBar (the usual home for this button) only mounts once
                 a canvas is selected, so a workspace that resolves to zero
                 canvases — an empty workspace, or a gallery row whose canvas was
@@ -446,7 +465,7 @@ export function DaemonCanvasPage({
           // Spatial is the only view this slice supports; markdown-view
           // persistence is deferred (canvas-workspace has no markdown-body
           // container to write to yet).
-          <div data-testid="spatial-editor-container" className="min-h-0 flex-1">
+          <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
             {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
                 gesture and open text editor all describe ONE canvas, and
                 `SpatialCanvas` carries no id for the editor to notice a switch

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -235,7 +235,7 @@ export function DaemonCanvasPage({
       <div
         role="alert"
         aria-live="assertive"
-        className="flex h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+        className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center"
       >
         <p className="max-w-md text-sm text-destructive">{controller.loadError}</p>
       </div>
@@ -296,7 +296,7 @@ export function DaemonCanvasPage({
           auto row, and the canvas owns minmax(0,1fr) — however many banner
           rows appear (or however tall they wrap), the canvas row is always
           exactly the remaining viewport height, never clipped below it. */}
-      <main className="relative grid h-dvh w-full grid-rows-[auto_minmax(0,1fr)]">
+      <main className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
         <div className="min-w-0">
           <h1 className="sr-only">Whiteboard (daemon)</h1>
           {controller.switchError && (

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -283,7 +283,7 @@ export function DaemonIndexPage({
 
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
-      <div className="flex h-dvh flex-col overflow-y-auto p-4">
+      <div className="flex h-full flex-col overflow-y-auto p-4">
         <h1 className="sr-only">Canvases</h1>
         <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
           {workspaces.length > 1 && (


### PR DESCRIPTION
## What

Two user reports, one structural slice.

**1. Header thickness changes clipped the canvas bottom → CSS Grid shell.**
The canvas pages stacked a variable set of header rows (top bar, switch-error alert, auth banner, branch banner, workspace row, import disclosure) above the editor in a flex column; a growing or wrapping header could push the editor's bottom edge below the viewport. Both `DaemonCanvasPage` and `BrowserLocalCanvasPage` now use a **two-row grid** — everything header-shaped stacks inside the `auto` row and the editor owns `minmax(0,1fr)` — so any number of banner rows (or any wrap height) resizes the editor instead of clipping it.

**2. Chrome was too text-heavy → iconified.**
- **Tool palette**: Select / Connect / Add note become icon-only (`MousePointer2` / `Spline` / `StickyNote`) with tooltips. Accessible names are unchanged — they moved to `aria-label`, which is what screen readers and `getByRole` resolve.
- **Header**: the History button drops its label (icon + tooltip, `aria-label="Version history"`); browser-local Duplicate/Delete become icon buttons.
- The daemon page's workspace row renders **only when it carries a real choice** (2+ workspaces) or capability teasers — the common single-workspace local case gets no extra header row at all (raw ids are not chrome, and every header row costs canvas height on a phone).

## Verification (live dev app)

Computed at runtime: `main` is `display: grid` with rows `81px 720px`, and the editor container's bottom edge sits exactly at `window.innerHeight` (801/801). Palette buttons expose aria-labels `Select` / `Connect` / `Add note` with no visible text; the single-workspace row is gone.

## Test plan

- [x] New real-geometry browser test: editor bottom ≤ viewport, **then the header stack is grown 120px** and the editor must shrink rather than slide below the viewport — the actual regression scenario
- [x] Contract updates: single-workspace selector now absent (jsdom), History accessible name, Add-note affordance (icon + aria-label + bordered palette container)
- [x] Scene-SVG test queries scoped to the `viewport-transform` layer (the palette now contains icon SVGs of its own)
- [x] web-browser 44 files / 239 passed; jsdom 1417 passed; typecheck / lint / knip clean
