### PR TITLE
feat: external iframe embeds with click-to-load facade

### DIFF
--- a/apps/web/src/components/spatial-editor/LinkEmbedLayer.tsx
+++ b/apps/web/src/components/spatial-editor/LinkEmbedLayer.tsx
@@ -1,0 +1,124 @@
+/**
+ * Editor-only iframe embeds for link nodes (embed spec J6). Rendered
+ * INSIDE the viewport-transform container so overlays ride pan/zoom like
+ * every canvas-space element; exports never contain any of this — the SVG
+ * card is the export form, and this layer only augments the live editor.
+ *
+ * Industry-standard shape (researched 2026-08-08): never auto-load
+ * iframes — a click-to-load facade per node, and at most
+ * MAX_LIVE_IFRAMES live at once (activating one more collapses the
+ * least-recently-activated back to its facade). The iframe is sandboxed
+ * without allow-same-origin, popups escape via the sandbox's own opener
+ * severing, and the referrer never leaves the app.
+ *
+ * Frame refusal (X-Frame-Options / frame-ancestors) is NOT reliably
+ * detectable from the parent — no error event fires — so there is no
+ * auto-degrade; the "open in new tab" affordance next to the collapse
+ * control is the escape hatch when a site refuses to render.
+ */
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { ExternalLink, Play, X } from 'lucide-react'
+import { useState } from 'react'
+import { isFollowableUrl } from './followable-url.js'
+
+const MAX_LIVE_IFRAMES = 3
+
+export interface LinkEmbedLayerProps {
+  readonly canvas: SpatialCanvas
+  /** The LOD gate: only link nodes this returns true for offer the facade. */
+  readonly shouldOffer: (node: Extract<SpatialNode, { type: 'link' }>) => boolean
+}
+
+export function LinkEmbedLayer({ canvas, shouldOffer }: LinkEmbedLayerProps) {
+  // Activation order doubles as the LRU: first entry is the oldest.
+  const [liveIds, setLiveIds] = useState<readonly string[]>([])
+
+  const linkNodes = canvas.nodes.filter(
+    (node): node is Extract<SpatialNode, { type: 'link' }> =>
+      node.type === 'link' && isFollowableUrl(node.url) && shouldOffer(node),
+  )
+  const liveSet = new Set(liveIds)
+
+  const activate = (id: string) => {
+    setLiveIds((prev) => {
+      const next = [...prev.filter((entry) => entry !== id), id]
+      return next.length > MAX_LIVE_IFRAMES ? next.slice(next.length - MAX_LIVE_IFRAMES) : next
+    })
+  }
+  const collapse = (id: string) => {
+    setLiveIds((prev) => prev.filter((entry) => entry !== id))
+  }
+
+  return (
+    <>
+      {linkNodes.map((node) =>
+        liveSet.has(node.id) ? (
+          <div
+            key={node.id}
+            data-editor-overlay
+            data-testid="link-embed-frame"
+            style={{
+              position: 'absolute',
+              left: node.x,
+              top: node.y,
+              width: node.width,
+              height: node.height,
+            }}
+            className="overflow-hidden rounded-md border bg-background shadow-sm"
+          >
+            <iframe
+              src={node.url}
+              title={node.url}
+              // No allow-same-origin: the embedded page runs in an opaque
+              // origin and cannot reach this app's storage or DOM.
+              sandbox="allow-scripts allow-popups"
+              referrerPolicy="no-referrer"
+              loading="lazy"
+              className="h-full w-full border-0"
+            />
+            <span className="absolute top-1 right-1 flex gap-1">
+              <a
+                href={node.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open in new tab"
+                className="flex size-6 items-center justify-center rounded bg-background/90 text-muted-foreground shadow hover:text-foreground"
+              >
+                <ExternalLink aria-hidden="true" className="size-3.5" />
+              </a>
+              <button
+                type="button"
+                aria-label="Collapse embed"
+                onClick={() => collapse(node.id)}
+                className="flex size-6 items-center justify-center rounded bg-background/90 text-muted-foreground shadow hover:text-foreground"
+              >
+                <X aria-hidden="true" className="size-3.5" />
+              </button>
+            </span>
+          </div>
+        ) : (
+          <button
+            key={node.id}
+            type="button"
+            data-editor-overlay
+            data-testid="link-embed-facade"
+            aria-label={`Load ${node.url}`}
+            onClick={() => activate(node.id)}
+            style={{
+              position: 'absolute',
+              // Centered on the node, small — the SVG card stays the
+              // visual; this is only the activation affordance.
+              left: node.x + node.width / 2 - 14,
+              top: node.y + node.height / 2 - 14 + 8,
+              width: 28,
+              height: 28,
+            }}
+            className="flex items-center justify-center rounded-full border bg-background/95 text-muted-foreground shadow hover:text-foreground"
+          >
+            <Play aria-hidden="true" className="size-3.5" />
+          </button>
+        ),
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -92,6 +92,7 @@ import {
 } from './geometry.js'
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
+import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
@@ -1968,6 +1969,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             // string and escapes text/attrs (see svg/format.ts) — the same
             // already-reviewed reasoning as CanvasViewer.tsx's identical sink.
             dangerouslySetInnerHTML={{ __html: svg }}
+          />
+          {/* Editor-only iframe embeds for link nodes (never in exports).
+              Rides the same transform as every canvas-space overlay; the
+              LOD gate mirrors the canvas-embed thresholds. */}
+          <LinkEmbedLayer
+            canvas={canvas}
+            shouldOffer={(node) =>
+              node.width * viewport.zoom >= EXPAND_MIN_W &&
+              node.height * viewport.zoom >= EXPAND_MIN_H
+            }
           />
           {marquee !== null && (
             <svg

--- a/apps/web/src/components/spatial-editor/link-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-embed.browser.test.tsx
@@ -1,0 +1,108 @@
+// External iframe embeds for link nodes (embed spec J6): a click-to-load
+// facade appears only above the LOD threshold; activation swaps in a
+// sandboxed iframe (no allow-same-origin, no referrer); at most three live
+// at once (LRU); collapse returns to the facade. Exports are untouched —
+// this layer is editor-only HTML.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const bigLink = (id: string, x: number) =>
+  ({
+    id,
+    type: 'link',
+    x,
+    y: 60,
+    width: 320,
+    height: 240,
+    url: `https://example.com/${id}`,
+  }) as const
+
+function makeHost(initial: SpatialCanvas) {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 1600, height: 600 }}>
+        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      </div>
+    )
+  }
+  return Host
+}
+
+it('offers the facade only above the LOD threshold, and activation swaps in a sandboxed iframe', async () => {
+  const canvas: SpatialCanvas = {
+    nodes: [
+      bigLink('l1', 60),
+      {
+        id: 'small',
+        type: 'link',
+        x: 500,
+        y: 60,
+        width: 200,
+        height: 60,
+        url: 'https://example.com/s',
+      },
+    ],
+    edges: [],
+  }
+  const Host = makeHost(canvas)
+  const { container } = render(<Host />)
+
+  const facades = container.querySelectorAll('[data-testid="link-embed-facade"]')
+  expect(facades).toHaveLength(1)
+
+  fireEvent.click(facades[0] as HTMLElement)
+  const frame = container.querySelector('[data-testid="link-embed-frame"] iframe')
+  expect(frame).not.toBeNull()
+  expect(frame?.getAttribute('src')).toBe('https://example.com/l1')
+  // Security posture: opaque origin, no referrer.
+  expect(frame?.getAttribute('sandbox')).toBe('allow-scripts allow-popups')
+  expect(frame?.getAttribute('referrerpolicy')).toBe('no-referrer')
+
+  // Collapse returns to the facade.
+  fireEvent.click(container.querySelector('[aria-label="Collapse embed"]') as HTMLElement)
+  expect(container.querySelector('[data-testid="link-embed-frame"]')).toBeNull()
+  expect(container.querySelectorAll('[data-testid="link-embed-facade"]')).toHaveLength(1)
+})
+
+it('caps live iframes at three — activating a fourth collapses the oldest', async () => {
+  const canvas: SpatialCanvas = {
+    nodes: [bigLink('a', 0), bigLink('b', 340), bigLink('c', 680), bigLink('d', 1020)],
+    edges: [],
+  }
+  const Host = makeHost(canvas)
+  const { container } = render(<Host />)
+
+  for (const label of ['a', 'b', 'c', 'd']) {
+    const facade = container.querySelector(
+      `[aria-label="Load https://example.com/${label}"]`,
+    ) as HTMLElement
+    fireEvent.click(facade)
+  }
+  const frames = [...container.querySelectorAll('[data-testid="link-embed-frame"] iframe')]
+  expect(frames).toHaveLength(3)
+  // 'a' (the oldest) collapsed back; b, c, d live.
+  expect(frames.map((f) => f.getAttribute('src'))).toEqual([
+    'https://example.com/b',
+    'https://example.com/c',
+    'https://example.com/d',
+  ])
+})
+
+it('never offers a facade for a non-followable URL scheme', async () => {
+  const canvas: SpatialCanvas = {
+    nodes: [{ ...bigLink('js', 60), url: 'javascript:alert(1)' } as never],
+    edges: [],
+  }
+  const Host = makeHost(canvas)
+  const { container } = render(<Host />)
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="spatial-editor"]')).not.toBeNull(),
+  )
+  expect(container.querySelector('[data-testid="link-embed-facade"]')).toBeNull()
+})


### PR DESCRIPTION
## Summary

J6, the final slice of the embed design: external URLs on link nodes become live, sandboxed iframe embeds — never auto-loaded.

- **Click-to-load facade**: link nodes above the LOD threshold (same on-screen-size gate as canvas embeds) offer a small Play button riding the viewport transform; below the threshold nothing is offered. Industry-standard shape — an iframe never loads without an explicit user activation.
- **Sandbox posture**: `sandbox="allow-scripts allow-popups"` (no `allow-same-origin` — the page runs in an opaque origin and cannot reach the app's storage or DOM), `referrerPolicy="no-referrer"`, `loading="lazy"`. Only followable (http/https) URLs ever offer the facade; `javascript:` and friends are excluded by the same `isFollowableUrl` gate as the open-URL sink.
- **Live budget (LRU)**: at most 3 iframes live at once; activating a fourth collapses the least-recently-activated back to its facade.
- **Escape hatch**: frame refusal (X-Frame-Options / frame-ancestors) is not detectable from the parent — no error event fires — so there is no auto-degrade; an open-in-new-tab control sits next to the collapse control.
- **Exports untouched**: the layer is editor-only HTML; the SVG card remains the export form.

## Visual repro

Facade above the LOD threshold (Play button on the link card):

![j6-facade.jpg](https://github.com/user-attachments/assets/6ed43a5b-8384-4243-af49-345ce171bc9b)

Activated: live sandboxed iframe rendering jsoncanvas.org, with open-in-new-tab + collapse controls:

![j6-live-iframe.jpg](https://github.com/user-attachments/assets/7d8a5761-ad7c-40ce-854a-b2489f7f5292)

Also live-verified: collapse returns the node to its facade.

## Test plan

- [x] `link-embed.browser.test.tsx` (real Chromium): facade only above LOD threshold; activation swaps in an iframe with the exact sandbox/referrer attributes; collapse returns the facade; LRU cap of 3 (fourth activation collapses the oldest); `javascript:` URL never offers a facade (3 passed)
- [x] Full suites: web-browser 275 / jsdom 1445 all green; lint clean
- [x] Live verification in Chrome (screenshots above; full facade → iframe → collapse cycle)
