### PR TITLE
fix: allow https iframes in the Pages CSP

### DIFF
--- a/apps/web/public-headers.test.ts
+++ b/apps/web/public-headers.test.ts
@@ -50,4 +50,16 @@ describe('public/_headers', () => {
     const csp = globalHeaders?.get('Content-Security-Policy') ?? ''
     expect(csp).toContain("worker-src 'self'")
   })
+
+  it('permits https frame-src so link-node iframe embeds are not blocked by our own CSP', () => {
+    // Without an explicit frame-src, child iframes fall back to
+    // default-src 'self' and every external embed renders as Chrome's
+    // "content blocked" page on the deployed origin (local dev has no
+    // _headers, so only production surfaced it). https: is sufficient:
+    // http iframes on the https origin are mixed content and blocked by
+    // the browser before CSP is consulted.
+    const globalHeaders = blocks.get('/*')
+    const csp = globalHeaders?.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain('frame-src https:')
+  })
 })

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,7 +3,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; worker-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; worker-src 'self'; frame-src https:
 
 # Cloudflare Pages applies the most specific matching path, so these two
 # path-scoped rules layer on top of `/*` above rather than replacing it.


### PR DESCRIPTION
## Summary

User report: link-node iframe embeds render as Chrome's このコンテンツはブロックされました page on the deployed app (mobile screenshot). Root cause: `public/_headers` declares a CSP with **no `frame-src`**, so child iframes fall back to `default-src 'self'` and every external embed is blocked by our own policy. Local dev serves no `_headers`, which is why only production surfaced it.

Fix: add `frame-src https:` to the global CSP. `https:` is sufficient — `http:` iframes on the https origin are mixed content and are blocked by the browser before CSP is consulted, and the editor's followable-url gate already restricts embeds to http/https.

## Test plan

- [x] `public-headers.test.ts` gains a red-first assertion that the CSP contains `frame-src https:` (4 passed)
- [ ] Verify on the Cloudflare Pages preview deployment that a link-node embed actually renders before merging (local cannot reproduce — headers only apply on Pages)