### PR TITLE
feat(canvas): JSON Canvas edge arrowheads, ends, and side pinning (J1)

### DIFF
--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -19,12 +19,14 @@
  * discrete pointerdown loses the focus fight with mousedown's default
  * action, while click fires after those defaults.
  */
-import { useEffect, useRef } from 'react'
+import { type ReactNode, useEffect, useRef } from 'react'
 import { cn } from '@/lib/utils'
 
 export interface ContextMenuActionItem {
   readonly kind?: 'action'
   readonly label: string
+  /** Leading icon (a lucide element); decorative — the label carries the name. */
+  readonly icon?: ReactNode
   readonly onSelect: () => void
   /** Visually separates destructive entries (Delete). */
   readonly danger?: boolean
@@ -33,6 +35,8 @@ export interface ContextMenuActionItem {
 export interface ContextMenuOption {
   /** Visible content of the option button (often a glyph). */
   readonly label: string
+  /** Icon rendered INSTEAD of the label text when provided (decorative). */
+  readonly icon?: ReactNode
   /** Accessible name when the visible label is a glyph; defaults to label. */
   readonly ariaLabel?: string
   readonly selected: boolean
@@ -123,7 +127,13 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
                   // reopen for every adjustment.
                   onClick={option.onSelect}
                 >
-                  {option.label}
+                  {option.icon !== undefined ? (
+                    <span aria-hidden="true" className="[&>svg]:size-3.5">
+                      {option.icon}
+                    </span>
+                  ) : (
+                    option.label
+                  )}
                 </button>
               ))}
             </span>
@@ -133,7 +143,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
             key={item.label}
             type="button"
             role="menuitem"
-            className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
+            className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
               item.danger ? 'text-red-600' : ''
             }`}
             onClick={() => {
@@ -141,6 +151,15 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
               item.onSelect()
             }}
           >
+            {item.icon !== undefined && (
+              // Danger rows keep the destructive color on the icon too.
+              <span
+                aria-hidden="true"
+                className={cn('[&>svg]:size-3.5', !item.danger && 'text-muted-foreground')}
+              >
+                {item.icon}
+              </span>
+            )}
             {item.label}
           </button>
         ),

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -6,6 +6,13 @@
  * itself. Empty canvas space gets its own creation entry, since "here" is
  * position information the bottom palette cannot express.
  *
+ * Two item shapes:
+ * - action items run once and CLOSE the menu (Edit, Delete);
+ * - option rows (`kind: 'options'`) are property pickers rendered as an
+ *   inline segmented group — selecting one applies immediately and KEEPS
+ *   the menu open, so adjusting several properties (arrows, both edge
+ *   sides) is one menu visit instead of an open-tap-reopen cycle per step.
+ *
  * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
  * presses inside the menu. Item actions fire on CLICK (not pointerdown) for
  * the same reason as the selection Edit control: an editor opened inside a
@@ -13,13 +20,37 @@
  * action, while click fires after those defaults.
  */
 import { useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
 
-export interface ContextMenuItem {
+export interface ContextMenuActionItem {
+  readonly kind?: 'action'
   readonly label: string
   readonly onSelect: () => void
   /** Visually separates destructive entries (Delete). */
   readonly danger?: boolean
 }
+
+export interface ContextMenuOption {
+  /** Visible content of the option button (often a glyph). */
+  readonly label: string
+  /** Accessible name when the visible label is a glyph; defaults to label. */
+  readonly ariaLabel?: string
+  readonly selected: boolean
+  readonly onSelect: () => void
+}
+
+export interface ContextMenuOptionsItem {
+  readonly kind: 'options'
+  readonly label: string
+  readonly options: readonly ContextMenuOption[]
+}
+
+/** Visual section boundary between action, property, and destructive groups. */
+export interface ContextMenuSeparator {
+  readonly kind: 'separator'
+}
+
+export type ContextMenuItem = ContextMenuActionItem | ContextMenuOptionsItem | ContextMenuSeparator
 
 export interface ContextMenuProps {
   /** Screen position relative to the editor root. */
@@ -62,22 +93,58 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
         }
       }}
     >
-      {items.map((item) => (
-        <button
-          key={item.label}
-          type="button"
-          role="menuitem"
-          className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
-            item.danger ? 'text-red-600' : ''
-          }`}
-          onClick={() => {
-            onClose()
-            item.onSelect()
-          }}
-        >
-          {item.label}
-        </button>
-      ))}
+      {items.map((item, index) =>
+        item.kind === 'separator' ? (
+          // biome-ignore lint/suspicious/noArrayIndexKey: separators are positional by nature and the items list is rebuilt per open
+          <hr key={`separator-${index}`} className="my-1 border-border" />
+        ) : item.kind === 'options' ? (
+          <fieldset
+            key={item.label}
+            aria-label={item.label}
+            className="m-0 flex items-center justify-between gap-2 border-0 p-0 px-3 py-1"
+          >
+            <span className="text-xs text-muted-foreground">{item.label}</span>
+            <span className="flex items-center gap-0.5">
+              {item.options.map((option) => (
+                <button
+                  key={option.label}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={option.selected}
+                  aria-label={option.ariaLabel ?? option.label}
+                  className={cn(
+                    'flex h-7 min-w-7 items-center justify-center rounded px-1 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                    option.selected
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'text-muted-foreground',
+                  )}
+                  // Applies immediately and keeps the menu open: option rows
+                  // are property pickers, and closing per pick would force a
+                  // reopen for every adjustment.
+                  onClick={option.onSelect}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </span>
+          </fieldset>
+        ) : (
+          <button
+            key={item.label}
+            type="button"
+            role="menuitem"
+            className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
+              item.danger ? 'text-red-600' : ''
+            }`}
+            onClick={() => {
+              onClose()
+              item.onSelect()
+            }}
+          >
+            {item.label}
+          </button>
+        ),
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -37,6 +37,17 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  PanelTop,
+  Pencil,
+  SquareDashed,
+  StickyNote,
+  Tag,
+  Trash2,
+} from 'lucide-react'
+import {
   forwardRef,
   useEffect,
   useImperativeHandle,
@@ -1133,12 +1144,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ] as const
                 const applyEdgeCommand = (command: EditorCommand) =>
                   applyResult({ state: { kind: 'idle' }, commands: [command] })
+                // Excel-border-style side pickers: a rectangle with the
+                // pinned side emphasized; dashed = unpinned (auto).
                 const SIDES = [
-                  { label: 'auto', ariaLabel: 'Auto', side: undefined },
-                  { label: '↑', ariaLabel: 'Top', side: 'top' },
-                  { label: '→', ariaLabel: 'Right', side: 'right' },
-                  { label: '↓', ariaLabel: 'Bottom', side: 'bottom' },
-                  { label: '←', ariaLabel: 'Left', side: 'left' },
+                  { label: 'auto', ariaLabel: 'Auto', icon: <SquareDashed />, side: undefined },
+                  { label: 'top', ariaLabel: 'Top', icon: <PanelTop />, side: 'top' },
+                  { label: 'right', ariaLabel: 'Right', icon: <PanelRight />, side: 'right' },
+                  { label: 'bottom', ariaLabel: 'Bottom', icon: <PanelBottom />, side: 'bottom' },
+                  { label: 'left', ariaLabel: 'Left', icon: <PanelLeft />, side: 'left' },
                 ] as const
                 const sideRow = (endpoint: 'from' | 'to') => {
                   const current = endpoint === 'from' ? edge.fromSide : edge.toSide
@@ -1147,6 +1160,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     label: endpoint === 'from' ? 'From side' : 'To side',
                     options: SIDES.map((entry) => ({
                       label: entry.label,
+                      icon: entry.icon,
                       ariaLabel: entry.ariaLabel,
                       selected: current === entry.side,
                       onSelect: () =>
@@ -1160,7 +1174,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   }
                 }
                 return [
-                  { label: 'Edit label', onSelect: () => setEdgeLabelEditId(edge.id) },
+                  {
+                    label: 'Edit label',
+                    icon: <Tag />,
+                    onSelect: () => setEdgeLabelEditId(edge.id),
+                  },
                   { kind: 'separator' as const },
                   {
                     kind: 'options' as const,
@@ -1183,6 +1201,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   { kind: 'separator' as const },
                   {
                     label: 'Delete',
+                    icon: <Trash2 />,
                     danger: true,
                     onSelect: () => {
                       applyResult({
@@ -1195,12 +1214,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ]
               }
               if (node === undefined) {
-                return [{ label: 'Add note here', onSelect: () => createNodeAt(contextMenu.point) }]
+                return [
+                  {
+                    label: 'Add note here',
+                    icon: <StickyNote />,
+                    onSelect: () => createNodeAt(contextMenu.point),
+                  },
+                ]
               }
               const items: ContextMenuItem[] = []
               if (node.type === 'text') {
                 items.push({
                   label: 'Edit text',
+                  icon: <Pencil />,
                   onSelect: () => {
                     applyResult(
                       reduceGesture(gestureState, canvas, {
@@ -1217,6 +1243,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }
               items.push({
                 label: 'Delete',
+                icon: <Trash2 />,
                 danger: true,
                 onSelect: () => {
                   applyResult(

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -20,7 +20,9 @@
  * Backspace-while-typing edits text instead of deleting the node), select
  * an edge (click its line) and delete it (Delete/Backspace), and edit an
  * edge's label (double-click its line; commits on blur, empty removes,
- * Escape cancels).
+ * Escape cancels), and restyle an edge from its context menu (arrowhead
+ * direction per JSON Canvas fromEnd/toEnd, and per-endpoint side pinning
+ * with an auto option).
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -87,7 +89,6 @@ export const SPATIAL_EDITOR_UNSUPPORTED = [
   'shape-tools',
   'grouping',
   'undo-redo',
-  'arrow-side-pinning',
   'snapping',
   'persistence',
   'sync',
@@ -1116,8 +1117,52 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   ? undefined
                   : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
               if (node === undefined && edge !== undefined) {
+                // Arrow direction reads the JSON Canvas defaults (fromEnd
+                // none, toEnd arrow); the four states are explicit items so
+                // one tap reaches any target state, with the current one
+                // check-marked.
+                const fromEnd = edge.fromEnd ?? 'none'
+                const toEnd = edge.toEnd ?? 'arrow'
+                const arrowStates = [
+                  { label: 'Arrow →', fromEnd: 'none', toEnd: 'arrow' },
+                  { label: 'Arrow ↔', fromEnd: 'arrow', toEnd: 'arrow' },
+                  { label: 'Arrow ←', fromEnd: 'arrow', toEnd: 'none' },
+                  { label: 'No arrows', fromEnd: 'none', toEnd: 'none' },
+                ] as const
+                const applyEdgeCommand = (command: EditorCommand) =>
+                  applyResult({ state: { kind: 'idle' }, commands: [command] })
+                const SIDE_CYCLE = [undefined, 'top', 'right', 'bottom', 'left'] as const
+                const sideItem = (endpoint: 'from' | 'to') => {
+                  const current = endpoint === 'from' ? edge.fromSide : edge.toSide
+                  const next = SIDE_CYCLE[(SIDE_CYCLE.indexOf(current) + 1) % SIDE_CYCLE.length]
+                  return {
+                    label: `${endpoint === 'from' ? 'From' : 'To'} side: ${current ?? 'auto'}`,
+                    onSelect: () =>
+                      applyEdgeCommand({
+                        kind: 'set-edge-side',
+                        id: edge.id,
+                        endpoint,
+                        side: next,
+                      }),
+                  }
+                }
                 return [
                   { label: 'Edit label', onSelect: () => setEdgeLabelEditId(edge.id) },
+                  ...arrowStates.map((state) => ({
+                    label:
+                      state.fromEnd === fromEnd && state.toEnd === toEnd
+                        ? `✓ ${state.label}`
+                        : state.label,
+                    onSelect: () =>
+                      applyEdgeCommand({
+                        kind: 'set-edge-ends',
+                        id: edge.id,
+                        fromEnd: state.fromEnd,
+                        toEnd: state.toEnd,
+                      }),
+                  })),
+                  sideItem('from'),
+                  sideItem('to'),
                   {
                     label: 'Delete',
                     danger: true,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -30,7 +30,7 @@
  *
  * NOT yet supported (see `SPATIAL_EDITOR_UNSUPPORTED`): freehand drawing
  * and shape tools (`x-whiteboard` extension authoring — its own slice),
- * grouping, undo/redo, arrow-side pinning, snapping,
+ * grouping, undo/redo, snapping,
  * persistence, and sync. Those are later phases.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
@@ -46,7 +46,7 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
-import { ContextMenu } from './ContextMenu.js'
+import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
@@ -1117,52 +1117,70 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   ? undefined
                   : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
               if (node === undefined && edge !== undefined) {
+                // Property pickers are inline option rows (one tap per
+                // choice, menu stays open) — a cycling item costs an
+                // open-tap-reopen per step. Sections group the menu:
+                // actions, then properties, then the destructive entry.
                 // Arrow direction reads the JSON Canvas defaults (fromEnd
-                // none, toEnd arrow); the four states are explicit items so
-                // one tap reaches any target state, with the current one
-                // check-marked.
+                // none, toEnd arrow).
                 const fromEnd = edge.fromEnd ?? 'none'
                 const toEnd = edge.toEnd ?? 'arrow'
                 const arrowStates = [
-                  { label: 'Arrow →', fromEnd: 'none', toEnd: 'arrow' },
-                  { label: 'Arrow ↔', fromEnd: 'arrow', toEnd: 'arrow' },
-                  { label: 'Arrow ←', fromEnd: 'arrow', toEnd: 'none' },
-                  { label: 'No arrows', fromEnd: 'none', toEnd: 'none' },
+                  { label: '→', ariaLabel: 'Forward', fromEnd: 'none', toEnd: 'arrow' },
+                  { label: '↔', ariaLabel: 'Both', fromEnd: 'arrow', toEnd: 'arrow' },
+                  { label: '←', ariaLabel: 'Backward', fromEnd: 'arrow', toEnd: 'none' },
+                  { label: '−', ariaLabel: 'None', fromEnd: 'none', toEnd: 'none' },
                 ] as const
                 const applyEdgeCommand = (command: EditorCommand) =>
                   applyResult({ state: { kind: 'idle' }, commands: [command] })
-                const SIDE_CYCLE = [undefined, 'top', 'right', 'bottom', 'left'] as const
-                const sideItem = (endpoint: 'from' | 'to') => {
+                const SIDES = [
+                  { label: 'auto', ariaLabel: 'Auto', side: undefined },
+                  { label: '↑', ariaLabel: 'Top', side: 'top' },
+                  { label: '→', ariaLabel: 'Right', side: 'right' },
+                  { label: '↓', ariaLabel: 'Bottom', side: 'bottom' },
+                  { label: '←', ariaLabel: 'Left', side: 'left' },
+                ] as const
+                const sideRow = (endpoint: 'from' | 'to') => {
                   const current = endpoint === 'from' ? edge.fromSide : edge.toSide
-                  const next = SIDE_CYCLE[(SIDE_CYCLE.indexOf(current) + 1) % SIDE_CYCLE.length]
                   return {
-                    label: `${endpoint === 'from' ? 'From' : 'To'} side: ${current ?? 'auto'}`,
-                    onSelect: () =>
-                      applyEdgeCommand({
-                        kind: 'set-edge-side',
-                        id: edge.id,
-                        endpoint,
-                        side: next,
-                      }),
+                    kind: 'options' as const,
+                    label: endpoint === 'from' ? 'From side' : 'To side',
+                    options: SIDES.map((entry) => ({
+                      label: entry.label,
+                      ariaLabel: entry.ariaLabel,
+                      selected: current === entry.side,
+                      onSelect: () =>
+                        applyEdgeCommand({
+                          kind: 'set-edge-side',
+                          id: edge.id,
+                          endpoint,
+                          side: entry.side,
+                        }),
+                    })),
                   }
                 }
                 return [
                   { label: 'Edit label', onSelect: () => setEdgeLabelEditId(edge.id) },
-                  ...arrowStates.map((state) => ({
-                    label:
-                      state.fromEnd === fromEnd && state.toEnd === toEnd
-                        ? `✓ ${state.label}`
-                        : state.label,
-                    onSelect: () =>
-                      applyEdgeCommand({
-                        kind: 'set-edge-ends',
-                        id: edge.id,
-                        fromEnd: state.fromEnd,
-                        toEnd: state.toEnd,
-                      }),
-                  })),
-                  sideItem('from'),
-                  sideItem('to'),
+                  { kind: 'separator' as const },
+                  {
+                    kind: 'options' as const,
+                    label: 'Arrows',
+                    options: arrowStates.map((state) => ({
+                      label: state.label,
+                      ariaLabel: state.ariaLabel,
+                      selected: state.fromEnd === fromEnd && state.toEnd === toEnd,
+                      onSelect: () =>
+                        applyEdgeCommand({
+                          kind: 'set-edge-ends',
+                          id: edge.id,
+                          fromEnd: state.fromEnd,
+                          toEnd: state.toEnd,
+                        }),
+                    })),
+                  },
+                  sideRow('from'),
+                  sideRow('to'),
+                  { kind: 'separator' as const },
                   {
                     label: 'Delete',
                     danger: true,
@@ -1179,7 +1197,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               if (node === undefined) {
                 return [{ label: 'Add note here', onSelect: () => createNodeAt(contextMenu.point) }]
               }
-              const items = []
+              const items: ContextMenuItem[] = []
               if (node.type === 'text') {
                 items.push({
                   label: 'Edit text',
@@ -1193,6 +1211,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     )
                   },
                 })
+                // Same grouping rule as the edge menu: the destructive
+                // entry sits in its own section.
+                items.push({ kind: 'separator' })
               }
               items.push({
                 label: 'Delete',

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -163,6 +163,72 @@ describe('applyCommand', () => {
     expect(next).toBe(canvas)
   })
 
+  it('set-edge-ends stores only non-default ends and removes fields at the spec default', () => {
+    const connected = applyCommand(baseCanvas(), {
+      kind: 'connect-nodes',
+      edgeId: 'e1',
+      fromNode: 'a',
+      toNode: 'b',
+    })
+
+    const both = applyCommand(connected, {
+      kind: 'set-edge-ends',
+      id: 'e1',
+      fromEnd: 'arrow',
+      toEnd: 'arrow',
+    })
+    expect(both.edges[0]).toMatchObject({ fromEnd: 'arrow' })
+    // toEnd 'arrow' IS the spec default — canonical form omits it.
+    expect(both.edges[0]).not.toHaveProperty('toEnd')
+    expect(spatialCanvasSchema.safeParse(both).success).toBe(true)
+
+    const none = applyCommand(both, {
+      kind: 'set-edge-ends',
+      id: 'e1',
+      fromEnd: 'none',
+      toEnd: 'none',
+    })
+    expect(none.edges[0]).not.toHaveProperty('fromEnd')
+    expect(none.edges[0]).toMatchObject({ toEnd: 'none' })
+
+    const defaults = applyCommand(none, {
+      kind: 'set-edge-ends',
+      id: 'e1',
+      fromEnd: 'none',
+      toEnd: 'arrow',
+    })
+    expect(defaults.edges[0]).not.toHaveProperty('fromEnd')
+    expect(defaults.edges[0]).not.toHaveProperty('toEnd')
+  })
+
+  it('set-edge-side pins one endpoint and undefined returns it to auto', () => {
+    const connected = applyCommand(baseCanvas(), {
+      kind: 'connect-nodes',
+      edgeId: 'e1',
+      fromNode: 'a',
+      toNode: 'b',
+    })
+
+    const pinned = applyCommand(connected, {
+      kind: 'set-edge-side',
+      id: 'e1',
+      endpoint: 'from',
+      side: 'top',
+    })
+    expect(pinned.edges[0]).toMatchObject({ fromSide: 'top' })
+    expect(pinned.edges[0]).not.toHaveProperty('toSide')
+    expect(spatialCanvasSchema.safeParse(pinned).success).toBe(true)
+
+    const auto = applyCommand(pinned, {
+      kind: 'set-edge-side',
+      id: 'e1',
+      endpoint: 'from',
+      side: undefined,
+    })
+    expect(auto.edges[0]).not.toHaveProperty('fromSide')
+    expect(spatialCanvasSchema.safeParse(auto).success).toBe(true)
+  })
+
   it('set-edge-label sets, updates, and (with an empty string) removes the label', () => {
     const connected = applyCommand(baseCanvas(), {
       kind: 'connect-nodes',

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -41,6 +41,19 @@ export type EditorCommand =
   | { readonly kind: 'delete-node'; readonly id: string }
   | { readonly kind: 'delete-edge'; readonly id: string }
   | { readonly kind: 'set-edge-label'; readonly id: string; readonly label: string }
+  | {
+      readonly kind: 'set-edge-ends'
+      readonly id: string
+      readonly fromEnd: 'none' | 'arrow'
+      readonly toEnd: 'none' | 'arrow'
+    }
+  | {
+      readonly kind: 'set-edge-side'
+      readonly id: string
+      readonly endpoint: 'from' | 'to'
+      // undefined returns the endpoint to derived (auto) routing.
+      readonly side: 'top' | 'right' | 'bottom' | 'left' | undefined
+    }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -144,6 +157,48 @@ function deleteNode(canvas: SpatialCanvas, id: string): SpatialCanvas {
 
 /** An empty label removes the field: the model's `label` is optional and an
  * empty string would serialize as an authored-but-blank label. */
+/** Ends equal to the JSON Canvas defaults (fromEnd none, toEnd arrow) are
+ * removed rather than written, keeping the stored document canonical. */
+function setEdgeEnds(
+  canvas: SpatialCanvas,
+  id: string,
+  fromEnd: 'none' | 'arrow',
+  toEnd: 'none' | 'arrow',
+): SpatialCanvas {
+  if (!canvas.edges.some((edge) => edge.id === id)) return canvas
+  return {
+    ...canvas,
+    edges: canvas.edges.map((edge) => {
+      if (edge.id !== id) return edge
+      const { fromEnd: _from, toEnd: _to, ...rest } = edge
+      return {
+        ...rest,
+        ...(fromEnd === 'none' ? {} : { fromEnd }),
+        ...(toEnd === 'arrow' ? {} : { toEnd }),
+      }
+    }),
+  }
+}
+
+/** `side: undefined` removes the pin so routing derives the side again. */
+function setEdgeSide(
+  canvas: SpatialCanvas,
+  id: string,
+  endpoint: 'from' | 'to',
+  side: 'top' | 'right' | 'bottom' | 'left' | undefined,
+): SpatialCanvas {
+  if (!canvas.edges.some((edge) => edge.id === id)) return canvas
+  const key = endpoint === 'from' ? 'fromSide' : 'toSide'
+  return {
+    ...canvas,
+    edges: canvas.edges.map((edge) => {
+      if (edge.id !== id) return edge
+      const { [key]: _removed, ...rest } = edge
+      return side === undefined ? rest : { ...rest, [key]: side }
+    }),
+  }
+}
+
 function setEdgeLabel(canvas: SpatialCanvas, id: string, label: string): SpatialCanvas {
   if (!canvas.edges.some((edge) => edge.id === id)) return canvas
   return {
@@ -175,6 +230,10 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return { ...canvas, edges: canvas.edges.filter((edge) => edge.id !== command.id) }
     case 'set-edge-label':
       return setEdgeLabel(canvas, command.id, command.label)
+    case 'set-edge-ends':
+      return setEdgeEnds(canvas, command.id, command.fromEnd, command.toEnd)
+    case 'set-edge-side':
+      return setEdgeSide(canvas, command.id, command.endpoint, command.side)
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -3,7 +3,7 @@
 // synthetic-event-only coverage is how this editor's first-touch bugs
 // survived unnoticed.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
@@ -161,7 +161,22 @@ it('right-clicking an edge offers Edit label and Delete, not node creation', asy
   expect(latest.canvas.edges).toHaveLength(1)
 })
 
-it('the edge menu marks the spec-default arrow state and applies a new direction', async () => {
+// Deterministic option-click for the inline property rows: applying an
+// option re-routes the edge and re-renders the scene under the pointer,
+// which Playwright's stability check intermittently reads as "element not
+// stable"; the menu button itself is static, so a direct DOM click is the
+// faithful interaction.
+function clickOption(container: HTMLElement, groupName: string, optionName: string) {
+  const group = [...container.querySelectorAll('fieldset')].find(
+    (g) => g.getAttribute('aria-label') === groupName,
+  ) as HTMLElement
+  const option = [...group.querySelectorAll('[role="menuitemradio"]')].find(
+    (o) => o.getAttribute('aria-label') === optionName,
+  ) as HTMLElement
+  fireEvent.click(option)
+}
+
+it('the arrow option row marks the spec default and applies a new direction in one tap', async () => {
   const { EdgeHost, latest } = makeEdgeHost()
   const { container } = render(<EdgeHost />)
 
@@ -169,16 +184,21 @@ it('the edge menu marks the spec-default arrow state and applies a new direction
   rightClick(rootOf(container), mid.x, mid.y)
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 
-  // Default fromEnd none / toEnd arrow reads as the checked "Arrow →".
-  await expect.element(page.getByRole('menuitem', { name: '✓ Arrow →' })).toBeInTheDocument()
+  // Default fromEnd none / toEnd arrow reads as the checked "Forward" radio.
+  const forward = [...container.querySelectorAll('[role="menuitemradio"]')].find(
+    (o) => o.getAttribute('aria-label') === 'Forward',
+  )
+  expect(forward?.getAttribute('aria-checked')).toBe('true')
 
-  await userEvent.click(page.getByRole('menuitem', { name: 'Arrow ↔' }))
+  clickOption(container, 'Arrows', 'Both')
   await vi.waitFor(() => expect(latest.canvas.edges[0].fromEnd).toBe('arrow'))
   // toEnd 'arrow' is the spec default — canonical form omits the field.
   expect(latest.canvas.edges[0]).not.toHaveProperty('toEnd')
   expect(latest.commands).toContain('set-edge-ends')
 
-  // The rendered scene now draws both arrowheads.
+  // Property picks keep the menu OPEN (several adjustments = one visit) and
+  // the rendered scene now draws both arrowheads.
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
   await vi.waitFor(() =>
     expect(
       container.querySelectorAll('[data-testid="viewport-transform"] svg polygon').length,
@@ -186,7 +206,7 @@ it('the edge menu marks the spec-default arrow state and applies a new direction
   )
 })
 
-it('the edge menu pins the from-side one step per activation (auto -> top)', async () => {
+it('the side option rows pin an endpoint directly, without cycling', async () => {
   const { EdgeHost, latest } = makeEdgeHost()
   const { container } = render(<EdgeHost />)
 
@@ -194,9 +214,18 @@ it('the edge menu pins the from-side one step per activation (auto -> top)', asy
   rightClick(rootOf(container), mid.x, mid.y)
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 
-  await userEvent.click(page.getByRole('menuitem', { name: 'From side: auto' }))
-  await vi.waitFor(() => expect(latest.canvas.edges[0].fromSide).toBe('top'))
+  // Direct pick inside the "From side" group — one tap to any side.
+  clickOption(container, 'From side', 'Bottom')
+  await vi.waitFor(() => expect(latest.canvas.edges[0].fromSide).toBe('bottom'))
   expect(latest.commands).toContain('set-edge-side')
+
+  // Menu is still open — pin the other endpoint in the same visit.
+  clickOption(container, 'To side', 'Top')
+  await vi.waitFor(() => expect(latest.canvas.edges[0].toSide).toBe('top'))
+
+  // And back to auto removes the pin.
+  clickOption(container, 'From side', 'Auto')
+  await vi.waitFor(() => expect(latest.canvas.edges[0]).not.toHaveProperty('fromSide'))
 })
 
 it('Delete from the edge menu removes the edge and leaves the nodes', async () => {

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -161,6 +161,44 @@ it('right-clicking an edge offers Edit label and Delete, not node creation', asy
   expect(latest.canvas.edges).toHaveLength(1)
 })
 
+it('the edge menu marks the spec-default arrow state and applies a new direction', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  // Default fromEnd none / toEnd arrow reads as the checked "Arrow →".
+  await expect.element(page.getByRole('menuitem', { name: '✓ Arrow →' })).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Arrow ↔' }))
+  await vi.waitFor(() => expect(latest.canvas.edges[0].fromEnd).toBe('arrow'))
+  // toEnd 'arrow' is the spec default — canonical form omits the field.
+  expect(latest.canvas.edges[0]).not.toHaveProperty('toEnd')
+  expect(latest.commands).toContain('set-edge-ends')
+
+  // The rendered scene now draws both arrowheads.
+  await vi.waitFor(() =>
+    expect(
+      container.querySelectorAll('[data-testid="viewport-transform"] svg polygon').length,
+    ).toBe(2),
+  )
+})
+
+it('the edge menu pins the from-side one step per activation (auto -> top)', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'From side: auto' }))
+  await vi.waitFor(() => expect(latest.canvas.edges[0].fromSide).toBe('top'))
+  expect(latest.commands).toContain('set-edge-side')
+})
+
 it('Delete from the edge menu removes the edge and leaves the nodes', async () => {
   const { EdgeHost, latest } = makeEdgeHost()
   const { container } = render(<EdgeHost />)

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -6,7 +6,6 @@ const REQUIRED_UNSUPPORTED = [
   'shape-tools',
   'grouping',
   'undo-redo',
-  'arrow-side-pinning',
   'snapping',
   'persistence',
   'sync',

--- a/packages/canvas-render/src/edge-arrows.ts
+++ b/packages/canvas-render/src/edge-arrows.ts
@@ -1,0 +1,62 @@
+import type { ResolvedEdgeNode } from './scene-graph.js'
+
+/**
+ * Arrowhead geometry shared by the SVG backend (which draws the triangles)
+ * and `sceneBounds` (which must include their wings so a derived viewBox
+ * never clips them). One producer keeps the two in agreement.
+ *
+ * Sizes are canvas units — arrowheads scale with the content under
+ * pan/zoom exactly like stroke geometry does.
+ */
+const ARROW_LENGTH = 10
+const ARROW_HALF_WIDTH = 4
+/** Below this segment length there is no usable direction — skip the arrow. */
+const MIN_DIRECTION_LENGTH = 1e-6
+
+export interface ArrowPolygon {
+  /** Tip first, then the two wing corners — the SVG emission order. */
+  readonly points: readonly { readonly x: number; readonly y: number }[]
+}
+
+function arrowAt(
+  tip: { readonly x: number; readonly y: number },
+  inward: { readonly x: number; readonly y: number },
+): ArrowPolygon | null {
+  const dx = tip.x - inward.x
+  const dy = tip.y - inward.y
+  const length = Math.hypot(dx, dy)
+  if (length < MIN_DIRECTION_LENGTH) return null
+  const ux = dx / length
+  const uy = dy / length
+  const baseX = tip.x - ux * ARROW_LENGTH
+  const baseY = tip.y - uy * ARROW_LENGTH
+  // Perpendicular (-uy, ux); corner order is fixed for determinism.
+  return {
+    points: [
+      tip,
+      { x: baseX - uy * ARROW_HALF_WIDTH, y: baseY + ux * ARROW_HALF_WIDTH },
+      { x: baseX + uy * ARROW_HALF_WIDTH, y: baseY - ux * ARROW_HALF_WIDTH },
+    ],
+  }
+}
+
+/**
+ * The arrowhead polygons of an edge, source arrow first. Total: a
+ * degenerate path (fewer than two points, or no finite direction at an
+ * end) simply yields no polygon for that end.
+ */
+export function edgeArrowPolygons(edge: ResolvedEdgeNode): readonly ArrowPolygon[] {
+  if (edge.path.length < 2) return []
+  const polygons: ArrowPolygon[] = []
+  if (edge.fromEnd === 'arrow') {
+    const arrow = arrowAt(edge.path[0], edge.path[1])
+    if (arrow) polygons.push(arrow)
+  }
+  if (edge.toEnd === 'arrow') {
+    const tip = edge.path[edge.path.length - 1]
+    const inward = edge.path[edge.path.length - 2]
+    const arrow = arrowAt(tip, inward)
+    if (arrow) polygons.push(arrow)
+  }
+  return polygons
+}

--- a/packages/canvas-render/src/layout/spatial-edges.test.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.test.ts
@@ -53,6 +53,29 @@ describe('routeEdge', () => {
     expect(result.toSide).toBe('bottom')
   })
 
+  it('threads the spec-default ends: fromEnd none, toEnd arrow', () => {
+    const nodes = [node('a', 0, 0, 100, 100), node('b', 200, 0, 100, 100)]
+    const result = routeEdge(nodes, edge({ id: 'e1', fromNode: 'a', toNode: 'b' }))
+    expect(result.fromEnd).toBe('none')
+    expect(result.toEnd).toBe('arrow')
+  })
+
+  it('passes explicit fromEnd/toEnd through', () => {
+    const nodes = [node('a', 0, 0, 100, 100), node('b', 200, 0, 100, 100)]
+    const result = routeEdge(
+      nodes,
+      edge({ id: 'e1', fromNode: 'a', toNode: 'b', fromEnd: 'arrow', toEnd: 'none' }),
+    )
+    expect(result.fromEnd).toBe('arrow')
+    expect(result.toEnd).toBe('none')
+  })
+
+  it('the degraded missing-endpoint edge still carries ends', () => {
+    const result = routeEdge([], edge({ id: 'e1', fromNode: 'ghost-a', toNode: 'ghost-b' }))
+    expect(result.fromEnd).toBe('none')
+    expect(result.toEnd).toBe('arrow')
+  })
+
   it('produces a deterministic self-edge loop path without throwing', () => {
     const nodes = [node('a', 0, 0, 100, 100)]
     const result = routeEdge(nodes, edge({ id: 'e1', fromNode: 'a', toNode: 'a' }))

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -92,6 +92,10 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
   const fromNode = nodes.find((n) => n.id === edge.fromNode)
   const toNode = nodes.find((n) => n.id === edge.toNode)
 
+  // JSON Canvas 1.0 defaults: no source arrowhead, a destination arrowhead.
+  const fromEnd = edge.fromEnd ?? 'none'
+  const toEnd = edge.toEnd ?? 'arrow'
+
   if (!fromNode || !toNode) {
     const origin = { x: 0, y: 0 }
     return {
@@ -100,6 +104,8 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
       path: [origin, origin],
       fromSide: edge.fromSide ?? 'right',
       toSide: edge.toSide ?? 'left',
+      fromEnd,
+      toEnd,
     }
   }
 
@@ -115,7 +121,15 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
     const start = sidePoint(fromRect, fromSide)
     const [loopOut, loopBack] = selfEdgeLoopControlPoints(start, fromSide)
     const end = sidePoint(toRect, toSide)
-    return { kind: 'edge', id: edge.id, path: [start, loopOut, loopBack, end], fromSide, toSide }
+    return {
+      kind: 'edge',
+      id: edge.id,
+      path: [start, loopOut, loopBack, end],
+      fromSide,
+      toSide,
+      fromEnd,
+      toEnd,
+    }
   }
 
   const derived = deriveDefaultSides(fromRect, toRect)
@@ -125,5 +139,5 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
   const start = sidePoint(fromRect, fromSide)
   const end = sidePoint(toRect, toSide)
 
-  return { kind: 'edge', id: edge.id, path: [start, end], fromSide, toSide }
+  return { kind: 'edge', id: edge.id, path: [start, end], fromSide, toSide, fromEnd, toEnd }
 }

--- a/packages/canvas-render/src/properties.test.ts
+++ b/packages/canvas-render/src/properties.test.ts
@@ -137,6 +137,8 @@ const sceneNodeArb: fc.Arbitrary<SceneNode> = fc.oneof(
       path,
       fromSide: 'right' as const,
       toSide: 'left' as const,
+      fromEnd: 'none' as const,
+      toEnd: 'none' as const,
     })),
   shapeNodeArb,
 )

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -80,11 +80,43 @@ describe('sceneBounds', () => {
           ],
           fromSide: 'right',
           toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
         },
-        { kind: 'edge', id: 'e2', path: [], fromSide: 'top', toSide: 'bottom' },
+        {
+          kind: 'edge',
+          id: 'e2',
+          path: [],
+          fromSide: 'top',
+          toSide: 'bottom',
+          fromEnd: 'none',
+          toEnd: 'none',
+        },
       ],
     }
     expect(sceneBounds(scene)).toEqual({ x: 0, y: 0, w: 50, h: 30 })
+  })
+
+  it('includes arrowhead wings in the bounds so a derived viewBox never clips them', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 30, y: 0 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    // The horizontal polyline alone spans y [0, 0]; the destination arrow's
+    // wings reach y = -4 and y = 4 at x = 20.
+    expect(sceneBounds(scene)).toEqual({ x: 0, y: -4, w: 30, h: 8 })
   })
 
   it('widens the bounds when a nested descendant lies outside its parent bbox', () => {

--- a/packages/canvas-render/src/scene-bounds.ts
+++ b/packages/canvas-render/src/scene-bounds.ts
@@ -1,3 +1,4 @@
+import { edgeArrowPolygons } from './edge-arrows.js'
 import type {
   BoundingBox,
   ListItemNode,
@@ -132,6 +133,17 @@ export function sceneBounds(scene: Scene): BoundingBox {
         if (isFinitePoint(p.x, p.y)) {
           const x = p.x + offsetX
           extent = widen(extent, x, p.y, x, p.y)
+        }
+      }
+      // Arrowhead wings reach beyond the polyline's own envelope; the
+      // shared geometry helper keeps this walk agreeing with what the SVG
+      // backend actually draws.
+      for (const arrow of edgeArrowPolygons(node)) {
+        for (const p of arrow.points) {
+          if (isFinitePoint(p.x, p.y)) {
+            const x = p.x + offsetX
+            extent = widen(extent, x, p.y, x, p.y)
+          }
         }
       }
     } else {

--- a/packages/canvas-render/src/scene-digest.test.ts
+++ b/packages/canvas-render/src/scene-digest.test.ts
@@ -125,6 +125,8 @@ describe('sceneDigest', () => {
           ],
           fromSide: 'right',
           toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
         },
       ],
     }

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -213,6 +213,11 @@ export interface ResolvedEdgeNode {
   readonly path: readonly { readonly x: number; readonly y: number }[]
   readonly fromSide: 'top' | 'right' | 'bottom' | 'left'
   readonly toSide: 'top' | 'right' | 'bottom' | 'left'
+  // Always resolved by the producer (routeEdge applies the JSON Canvas
+  // defaults: fromEnd 'none', toEnd 'arrow') — required here so no scene
+  // constructor can forget which ends carry an arrowhead.
+  readonly fromEnd: 'none' | 'arrow'
+  readonly toEnd: 'none' | 'arrow'
   readonly appearance?: Appearance
 }
 

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -463,7 +463,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="30,0 20,4 20,-4" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
     )
   })
 
@@ -485,7 +485,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="0,0 10,-4 10,4" role="presentation"/><polygon points="30,0 20,4 20,-4" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="0,0 10,-4 10,4" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
     )
   })
 

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -415,6 +415,8 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
           ],
           fromSide: 'right',
           toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
           appearance: { stroke: '#888', strokeWidth: 1.5 },
         },
       ],
@@ -433,11 +435,102 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
           path: [{ x: 0, y: 0 }],
           fromSide: 'right',
           toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
         },
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
       '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0" role="presentation"/></svg>',
+    )
+  })
+
+  it('draws a filled destination arrowhead for toEnd=arrow, oriented along the last segment', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 30, y: 0 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="30,0 20,4 20,-4" role="presentation"/></svg>',
+    )
+  })
+
+  it('draws both arrowheads for fromEnd=arrow toEnd=arrow, source arrow first', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 30, y: 0 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'arrow',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="0,0 10,-4 10,4" role="presentation"/><polygon points="30,0 20,4 20,-4" role="presentation"/></svg>',
+    )
+  })
+
+  it('the arrowhead inherits the edge stroke color as its fill', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 30, y: 0 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+          appearance: { stroke: '#888' },
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" stroke="#888" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="#888" role="presentation"/></svg>',
+    )
+  })
+
+  it('a degenerate zero-length edge draws no arrowhead', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 5, y: 5 },
+            { x: 5, y: 5 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'arrow',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="5,5 5,5" role="presentation"/></svg>',
     )
   })
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,3 +1,4 @@
+import { edgeArrowPolygons } from '../edge-arrows.js'
 import { sceneBounds } from '../scene-bounds.js'
 import type {
   Appearance,
@@ -160,7 +161,22 @@ function renderNode(node: SceneNode): string {
     case 'edge': {
       const points = node.path.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
       const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
-      return `<polyline points="${points}"${appearance} ${PRESENTATION_ATTR}/>`
+      const polyline = `<polyline points="${points}"${appearance} ${PRESENTATION_ATTR}/>`
+      // Arrowheads are filled triangles in the edge's stroke color, drawn
+      // after (over) the polyline. Geometry comes from the shared helper so
+      // sceneBounds always agrees on how far the wings reach.
+      const stroke = node.appearance?.stroke
+      const arrowFill =
+        typeof stroke === 'string' && stroke.length > 0 ? ` fill="${escapeXmlAttr(stroke)}"` : ''
+      const arrows = edgeArrowPolygons(node)
+        .map((arrow) => {
+          const arrowPoints = arrow.points
+            .map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`)
+            .join(' ')
+          return `<polygon points="${arrowPoints}"${arrowFill} ${PRESENTATION_ATTR}/>`
+        })
+        .join('')
+      return `${polyline}${arrows}`
     }
     case 'shape':
       return renderShape(node)

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -166,8 +166,13 @@ function renderNode(node: SceneNode): string {
       // after (over) the polyline. Geometry comes from the shared helper so
       // sceneBounds always agrees on how far the wings reach.
       const stroke = node.appearance?.stroke
+      // No stroke means the polyline itself is invisible (SVG's default
+      // stroke is none) — the arrow must match it, not fall back to the
+      // polygon's default black fill and float detached.
       const arrowFill =
-        typeof stroke === 'string' && stroke.length > 0 ? ` fill="${escapeXmlAttr(stroke)}"` : ''
+        typeof stroke === 'string' && stroke.length > 0
+          ? ` fill="${escapeXmlAttr(stroke)}"`
+          : ' fill="none"'
       const arrows = edgeArrowPolygons(node)
         .map((arrow) => {
           const arrowPoints = arrow.points

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -159,6 +159,10 @@ export function buildShapeAppearanceGoldenScene(): Scene {
         ],
         fromSide: 'right',
         toSide: 'left',
+        // Spec-default destination arrowhead — deliberately exercised by the
+        // golden so the arrow serialization format is pinned cross-platform.
+        fromEnd: 'none',
+        toEnd: 'arrow',
         appearance: { stroke: '#888', strokeWidth: 1.5 },
       },
     ],
@@ -177,4 +181,5 @@ export const SHAPE_APPEARANCE_GOLDEN_SVG =
   '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
   '<g><text x="0" y="80" fill="#111" font-family="Inter" font-size="14">Styled</text></g>' +
   '<polyline points="0,120 100,120" stroke="#888" stroke-width="1.5" role="presentation"/>' +
+  '<polygon points="100,120 90,124 90,116" fill="#888" role="presentation"/>' +
   '</svg>'

--- a/packages/server-core/src/tools/edge-patch.test.ts
+++ b/packages/server-core/src/tools/edge-patch.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../test-utils/fake-canvas-doc-store.js'
 import { createInMemoryWorkspaceIndex } from '../test-utils/in-memory-workspace-index.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
-import { createEdgePatchTool } from './edge-patch.js'
+import { createEdgePatchTool, edgePatchFieldsSchema } from './edge-patch.js'
 import { EdgeNotFoundError, PatchValidationError } from './errors.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -64,6 +64,35 @@ describe('edge_patch tool', () => {
       label: 'connects',
       fromSide: 'right',
       toSide: 'left',
+    })
+  })
+
+  test('the patch schema accepts fromEnd/toEnd and rejects invalid ends', () => {
+    // The tool's execute is schema-gated at the MCP layer, so the SCHEMA is
+    // the contract that must admit ends — a strict schema without them
+    // silently locked agents out of arrowheads.
+    expect(edgePatchFieldsSchema.safeParse({ fromEnd: 'arrow', toEnd: 'none' }).success).toBe(true)
+    expect(edgePatchFieldsSchema.safeParse({ toEnd: 'diamond' }).success).toBe(false)
+  })
+
+  test('patches fromEnd/toEnd so an agent can restyle arrowheads', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, BASE_CANVAS)
+    const tool = createEdgePatchTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      edgeId: 'e1',
+      patch: { fromEnd: 'arrow', toEnd: 'none' },
+    })
+
+    expect(result.edge).toEqual({
+      id: 'e1',
+      fromNode: 'n1',
+      toNode: 'n2',
+      fromEnd: 'arrow',
+      toEnd: 'none',
     })
   })
 

--- a/packages/server-core/src/tools/edge-patch.ts
+++ b/packages/server-core/src/tools/edge-patch.ts
@@ -19,6 +19,8 @@ export const edgePatchFieldsSchema = z
     toNode: nodeIdSchema.optional(),
     fromSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
     toSide: z.enum(['top', 'right', 'bottom', 'left']).optional(),
+    fromEnd: z.enum(['none', 'arrow']).optional(),
+    toEnd: z.enum(['none', 'arrow']).optional(),
     color: canvasColorSchema.optional(),
     label: z.string().optional(),
   })


### PR DESCRIPTION
## What

First slice (J1) of the JSON Canvas 1.0 full-spec plan. The spec defaults every edge to a **destination arrowhead** (`toEnd: arrow`), but no layer ever rendered ends — edges were bare polylines — and `edge_patch` could not even set them.

- **canvas-render**: `ResolvedEdgeNode` carries `fromEnd/toEnd` (required — `routeEdge` resolves the spec defaults, so no scene constructor can forget). The SVG backend draws filled-triangle arrowheads in the edge's stroke color, oriented along the terminal segment. Geometry lives in one shared helper (`edge-arrows.ts`) that `sceneBounds` also walks, so a derived viewBox never clips the wings. Degenerate zero-length directions skip the arrow (total, never throws). The shape/appearance **golden is regenerated deliberately** — its edge now exercises the arrow serialization format.
- **server-core**: `edge_patch` accepts `fromEnd/toEnd` (schema-tested — the strict schema was silently locking agents out of arrowheads even though the model supported them).
- **editor**: the edge context menu gains one-tap arrow direction states (`→ / ↔ / ← / none`, current one check-marked; ends equal to the spec defaults are removed so stored documents stay canonical) and per-endpoint **side pinning** cycles (auto/top/right/bottom/left). `arrow-side-pinning` leaves `SPATIAL_EDITOR_UNSUPPORTED`.

One renderer invariant holds: editor, viewer, and headless export all pick the arrows up from the same scene builder.

## Verification (live dev app)

Real canvas with three edges: three destination arrowheads render (`<polygon … fill="#737373">`, the theme stroke color). Right-clicking an edge shows `Edit label / ✓ Arrow → / Arrow ↔ / Arrow ← / No arrows / From side: auto / To side: auto / Delete`; selecting `Arrow ↔` immediately renders the fourth polygon (both ends on that edge).

## Test plan

- [x] Red first: routeEdge threads spec-default and explicit ends (incl. the degraded missing-endpoint path); backend emits tip-first polygons with exact coordinates, stroke-color fill, and none for zero-length edges; sceneBounds includes arrow wings
- [x] Red first: `edgePatchFieldsSchema` admits ends and rejects invalid values; tool round-trip
- [x] Red first: commands — `set-edge-ends` canonical default-removal, `set-edge-side` pin/auto; real-browser context-menu flow (checkmark on the default state, `Arrow ↔` → both polygons, side pin auto→top)
- [x] canvas-render 246 (golden updated deliberately), server-core 226, apps/web jsdom 1427 + browser 243, full `pnpm test` (the two knowns: stale-dist artifact smoke green after `pnpm build`; /pair test passes in isolation)
- [x] typecheck / lint / knip clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable arrowheads on both ends of spatial editor edges.
  * Added edge options for arrow direction and endpoint side pinning.
  * Added accessible option pickers that keep menus open while selecting.
  * Edge arrows now render correctly, follow edge colors, and remain within scene bounds.
  * Edge editing supports saving and updating arrow and pinning settings.

* **Bug Fixes**
  * Prevented arrowheads from being clipped or rendered on zero-length edges.

* **Tests**
  * Expanded coverage for edge options, rendering, validation, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->