### PR TITLE
feat: JSON Canvas link nodes — Add link dialog, follow, and Edit URL

### DIFF
--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -1,0 +1,90 @@
+/**
+ * URL entry surface for link nodes — used both by the palette's "Add link"
+ * (create) and the context menu's "Edit URL" (rewrite).
+ *
+ * Validation delegates to the same rule the canvas-model schema enforces
+ * (`z.url()`), so a URL this dialog accepts can never fail schema
+ * validation downstream — one authority, no drift.
+ *
+ * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
+ * presses inside it. Positioning is inline for the same reason as the
+ * context menu: it must behave identically where the app stylesheet is
+ * absent (browser-mode component tests).
+ */
+import { useState } from 'react'
+import { z } from 'zod'
+
+const urlSchema = z.url()
+
+export interface LinkUrlDialogProps {
+  readonly title: string
+  readonly initialUrl?: string
+  readonly onSubmit: (url: string) => void
+  readonly onCancel: () => void
+}
+
+export function LinkUrlDialog({ title, initialUrl, onSubmit, onCancel }: LinkUrlDialogProps) {
+  const [value, setValue] = useState(initialUrl ?? '')
+  const isValid = urlSchema.safeParse(value).success
+
+  return (
+    <div
+      data-editor-overlay
+      data-testid="link-url-dialog"
+      role="dialog"
+      aria-label={title}
+      className="rounded-md border bg-background p-3 shadow-lg"
+      style={{
+        position: 'absolute',
+        zIndex: 30,
+        left: '50%',
+        top: '35%',
+        transform: 'translate(-50%, -50%)',
+        width: 'max-content',
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          onCancel()
+        }
+      }}
+    >
+      <form
+        className="flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (isValid) onSubmit(value)
+        }}
+      >
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          {title}
+          <input
+            // biome-ignore lint/a11y/noAutofocus: the dialog exists only to take this URL; focusing it is the entire interaction
+            autoFocus
+            type="url"
+            value={value}
+            placeholder="https://example.com"
+            onChange={(e) => setValue(e.target.value)}
+            className="w-72 rounded border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded px-2 py-1 text-sm text-muted-foreground hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!isValid}
+            className="rounded bg-primary px-2 py-1 text-sm text-primary-foreground disabled:opacity-50"
+          >
+            OK
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -13,8 +13,11 @@
  */
 import { useState } from 'react'
 import { z } from 'zod'
+import { isFollowableUrl } from './followable-url.js'
 
-const urlSchema = z.url()
+// z.url() alone accepts any parseable URL — including javascript: — so the
+// scheme allowlist is part of validity here, not just of the open sink.
+const urlSchema = z.url().refine(isFollowableUrl)
 
 export interface LinkUrlDialogProps {
   readonly title: string

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -67,6 +67,7 @@ import { applyCommand } from './commands.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
 import { editorTextFill } from './editor-appearance.js'
+import { isFollowableUrl } from './followable-url.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
 import {
   distanceToPolyline,
@@ -1126,8 +1127,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /** The one place a stored URL is turned into navigation. noopener keeps
-     * the canvas tab unreachable from the opened page. */
+     * the canvas tab unreachable from the opened page, and the scheme guard
+     * holds HERE (not only in the dialog) because canvases arrive via sync
+     * and import — a hostile javascript:/data: URL must never reach
+     * window.open. */
     const openLinkNode = (node: Extract<SpatialNode, { type: 'link' }>) => {
+      if (!isFollowableUrl(node.url)) return
       window.open(node.url, '_blank', 'noopener,noreferrer')
     }
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -22,7 +22,9 @@
  * edge's label (double-click its line; commits on blur, empty removes,
  * Escape cancels), and restyle an edge from its context menu (arrowhead
  * direction per JSON Canvas fromEnd/toEnd, and per-endpoint side pinning
- * with an auto option).
+ * with an auto option), create a link node (the palette's "Add link" URL
+ * dialog), follow it (double-click, or "Open link" in its context menu —
+ * opens in a new tab with noopener), and rewrite its URL ("Edit URL").
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -33,11 +35,12 @@
  * grouping, undo/redo, snapping,
  * persistence, and sync. Those are later phases.
  */
-import type { CanvasColor, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { CanvasColor, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { MeasureText, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
 import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
+  ExternalLink,
   PanelBottom,
   PanelLeft,
   PanelRight,
@@ -73,9 +76,9 @@ import {
   polylineMidpoint,
   resizeBoxByDelta,
 } from './geometry.js'
-
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
+import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
@@ -331,6 +334,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     )
     const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
     const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
+    // The URL dialog serves both palette-create and context-menu-edit; which
+    // one decides what its submit does.
+    const [linkDialog, setLinkDialog] = useState<
+      { readonly mode: 'create' } | { readonly mode: 'edit'; readonly nodeId: string } | null
+    >(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
     /**
@@ -807,6 +815,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           )
           return
         }
+        // A link node's double press follows the reference, mirroring the
+        // text node's double-press-edits rule: the object's primary action.
+        if (node?.type === 'link') {
+          applyResult(result)
+          openLinkNode(node)
+          return
+        }
       }
       const moved = result.commands.find((c) => c.kind === 'move-node')
       if (moved !== undefined && extraIds.size > 0 && gestureState.kind === 'moving') {
@@ -1075,6 +1090,47 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       createNodeAt(point)
     }
 
+    /** Link nodes are label-only chrome — a note-height box would be mostly
+     * empty, so they get a shorter default. */
+    const LINK_NODE_HEIGHT = 60
+    const createLinkAtViewportCenter = (url: string) => {
+      const root = rootRef.current
+      const centerScreen =
+        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+      const preferred = screenToCanvas(centerScreen, viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point = findFreeSpot(
+        preferred,
+        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
+        occupied,
+      )
+      const id =
+        createId?.() ??
+        (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : String(Math.random()))
+      const node: SpatialNode = {
+        id,
+        type: 'link',
+        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+        y: Math.round(point.y - LINK_NODE_HEIGHT / 2),
+        width: NEW_NODE_WIDTH,
+        height: LINK_NODE_HEIGHT,
+        url,
+      }
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [{ kind: 'create-node', node }],
+        selectedId: id,
+      })
+    }
+
+    /** The one place a stored URL is turned into navigation. noopener keeps
+     * the canvas tab unreachable from the opened page. */
+    const openLinkNode = (node: Extract<SpatialNode, { type: 'link' }>) => {
+      window.open(node.url, '_blank', 'noopener,noreferrer')
+    }
+
     return (
       <div
         ref={rootRef}
@@ -1113,7 +1169,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
-        <ToolPalette onCreateNode={createNodeAtViewportCenter} tool={tool} onToolChange={setTool} />
+        <ToolPalette
+          onCreateNode={createNodeAtViewportCenter}
+          onCreateLink={() => setLinkDialog({ mode: 'create' })}
+          tool={tool}
+          onToolChange={setTool}
+        />
         {contextMenu !== null && (
           <ContextMenu
             x={contextMenu.x}
@@ -1281,6 +1342,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ]
               }
               const items: ContextMenuItem[] = []
+              if (node.type === 'link') {
+                items.push({
+                  label: 'Open link',
+                  icon: <ExternalLink />,
+                  onSelect: () => openLinkNode(node),
+                })
+                items.push({
+                  label: 'Edit URL',
+                  icon: <Pencil />,
+                  onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
+                })
+                items.push({ kind: 'separator' })
+              }
               if (node.type === 'text') {
                 items.push({
                   label: 'Edit text',
@@ -1323,6 +1397,31 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               })
               return items
             })()}
+          />
+        )}
+        {linkDialog !== null && (
+          <LinkUrlDialog
+            title={linkDialog.mode === 'create' ? 'Add link' : 'Edit URL'}
+            initialUrl={
+              linkDialog.mode === 'edit'
+                ? (() => {
+                    const target = canvas.nodes.find((n) => n.id === linkDialog.nodeId)
+                    return target?.type === 'link' ? target.url : undefined
+                  })()
+                : undefined
+            }
+            onSubmit={(url) => {
+              if (linkDialog.mode === 'create') {
+                createLinkAtViewportCenter(url)
+              } else {
+                applyResult({
+                  state: { kind: 'idle' },
+                  commands: [{ kind: 'set-node-url', id: linkDialog.nodeId, url }],
+                })
+              }
+              setLinkDialog(null)
+            }}
+            onCancel={() => setLinkDialog(null)}
           />
         )}
         <div

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -17,13 +17,14 @@
  * presses originating here (see SpatialEditor's isOverlayEvent): without
  * that, the root would capture the pointer and swallow the buttons' clicks.
  */
-import { MousePointer2, Spline, StickyNote } from 'lucide-react'
+import { Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export type EditorTool = 'select' | 'connect'
 
 interface ToolPaletteProps {
   readonly onCreateNode: () => void
+  readonly onCreateLink: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
 }
@@ -31,7 +32,7 @@ interface ToolPaletteProps {
 const TOOL_BUTTON_CLASS =
   'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
 
-export function ToolPalette({ onCreateNode, tool, onToolChange }: ToolPaletteProps) {
+export function ToolPalette({ onCreateNode, onCreateLink, tool, onToolChange }: ToolPaletteProps) {
   return (
     <div
       data-editor-overlay
@@ -84,6 +85,20 @@ export function ToolPalette({ onCreateNode, tool, onToolChange }: ToolPalettePro
           </button>
         </TooltipTrigger>
         <TooltipContent>Add note</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="add-link-button"
+            aria-label="Add link"
+            onClick={onCreateLink}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <Link aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Add link</TooltipContent>
       </Tooltip>
     </div>
   )

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -281,6 +281,46 @@ describe('applyCommand', () => {
     expect(next).toBe(canvas)
   })
 
+  it('set-node-url updates a link node and ignores non-link targets', () => {
+    const withLink = applyCommand(baseCanvas(), {
+      kind: 'create-node',
+      node: {
+        id: 'l1',
+        type: 'link',
+        x: 0,
+        y: 200,
+        width: 200,
+        height: 60,
+        url: 'https://example.com/',
+      },
+    })
+
+    const updated = applyCommand(withLink, {
+      kind: 'set-node-url',
+      id: 'l1',
+      url: 'https://jsoncanvas.org/',
+    })
+    expect(updated.nodes.find((n) => n.id === 'l1')).toMatchObject({
+      url: 'https://jsoncanvas.org/',
+    })
+    expect(spatialCanvasSchema.safeParse(updated).success).toBe(true)
+
+    // A text node has no url — the command is a no-op, not a corruption.
+    const onText = applyCommand(withLink, {
+      kind: 'set-node-url',
+      id: 'a',
+      url: 'https://example.com/',
+    })
+    expect(onText).toBe(withLink)
+
+    const onMissing = applyCommand(withLink, {
+      kind: 'set-node-url',
+      id: 'missing',
+      url: 'https://example.com/',
+    })
+    expect(onMissing).toBe(withLink)
+  })
+
   it('create then delete the same node is the identity (up to deep equality)', () => {
     const canvas = baseCanvas()
     const node = { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' } as const

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -64,6 +64,13 @@ export type EditorCommand =
       readonly color: CanvasColor | undefined
     }
   | {
+      // Rewrites a link node's destination. Only link nodes carry a url —
+      // any other target (or a missing id) is a no-op, never a corruption.
+      readonly kind: 'set-node-url'
+      readonly id: string
+      readonly url: string
+    }
+  | {
       readonly kind: 'set-edge-side'
       readonly id: string
       readonly endpoint: 'from' | 'to'
@@ -213,6 +220,16 @@ function setNodeColor(
   }
 }
 
+function setNodeUrl(canvas: SpatialCanvas, id: string, url: string): SpatialCanvas {
+  if (!canvas.nodes.some((node) => node.id === id && node.type === 'link')) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.map((node) =>
+      node.id === id && node.type === 'link' ? { ...node, url } : node,
+    ),
+  }
+}
+
 function setEdgeColor(
   canvas: SpatialCanvas,
   id: string,
@@ -287,6 +304,8 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setNodeColor(canvas, command.id, command.color)
     case 'set-edge-color':
       return setEdgeColor(canvas, command.id, command.color)
+    case 'set-node-url':
+      return setNodeUrl(canvas, command.id, command.url)
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/followable-url.ts
+++ b/apps/web/src/components/spatial-editor/followable-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether a link node's URL is safe to FOLLOW from the editor.
+ *
+ * The canvas-model schema deliberately stays at `z.url()` (JSON Canvas puts
+ * no scheme restriction on the field), but following a reference is this
+ * editor's own action — and a `javascript:` or `data:` URL handed to
+ * `window.open` executes in the app's origin. Canvases arrive via sync and
+ * import, not only via our own dialog, so the guard must hold at the open
+ * sink regardless of where the node came from.
+ */
+export function isFollowableUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -1,0 +1,171 @@
+// Link nodes (JSON Canvas `type: 'link'`): created from the palette's URL
+// dialog, followed via double press or the context menu, rewritten via
+// Edit URL. Real pointer input where the double-press pairing matters —
+// synthetic-event-only coverage is how this editor's first-touch bugs
+// survived unnoticed.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const empty: SpatialCanvas = { nodes: [], edges: [] }
+
+const withLink: SpatialCanvas = {
+  nodes: [
+    {
+      id: 'l1',
+      type: 'link',
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 60,
+      url: 'https://example.com/docs',
+    },
+  ],
+  edges: [],
+}
+
+function makeHost(initial: SpatialCanvas) {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: initial, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+// The dialog sits centered in the editor, which the vitest browser iframe's
+// visible viewport may not fully contain — Playwright then refuses the
+// click as "outside of the viewport". The button itself is static, so a
+// direct DOM click is the faithful interaction (same rationale as the
+// context-menu option rows).
+function clickOk(container: HTMLElement) {
+  const ok = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent === 'OK',
+  ) as HTMLButtonElement
+  fireEvent.click(ok)
+}
+
+function rightClick(el: HTMLElement, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      button: 2,
+    }),
+  )
+}
+
+it('Add link opens the URL dialog and a valid submit creates a link node', async () => {
+  const { Host, latest } = makeHost(empty)
+  const { container } = render(<Host />)
+
+  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  await expect.element(page.getByTestId('link-url-dialog')).toBeInTheDocument()
+
+  const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
+  await userEvent.fill(input, 'https://jsoncanvas.org/spec/1.0/')
+  clickOk(container)
+
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
+  expect(latest.canvas.nodes[0]).toMatchObject({
+    type: 'link',
+    url: 'https://jsoncanvas.org/spec/1.0/',
+  })
+  expect(latest.commands).toContain('create-node')
+  // The dialog closes and the node renders its URL as the label.
+  expect(container.querySelector('[data-testid="link-url-dialog"]')).toBeNull()
+  await vi.waitFor(() =>
+    expect(container.textContent).toContain('https://jsoncanvas.org/spec/1.0/'),
+  )
+})
+
+it('an invalid URL cannot be submitted', async () => {
+  const { Host, latest } = makeHost(empty)
+  const { container } = render(<Host />)
+
+  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
+  await userEvent.fill(input, 'not a url')
+
+  const ok = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent === 'OK',
+  ) as HTMLButtonElement
+  expect(ok.disabled).toBe(true)
+  fireEvent.submit(ok.closest('form') as HTMLFormElement)
+  expect(latest.canvas.nodes).toHaveLength(0)
+
+  // Escape dismisses without creating anything.
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="link-url-dialog"]')).toBeNull(),
+  )
+  expect(latest.canvas.nodes).toHaveLength(0)
+})
+
+it('a real double-click on a link node opens its URL in a new tab', async () => {
+  const { Host } = makeHost(withLink)
+  const { container } = render(<Host />)
+  const opened: string[] = []
+  const openSpy = vi.spyOn(window, 'open').mockImplementation((url) => {
+    opened.push(String(url))
+    return null
+  })
+  try {
+    await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 130 } })
+    await vi.waitFor(() => expect(opened).toEqual(['https://example.com/docs']))
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com/docs',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  } finally {
+    openSpy.mockRestore()
+  }
+})
+
+it('the link context menu offers Open link and Edit URL rewrites the target', async () => {
+  const { Host, latest } = makeHost(withLink)
+  const { container } = render(<Host />)
+
+  rightClick(rootOf(container), 200, 130)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).toContain('Open link')
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Edit URL' }))
+  await expect.element(page.getByTestId('link-url-dialog')).toBeInTheDocument()
+
+  const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
+  // The dialog opens prefilled with the current URL.
+  expect(input.value).toBe('https://example.com/docs')
+  await userEvent.fill(input, 'https://example.com/changed')
+  clickOk(container)
+
+  await vi.waitFor(() =>
+    expect(latest.canvas.nodes[0]).toMatchObject({ url: 'https://example.com/changed' }),
+  )
+  expect(latest.commands).toContain('set-node-url')
+})

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -169,3 +169,45 @@ it('the link context menu offers Open link and Edit URL rewrites the target', as
   )
   expect(latest.commands).toContain('set-node-url')
 })
+
+// The model schema's z.url() accepts any parseable URL — including
+// javascript: — because JSON Canvas doesn't restrict the field. FOLLOWING
+// one is this editor's decision, and canvases arrive via sync/import, so
+// the guard must live at the open sink, not only in the dialog.
+it('a javascript: URL is neither followable nor accepted by the dialog', async () => {
+  const hostile: SpatialCanvas = {
+    nodes: [
+      {
+        id: 'x1',
+        type: 'link',
+        x: 100,
+        y: 100,
+        width: 200,
+        height: 60,
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal fixture
+        url: 'javascript:alert(1)',
+      },
+    ],
+    edges: [],
+  }
+  const { Host } = makeHost(hostile)
+  const { container } = render(<Host />)
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+  try {
+    await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 130 } })
+    // Give any (buggy) open a tick to fire before asserting silence.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(openSpy).not.toHaveBeenCalled()
+  } finally {
+    openSpy.mockRestore()
+  }
+
+  // And the dialog refuses to mint one in the first place.
+  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
+  await userEvent.fill(input, 'javascript:alert(1)')
+  const ok = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent === 'OK',
+  ) as HTMLButtonElement
+  expect(ok.disabled).toBe(true)
+})


### PR DESCRIPTION
## Summary

J3 of the JSON Canvas 1.0 full-spec plan: link nodes become creatable and followable in the spatial editor. (Rendering already existed — canvas-render draws link nodes as chrome + URL label.)

- **Palette "Add link"**: a new palette button opens a URL dialog; a valid submit creates a `type: 'link'` node at the viewport center (free-spot cascade, shorter default box since the node is label-only chrome) and selects it.
- **Follow the reference**: double-click a link node opens its URL in a new tab (`noopener,noreferrer`), mirroring the text node's double-press-edits rule; the context menu adds **Open link** and **Edit URL** alongside the shared Color row and Delete.
- **`set-node-url` command**: rewrites a link node's destination; a non-link target or missing id is a no-op. Canonical storage matches the other `set-*` commands.
- **One validation authority**: the dialog validates with the same `z.url()` rule the canvas-model schema enforces, so an accepted URL can never fail schema validation downstream. Invalid input keeps OK disabled and submit inert; Escape dismisses.

## Visual repro

Add link dialog → created link node (URL label, selected):

![j3-link-created.jpg](https://github.com/user-attachments/assets/9367391e-cbb8-429d-b3e6-01925708cfb3)

Link node context menu (Open link / Edit URL / Color / Delete), clamped inside near the edge:

![j3-link-menu.jpg](https://github.com/user-attachments/assets/96cae4f4-0f85-43ab-832e-106f16dbb278)

Live-verified in Chrome: double-clicking the created node opened https://jsoncanvas.org/spec/1.0/ in a new tab.

## Notes for review

- A live-caught bug during this slice: the dialog initially rendered inside the pan/zoom transform, so its percentage position resolved against the transformed container and it opened far off-center. It now renders at the root overlay layer (same layer as the context menu), with positioning inline so browser-mode tests (which run without the app stylesheet) exercise the same geometry.

## Test plan

- [x] `commands.test.ts`: set-node-url applies / no-ops on non-link or missing targets (22 passed)
- [x] `link-node.browser.test.tsx`: create via dialog, invalid-URL blocked + Escape dismiss, double-click opens URL (window.open spy, noopener), Edit URL prefilled + rewrite (4 passed)
- [x] Full suite green (one unrelated App.test.tsx lazy-route flake under full-suite load; passes 43/43 in isolation); `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean
- [x] Live verification in Chrome (screenshots above)
