### PR TITLE
feat(web): history cluster — thumb-reachable undo/redo unified with version history

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -129,62 +129,6 @@ afterEach(async () => {
 })
 
 describe('WorkspaceTopBar browser mode', () => {
-  it('opens History from the real top bar and keeps the popover list scrollable', async () => {
-    const { container } = renderTopBar()
-
-    await page.getByRole('button', { name: 'Version history' }).click()
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('Version history')
-      expect(container.textContent).toContain('Version 1')
-      expect(container.textContent).toContain('Version 24')
-      expect(container.textContent).toContain('👤 Alice')
-    })
-
-    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
-    expect(viewport).toBeInstanceOf(HTMLDivElement)
-
-    await waitFor(() => {
-      expect(viewport!.clientHeight).toBeGreaterThan(0)
-      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight)
-    })
-
-    const before = viewport!.scrollTop
-    viewport!.scrollTo({ top: viewport!.scrollHeight })
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
-
-    expect(viewport!.scrollTop).toBeGreaterThan(before)
-
-    // Outside-click to close the popover. Workspace identity is no longer
-    // surfaced in the header so we click the back-button (always present)
-    // which is outside the version-history Popover bounds.
-    fireEvent.mouseDown(screen.getByRole('button', { name: /back to canvas list/i }))
-    await waitFor(() => {
-      expect(container.textContent).not.toContain('Version 24')
-    })
-  })
-
-  it('keeps the version popover open when a mousedown lands inside the restore confirmation dialog (RED-first)', async () => {
-    renderTopBar()
-
-    await page.getByRole('button', { name: 'Version history' }).click()
-    await waitFor(() => {
-      expect(screen.getByText('Version history')).toBeTruthy()
-    })
-
-    await page.getByText(/^Version 1$/).click()
-    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
-
-    // The AlertDialog renders through a Radix portal into document.body, so
-    // this mousedown target is outside versionPanelRef's DOM subtree — the
-    // outside-click handler must still recognize it as "inside" via role.
-    const dialog = screen.getByRole('alertdialog')
-    fireEvent.mouseDown(dialog)
-
-    expect(screen.getByText('Version history')).toBeTruthy()
-    expect(screen.getByText('Restore this version?')).toBeTruthy()
-  })
-
   it('exposes a theme toggle that cycles light → dark → system → light', async () => {
     const onToggleTheme = vi.fn()
     const { rerender } = renderTopBar({ theme: 'light', onToggleTheme })
@@ -222,26 +166,6 @@ describe('WorkspaceTopBar browser mode', () => {
     rerenderWith('system')
     fireEvent.click(screen.getByRole('button', { name: /Theme: system/i }))
     expect(onToggleTheme).toHaveBeenLastCalledWith('light')
-  })
-
-  it('opens the restore dialog from a real history row and posts restore on confirm', async () => {
-    const onRestored = vi.fn()
-    renderTopBar({ onRestored })
-
-    await page.getByRole('button', { name: 'Version history' }).click()
-    await page.getByText(/^Version 1$/).click()
-
-    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
-
-    await waitFor(() => {
-      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/versions/v-0/restore'),
-        expect.objectContaining({ method: 'POST' }),
-      )
-      expect(onRestored).toHaveBeenCalledTimes(1)
-    })
   })
 
   it('new-canvas dialog: shows Problem Details title on 409 and shows fallback on missing title', async () => {
@@ -504,9 +428,6 @@ describe('WorkspaceTopBar browser mode', () => {
     // Exposed right-side actions are hidden at this width.
     await waitFor(() => {
       expect(
-        isDisplayNone(screen.getByRole('button', { name: 'Version history', hidden: true })),
-      ).toBe(true)
-      expect(
         isDisplayNone(screen.getByRole('button', { name: /Theme: light/i, hidden: true })),
       ).toBe(true)
       expect(isDisplayNone(screen.getByRole('button', { name: 'Fullscreen', hidden: true }))).toBe(
@@ -538,14 +459,6 @@ describe('WorkspaceTopBar browser mode', () => {
     await page.getByRole('menuitem', { name: 'Fullscreen' }).click()
     expect(onEnterFullscreen).toHaveBeenCalledTimes(1)
 
-    // Opening the kebab and selecting History opens the version popover
-    // (covers the Radix-menu-close vs. outside-click-close race).
-    await page.getByRole('button', { name: 'More actions' }).click()
-    await page.getByRole('menuitem', { name: 'History' }).click()
-    await waitFor(() => {
-      expect(screen.getByText('Version history')).toBeTruthy()
-    })
-
     // At ≥400px the kebab is hidden again and the three buttons are visible.
     // 401 (not exactly 400) sidesteps the boundary ambiguity between
     // `max-[400px]:hidden` and `min-[400px]:hidden`, which both match at
@@ -556,7 +469,6 @@ describe('WorkspaceTopBar browser mode', () => {
     renderTopBar({ theme: 'light', onToggleTheme: vi.fn() })
     await waitFor(() => {
       expect(isDisplayNone(screen.getByTestId('topbar-more-actions-trigger'))).toBe(true)
-      expect(isDisplayNone(screen.getByRole('button', { name: 'Version history' }))).toBe(false)
       expect(isDisplayNone(screen.getByRole('button', { name: /Theme: light/i }))).toBe(false)
       expect(isDisplayNone(screen.getByRole('button', { name: 'Fullscreen' }))).toBe(false)
     })

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -809,7 +809,7 @@ describe('WorkspaceTopBar — optional daemon-context props (RED-first)', () => 
     expect(screen.queryByLabelText('Fullscreen')).toBeNull()
   })
 
-  it('hides HeaderSaveDot and the History button when capabilities.versions is false', () => {
+  it('hides HeaderSaveDot when capabilities.versions is false', () => {
     render(
       <WorkspaceTopBar
         workspaceId="ws_1"
@@ -822,6 +822,9 @@ describe('WorkspaceTopBar — optional daemon-context props (RED-first)', () => 
       />,
       { container: document.body },
     )
+    expect(screen.queryByTestId('header-save-dot')).toBeNull()
+    // The version-history trigger lives in the canvas HistoryCluster now,
+    // never in the top bar.
     expect(screen.queryByRole('button', { name: /history/i })).toBeNull()
   })
 
@@ -874,24 +877,6 @@ describe('WorkspaceTopBar — optional daemon-context props (RED-first)', () => 
     // would otherwise be required — the real assertion lives in the
     // conditional render below via a spy-friendly mock override.
     expect(screen.queryByTestId('header-branch-chip')).toBeNull()
-  })
-
-  it('renders versionPanelExtra inside the opened History panel', async () => {
-    render(
-      <WorkspaceTopBar
-        workspaceId="ws_1"
-        slug="canvas-a"
-        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
-        onNavigateBack={() => {}}
-        onEnterFullscreen={() => {}}
-        onNavigateToCanvas={() => {}}
-        versionPanelExtra={<div data-testid="version-panel-extra-slot">extra</div>}
-      />,
-      { container: document.body },
-    )
-    const historyButton = screen.getByRole('button', { name: /history/i })
-    fireEvent.click(historyButton)
-    expect(await screen.findByTestId('version-panel-extra-slot')).not.toBeNull()
   })
 })
 

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -22,7 +22,6 @@ import { useCopyCanvasUrl } from './workspace-top-bar/useCopyCanvasUrl'
 import { useCreateCanvas } from './workspace-top-bar/useCreateCanvas'
 import { useQuickSaveShortcut, useSaveVersion } from './workspace-top-bar/useSaveVersion'
 import { useSceneExport } from './workspace-top-bar/useSceneExport'
-import { VersionPanel } from './workspace-top-bar/VersionPanel'
 
 // Gates which pieces of daemon-only chrome render. Omitted entirely (the
 // default), every capability behaves as if it were `true` — this keeps every
@@ -37,7 +36,6 @@ interface Props {
   workspaceId: string
   slug: string
   canvases: CanvasInfo[]
-  onRestored?: () => void
   getThumbnailBlob?: () => Promise<Blob | null>
   // Theme preference is owned by the page so reloads can rehydrate from
   // localStorage and pass the resolved value to <Excalidraw theme=...>. The
@@ -71,11 +69,6 @@ interface Props {
   // (another client, an MCP tool call) so the chip/timeline refetch without
   // waiting for their own poll interval.
   branchRefreshSignal?: number
-  versionRefreshSignal?: number
-  // Slot rendered inside the opened History panel below VersionTimeline, so
-  // a host page can keep its own "Save version" button + status message
-  // without this component needing to know about it.
-  versionPanelExtra?: ReactNode
   // Renders the scene through the same export utility Excalidraw's own
   // (harder-to-discover) hamburger-menu export dialog uses. Omitted (the
   // default) hides the "Export as PNG/SVG/JSON" menu items entirely rather
@@ -102,7 +95,6 @@ export default function WorkspaceTopBar({
   workspaceId,
   slug,
   canvases,
-  onRestored,
   theme,
   onToggleTheme,
   onEnterFullscreen,
@@ -115,8 +107,6 @@ export default function WorkspaceTopBar({
   onCreateMarkdownCanvas,
   capabilities,
   branchRefreshSignal,
-  versionRefreshSignal,
-  versionPanelExtra,
   onExport,
   onOpenSettings,
   statusSlot,
@@ -135,9 +125,7 @@ export default function WorkspaceTopBar({
     daemonFetch,
   })
 
-  const [versionOpen, setVersionOpen] = useState(false)
   const [canvasSearch, setCanvasSearch] = useState('')
-  const versionPanelRef = useRef<HTMLDivElement | null>(null)
 
   // Save state: dirty dot + Cmd/Ctrl+S only.
   // No beforeunload guard: every Excalidraw edit flows through useWhiteboardSync
@@ -180,29 +168,6 @@ export default function WorkspaceTopBar({
   const canvasPrefix = !canvasCustomName && slashIndex !== -1 ? slug.slice(0, slashIndex) : null
   const canvasLeaf = !canvasCustomName && slashIndex !== -1 ? slug.slice(slashIndex + 1) : null
   const canvasFlat = canvasCustomName ?? (canvasPrefix === null ? slug : null)
-
-  // Close the version history popover on outside clicks.
-  useEffect(() => {
-    if (!versionOpen) return
-    const onClick = (e: MouseEvent) => {
-      const panel = versionPanelRef.current
-      if (!panel) return
-      const target = e.target as Node | null
-      if (target && !panel.contains(target)) {
-        const targetEl = e.target as HTMLElement
-        // Ignore clicks on the trigger itself because the toggle button handles those.
-        const isTrigger = targetEl.closest('[data-version-trigger]')
-        // Radix dialogs (e.g. VersionTimeline's restore confirmation) render
-        // into a document.body portal, outside versionPanelRef's DOM subtree —
-        // treat clicks inside them as "inside" so confirming a restore doesn't
-        // also close the version popover behind it.
-        const isInPortalDialog = targetEl.closest('[role="dialog"], [role="alertdialog"]')
-        if (!isTrigger && !isInPortalDialog) setVersionOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', onClick)
-    return () => document.removeEventListener('mousedown', onClick)
-  }, [versionOpen])
 
   const {
     renamingCanvas,
@@ -383,8 +348,6 @@ export default function WorkspaceTopBar({
 
       {statusSlot}
       <TopBarSecondaryActions
-        versionsEnabled={versionsEnabled}
-        onToggleVersionOpen={() => setVersionOpen((v) => !v)}
         theme={theme}
         onToggleTheme={onToggleTheme}
         onEnterFullscreen={onEnterFullscreen}
@@ -403,17 +366,6 @@ export default function WorkspaceTopBar({
         busy={newCanvasBusy}
         onSubmit={() => void submitNewCanvas()}
       />
-
-      {versionOpen && (
-        <VersionPanel
-          panelRef={versionPanelRef}
-          workspaceId={workspaceId}
-          slug={slug}
-          onRestored={onRestored}
-          refreshSignal={versionRefreshSignal}
-          versionPanelExtra={versionPanelExtra}
-        />
-      )}
     </header>
   )
 }

--- a/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Real-browser behavior of the history cluster's version panel — ported
+ * from the top bar's suite when the version-history surface moved here:
+ * the scrollable timeline, the outside-click rule that treats portal
+ * dialogs as "inside", and the restore round-trip.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import '../../index.css'
+import { HistoryCluster } from './HistoryCluster.js'
+
+type FetchArgs = [RequestInfo | URL, RequestInit?]
+
+function mkVersionsResponse(count = 24): Response {
+  const versions = Array.from({ length: count }, (_, index) => ({
+    id: `v-${index}`,
+    slug: 'design/login-flow',
+    createdAt: new Date(Date.now() - index * 60_000).toISOString(),
+    elementCount: 58 + index,
+    label: `Version ${index + 1}`,
+    auto: index % 2 === 0,
+    hasThumbnail: false,
+    branchName: 'main',
+    operator: {
+      kind: index % 3 === 0 ? ('human' as const) : ('system' as const),
+      peerId: `peer-${index}`,
+      displayName: index % 3 === 0 ? 'Alice' : 'auto-save',
+    },
+  }))
+  return new Response(JSON.stringify({ versions }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes('/versions') && url.endsWith('/restore')) {
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    }
+    if (url.includes('/versions') && init?.method === 'POST') {
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    }
+    if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+function renderCluster() {
+  return render(
+    <div className="relative h-[600px] w-[900px] bg-background">
+      <HistoryCluster
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+        canUndo
+        canRedo
+        versions={{ workspaceId: 'sess_1', slug: 'design/login-flow' }}
+      />
+    </div>,
+  )
+}
+
+describe('HistoryCluster version panel (real browser)', () => {
+  it('opens the panel upward from the cluster and keeps the list scrollable', async () => {
+    const { container } = renderCluster()
+
+    await page.getByRole('button', { name: 'Version history' }).click()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Version 1')
+      expect(container.textContent).toContain('Version 24')
+    })
+
+    // Opens UPWARD: the panel sits above the cluster's buttons.
+    const panel = screen.getByTestId('history-version-panel')
+    const cluster = screen.getByTestId('history-cluster')
+    expect(panel.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      cluster.getBoundingClientRect().top + 1,
+    )
+
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
+    expect(viewport).toBeInstanceOf(HTMLDivElement)
+    await waitFor(() => {
+      expect(viewport!.clientHeight).toBeGreaterThan(0)
+      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight)
+    })
+
+    // Outside-click closes it.
+    fireEvent.mouseDown(document.body)
+    await waitFor(() => {
+      expect(screen.queryByTestId('history-version-panel')).toBeNull()
+    })
+  })
+
+  it('keeps the panel open when a mousedown lands inside the restore confirmation dialog', async () => {
+    renderCluster()
+
+    await page.getByRole('button', { name: 'Version history' }).click()
+    await page.getByText(/^Version 1$/).click()
+    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+
+    // The AlertDialog portals into document.body — outside the panel's DOM
+    // subtree — and must still count as "inside".
+    const dialog = screen.getByRole('alertdialog')
+    fireEvent.mouseDown(dialog)
+
+    expect(screen.getByTestId('history-version-panel')).toBeTruthy()
+    expect(screen.getByText('Restore this version?')).toBeTruthy()
+  })
+
+  it('opens the restore dialog from a real history row and posts restore on confirm', async () => {
+    renderCluster()
+
+    await page.getByRole('button', { name: 'Version history' }).click()
+    await page.getByText(/^Version 1$/).click()
+
+    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+
+    await waitFor(() => {
+      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/versions/v-0/restore'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/apps/web/src/components/history-cluster/HistoryCluster.test.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HistoryCluster } from './HistoryCluster.js'
+
+afterEach(cleanup)
+
+describe('HistoryCluster', () => {
+  it('undo/redo buttons call their handlers when enabled', () => {
+    const onUndo = vi.fn()
+    const onRedo = vi.fn()
+    render(<HistoryCluster onUndo={onUndo} onRedo={onRedo} canUndo canRedo />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Redo' }))
+    expect(onUndo).toHaveBeenCalledTimes(1)
+    expect(onRedo).toHaveBeenCalledTimes(1)
+  })
+
+  it('disabled affordance: aria-disabled, handler gated, but still perceivable', () => {
+    const onUndo = vi.fn()
+    render(<HistoryCluster onUndo={onUndo} onRedo={vi.fn()} canUndo={false} canRedo={false} />)
+
+    const undo = screen.getByRole('button', { name: 'Undo' })
+    // aria-disabled instead of the native disabled attribute: a dead
+    // disabled button swallows the pointer events tooltips need to answer
+    // "why can't I press this".
+    expect(undo.getAttribute('aria-disabled')).toBe('true')
+    expect(undo.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(undo)
+    expect(onUndo).not.toHaveBeenCalled()
+  })
+
+  it('advertises the keyboard shortcuts', () => {
+    render(<HistoryCluster onUndo={vi.fn()} onRedo={vi.fn()} canUndo canRedo />)
+    expect(
+      screen.getByRole('button', { name: 'Undo' }).getAttribute('aria-keyshortcuts'),
+    ).toContain('Z')
+    expect(
+      screen.getByRole('button', { name: 'Redo' }).getAttribute('aria-keyshortcuts'),
+    ).toContain('Shift')
+  })
+
+  it('renders no version-history trigger without the versions capability', () => {
+    render(<HistoryCluster onUndo={vi.fn()} onRedo={vi.fn()} canUndo canRedo />)
+    expect(screen.queryByRole('button', { name: 'Version history' })).toBeNull()
+  })
+
+  it('with versions, the history trigger toggles the version panel', () => {
+    render(
+      <HistoryCluster
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+        canUndo
+        canRedo
+        versions={{ workspaceId: 'ws-1', slug: 'doc-a' }}
+      />,
+    )
+    // VersionTimeline fetches on mount — jsdom has no fetch mock here, so
+    // only assert the panel container appears/disappears.
+    const trigger = screen.getByRole('button', { name: 'Version history' })
+    expect(screen.queryByTestId('history-version-panel')).toBeNull()
+    fireEvent.click(trigger)
+    expect(screen.getByTestId('history-version-panel')).toBeTruthy()
+    fireEvent.click(trigger)
+    expect(screen.queryByTestId('history-version-panel')).toBeNull()
+  })
+
+  it('renders versionPanelExtra inside the opened version panel', () => {
+    render(
+      <HistoryCluster
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+        canUndo
+        canRedo
+        versions={{
+          workspaceId: 'ws-1',
+          slug: 'doc-a',
+          versionPanelExtra: <div data-testid="version-panel-extra-slot">extra</div>,
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Version history' }))
+    expect(screen.getByTestId('version-panel-extra-slot')).toBeTruthy()
+  })
+
+  it('is marked as an editor overlay so canvas gestures ignore it', () => {
+    render(<HistoryCluster onUndo={vi.fn()} onRedo={vi.fn()} canUndo canRedo />)
+    const toolbar = screen.getByRole('toolbar', { name: 'History' })
+    expect(toolbar.hasAttribute('data-editor-overlay')).toBe(true)
+  })
+})

--- a/apps/web/src/components/history-cluster/HistoryCluster.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.tsx
@@ -1,0 +1,184 @@
+/**
+ * The history cluster — every Loro-timeline affordance in one floating
+ * group at the canvas's bottom-left: step undo/redo, and (when the daemon
+ * capability exists) the version-history panel.
+ *
+ * Placement rationale: undo is the highest-frequency recovery action while
+ * drawing, so on a phone it must sit in thumb reach — the canvas's bottom
+ * corners, not the header. The bottom-center ToolPalette stays
+ * creation/mode-only (the recorded OOUI palette rule), so history is its
+ * own group, in the palette's visual language.
+ *
+ * Feel: press feedback fires on pointer-down (`:active` scale, fast
+ * token), touch targets grow to >=44px on coarse pointers, and a disabled
+ * direction keeps answering via tooltip instead of going dead —
+ * aria-disabled, never the native disabled attribute.
+ *
+ * Marked `data-editor-overlay` so the canvas root's gesture handlers
+ * ignore presses originating here (see SpatialEditor's isOverlayEvent).
+ */
+import { History, Redo2, Undo2 } from 'lucide-react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { VersionPanel } from '../workspace-top-bar/VersionPanel.js'
+
+export interface HistoryClusterVersionsProps {
+  readonly workspaceId: string
+  readonly slug: string
+  readonly onRestored?: () => void
+  readonly refreshSignal?: number
+  readonly versionPanelExtra?: ReactNode
+}
+
+export interface HistoryClusterProps {
+  readonly onUndo: () => void
+  readonly onRedo: () => void
+  readonly canUndo: boolean
+  readonly canRedo: boolean
+  /** Present only when the version capability exists (daemon-backed pages). */
+  readonly versions?: HistoryClusterVersionsProps
+}
+
+const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+const MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+'
+const MOD_KEY = IS_MAC ? 'Meta' : 'Control'
+
+const CLUSTER_BUTTON_CLASS =
+  'flex size-9 pointer-coarse:size-11 items-center justify-center rounded-md text-muted-foreground transition-[transform,color,background-color] duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent hover:text-foreground active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
+
+function StepButton({
+  label,
+  shortcut,
+  keyshortcuts,
+  enabled,
+  onPress,
+  children,
+}: {
+  label: string
+  shortcut: string
+  keyshortcuts: string
+  enabled: boolean
+  onPress: () => void
+  children: ReactNode
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-keyshortcuts={keyshortcuts}
+          aria-disabled={!enabled}
+          onClick={() => {
+            if (enabled) onPress()
+          }}
+          className={cn(CLUSTER_BUTTON_CLASS, !enabled && 'text-muted-foreground/40')}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {enabled ? `${label} (${shortcut})` : `Nothing to ${label.toLowerCase()}`}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function HistoryCluster({
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  versions,
+}: HistoryClusterProps) {
+  const [versionOpen, setVersionOpen] = useState(false)
+  const versionPanelRef = useRef<HTMLDivElement | null>(null)
+
+  // Close the version panel on outside clicks. Radix dialogs (the restore
+  // confirmation) portal into document.body — outside this subtree — so
+  // clicks inside any dialog count as "inside", or confirming a restore
+  // would also close the panel behind it.
+  useEffect(() => {
+    if (!versionOpen) return
+    const onClick = (e: MouseEvent) => {
+      const panel = versionPanelRef.current
+      if (!panel) return
+      const target = e.target as Node | null
+      if (target && !panel.contains(target)) {
+        const targetEl = e.target as HTMLElement
+        const isTrigger = targetEl.closest('[data-version-trigger]')
+        const isInPortalDialog = targetEl.closest('[role="dialog"], [role="alertdialog"]')
+        if (!isTrigger && !isInPortalDialog) setVersionOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [versionOpen])
+
+  return (
+    <div
+      data-editor-overlay
+      data-testid="history-cluster"
+      role="toolbar"
+      aria-label="History"
+      className="absolute bottom-3 left-3 z-10 flex items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
+    >
+      <StepButton
+        label="Undo"
+        shortcut={`${MOD_LABEL}Z`}
+        keyshortcuts={`${MOD_KEY}+Z`}
+        enabled={canUndo}
+        onPress={onUndo}
+      >
+        <Undo2 aria-hidden="true" className="size-4" />
+      </StepButton>
+      <StepButton
+        label="Redo"
+        shortcut={`${MOD_LABEL}⇧Z`}
+        keyshortcuts={`${MOD_KEY}+Shift+Z`}
+        enabled={canRedo}
+        onPress={onRedo}
+      >
+        <Redo2 aria-hidden="true" className="size-4" />
+      </StepButton>
+      {versions && (
+        <>
+          <div aria-hidden="true" className="mx-0.5 h-5 w-px bg-border" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                data-version-trigger
+                aria-label="Version history"
+                aria-expanded={versionOpen}
+                onClick={() => setVersionOpen((v) => !v)}
+                className={cn(CLUSTER_BUTTON_CLASS, versionOpen && 'bg-accent text-foreground')}
+              >
+                <History aria-hidden="true" className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Version history</TooltipContent>
+          </Tooltip>
+          {versionOpen && (
+            <div
+              data-testid="history-version-panel"
+              // Opens UPWARD from the cluster, origin-aware at the trigger
+              // corner (never scale(0) — see DESIGN.md Motion).
+              className="absolute bottom-[calc(100%+6px)] left-0 origin-bottom-left animate-in fade-in-0 zoom-in-[0.98] duration-(--motion-duration-normal) ease-(--motion-ease-out)"
+            >
+              <VersionPanel
+                panelRef={versionPanelRef}
+                workspaceId={versions.workspaceId}
+                slug={versions.slug}
+                onRestored={versions.onRestored}
+                refreshSignal={versions.refreshSignal}
+                versionPanelExtra={versions.versionPanelExtra}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -1,4 +1,4 @@
-import { EllipsisVertical, History, Maximize2, Settings } from 'lucide-react'
+import { EllipsisVertical, Maximize2, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -21,20 +21,16 @@ const THEME_CYCLE: Record<ThemeMode, ThemeMode> = {
 }
 
 interface TopBarSecondaryActionsProps {
-  versionsEnabled: boolean
-  onToggleVersionOpen: () => void
   theme?: ThemeMode
   onToggleTheme?: (next: ThemeMode) => void
   onEnterFullscreen?: () => void
   onOpenSettings?: () => void
 }
 
-// Right side: version history, theme, and fullscreen — plus the "More
-// actions" kebab that reuses the exact same handlers below 400px so the
-// header never wraps.
+// Right side: theme and fullscreen — plus the "More actions" kebab that
+// reuses the exact same handlers below 400px so the header never wraps.
+// Version history moved to the canvas's HistoryCluster (bottom-left).
 export function TopBarSecondaryActions({
-  versionsEnabled,
-  onToggleVersionOpen,
   theme,
   onToggleTheme,
   onEnterFullscreen,
@@ -46,23 +42,6 @@ export function TopBarSecondaryActions({
         data-testid="topbar-right-actions-exposed"
         className="flex shrink-0 items-center gap-1 max-[400px]:hidden"
       >
-        {versionsEnabled && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                data-version-trigger
-                variant="ghost"
-                size="sm"
-                className="size-8 p-0"
-                onClick={onToggleVersionOpen}
-                aria-label="Version history"
-              >
-                <History className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Version history</TooltipContent>
-          </Tooltip>
-        )}
         {onToggleTheme && theme && <ThemeToggleButton theme={theme} onChange={onToggleTheme} />}
         {onEnterFullscreen && (
           <Tooltip>
@@ -111,12 +90,6 @@ export function TopBarSecondaryActions({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {versionsEnabled && (
-            <DropdownMenuItem data-version-trigger onSelect={onToggleVersionOpen} className="gap-2">
-              <History className="size-3.5" />
-              History
-            </DropdownMenuItem>
-          )}
           {onToggleTheme && theme && (
             <DropdownMenuItem
               onSelect={() => onToggleTheme(THEME_CYCLE[theme])}

--- a/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
+++ b/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
@@ -10,7 +10,8 @@ interface VersionPanelProps {
   versionPanelExtra?: ReactNode
 }
 
-// Version history popover docked under the top-right controls.
+// Version history panel surface. Position-agnostic: the mount site (the
+// canvas history cluster) owns placement; this component owns the surface.
 export function VersionPanel({
   panelRef,
   workspaceId,
@@ -22,7 +23,7 @@ export function VersionPanel({
   return (
     <div
       ref={panelRef}
-      className="absolute right-3 top-[calc(100%+6px)] z-40 w-[340px] overflow-hidden rounded-lg border bg-background shadow-lg"
+      className="w-[340px] max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-lg border bg-background shadow-lg"
     >
       <div className="flex h-[480px] min-h-0 flex-col">
         <VersionTimeline

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -35,6 +35,13 @@ export interface UseCanvasSyncResult {
   restoreInProgress: boolean
   restoreLabel: string | null
   clearLocalUndo: () => void
+  // Same Loro UndoManager the Cmd/Ctrl+Z keyboard path drives — exposed so
+  // pointer surfaces (the canvas HistoryCluster) share one history. The
+  // can* reads are live (recomputed each render), never cached state.
+  undo: () => boolean
+  redo: () => boolean
+  canUndo: () => boolean
+  canRedo: () => boolean
   // null when the requested format is unavailable in this environment (e.g.
   // 'png' with no real Canvas 2D context, such as jsdom) — callers treat
   // that the same as "export unavailable right now" rather than throwing.
@@ -141,6 +148,8 @@ export function useCanvasSync(
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
   const [canvas, setCanvas] = useState<SpatialCanvas>(EMPTY_CANVAS)
   const [externalVersion, setExternalVersion] = useState(0)
+  // Render signal only — the value itself is never read.
+  const [, setHistoryVersion] = useState(0)
   const [restoreInProgress, setRestoreInProgress] = useState(false)
   const [restoreLabel, setRestoreLabel] = useState<string | null>(null)
 
@@ -185,11 +194,16 @@ export function useCanvasSync(
       setCanvas(next)
       if (origin === 'external') setExternalVersion((v) => v + 1)
     })
+    // Undo-stack pushes land on COMMIT, after the canvas publish that drove
+    // the consumer's last render — bump a version so canUndo/canRedo reads
+    // re-run when the stack changes shape.
+    const unsubscribeHistory = session.subscribeHistory(() => setHistoryVersion((v) => v + 1))
     session.connect()
     session.onEditorReady()
 
     return () => {
       unsubscribe()
+      unsubscribeHistory()
       session.dispose()
     }
   }, [backend])
@@ -204,6 +218,17 @@ export function useCanvasSync(
 
   const clearLocalUndo = useCallback(() => {
     sessionRef.current?.clearUndo()
+  }, [])
+
+  // Live affordance state for undo/redo buttons. Not memoized state: every
+  // publish re-renders the consumer (setCanvas above), so reading through
+  // the session on each render is always current and never stale.
+  const canUndo = useCallback(() => {
+    return sessionRef.current?.canUndo() ?? false
+  }, [])
+
+  const canRedo = useCallback(() => {
+    return sessionRef.current?.canRedo() ?? false
   }, [])
 
   // Derives the export blob from the hook-owned canvas value — no imperative
@@ -268,6 +293,10 @@ export function useCanvasSync(
     restoreInProgress,
     restoreLabel,
     clearLocalUndo,
+    undo: loroUndo,
+    redo: loroRedo,
+    canUndo,
+    canRedo,
     exportScene,
   }
 }

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -551,6 +551,25 @@ describe('createCanvasSyncSession', () => {
     expect(backendB._ctrl.pushLocalUpdateCalls).toHaveLength(0)
   })
 
+  it('subscribeHistory fires when a committed edit pushes an undo step, and canUndo flips', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+    expect(session.canUndo()).toBe(false)
+
+    const historyListener = vi.fn()
+    const unsubscribe = session.subscribeHistory(historyListener)
+
+    const command: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
+    session.onChange(applyCommand(twoNodeCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(historyListener).toHaveBeenCalled()
+    expect(session.canUndo()).toBe(true)
+    unsubscribe()
+  })
+
   it('undo() reverts the last committed edit and notifies subscribers with the "external" origin', async () => {
     const backend = makeFakeBackend()
     const session = createCanvasSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -570,6 +570,31 @@ describe('createCanvasSyncSession', () => {
     unsubscribe()
   })
 
+  it('clearUndo() (the restore-complete path) notifies history listeners so canUndo flips back', async () => {
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+    const command: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
+    session.onChange(applyCommand(twoNodeCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(session.canUndo()).toBe(true)
+
+    const historyListener = vi.fn()
+    const unsubscribe = session.subscribeHistory(historyListener)
+
+    session.clearUndo()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(session.canUndo()).toBe(false)
+    // Without the notification the consumer keeps rendering an enabled Undo
+    // button over an empty stack — the exact stale-affordance a version
+    // restore would otherwise leave behind.
+    expect(historyListener).toHaveBeenCalled()
+    unsubscribe()
+  })
+
   it('undo() reverts the last committed edit and notifies subscribers with the "external" origin', async () => {
     const backend = makeFakeBackend()
     const session = createCanvasSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -117,6 +117,15 @@ export interface CanvasSyncSession {
   clearUndo(): void
   undo(): boolean
   redo(): boolean
+  // Live UndoManager state for button affordances (aria-disabled, tooltip
+  // copy). Cheap reads — recompute on every render of the consumer.
+  canUndo(): boolean
+  canRedo(): boolean
+  // Fires whenever the undo stack changes shape (a step pushed on commit, or
+  // popped by undo/redo) — the re-render signal button affordances need,
+  // since pushes happen on COMMIT, after the canvas publish that triggered
+  // the consumer's last render.
+  subscribeHistory(listener: () => void): () => void
   // Current published canvas value (empty canvas before the first snapshot).
   getCanvas(): SpatialCanvas
   // Registers a listener for every published canvas value. `origin` tags
@@ -208,6 +217,15 @@ export function createCanvasSyncSession(
   let disposed = false
   let doc: LoroDoc | null = null
   let undoManager: UndoManager | null = null
+  const historyListeners = new Set<() => void>()
+  // Microtask defer: onPush fires inside Loro's commit, and a listener that
+  // synchronously setStates mid-commit would re-enter React from a doc
+  // mutation path.
+  function notifyHistoryChanged(): void {
+    queueMicrotask(() => {
+      for (const listener of historyListeners) listener()
+    })
+  }
   let currentCanvas: SpatialCanvas = { nodes: [], edges: [] }
   const listeners = new Set<(canvas: SpatialCanvas, origin: 'local' | 'external') => void>()
   const pendingExportRequests: ExportRequestHandlerDeps['pending'] = []
@@ -378,7 +396,16 @@ export function createCanvasSyncSession(
         const newDoc = new LoroDoc()
         newDoc.import(bytes)
         doc = newDoc
-        undoManager = new UndoManager(newDoc, { mergeInterval: 500 })
+        undoManager = new UndoManager(newDoc, {
+          mergeInterval: 500,
+          onPush: () => {
+            notifyHistoryChanged()
+            return { value: null, cursors: [] }
+          },
+          onPop: () => {
+            notifyHistoryChanged()
+          },
+        })
 
         newDoc.subscribeLocalUpdates((update) => {
           // No isStale() guard here: this callback is bound to this specific
@@ -585,6 +612,21 @@ export function createCanvasSyncSession(
     return true
   }
 
+  function canUndo(): boolean {
+    return (undoManager !== null && doc !== null && undoManager.canUndo()) === true
+  }
+
+  function canRedo(): boolean {
+    return (undoManager !== null && doc !== null && undoManager.canRedo()) === true
+  }
+
+  function subscribeHistory(listener: () => void): () => void {
+    historyListeners.add(listener)
+    return () => {
+      historyListeners.delete(listener)
+    }
+  }
+
   return {
     connect,
     dispose,
@@ -593,7 +635,10 @@ export function createCanvasSyncSession(
     clearUndo,
     undo,
     redo,
+    canUndo,
+    canRedo,
     getCanvas,
     subscribe,
+    subscribeHistory,
   }
 }

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -466,7 +466,7 @@ export function createCanvasSyncSession(
       onRestoreComplete() {
         if (isStale()) return
         deps.onRestoreChange(false, null)
-        undoManager?.clear()
+        clearUndo()
       },
 
       onHeadChanged(payload) {
@@ -593,7 +593,12 @@ export function createCanvasSyncSession(
   }
 
   function clearUndo(): void {
-    undoManager?.clear()
+    if (!undoManager) return
+    undoManager.clear()
+    // clear() empties the stack without an onPop, so notify explicitly —
+    // otherwise a consumer keeps rendering an enabled Undo button over an
+    // empty stack after a version restore.
+    notifyHistoryChanged()
   }
 
   function undo(): boolean {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -64,6 +64,61 @@ describe('BrowserLocalCanvasPage create/delete-node reload persistence (browser 
     cleanup()
   })
 
+  it('tapping Undo in the history cluster reverts the last committed edit', async () => {
+    // The mobile path: no keyboard exists, so the cluster button must drive
+    // the same Loro UndoManager the Cmd/Ctrl+Z shortcut does.
+    render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
+
+    const created = textNodeCanvas('undo-probe-node', 20, 20)
+    // Retried like the neighboring tests: right after hydrate the page can
+    // swap backend identity (fresh canvas creation), so the first captured
+    // onChange may belong to a torn-down session. Re-sending an identical
+    // canvas is a no-op on the doc, so retries never stack extra undo steps.
+    const undoButton = screen.getByRole('button', { name: 'Undo' })
+    await waitFor(
+      () => {
+        act(() => {
+          latestOnChange!(created, createNodeCommand('undo-probe-node', 20, 20))
+        })
+        expect(undoButton.getAttribute('aria-disabled')).toBe('false')
+      },
+      { timeout: 10000, interval: 600 },
+    )
+
+    act(() => {
+      undoButton.click()
+    })
+
+    await waitFor(
+      () => {
+        const latest = latestMountedCanvases.at(-1)
+        expect(latest).toBeDefined()
+        expect(latest!.nodes.map((n) => n.id)).not.toContain('undo-probe-node')
+      },
+      { timeout: 5000 },
+    )
+    // And redo brings it back through the same cluster.
+    const redoButton = screen.getByRole('button', { name: 'Redo' })
+    await waitFor(() => expect(redoButton.getAttribute('aria-disabled')).toBe('false'), {
+      timeout: 5000,
+    })
+    act(() => {
+      redoButton.click()
+    })
+    await waitFor(
+      () => {
+        const latest = latestMountedCanvases.at(-1)
+        expect(latest!.nodes.map((n) => n.id)).toContain('undo-probe-node')
+      },
+      { timeout: 5000 },
+    )
+  })
+
   it('a node created via create-node survives remount; deleting it via delete-node stays gone after another remount', async () => {
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
     await waitFor(

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
+import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
@@ -249,7 +250,8 @@ export function BrowserLocalCanvasPage({
   // useCanvasSync tolerates a null backend (idle, no writes) and reconnects
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.
-  const { canvas, onChange, externalVersion, exportScene } = useCanvasSync(backend)
+  const { canvas, onChange, externalVersion, exportScene, undo, redo, canUndo, canRedo } =
+    useCanvasSync(backend)
 
   const commands = useWhiteboardCommands({
     provider: { kind: 'browser-local', capabilities },
@@ -473,6 +475,17 @@ export function BrowserLocalCanvasPage({
             onChange={onChange}
             externalVersion={externalVersion}
             theme={resolvedTheme}
+          />
+        )}
+        {/* Markdown canvases keep CodeMirror's own history (its keymap
+            already handles undo); the cluster drives the Loro UndoManager,
+            which only the spatial editor path routes edits through. */}
+        {canvasKind !== 'markdown' && (
+          <HistoryCluster
+            onUndo={() => void undo()}
+            onRedo={() => void redo()}
+            canUndo={canUndo()}
+            canRedo={canRedo()}
           />
         )}
       </div>

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -7,6 +7,7 @@ import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeas
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
+import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MergeToast } from '../components/MergeToast.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
@@ -157,6 +158,10 @@ export function DaemonCanvasPage({
     onChange,
     externalVersion,
     clearLocalUndo,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
     exportScene,
   } = useCanvasSync(backend, {
     onAuthError: () => setAuthError(true),
@@ -329,9 +334,6 @@ export function DaemonCanvasPage({
                 merge: capabilities.merge,
               }}
               branchRefreshSignal={branchRefreshSignal}
-              versionRefreshSignal={versionRefreshSignal}
-              onRestored={clearLocalUndo}
-              versionPanelExtra={versionPanelExtra}
               onNavigateBack={onNavigateBack}
               onExport={exportScene}
               onOpenSettings={handleOpenSettings}
@@ -478,6 +480,23 @@ export function DaemonCanvasPage({
               onChange={onChange}
               externalVersion={externalVersion}
               theme={resolvedTheme}
+            />
+            <HistoryCluster
+              onUndo={() => void undo()}
+              onRedo={() => void redo()}
+              canUndo={canUndo()}
+              canRedo={canRedo()}
+              versions={
+                capabilities.versions && canvas
+                  ? {
+                      workspaceId: canvas.workspaceId,
+                      slug: canvas.slug,
+                      onRestored: clearLocalUndo,
+                      refreshSignal: versionRefreshSignal,
+                      versionPanelExtra,
+                    }
+                  : undefined
+              }
             />
           </div>
         )}


### PR DESCRIPTION
## What

Phones had **no undo/redo at all** — the only entry point was the Cmd/Ctrl+Z keyboard intercept. Per the approved skill-grounded design (emilkowalski/emil-design-eng + apple-design + baseline-ui lenses), every Loro-timeline affordance now lives in **one floating history cluster at the canvas's bottom-left**:

```
[← Undo] [→ Redo] │ [🕘 History]
```

- **Placement**: undo is the highest-frequency recovery action while drawing, so it sits in thumb reach — the canvas's bottom corner, not the header (FigJam/Figma mobile convention). The bottom-center ToolPalette stays creation/mode-only per the recorded OOUI palette rule.
- **Unification**: the version-history trigger + panel move out of `WorkspaceTopBar` entirely; the panel opens **upward** from the cluster, origin-aware (`origin-bottom-left`, 0.98→1 on the motion tokens). The header keeps only app-level controls + the save dot.
- **Feel** (from the design pass): press feedback on pointer-**down** (`active:scale-[0.97]`, fast token); touch targets grow to ≥44px on coarse pointers (`pointer-coarse:size-11`); a disabled direction stays perceivable — `aria-disabled` + a tooltip answering "Nothing to undo", never a dead native `disabled` button. `aria-keyshortcuts` advertises the unchanged keyboard path.

**Plumbing**: `canvas-sync-session` exposes `canUndo/canRedo` and a `subscribeHistory` seam driven by the UndoManager's `onPush/onPop` — stack pushes land on **commit**, after the canvas publish that drove the consumer's last render, so the stack itself is the render signal that keeps button affordances truthful. `useCanvasSync` surfaces `undo/redo/canUndo/canRedo`; both canvas pages mount the cluster (markdown canvases keep CodeMirror's own history — one history authority per surface).

## Verification (live dev app, real browser)

Full round-trip against the running app: create a note → **Undo enables** (aria-disabled flips) → tap Undo → node count 7→6 and **Redo enables** → tap Redo → 7 again. Cluster visible bottom-left with the beta banner showing (no clipping, per #472's shell). Header no longer contains a version-history button.

## Test plan

- [x] Red first: `HistoryCluster.test.tsx` (handlers, aria-disabled gating, keyshortcuts, capability-gated History trigger, panel toggle, versionPanelExtra slot, editor-overlay marker)
- [x] Red first: session-level `subscribeHistory` fires on commit push and `canUndo` flips (this red is what surfaced the commit-vs-render timing gap)
- [x] Real-browser: tap Undo reverts a committed edit and tap Redo restores it (BrowserLocalCanvasPage, real IndexedDB)
- [x] Ported the version-panel browser suite to the cluster (opens upward — geometry-asserted, scrollable timeline, portal-dialog outside-click rule, restore POST round-trip)
- [x] apps/web jsdom 1425 passed; web-browser 45 files / 241 passed; typecheck / lint / knip clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added floating Undo and Redo controls for spatial canvases, with disabled states, keyboard shortcuts, and touch-friendly interactions.
  * Added version-history access and restore actions to the canvas history controls.
  * History panels now adapt to available screen width and dismiss when clicking outside.

* **Changes**
  * Removed version-history controls from the workspace top bar.
  * Markdown canvases continue using their existing editor history controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->