### PR TITLE
feat: JSON Canvas preset colors as swappable theme data + context-menu Color row

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -70,3 +70,17 @@ Canvas rendering (nodes/edges/selection) is themed by canvas-render's
 `createSpatialTheme` — a separate authority that shares this document's
 direction. The editor UI must not restyle scene SVG output directly; export
 bytes never depend on the app's ambient UI theme.
+
+### Preset colors ('1'..'6')
+
+JSON Canvas preset colors are semantic slots stored in the data, resolved
+to concrete paint by the theme palette (`SpatialPalette.presets` in
+canvas-render) — swappable data, never hardcoded in resolver code. Per
+mode the accents are: light = Tailwind 600 strokes over 100-tint fills,
+dark = 400 strokes over 950-tint fills. Nodes render accent stroke +
+tint fill (text keeps the theme's text color); edges render the accent
+as stroke. Floors are pinned by tests, not exact hexes: preset strokes
+hold ≥3:1 against the mode background, and label text holds ≥4.5:1
+against the tint fill — a replacement palette must keep passing both.
+The editor's Color row previews swatches from the CURRENT mode's palette
+strokes, while the stored value stays the slot key.

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -19,8 +19,11 @@
  * discrete pointerdown loses the focus fight with mousedown's default
  * action, while click fires after those defaults.
  */
-import { type ReactNode, useEffect, useRef } from 'react'
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
+
+/** Gap kept between the menu and the editor edge when nudging it inside. */
+const MENU_EDGE_MARGIN_PX = 4
 
 export interface ContextMenuActionItem {
   readonly kind?: 'action'
@@ -66,6 +69,25 @@ export interface ContextMenuProps {
 
 export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null)
+  // A menu opened near the editor's right/bottom edge would clip outside it,
+  // so the requested position is nudged back inside once the real menu size
+  // is measurable. useLayoutEffect corrects before paint — no visible jump.
+  const [pos, setPos] = useState({ x, y })
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    const parent = el?.offsetParent
+    if (el == null || !(parent instanceof HTMLElement)) {
+      setPos((prev) => (prev.x === x && prev.y === y ? prev : { x, y }))
+      return
+    }
+    const clamp = (value: number, max: number) =>
+      Math.max(MENU_EDGE_MARGIN_PX, Math.min(value, max))
+    const next = {
+      x: clamp(x, parent.clientWidth - el.offsetWidth - MENU_EDGE_MARGIN_PX),
+      y: clamp(y, parent.clientHeight - el.offsetHeight - MENU_EDGE_MARGIN_PX),
+    }
+    setPos((prev) => (prev.x === next.x && prev.y === next.y ? prev : next))
+  }, [x, y])
 
   // Focus the menu on open so Escape works without an extra click, and close
   // on any pointerdown outside — both standard menu dismissal paths.
@@ -88,8 +110,12 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       role="menu"
       aria-label="Canvas actions"
       tabIndex={-1}
-      className="absolute z-20 min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none"
-      style={{ left: x, top: y }}
+      className="min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none"
+      // Positioning (incl. stacking) is inline, not utility classes: the
+      // edge-clamping above measures the absolutely-positioned box, and it
+      // must behave the same where the app stylesheet is absent
+      // (browser-mode component tests).
+      style={{ position: 'absolute', zIndex: 20, left: pos.x, top: pos.y }}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.stopPropagation()

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -115,7 +115,11 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       // edge-clamping above measures the absolutely-positioned box, and it
       // must behave the same where the app stylesheet is absent
       // (browser-mode component tests).
-      style={{ position: 'absolute', zIndex: 20, left: pos.x, top: pos.y }}
+      // width: max-content keeps the measured size intrinsic — an absolute
+      // box otherwise shrinks to fit the space left of the containing-block
+      // edge, so a menu opened near the edge would measure (and wrap) narrow
+      // and the clamp would compute from the wrong width.
+      style={{ position: 'absolute', zIndex: 20, width: 'max-content', left: pos.x, top: pos.y }}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.stopPropagation()

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -33,8 +33,9 @@
  * grouping, undo/redo, snapping,
  * persistence, and sync. Those are later phases.
  */
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+import type { CanvasColor, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { MeasureText, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
+import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
   PanelBottom,
@@ -1127,6 +1128,60 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 contextMenu.edgeId === undefined
                   ? undefined
                   : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
+              // The swatch chips preview the CURRENT mode's preset strokes so
+              // the picker shows what will actually render; the stored value
+              // stays the semantic slot ('1'..'6'), never a resolved hex.
+              const presetSwatches = (
+                theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
+              ).presets
+              const presetEntries: readonly {
+                readonly key: SpatialPresetKey
+                readonly name: string
+              }[] = [
+                { key: '1', name: 'Red' },
+                { key: '2', name: 'Orange' },
+                { key: '3', name: 'Yellow' },
+                { key: '4', name: 'Green' },
+                { key: '5', name: 'Cyan' },
+                { key: '6', name: 'Purple' },
+              ]
+              const colorRow = (
+                current: CanvasColor | undefined,
+                apply: (color: CanvasColor | undefined) => void,
+              ) => ({
+                kind: 'options' as const,
+                label: 'Color',
+                options: [
+                  {
+                    label: 'default',
+                    ariaLabel: 'Default',
+                    icon: <SquareDashed />,
+                    selected: current === undefined,
+                    onSelect: () => apply(undefined),
+                  },
+                  ...presetEntries.map((entry) => ({
+                    label: entry.key,
+                    ariaLabel: entry.name,
+                    icon: (
+                      // Paint-critical props are inline, not utility classes:
+                      // a default-inline span ignores width/height entirely
+                      // (it laid out 0x0 live), and the chip must also paint
+                      // where the app stylesheet is absent.
+                      <span
+                        style={{
+                          display: 'block',
+                          width: 14,
+                          height: 14,
+                          borderRadius: '50%',
+                          backgroundColor: presetSwatches[entry.key].stroke,
+                        }}
+                      />
+                    ),
+                    selected: current === entry.key,
+                    onSelect: () => apply(entry.key),
+                  })),
+                ],
+              })
               if (node === undefined && edge !== undefined) {
                 // Property pickers are inline option rows (one tap per
                 // choice, menu stays open) — a cycling item costs an
@@ -1198,6 +1253,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   },
                   sideRow('from'),
                   sideRow('to'),
+                  colorRow(edge.color, (color) =>
+                    applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
+                  ),
                   { kind: 'separator' as const },
                   {
                     label: 'Delete',
@@ -1241,6 +1299,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 // entry sits in its own section.
                 items.push({ kind: 'separator' })
               }
+              items.push(
+                colorRow(node.color, (color) =>
+                  applyResult({
+                    state: { kind: 'idle' },
+                    commands: [{ kind: 'set-node-color', id: node.id, color }],
+                  }),
+                ),
+              )
+              items.push({ kind: 'separator' })
               items.push({
                 label: 'Delete',
                 icon: <Trash2 />,

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -163,6 +163,31 @@ describe('applyCommand', () => {
     expect(next).toBe(canvas)
   })
 
+  it('set-node-color applies a preset and undefined returns the node to the theme default', () => {
+    const colored = applyCommand(baseCanvas(), { kind: 'set-node-color', id: 'a', color: '4' })
+    expect(colored.nodes.find((n) => n.id === 'a')).toMatchObject({ color: '4' })
+    expect(spatialCanvasSchema.safeParse(colored).success).toBe(true)
+
+    const cleared = applyCommand(colored, { kind: 'set-node-color', id: 'a', color: undefined })
+    expect(cleared.nodes.find((n) => n.id === 'a')).not.toHaveProperty('color')
+    expect(spatialCanvasSchema.safeParse(cleared).success).toBe(true)
+  })
+
+  it('set-edge-color applies a preset and undefined removes it', () => {
+    const connected = applyCommand(baseCanvas(), {
+      kind: 'connect-nodes',
+      edgeId: 'e1',
+      fromNode: 'a',
+      toNode: 'b',
+    })
+    const colored = applyCommand(connected, { kind: 'set-edge-color', id: 'e1', color: '6' })
+    expect(colored.edges[0]).toMatchObject({ color: '6' })
+
+    const cleared = applyCommand(colored, { kind: 'set-edge-color', id: 'e1', color: undefined })
+    expect(cleared.edges[0]).not.toHaveProperty('color')
+    expect(spatialCanvasSchema.safeParse(cleared).success).toBe(true)
+  })
+
   it('set-edge-ends stores only non-default ends and removes fields at the spec default', () => {
     const connected = applyCommand(baseCanvas(), {
       kind: 'connect-nodes',

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -18,7 +18,12 @@
  * `toNode` referenced the removed node, so no command sequence can ever
  * produce a canvas with a dangling edge endpoint.
  */
-import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type {
+  CanvasColor,
+  CanvasEdge,
+  SpatialCanvas,
+  SpatialNode,
+} from '@kamiazya/whiteboard-canvas-model'
 
 export type EditorCommand =
   | { readonly kind: 'move-node'; readonly id: string; readonly x: number; readonly y: number }
@@ -46,6 +51,17 @@ export type EditorCommand =
       readonly id: string
       readonly fromEnd: 'none' | 'arrow'
       readonly toEnd: 'none' | 'arrow'
+    }
+  | {
+      readonly kind: 'set-node-color'
+      readonly id: string
+      // undefined returns the object to the theme default (field removed).
+      readonly color: CanvasColor | undefined
+    }
+  | {
+      readonly kind: 'set-edge-color'
+      readonly id: string
+      readonly color: CanvasColor | undefined
     }
   | {
       readonly kind: 'set-edge-side'
@@ -180,6 +196,39 @@ function setEdgeEnds(
   }
 }
 
+/** `color: undefined` removes the field — the theme default, canonically. */
+function setNodeColor(
+  canvas: SpatialCanvas,
+  id: string,
+  color: CanvasColor | undefined,
+): SpatialCanvas {
+  if (!canvas.nodes.some((node) => node.id === id)) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.map((node) => {
+      if (node.id !== id) return node
+      const { color: _removed, ...rest } = node
+      return color === undefined ? rest : { ...rest, color }
+    }),
+  }
+}
+
+function setEdgeColor(
+  canvas: SpatialCanvas,
+  id: string,
+  color: CanvasColor | undefined,
+): SpatialCanvas {
+  if (!canvas.edges.some((edge) => edge.id === id)) return canvas
+  return {
+    ...canvas,
+    edges: canvas.edges.map((edge) => {
+      if (edge.id !== id) return edge
+      const { color: _removed, ...rest } = edge
+      return color === undefined ? rest : { ...rest, color }
+    }),
+  }
+}
+
 /** `side: undefined` removes the pin so routing derives the side again. */
 function setEdgeSide(
   canvas: SpatialCanvas,
@@ -234,6 +283,10 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setEdgeEnds(canvas, command.id, command.fromEnd, command.toEnd)
     case 'set-edge-side':
       return setEdgeSide(canvas, command.id, command.endpoint, command.side)
+    case 'set-node-color':
+      return setNodeColor(canvas, command.id, command.color)
+    case 'set-edge-color':
+      return setEdgeColor(canvas, command.id, command.color)
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -278,6 +278,20 @@ it('context-menu targeting keeps node and edge selection mutually exclusive', as
   expect(latest.canvas.nodes).toHaveLength(2)
 })
 
+it('a menu opened near the right/bottom edge is nudged back inside the editor', async () => {
+  const { container } = render(<Host />)
+  rightClick(rootOf(container), 795, 590)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  const root = rootOf(container).getBoundingClientRect()
+  const rect = menu.getBoundingClientRect()
+  expect(rect.right).toBeLessThanOrEqual(root.right)
+  expect(rect.bottom).toBeLessThanOrEqual(root.bottom)
+  expect(rect.left).toBeGreaterThanOrEqual(root.left)
+  expect(rect.top).toBeGreaterThanOrEqual(root.top)
+})
+
 // --- Color row: presets are one-tap picks on both node and edge menus ---
 
 function makeNodeHost() {

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -3,6 +3,7 @@
 // synthetic-event-only coverage is how this editor's first-touch bugs
 // survived unnoticed.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
@@ -275,4 +276,89 @@ it('context-menu targeting keeps node and edge selection mutually exclusive', as
   // the edge selection made by the second right-click only.
   await vi.waitFor(() => expect(latest.canvas.edges).toHaveLength(0))
   expect(latest.canvas.nodes).toHaveLength(2)
+})
+
+// --- Color row: presets are one-tap picks on both node and edge menus ---
+
+function makeNodeHost() {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
+  function NodeHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { NodeHost, latest }
+}
+
+it('the node Color row applies a preset in one tap and Default removes it', async () => {
+  const { NodeHost, latest } = makeNodeHost()
+  const { container } = render(<NodeHost />)
+  rightClick(rootOf(container), 200, 150)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  // The swatch chip must actually paint: a default-inline span ignores
+  // size-* and lays out 0x0 (a real defect caught live), so pin its box.
+  const colorGroup = [...container.querySelectorAll('fieldset')].find(
+    (g) => g.getAttribute('aria-label') === 'Color',
+  ) as HTMLElement
+  // firstElementChild twice: button > icon wrapper > swatch chip. A `span
+  // span` selector would match the wrapper itself (its ancestor span sits
+  // outside the button, but querySelector still counts it).
+  const redSwatch = [...colorGroup.querySelectorAll('[role="menuitemradio"]')].find(
+    (o) => o.getAttribute('aria-label') === 'Red',
+  )?.firstElementChild?.firstElementChild as HTMLElement
+  expect(redSwatch.getBoundingClientRect().width).toBeGreaterThan(0)
+  expect(redSwatch.style.backgroundColor).not.toBe('')
+
+  clickOption(container, 'Color', 'Red')
+  await vi.waitFor(() => expect(latest.canvas.nodes[0].color).toBe('1'))
+  expect(latest.commands).toContain('set-node-color')
+
+  // Property picks keep the menu open, and the scene re-renders with the
+  // preset accent: the node's chrome rect now carries the palette stroke.
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  const accent = SPATIAL_LIGHT_PALETTE.presets['1']
+  await vi.waitFor(() =>
+    expect(
+      container.querySelector(
+        `[data-testid="viewport-transform"] svg rect[stroke="${accent.stroke}"]`,
+      ),
+    ).not.toBeNull(),
+  )
+
+  clickOption(container, 'Color', 'Default')
+  await vi.waitFor(() => expect(latest.canvas.nodes[0]).not.toHaveProperty('color'))
+})
+
+it('the edge Color row recolors the stroke via the palette preset', async () => {
+  const { EdgeHost, latest } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  clickOption(container, 'Color', 'Purple')
+  await vi.waitFor(() => expect(latest.canvas.edges[0].color).toBe('6'))
+  expect(latest.commands).toContain('set-edge-color')
+
+  const accent = SPATIAL_LIGHT_PALETTE.presets['6']
+  await vi.waitFor(() =>
+    expect(
+      container.querySelector(
+        `[data-testid="viewport-transform"] svg polyline[stroke="${accent.stroke}"]`,
+      ),
+    ).not.toBeNull(),
+  )
 })

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -286,8 +286,10 @@ it('a menu opened near the right/bottom edge is nudged back inside the editor', 
   const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
   const root = rootOf(container).getBoundingClientRect()
   const rect = menu.getBoundingClientRect()
-  expect(rect.right).toBeLessThanOrEqual(root.right)
-  expect(rect.bottom).toBeLessThanOrEqual(root.bottom)
+  // The clamp keeps a 4px gap, not mere containment — a regression that
+  // flushes the menu against the edge must fail here too.
+  expect(rect.right).toBeLessThanOrEqual(root.right - 4)
+  expect(rect.bottom).toBeLessThanOrEqual(root.bottom - 4)
   expect(rect.left).toBeGreaterThanOrEqual(root.left)
   expect(rect.top).toBeGreaterThanOrEqual(root.top)
 })

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -47,7 +47,12 @@ export { escapeXmlAttr, escapeXmlText, formatCoord } from './svg/format.js'
 export { SPATIAL_THEME_FONT_FAMILY } from './theme/font-family.js'
 export type { SpatialGeometry } from './theme/spatial-geometry.js'
 export { SPATIAL_THEME_GEOMETRY } from './theme/spatial-geometry.js'
-export type { SpatialNodeStyle, SpatialPalette } from './theme/spatial-palette.js'
+export type {
+  SpatialNodeStyle,
+  SpatialPalette,
+  SpatialPresetAccent,
+  SpatialPresetKey,
+} from './theme/spatial-palette.js'
 export { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from './theme/spatial-palette.js'
 export type { SpatialThemeMode, SpatialThemeOptions } from './theme/spatial-theme.js'
 export { createSpatialTheme } from './theme/spatial-theme.js'

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -9,6 +9,21 @@ export interface SpatialNodeStyle {
   readonly stroke: string
 }
 
+/** JSON Canvas 1.0 numbered preset keys ('1' red … '6' purple). */
+export type SpatialPresetKey = '1' | '2' | '3' | '4' | '5' | '6'
+
+/**
+ * One preset accent: the strong stroke and the quiet tint fill. The design
+ * rule (apps/web/DESIGN.md): a preset colors a node's BORDER strongly and
+ * its background as a tint — body text keeps the theme text color, so
+ * readability never depends on the accent hue. Edges (and their J1
+ * arrowheads) take `stroke` directly.
+ */
+export interface SpatialPresetAccent {
+  readonly stroke: string
+  readonly fill: string
+}
+
 export interface SpatialPalette {
   readonly node: Readonly<Record<'text' | 'file' | 'link' | 'group', SpatialNodeStyle>>
   /** Stroke applied to a routed edge when it carries no authored color. */
@@ -17,6 +32,14 @@ export interface SpatialPalette {
   readonly labelFill: string
   /** Uniform corner radius (px) applied to every node's chrome shape. */
   readonly cornerRadiusPx: number
+  /**
+   * The six JSON Canvas preset accents, PER MODE — swappable theme DATA,
+   * never hardcoded in resolver code. Floors any replacement must keep
+   * (pinned by spatial-theme.test.ts, as floors rather than exact values):
+   * stroke >= 3:1 against the mode background (WCAG 1.4.11), labelFill
+   * >= 4.5:1 against the tint fill (WCAG 1.4.3).
+   */
+  readonly presets: Readonly<Record<SpatialPresetKey, SpatialPresetAccent>>
 }
 
 // Quiet-tool direction (apps/web/DESIGN.md): node and edge strokes sit at
@@ -39,6 +62,16 @@ export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
   edgeStroke: '#737373',
   labelFill: '#404040',
   cornerRadiusPx: 6,
+  // Tailwind 600 strokes (3.2-5.4:1 on white) over 100 tints (body text
+  // 8.5-9.3:1) — the same ramp as the app's approved state colors.
+  presets: {
+    '1': { stroke: '#dc2626', fill: '#fee2e2' },
+    '2': { stroke: '#ea580c', fill: '#ffedd5' },
+    '3': { stroke: '#d97706', fill: '#fef3c7' },
+    '4': { stroke: '#059669', fill: '#d1fae5' },
+    '5': { stroke: '#0891b2', fill: '#cffafe' },
+    '6': { stroke: '#9333ea', fill: '#f3e8ff' },
+  },
 }
 
 // Seeded from the pre-theme editor's dark palette (EDITOR_DARK_PALETTE) — a
@@ -58,4 +91,14 @@ export const SPATIAL_DARK_PALETTE: SpatialPalette = {
   edgeStroke: '#9BA3AF',
   labelFill: '#E6E8EB',
   cornerRadiusPx: 4,
+  // Tailwind 400 strokes (7.2-11.9:1 on the near-black canvas) over 950
+  // tints (near-white body text 10.9-13.2:1).
+  presets: {
+    '1': { stroke: '#f87171', fill: '#450a0a' },
+    '2': { stroke: '#fb923c', fill: '#431407' },
+    '3': { stroke: '#fbbf24', fill: '#451a03' },
+    '4': { stroke: '#34d399', fill: '#022c22' },
+    '5': { stroke: '#22d3ee', fill: '#083344' },
+    '6': { stroke: '#c084fc', fill: '#3b0764' },
+  },
 }

--- a/packages/canvas-render/src/theme/spatial-theme.test.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.test.ts
@@ -22,10 +22,42 @@ function edge(overrides: Partial<CanvasEdge> = {}): CanvasEdge {
 }
 
 describe('createSpatialTheme', () => {
-  it('resolves a JSON Canvas numbered preset color to its approximated hex', () => {
+  it('resolves a node preset as accent stroke + tint fill from the palette (never a solid accent fill)', () => {
     const theme = createSpatialTheme({ mode: 'light' })
     const { appearance } = theme.resolveNode(textNode({ color: '1' }))
-    expect(appearance?.fill).toBe('#e03131')
+    expect(appearance).toEqual({
+      stroke: SPATIAL_LIGHT_PALETTE.presets['1'].stroke,
+      fill: SPATIAL_LIGHT_PALETTE.presets['1'].fill,
+    })
+  })
+
+  it('resolves node presets per MODE — dark mode reads the dark palette accents', () => {
+    const theme = createSpatialTheme({ mode: 'dark' })
+    const { appearance } = theme.resolveNode(textNode({ color: '3' }))
+    expect(appearance).toEqual({
+      stroke: SPATIAL_DARK_PALETTE.presets['3'].stroke,
+      fill: SPATIAL_DARK_PALETTE.presets['3'].fill,
+    })
+    expect(SPATIAL_DARK_PALETTE.presets['3'].stroke).not.toBe(
+      SPATIAL_LIGHT_PALETTE.presets['3'].stroke,
+    )
+  })
+
+  it('accepts a wholesale palette override — presets are swappable theme DATA', () => {
+    const custom = {
+      ...SPATIAL_LIGHT_PALETTE,
+      presets: {
+        ...SPATIAL_LIGHT_PALETTE.presets,
+        '1': { stroke: '#123456', fill: '#abcdef' },
+      },
+    }
+    const theme = createSpatialTheme({ mode: 'light', palette: custom })
+    expect(theme.resolveNode(textNode({ color: '1' })).appearance).toEqual({
+      stroke: '#123456',
+      fill: '#abcdef',
+    })
+    // Non-preset resolution rides the same override.
+    expect(theme.resolveEdge(edge())?.stroke).toBe(custom.edgeStroke)
   })
 
   it('passes through an already-hex node color unchanged', () => {
@@ -76,9 +108,11 @@ describe('createSpatialTheme', () => {
     expect(theme.resolveEdge(edge())).toEqual({ stroke: SPATIAL_LIGHT_PALETTE.edgeStroke })
   })
 
-  it('resolves an edge preset color to its approximated hex', () => {
+  it('resolves an edge preset color to the palette accent stroke', () => {
     const theme = createSpatialTheme({ mode: 'light' })
-    expect(theme.resolveEdge(edge({ color: '3' }))).toEqual({ stroke: '#f08c00' })
+    expect(theme.resolveEdge(edge({ color: '3' }))).toEqual({
+      stroke: SPATIAL_LIGHT_PALETTE.presets['3'].stroke,
+    })
   })
 
   it('resolves a label to the palette label fill and the shared theme font family', () => {
@@ -87,6 +121,33 @@ describe('createSpatialTheme', () => {
       fill: SPATIAL_LIGHT_PALETTE.labelFill,
       fontFamily: SPATIAL_THEME_FONT_FAMILY,
     })
+  })
+
+  it('every preset clears the WCAG floors in BOTH modes (3:1 stroke vs bg, 4.5:1 text vs tint)', () => {
+    // These are floors, not pinned values — the palette is swappable data,
+    // and any replacement must keep colored nodes readable in both themes.
+    const luminance = (hex: string) => {
+      const channel = (i: number) => {
+        const c = Number.parseInt(hex.slice(i, i + 2), 16) / 255
+        return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+      }
+      return 0.2126 * channel(1) + 0.7152 * channel(3) + 0.0722 * channel(5)
+    }
+    const contrast = (a: string, b: string) => {
+      const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+      return (hi + 0.05) / (lo + 0.05)
+    }
+    const cases = [
+      { palette: SPATIAL_LIGHT_PALETTE, bg: '#ffffff' },
+      { palette: SPATIAL_DARK_PALETTE, bg: '#0a0a0a' },
+    ]
+    for (const { palette, bg } of cases) {
+      for (const key of ['1', '2', '3', '4', '5', '6'] as const) {
+        const accent = palette.presets[key]
+        expect(contrast(accent.stroke, bg)).toBeGreaterThanOrEqual(3)
+        expect(contrast(palette.labelFill, accent.fill)).toBeGreaterThanOrEqual(4.5)
+      }
+    }
   })
 
   it('resolves node/edge/label colors from the dark palette in dark mode', () => {

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -28,29 +28,33 @@ import {
   SPATIAL_DARK_PALETTE,
   SPATIAL_LIGHT_PALETTE,
   type SpatialPalette,
+  type SpatialPresetAccent,
 } from './spatial-palette.js'
 
 export type SpatialThemeMode = 'light' | 'dark'
 
 export interface SpatialThemeOptions {
   readonly mode: SpatialThemeMode
+  /**
+   * Wholesale palette replacement — the theme layer's swap point. Presets,
+   * chrome colors, and geometry-adjacent values (corner radius) all come
+   * from the palette, so restyling is a data change, never a resolver
+   * change. Callers providing a palette get a freshly built resolver each
+   * call and own its memoization (the per-mode defaults stay frozen
+   * singletons).
+   */
+  readonly palette?: SpatialPalette
 }
 
-// JSON Canvas 1.0's six numbered color presets, approximated as hex so this
-// theme's Appearance output can carry a concrete fill/stroke without
-// canvas-render ever having to know about presets.
-const PRESET_COLOR_HEX: Readonly<Record<string, string>> = {
-  '1': '#e03131',
-  '2': '#e8590c',
-  '3': '#f08c00',
-  '4': '#2f9e44',
-  '5': '#1971c2',
-  '6': '#9c36b5',
+/** A numbered preset resolved through the palette; null for hex/unknown. */
+function presetAccent(color: CanvasColor | undefined, palette: SpatialPalette) {
+  if (color === undefined || color.startsWith('#')) return null
+  return (palette.presets as Partial<Record<string, SpatialPresetAccent>>)[color] ?? null
 }
 
-function resolvePresetOrHex(color: CanvasColor | undefined): string | undefined {
-  if (color === undefined) return undefined
-  return color.startsWith('#') ? color : PRESET_COLOR_HEX[color]
+/** An author-supplied raw hex, passed through untouched; undefined otherwise. */
+function rawHex(color: CanvasColor | undefined): string | undefined {
+  return color !== undefined && color.startsWith('#') ? color : undefined
 }
 
 function shapeRadius(node: SpatialNode, palette: SpatialPalette): number {
@@ -69,14 +73,19 @@ function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {
       // (`layoutSpatialCanvas`'s own defensive `unknown-node-kind` branch),
       // keeping this resolver total rather than throwing on a bad node.
       const style = palette.node[node.type] ?? palette.node.text
-      const appearance: Appearance = {
-        fill: resolvePresetOrHex(node.color) ?? style.fill,
-        stroke: style.stroke,
-      }
+      // Preset: accent STROKE + tint FILL (body text keeps the theme text
+      // color — readability never depends on the accent hue). Raw hex: the
+      // author's exact fill, unchanged (their own responsibility).
+      const accent = presetAccent(node.color, palette)
+      const appearance: Appearance =
+        accent !== null
+          ? { fill: accent.fill, stroke: accent.stroke }
+          : { fill: rawHex(node.color) ?? style.fill, stroke: style.stroke }
       return { radius: shapeRadius(node, palette), appearance }
     },
     resolveEdge: (edge: CanvasEdge) => ({
-      stroke: resolvePresetOrHex(edge.color) ?? palette.edgeStroke,
+      stroke:
+        presetAccent(edge.color, palette)?.stroke ?? rawHex(edge.color) ?? palette.edgeStroke,
     }),
     resolveLabel: () => ({ fill: palette.labelFill, fontFamily: SPATIAL_THEME_FONT_FAMILY }),
   }
@@ -91,5 +100,6 @@ const THEMES: Readonly<Record<SpatialThemeMode, SpatialAppearanceResolver>> = Ob
 })
 
 export function createSpatialTheme(options: SpatialThemeOptions): SpatialAppearanceResolver {
+  if (options.palette !== undefined) return buildTheme(options.palette)
   return THEMES[options.mode]
 }

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -84,8 +84,7 @@ function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {
       return { radius: shapeRadius(node, palette), appearance }
     },
     resolveEdge: (edge: CanvasEdge) => ({
-      stroke:
-        presetAccent(edge.color, palette)?.stroke ?? rawHex(edge.color) ?? palette.edgeStroke,
+      stroke: presetAccent(edge.color, palette)?.stroke ?? rawHex(edge.color) ?? palette.edgeStroke,
     }),
     resolveLabel: () => ({ fill: palette.labelFill, fontFamily: SPATIAL_THEME_FONT_FAMILY }),
   }


### PR DESCRIPTION
## Summary

J2 of the JSON Canvas 1.0 full-spec plan: preset colors (`'1'..'6'`) become first-class, theme-swappable data, applied from the context menu.

- **canvas-render**: `SpatialPalette` gains a `presets` record (`{stroke, fill}` per slot) — light mode uses Tailwind 600 strokes over 100-tint fills, dark mode 400 strokes over 950-tint fills. `createSpatialTheme({ mode, palette? })` accepts a wholesale palette override, so presets stay theme DATA, never resolver code. Node presets render accent stroke + tint fill (text keeps the theme text color); edge presets render as stroke.
- **Contrast floors as tests, not pinned hexes**: every preset stroke must hold ≥3:1 against its mode background and label text ≥4.5:1 against the tint fill — a replacement palette keeps passing or fails loudly.
- **apps/web**: new `set-node-color` / `set-edge-color` commands (canonical storage — `undefined` removes the field), and an inline **Color** options row on both node and edge context menus: Default + six swatch chips previewing the current mode's palette strokes.
- **Context-menu edge clamping** (reported mid-review): a menu opened near the right/bottom edge used to clip outside the editor; its position is now clamped to the editor bounds in a pre-paint layout effect (4px gap).

## Visual repro

Light mode — node preset `1` (accent border + tint fill, readable text) and edge preset `6`:

![j2-preset-light.jpg](https://github.com/user-attachments/assets/46618012-660b-449d-9950-33c2503f5db9)

Dark mode — same canvas, same stored slots, dark palette resolution:

![j2-preset-dark.jpg](https://github.com/user-attachments/assets/bfacf90c-3af3-4490-8abe-47c41e194458)

Menu opened at the far right/bottom corner stays fully inside the editor:

![j2-menu-clamp.jpg](https://github.com/user-attachments/assets/0a201490-d7fc-42c5-8bab-1ff26092d106)

## Notes for review

- The swatch chips and the menu's positioning (absolute/z-index/left/top) are inline styles by design: a default-inline span ignores width/height (the chips painted 0×0 live), and browser-mode component tests run without the app stylesheet — inline props make the behavior identical in both environments and the clamp testable.
- Canonical storage discipline matches J1: values equal to the implicit default (`color: undefined`) are removed, never stored.

## Test plan

- [x] `commands.test.ts`: set-node-color / set-edge-color apply + remove (jsdom, 21 passed)
- [x] `context-menu.browser.test.tsx`: Color row one-tap apply on node + edge, swatch paints (>0 box), scene re-renders with palette stroke, edge-clamp geometry (12 passed)
- [x] canvas-render: preset resolution light/dark, palette swap test, WCAG floor tests for all 6 presets × both modes (249 passed)
- [x] Full suite: 553 files / 5954 tests green; `pnpm -r typecheck`, `pnpm knip`, `pnpm lint:noconsole` clean
- [x] Live verification in Chrome, both themes (screenshots above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added light and dark theme-aware color presets for spatial editor nodes and edges.
  - Added options to apply preset colors or restore the default color.
  - Preset colors now support accessible fills and borders across themes.
- **Bug Fixes**
  - Context menus now remain fully visible within the editor area, even near its edges.
- **Documentation**
  - Documented preset color slots, theme behavior, palette resolution, and contrast requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->