### PR TITLE
feat: JSON Canvas group nodes — frames, containment moves, and labels

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -24,7 +24,11 @@
  * direction per JSON Canvas fromEnd/toEnd, and per-endpoint side pinning
  * with an auto option), create a link node (the palette's "Add link" URL
  * dialog), follow it (double-click, or "Open link" in its context menu —
- * opens in a new tab with noopener), and rewrite its URL ("Edit URL").
+ * opens in a new tab with noopener), rewrite its URL ("Edit URL"), create
+ * a group frame (the palette's "Add group" empty frame, or "Group
+ * selection" from a multi-selected node's context menu), move a frame
+ * with its geometrically contained members, and edit the frame's label
+ * (double-click, or "Edit label" in its context menu; empty removes).
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -41,6 +45,7 @@ import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboar
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
   ExternalLink,
+  Frame,
   PanelBottom,
   PanelLeft,
   PanelRight,
@@ -86,6 +91,7 @@ import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
+  canvasToScreen,
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
   type Point,
@@ -337,6 +343,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
     // The URL dialog serves both palette-create and context-menu-edit; which
     // one decides what its submit does.
+    const [groupLabelEditId, setGroupLabelEditId] = useState<string | null>(null)
     const [linkDialog, setLinkDialog] = useState<
       { readonly mode: 'create' } | { readonly mode: 'edit'; readonly nodeId: string } | null
     >(null)
@@ -823,9 +830,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           openLinkNode(node)
           return
         }
+        // A group's double press edits its label — the frame's one own datum.
+        if (node?.type === 'group') {
+          applyResult(result)
+          setGroupLabelEditId(node.id)
+          return
+        }
       }
       const moved = result.commands.find((c) => c.kind === 'move-node')
-      if (moved !== undefined && extraIds.size > 0 && gestureState.kind === 'moving') {
+      if (moved !== undefined && gestureState.kind === 'moving') {
         const dx = moved.x - gestureState.startX
         const dy = moved.y - gestureState.startY
         const extras = [...extraIds]
@@ -836,8 +849,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               ? []
               : [{ kind: 'move-node' as const, id, x: node.x + dx, y: node.y + dy }]
           })
-        applyResult({ ...result, commands: [...result.commands, ...extras] })
-        return
+        // Moving a group frame carries its members along: every node fully
+        // contained in the frame's PRE-move box (JSON Canvas containment is
+        // geometric — there is no parent pointer) gets the same delta.
+        const movedNode = canvasRef.current.nodes.find((n) => n.id === moved.id)
+        const alreadyMoving = new Set([moved.id, ...extras.map((c) => c.id)])
+        const memberMoves =
+          movedNode?.type === 'group'
+            ? canvasRef.current.nodes
+                .filter(
+                  (n) =>
+                    !alreadyMoving.has(n.id) &&
+                    n.x >= gestureState.startX &&
+                    n.y >= gestureState.startY &&
+                    n.x + n.width <= gestureState.startX + movedNode.width &&
+                    n.y + n.height <= gestureState.startY + movedNode.height,
+                )
+                .map((n) => ({ kind: 'move-node' as const, id: n.id, x: n.x + dx, y: n.y + dy }))
+            : []
+        if (extras.length > 0 || memberMoves.length > 0) {
+          applyResult({ ...result, commands: [...result.commands, ...extras, ...memberMoves] })
+          return
+        }
       }
       applyResult(result)
     }
@@ -1089,6 +1122,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         occupied,
       )
       createNodeAt(point)
+      panToShow({
+        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+        y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
+        width: NEW_NODE_WIDTH,
+        height: NEW_NODE_HEIGHT,
+      })
     }
 
     /** Link nodes are label-only chrome — a note-height box would be mostly
@@ -1124,6 +1163,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         commands: [{ kind: 'create-node', node }],
         selectedId: id,
       })
+      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
     }
 
     /** The one place a stored URL is turned into navigation. noopener keeps
@@ -1134,6 +1174,109 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const openLinkNode = (node: Extract<SpatialNode, { type: 'link' }>) => {
       if (!isFollowableUrl(node.url)) return
       window.open(node.url, '_blank', 'noopener,noreferrer')
+    }
+
+    /**
+     * The free-spot cascade can push a palette-created node outside the
+     * visible viewport, leaving the user staring at an unchanged canvas.
+     * When the created box does not fully fit on screen, pan (keeping the
+     * zoom) so it sits centered — creation is always visible feedback.
+     */
+    const panToShow = (box: Box) => {
+      const root = rootRef.current
+      if (root === null) return
+      const topLeft = canvasToScreen({ x: box.x, y: box.y }, viewport)
+      const bottomRight = canvasToScreen({ x: box.x + box.width, y: box.y + box.height }, viewport)
+      const fits =
+        topLeft.x >= 0 &&
+        topLeft.y >= 0 &&
+        bottomRight.x <= root.clientWidth &&
+        bottomRight.y <= root.clientHeight
+      if (fits) return
+      const centerX = box.x + box.width / 2
+      const centerY = box.y + box.height / 2
+      setViewport((vp) => ({
+        ...vp,
+        x: centerX - root.clientWidth / 2 / vp.zoom,
+        y: centerY - root.clientHeight / 2 / vp.zoom,
+      }))
+    }
+
+    const GROUP_FRAME_WIDTH = 320
+    const GROUP_FRAME_HEIGHT = 200
+    /** Padding between a grouped selection's bounds and its new frame. */
+    const GROUP_PADDING_PX = 24
+
+    const newId = () =>
+      createId?.() ??
+      (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : String(Math.random()))
+
+    const createGroupAtViewportCenter = () => {
+      const root = rootRef.current
+      const centerScreen =
+        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+      const preferred = screenToCanvas(centerScreen, viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point = findFreeSpot(
+        preferred,
+        { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT },
+        occupied,
+      )
+      const id = newId()
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [
+          {
+            kind: 'create-group',
+            node: {
+              id,
+              type: 'group',
+              x: Math.round(point.x - GROUP_FRAME_WIDTH / 2),
+              y: Math.round(point.y - GROUP_FRAME_HEIGHT / 2),
+              width: GROUP_FRAME_WIDTH,
+              height: GROUP_FRAME_HEIGHT,
+            },
+          },
+        ],
+        selectedId: id,
+      })
+      panToShow({
+        x: Math.round(point.x - GROUP_FRAME_WIDTH / 2),
+        y: Math.round(point.y - GROUP_FRAME_HEIGHT / 2),
+        width: GROUP_FRAME_WIDTH,
+        height: GROUP_FRAME_HEIGHT,
+      })
+    }
+
+    /** Frames the current multi-selection: enclosing box + padding. */
+    const groupSelection = (memberIds: readonly string[]) => {
+      const members = canvasRef.current.nodes.filter((n) => memberIds.includes(n.id))
+      if (members.length === 0) return
+      const minX = Math.min(...members.map((n) => n.x)) - GROUP_PADDING_PX
+      const minY = Math.min(...members.map((n) => n.y)) - GROUP_PADDING_PX
+      const maxX = Math.max(...members.map((n) => n.x + n.width)) + GROUP_PADDING_PX
+      const maxY = Math.max(...members.map((n) => n.y + n.height)) + GROUP_PADDING_PX
+      const id = newId()
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [
+          {
+            kind: 'create-group',
+            node: {
+              id,
+              type: 'group',
+              x: minX,
+              y: minY,
+              width: maxX - minX,
+              height: maxY - minY,
+            },
+          },
+        ],
+        selectedId: id,
+      })
+      setExtraIds(new Set())
     }
 
     return (
@@ -1177,6 +1320,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         <ToolPalette
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
+          onCreateGroup={createGroupAtViewportCenter}
           tool={tool}
           onToolChange={setTool}
         />
@@ -1347,6 +1491,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ]
               }
               const items: ContextMenuItem[] = []
+              if (node.type === 'group') {
+                items.push({
+                  label: 'Edit label',
+                  icon: <Tag />,
+                  onSelect: () => setGroupLabelEditId(node.id),
+                })
+                items.push({ kind: 'separator' })
+              }
+              // Framing an existing multi-selection is reached from any of
+              // its members — the frame encloses every selected node.
+              if (extraIds.size > 0 && node.type !== 'group') {
+                items.push({
+                  label: 'Group selection',
+                  icon: <Frame />,
+                  onSelect: () => groupSelection([node.id, ...extraIds]),
+                })
+                items.push({ kind: 'separator' })
+              }
               if (node.type === 'link') {
                 items.push({
                   label: 'Open link',
@@ -1706,6 +1868,30 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     setEdgeLabelEditId(null)
                   }}
                   onCancel={() => setEdgeLabelEditId(null)}
+                />
+              )
+            })()}
+          {groupLabelEditId !== null &&
+            (() => {
+              const group = canvas.nodes.find((entry) => entry.id === groupLabelEditId)
+              if (group === undefined || group.type !== 'group') return null
+              return (
+                <TextNodeEditor
+                  // The label renders along the frame's top edge — the
+                  // editor covers that band rather than the whole frame.
+                  box={{ x: group.x, y: group.y, width: group.width, height: 48 }}
+                  initialText={group.label ?? ''}
+                  testId="group-label-editor"
+                  onCommit={(label) => {
+                    applyResult({
+                      state: { kind: 'idle' },
+                      commands: [
+                        { kind: 'set-group-label', id: group.id, label: label.trim() } as const,
+                      ],
+                    })
+                    setGroupLabelEditId(null)
+                  }}
+                  onCancel={() => setGroupLabelEditId(null)}
                 />
               )
             })()}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -645,6 +645,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // pointerdown path): Delete acts on a selected edge FIRST, so leaving
       // the other object type selected makes Delete remove the wrong thing.
       if (hitId !== undefined) {
+        // Right-clicking a member of an existing multi-selection must not
+        // shrink it: promote the target to primary and keep the old primary
+        // in the extras, or "Group selection" silently loses a node.
+        if (extraIds.has(hitId)) {
+          setExtraIds((prev) => {
+            const next = new Set(prev)
+            next.delete(hitId)
+            if (selectedId !== null && selectedId !== hitId) next.add(selectedId)
+            return next
+          })
+        }
         setSelectedId(hitId)
         setSelectedEdgeId(null)
       }
@@ -1500,8 +1511,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 items.push({ kind: 'separator' })
               }
               // Framing an existing multi-selection is reached from any of
-              // its members — the frame encloses every selected node.
-              if (extraIds.size > 0 && node.type !== 'group') {
+              // its members — the frame encloses every selected node,
+              // including group frames: nesting is geometric in JSON Canvas,
+              // and containment moves already handle nested frames.
+              if (extraIds.size > 0) {
                 items.push({
                   label: 'Group selection',
                   icon: <Frame />,

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -17,7 +17,7 @@
  * presses originating here (see SpatialEditor's isOverlayEvent): without
  * that, the root would capture the pointer and swallow the buttons' clicks.
  */
-import { Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
+import { Frame, Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export type EditorTool = 'select' | 'connect'
@@ -25,6 +25,7 @@ export type EditorTool = 'select' | 'connect'
 interface ToolPaletteProps {
   readonly onCreateNode: () => void
   readonly onCreateLink: () => void
+  readonly onCreateGroup: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
 }
@@ -32,7 +33,13 @@ interface ToolPaletteProps {
 const TOOL_BUTTON_CLASS =
   'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
 
-export function ToolPalette({ onCreateNode, onCreateLink, tool, onToolChange }: ToolPaletteProps) {
+export function ToolPalette({
+  onCreateNode,
+  onCreateLink,
+  onCreateGroup,
+  tool,
+  onToolChange,
+}: ToolPaletteProps) {
   return (
     <div
       data-editor-overlay
@@ -99,6 +106,20 @@ export function ToolPalette({ onCreateNode, onCreateLink, tool, onToolChange }: 
           </button>
         </TooltipTrigger>
         <TooltipContent>Add link</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="add-group-button"
+            aria-label="Add group"
+            onClick={onCreateGroup}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <Frame aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Add group</TooltipContent>
       </Tooltip>
     </div>
   )

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -321,6 +321,44 @@ describe('applyCommand', () => {
     expect(onMissing).toBe(withLink)
   })
 
+  it('create-group prepends the frame so members stay clickable above it', () => {
+    const group = {
+      id: 'g1',
+      type: 'group',
+      x: -20,
+      y: -20,
+      width: 400,
+      height: 200,
+      label: 'cluster',
+    } as const
+    const grouped = applyCommand(baseCanvas(), { kind: 'create-group', node: group })
+    // Array order IS z-order: the frame sits at the bottom, so hit-testing
+    // (last containing box wins) still reaches the members inside it.
+    expect(grouped.nodes[0]).toMatchObject({ id: 'g1', type: 'group' })
+    expect(grouped.nodes).toHaveLength(3)
+    expect(spatialCanvasSchema.safeParse(grouped).success).toBe(true)
+
+    const collided = applyCommand(grouped, { kind: 'create-group', node: group })
+    expect(collided).toBe(grouped)
+  })
+
+  it('set-group-label sets, updates, empty-removes, and ignores non-groups', () => {
+    const grouped = applyCommand(baseCanvas(), {
+      kind: 'create-group',
+      node: { id: 'g1', type: 'group', x: -20, y: -20, width: 400, height: 200 },
+    })
+
+    const labeled = applyCommand(grouped, { kind: 'set-group-label', id: 'g1', label: 'phase 1' })
+    expect(labeled.nodes[0]).toMatchObject({ id: 'g1', label: 'phase 1' })
+    expect(spatialCanvasSchema.safeParse(labeled).success).toBe(true)
+
+    const cleared = applyCommand(labeled, { kind: 'set-group-label', id: 'g1', label: '' })
+    expect(cleared.nodes[0]).not.toHaveProperty('label')
+
+    const onText = applyCommand(labeled, { kind: 'set-group-label', id: 'a', label: 'x' })
+    expect(onText).toBe(labeled)
+  })
+
   it('create then delete the same node is the identity (up to deep equality)', () => {
     const canvas = baseCanvas()
     const node = { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' } as const

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -64,6 +64,20 @@ export type EditorCommand =
       readonly color: CanvasColor | undefined
     }
   | {
+      // Creates a group frame at the BOTTOM of the z-order (array start),
+      // so hit-testing (last containing box wins) still reaches members
+      // drawn above it. A colliding id is a no-op, like create-node.
+      readonly kind: 'create-group'
+      readonly node: Extract<SpatialNode, { type: 'group' }>
+    }
+  | {
+      // Sets a group frame's label; an empty string removes the field
+      // (canonical form, like set-edge-label). Non-group targets no-op.
+      readonly kind: 'set-group-label'
+      readonly id: string
+      readonly label: string
+    }
+  | {
       // Rewrites a link node's destination. Only link nodes carry a url —
       // any other target (or a missing id) is a no-op, never a corruption.
       readonly kind: 'set-node-url'
@@ -220,6 +234,26 @@ function setNodeColor(
   }
 }
 
+function createGroup(
+  canvas: SpatialCanvas,
+  node: Extract<SpatialNode, { type: 'group' }>,
+): SpatialCanvas {
+  if (canvas.nodes.some((existing) => existing.id === node.id)) return canvas
+  return { ...canvas, nodes: [node, ...canvas.nodes] }
+}
+
+function setGroupLabel(canvas: SpatialCanvas, id: string, label: string): SpatialCanvas {
+  if (!canvas.nodes.some((node) => node.id === id && node.type === 'group')) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.map((node) => {
+      if (node.id !== id || node.type !== 'group') return node
+      const { label: _removed, ...rest } = node
+      return label === '' ? rest : { ...rest, label }
+    }),
+  }
+}
+
 function setNodeUrl(canvas: SpatialCanvas, id: string, url: string): SpatialCanvas {
   if (!canvas.nodes.some((node) => node.id === id && node.type === 'link')) return canvas
   return {
@@ -306,6 +340,10 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setEdgeColor(canvas, command.id, command.color)
     case 'set-node-url':
       return setNodeUrl(canvas, command.id, command.url)
+    case 'create-group':
+      return createGroup(canvas, command.node)
+    case 'set-group-label':
+      return setGroupLabel(canvas, command.id, command.label)
     case 'delete-node':
       return deleteNode(canvas, command.id)
   }

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -129,6 +129,20 @@ it('a real double-click on the frame edits its label; empty commit removes it', 
   await userEvent.click(root, { position: { x: 700, y: 500 } })
   await vi.waitFor(() => expect(nodeById(latest, 'g1')).toMatchObject({ label: 'phase 1' }))
   expect(latest.commands).toContain('set-group-label')
+
+  // Clearing the label through the SAME UI path (fill empty + blur-commit)
+  // removes the field — the reducer's empty-removes rule reached from the
+  // editor, not only from commands.test.ts.
+  await userEvent.dblClick(root, { position: { x: 100, y: 100 } })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="group-label-editor"]')).not.toBeNull(),
+  )
+  const reopened = container.querySelector(
+    '[data-testid="group-label-editor"]',
+  ) as HTMLTextAreaElement
+  await userEvent.fill(reopened, '')
+  await userEvent.click(root, { position: { x: 700, y: 500 } })
+  await vi.waitFor(() => expect(nodeById(latest, 'g1')).not.toHaveProperty('label'))
 })
 
 it('Group selection from a multi-selected node frames the selection with padding', async () => {
@@ -211,5 +225,44 @@ it('a palette-created frame that lands off-screen pans the viewport to show it',
     expect(frameRect.top).toBeGreaterThanOrEqual(root.top)
     expect(frameRect.right).toBeLessThanOrEqual(root.right)
     expect(frameRect.bottom).toBeLessThanOrEqual(root.bottom)
+  })
+})
+
+it('Group selection can frame a selection that includes a group frame', async () => {
+  const mixed: SpatialCanvas = {
+    nodes: [
+      { id: 'g1', type: 'group', x: 80, y: 80, width: 200, height: 140 },
+      { id: 'a', type: 'text', x: 120, y: 120, width: 100, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 400, y: 120, width: 120, height: 60, text: 'B' },
+    ],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(mixed)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  // Marquee over everything: frame, its member, and the loose node.
+  fireEvent.pointerDown(root, { pointerId: 1, clientX: 40, clientY: 40, buttons: 1 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: 600, clientY: 400, buttons: 1 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: 600, clientY: 400 })
+  await vi.waitFor(() =>
+    expect(
+      container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length,
+    ).toBeGreaterThanOrEqual(1),
+  )
+
+  rightClick(root, 450, 150)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await userEvent.click(page.getByRole('menuitem', { name: 'Group selection' }))
+
+  // A new OUTER frame prepends, enclosing the inner frame and both nodes
+  // (min corner 80,80 / max corner 520,220, plus 24px padding).
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(4))
+  expect(latest.canvas.nodes[0]).toMatchObject({
+    type: 'group',
+    x: 56,
+    y: 56,
+    width: 488,
+    height: 188,
   })
 })

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -1,0 +1,179 @@
+// Group nodes (JSON Canvas `type: 'group'`): an empty frame from the
+// palette, "Group selection" framing a multi-selection, geometric
+// containment moves (the frame carries fully-contained nodes), label
+// editing, and frame deletion that keeps members. Real pointer input for
+// the drag/double-press paths.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const grouped: SpatialCanvas = {
+  nodes: [
+    // Frame first = bottom of the z-order, members drawn (and hit) above.
+    { id: 'g1', type: 'group', x: 80, y: 80, width: 360, height: 220, label: 'cluster' },
+    { id: 'a', type: 'text', x: 120, y: 120, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 280, y: 200, width: 120, height: 60, text: 'B' },
+    // Outside the frame — must NOT move with it.
+    { id: 'c', type: 'text', x: 600, y: 400, width: 120, height: 60, text: 'C' },
+  ],
+  edges: [],
+}
+
+function makeHost(initial: SpatialCanvas) {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: initial, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function rightClick(el: HTMLElement, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      button: 2,
+    }),
+  )
+}
+
+function nodeById(latest: { canvas: SpatialCanvas }, id: string) {
+  const node = latest.canvas.nodes.find((n) => n.id === id)
+  if (node === undefined) throw new Error(`node ${id} missing`)
+  return node
+}
+
+it('the palette Add group button creates an empty frame at the bottom of the z-order', async () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  render(<Host />)
+
+  await userEvent.click(page.getByRole('button', { name: 'Add group' }))
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
+  expect(latest.canvas.nodes[0]).toMatchObject({ type: 'group' })
+  expect(latest.commands).toContain('create-group')
+})
+
+it('dragging the frame moves its contained members and leaves outsiders alone', async () => {
+  const { Host, latest } = makeHost(grouped)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  // Press inside the frame but OUTSIDE both members (frame padding area),
+  // so the hit resolves to the group, then drag it 60,40.
+  await userEvent.click(root, { position: { x: 100, y: 100 } })
+  fireEvent.pointerDown(root, { pointerId: 1, clientX: 100, clientY: 100, buttons: 1 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: 160, clientY: 140, buttons: 1 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: 160, clientY: 140 })
+
+  await vi.waitFor(() => expect(nodeById(latest, 'g1')).toMatchObject({ x: 140, y: 120 }))
+  expect(nodeById(latest, 'a')).toMatchObject({ x: 180, y: 160 })
+  expect(nodeById(latest, 'b')).toMatchObject({ x: 340, y: 240 })
+  // The outsider never moved.
+  expect(nodeById(latest, 'c')).toMatchObject({ x: 600, y: 400 })
+})
+
+it('dragging a member inside the frame moves only that member', async () => {
+  const { Host, latest } = makeHost(grouped)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  fireEvent.pointerDown(root, { pointerId: 1, clientX: 180, clientY: 150, buttons: 1 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: 200, clientY: 170, buttons: 1 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: 200, clientY: 170 })
+
+  await vi.waitFor(() => expect(nodeById(latest, 'a')).toMatchObject({ x: 140, y: 140 }))
+  expect(nodeById(latest, 'g1')).toMatchObject({ x: 80, y: 80 })
+  expect(nodeById(latest, 'b')).toMatchObject({ x: 280, y: 200 })
+})
+
+it('a real double-click on the frame edits its label; empty commit removes it', async () => {
+  const { Host, latest } = makeHost(grouped)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  await userEvent.dblClick(root, { position: { x: 100, y: 100 } })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="group-label-editor"]')).not.toBeNull(),
+  )
+  const editor = container.querySelector(
+    '[data-testid="group-label-editor"]',
+  ) as HTMLTextAreaElement
+  expect(editor.value).toBe('cluster')
+
+  await userEvent.fill(editor, 'phase 1')
+  await userEvent.click(root, { position: { x: 700, y: 500 } })
+  await vi.waitFor(() => expect(nodeById(latest, 'g1')).toMatchObject({ label: 'phase 1' }))
+  expect(latest.commands).toContain('set-group-label')
+})
+
+it('Group selection from a multi-selected node frames the selection with padding', async () => {
+  const twoLoose: SpatialCanvas = {
+    nodes: [
+      { id: 'a', type: 'text', x: 120, y: 120, width: 120, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 300, y: 220, width: 120, height: 60, text: 'B' },
+    ],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(twoLoose)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  // Marquee-select both nodes.
+  fireEvent.pointerDown(root, { pointerId: 1, clientX: 60, clientY: 60, buttons: 1 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: 500, clientY: 400, buttons: 1 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: 500, clientY: 400 })
+  // Primary selection renders the overlay; the second node is an extra
+  // outline (same split marquee.browser.test.tsx asserts).
+  await vi.waitFor(() =>
+    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
+      1,
+    ),
+  )
+
+  rightClick(root, 180, 150)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await userEvent.click(page.getByRole('menuitem', { name: 'Group selection' }))
+
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(3))
+  const frame = latest.canvas.nodes[0]
+  // Enclosing box (120,120)-(420,280) plus the 24px padding on every side.
+  expect(frame).toMatchObject({ type: 'group', x: 96, y: 96, width: 348, height: 208 })
+})
+
+it('deleting the frame keeps its members', async () => {
+  const { Host, latest } = makeHost(grouped)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  rightClick(root, 100, 100)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await userEvent.click(page.getByRole('menuitem', { name: 'Delete' }))
+
+  await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(false))
+  expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'c'])
+})

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -177,3 +177,39 @@ it('deleting the frame keeps its members', async () => {
   await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(false))
   expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'c'])
 })
+
+it('a palette-created frame that lands off-screen pans the viewport to show it', async () => {
+  // The viewport center is fully occupied, so the free-spot cascade pushes
+  // the new frame outside the visible viewport — creation must bring it
+  // back into view instead of leaving the user staring at nothing.
+  const crowded: SpatialCanvas = {
+    nodes: [
+      { id: 'wall', type: 'text', x: -400, y: -300, width: 1600, height: 1200, text: 'wall' },
+    ],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(crowded)
+  const { container } = render(<Host />)
+
+  // The wall node covers the palette in the unstyled test env (no app CSS =
+  // no z-index), so Playwright refuses the click — the button itself is
+  // static, so a direct DOM click is the faithful interaction.
+  fireEvent.click(container.querySelector('[data-testid="add-group-button"]') as HTMLElement)
+  await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(true))
+
+  const root = rootOf(container).getBoundingClientRect()
+  await vi.waitFor(() => {
+    const frameRect = [
+      ...(container.querySelectorAll(
+        '[data-testid="viewport-transform"] svg rect',
+      ) as NodeListOf<SVGRectElement>),
+    ]
+      .filter((r) => Number(r.getAttribute('width')) >= 300)
+      .map((r) => r.getBoundingClientRect())[0]
+    expect(frameRect).toBeDefined()
+    expect(frameRect.left).toBeGreaterThanOrEqual(root.left)
+    expect(frameRect.top).toBeGreaterThanOrEqual(root.top)
+    expect(frameRect.right).toBeLessThanOrEqual(root.right)
+    expect(frameRect.bottom).toBeLessThanOrEqual(root.bottom)
+  })
+})


### PR DESCRIPTION
## Summary

J4 of the JSON Canvas 1.0 full-spec plan: group nodes become creatable, movable-with-members, and labelable in the spatial editor.

- **Create**: the palette gains "Add group" (empty 320×200 frame); a multi-selected node's context menu gains "Group selection", framing the selection's enclosing box with 24px padding. `create-group` **prepends** the frame — array order is z-order in JSON Canvas, so the frame sits at the bottom and hit-testing (last containing box wins) still reaches members drawn above it.
- **Containment move**: dragging a frame carries every node fully contained in its pre-move box (JSON Canvas containment is geometric — there is no parent pointer); dragging a member alone never drags the frame; outsiders never move.
- **Label**: double-click (or "Edit label") edits the frame's label via the same inline editor edges use; an empty commit removes the field (canonical storage). `set-group-label` no-ops on non-group targets.
- **Delete keeps members**: removing the frame removes only the frame.
- **Dogfood fix folded in**: palette creation now pans the viewport to the created node when the free-spot cascade lands it off-screen — creation was silently invisible on a crowded canvas (hit this live with notes, links, and frames alike).

## Visual repro

Add group on a crowded canvas — the viewport pans so the new frame is visible and selected:

![j4-group-created-panned.jpg](https://github.com/user-attachments/assets/a5f69dbb-02c4-465c-9a26-b94bd5ae15ba)

Double-click → label edit → committed label renders along the frame's top edge:

![j4-group-label.jpg](https://github.com/user-attachments/assets/04a55de3-d5bc-4e86-aafc-3de2e1262a1f)

## Test plan

- [x] `commands.test.ts`: create-group prepend + collision no-op, set-group-label set/update/empty-remove/non-group no-op (24 passed)
- [x] `group-node.browser.test.tsx` (real Chromium): empty-frame creation, containment move + outsider isolation, member-only move, label edit via real double-click, Group selection geometry (enclosing box + padding), delete-keeps-members, pan-to-show regression (7 passed)
- [x] Full suite: 5971 passed (one pre-existing `App.test.tsx` /pair lazy-route flake under full-suite load — passes 43/43 in isolation, now recurring so it is filed for a root-cause fix); typecheck / lint / knip clean
- [x] Live verification in Chrome: Add group → auto-pan → label edit (screenshots above). Drag flows are covered by the real-Chromium browser tests; the Chrome-extension harness cannot synthesize pointer-move drags, so containment moves were not manually re-verified beyond that layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added groups/frames for organizing spatial editor nodes.
  * Create groups from the palette, context menu, or multi-selection.
  * Edit group labels by double-clicking or using the context menu.
  * Moving a group automatically moves contained nodes, while members can still be moved independently.
  * Newly created groups and nodes are automatically brought into view.
  * Deleting a group preserves its member nodes.

* **Bug Fixes**
  * Improved group ordering and label handling, including removing empty labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->