### PR TITLE
feat: image file nodes and outside container labels

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -246,7 +246,7 @@
    constants naming the same string remains a deliberate, documented
    duplication rather than a shared import.
 
-8. **`ImageSceneNode` and the `resolveFileImage` seam** (J5b): the scene
+9. **`ImageSceneNode` and the `resolveFileImage` seam** (J5b): the scene
    graph's one raster/vector image node — `bbox` is the FRAME (aspect always
    preserved via `preserveAspectRatio="xMidYMid meet"`), `href` is emitted
    verbatim (data: URI in exports, blob:/app URL live), `alt` renders as a

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -246,6 +246,16 @@
    constants naming the same string remains a deliberate, documented
    duplication rather than a shared import.
 
+8. **`ImageSceneNode` and the `resolveFileImage` seam** (J5b): the scene
+   graph's one raster/vector image node — `bbox` is the FRAME (aspect always
+   preserved via `preserveAspectRatio="xMidYMid meet"`), `href` is emitted
+   verbatim (data: URI in exports, blob:/app URL live), `alt` renders as a
+   `<title>` child and its absence marks the image presentation.
+   `layoutSpatialCanvas`'s `resolveFileImage` is checked BEFORE the
+   canvas-embed seam and is not LOD-gated (a scaled-down image is still a
+   meaningful thumbnail); any failure keeps the card. Image nodes are
+   bbox-only leaves for sceneBounds/translate/scale.
+
 ## Conventions
 
 - Every scene-node variant retains semantic provenance (heading `level`,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,6 +50,7 @@ import {
   ExternalLink,
   FileBox,
   Frame,
+  Image as ImageIcon,
   Link,
   PanelBottom,
   PanelLeft,
@@ -169,6 +170,16 @@ export interface SpatialEditorProps {
    * returns undefined and the card renders. Absent → embeds never expand.
    */
   readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
+  /** Image content for media file nodes (data:/blob: href). Sync, cached by the host. */
+  readonly resolveFileImage?: (
+    file: string,
+  ) => { readonly href: string; readonly alt?: string } | undefined
+  /**
+   * Stores a picked/dropped/pasted image and returns the reference to put
+   * in the created file node, or undefined on failure (nothing is
+   * created). Absent → all image-creation affordances hide.
+   */
+  readonly onAddImage?: (file: File) => Promise<string | undefined>
 }
 
 /** Imperative surface for a page that needs to drive the viewport from
@@ -239,6 +250,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       onOpenFileRef,
       paletteLeading,
       resolveFileCanvas,
+      resolveFileImage,
+      onAddImage,
     },
     forwardedRef,
   ) {
@@ -413,8 +426,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           resolveFileLabel,
           resolveFileCanvas,
           expandFileNode,
+          resolveFileImage,
         }),
-      [canvas, resolvedMeasure, theme, resolveFileLabel, resolveFileCanvas, expandFileNode],
+      [
+        canvas,
+        resolvedMeasure,
+        theme,
+        resolveFileLabel,
+        resolveFileCanvas,
+        expandFileNode,
+        resolveFileImage,
+      ],
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
@@ -1305,6 +1327,48 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
     }
 
+    /** Default frame for a created image node; the picture letterboxes into it. */
+    const IMAGE_NODE_WIDTH = 240
+    const IMAGE_NODE_HEIGHT = 180
+    const imageInputRef = useRef<HTMLInputElement | null>(null)
+    /** Where the pending picker-created image should land; null = viewport center. */
+    const pendingImagePointRef = useRef<Point | null>(null)
+
+    const createImageNodeAt = (file: string, at?: Point) => {
+      const root = rootRef.current
+      const centerScreen =
+        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+      const preferred = screenToCanvas(centerScreen, viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point =
+        at ??
+        findFreeSpot(preferred, { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT }, occupied)
+      const id = newId()
+      const node: SpatialNode = {
+        id,
+        type: 'file',
+        x: Math.round(point.x - IMAGE_NODE_WIDTH / 2),
+        y: Math.round(point.y - IMAGE_NODE_HEIGHT / 2),
+        width: IMAGE_NODE_WIDTH,
+        height: IMAGE_NODE_HEIGHT,
+        file,
+      }
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [{ kind: 'create-node', node }],
+        selectedId: id,
+      })
+      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+    }
+
+    /** Stores the image via the host seam, then creates the node. */
+    const addImageFile = (file: File, at?: Point) => {
+      if (onAddImage === undefined || !file.type.startsWith('image/')) return
+      void onAddImage(file).then((ref) => {
+        if (ref !== undefined) createImageNodeAt(ref, at)
+      })
+    }
+
     /** The one place a stored URL is turned into navigation. noopener keeps
      * the canvas tab unreachable from the opened page, and the scheme guard
      * holds HERE (not only in the dialog) because canvases arrive via sync
@@ -1441,6 +1505,30 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }}
         onPointerDown={handlePointerDown}
         onContextMenu={handleContextMenu}
+        // Image intake: drop anywhere on the canvas, or paste — both route
+        // through the same host storage seam as the picker.
+        onDragOver={(e) => {
+          if (onAddImage !== undefined && e.dataTransfer.types.includes('Files')) {
+            e.preventDefault()
+          }
+        }}
+        onDrop={(e) => {
+          if (onAddImage === undefined) return
+          const file = [...e.dataTransfer.files].find((f) => f.type.startsWith('image/'))
+          if (file === undefined) return
+          e.preventDefault()
+          const root = rootRef.current
+          if (root === null) return
+          const local = clientPointToRootLocal(e, root)
+          addImageFile(file, screenToCanvas(local, viewport))
+        }}
+        onPaste={(e) => {
+          if (onAddImage === undefined) return
+          const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith('image/'))
+          if (file === undefined) return
+          e.preventDefault()
+          addImageFile(file)
+        }}
         onKeyUp={(e) => {
           if (e.key === ' ') spaceDownRef.current = false
         }}
@@ -1462,9 +1550,35 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           onCreateCanvasRef={
             fileRefOptions === undefined ? undefined : () => setCanvasPicker({ mode: 'create' })
           }
+          onCreateImage={
+            onAddImage === undefined
+              ? undefined
+              : () => {
+                  pendingImagePointRef.current = null
+                  imageInputRef.current?.click()
+                }
+          }
           tool={tool}
           onToolChange={setTool}
         />
+        {onAddImage !== undefined && (
+          <input
+            ref={imageInputRef}
+            data-editor-overlay
+            data-testid="image-file-input"
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              e.target.value = ''
+              if (file !== undefined) {
+                addImageFile(file, pendingImagePointRef.current ?? undefined)
+                pendingImagePointRef.current = null
+              }
+            }}
+          />
+        )}
         {contextMenu !== null && (
           <ContextMenu
             x={contextMenu.x}
@@ -1648,6 +1762,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     label: 'Add canvas here',
                     icon: <FileBox />,
                     onSelect: () => setCanvasPicker({ mode: 'create', point: contextMenu.point }),
+                  })
+                }
+                if (onAddImage !== undefined) {
+                  emptyItems.push({
+                    label: 'Add image here',
+                    icon: <ImageIcon />,
+                    onSelect: () => {
+                      pendingImagePointRef.current = contextMenu.point
+                      imageInputRef.current?.click()
+                    },
                   })
                 }
                 return emptyItems

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2210,9 +2210,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               if (group === undefined || group.type !== 'group') return null
               return (
                 <TextNodeEditor
-                  // The label renders along the frame's top edge — the
-                  // editor covers that band rather than the whole frame.
-                  box={{ x: group.x, y: group.y, width: group.width, height: 48 }}
+                  // The label renders OUTSIDE, above the frame (container
+                  // convention) — the editor sits on that band.
+                  box={{ x: group.x, y: group.y - 44, width: group.width, height: 40 }}
                   initialText={group.label ?? ''}
                   testId="group-label-editor"
                   onCommit={(label) => {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -180,6 +180,12 @@ export interface SpatialEditorProps {
    * created). Absent → all image-creation affordances hide.
    */
   readonly onAddImage?: (file: File) => Promise<string | undefined>
+  /**
+   * Whether a file reference denotes a stored IMAGE asset rather than a
+   * canvas. Image references get no canvas actions (follow, retarget) —
+   * navigating to an asset reference is a dead end.
+   */
+  readonly isImageFileRef?: (file: string) => boolean
 }
 
 /** Imperative surface for a page that needs to drive the viewport from
@@ -252,6 +258,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       resolveFileCanvas,
       resolveFileImage,
       onAddImage,
+      isImageFileRef,
     },
     forwardedRef,
   ) {
@@ -481,14 +488,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (node === undefined) return undefined
       const rendered = renderCanvasToSvg(
         { nodes: [node], edges: [] },
-        { measure: resolvedMeasure, theme, resolveFileLabel },
+        { measure: resolvedMeasure, theme, resolveFileLabel, resolveFileImage },
       )
       return {
         svg: rendered.svg,
         originX: gestureState.startX - rendered.bounds.x,
         originY: gestureState.startY - rendered.bounds.y,
       }
-    }, [gestureState, canvas, resolvedMeasure, theme, resolveFileLabel])
+    }, [gestureState, canvas, resolvedMeasure, theme, resolveFileLabel, resolveFileImage])
 
     useImperativeHandle(
       forwardedRef,
@@ -967,8 +974,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           return
         }
         // A file node's double press follows the reference (navigate), the
-        // same primary-action rule as link nodes.
-        if (node?.type === 'file' && onOpenFileRef !== undefined) {
+        // same primary-action rule as link nodes. Image references are not
+        // followable — navigating to an asset id is a dead end.
+        if (
+          node?.type === 'file' &&
+          onOpenFileRef !== undefined &&
+          isImageFileRef?.(node.file) !== true
+        ) {
           applyResult(result)
           onOpenFileRef(node.file, node.subpath)
           return
@@ -1514,9 +1526,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }}
         onDrop={(e) => {
           if (onAddImage === undefined) return
+          if (e.dataTransfer.files.length === 0) return
+          // Cancel the browser's default file-drop handling (navigation to
+          // the file) for EVERY file drop, then only act on images.
+          e.preventDefault()
           const file = [...e.dataTransfer.files].find((f) => f.type.startsWith('image/'))
           if (file === undefined) return
-          e.preventDefault()
           const root = rootRef.current
           if (root === null) return
           const local = clientPointToRootLocal(e, root)
@@ -1797,7 +1812,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 })
                 items.push({ kind: 'separator' })
               }
-              if (node.type === 'file') {
+              if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
                 if (onOpenFileRef !== undefined) {
                   items.push({
                     label: 'Open canvas',

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -23,7 +23,16 @@
  * Marked `data-editor-overlay` so the canvas root's gesture handlers
  * ignore presses originating here (see SpatialEditor's isOverlayEvent).
  */
-import { FileBox, Frame, Link, MousePointer2, Plus, Spline, StickyNote } from 'lucide-react'
+import {
+  FileBox,
+  Frame,
+  Image as ImageIcon,
+  Link,
+  MousePointer2,
+  Plus,
+  Spline,
+  StickyNote,
+} from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
@@ -37,6 +46,8 @@ interface ToolPaletteProps {
   readonly onCreateGroup: () => void
   /** Absent when the host supplies no canvas listing — the entry hides. */
   readonly onCreateCanvasRef?: () => void
+  /** Absent when the host supplies no image storage — the entry hides. */
+  readonly onCreateImage?: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
 }
@@ -56,6 +67,7 @@ export function ToolPalette({
   onCreateLink,
   onCreateGroup,
   onCreateCanvasRef,
+  onCreateImage,
   tool,
   onToolChange,
 }: ToolPaletteProps) {
@@ -106,6 +118,15 @@ export function ToolPalette({
             label: 'Add canvas',
             icon: <FileBox aria-hidden="true" className="size-4" />,
             onSelect: onCreateCanvasRef,
+          },
+        ]
+      : []),
+    ...(onCreateImage !== undefined
+      ? [
+          {
+            label: 'Add image',
+            icon: <ImageIcon aria-hidden="true" className="size-4" />,
+            onSelect: onCreateImage,
           },
         ]
       : []),

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -1,0 +1,127 @@
+// Media file nodes (embed spec J5b): images arrive via the host's storage
+// seam (picker input, drop, paste) and render as <image> elements filling
+// the node's padded box. The reference is opaque to the editor; the host
+// resolves it to an href.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// A 1x1 transparent PNG.
+const PNG_HREF =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+
+function makeHost(initial: SpatialCanvas) {
+  const latest: { canvas: SpatialCanvas; commands: string[]; stored: File[] } = {
+    canvas: initial,
+    commands: [],
+    stored: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+          onAddImage={(file) => {
+            latest.stored.push(file)
+            return Promise.resolve(`asset:${latest.stored.length}`)
+          }}
+          resolveFileImage={(file) =>
+            file.startsWith('asset:') ? { href: PNG_HREF, alt: 'stored image' } : undefined
+          }
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function pngFile(): File {
+  return new File([new Uint8Array([137, 80, 78, 71])], 'chart.png', { type: 'image/png' })
+}
+
+it('picking an image via the + menu stores it and renders an <image> in the node', async () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+  const item = [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
+    (b) => b.getAttribute('aria-label') === 'Add image',
+  ) as HTMLElement
+  expect(item).toBeDefined()
+  fireEvent.click(item)
+
+  const input = container.querySelector('[data-testid="image-file-input"]') as HTMLInputElement
+  fireEvent.change(input, { target: { files: [pngFile()] } })
+
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
+  expect(latest.canvas.nodes[0]).toMatchObject({ type: 'file', file: 'asset:1' })
+  expect(latest.stored[0]?.name).toBe('chart.png')
+
+  await vi.waitFor(() => {
+    const image = container.querySelector('[data-testid="viewport-transform"] svg image')
+    expect(image).not.toBeNull()
+    expect(image?.getAttribute('href')).toBe(PNG_HREF)
+    expect(image?.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet')
+  })
+})
+
+it('dropping an image file creates the node at the drop point', async () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+
+  // Real Chromium: a native DragEvent carrying a genuine DataTransfer.
+  const dataTransfer = new DataTransfer()
+  dataTransfer.items.add(pngFile())
+  root.dispatchEvent(
+    new DragEvent('drop', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + 300,
+      clientY: r.top + 200,
+      dataTransfer,
+    }),
+  )
+
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
+  const node = latest.canvas.nodes[0]
+  // Centered on the drop point (identity viewport).
+  expect(node.x + node.width / 2).toBeCloseTo(300, 0)
+  expect(node.y + node.height / 2).toBeCloseTo(200, 0)
+})
+
+it('without the storage seam, image affordances hide and non-image drops are ignored', async () => {
+  function BareHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>({ nodes: [], edges: [] })
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      </div>
+    )
+  }
+  const { container } = render(<BareHost />)
+  expect(container.querySelector('[data-testid="image-file-input"]')).toBeNull()
+
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+  expect(
+    [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].some(
+      (b) => b.getAttribute('aria-label') === 'Add image',
+    ),
+  ).toBe(false)
+})

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -6,6 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -15,10 +16,16 @@ const PNG_HREF =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
 
 function makeHost(initial: SpatialCanvas) {
-  const latest: { canvas: SpatialCanvas; commands: string[]; stored: File[] } = {
+  const latest: {
+    canvas: SpatialCanvas
+    commands: string[]
+    stored: File[]
+    opened: string[]
+  } = {
     canvas: initial,
     commands: [],
     stored: [],
+    opened: [],
   }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
@@ -39,6 +46,8 @@ function makeHost(initial: SpatialCanvas) {
           resolveFileImage={(file) =>
             file.startsWith('asset:') ? { href: PNG_HREF, alt: 'stored image' } : undefined
           }
+          isImageFileRef={(file) => file.startsWith('asset:')}
+          onOpenFileRef={(file) => latest.opened.push(file)}
         />
       </div>
     )
@@ -124,4 +133,32 @@ it('without the storage seam, image affordances hide and non-image drops are ign
       (b) => b.getAttribute('aria-label') === 'Add image',
     ),
   ).toBe(false)
+})
+
+it('image references get no canvas actions: double-click never navigates, menu skips follow/retarget', async () => {
+  const withImage: SpatialCanvas = {
+    nodes: [{ id: 'i1', type: 'file', x: 100, y: 100, width: 240, height: 180, file: 'asset:img' }],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(withImage)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  expect(latest.opened).toEqual([])
+
+  const r = root.getBoundingClientRect()
+  root.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + 200,
+      clientY: r.top + 150,
+      button: 2,
+    }),
+  )
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).not.toContain('Open canvas')
+  expect(container.textContent).not.toContain('Change target')
 })

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -26,6 +26,10 @@ export interface RenderCanvasOptions {
   readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
   /** Passed through to layout: the LOD gate deciding card vs miniature. */
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
+  /** Passed through to layout: image content for media file nodes. */
+  readonly resolveFileImage?: (
+    file: string,
+  ) => { readonly href: string; readonly alt?: string } | undefined
 }
 
 export interface RenderedCanvas {
@@ -66,6 +70,7 @@ export function renderCanvasToSvg(
     resolveFileLabel: options.resolveFileLabel,
     resolveFileCanvas: options.resolveFileCanvas,
     expandFileNode: options.expandFileNode,
+    resolveFileImage: options.resolveFileImage,
   })
   const bounds = sceneBounds(scene)
   const svg = renderSceneToSvg(scene, {

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -12,6 +12,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
 import { getAppLogger } from './app-logger.js'
+import { CanvasFileStore } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
 
 const log = getAppLogger('canvas-embed-content')
@@ -36,4 +37,37 @@ export async function loadEmbeddedSpatialCanvas(
 /** The file references present in a canvas, deduplicated. */
 export function collectFileRefs(canvas: SpatialCanvas): readonly string[] {
   return [...new Set(canvas.nodes.flatMap((node) => (node.type === 'file' ? [node.file] : [])))]
+}
+
+/** Reference prefix distinguishing stored image assets from canvas ids. */
+export const IMAGE_REF_PREFIX = 'asset:'
+
+export function isImageRef(file: string): boolean {
+  return file.startsWith(IMAGE_REF_PREFIX)
+}
+
+/**
+ * Stores a picked/dropped/pasted image in the canvas file store and returns
+ * the reference for the created file node, or undefined on failure.
+ */
+export async function storeImageAsset(file: File): Promise<string | undefined> {
+  try {
+    const ref = `${IMAGE_REF_PREFIX}${crypto.randomUUID()}`
+    await new CanvasFileStore().put(ref, {
+      mimeType: file.type,
+      blob: file,
+      created: Date.now(),
+    })
+    return ref
+  } catch (err) {
+    log.warn('image asset store failed', { err })
+    return undefined
+  }
+}
+
+/** Loads a stored image asset as an object URL, or undefined when missing. */
+export async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
+  const blob = await new CanvasFileStore().get(ref)
+  if (blob === null) return undefined
+  return URL.createObjectURL(blob)
 }

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -40,7 +40,7 @@ export function collectFileRefs(canvas: SpatialCanvas): readonly string[] {
 }
 
 /** Reference prefix distinguishing stored image assets from canvas ids. */
-export const IMAGE_REF_PREFIX = 'asset:'
+const IMAGE_REF_PREFIX = 'asset:'
 
 export function isImageRef(file: string): boolean {
   return file.startsWith(IMAGE_REF_PREFIX)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -316,9 +316,18 @@ export function BrowserLocalCanvasPage({
       (loaded) => {
         if (cancelled) return
         setImageUrls((prev) => {
+          // When every load failed, keep the SAME map instance: a fresh
+          // (equal) map would re-trigger this effect and spin the failed
+          // reads forever. Failed refs retry only on the next canvas change.
+          let added = false
           const next = new Map(prev)
-          for (const [ref, url] of loaded) if (url !== undefined) next.set(ref, url)
-          return next
+          for (const [ref, url] of loaded) {
+            if (url !== undefined) {
+              next.set(ref, url)
+              added = true
+            }
+          }
+          return added ? next : prev
         })
       },
     )
@@ -565,6 +574,7 @@ export function BrowserLocalCanvasPage({
             resolveFileCanvas={resolveFileCanvas}
             resolveFileImage={resolveFileImage}
             onAddImage={storeImageAsset}
+            isImageFileRef={isImageRef}
             paletteLeading={
               <HistoryCluster
                 onUndo={() => void undo()}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -27,7 +27,13 @@ import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { collectFileRefs, loadEmbeddedSpatialCanvas } from '../lib/canvas-embed-content.js'
+import {
+  collectFileRefs,
+  isImageRef,
+  loadEmbeddedSpatialCanvas,
+  loadImageAssetUrl,
+  storeImageAsset,
+} from '../lib/canvas-embed-content.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -161,6 +167,17 @@ export function BrowserLocalCanvasPage({
   // updatedAt moves in the list (edits elsewhere show up on next refresh).
   const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, SpatialCanvas>>(new Map())
   const embedStampsRef = useRef<Map<string, string>>(new Map())
+  // Image assets are immutable once stored, so object URLs cache forever
+  // per session and are revoked together on unmount.
+  const [imageUrls, setImageUrls] = useState<ReadonlyMap<string, string>>(new Map())
+  const imageUrlsRef = useRef<ReadonlyMap<string, string>>(imageUrls)
+  imageUrlsRef.current = imageUrls
+  useEffect(
+    () => () => {
+      for (const url of imageUrlsRef.current.values()) URL.revokeObjectURL(url)
+    },
+    [],
+  )
   const listGenerationRef = useRef(0)
   // Fullscreen target for WorkspaceTopBar's onEnterFullscreen; the whole page
   // (editor + chrome), not just the Excalidraw canvas.
@@ -264,7 +281,7 @@ export function BrowserLocalCanvasPage({
   // Pre-fetch referenced canvases for inline embeds; refresh when the
   // referenced canvas's updatedAt moves in the list.
   useEffect(() => {
-    const refs = collectFileRefs(canvas)
+    const refs = collectFileRefs(canvas).filter((ref) => !isImageRef(ref))
     if (refs.length === 0) return
     let cancelled = false
     const stampOf = new Map(canvases.map((entry) => [entry.id, entry.updatedAt]))
@@ -291,6 +308,31 @@ export function BrowserLocalCanvasPage({
     }
   }, [canvas, canvases, embedContent])
   const resolveFileCanvas = useCallback((file: string) => embedContent.get(file), [embedContent])
+  useEffect(() => {
+    const refs = collectFileRefs(canvas).filter((ref) => isImageRef(ref) && !imageUrls.has(ref))
+    if (refs.length === 0) return
+    let cancelled = false
+    void Promise.all(refs.map(async (ref) => [ref, await loadImageAssetUrl(ref)] as const)).then(
+      (loaded) => {
+        if (cancelled) return
+        setImageUrls((prev) => {
+          const next = new Map(prev)
+          for (const [ref, url] of loaded) if (url !== undefined) next.set(ref, url)
+          return next
+        })
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [canvas, imageUrls])
+  const resolveFileImage = useCallback(
+    (file: string) => {
+      const href = imageUrls.get(file)
+      return href === undefined ? undefined : { href }
+    },
+    [imageUrls],
+  )
 
   const commands = useWhiteboardCommands({
     provider: { kind: 'browser-local', capabilities },
@@ -521,6 +563,8 @@ export function BrowserLocalCanvasPage({
               .map((entry) => ({ file: entry.id, label: entry.name }))}
             onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
             resolveFileCanvas={resolveFileCanvas}
+            resolveFileImage={resolveFileImage}
+            onAddImage={storeImageAsset}
             paletteLeading={
               <HistoryCluster
                 onUndo={() => void undo()}

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -337,6 +337,11 @@ describe('layoutSpatialCanvas', () => {
     const scene = layoutSpatialCanvas(canvas([labeled]), baseOptions())
     const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun')
     expect(label?.text).toBe('Section A')
+    // Container labels sit OUTSIDE the frame, above its top edge (the
+    // jsoncanvas.org convention) — that is what visually distinguishes a
+    // container from a regular node.
+    expect(label !== undefined && label.bbox.y + label.bbox.h <= labeled.y).toBe(true)
+    expect(label?.bbox.x).toBe(labeled.x)
 
     const unlabeled: Extract<SpatialNode, { type: 'group' }> = {
       ...labeled,

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -191,6 +191,23 @@ function placeInNode(
   return translateScene(content, node.x + padding, node.y + padding).nodes
 }
 
+/** Gap between a container's outside label and its frame's top edge. */
+const CONTAINER_LABEL_GAP_PX = 4
+
+/**
+ * Places a container's label OUTSIDE the frame, above its top-left corner
+ * — the jsoncanvas.org convention. An outside label is what visually
+ * distinguishes a container (group frame, expanded canvas embed) from a
+ * regular node, whose label stays inside its card.
+ */
+function placeAboveNode(node: SpatialNode, content: Scene): readonly SceneNode[] {
+  const bottom = Math.max(
+    0,
+    ...content.nodes.map((entry) => (entry.kind === 'edge' ? 0 : entry.bbox.y + entry.bbox.h)),
+  )
+  return translateScene(content, node.x, node.y - CONTAINER_LABEL_GAP_PX - bottom).nodes
+}
+
 /**
  * Composes a `text` node's chrome plus its laid-out markdown body. A
  * malformed body (one whose parsed mdast falls outside the caller's
@@ -279,16 +296,16 @@ function composeFileEmbed(
   })
   const bounds = sceneBounds(childScene)
   const padding = options.geometry.paddingPx
-  // The label band keeps the reference title readable above the miniature.
-  const labelBand = options.geometry.labelFontSizePx * 1.6
+  // The reference label sits OUTSIDE the frame (see placeAboveNode), so
+  // the miniature gets the whole padded box.
   const innerW = node.width - 2 * padding
-  const innerH = node.height - 2 * padding - labelBand
+  const innerH = node.height - 2 * padding
   const fit = Math.min(innerW / bounds.w, innerH / bounds.h, 1)
   if (!Number.isFinite(fit) || fit <= 0) return undefined
 
   const atOrigin = translateScene(childScene, -bounds.x, -bounds.y)
   const scaled = scaleScene(atOrigin, fit)
-  const placed = translateScene(scaled, node.x + padding, node.y + padding + labelBand)
+  const placed = translateScene(scaled, node.x + padding, node.y + padding)
   return {
     kind: 'embedResolved',
     bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
@@ -337,7 +354,7 @@ function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonl
         const label = labelOf(node, options)
         return label === undefined
           ? [chrome, embed]
-          : [chrome, ...placeInNode(node, { nodes: [labelRun(label, options)] }, options), embed]
+          : [chrome, ...placeAboveNode(node, { nodes: [labelRun(label, options)] }), embed]
       }
       break
     }
@@ -347,9 +364,15 @@ function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonl
   switch (node.type) {
     case 'text':
       return composeTextNode(node, options)
-    case 'file':
-    case 'link':
     case 'group': {
+      const chrome = chromeShape(node, options)
+      const label = labelOf(node, options)
+      return label === undefined
+        ? [chrome]
+        : [chrome, ...placeAboveNode(node, { nodes: [labelRun(label, options)] })]
+    }
+    case 'file':
+    case 'link': {
       const chrome = chromeShape(node, options)
       const label = labelOf(node, options)
       return label === undefined

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -90,6 +90,16 @@ export interface SpatialLayoutOptions {
    * editor decides by on-screen size, export by intrinsic size.
    */
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
+  /**
+   * Resolves a file node's reference to a renderable IMAGE (href emitted
+   * verbatim into the SVG — a data: URI in exports, a blob:/app URL in the
+   * editor). Checked BEFORE the canvas-embed seam and not LOD-gated: a
+   * scaled-down image is still a meaningful thumbnail, unlike crushed
+   * canvas content. `undefined` (or a throw) keeps the card.
+   */
+  readonly resolveFileImage?: (
+    file: string,
+  ) => { readonly href: string; readonly alt?: string } | undefined
 }
 
 /** Internal: options with geometry resolved exactly once per layout call. */
@@ -287,9 +297,40 @@ function composeFileEmbed(
   }
 }
 
+/** The image rendering of a file node: fills the padded box, aspect kept. */
+function composeFileImage(
+  node: Extract<SpatialNode, { type: 'file' }>,
+  options: ResolvedLayoutOptions,
+): SceneNode | undefined {
+  if (options.resolveFileImage === undefined) return undefined
+  let resolved: { readonly href: string; readonly alt?: string } | undefined
+  try {
+    resolved = options.resolveFileImage(node.file)
+  } catch {
+    resolved = undefined
+  }
+  if (resolved === undefined) return undefined
+  const padding = options.geometry.paddingPx
+  const w = node.width - 2 * padding
+  const h = node.height - 2 * padding
+  if (!(w > 0) || !(h > 0)) return undefined
+  return {
+    kind: 'image',
+    bbox: { x: node.x + padding, y: node.y + padding, w, h },
+    href: resolved.href,
+    ...(resolved.alt !== undefined ? { alt: resolved.alt } : {}),
+  }
+}
+
 function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonly SceneNode[] {
   switch (node.type) {
     case 'file': {
+      const image = composeFileImage(node, options)
+      if (image !== undefined) {
+        // Full-bleed image, no label run — the filename would overlap the
+        // picture; the accessible name travels on the image node itself.
+        return [chromeShape(node, options), image]
+      }
       const embed = composeFileEmbed(node, options)
       if (embed !== undefined) {
         const chrome = chromeShape(node, options)

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -168,14 +168,19 @@ function labelRun(text: string, options: ResolvedLayoutOptions): TextRunNode {
     sizePx: options.geometry.labelFontSizePx,
   }
   const metrics = options.measure(text, font)
+  // A TRUE top-left bbox with an explicit baseline — the earlier
+  // baseline-smuggled-into-bbox.y convention made every geometric
+  // computation over the box (outside-label placement, bounds) off by one
+  // ascent while rendering identically.
   return {
     kind: 'textRun',
     bbox: {
       x: 0,
-      y: metrics.ascent,
+      y: 0,
       w: metrics.advanceWidth,
       h: metrics.ascent + metrics.descent,
     },
+    baseline: metrics.ascent,
     text,
     appearance: { ...labelAppearance, fontSize: options.geometry.labelFontSizePx },
   }

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -163,6 +163,8 @@ describe('file-node images', () => {
     // Padded box of the 220x180 node at (100,100).
     expect(image.bbox.x).toBeGreaterThan(100)
     expect(image.bbox.w).toBeLessThan(220)
+    expect(image.bbox.y).toBeGreaterThan(100)
+    expect(image.bbox.h).toBeLessThan(180)
     // No label run overlaps the picture.
     expect(scene.nodes.some((n) => n.kind === 'textRun')).toBe(false)
   })

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -139,3 +139,49 @@ describe('file-node inline embeds', () => {
     expect(depth).toBe(3)
   })
 })
+
+describe('file-node images', () => {
+  it('renders a resolved image full-bleed in the padded box with the accessible name', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileImage: (file) =>
+          file === 'child' ? { href: 'data:image/png;base64,AAA', alt: 'A chart' } : undefined,
+      }),
+    )
+    const image = scene.nodes.find((n) => n.kind === 'image')
+    if (image === undefined || image.kind !== 'image') throw new Error('image expected')
+    expect(image.href).toBe('data:image/png;base64,AAA')
+    expect(image.alt).toBe('A chart')
+    // Padded box of the 220x180 node at (100,100).
+    expect(image.bbox.x).toBeGreaterThan(100)
+    expect(image.bbox.w).toBeLessThan(220)
+    // No label run overlaps the picture.
+    expect(scene.nodes.some((n) => n.kind === 'textRun')).toBe(false)
+  })
+
+  it('image resolution wins over the canvas-embed seam and failures keep the card', () => {
+    const both = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileImage: () => ({ href: 'data:image/png;base64,AAA' }),
+        resolveFileCanvas: () => childCanvas,
+        expandFileNode: () => true,
+      }),
+    )
+    expect(both.nodes.some((n) => n.kind === 'image')).toBe(true)
+    expect(both.nodes.some((n) => n.kind === 'embedResolved')).toBe(false)
+
+    const throwing = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileImage: () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+    expect(throwing.nodes.some((n) => n.kind === 'image')).toBe(false)
+    // The card label still renders.
+    expect(throwing.nodes.some((n) => n.kind === 'textRun')).toBe(true)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -66,6 +66,13 @@ describe('file-node inline embeds', () => {
     expect(box.bbox.x).toBeGreaterThanOrEqual(100)
     expect(box.bbox.x + box.bbox.w).toBeLessThanOrEqual(320)
     expect(box.bbox.y + box.bbox.h).toBeLessThanOrEqual(280)
+
+    // The reference label sits OUTSIDE, above the frame (container
+    // convention), leaving the whole padded box to the miniature.
+    const label = scene.nodes.find(
+      (n): n is import('../scene-graph.js').TextRunNode => n.kind === 'textRun',
+    )
+    expect(label !== undefined && label.bbox.y + label.bbox.h <= 100).toBe(true)
   })
 
   it('never upscales a small child (fit caps at 1)', () => {

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -200,6 +200,21 @@ export interface EmbedResolvedNode {
   readonly children: readonly SceneNode[]
 }
 
+/**
+ * A rendered raster/vector image. `href` is emitted verbatim as the SVG
+ * image reference — a data: URI in exports (deterministic given the same
+ * bytes), a blob:/app URL in the live editor. Aspect is always preserved
+ * (xMidYMid meet), so the bbox is the FRAME, not necessarily the painted
+ * extent.
+ */
+export interface ImageSceneNode {
+  readonly kind: 'image'
+  readonly bbox: BoundingBox
+  readonly href: string
+  /** Accessible name for the image; absent renders as presentation. */
+  readonly alt?: string
+}
+
 export interface GroupSceneNode {
   readonly kind: 'group'
   readonly bbox: BoundingBox
@@ -238,6 +253,7 @@ export type SceneNode =
   | TextRunNode
   | ResolvedEdgeNode
   | ShapeSceneNode
+  | ImageSceneNode
 
 /** A fully laid-out document: ordered top-level scene nodes in paint order. */
 export interface Scene {

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -693,3 +693,31 @@ describe('renderSceneToSvg — document envelope options', () => {
     ).toBe(true)
   })
 })
+
+describe('image nodes', () => {
+  it('emits <image> with fixed attribute order, escaped href, and title-as-alt', () => {
+    const svg = renderSceneToSvg({
+      nodes: [
+        {
+          kind: 'image',
+          bbox: { x: 10, y: 20, w: 100, h: 50 },
+          href: 'data:image/png;base64,A&B"C',
+          alt: 'A <chart>',
+        },
+      ],
+    })
+    expect(svg).toContain(
+      '<image x="10" y="20" width="100" height="50" href="data:image/png;base64,A&amp;B&quot;C" preserveAspectRatio="xMidYMid meet"><title>A &lt;chart&gt;</title></image>',
+    )
+  })
+
+  it('an alt-less image is marked presentation', () => {
+    const svg = renderSceneToSvg({
+      nodes: [
+        { kind: 'image', bbox: { x: 0, y: 0, w: 10, h: 10 }, href: 'data:image/png;base64,AA' },
+      ],
+    })
+    expect(svg).toContain('role="presentation"')
+    expect(svg).not.toContain('<title>')
+  })
+})

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -185,6 +185,18 @@ function renderNode(node: SceneNode): string {
     }
     case 'shape':
       return renderShape(node)
+    case 'image': {
+      // Fixed attribute order (x y width height href preserveAspectRatio)
+      // per this package's canonical-serialization rule. Aspect is always
+      // preserved; alt renders as a <title> child (the SVG accessible-name
+      // mechanism), absence marks the image as presentation.
+      const title =
+        node.alt !== undefined && node.alt.length > 0
+          ? `<title>${escapeXmlText(node.alt)}</title>`
+          : ''
+      const roleAttr = title === '' ? ` ${PRESENTATION_ATTR}` : ''
+      return `<image ${rectAttrs(node.bbox)} href="${escapeXmlAttr(node.href)}" preserveAspectRatio="xMidYMid meet"${roleAttr}>${title}</image>`
+    }
   }
 }
 

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -36,6 +36,7 @@ export function translateNode(node: SceneNode, dx: number, dy: number): SceneNod
     case 'svgFragment':
     case 'embedPlaceholder':
     case 'shape':
+    case 'image':
       return { ...node, bbox }
     case 'heading':
     case 'paragraph':


### PR DESCRIPTION
## Summary

J5b of the embed design plus a container-labeling refinement from live dogfooding (user feedback, 2026-08-08).

**Image file nodes**

- **canvas-render `ImageSceneNode`**: the scene graph's one image node — bbox is the frame (aspect always preserved via `xMidYMid meet`), `href` emits verbatim (data: URI in exports, blob:/app URL live), `alt` renders as a `<title>` child and its absence marks the image presentation. Bbox-only leaf for sceneBounds/translate/scale; server-core's translateNode covers the new kind.
- **`resolveFileImage` seam**: checked BEFORE the canvas-embed seam and not LOD-gated (a scaled-down image is still a meaningful thumbnail); any failure keeps the card. Full-bleed in the padded box, no overlapping label run.
- **Editor intake**: "Add image" in the + menu and the empty-space context menu (anchored at the click point), drop anywhere on the canvas (node centered on the drop point), and paste — all through the host's `onAddImage` storage seam; absent seam hides every affordance.
- **Browser-local wiring**: assets store under an `asset:` reference prefix in the existing `CanvasFileStore`; the page caches object URLs (revoked together on unmount) behind the synchronous resolver — images render live and survive reload from IndexedDB (verified).

**Container labels move outside** (user feedback while dogfooding, matching jsoncanvas.org): group frames and expanded canvas embeds draw their label ABOVE the frame — an outside label is what visually distinguishes a container from a regular node, whose label stays inside its card. The embed miniature gains the whole padded box, and the group-label editing band follows the label outside.

## Visual repro

Image node created through the real page path (stored in IndexedDB → object URL → `<image>`), auto-panned and selected:

![j5b-image-node.jpg](https://github.com/user-attachments/assets/b150c291-bcec-4f7d-a280-b9a035b941c9)

Embedded-canvas label now OUTSIDE the frame, miniature filling the padded box:

![j5b-outside-label.jpg](https://github.com/user-attachments/assets/b951a376-0d74-490c-8036-f0a8b062651d)

Also live-verified: the stored image survives a full page reload (IndexedDB) and its blob decodes.

## Test plan

- [x] canvas-render: image emission (fixed attribute order, escaped href, title-as-alt, presentation fallback), resolveFileImage compose (full-bleed, image-wins-over-embed, throw → card), container-label-outside placement for groups and expanded embeds — 264 passed
- [x] `image-node.browser.test.tsx` (real Chromium): + menu picker → store → `<image>` render, native-DragEvent drop placement at point, seam-absent affordance hiding (3 passed)
- [x] Full suites: web-browser 271 / jsdom 1443 / all 6006 (known `/pair` flake only); lint / knip / `pnpm -r typecheck` clean
- [x] Live verification in Chrome (screenshots above; reload persistence + blob decode probed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image support to the spatial canvas, including selection, drag-and-drop, paste, and context-menu insertion.
  * Images can be saved, loaded, and rendered with preserved aspect ratios and optional alternative text.
  * Added accessible SVG image output, including presentation semantics when alternative text is unavailable.
* **Improvements**
  * Image failures now preserve the surrounding card instead of breaking rendering.
  * Group and embedded-canvas labels now appear above their frames.
* **Tests**
  * Added coverage for image insertion, storage, rendering, accessibility, positioning, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->