### PR TITLE
feat: hand tool for one-pointer canvas panning

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -657,7 +657,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const screenPointForPan = clientPointToRootLocal(e, root)
       // Middle-button (or Space-held) drag pans from ANYWHERE — Excalidraw
       // semantics; a plain left drag on empty space marquee-selects instead.
-      if (e.button === 1 || (e.button === 0 && spaceDownRef.current)) {
+      // The hand tool makes EVERY plain press a pan (nodes included): it is
+      // the one-handed touch navigation mode, where a second finger is not
+      // available to promote the gesture.
+      if (e.button === 1 || (e.button === 0 && (spaceDownRef.current || tool === 'hand'))) {
         e.preventDefault()
         isPanningRef.current = true
         lastPanPointRef.current = screenPointForPan
@@ -1515,6 +1518,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           overflow: 'hidden',
           touchAction: 'none',
           outline: 'none',
+          cursor: tool === 'hand' ? 'grab' : undefined,
         }}
         onPointerDown={handlePointerDown}
         onContextMenu={handleContextMenu}

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -26,6 +26,7 @@
 import {
   FileBox,
   Frame,
+  Hand,
   Image as ImageIcon,
   Link,
   MousePointer2,
@@ -36,7 +37,7 @@ import {
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
-export type EditorTool = 'select' | 'connect'
+export type EditorTool = 'select' | 'hand' | 'connect'
 
 interface ToolPaletteProps {
   /** Host-supplied controls (undo/redo/versions) docked as the leading group. */
@@ -161,6 +162,21 @@ export function ToolPalette({
           </button>
         </TooltipTrigger>
         <TooltipContent>Select</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="hand-tool-button"
+            aria-pressed={tool === 'hand'}
+            aria-label="Hand (pan)"
+            onClick={() => onToolChange('hand')}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <Hand aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Hand — drag to pan</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -1,0 +1,110 @@
+// Hand tool: a dock mode where a single pointer drag pans the viewport
+// instead of selecting or moving nodes — the one-handed mobile
+// navigation path (two-finger pan stays available in every mode).
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 80, text: 'hello' }],
+  edges: [],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas; commands: string[] } = {
+    canvas: initial,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command.kind)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function transformOf(container: HTMLElement): string {
+  const vt = container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+  return vt.style.transform
+}
+
+function drag(root: HTMLElement, from: [number, number], to: [number, number]) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + from[0],
+    clientY: r.top + from[1],
+  })
+  fireEvent.pointerMove(root, {
+    pointerId: 1,
+    clientX: r.left + to[0],
+    clientY: r.top + to[1],
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    clientX: r.left + to[0],
+    clientY: r.top + to[1],
+  })
+}
+
+it('in hand mode a plain drag pans the viewport — over empty space AND over a node', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  const hand = container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement
+  expect(hand).not.toBeNull()
+  fireEvent.click(hand)
+  expect(hand.getAttribute('aria-pressed')).toBe('true')
+
+  const before = transformOf(container)
+  drag(root, [500, 400], [420, 340])
+  expect(transformOf(container)).not.toBe(before)
+
+  // Over the node (screen 100..300 x 100..180 at identity viewport... after
+  // the pan above the node moved; drag across its current screen position):
+  const mid = transformOf(container)
+  drag(root, [120, 120], [200, 220])
+  expect(transformOf(container)).not.toBe(mid)
+
+  // Panning never mutated the canvas and never started a node move.
+  expect(latest.commands).toEqual([])
+  expect(latest.canvas.nodes[0]).toMatchObject({ x: 100, y: 100 })
+  // And no selection was made along the way.
+  expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+})
+
+it('switching back to select restores normal behavior (drag on a node selects it)', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+  fireEvent.click(container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
+  fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
+
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 150,
+    clientY: r.top + 130,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 150, clientY: r.top + 130 })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+})


### PR DESCRIPTION
## Summary

User request from mobile dogfooding: panning on a phone required a second finger, so one-handed use had no way to move the canvas.

- **Hand tool in the dock** (between Select and Connect): in hand mode every plain press — mouse or single touch, over empty space or over a node — pans the viewport, joining the existing middle-button/Space pan path. Nothing selects, nothing moves, no canvas mutation.
- Cursor switches to `grab`; two-finger pan/pinch stays available in every mode.
- Select/Connect behavior is untouched when switching back.

## Visual repro

Hand tool active in the dock (single-pointer drag pans):

![hand-tool.jpg](https://github.com/user-attachments/assets/0d942c23-e1be-4375-aeaa-caf2e209c305)

Live-verified in Chrome: single-touch pointer drag pans the viewport, no selection appears, and the canvas data is unchanged.

## Test plan

- [x] `hand-tool.browser.test.tsx` (real Chromium): hand-mode drag pans over empty space AND over a node with zero commands emitted and no selection; switching back to select restores node selection (2 passed)
- [x] Full suites: web-browser 277 / jsdom 1445 all green; lint clean
