### PR TITLE
feat: bottom dock redesign — one container, creation in a + menu

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -64,6 +64,23 @@ Tailwind palette colors in chrome.
   globally by the base-layer guard in `src/index.css` — component code
   must not assume an animation ran (never gate logic on motion).
 
+## Bottom chrome: one dock, fixed width
+
+All bottom-anchored canvas chrome lives in ONE flex container (the tool
+palette dock). Host controls (undo/redo/version history) join it through
+`SpatialEditor`'s `paletteLeading` slot — never as an independently
+positioned floating island, because independent islands collide as tools
+grow (the 2026-08-08 phone overlap).
+
+The dock's button set is FIXED and small ([history | select/connect | +]):
+creation tools live in the "+" menu (the tldraw/FigJam shape, user
+decision 2026-08-08), so the dock stays a single row at any viewport and
+a new node type extends the menu, never the dock's width. Wrapping and
+overflow-scrolling are both rejected: wrapping stacks rows as tools grow,
+and scrolling clips popovers anchored inside the dock (version history,
+the + menu). Opening the + menu focuses its first entry (keyboard path:
+Enter, Enter).
+
 ## Canvas theme boundary
 
 Canvas rendering (nodes/edges/selection) is themed by canvas-render's

--- a/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
@@ -58,13 +58,18 @@ afterEach(() => {
 function renderCluster() {
   return render(
     <div className="relative h-[600px] w-[900px] bg-background">
-      <HistoryCluster
-        onUndo={vi.fn()}
-        onRedo={vi.fn()}
-        canUndo
-        canRedo
-        versions={{ workspaceId: 'sess_1', slug: 'design/login-flow' }}
-      />
+      {/* The cluster is unpositioned by design — the bottom dock owns its
+          placement — so the harness supplies the dock's bottom anchoring,
+          or the upward-opening version panel would sit above the viewport. */}
+      <div className="absolute bottom-3 left-3">
+        <HistoryCluster
+          onUndo={vi.fn()}
+          onRedo={vi.fn()}
+          canUndo
+          canRedo
+          versions={{ workspaceId: 'sess_1', slug: 'design/login-flow' }}
+        />
+      </div>
     </div>,
   )
 }

--- a/apps/web/src/components/history-cluster/HistoryCluster.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.tsx
@@ -1,13 +1,15 @@
 /**
- * The history cluster — every Loro-timeline affordance in one floating
- * group at the canvas's bottom-left: step undo/redo, and (when the daemon
- * capability exists) the version-history panel.
+ * The history cluster — every Loro-timeline affordance in one group:
+ * step undo/redo, and (when the daemon capability exists) the
+ * version-history panel.
  *
- * Placement rationale: undo is the highest-frequency recovery action while
- * drawing, so on a phone it must sit in thumb reach — the canvas's bottom
- * corners, not the header. The bottom-center ToolPalette stays
- * creation/mode-only (the recorded OOUI palette rule), so history is its
- * own group, in the palette's visual language.
+ * This component is deliberately UNPOSITIONED: it renders as the bottom
+ * dock's leading group (SpatialEditor's `paletteLeading` slot), because
+ * independently positioned floating islands collide as tools grow — on a
+ * phone the old bottom-left cluster overlapped the widening palette. The
+ * dock is the single layout authority; this group only brings content.
+ * History stays visually separated from creation/mode tools by the dock's
+ * divider (the recorded OOUI palette rule).
  *
  * Feel: press feedback fires on pointer-down (`:active` scale, fast
  * token), touch targets grow to >=44px on coarse pointers, and a disabled
@@ -122,7 +124,7 @@ export function HistoryCluster({
       data-testid="history-cluster"
       role="toolbar"
       aria-label="History"
-      className="absolute bottom-3 left-3 z-10 flex items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
+      className="relative flex items-center gap-0.5"
     >
       <StepButton
         label="Undo"

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -82,9 +82,12 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
     }
     const clamp = (value: number, max: number) =>
       Math.max(MENU_EDGE_MARGIN_PX, Math.min(value, max))
+    // Ceil the measured box: offsetWidth/Height round to integers, so a
+    // fractional menu width would overshoot the margin by a subpixel.
+    const menuRect = el.getBoundingClientRect()
     const next = {
-      x: clamp(x, parent.clientWidth - el.offsetWidth - MENU_EDGE_MARGIN_PX),
-      y: clamp(y, parent.clientHeight - el.offsetHeight - MENU_EDGE_MARGIN_PX),
+      x: clamp(x, parent.clientWidth - Math.ceil(menuRect.width) - MENU_EDGE_MARGIN_PX),
+      y: clamp(y, parent.clientHeight - Math.ceil(menuRect.height) - MENU_EDGE_MARGIN_PX),
     }
     setPos((prev) => (prev.x === next.x && prev.y === next.y ? prev : next))
   }, [x, y])

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -65,6 +65,17 @@ afterEach(() => {
   cleanup()
 })
 
+/** Creation moved into the dock's + menu — one path for every entry. */
+async function addNoteViaMenu() {
+  await page
+    .getByTestId('add-button')
+    .element()
+    .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  const item = page.getByRole('menuitem', { name: 'Add note' })
+  await expect.element(item).toBeInTheDocument()
+  await item.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
 describe('SpatialEditor (browser)', () => {
   it('renders the canvas-render svg for both nodes', async () => {
     const onChange = vi.fn()
@@ -1172,7 +1183,8 @@ describe('SpatialEditor (browser)', () => {
     // cannot detect the root capturing the pointer and swallowing the
     // button's click — the bug that made this button do nothing in the
     // running app while this test stayed green.
-    await userEvent.click(page.getByTestId('add-node-button'))
+    await userEvent.click(page.getByTestId('add-button'))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
@@ -1192,13 +1204,16 @@ describe('SpatialEditor (browser)', () => {
         />
       </div>,
     )
-    const button = page.getByTestId('add-node-button')
+    const button = page.getByTestId('add-button')
     ;(button.element() as HTMLButtonElement).focus()
     expect(document.activeElement).toBe(button.element())
     // A real key press through the browser, not a synthetic keydown followed
     // by a synthetic click: dispatching the click ourselves would exercise
     // the mouse path and prove nothing about keyboard reachability, which is
-    // the whole point of this case.
+    // the whole point of this case. Opening the + menu moves focus to its
+    // first entry (Add note), so the whole path is Enter, Enter.
+    await userEvent.keyboard('{Enter}')
+    await expect.element(page.getByTestId('add-menu')).toBeInTheDocument()
     await userEvent.keyboard('{Enter}')
 
     expect(onChange).toHaveBeenCalledTimes(1)
@@ -1741,13 +1756,12 @@ describe('node placement and affordances', () => {
         />
       </div>,
     )
-    const button = page.getByTestId('add-node-button')
-    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await addNoteViaMenu()
     await waitFor(() => {
       const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
       expect(canvas.nodes).toHaveLength(1)
     })
-    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await addNoteViaMenu()
     await waitFor(() => {
       const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
       expect(canvas.nodes).toHaveLength(2)
@@ -1771,8 +1785,7 @@ describe('node placement and affordances', () => {
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
-    const button = page.getByTestId('add-node-button')
-    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await addNoteViaMenu()
 
     const textEditor = page.getByTestId('text-node-editor')
     await textEditor.fill('typed before clicking away')
@@ -1816,8 +1829,7 @@ describe('node placement and affordances', () => {
         />
       </div>,
     )
-    const button = page.getByTestId('add-node-button')
-    await button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await addNoteViaMenu()
 
     const textEditor = page.getByTestId('text-node-editor')
     await textEditor.fill('should be discarded')
@@ -1839,11 +1851,12 @@ describe('node placement and affordances', () => {
         <SpatialEditor canvas={{ nodes: [], edges: [] }} onChange={vi.fn()} measure={fakeMeasure} />
       </div>,
     )
-    const button = page.getByTestId('add-node-button').element() as HTMLButtonElement
+    const button = page.getByTestId('add-button').element() as HTMLButtonElement
     const icon = button.querySelector('svg')
     expect(icon).not.toBeNull()
     expect((icon as SVGElement).getBoundingClientRect().width).toBeGreaterThan(0)
-    expect(button.getAttribute('aria-label')).toBe('Add note')
+    expect(button.getAttribute('aria-label')).toBe('Add')
+    expect(button.getAttribute('aria-haspopup')).toBe('menu')
     const palette = button.closest('[data-testid="tool-palette"]') as HTMLElement
     expect(Number.parseFloat(getComputedStyle(palette).borderWidth)).toBeGreaterThan(0)
     button.focus()

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -53,6 +53,32 @@ describe('Add button (creation menu)', () => {
     const command = onChange.mock.calls[0][1] as { kind: string }
     expect(command.kind).toBe('create-node')
   })
+
+  it('Escape closes the menu and hands focus back to the + trigger', () => {
+    // Programmatic focus reads as focus-visible to Radix, which opens the
+    // trigger's tooltip and measures it — jsdom has no ResizeObserver, so
+    // stub the minimal contract for this test only.
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    )
+    const { getByTestId } = render(
+      <SpatialEditor canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+    )
+    const button = getByTestId('add-button') as HTMLButtonElement
+    fireEvent.click(button)
+    const menu = getByTestId('add-menu')
+    fireEvent.keyDown(menu, { key: 'Escape' })
+    expect(getByTestId('tool-palette').querySelector('[data-testid="add-menu"]')).toBeNull()
+    // Closing unmounts the focused entry — without the hand-back, focus
+    // falls to <body> and the keyboard user loses their place.
+    expect(document.activeElement).toBe(button)
+    vi.unstubAllGlobals()
+  })
 })
 
 describe('SpatialEditorHandle', () => {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -5,7 +5,7 @@
  * distinction on a mid-gesture canvas prop swap.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { createRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SpatialEditor, type SpatialEditorHandle } from './SpatialEditor.js'
@@ -33,17 +33,25 @@ afterEach(() => {
   cleanup()
 })
 
-describe('Add note button', () => {
-  it('exists as a real, accessibly-named button reachable without a selection', () => {
-    const { getByTestId } = render(
-      <SpatialEditor canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+describe('Add button (creation menu)', () => {
+  it('opens the + menu whose entries create without a selection', () => {
+    const onChange = vi.fn()
+    const { getByTestId, getByRole } = render(
+      <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />,
     )
-    const button = getByTestId('add-node-button') as HTMLButtonElement
+    const button = getByTestId('add-button') as HTMLButtonElement
     expect(button.tagName).toBe('BUTTON')
     // Icon-only since the chrome iconification: the accessible name lives
     // on aria-label, which is what assistive tech (and getByRole) resolve.
-    expect(button.getAttribute('aria-label')).toBe('Add note')
-    expect(button.disabled).toBe(false)
+    expect(button.getAttribute('aria-label')).toBe('Add')
+    expect(button.getAttribute('aria-haspopup')).toBe('menu')
+
+    fireEvent.click(button)
+    const item = getByRole('menuitem', { name: 'Add note' })
+    fireEvent.click(item)
+    expect(onChange).toHaveBeenCalled()
+    const command = onChange.mock.calls[0][1] as { kind: string }
+    expect(command.kind).toBe('create-node')
   })
 })
 
@@ -171,5 +179,25 @@ describe('SpatialEditor externalVersion origin handling', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
     const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
     expect(command).toEqual({ kind: 'move-node', id: 'a', x: 50, y: 35 })
+  })
+})
+
+describe('bottom dock composition', () => {
+  it('renders paletteLeading inside the ONE tool-palette container', () => {
+    // The dock is the single layout authority for bottom chrome: host-
+    // supplied groups (undo/redo/versions) join the palette's own flex
+    // container instead of floating as an independently positioned island —
+    // independently positioned islands collide as tools grow (the phone
+    // overlap this redesign replaces).
+    const { container } = render(
+      <SpatialEditor
+        canvas={{ nodes: [], edges: [] }}
+        onChange={vi.fn()}
+        measure={fakeMeasure}
+        paletteLeading={<div data-testid="history-slot">history</div>}
+      />,
+    )
+    const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+    expect(palette.querySelector('[data-testid="history-slot"]')).not.toBeNull()
   })
 })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,6 +50,7 @@ import {
   ExternalLink,
   FileBox,
   Frame,
+  Link,
   PanelBottom,
   PanelLeft,
   PanelRight,
@@ -373,11 +374,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // The URL dialog serves both palette-create and context-menu-edit; which
     // one decides what its submit does.
     const [groupLabelEditId, setGroupLabelEditId] = useState<string | null>(null)
+    // `point` (canvas space) is present when creation came from the
+    // empty-space context menu: the user already chose WHERE, so the node
+    // lands there instead of the viewport-center free spot.
     const [linkDialog, setLinkDialog] = useState<
-      { readonly mode: 'create' } | { readonly mode: 'edit'; readonly nodeId: string } | null
+      | { readonly mode: 'create'; readonly point?: Point }
+      | { readonly mode: 'edit'; readonly nodeId: string }
+      | null
     >(null)
     const [canvasPicker, setCanvasPicker] = useState<
-      { readonly mode: 'create' } | { readonly mode: 'retarget'; readonly nodeId: string } | null
+      | { readonly mode: 'create'; readonly point?: Point }
+      | { readonly mode: 'retarget'; readonly nodeId: string }
+      | null
     >(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
 
@@ -1183,17 +1191,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /** Link nodes are label-only chrome — a note-height box would be mostly
      * empty, so they get a shorter default. */
     const LINK_NODE_HEIGHT = 60
-    const createLinkAtViewportCenter = (url: string) => {
+    const createLinkAtViewportCenter = (url: string, at?: Point) => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = findFreeSpot(
-        preferred,
-        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
-        occupied,
-      )
+      const point =
+        at ?? findFreeSpot(preferred, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }, occupied)
       const id =
         createId?.() ??
         (typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -1217,17 +1222,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /** File nodes are reference cards like links — same shorter default box. */
-    const createFileRefAtViewportCenter = (file: string) => {
+    const createFileRefAtViewportCenter = (file: string, at?: Point) => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = findFreeSpot(
-        preferred,
-        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
-        occupied,
-      )
+      const point =
+        at ?? findFreeSpot(preferred, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }, occupied)
       const id = newId()
       const node: SpatialNode = {
         id,
@@ -1293,17 +1295,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         ? crypto.randomUUID()
         : String(Math.random()))
 
-    const createGroupAtViewportCenter = () => {
+    const createGroupAtViewportCenter = (at?: Point) => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = findFreeSpot(
-        preferred,
-        { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT },
-        occupied,
-      )
+      const point =
+        at ??
+        findFreeSpot(preferred, { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT }, occupied)
       const id = newId()
       applyResult({
         state: { kind: 'idle' },
@@ -1566,13 +1566,34 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 ]
               }
               if (node === undefined) {
-                return [
+                // The same creation set as the dock's + menu, anchored at
+                // the click point — "here" is exactly the information the
+                // bottom dock cannot express.
+                const emptyItems: ContextMenuItem[] = [
                   {
                     label: 'Add note here',
                     icon: <StickyNote />,
                     onSelect: () => createNodeAt(contextMenu.point),
                   },
+                  {
+                    label: 'Add link here',
+                    icon: <Link />,
+                    onSelect: () => setLinkDialog({ mode: 'create', point: contextMenu.point }),
+                  },
+                  {
+                    label: 'Add group here',
+                    icon: <Frame />,
+                    onSelect: () => createGroupAtViewportCenter(contextMenu.point),
+                  },
                 ]
+                if (fileRefOptions !== undefined) {
+                  emptyItems.push({
+                    label: 'Add canvas here',
+                    icon: <FileBox />,
+                    onSelect: () => setCanvasPicker({ mode: 'create', point: contextMenu.point }),
+                  })
+                }
+                return emptyItems
               }
               const items: ContextMenuItem[] = []
               if (node.type === 'group') {
@@ -1685,7 +1706,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             }
             onPick={(file) => {
               if (canvasPicker.mode === 'create') {
-                createFileRefAtViewportCenter(file)
+                createFileRefAtViewportCenter(file, canvasPicker.point)
               } else {
                 applyResult({
                   state: { kind: 'idle' },
@@ -1710,7 +1731,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             }
             onSubmit={(url) => {
               if (linkDialog.mode === 'create') {
-                createLinkAtViewportCenter(url)
+                createLinkAtViewportCenter(url, linkDialog.point)
               } else {
                 applyResult({
                   state: { kind: 'idle' },

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -62,6 +62,7 @@ import {
 } from 'lucide-react'
 import {
   forwardRef,
+  type ReactNode,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
@@ -156,6 +157,11 @@ export interface SpatialEditorProps {
   readonly fileRefOptions?: readonly FileRefOption[]
   /** Follows a file node's reference (navigation). Absent → follow hides. */
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
+  /**
+   * Host controls (undo/redo/version history) docked as the palette's
+   * leading group — the palette is the single bottom-chrome container.
+   */
+  readonly paletteLeading?: ReactNode
 }
 
 /** Imperative surface for a page that needs to drive the viewport from
@@ -224,6 +230,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       theme = 'light',
       fileRefOptions,
       onOpenFileRef,
+      paletteLeading,
     },
     forwardedRef,
   ) {
@@ -1391,6 +1398,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
         <ToolPalette
+          leading={paletteLeading}
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -1,41 +1,57 @@
 /**
- * Bottom tool palette — the OOUI creation surface.
+ * Bottom dock — the ONE container for all bottom-anchored canvas chrome.
+ *
+ * Two layout decisions, both recorded after real collisions:
+ * - Host controls (undo/redo/version history) join this container through
+ *   the `leading` slot instead of floating as independently positioned
+ *   islands — independent islands collide as tools grow (the 2026-08-08
+ *   phone overlap).
+ * - Creation tools live in a "+" menu, not as one flat button per type
+ *   (the tldraw/FigJam shape, user decision 2026-08-08): the dock keeps a
+ *   FIXED small button set that fits any viewport in a single row, and new
+ *   node types extend the menu, never the dock's width.
  *
  * Design rule (recorded in the ooui-palette-vs-object-actions decision):
  * what does NOT exist yet comes from the palette; what already exists is
- * acted on from the object itself (selection affordances, and later a
- * context menu). So this strip carries creation and interaction-mode
- * controls only — it must never grow per-object actions like delete or
- * color, which belong on the selected object.
+ * acted on from the object itself. The "+" menu is the palette's creation
+ * surface — it must never grow per-object actions.
  *
- * Icon-only buttons (chrome carries no sentence-shaped copy): every button
- * keeps its full accessible name via aria-label — which is also what the
- * existing getByRole('button', { name: ... }) tests and screen readers
- * resolve — and a tooltip supplies the sighted-hover equivalent.
+ * Icon-only dock buttons keep their accessible names via aria-label; the
+ * "+" menu's entries show icon AND label (a menu is a reading surface,
+ * not a memorized strip).
  *
- * Marked `data-editor-overlay` so the canvas root's gesture handlers ignore
- * presses originating here (see SpatialEditor's isOverlayEvent): without
- * that, the root would capture the pointer and swallow the buttons' clicks.
+ * Marked `data-editor-overlay` so the canvas root's gesture handlers
+ * ignore presses originating here (see SpatialEditor's isOverlayEvent).
  */
-import { FileBox, Frame, Link, MousePointer2, Spline, StickyNote } from 'lucide-react'
+import { FileBox, Frame, Link, MousePointer2, Plus, Spline, StickyNote } from 'lucide-react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export type EditorTool = 'select' | 'connect'
 
 interface ToolPaletteProps {
+  /** Host-supplied controls (undo/redo/versions) docked as the leading group. */
+  readonly leading?: ReactNode
   readonly onCreateNode: () => void
   readonly onCreateLink: () => void
   readonly onCreateGroup: () => void
-  /** Absent when the host supplies no canvas listing — the button hides. */
+  /** Absent when the host supplies no canvas listing — the entry hides. */
   readonly onCreateCanvasRef?: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
 }
 
 const TOOL_BUTTON_CLASS =
-  'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
+  'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
+
+interface AddMenuEntry {
+  readonly label: string
+  readonly icon: ReactNode
+  readonly onSelect: () => void
+}
 
 export function ToolPalette({
+  leading,
   onCreateNode,
   onCreateLink,
   onCreateGroup,
@@ -43,14 +59,72 @@ export function ToolPalette({
   tool,
   onToolChange,
 }: ToolPaletteProps) {
+  const [addOpen, setAddOpen] = useState(false)
+  const dockRef = useRef<HTMLDivElement | null>(null)
+  const addMenuRef = useRef<HTMLDivElement | null>(null)
+
+  // Menu convention: opening moves focus to the first entry, so the
+  // keyboard path is + → Enter → Enter without a mouse detour.
+  useEffect(() => {
+    if (!addOpen) return
+    addMenuRef.current?.querySelector('button')?.focus()
+  }, [addOpen])
+
+  // Close the add menu on any pointerdown outside the dock — the standard
+  // menu dismissal path (Escape is handled on the menu itself).
+  useEffect(() => {
+    if (!addOpen) return
+    const onPointerDownAnywhere = (e: PointerEvent) => {
+      const dock = dockRef.current
+      if (dock !== null && e.target instanceof Node && dock.contains(e.target)) return
+      setAddOpen(false)
+    }
+    window.addEventListener('pointerdown', onPointerDownAnywhere, true)
+    return () => window.removeEventListener('pointerdown', onPointerDownAnywhere, true)
+  }, [addOpen])
+
+  const entries: readonly AddMenuEntry[] = [
+    {
+      label: 'Add note',
+      icon: <StickyNote aria-hidden="true" className="size-4" />,
+      onSelect: onCreateNode,
+    },
+    {
+      label: 'Add link',
+      icon: <Link aria-hidden="true" className="size-4" />,
+      onSelect: onCreateLink,
+    },
+    {
+      label: 'Add group',
+      icon: <Frame aria-hidden="true" className="size-4" />,
+      onSelect: onCreateGroup,
+    },
+    ...(onCreateCanvasRef !== undefined
+      ? [
+          {
+            label: 'Add canvas',
+            icon: <FileBox aria-hidden="true" className="size-4" />,
+            onSelect: onCreateCanvasRef,
+          },
+        ]
+      : []),
+  ]
+
   return (
     <div
+      ref={dockRef}
       data-editor-overlay
       data-testid="tool-palette"
       role="toolbar"
       aria-label="Canvas tools"
       className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
     >
+      {leading !== undefined && (
+        <>
+          {leading}
+          <div aria-hidden="true" className="mx-0.5 h-5 w-px bg-border" />
+        </>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <button
@@ -86,59 +160,54 @@ export function ToolPalette({
         <TooltipTrigger asChild>
           <button
             type="button"
-            data-testid="add-node-button"
-            aria-label="Add note"
-            onClick={onCreateNode}
+            data-testid="add-button"
+            aria-label="Add"
+            aria-haspopup="menu"
+            aria-expanded={addOpen}
+            onClick={() => setAddOpen((open) => !open)}
             className={TOOL_BUTTON_CLASS}
           >
-            <StickyNote aria-hidden="true" className="size-4" />
+            <Plus aria-hidden="true" className="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Add note</TooltipContent>
+        <TooltipContent>Add</TooltipContent>
       </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            data-testid="add-link-button"
-            aria-label="Add link"
-            onClick={onCreateLink}
-            className={TOOL_BUTTON_CLASS}
-          >
-            <Link aria-hidden="true" className="size-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Add link</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            data-testid="add-group-button"
-            aria-label="Add group"
-            onClick={onCreateGroup}
-            className={TOOL_BUTTON_CLASS}
-          >
-            <Frame aria-hidden="true" className="size-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Add group</TooltipContent>
-      </Tooltip>
-      {onCreateCanvasRef !== undefined && (
-        <Tooltip>
-          <TooltipTrigger asChild>
+      {addOpen && (
+        <div
+          ref={addMenuRef}
+          data-testid="add-menu"
+          role="menu"
+          aria-label="Add"
+          // Opens UPWARD from the dock, origin-aware at the bottom edge
+          // (never scale(0) — see DESIGN.md Motion). Right-anchored so the
+          // menu hugs the "+" end of the dock.
+          className="absolute right-0 bottom-[calc(100%+6px)] min-w-40 origin-bottom-right animate-in rounded-md border bg-background py-1 shadow-lg fade-in-0 zoom-in-[0.98] duration-(--motion-duration-normal) ease-(--motion-ease-out)"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.stopPropagation()
+              setAddOpen(false)
+            }
+          }}
+        >
+          {entries.map((entry) => (
             <button
+              key={entry.label}
               type="button"
-              data-testid="add-canvas-button"
-              aria-label="Add canvas"
-              onClick={onCreateCanvasRef}
-              className={TOOL_BUTTON_CLASS}
+              role="menuitem"
+              aria-label={entry.label}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+              onClick={() => {
+                setAddOpen(false)
+                entry.onSelect()
+              }}
             >
-              <FileBox aria-hidden="true" className="size-4" />
+              <span aria-hidden="true" className="text-muted-foreground">
+                {entry.icon}
+              </span>
+              {entry.label.replace(/^Add /, '')}
             </button>
-          </TooltipTrigger>
-          <TooltipContent>Add canvas</TooltipContent>
-        </Tooltip>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -62,6 +62,7 @@ export function ToolPalette({
   const [addOpen, setAddOpen] = useState(false)
   const dockRef = useRef<HTMLDivElement | null>(null)
   const addMenuRef = useRef<HTMLDivElement | null>(null)
+  const addButtonRef = useRef<HTMLButtonElement | null>(null)
 
   // Menu convention: opening moves focus to the first entry, so the
   // keyboard path is + → Enter → Enter without a mouse detour.
@@ -159,6 +160,7 @@ export function ToolPalette({
       <Tooltip>
         <TooltipTrigger asChild>
           <button
+            ref={addButtonRef}
             type="button"
             data-testid="add-button"
             aria-label="Add"
@@ -186,6 +188,10 @@ export function ToolPalette({
             if (e.key === 'Escape') {
               e.stopPropagation()
               setAddOpen(false)
+              // Closing unmounts the focused entry; without an explicit
+              // hand-back, focus falls to <body> and the keyboard user
+              // loses their place.
+              addButtonRef.current?.focus()
             }
           }}
         >

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -35,7 +35,8 @@ it('a real pointer click on "Add note" creates a node and opens its editor', asy
   const commands: string[] = []
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
 
-  await userEvent.click(page.getByRole('button', { name: 'Add note' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
 
   expect(commands).toEqual(['create-node'])
   expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
@@ -46,7 +47,8 @@ it('committing the new note untouched keeps a visible empty node, not a blank ca
   const commands: string[] = []
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
 
-  await userEvent.click(page.getByRole('button', { name: 'Add note' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
   // Click empty canvas space without typing — the editor commits the (empty)
   // pending text and the node must survive as a visible box.
   await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element, {

--- a/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
@@ -1,0 +1,76 @@
+// Real-layout regression for the bottom dock redesign: on a phone the old
+// independently-positioned history cluster overlapped the widening palette
+// (user phone screenshot, 2026-08-08). The dock is now the single layout
+// authority with a FIXED small button set — creation tools live in the "+"
+// menu (user decision, tldraw/FigJam shape), so the dock stays one row at
+// any viewport and new node types never widen it. Imports the real
+// stylesheet: this test is ABOUT layout.
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import '../../index.css'
+import { HistoryCluster } from '../history-cluster/HistoryCluster.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function renderAt(width: number) {
+  return render(
+    <div className="relative bg-background" style={{ width, height: 600 }}>
+      <SpatialEditor
+        canvas={{ nodes: [], edges: [] }}
+        onChange={vi.fn()}
+        theme="light"
+        fileRefOptions={[]}
+        paletteLeading={<HistoryCluster onUndo={vi.fn()} onRedo={vi.fn()} canUndo canRedo />}
+      />
+    </div>,
+  )
+}
+
+it('the dock keeps history and tools in ONE single-row container that fits a phone width', () => {
+  const { container } = renderAt(375)
+  const host = container.firstElementChild as HTMLElement
+  const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+  const cluster = container.querySelector('[data-testid="history-cluster"]') as HTMLElement
+
+  // One container: the history group is INSIDE the dock, so there is no
+  // second floating island left to collide with.
+  expect(palette.contains(cluster)).toBe(true)
+
+  // The dock fits the narrow host in a single row.
+  const hostRect = host.getBoundingClientRect()
+  const dockRect = palette.getBoundingClientRect()
+  expect(dockRect.left).toBeGreaterThanOrEqual(hostRect.left)
+  expect(dockRect.right).toBeLessThanOrEqual(hostRect.right)
+  const tops = new Set(
+    [...palette.querySelectorAll('button')].map((b) => Math.round(b.getBoundingClientRect().top)),
+  )
+  expect(tops.size).toBe(1)
+})
+
+it('creation entries live in the + menu, which opens upward inside the viewport', () => {
+  const { container } = renderAt(375)
+  const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+
+  // No flat per-type creation buttons on the dock itself.
+  for (const label of ['Add note', 'Add link', 'Add group', 'Add canvas']) {
+    expect(
+      [...palette.querySelectorAll(':scope > button, :scope [data-slot="tooltip-trigger"]')].some(
+        (b) => b.getAttribute('aria-label') === label,
+      ),
+    ).toBe(false)
+  }
+
+  fireEvent.click(palette.querySelector('[data-testid="add-button"]') as HTMLElement)
+  const menu = container.querySelector('[data-testid="add-menu"]') as HTMLElement
+  const items = [...menu.querySelectorAll('[role="menuitem"]')].map((b) =>
+    b.getAttribute('aria-label'),
+  )
+  expect(items).toEqual(['Add note', 'Add link', 'Add group', 'Add canvas'])
+
+  // Opens upward from the dock and stays inside the host, above the dock.
+  const menuRect = menu.getBoundingClientRect()
+  const dockRect = palette.getBoundingClientRect()
+  expect(menuRect.bottom).toBeLessThanOrEqual(dockRect.top)
+  expect(menuRect.top).toBeGreaterThanOrEqual(0)
+})

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -65,7 +65,12 @@ it('Add canvas opens the picker and picking creates a file node with that refere
   const { Host, latest } = makeHost({ nodes: [], edges: [] })
   const { container } = render(<Host />)
 
-  fireEvent.click(container.querySelector('[data-testid="add-canvas-button"]') as HTMLElement)
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+  fireEvent.click(
+    [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
+      (b) => b.getAttribute('aria-label') === 'Add canvas',
+    ) as HTMLElement,
+  )
   await expect.element(page.getByTestId('canvas-picker-dialog')).toBeInTheDocument()
 
   const option = [
@@ -133,7 +138,14 @@ it('without host seams, neither the Add canvas button nor file follow-affordance
   }
   const { container } = render(<BareHost />)
 
-  expect(container.querySelector('[data-testid="add-canvas-button"]')).toBeNull()
+  // Without the host seam the + menu offers no canvas entry.
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+  expect(
+    [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].some(
+      (b) => b.getAttribute('aria-label') === 'Add canvas',
+    ),
+  ).toBe(false)
+  await userEvent.keyboard('{Escape}')
 
   rightClick(rootOf(container), 200, 130)
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -87,6 +87,47 @@ it('right-clicking empty space offers creation at that point', async () => {
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
 })
 
+it('empty space offers the full creation set, anchored at the click point', async () => {
+  const { Host, latest } = (() => {
+    const l: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
+    function H() {
+      const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+      l.canvas = canvas
+      return (
+        <div style={{ width: 800, height: 600 }}>
+          <SpatialEditor
+            canvas={canvas}
+            onChange={(next, command) => {
+              l.commands.push(command.kind)
+              setCanvas(next)
+            }}
+            theme="light"
+            fileRefOptions={[{ file: 'c1', label: 'Other canvas' }]}
+          />
+        </div>
+      )
+    }
+    return { Host: H, latest: l }
+  })()
+  const { container } = render(<Host />)
+  rightClick(rootOf(container), 600, 450)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  // The dock's + menu creation set, repeated "here" (canvas entry appears
+  // because the host supplies the reference seam).
+  for (const label of ['Add note here', 'Add link here', 'Add group here', 'Add canvas here']) {
+    expect(container.textContent).toContain(label)
+  }
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add group here' }))
+  await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(true))
+  const frame = latest.canvas.nodes.find((n) => n.type === 'group')
+  if (frame === undefined) throw new Error('frame missing')
+  // Centered on the click point (600,450 screen = canvas at identity view).
+  expect(frame.x + frame.width / 2).toBeCloseTo(600, 0)
+  expect(frame.y + frame.height / 2).toBeCloseTo(450, 0)
+})
+
 it('Escape closes the menu without acting', async () => {
   const commands: string[] = []
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -72,7 +72,8 @@ it('the palette Add group button creates an empty frame at the bottom of the z-o
   const { Host, latest } = makeHost({ nodes: [], edges: [] })
   render(<Host />)
 
-  await userEvent.click(page.getByRole('button', { name: 'Add group' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add group' }))
   await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
   expect(latest.canvas.nodes[0]).toMatchObject({ type: 'group' })
   expect(latest.commands).toContain('create-group')
@@ -206,9 +207,14 @@ it('a palette-created frame that lands off-screen pans the viewport to show it',
   const { container } = render(<Host />)
 
   // The wall node covers the palette in the unstyled test env (no app CSS =
-  // no z-index), so Playwright refuses the click — the button itself is
-  // static, so a direct DOM click is the faithful interaction.
-  fireEvent.click(container.querySelector('[data-testid="add-group-button"]') as HTMLElement)
+  // no z-index), so Playwright refuses the click — the buttons themselves
+  // are static, so direct DOM clicks are the faithful interaction.
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+  fireEvent.click(
+    [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
+      (b) => b.getAttribute('aria-label') === 'Add group',
+    ) as HTMLElement,
+  )
   await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(true))
 
   const root = rootOf(container).getBoundingClientRect()

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -83,7 +83,8 @@ it('Add link opens the URL dialog and a valid submit creates a link node', async
   const { Host, latest } = makeHost(empty)
   const { container } = render(<Host />)
 
-  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
   await expect.element(page.getByTestId('link-url-dialog')).toBeInTheDocument()
 
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
@@ -107,7 +108,8 @@ it('an invalid URL cannot be submitted', async () => {
   const { Host, latest } = makeHost(empty)
   const { container } = render(<Host />)
 
-  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
   await userEvent.fill(input, 'not a url')
 
@@ -203,7 +205,8 @@ it('a javascript: URL is neither followable nor accepted by the dialog', async (
   }
 
   // And the dialog refuses to mint one in the first place.
-  await userEvent.click(page.getByRole('button', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('button', { name: 'Add' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
   await userEvent.fill(input, 'javascript:alert(1)')
   const ok = [...container.querySelectorAll('button')].find(

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -9,6 +9,7 @@
  * command shape a real create/delete gesture would report.
  */
 
+import type { ReactNode } from 'react'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
@@ -42,10 +43,16 @@ let latestOnChange: OnChange | null = null
 let latestMountedCanvases: SpatialCanvas[] = []
 
 vi.mock('../components/spatial-editor/index.js', () => ({
-  SpatialEditor: (props: { canvas: SpatialCanvas; onChange?: OnChange }) => {
+  SpatialEditor: (props: {
+    canvas: SpatialCanvas
+    onChange?: OnChange
+    paletteLeading?: ReactNode
+  }) => {
     latestOnChange = props.onChange ?? null
     latestMountedCanvases.push(props.canvas)
-    return null
+    // The real editor docks host controls (undo/redo) via paletteLeading;
+    // the stub must render them or the page's history buttons vanish.
+    return <>{props.paletteLeading}</>
   },
 }))
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -9,10 +9,9 @@
  * command shape a real create/delete gesture would report.
  */
 
-import type { ReactNode } from 'react'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -481,19 +481,19 @@ export function BrowserLocalCanvasPage({
               .filter((entry) => entry.id !== canvasId)
               .map((entry) => ({ file: entry.id, label: entry.name }))}
             onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
+            paletteLeading={
+              <HistoryCluster
+                onUndo={() => void undo()}
+                onRedo={() => void redo()}
+                canUndo={canUndo()}
+                canRedo={canRedo()}
+              />
+            }
           />
         )}
         {/* Markdown canvases keep CodeMirror's own history (its keymap
-            already handles undo); the cluster drives the Loro UndoManager,
-            which only the spatial editor path routes edits through. */}
-        {canvasKind !== 'markdown' && (
-          <HistoryCluster
-            onUndo={() => void undo()}
-            onRedo={() => void redo()}
-            canUndo={canUndo()}
-            canRedo={canRedo()}
-          />
-        )}
+            already handles undo); the history group rides the spatial
+            editor's dock via paletteLeading above. */}
       </div>
       <SettingsPanel
         open={settingsOpen}

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -486,22 +486,24 @@ export function DaemonCanvasPage({
                 .filter((entry) => entry.slug !== canvas?.slug)
                 .map((entry) => ({ file: entry.slug, label: entry.slug }))}
               onOpenFileRef={(file) => controller.switchCanvas(file)}
-            />
-            <HistoryCluster
-              onUndo={() => void undo()}
-              onRedo={() => void redo()}
-              canUndo={canUndo()}
-              canRedo={canRedo()}
-              versions={
-                capabilities.versions && canvas
-                  ? {
-                      workspaceId: canvas.workspaceId,
-                      slug: canvas.slug,
-                      onRestored: clearLocalUndo,
-                      refreshSignal: versionRefreshSignal,
-                      versionPanelExtra,
-                    }
-                  : undefined
+              paletteLeading={
+                <HistoryCluster
+                  onUndo={() => void undo()}
+                  onRedo={() => void redo()}
+                  canUndo={canUndo()}
+                  canRedo={canRedo()}
+                  versions={
+                    capabilities.versions && canvas
+                      ? {
+                          workspaceId: canvas.workspaceId,
+                          slug: canvas.slug,
+                          onRestored: clearLocalUndo,
+                          refreshSignal: versionRefreshSignal,
+                          versionPanelExtra,
+                        }
+                      : undefined
+                  }
+                />
               }
             />
           </div>


### PR DESCRIPTION
## Summary

Bottom-chrome redesign replacing positional patching with structure (user direction, 2026-08-08): the reported phone overlap between the tool palette and the history cluster is a symptom of independently positioned floating islands, which re-collide every time a tool is added.

Two structural decisions:

- **One dock.** Host controls (undo/redo/version history) join the palette container through `SpatialEditor`'s new `paletteLeading` slot. `HistoryCluster` is now unpositioned by design — the dock owns placement, so there is no second island left to collide.
- **Fixed dock width.** Creation tools move into a **"+" menu** (the tldraw/FigJam shape, chosen over full-width mobile bars): the dock stays `[history | select/connect | +]` in a single row at ANY viewport, and a new node type (J5b media, J6 iframes…) extends the menu, never the dock's width. Wrapping and overflow-scrolling were both evaluated and rejected — wrapping stacks rows as tools grow (and an absolutely-centered fit-content dock wraps prematurely at 50% viewport width, observed live), scrolling clips the popovers anchored inside the dock (version history, the + menu).
- Opening the + menu focuses its first entry, so keyboard creation is + → Enter → Enter. Entries show icon AND label; Escape and outside-press dismiss.

## Visual repro

Narrow viewport — one single-row dock (undo/redo | select/connect | +), no second island:

![dock-narrow.jpg](https://github.com/user-attachments/assets/cbd0dd38-1e96-489f-ac3f-d47b358ae78e)

The + menu opens upward with icon + label entries (canvas entry appears only when the host supplies the reference seam):

![dock-add-menu.jpg](https://github.com/user-attachments/assets/95d148b4-63fe-48f0-9845-97453d942d56)

Live-verified: picking "note" creates the node and opens its editor; menu closes on pick/Escape/outside-press.

## Test plan

- [x] `bottom-dock.browser.test.tsx` (REAL stylesheet): at 375px the dock contains the history group, fits the host, stays one row; creation entries exist only in the + menu, which opens upward inside the viewport (2 passed)
- [x] All creation-path tests updated to the menu flow (SpatialEditor jsdom + browser, add-note-real-pointer, link/group/canvas-ref): web-browser 265 passed / 49 files, jsdom 1441 passed / 121 files
- [x] `HistoryCluster.browser.test.tsx` harness now supplies the dock's bottom anchoring (the cluster is unpositioned by design)
- [x] typecheck clean; DESIGN.md records the dock rule (one container, fixed width, no wrap/scroll)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified bottom tool dock with host controls and an upward-opening **Add** menu.
  * Consolidated note, link, group, and canvas creation actions under the **Add** menu.
  * Added accessible labels, keyboard focus handling, and Escape/outside-click dismissal.
  * Integrated undo/redo controls into the dock for a consistent layout.

* **Bug Fixes**
  * Improved dock behavior on narrow screens by keeping controls in a single row.
  * Ensured creation menus remain visible within the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->