### PR TITLE
feat: inline canvas embeds with LOD auto-expansion

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -16,6 +16,15 @@
   translation used to place a node's laid-out content at its absolute
   position, alongside the renderers whose x-transform-boundary convention
   it must agree with (see decision #5 and `svg/backend.ts`).
+- `scaleScene` (`layout/scale-scene.ts`): the multiplicative sibling of
+  `translateScene` — uniform scaling about the origin for composing a
+  resolved child canvas into a parent node's box (scale-then-translate).
+  Uniform scaling commutes with the x-transform-boundary representation,
+  so unlike translation it needs no wrapper special-casing. Size-bearing
+  paint fields (fontSize/strokeWidth/radius/baseline) scale with the
+  geometry; `svgFragment` payloads and backend-derived arrowhead sizing
+  deliberately do not (documented, test-pinned). Total: factor 1 is the
+  identity, non-finite/non-positive factors return the input unchanged.
 - The injected text-measurement seam (`measure.ts`: `FontDescriptor`,
   `TextMetrics`, `MeasureText`) — layout never imports a font or measurer.
 - The SVG backend (`svg/backend.ts` + `svg/format.ts`): scene -> SVG string,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -163,6 +163,12 @@ export interface SpatialEditorProps {
    * leading group — the palette is the single bottom-chrome container.
    */
   readonly paletteLeading?: ReactNode
+  /**
+   * Referenced canvas CONTENT for inline embeds (embed spec J5a-2). Must
+   * be synchronous — hosts pre-fetch and cache; an unresolved reference
+   * returns undefined and the card renders. Absent → embeds never expand.
+   */
+  readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
 }
 
 /** Imperative surface for a page that needs to drive the viewport from
@@ -232,6 +238,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       fileRefOptions,
       onOpenFileRef,
       paletteLeading,
+      resolveFileCanvas,
     },
     forwardedRef,
   ) {
@@ -348,6 +355,49 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [canvas, externalVersion])
 
+    /**
+     * The LOD gate (embed spec v2, user decision 2026-08-08): a file node
+     * expands into an inline miniature only while its ON-SCREEN box is
+     * large enough to be legible. Hysteresis (expand at >=200x140, collapse
+     * below 160x110 CSS px) keeps pinch-zoom from flickering at the
+     * boundary, and a budget caps simultaneous miniatures at the largest
+     * candidates (deterministic tie-break by node id). The set is state so
+     * layout re-runs only when membership actually changes — never per
+     * zoom frame.
+     */
+    const EXPAND_MIN_W = 200
+    const EXPAND_MIN_H = 140
+    const COLLAPSE_MIN_W = 160
+    const COLLAPSE_MIN_H = 110
+    const EMBED_BUDGET = 8
+    const [expandedFileIds, setExpandedFileIds] = useState<ReadonlySet<string>>(new Set())
+    useEffect(() => {
+      if (resolveFileCanvas === undefined) return
+      const zoom = viewport.zoom
+      const candidates = canvas.nodes
+        .filter((node): node is Extract<SpatialNode, { type: 'file' }> => node.type === 'file')
+        .filter((node) => {
+          const w = node.width * zoom
+          const h = node.height * zoom
+          return expandedFileIds.has(node.id)
+            ? w >= COLLAPSE_MIN_W && h >= COLLAPSE_MIN_H
+            : w >= EXPAND_MIN_W && h >= EXPAND_MIN_H
+        })
+        .sort((a, b) => b.width * b.height - a.width * a.height || a.id.localeCompare(b.id))
+        .slice(0, EMBED_BUDGET)
+      const next = new Set(candidates.map((node) => node.id))
+      const unchanged =
+        next.size === expandedFileIds.size && [...next].every((id) => expandedFileIds.has(id))
+      if (!unchanged) setExpandedFileIds(next)
+    }, [canvas, viewport.zoom, resolveFileCanvas, expandedFileIds])
+    const expandFileNode = useMemo(
+      () =>
+        resolveFileCanvas === undefined
+          ? undefined
+          : (node: Extract<SpatialNode, { type: 'file' }>) => expandedFileIds.has(node.id),
+      [resolveFileCanvas, expandedFileIds],
+    )
+
     // Opaque file references (browser-local canvas ids) become readable
     // card labels through the host-supplied options list.
     const resolveFileLabel = useMemo(() => {
@@ -356,8 +406,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return (file: string) => byFile.get(file)
     }, [fileRefOptions])
     const { svg, bounds, scene } = useMemo(
-      () => renderCanvasToSvg(canvas, { measure: resolvedMeasure, theme, resolveFileLabel }),
-      [canvas, resolvedMeasure, theme, resolveFileLabel],
+      () =>
+        renderCanvasToSvg(canvas, {
+          measure: resolvedMeasure,
+          theme,
+          resolveFileLabel,
+          resolveFileCanvas,
+          expandFileNode,
+        }),
+      [canvas, resolvedMeasure, theme, resolveFileLabel, resolveFileCanvas, expandFileNode],
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a

--- a/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
@@ -1,0 +1,87 @@
+// LOD auto-expansion for canvas embeds (embed spec v2): a file node whose
+// on-screen box is large enough renders the referenced canvas as an inline
+// miniature; smaller ones stay cards. The decision follows zoom — zooming
+// out far enough collapses the miniature back to a card (hysteresis keeps
+// the boundary from flickering).
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const referenced: SpatialCanvas = {
+  nodes: [
+    { id: 'r1', type: 'text', x: 0, y: 0, width: 300, height: 150, text: 'inside' },
+    { id: 'r2', type: 'text', x: 400, y: 0, width: 200, height: 100, text: 'more' },
+  ],
+  edges: [],
+}
+
+function makeHost(initial: SpatialCanvas) {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+          fileRefOptions={[{ file: 'ref-1', label: 'Referenced canvas' }]}
+          resolveFileCanvas={(file) => (file === 'ref-1' ? referenced : undefined)}
+        />
+      </div>
+    )
+  }
+  return Host
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function embeddedTextExists(container: HTMLElement): boolean {
+  return (container.textContent ?? '').includes('inside')
+}
+
+it('a large file node renders the referenced canvas inline; a small one stays a card', async () => {
+  const large: SpatialCanvas = {
+    nodes: [{ id: 'big', type: 'file', x: 60, y: 60, width: 320, height: 240, file: 'ref-1' }],
+    edges: [],
+  }
+  const Host = makeHost(large)
+  const { container } = render(<Host />)
+  await vi.waitFor(() => expect(embeddedTextExists(container)).toBe(true))
+
+  cleanup()
+
+  const small: SpatialCanvas = {
+    nodes: [{ id: 'tiny', type: 'file', x: 60, y: 60, width: 120, height: 80, file: 'ref-1' }],
+    edges: [],
+  }
+  const SmallHost = makeHost(small)
+  const { container: smallContainer } = render(<SmallHost />)
+  // Below the expand threshold: the card (resolved label) renders, not the
+  // referenced content.
+  expect(embeddedTextExists(smallContainer)).toBe(false)
+  expect(smallContainer.textContent).toContain('Referenced canvas')
+})
+
+it('zooming far out collapses an expanded miniature back to the card', async () => {
+  const large: SpatialCanvas = {
+    nodes: [{ id: 'big', type: 'file', x: 300, y: 220, width: 320, height: 240, file: 'ref-1' }],
+    edges: [],
+  }
+  const Host = makeHost(large)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await vi.waitFor(() => expect(embeddedTextExists(container)).toBe(true))
+
+  // Wheel-zoom out until the node's on-screen box is far below the
+  // collapse threshold (320px * 0.3 < 160px).
+  for (let i = 0; i < 14; i += 1) {
+    fireEvent.wheel(root, { deltaY: 120, ctrlKey: true, clientX: 400, clientY: 300 })
+  }
+  await vi.waitFor(() => expect(embeddedTextExists(container)).toBe(false))
+})

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -22,6 +22,10 @@ export interface RenderCanvasOptions {
   readonly theme?: ResolvedTheme
   /** Passed through to layout: opaque file references become readable labels. */
   readonly resolveFileLabel?: (file: string) => string | undefined
+  /** Passed through to layout: referenced canvas content for inline embeds. */
+  readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
+  /** Passed through to layout: the LOD gate deciding card vs miniature. */
+  readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
 }
 
 export interface RenderedCanvas {
@@ -60,6 +64,8 @@ export function renderCanvasToSvg(
     parseBody: parseMarkdownBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
     resolveFileLabel: options.resolveFileLabel,
+    resolveFileCanvas: options.resolveFileCanvas,
+    expandFileNode: options.expandFileNode,
   })
   const bounds = sceneBounds(scene)
   const svg = renderSceneToSvg(scene, {

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -1,0 +1,39 @@
+/**
+ * Content loading for inline canvas embeds (embed spec J5a-2), browser-local
+ * flavor: a file node's reference is a browser-local canvas id, and the
+ * editor's `resolveFileCanvas` seam is SYNCHRONOUS by contract — so the page
+ * pre-fetches referenced canvases here and hands the editor a cache lookup.
+ *
+ * Totality mirrors the layout seam: any load/import failure resolves to
+ * `undefined` and the editor keeps the card — a broken reference must never
+ * take down the page.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { Loro } from 'loro-crdt'
+import { getAppLogger } from './app-logger.js'
+import { LoroStore } from './loro-store.js'
+
+const log = getAppLogger('canvas-embed-content')
+
+/** Loads one referenced canvas's spatial content from IndexedDB. */
+export async function loadEmbeddedSpatialCanvas(
+  canvasId: string,
+): Promise<SpatialCanvas | undefined> {
+  try {
+    const result = await new LoroStore().load(canvasId)
+    if (result.kind !== 'ok') return undefined
+    const doc = new Loro()
+    doc.import(result.snapshot)
+    for (const delta of result.deltas ?? []) doc.import(delta)
+    return readSpatialCanvas(doc)
+  } catch (err) {
+    log.warn('embedded canvas load failed', { canvasId, err })
+    return undefined
+  }
+}
+
+/** The file references present in a canvas, deduplicated. */
+export function collectFileRefs(canvas: SpatialCanvas): readonly string[] {
+  return [...new Set(canvas.nodes.flatMap((node) => (node.type === 'file' ? [node.file] : [])))]
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,3 +1,4 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { Copy, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -26,6 +27,7 @@ import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { collectFileRefs, loadEmbeddedSpatialCanvas } from '../lib/canvas-embed-content.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -153,6 +155,12 @@ export function BrowserLocalCanvasPage({
   // The generation guard drops a stale resolution that would otherwise
   // clobber a newer refresh triggered by a fast switch.
   const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
+  // Referenced-canvas content cache for inline embeds: the editor's
+  // resolveFileCanvas seam is synchronous, so referenced canvases are
+  // pre-fetched here. Entries refresh when the referenced canvas's
+  // updatedAt moves in the list (edits elsewhere show up on next refresh).
+  const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, SpatialCanvas>>(new Map())
+  const embedStampsRef = useRef<Map<string, string>>(new Map())
   const listGenerationRef = useRef(0)
   // Fullscreen target for WorkspaceTopBar's onEnterFullscreen; the whole page
   // (editor + chrome), not just the Excalidraw canvas.
@@ -252,6 +260,37 @@ export function BrowserLocalCanvasPage({
   // represented as null instead of a throwaway placeholder canvas id.
   const { canvas, onChange, externalVersion, exportScene, undo, redo, canUndo, canRedo } =
     useCanvasSync(backend)
+
+  // Pre-fetch referenced canvases for inline embeds; refresh when the
+  // referenced canvas's updatedAt moves in the list.
+  useEffect(() => {
+    const refs = collectFileRefs(canvas)
+    if (refs.length === 0) return
+    let cancelled = false
+    const stampOf = new Map(canvases.map((entry) => [entry.id, entry.updatedAt]))
+    const stale = refs.filter(
+      (ref) => !embedContent.has(ref) || embedStampsRef.current.get(ref) !== stampOf.get(ref),
+    )
+    if (stale.length === 0) return
+    void Promise.all(
+      stale.map(async (ref) => [ref, await loadEmbeddedSpatialCanvas(ref)] as const),
+    ).then((loaded) => {
+      if (cancelled) return
+      setEmbedContent((prev) => {
+        const next = new Map(prev)
+        for (const [ref, content] of loaded) {
+          if (content !== undefined) next.set(ref, content)
+          else next.delete(ref)
+          embedStampsRef.current.set(ref, stampOf.get(ref) ?? '')
+        }
+        return next
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [canvas, canvases, embedContent])
+  const resolveFileCanvas = useCallback((file: string) => embedContent.get(file), [embedContent])
 
   const commands = useWhiteboardCommands({
     provider: { kind: 'browser-local', capabilities },
@@ -481,6 +520,7 @@ export function BrowserLocalCanvasPage({
               .filter((entry) => entry.id !== canvasId)
               .map((entry) => ({ file: entry.id, label: entry.name }))}
             onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
+            resolveFileCanvas={resolveFileCanvas}
             paletteLeading={
               <HistoryCluster
                 onUndo={() => void undo()}

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -8,6 +8,7 @@ export type {
 export type { SpatialLayoutDegradation, SpatialLayoutOptions } from './layout/spatial-canvas.js'
 export { layoutSpatialCanvas } from './layout/spatial-canvas.js'
 export { routeEdge } from './layout/spatial-edges.js'
+export { scaleScene } from './layout/scale-scene.js'
 export { translateScene } from './layout/translate-scene.js'
 export type { FontDescriptor, MeasureText, TextMetrics } from './measure.js'
 export { clampAdvance } from './measure.js'

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -1,6 +1,7 @@
 export * from './layout/embed-recursion.js'
 export type { MdastLayoutOptions } from './layout/mdast-blocks.js'
 export { layoutMdastBlocks } from './layout/mdast-blocks.js'
+export { scaleScene } from './layout/scale-scene.js'
 export type {
   SpatialAppearanceResolver,
   SpatialNodeAppearance,
@@ -8,7 +9,6 @@ export type {
 export type { SpatialLayoutDegradation, SpatialLayoutOptions } from './layout/spatial-canvas.js'
 export { layoutSpatialCanvas } from './layout/spatial-canvas.js'
 export { routeEdge } from './layout/spatial-edges.js'
-export { scaleScene } from './layout/scale-scene.js'
 export { translateScene } from './layout/translate-scene.js'
 export type { FontDescriptor, MeasureText, TextMetrics } from './measure.js'
 export { clampAdvance } from './measure.js'

--- a/packages/canvas-render/src/layout/scale-scene.test.ts
+++ b/packages/canvas-render/src/layout/scale-scene.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { ListBlockNode, Scene, ShapeSceneNode, TextRunNode } from '../scene-graph.js'
+import { scaleScene } from './scale-scene.js'
+
+const run = (over?: Partial<TextRunNode>): TextRunNode => ({
+  kind: 'textRun',
+  bbox: { x: 10, y: 20, w: 100, h: 16 },
+  text: 'hello',
+  baseline: 12,
+  appearance: { fontSize: 16, strokeWidth: 2, fill: '#111111' },
+  ...over,
+})
+
+describe('scaleScene', () => {
+  it('scales bboxes, baselines, paths, radius, and size-bearing appearance uniformly', () => {
+    const scene: Scene = {
+      nodes: [
+        run(),
+        {
+          kind: 'shape',
+          bbox: { x: 0, y: 0, w: 200, h: 100 },
+          radius: 8,
+          appearance: { stroke: '#222222', strokeWidth: 1 },
+        } satisfies ShapeSceneNode,
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 100, y: 50 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+          appearance: { stroke: '#333333', strokeWidth: 2 },
+        },
+      ],
+    }
+    const half = scaleScene(scene, 0.5)
+
+    const scaledRun = half.nodes[0] as TextRunNode
+    expect(scaledRun.bbox).toEqual({ x: 5, y: 10, w: 50, h: 8 })
+    expect(scaledRun.baseline).toBe(6)
+    expect(scaledRun.appearance).toEqual({ fontSize: 8, strokeWidth: 1, fill: '#111111' })
+
+    const scaledShape = half.nodes[1] as ShapeSceneNode
+    expect(scaledShape.bbox).toEqual({ x: 0, y: 0, w: 100, h: 50 })
+    expect(scaledShape.radius).toBe(4)
+    expect(scaledShape.appearance?.strokeWidth).toBe(0.5)
+
+    const scaledEdge = half.nodes[2]
+    if (scaledEdge.kind !== 'edge') throw new Error('edge expected')
+    expect(scaledEdge.path).toEqual([
+      { x: 0, y: 0 },
+      { x: 50, y: 25 },
+    ])
+  })
+
+  it('scales wrapper-relative children by the same factor (uniform scaling commutes with the x-transform boundary)', () => {
+    // listItem children store x RELATIVE to the wrapper; uniform scaling
+    // about the origin scales wrapper offset and relative offset alike, so
+    // absolute positions still land at factor * original.
+    const list: ListBlockNode = {
+      kind: 'list',
+      bbox: { x: 20, y: 0, w: 200, h: 40 },
+      ordered: false,
+      depth: 0,
+      items: [
+        {
+          kind: 'listItem',
+          bbox: { x: 20, y: 0, w: 200, h: 20 },
+          children: [run({ bbox: { x: 8, y: 0, w: 100, h: 16 } })],
+        },
+      ],
+    }
+    const scaled = scaleScene({ nodes: [list] }, 2)
+    const scaledList = scaled.nodes[0] as ListBlockNode
+    const item = scaledList.items[0]
+    expect(item.bbox.x).toBe(40)
+    const child = item.children[0] as TextRunNode
+    // Relative x scales too: absolute = 40 (wrapper transform) + 16 = 56 = 2 * (20 + 8).
+    expect(child.bbox.x).toBe(16)
+  })
+
+  it('factor 1 is the identity and degenerate factors return the scene unchanged (total, never throws)', () => {
+    const scene: Scene = { nodes: [run()] }
+    expect(scaleScene(scene, 1)).toEqual(scene)
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(scaleScene(scene, bad)).toBe(scene)
+    }
+  })
+
+  it('leaves svgFragment content verbatim while scaling its bbox (documented limitation)', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'svgFragment',
+          bbox: { x: 10, y: 10, w: 40, h: 20 },
+          svg: '<g><text>x</text></g>',
+        },
+      ],
+    }
+    const scaled = scaleScene(scene, 0.5)
+    const fragment = scaled.nodes[0]
+    if (fragment.kind !== 'svgFragment') throw new Error('fragment expected')
+    expect(fragment.bbox).toEqual({ x: 5, y: 5, w: 20, h: 10 })
+    expect(fragment.svg).toBe('<g><text>x</text></g>')
+  })
+})

--- a/packages/canvas-render/src/layout/scale-scene.ts
+++ b/packages/canvas-render/src/layout/scale-scene.ts
@@ -1,0 +1,132 @@
+// Pure scene -> scene uniform scaling about the origin, the multiplicative
+// sibling of `translateScene`. Composing a resolved child canvas into a
+// parent file-node's box is scale-then-translate: lay the child out at its
+// native size, scale it to fit, then shift it to the node's position.
+//
+// Unlike translation, scaling needs NO x-transform-boundary special case:
+// `renderListItem`/`renderTableCell` children store x RELATIVE to their
+// wrapper, and uniform scaling about the origin commutes with that
+// representation (f*(wrapper + relative) = f*wrapper + f*relative), so
+// every coordinate at every depth simply multiplies by the factor.
+//
+// Size-bearing paint fields scale with the geometry (fontSize, strokeWidth,
+// shape radius, textRun baseline) so a scaled scene renders as a uniform
+// miniature, not as full-weight strokes on shrunken boxes. Two documented
+// non-scaling cases: an `svgFragment`'s verbatim SVG string cannot be
+// scaled here (only its bbox is — a fragment inside a scaled embed renders
+// at its authored size), and edge arrowheads are derived by the backend
+// from the scaled path with fixed canvas-unit sizing, so they come out
+// relatively larger inside a miniature. Both are acceptable for embed
+// rendering and pinned by tests rather than hidden.
+import type {
+  Appearance,
+  BoundingBox,
+  ListItemNode,
+  Scene,
+  SceneNode,
+  TableCellSceneNode,
+  TableRowSceneNode,
+} from '../scene-graph.js'
+
+type ScalableNode = SceneNode | ListItemNode | TableRowSceneNode | TableCellSceneNode
+
+function scaleBbox(bbox: BoundingBox, f: number): BoundingBox {
+  return { x: bbox.x * f, y: bbox.y * f, w: bbox.w * f, h: bbox.h * f }
+}
+
+function scaleAppearance(appearance: Appearance | undefined, f: number): Appearance | undefined {
+  if (appearance === undefined) return undefined
+  const next: Appearance = {
+    ...appearance,
+    ...(appearance.fontSize !== undefined ? { fontSize: appearance.fontSize * f } : {}),
+    ...(appearance.strokeWidth !== undefined ? { strokeWidth: appearance.strokeWidth * f } : {}),
+  }
+  return next
+}
+
+function scaleNode(node: ScalableNode, f: number): ScalableNode {
+  switch (node.kind) {
+    case 'edge':
+      return {
+        ...node,
+        path: node.path.map((point) => ({ x: point.x * f, y: point.y * f })),
+        appearance: scaleAppearance(node.appearance, f),
+      }
+    case 'textRun':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        ...(node.baseline !== undefined ? { baseline: node.baseline * f } : {}),
+        appearance: scaleAppearance(node.appearance, f),
+      }
+    case 'shape':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        ...(node.radius !== undefined ? { radius: node.radius * f } : {}),
+        appearance: scaleAppearance(node.appearance, f),
+      }
+    case 'heading':
+    case 'paragraph':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        runs: node.runs.map((r) => scaleNode(r, f) as never),
+      }
+    case 'list':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        items: node.items.map((item) => scaleNode(item, f) as ListItemNode),
+      }
+    case 'listItem':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        children: node.children.map((child) => scaleNode(child, f) as SceneNode),
+      }
+    case 'table':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        rows: node.rows.map((row) => scaleNode(row, f) as TableRowSceneNode),
+      }
+    case 'tableRow':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        cells: node.cells.map((cell) => scaleNode(cell, f) as TableCellSceneNode),
+      }
+    case 'tableCell':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        runs: node.runs.map((r) => scaleNode(r, f) as never),
+      }
+    case 'blockquote':
+    case 'embedResolved':
+    case 'group':
+      return {
+        ...node,
+        bbox: scaleBbox(node.bbox, f),
+        children: node.children.map((child) => scaleNode(child, f) as SceneNode),
+      } as ScalableNode
+    default:
+      // codeBlock, thematicBreak, rawHtml, unresolvedReference,
+      // svgFragment, embedPlaceholder: bbox-only nodes (their string
+      // payloads render verbatim — see the module comment).
+      return { ...node, bbox: scaleBbox(node.bbox, f) }
+  }
+}
+
+/**
+ * Scales every coordinate in the scene by `factor` about the origin.
+ * Total: `factor` 1 is the identity; a non-finite or non-positive factor
+ * returns the input scene unchanged rather than producing degenerate
+ * geometry.
+ */
+export function scaleScene(scene: Scene, factor: number): Scene {
+  if (!Number.isFinite(factor) || factor <= 0) return scene
+  if (factor === 1) return scene
+  return { nodes: scene.nodes.map((node) => scaleNode(node, factor) as SceneNode) }
+}

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -27,6 +27,7 @@
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import type { MeasureText } from '../measure.js'
+import { sceneBounds } from '../scene-bounds.js'
 import type {
   ResolvedEdgeNode,
   Scene,
@@ -36,6 +37,7 @@ import type {
 } from '../scene-graph.js'
 import { SPATIAL_THEME_GEOMETRY, type SpatialGeometry } from '../theme/spatial-geometry.js'
 import { layoutMdastBlocks } from './mdast-blocks.js'
+import { scaleScene } from './scale-scene.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
 import { routeEdge } from './spatial-edges.js'
 import { translateScene } from './translate-scene.js'
@@ -74,10 +76,27 @@ export interface SpatialLayoutOptions {
    * resolver, so exported labels stay a pure function of the canvas.
    */
   readonly resolveFileLabel?: (file: string) => string | undefined
+  /**
+   * Resolves a file node's reference to the referenced spatial canvas for
+   * INLINE embedding. Absent, or `undefined` for a reference, keeps the
+   * card-only rendering. Recursion is depth-capped (3) with path-local
+   * cycle detection — a re-visit on the current path degrades to the card.
+   */
+  readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
+  /**
+   * The caller's expansion policy (the LOD gate): called per file node
+   * when `resolveFileCanvas` is present; `false` (or an absent callback)
+   * keeps the card. canvas-render itself has no expansion policy — the
+   * editor decides by on-screen size, export by intrinsic size.
+   */
+  readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
 }
 
 /** Internal: options with geometry resolved exactly once per layout call. */
 interface ResolvedLayoutOptions extends SpatialLayoutOptions {
+  /** File references on the CURRENT recursion path, plus its depth. */
+  readonly embedPath: ReadonlySet<string>
+  readonly embedDepth: number
   readonly geometry: SpatialGeometry
 }
 
@@ -214,7 +233,76 @@ function labelOf(
   }
 }
 
+/** Depth cap matching embed-recursion.ts's contract: root is 0, the 4th level degrades. */
+const FILE_EMBED_DEPTH_CAP = 3
+
+/**
+ * The inline-embedded rendering of a file node: the referenced canvas laid
+ * out at native size, scaled to fit the node's content area (never
+ * upscaled), and placed under the label band. Returns undefined whenever
+ * the card should render instead — no resolver, policy says collapsed,
+ * unresolvable reference, cycle on the current path, depth cap, or a
+ * degenerate fit.
+ */
+function composeFileEmbed(
+  node: Extract<SpatialNode, { type: 'file' }>,
+  options: ResolvedLayoutOptions,
+): SceneNode | undefined {
+  const resolveFileCanvas = options.resolveFileCanvas
+  if (resolveFileCanvas === undefined) return undefined
+  if (options.expandFileNode?.(node) !== true) return undefined
+  if (options.embedDepth >= FILE_EMBED_DEPTH_CAP || options.embedPath.has(node.file)) {
+    return undefined
+  }
+  let child: SpatialCanvas | undefined
+  try {
+    child = resolveFileCanvas(node.file)
+  } catch {
+    child = undefined
+  }
+  if (child === undefined) return undefined
+
+  const childScene = layoutSpatialCanvasInternal(child, {
+    ...options,
+    embedPath: new Set([...options.embedPath, node.file]),
+    embedDepth: options.embedDepth + 1,
+  })
+  const bounds = sceneBounds(childScene)
+  const padding = options.geometry.paddingPx
+  // The label band keeps the reference title readable above the miniature.
+  const labelBand = options.geometry.labelFontSizePx * 1.6
+  const innerW = node.width - 2 * padding
+  const innerH = node.height - 2 * padding - labelBand
+  const fit = Math.min(innerW / bounds.w, innerH / bounds.h, 1)
+  if (!Number.isFinite(fit) || fit <= 0) return undefined
+
+  const atOrigin = translateScene(childScene, -bounds.x, -bounds.y)
+  const scaled = scaleScene(atOrigin, fit)
+  const placed = translateScene(scaled, node.x + padding, node.y + padding + labelBand)
+  return {
+    kind: 'embedResolved',
+    bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
+    canvasId: node.file,
+    children: placed.nodes,
+  }
+}
+
 function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonly SceneNode[] {
+  switch (node.type) {
+    case 'file': {
+      const embed = composeFileEmbed(node, options)
+      if (embed !== undefined) {
+        const chrome = chromeShape(node, options)
+        const label = labelOf(node, options)
+        return label === undefined
+          ? [chrome, embed]
+          : [chrome, ...placeInNode(node, { nodes: [labelRun(label, options)] }, options), embed]
+      }
+      break
+    }
+    default:
+      break
+  }
   switch (node.type) {
     case 'text':
       return composeTextNode(node, options)
@@ -322,10 +410,18 @@ function composeEdgeLabel(
  * `resolveGeometry`) and threaded to every helper as `ResolvedLayoutOptions`.
  */
 export function layoutSpatialCanvas(canvas: SpatialCanvas, options: SpatialLayoutOptions): Scene {
-  const resolved: ResolvedLayoutOptions = {
+  return layoutSpatialCanvasInternal(canvas, {
     ...options,
     geometry: resolveGeometry(options.geometry),
-  }
+    embedPath: new Set(),
+    embedDepth: 0,
+  })
+}
+
+function layoutSpatialCanvasInternal(
+  canvas: SpatialCanvas,
+  resolved: ResolvedLayoutOptions,
+): Scene {
   const nodeContent = canvas.nodes.flatMap((node) => composeNode(node, resolved))
   const edgeContent = canvas.edges.map((edge) => composeEdge(canvas, edge, resolved))
   const labelContent = canvas.edges

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -1,0 +1,141 @@
+// Inline file-node embeds: the referenced canvas renders as a scaled
+// miniature inside the node's content area, gated by the caller's
+// expansion policy, with the depth cap and path-local cycle handling this
+// package's embed contract already promises.
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import type { EmbedResolvedNode, ShapeSceneNode } from '../scene-graph.js'
+import { createFakeMeasure } from '../test-utils/fake-measure.js'
+import { layoutSpatialCanvas, type SpatialLayoutOptions } from './spatial-canvas.js'
+
+const APPEARANCE = {
+  resolveNode: () => ({}),
+  resolveEdge: () => ({}),
+  resolveLabel: () => ({}),
+}
+
+function baseOptions(over?: Partial<SpatialLayoutOptions>): SpatialLayoutOptions {
+  return {
+    measure: createFakeMeasure(),
+    parseBody: () => ({ type: 'root', children: [] }),
+    appearance: APPEARANCE,
+    ...over,
+  }
+}
+
+const fileNode = (over?: Partial<Extract<SpatialNode, { type: 'file' }>>) =>
+  ({
+    id: 'f1',
+    type: 'file',
+    x: 100,
+    y: 100,
+    width: 220,
+    height: 180,
+    file: 'child',
+    ...over,
+  }) satisfies SpatialNode
+
+const childCanvas: SpatialCanvas = {
+  nodes: [{ id: 'c1', type: 'text', x: 0, y: 0, width: 400, height: 200, text: '' }],
+  edges: [],
+}
+
+function embedOf(scene: { nodes: readonly { kind: string }[] }): EmbedResolvedNode | undefined {
+  return scene.nodes.find((n): n is EmbedResolvedNode => n.kind === 'embedResolved')
+}
+
+describe('file-node inline embeds', () => {
+  it('expands a resolved reference into a scaled miniature inside the content area', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileCanvas: (file) => (file === 'child' ? childCanvas : undefined),
+        expandFileNode: () => true,
+      }),
+    )
+    const embed = embedOf(scene)
+    expect(embed).toBeDefined()
+    expect(embed?.canvasId).toBe('child')
+
+    // The child's 400x200 shape fits the node's inner area scaled down —
+    // every embedded coordinate stays inside the node box.
+    const childShape = embed?.children.find((n): n is ShapeSceneNode => n.kind === 'shape')
+    expect(childShape).toBeDefined()
+    const box = childShape as ShapeSceneNode
+    expect(box.bbox.w).toBeLessThan(400)
+    expect(box.bbox.x).toBeGreaterThanOrEqual(100)
+    expect(box.bbox.x + box.bbox.w).toBeLessThanOrEqual(320)
+    expect(box.bbox.y + box.bbox.h).toBeLessThanOrEqual(280)
+  })
+
+  it('never upscales a small child (fit caps at 1)', () => {
+    const tiny: SpatialCanvas = {
+      nodes: [{ id: 'c1', type: 'text', x: 0, y: 0, width: 40, height: 20, text: '' }],
+      edges: [],
+    }
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({ resolveFileCanvas: () => tiny, expandFileNode: () => true }),
+    )
+    const shape = embedOf(scene)?.children.find((n): n is ShapeSceneNode => n.kind === 'shape')
+    expect(shape?.bbox.w).toBe(40)
+  })
+
+  it('keeps the card without a resolver, without expansion, or on an unresolvable reference', () => {
+    const noResolver = layoutSpatialCanvas({ nodes: [fileNode()], edges: [] }, baseOptions())
+    expect(embedOf(noResolver)).toBeUndefined()
+
+    const collapsed = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({ resolveFileCanvas: () => childCanvas, expandFileNode: () => false }),
+    )
+    expect(embedOf(collapsed)).toBeUndefined()
+
+    const unresolvable = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({ resolveFileCanvas: () => undefined, expandFileNode: () => true }),
+    )
+    expect(embedOf(unresolvable)).toBeUndefined()
+  })
+
+  it('degrades a cycle on the current path to the card instead of recursing forever', () => {
+    const a: SpatialCanvas = { nodes: [fileNode({ id: 'fa', file: 'b' })], edges: [] }
+    const b: SpatialCanvas = { nodes: [fileNode({ id: 'fb', file: 'a' })], edges: [] }
+    const scene = layoutSpatialCanvas(
+      a,
+      baseOptions({
+        resolveFileCanvas: (file) => (file === 'a' ? a : file === 'b' ? b : undefined),
+        expandFileNode: () => true,
+      }),
+    )
+    // Path-local means the REFERENCE chain: the root canvas itself was not
+    // reached via a reference, so a → b → a renders one more level before
+    // the 'b' reference inside that inner 'a' hits the path and degrades
+    // to the card. The point pinned here is boundedness, not zero nesting.
+    const outer = embedOf(scene)
+    expect(outer?.canvasId).toBe('b')
+    const inner = outer?.children.find((n): n is EmbedResolvedNode => n.kind === 'embedResolved')
+    expect(inner?.canvasId).toBe('a')
+    const third = inner?.children.find((n) => n.kind === 'embedResolved')
+    expect(third).toBeUndefined()
+  })
+
+  it('caps recursion depth at 3', () => {
+    const canvases: Record<string, SpatialCanvas> = {}
+    for (let i = 0; i < 6; i += 1) {
+      canvases[`c${i}`] = { nodes: [fileNode({ id: `f${i}`, file: `c${i + 1}` })], edges: [] }
+    }
+    canvases.c6 = { nodes: [], edges: [] }
+    const scene = layoutSpatialCanvas(
+      canvases.c0 as SpatialCanvas,
+      baseOptions({ resolveFileCanvas: (file) => canvases[file], expandFileNode: () => true }),
+    )
+    let depth = 0
+    let current = embedOf(scene)
+    while (current !== undefined) {
+      depth += 1
+      current = current.children.find((n): n is EmbedResolvedNode => n.kind === 'embedResolved')
+    }
+    expect(depth).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary

J5a-2 of the embed design (whiteboard note `link-node-embed-design` v2 — the user's LOD decisions from 2026-08-08): canvas-reference file nodes now render the referenced canvas as an **inline miniature**, automatically expanded or collapsed by on-screen size.

- **`scaleScene`** (canvas-render): the multiplicative sibling of `translateScene` — uniform scaling about the origin. Uniform scaling commutes with the listItem/tableCell x-transform-boundary representation, so unlike translation it needs no wrapper special-casing. Size-bearing paint fields (fontSize, strokeWidth, radius, baseline) scale with the geometry; `svgFragment` payloads and backend-derived arrowhead sizing deliberately do not (documented + test-pinned). Total: factor 1 is identity, degenerate factors return the input unchanged.
- **Inline embeds behind seams** (canvas-render): `layoutSpatialCanvas` gains `resolveFileCanvas` (reference → canvas data) and `expandFileNode` (the caller's LOD policy — the renderer itself has no expansion policy, per assigned-not-invented). An expanded file node composes chrome + label + an `embedResolved` node: the child laid out at native size, translate → scale-to-fit → translate under the label band, never upscaled. Depth cap 3, path-local cycle detection over the reference chain (boundedness pinned by tests); every failure keeps the card.
- **LOD gate in the editor**: expand while the node's ON-SCREEN box ≥ 200×140 CSS px, collapse below 160×110 (hysteresis stops pinch-zoom flicker), at most 8 simultaneous miniatures (largest first, deterministic tie-break). Membership is state — layout re-runs only when the set changes, never per zoom frame. Real-browser regression covers expand, stay-card, and wheel-zoom-out collapse.
- **Browser-local content plumbing**: the page pre-fetches referenced canvases (Loro snapshot+deltas from IndexedDB → `readSpatialCanvas`) into a cache backing the synchronous `resolveFileCanvas` seam; entries refresh when the referenced canvas's `updatedAt` moves. Daemon pages are a follow-up (slug references, HTTP content) — tracked with the rename-resilience issue `canvas-ref-rename-resilience`.

## Visual repro

A canvas-reference card, enlarged past the LOD threshold, rendering the referenced canvas's content inline under its title (live, browser-local):

![j5a2-embed.jpg](https://github.com/user-attachments/assets/474d8393-ad35-4f01-858d-34846c0b3a58)

Live-verified: the same card below the threshold stays a title-only card, and the real-browser test drives wheel-zoom-out collapse.

## Test plan

- [x] canvas-render: `scale-scene.test.ts` (uniform scaling, wrapper-relative commutation, totality, svgFragment limitation) + `spatial-embed.test.ts` (expand/fit/no-upscale, seam-absent/collapsed/unresolvable → card, cycle boundedness, depth cap 3) — 260 passed
- [x] `canvas-embed-lod.browser.test.tsx` (real Chromium): expand at size, stay-card below threshold, wheel-zoom-out collapse (2 passed)
- [x] Full suite: 5999 passed (known `/pair` lazy-route flake under full-suite load only — filed, passes in isolation); lint / knip / `pnpm -r typecheck` clean
- [x] Live verification in Chrome (screenshot above)
