### PR TITLE
feat: file nodes reference other canvases — picker, resolved cards, follow

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasPickerDialog.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasPickerDialog.tsx
@@ -1,0 +1,91 @@
+/**
+ * Canvas picker — the reference-entry surface for file nodes, used by the
+ * palette's "Add canvas" (create) and the context menu's "Change target"
+ * (retarget). The host page supplies the options: the editor treats a
+ * file reference as an opaque string whose meaning (browser-local canvas
+ * id, daemon alias path) the composition root owns.
+ *
+ * Marked `data-editor-overlay` so canvas gestures ignore presses inside
+ * it. Positioning is inline for the same reason as the context menu: it
+ * must behave identically where the app stylesheet is absent
+ * (browser-mode component tests).
+ */
+
+export interface FileRefOption {
+  /** Opaque reference stored as the file node's `file` value. */
+  readonly file: string
+  /** Human-readable name shown in the picker. */
+  readonly label: string
+}
+
+export interface CanvasPickerDialogProps {
+  readonly title: string
+  readonly options: readonly FileRefOption[]
+  /** The currently referenced file when retargeting; marked in the list. */
+  readonly currentFile?: string
+  readonly onPick: (file: string) => void
+  readonly onCancel: () => void
+}
+
+export function CanvasPickerDialog({
+  title,
+  options,
+  currentFile,
+  onPick,
+  onCancel,
+}: CanvasPickerDialogProps) {
+  return (
+    <div
+      data-editor-overlay
+      data-testid="canvas-picker-dialog"
+      role="dialog"
+      aria-label={title}
+      className="rounded-md border bg-background p-3 shadow-lg"
+      style={{
+        position: 'absolute',
+        zIndex: 30,
+        left: '50%',
+        top: '35%',
+        transform: 'translate(-50%, -50%)',
+        width: 'max-content',
+        minWidth: 240,
+        maxWidth: 360,
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          onCancel()
+        }
+      }}
+    >
+      <div className="mb-2 text-xs text-muted-foreground">{title}</div>
+      {options.length === 0 ? (
+        <div className="px-1 py-2 text-sm text-muted-foreground">No other canvases yet.</div>
+      ) : (
+        <ul className="m-0 flex max-h-64 list-none flex-col gap-0.5 overflow-y-auto p-0">
+          {options.map((option) => (
+            <li key={option.file}>
+              <button
+                type="button"
+                aria-current={option.file === currentFile}
+                onClick={() => onPick(option.file)}
+                className="w-full rounded px-2 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none aria-[current=true]:bg-accent"
+              >
+                {option.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-2 flex justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded px-2 py-1 text-sm text-muted-foreground hover:bg-accent"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -27,8 +27,11 @@
  * opens in a new tab with noopener), rewrite its URL ("Edit URL"), create
  * a group frame (the palette's "Add group" empty frame, or "Group
  * selection" from a multi-selected node's context menu), move a frame
- * with its geometrically contained members, and edit the frame's label
- * (double-click, or "Edit label" in its context menu; empty removes).
+ * with its geometrically contained members, edit the frame's label
+ * (double-click, or "Edit label" in its context menu; empty removes),
+ * and — when the host supplies the seams — create a file node referencing
+ * another canvas (the palette's "Add canvas" picker), follow it
+ * (double-click / "Open canvas"), and retarget it ("Change target").
  *
  * The component is CONTROLLED and owns no persistence: every mutating
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
@@ -45,6 +48,7 @@ import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboar
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
   ExternalLink,
+  FileBox,
   Frame,
   PanelBottom,
   PanelLeft,
@@ -66,6 +70,7 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
@@ -143,6 +148,14 @@ export interface SpatialEditorProps {
    * `resolvedTheme` or its nodes/edges go invisible in dark mode.
    */
   readonly theme?: ResolvedTheme
+  /**
+   * Canvas references the picker offers for file nodes. The reference is an
+   * OPAQUE string owned by the composition root (browser-local canvas id,
+   * daemon alias path). Absent → the "Add canvas" affordance hides.
+   */
+  readonly fileRefOptions?: readonly FileRefOption[]
+  /** Follows a file node's reference (navigation). Absent → follow hides. */
+  readonly onOpenFileRef?: (file: string, subpath?: string) => void
 }
 
 /** Imperative surface for a page that needs to drive the viewport from
@@ -209,6 +222,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       className,
       testId = DEFAULT_TEST_ID,
       theme = 'light',
+      fileRefOptions,
+      onOpenFileRef,
     },
     forwardedRef,
   ) {
@@ -325,9 +340,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [canvas, externalVersion])
 
+    // Opaque file references (browser-local canvas ids) become readable
+    // card labels through the host-supplied options list.
+    const resolveFileLabel = useMemo(() => {
+      if (fileRefOptions === undefined) return undefined
+      const byFile = new Map(fileRefOptions.map((option) => [option.file, option.label]))
+      return (file: string) => byFile.get(file)
+    }, [fileRefOptions])
     const { svg, bounds, scene } = useMemo(
-      () => renderCanvasToSvg(canvas, { measure: resolvedMeasure, theme }),
-      [canvas, resolvedMeasure, theme],
+      () => renderCanvasToSvg(canvas, { measure: resolvedMeasure, theme, resolveFileLabel }),
+      [canvas, resolvedMeasure, theme, resolveFileLabel],
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
@@ -347,6 +369,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const [linkDialog, setLinkDialog] = useState<
       { readonly mode: 'create' } | { readonly mode: 'edit'; readonly nodeId: string } | null
     >(null)
+    const [canvasPicker, setCanvasPicker] = useState<
+      { readonly mode: 'create' } | { readonly mode: 'retarget'; readonly nodeId: string } | null
+    >(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
     /**
@@ -362,14 +387,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (node === undefined) return undefined
       const rendered = renderCanvasToSvg(
         { nodes: [node], edges: [] },
-        { measure: resolvedMeasure, theme },
+        { measure: resolvedMeasure, theme, resolveFileLabel },
       )
       return {
         svg: rendered.svg,
         originX: gestureState.startX - rendered.bounds.x,
         originY: gestureState.startY - rendered.bounds.y,
       }
-    }, [gestureState, canvas, resolvedMeasure, theme])
+    }, [gestureState, canvas, resolvedMeasure, theme, resolveFileLabel])
 
     useImperativeHandle(
       forwardedRef,
@@ -847,6 +872,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           setGroupLabelEditId(node.id)
           return
         }
+        // A file node's double press follows the reference (navigate), the
+        // same primary-action rule as link nodes.
+        if (node?.type === 'file' && onOpenFileRef !== undefined) {
+          applyResult(result)
+          onOpenFileRef(node.file, node.subpath)
+          return
+        }
       }
       const moved = result.commands.find((c) => c.kind === 'move-node')
       if (moved !== undefined && gestureState.kind === 'moving') {
@@ -1177,6 +1209,36 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
     }
 
+    /** File nodes are reference cards like links — same shorter default box. */
+    const createFileRefAtViewportCenter = (file: string) => {
+      const root = rootRef.current
+      const centerScreen =
+        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+      const preferred = screenToCanvas(centerScreen, viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point = findFreeSpot(
+        preferred,
+        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
+        occupied,
+      )
+      const id = newId()
+      const node: SpatialNode = {
+        id,
+        type: 'file',
+        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+        y: Math.round(point.y - LINK_NODE_HEIGHT / 2),
+        width: NEW_NODE_WIDTH,
+        height: LINK_NODE_HEIGHT,
+        file,
+      }
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [{ kind: 'create-node', node }],
+        selectedId: id,
+      })
+      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+    }
+
     /** The one place a stored URL is turned into navigation. noopener keeps
      * the canvas tab unreachable from the opened page, and the scheme guard
      * holds HERE (not only in the dialog) because canvases arrive via sync
@@ -1332,6 +1394,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}
+          onCreateCanvasRef={
+            fileRefOptions === undefined ? undefined : () => setCanvasPicker({ mode: 'create' })
+          }
           tool={tool}
           onToolChange={setTool}
         />
@@ -1522,6 +1587,25 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 })
                 items.push({ kind: 'separator' })
               }
+              if (node.type === 'file') {
+                if (onOpenFileRef !== undefined) {
+                  items.push({
+                    label: 'Open canvas',
+                    icon: <ExternalLink />,
+                    onSelect: () => onOpenFileRef(node.file, node.subpath),
+                  })
+                }
+                if (fileRefOptions !== undefined) {
+                  items.push({
+                    label: 'Change target',
+                    icon: <FileBox />,
+                    onSelect: () => setCanvasPicker({ mode: 'retarget', nodeId: node.id }),
+                  })
+                }
+                if (onOpenFileRef !== undefined || fileRefOptions !== undefined) {
+                  items.push({ kind: 'separator' })
+                }
+              }
               if (node.type === 'link') {
                 items.push({
                   label: 'Open link',
@@ -1577,6 +1661,32 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               })
               return items
             })()}
+          />
+        )}
+        {canvasPicker !== null && fileRefOptions !== undefined && (
+          <CanvasPickerDialog
+            title={canvasPicker.mode === 'create' ? 'Add canvas' : 'Change target'}
+            options={fileRefOptions}
+            currentFile={
+              canvasPicker.mode === 'retarget'
+                ? (() => {
+                    const target = canvas.nodes.find((n) => n.id === canvasPicker.nodeId)
+                    return target?.type === 'file' ? target.file : undefined
+                  })()
+                : undefined
+            }
+            onPick={(file) => {
+              if (canvasPicker.mode === 'create') {
+                createFileRefAtViewportCenter(file)
+              } else {
+                applyResult({
+                  state: { kind: 'idle' },
+                  commands: [{ kind: 'set-node-file', id: canvasPicker.nodeId, file }],
+                })
+              }
+              setCanvasPicker(null)
+            }}
+            onCancel={() => setCanvasPicker(null)}
           />
         )}
         {linkDialog !== null && (

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -17,7 +17,7 @@
  * presses originating here (see SpatialEditor's isOverlayEvent): without
  * that, the root would capture the pointer and swallow the buttons' clicks.
  */
-import { Frame, Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
+import { FileBox, Frame, Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export type EditorTool = 'select' | 'connect'
@@ -26,6 +26,8 @@ interface ToolPaletteProps {
   readonly onCreateNode: () => void
   readonly onCreateLink: () => void
   readonly onCreateGroup: () => void
+  /** Absent when the host supplies no canvas listing — the button hides. */
+  readonly onCreateCanvasRef?: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
 }
@@ -37,6 +39,7 @@ export function ToolPalette({
   onCreateNode,
   onCreateLink,
   onCreateGroup,
+  onCreateCanvasRef,
   tool,
   onToolChange,
 }: ToolPaletteProps) {
@@ -121,6 +124,22 @@ export function ToolPalette({
         </TooltipTrigger>
         <TooltipContent>Add group</TooltipContent>
       </Tooltip>
+      {onCreateCanvasRef !== undefined && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              data-testid="add-canvas-button"
+              aria-label="Add canvas"
+              onClick={onCreateCanvasRef}
+              className={TOOL_BUTTON_CLASS}
+            >
+              <FileBox aria-hidden="true" className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Add canvas</TooltipContent>
+        </Tooltip>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -17,9 +17,7 @@ const OPTIONS = [
 ] as const
 
 const withFileNode: SpatialCanvas = {
-  nodes: [
-    { id: 'f1', type: 'file', x: 100, y: 100, width: 200, height: 60, file: 'canvas-a' },
-  ],
+  nodes: [{ id: 'f1', type: 'file', x: 100, y: 100, width: 200, height: 60, file: 'canvas-a' }],
   edges: [],
 }
 
@@ -70,9 +68,9 @@ it('Add canvas opens the picker and picking creates a file node with that refere
   fireEvent.click(container.querySelector('[data-testid="add-canvas-button"]') as HTMLElement)
   await expect.element(page.getByTestId('canvas-picker-dialog')).toBeInTheDocument()
 
-  const option = [...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button')].find(
-    (b) => b.textContent === 'Meeting notes',
-  ) as HTMLButtonElement
+  const option = [
+    ...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button'),
+  ].find((b) => b.textContent === 'Meeting notes') as HTMLButtonElement
   fireEvent.click(option)
 
   await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
@@ -112,9 +110,9 @@ it('the file context menu offers Open canvas and Change target retargets via the
   ]
   expect(current.map((b) => b.textContent)).toEqual(['Release plan'])
 
-  const target = [...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button')].find(
-    (b) => b.textContent === 'Meeting notes',
-  ) as HTMLButtonElement
+  const target = [
+    ...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button'),
+  ].find((b) => b.textContent === 'Meeting notes') as HTMLButtonElement
   fireEvent.click(target)
 
   await vi.waitFor(() =>

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -1,0 +1,144 @@
+// File nodes as canvas references (embed spec J5a): created from the
+// palette's canvas picker, followed via double press or the context menu,
+// retargeted via "Change target". The reference string is opaque to the
+// editor — the host page owns its meaning.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const OPTIONS = [
+  { file: 'canvas-a', label: 'Release plan' },
+  { file: 'canvas-b', label: 'Meeting notes' },
+] as const
+
+const withFileNode: SpatialCanvas = {
+  nodes: [
+    { id: 'f1', type: 'file', x: 100, y: 100, width: 200, height: 60, file: 'canvas-a' },
+  ],
+  edges: [],
+}
+
+function makeHost(initial: SpatialCanvas, onOpen?: (file: string, subpath?: string) => void) {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: initial, commands: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+          fileRefOptions={OPTIONS}
+          onOpenFileRef={onOpen}
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function rightClick(el: HTMLElement, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      button: 2,
+    }),
+  )
+}
+
+it('Add canvas opens the picker and picking creates a file node with that reference', async () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+
+  fireEvent.click(container.querySelector('[data-testid="add-canvas-button"]') as HTMLElement)
+  await expect.element(page.getByTestId('canvas-picker-dialog')).toBeInTheDocument()
+
+  const option = [...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button')].find(
+    (b) => b.textContent === 'Meeting notes',
+  ) as HTMLButtonElement
+  fireEvent.click(option)
+
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
+  expect(latest.canvas.nodes[0]).toMatchObject({ type: 'file', file: 'canvas-b' })
+  expect(latest.commands).toContain('create-node')
+  expect(container.querySelector('[data-testid="canvas-picker-dialog"]')).toBeNull()
+  // The card shows the RESOLVED label, not the opaque reference — the
+  // stored value stays the reference, display goes through the resolver.
+  await vi.waitFor(() => expect(container.textContent).toContain('Meeting notes'))
+  expect(container.textContent).not.toContain('canvas-b')
+})
+
+it('a real double-click on a file node follows the reference', async () => {
+  const opened: string[] = []
+  const { Host } = makeHost(withFileNode, (file) => opened.push(file))
+  const { container } = render(<Host />)
+
+  await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 130 } })
+  await vi.waitFor(() => expect(opened).toEqual(['canvas-a']))
+})
+
+it('the file context menu offers Open canvas and Change target retargets via the picker', async () => {
+  const opened: string[] = []
+  const { Host, latest } = makeHost(withFileNode, (file) => opened.push(file))
+  const { container } = render(<Host />)
+
+  rightClick(rootOf(container), 200, 130)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).toContain('Open canvas')
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Change target' }))
+  await expect.element(page.getByTestId('canvas-picker-dialog')).toBeInTheDocument()
+
+  // The current reference is marked in the list.
+  const current = [
+    ...container.querySelectorAll('[data-testid="canvas-picker-dialog"] [aria-current="true"]'),
+  ]
+  expect(current.map((b) => b.textContent)).toEqual(['Release plan'])
+
+  const target = [...container.querySelectorAll('[data-testid="canvas-picker-dialog"] button')].find(
+    (b) => b.textContent === 'Meeting notes',
+  ) as HTMLButtonElement
+  fireEvent.click(target)
+
+  await vi.waitFor(() =>
+    expect(latest.canvas.nodes[0]).toMatchObject({ type: 'file', file: 'canvas-b' }),
+  )
+  expect(latest.commands).toContain('set-node-file')
+})
+
+it('without host seams, neither the Add canvas button nor file follow-affordances appear', async () => {
+  const bare: SpatialCanvas = withFileNode
+  function BareHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(bare)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      </div>
+    )
+  }
+  const { container } = render(<BareHost />)
+
+  expect(container.querySelector('[data-testid="add-canvas-button"]')).toBeNull()
+
+  rightClick(rootOf(container), 200, 130)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).not.toContain('Open canvas')
+  expect(container.textContent).not.toContain('Change target')
+})

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -359,6 +359,29 @@ describe('applyCommand', () => {
     expect(onText).toBe(labeled)
   })
 
+  it('set-node-file retargets a file node and ignores non-file targets', () => {
+    const withFile = applyCommand(baseCanvas(), {
+      kind: 'create-node',
+      node: { id: 'f1', type: 'file', x: 0, y: 300, width: 200, height: 60, file: 'notes/plan' },
+    })
+
+    const retargeted = applyCommand(withFile, {
+      kind: 'set-node-file',
+      id: 'f1',
+      file: 'notes/roadmap',
+    })
+    expect(retargeted.nodes.find((n) => n.id === 'f1')).toMatchObject({ file: 'notes/roadmap' })
+    // Retargeting clears a stale subpath: a heading anchor from the old
+    // document has no meaning in the new one.
+    expect(retargeted.nodes.find((n) => n.id === 'f1')).not.toHaveProperty('subpath')
+    expect(spatialCanvasSchema.safeParse(retargeted).success).toBe(true)
+
+    const onText = applyCommand(withFile, { kind: 'set-node-file', id: 'a', file: 'x' })
+    expect(onText).toBe(withFile)
+    const onMissing = applyCommand(withFile, { kind: 'set-node-file', id: 'zzz', file: 'x' })
+    expect(onMissing).toBe(withFile)
+  })
+
   it('create then delete the same node is the identity (up to deep equality)', () => {
     const canvas = baseCanvas()
     const node = { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' } as const

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -78,6 +78,13 @@ export type EditorCommand =
       readonly label: string
     }
   | {
+      // Retargets a file node at another document. A stale subpath from the
+      // old target has no meaning in the new one, so it is always cleared.
+      readonly kind: 'set-node-file'
+      readonly id: string
+      readonly file: string
+    }
+  | {
       // Rewrites a link node's destination. Only link nodes carry a url —
       // any other target (or a missing id) is a no-op, never a corruption.
       readonly kind: 'set-node-url'
@@ -234,6 +241,18 @@ function setNodeColor(
   }
 }
 
+function setNodeFile(canvas: SpatialCanvas, id: string, file: string): SpatialCanvas {
+  if (!canvas.nodes.some((node) => node.id === id && node.type === 'file')) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.map((node) => {
+      if (node.id !== id || node.type !== 'file') return node
+      const { subpath: _removed, ...rest } = node
+      return { ...rest, file }
+    }),
+  }
+}
+
 function createGroup(
   canvas: SpatialCanvas,
   node: Extract<SpatialNode, { type: 'group' }>,
@@ -340,6 +359,8 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setEdgeColor(canvas, command.id, command.color)
     case 'set-node-url':
       return setNodeUrl(canvas, command.id, command.url)
+    case 'set-node-file':
+      return setNodeFile(canvas, command.id, command.file)
     case 'create-group':
       return createGroup(canvas, command.node)
     case 'set-group-label':

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -20,6 +20,8 @@ export interface RenderCanvasOptions {
   readonly measure: MeasureText
   /** Defaults to 'light' so existing call sites render the pre-existing chrome unchanged. */
   readonly theme?: ResolvedTheme
+  /** Passed through to layout: opaque file references become readable labels. */
+  readonly resolveFileLabel?: (file: string) => string | undefined
 }
 
 export interface RenderedCanvas {
@@ -57,6 +59,7 @@ export function renderCanvasToSvg(
     measure: options.measure,
     parseBody: parseMarkdownBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
+    resolveFileLabel: options.resolveFileLabel,
   })
   const bounds = sceneBounds(scene)
   const svg = renderSceneToSvg(scene, {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -475,6 +475,12 @@ export function BrowserLocalCanvasPage({
             onChange={onChange}
             externalVersion={externalVersion}
             theme={resolvedTheme}
+            // File-node reference = browser-local canvas id; the current
+            // canvas is excluded (a self-reference card is pure noise).
+            fileRefOptions={canvases
+              .filter((entry) => entry.id !== canvasId)
+              .map((entry) => ({ file: entry.id, label: entry.name }))}
+            onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
           />
         )}
         {/* Markdown canvases keep CodeMirror's own history (its keymap

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -480,6 +480,12 @@ export function DaemonCanvasPage({
               onChange={onChange}
               externalVersion={externalVersion}
               theme={resolvedTheme}
+              // File-node reference = the canvas slug within this workspace
+              // (the daemon's alias path); the current canvas is excluded.
+              fileRefOptions={controller.canvases
+                .filter((entry) => entry.slug !== canvas?.slug)
+                .map((entry) => ({ file: entry.slug, label: entry.slug }))}
+              onOpenFileRef={(file) => controller.switchCanvas(file)}
             />
             <HistoryCluster
               onUndo={() => void undo()}

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -272,6 +272,43 @@ describe('layoutSpatialCanvas', () => {
     expect(label?.bbox.x).toBe(node.x + NODE_PADDING_PX)
   })
 
+  it('resolveFileLabel replaces a file node label; failures fall back to the raw reference', () => {
+    const node: Extract<SpatialNode, { type: 'file' }> = {
+      id: 'f1',
+      type: 'file',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      file: 'opaque-id-123',
+    }
+    const resolved = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileLabel: (file) => (file === 'opaque-id-123' ? 'Release plan' : undefined),
+    })
+    const label = resolved.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
+    expect(label?.text).toBe('Release plan')
+
+    // Unknown reference -> undefined -> the raw string still shows, and a
+    // throwing resolver degrades the same way instead of aborting layout.
+    const unknown = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileLabel: () => undefined,
+    })
+    expect(unknown.nodes.find((n): n is TextRunNode => n.kind === 'textRun')?.text).toBe(
+      'opaque-id-123',
+    )
+    const throwing = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileLabel: () => {
+        throw new Error('boom')
+      },
+    })
+    expect(throwing.nodes.find((n): n is TextRunNode => n.kind === 'textRun')?.text).toBe(
+      'opaque-id-123',
+    )
+  })
+
   it('renders a link node as chrome plus a label containing the url', () => {
     const node: Extract<SpatialNode, { type: 'link' }> = {
       id: 'l1',

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -66,6 +66,14 @@ export interface SpatialLayoutOptions {
    */
   readonly geometry?: SpatialGeometry
   readonly onDegrade?: (event: SpatialLayoutDegradation) => void
+  /**
+   * Human-readable label for a file node's reference. A composition root
+   * whose file references are opaque ids (the browser-local store) resolves
+   * them to titles here; `undefined` (or a throw — total-layout rule) falls
+   * back to the raw reference string. Absent in exports that have no
+   * resolver, so exported labels stay a pure function of the canvas.
+   */
+  readonly resolveFileLabel?: (file: string) => string | undefined
 }
 
 /** Internal: options with geometry resolved exactly once per layout call. */
@@ -186,10 +194,19 @@ function composeTextNode(
 /** The readable label of a non-text node, or `undefined` when it has none. */
 function labelOf(
   node: Extract<SpatialNode, { type: 'file' | 'link' | 'group' }>,
+  options: ResolvedLayoutOptions,
 ): string | undefined {
   switch (node.type) {
-    case 'file':
-      return node.subpath ? `${node.file}${node.subpath}` : node.file
+    case 'file': {
+      let resolved: string | undefined
+      try {
+        resolved = options.resolveFileLabel?.(node.file)
+      } catch {
+        resolved = undefined
+      }
+      const base = resolved ?? node.file
+      return node.subpath ? `${base}${node.subpath}` : base
+    }
     case 'link':
       return node.url
     case 'group':
@@ -205,7 +222,7 @@ function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonl
     case 'link':
     case 'group': {
       const chrome = chromeShape(node, options)
-      const label = labelOf(node)
+      const label = labelOf(node, options)
       return label === undefined
         ? [chrome]
         : [chrome, ...placeInNode(node, { nodes: [labelRun(label, options)] }, options)]


### PR DESCRIPTION
## Summary

J5a of the embed design (whiteboard note `link-node-embed-design`, direction and LOD decisions from the user on 2026-08-08): file nodes become references to OTHER CANVASES in this tool — created from a picker, rendered as readable cards, followed by double-click. This is the collapsed-card + navigation foundation; LOD auto-expansion (inline rendering by on-screen size, with hysteresis and budgets) is the next slice, which needs scene-scaling composition in canvas-render first.

- **Palette "Add canvas"** opens a picker of host-supplied references; picking creates a JSON Canvas `file` node. The reference string is OPAQUE to the editor — the composition root owns its meaning (browser-local: canvas id; daemon: slug within the workspace). Spec-compatible: an exported `.canvas` shows a plain file node to other implementations.
- **Readable cards via a new canvas-render seam**: `resolveFileLabel` on `SpatialLayoutOptions` maps opaque references to titles at layout time; `undefined` or a throwing resolver falls back to the raw reference (total-layout rule). Exports without a resolver keep labels a pure function of the canvas. Caught live: the card initially showed the raw UUID.
- **Follow**: double-click (or "Open canvas") navigates via the host's `onOpenFileRef` seam — router navigation on the browser-local page, `switchCanvas` on the daemon page. "Change target" reopens the picker (`set-node-file`; a stale `#subpath` is always cleared).
- **Optional seams**: without them the affordances hide entirely, keeping the editor pure for viewer-like hosts.

## Visual repro

Add canvas picker listing the other canvases:

![j5a-picker.jpg](https://github.com/user-attachments/assets/3401ef7b-4b67-4cb2-825d-1c0db5738fbd)

Created reference cards showing the RESOLVED canvas name (not the stored id); the new node auto-panned into view and selected:

![j5a-cards.jpg](https://github.com/user-attachments/assets/9b9587f7-1d75-4998-8753-873a54368c32)

Live-verified in Chrome: double-clicking the card navigated to `/local/bfa02230-…` (the referenced canvas).

## Test plan

- [x] canvas-render: resolveFileLabel resolution + undefined/throw fallback (250 passed)
- [x] `commands.test.ts`: set-node-file retarget + subpath clearing + non-file/missing no-ops (25 passed)
- [x] `canvas-ref-node.browser.test.tsx` (real Chromium): picker create with resolved card label, double-click follow, Change target with current-marking, seams-absent affordance hiding (4 passed)
- [x] Full suite: 5981 passed (the known `App.test.tsx` /pair lazy-route flake under full-suite load only — filed, passes in isolation); lint / knip / `pnpm -r typecheck` clean
- [x] Live verification in Chrome (screenshots above)
