### PR TITLE
feat: hand tool as the default view-only mode with zoom controls

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -50,6 +50,7 @@ function ControlledEditor({
   const [canvas, setCanvas] = useState(initial)
   return (
     <SpatialEditor
+      defaultTool="select"
       canvas={canvas}
       onChange={(next, command) => {
         setCanvas(next)
@@ -81,7 +82,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     const { container } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const rects = container.querySelectorAll('svg rect')
@@ -93,7 +99,12 @@ describe('SpatialEditor (browser)', () => {
     const canvasValue = twoNodeCanvas()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={canvasValue} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvasValue}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -139,7 +150,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -164,7 +180,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -220,6 +241,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={twoNodeCanvas()}
           onChange={onChange}
           measure={fakeMeasure}
@@ -270,7 +292,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -312,6 +339,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={twoNodeCanvas()}
           onChange={onChange}
           measure={fakeMeasure}
@@ -358,7 +386,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -400,7 +433,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -446,7 +484,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -507,7 +550,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     const { container } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -564,7 +612,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -585,7 +638,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     const { container } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -619,7 +677,12 @@ describe('SpatialEditor (browser)', () => {
     const releaseSpy = vi.spyOn(HTMLElement.prototype, 'releasePointerCapture')
     const { unmount } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -650,7 +713,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -719,7 +787,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -791,6 +864,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={twoNodeCanvas()}
           onChange={onChange}
           measure={fakeMeasure}
@@ -875,7 +949,12 @@ describe('SpatialEditor (browser)', () => {
     const measure = vi.fn(fakeMeasure)
     const { container } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={measure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={measure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -954,6 +1033,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           ref={ref}
           canvas={twoNodeCanvas()}
           onChange={onChange}
@@ -1024,7 +1104,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1063,7 +1148,12 @@ describe('SpatialEditor (browser)', () => {
     const initial = twoNodeCanvas()
     const { rerender } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={initial} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={initial}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1095,7 +1185,12 @@ describe('SpatialEditor (browser)', () => {
     }
     rerender(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={sameTargetStillValid} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={sameTargetStillValid}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     expect(page.getByTestId('drag-preview').element()).toBeTruthy()
@@ -1171,6 +1266,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={twoNodeCanvas()}
           onChange={onChange}
           measure={fakeMeasure}
@@ -1197,6 +1293,7 @@ describe('SpatialEditor (browser)', () => {
     render(
       <div style={{ width: 600, height: 400 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={twoNodeCanvas()}
           onChange={onChange}
           measure={fakeMeasure}
@@ -1223,7 +1320,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     const { container } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1260,7 +1362,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1291,7 +1398,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1520,7 +1632,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     const { rerender } = render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1545,6 +1662,7 @@ describe('SpatialEditor (browser)', () => {
       rerender(
         <div style={{ width: 600, height: 400 }}>
           <SpatialEditor
+            defaultTool="select"
             canvas={withoutA}
             onChange={onChange}
             measure={fakeMeasure}
@@ -1569,7 +1687,12 @@ describe('SpatialEditor (browser)', () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={twoNodeCanvas()}
+          onChange={onChange}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const editor = page.getByTestId('spatial-editor')
@@ -1657,7 +1780,7 @@ describe('SpatialEditor (browser) — spatial text layout defects', () => {
     const onChange = vi.fn()
     const { container } = render(
       <div style={{ width: 900, height: 600 }}>
-        <SpatialEditor canvas={fourDefectCanvas()} onChange={onChange} />
+        <SpatialEditor defaultTool="select" canvas={fourDefectCanvas()} onChange={onChange} />
       </div>,
     )
 
@@ -1848,7 +1971,12 @@ describe('node placement and affordances', () => {
     // name lives on aria-label (what assistive tech and tooltips read).
     render(
       <div style={{ width: 600, height: 400 }}>
-        <SpatialEditor canvas={{ nodes: [], edges: [] }} onChange={vi.fn()} measure={fakeMeasure} />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={{ nodes: [], edges: [] }}
+          onChange={vi.fn()}
+          measure={fakeMeasure}
+        />
       </div>,
     )
     const button = page.getByTestId('add-button').element() as HTMLButtonElement

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -37,7 +37,12 @@ describe('Add button (creation menu)', () => {
   it('opens the + menu whose entries create without a selection', () => {
     const onChange = vi.fn()
     const { getByTestId, getByRole } = render(
-      <SpatialEditor canvas={twoNodeCanvas()} onChange={onChange} measure={fakeMeasure} />,
+      <SpatialEditor
+        defaultTool="select"
+        canvas={twoNodeCanvas()}
+        onChange={onChange}
+        measure={fakeMeasure}
+      />,
     )
     const button = getByTestId('add-button') as HTMLButtonElement
     expect(button.tagName).toBe('BUTTON')
@@ -67,7 +72,12 @@ describe('Add button (creation menu)', () => {
       },
     )
     const { getByTestId } = render(
-      <SpatialEditor canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+      <SpatialEditor
+        defaultTool="select"
+        canvas={twoNodeCanvas()}
+        onChange={vi.fn()}
+        measure={fakeMeasure}
+      />,
     )
     const button = getByTestId('add-button') as HTMLButtonElement
     fireEvent.click(button)
@@ -85,7 +95,13 @@ describe('SpatialEditorHandle', () => {
   it('setViewport applies the given viewport to the rendered transform', () => {
     const ref = createRef<SpatialEditorHandle>()
     const { container } = render(
-      <SpatialEditor ref={ref} canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+      <SpatialEditor
+        defaultTool="select"
+        ref={ref}
+        canvas={twoNodeCanvas()}
+        onChange={vi.fn()}
+        measure={fakeMeasure}
+      />,
     )
     expect(transformOf(container)).toBe('scale(1) translate(0px, 0px)')
 
@@ -99,7 +115,13 @@ describe('SpatialEditorHandle', () => {
   it('fitToContent(nodeIds) fits the viewport to only the named nodes', () => {
     const ref = createRef<SpatialEditorHandle>()
     const { container } = render(
-      <SpatialEditor ref={ref} canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+      <SpatialEditor
+        defaultTool="select"
+        ref={ref}
+        canvas={twoNodeCanvas()}
+        onChange={vi.fn()}
+        measure={fakeMeasure}
+      />,
     )
 
     act(() => {
@@ -114,7 +136,13 @@ describe('SpatialEditorHandle', () => {
   it('fitToContent() with no ids fits the viewport to every node', () => {
     const ref = createRef<SpatialEditorHandle>()
     const { container } = render(
-      <SpatialEditor ref={ref} canvas={twoNodeCanvas()} onChange={vi.fn()} measure={fakeMeasure} />,
+      <SpatialEditor
+        defaultTool="select"
+        ref={ref}
+        canvas={twoNodeCanvas()}
+        onChange={vi.fn()}
+        measure={fakeMeasure}
+      />,
     )
 
     act(() => {
@@ -147,6 +175,7 @@ describe('SpatialEditor externalVersion origin handling', () => {
     const canvasValue = twoNodeCanvas()
     const { container, rerender } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={canvasValue}
         externalVersion={0}
         onChange={onChange}
@@ -159,6 +188,7 @@ describe('SpatialEditor externalVersion origin handling', () => {
     // Same node contents (the undo/redo shape) but externalVersion advanced.
     rerender(
       <SpatialEditor
+        defaultTool="select"
         canvas={{ ...canvasValue }}
         externalVersion={1}
         onChange={onChange}
@@ -178,6 +208,7 @@ describe('SpatialEditor externalVersion origin handling', () => {
     const canvasValue = twoNodeCanvas()
     const { container, rerender } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={canvasValue}
         externalVersion={0}
         onChange={onChange}
@@ -191,6 +222,7 @@ describe('SpatialEditor externalVersion origin handling', () => {
     // own controlled re-render after onChange, not an external replacement.
     rerender(
       <SpatialEditor
+        defaultTool="select"
         canvas={{ ...canvasValue }}
         externalVersion={0}
         onChange={onChange}
@@ -217,6 +249,7 @@ describe('bottom dock composition', () => {
     // overlap this redesign replaces).
     const { container } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={{ nodes: [], edges: [] }}
         onChange={vi.fn()}
         measure={fakeMeasure}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -49,6 +49,7 @@ import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
   ExternalLink,
   FileBox,
+  Focus,
   Frame,
   Image as ImageIcon,
   Link,
@@ -61,6 +62,8 @@ import {
   StickyNote,
   Tag,
   Trash2,
+  ZoomIn,
+  ZoomOut,
 } from 'lucide-react'
 import {
   forwardRef,
@@ -97,7 +100,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
-import { type EditorTool, ToolPalette } from './ToolPalette.js'
+import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   canvasToScreen,
@@ -152,6 +155,13 @@ export interface SpatialEditorProps {
    * `resolvedTheme` or its nodes/edges go invisible in dark mode.
    */
   readonly theme?: ResolvedTheme
+  /**
+   * The tool active on mount. Defaults to 'hand' — the product opens in
+   * navigation mode (user decision 2026-08-08): a plain drag pans and no
+   * press can select, move, or edit until the user switches to Select.
+   * Tests exercising editing flows pass 'select' explicitly.
+   */
+  readonly defaultTool?: EditorTool
   /**
    * Canvas references the picker offers for file nodes. The reference is an
    * OPAQUE string owned by the composition root (browser-local canvas id,
@@ -209,6 +219,9 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  * common OS double-click interval; not user-configurable today.
  */
 const DOUBLE_PRESS_WINDOW_MS = 400
+
+/** One click of the hand-mode zoom buttons scales by this factor. */
+const ZOOM_STEP_FACTOR = 1.25
 const ZOOM_WHEEL_FACTOR = 1.1
 /** Canvas-space px per arrow-key nudge on a focused resize handle; Shift multiplies by 4. */
 const RESIZE_KEYBOARD_STEP = 8
@@ -253,6 +266,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       className,
       testId = DEFAULT_TEST_ID,
       theme = 'light',
+      defaultTool = 'hand',
       fileRefOptions,
       onOpenFileRef,
       paletteLeading,
@@ -278,11 +292,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * ~30ms on an 80-node canvas — far past a frame budget).
      */
     const [livePoint, setLivePoint] = useState<Point | null>(null)
-    // OOUI interaction mode (S6/S7): Select is the default and matches the
-    // pre-tool behavior byte-for-byte; Connect arms object-first click-A,
-    // click-B edge creation. Creation is deliberately NOT a mode — the
-    // palette's Add note and double-click-anywhere both work in every mode.
-    const [tool, setTool] = useState<EditorTool>('select')
+    // OOUI interaction mode (S6/S7): Hand (navigation) is the default —
+    // Select restores the pre-tool editing behavior byte-for-byte; Connect
+    // arms object-first click-A, click-B edge creation. Creation is
+    // deliberately NOT a mode — the palette's Add note works in every mode.
+    const [tool, setTool] = useState<EditorTool>(defaultTool)
     /** Open right-click menu: screen position (root-relative) + hit target. */
     const [contextMenu, setContextMenu] = useState<{
       x: number
@@ -766,6 +780,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       // Replace the browser menu with the object's own action menu.
       e.preventDefault()
+      // Hand mode is navigation-ONLY: a touch long-press synthesises a
+      // contextmenu, and surfacing the edit menu there made phone panning
+      // fall into editing mid-gesture (user report 2026-08-08). Switching
+      // to Select is the explicit gate into editing affordances.
+      if (tool === 'hand') return
       const root = rootRef.current
       if (root === null) return
       const screenPoint = clientPointToRootLocal(e, root)
@@ -1263,11 +1282,47 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * CURRENT node boxes (read from `canvasRef.current`, not the possibly-
      * stale `canvas` prop) so two rapid clicks still see each other's result.
      */
-    const createNodeAtViewportCenter = () => {
+    /** Root-local screen point at the middle of the visible canvas. */
+    const viewportCenterScreen = () => {
       const root = rootRef.current
-      const centerScreen =
-        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const preferred = screenToCanvas(centerScreen, viewport)
+      return root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+    }
+
+    /** Hand-mode zoom controls: zoom about the viewport CENTER, not a pointer. */
+    const zoomAtViewportCenter = (factor: number) => {
+      setViewport((vp) => zoomAt(vp, viewportCenterScreen(), factor))
+    }
+
+    /**
+     * Pans so the union of all node boxes sits centered in the viewport,
+     * keeping the current zoom (the hand-mode "where did my content go"
+     * recovery). No boxes → no-op.
+     */
+    const centerContentInViewport = () => {
+      if (boxes.length === 0) return
+      let minX = Number.POSITIVE_INFINITY
+      let minY = Number.POSITIVE_INFINITY
+      let maxX = Number.NEGATIVE_INFINITY
+      let maxY = Number.NEGATIVE_INFINITY
+      for (const { box } of boxes) {
+        if (!Number.isFinite(box.x) || !Number.isFinite(box.y)) continue
+        minX = Math.min(minX, box.x)
+        minY = Math.min(minY, box.y)
+        maxX = Math.max(maxX, box.x + box.width)
+        maxY = Math.max(maxY, box.y + box.height)
+      }
+      if (!Number.isFinite(minX) || !Number.isFinite(minY)) return
+      const contentCenter = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+      const center = viewportCenterScreen()
+      setViewport((vp) => ({
+        zoom: vp.zoom,
+        x: contentCenter.x - center.x / vp.zoom,
+        y: contentCenter.y - center.y / vp.zoom,
+      }))
+    }
+
+    const createNodeAtViewportCenter = () => {
+      const preferred = screenToCanvas(viewportCenterScreen(), viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
       const point = findFreeSpot(
         preferred,
@@ -1563,7 +1618,54 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
         <ToolPalette
-          leading={paletteLeading}
+          // Hand mode is view-only, so the dock's leading slot shows VIEW
+          // controls (zoom in/out, 100% reset, center content) instead of
+          // the host's EDIT history cluster — undo/redo has nothing to act
+          // on in a mode where no press can change the canvas.
+          leading={
+            tool === 'hand' ? (
+              <>
+                <button
+                  type="button"
+                  data-testid="zoom-out-button"
+                  aria-label="Zoom out"
+                  onClick={() => zoomAtViewportCenter(1 / ZOOM_STEP_FACTOR)}
+                  className={TOOL_BUTTON_CLASS}
+                >
+                  <ZoomOut aria-hidden="true" className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="zoom-reset-button"
+                  aria-label="Reset zoom to 100%"
+                  onClick={() => zoomAtViewportCenter(1 / viewport.zoom)}
+                  className={`${TOOL_BUTTON_CLASS} w-12 text-xs tabular-nums`}
+                >
+                  {Math.round(viewport.zoom * 100)}%
+                </button>
+                <button
+                  type="button"
+                  data-testid="zoom-in-button"
+                  aria-label="Zoom in"
+                  onClick={() => zoomAtViewportCenter(ZOOM_STEP_FACTOR)}
+                  className={TOOL_BUTTON_CLASS}
+                >
+                  <ZoomIn aria-hidden="true" className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="zoom-center-button"
+                  aria-label="Center content"
+                  onClick={centerContentInViewport}
+                  className={TOOL_BUTTON_CLASS}
+                >
+                  <Focus aria-hidden="true" className="size-4" />
+                </button>
+              </>
+            ) : (
+              paletteLeading
+            )
+          }
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}
@@ -1579,7 +1681,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 }
           }
           tool={tool}
-          onToolChange={setTool}
+          onToolChange={(next) => {
+            setTool(next)
+            // A context menu is an edit affordance of the mode it was
+            // opened in — switching tools (especially into view-only hand
+            // mode) must not leave it floating.
+            setContextMenu(null)
+          }}
         />
         {onAddImage !== undefined && (
           <input

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -53,7 +53,7 @@ interface ToolPaletteProps {
   readonly onToolChange: (tool: EditorTool) => void
 }
 
-const TOOL_BUTTON_CLASS =
+export const TOOL_BUTTON_CLASS =
   'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
 
 interface AddMenuEntry {
@@ -148,21 +148,9 @@ export function ToolPalette({
           <div aria-hidden="true" className="mx-0.5 h-5 w-px bg-border" />
         </>
       )}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            data-testid="select-tool-button"
-            aria-pressed={tool === 'select'}
-            aria-label="Select"
-            onClick={() => onToolChange('select')}
-            className={TOOL_BUTTON_CLASS}
-          >
-            <MousePointer2 aria-hidden="true" className="size-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Select</TooltipContent>
-      </Tooltip>
+      {/* Hand leads the tool group: it is the DEFAULT (navigation-first,
+          user decision 2026-08-08), so it sits leftmost where the active
+          mode reads first. */}
       <Tooltip>
         <TooltipTrigger asChild>
           <button
@@ -177,6 +165,21 @@ export function ToolPalette({
           </button>
         </TooltipTrigger>
         <TooltipContent>Hand — drag to pan</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-testid="select-tool-button"
+            aria-pressed={tool === 'select'}
+            aria-label="Select"
+            onClick={() => onToolChange('select')}
+            className={TOOL_BUTTON_CLASS}
+          >
+            <MousePointer2 aria-hidden="true" className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Select</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -20,6 +20,7 @@ function Host({ onCommand }: { onCommand: (kind: string) => void }) {
   return (
     <div style={{ width: 800, height: 600 }}>
       <SpatialEditor
+        defaultTool="select"
         canvas={canvas}
         onChange={(next, command) => {
           onCommand(command.kind)

--- a/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
@@ -30,7 +30,12 @@ function makeHost(initial: SpatialCanvas) {
     latest.canvas = canvas
     return (
       <div style={{ width: 800, height: 600 }}>
-        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
       </div>
     )
   }

--- a/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
@@ -17,6 +17,7 @@ function renderAt(width: number) {
   return render(
     <div className="relative bg-background" style={{ width, height: 600 }}>
       <SpatialEditor
+        defaultTool="select"
         canvas={{ nodes: [], edges: [] }}
         onChange={vi.fn()}
         theme="light"
@@ -38,6 +39,27 @@ it('the dock keeps history and tools in ONE single-row container that fits a pho
   expect(palette.contains(cluster)).toBe(true)
 
   // The dock fits the narrow host in a single row.
+  const hostRect = host.getBoundingClientRect()
+  const dockRect = palette.getBoundingClientRect()
+  expect(dockRect.left).toBeGreaterThanOrEqual(hostRect.left)
+  expect(dockRect.right).toBeLessThanOrEqual(hostRect.right)
+  const tops = new Set(
+    [...palette.querySelectorAll('button')].map((b) => Math.round(b.getBoundingClientRect().top)),
+  )
+  expect(tops.size).toBe(1)
+})
+
+it('hand mode swaps history for the zoom cluster and still fits a phone width in one row', () => {
+  const { container } = renderAt(375)
+  const host = container.firstElementChild as HTMLElement
+  const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+
+  fireEvent.click(palette.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
+  expect(container.querySelector('[data-testid="history-cluster"]')).toBeNull()
+  expect(palette.querySelector('[data-testid="zoom-reset-button"]')).not.toBeNull()
+
+  // The wider zoom cluster (4 controls incl. the % readout) must not push
+  // the dock past the phone edge or wrap it to a second row.
   const hostRect = host.getBoundingClientRect()
   const dockRect = palette.getBoundingClientRect()
   expect(dockRect.left).toBeGreaterThanOrEqual(hostRect.left)

--- a/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
@@ -25,6 +25,7 @@ function makeHost(initial: SpatialCanvas) {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next) => setCanvas(next)}
           theme="light"

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -29,6 +29,7 @@ function makeHost(initial: SpatialCanvas, onOpen?: (file: string, subpath?: stri
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)
@@ -132,7 +133,12 @@ it('without host seams, neither the Add canvas button nor file follow-affordance
     const [canvas, setCanvas] = useState<SpatialCanvas>(bare)
     return (
       <div style={{ width: 800, height: 600 }}>
-        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
       </div>
     )
   }

--- a/apps/web/src/components/spatial-editor/connect-sides.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/connect-sides.browser.test.tsx
@@ -23,6 +23,7 @@ function Host({ onCommand }: { onCommand: (kind: string) => void }) {
   return (
     <div style={{ width: 800, height: 600 }}>
       <SpatialEditor
+        defaultTool="select"
         canvas={canvas}
         onChange={(next, command) => {
           onCommand(command.kind)

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -22,6 +22,7 @@ function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
   return (
     <div style={{ width: 800, height: 600 }}>
       <SpatialEditor
+        defaultTool="select"
         canvas={canvas}
         onChange={(next, command) => {
           onCommand?.(command.kind)
@@ -96,6 +97,7 @@ it('empty space offers the full creation set, anchored at the click point', asyn
       return (
         <div style={{ width: 800, height: 600 }}>
           <SpatialEditor
+            defaultTool="select"
             canvas={canvas}
             onChange={(next, command) => {
               l.commands.push(command.kind)
@@ -158,6 +160,7 @@ function makeEdgeHost() {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)
@@ -345,6 +348,7 @@ function makeNodeHost() {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
@@ -25,6 +25,7 @@ function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
   return (
     <div style={{ width: 800, height: 600 }}>
       <SpatialEditor
+        defaultTool="select"
         canvas={canvas}
         onChange={(next, command) => {
           onCommand?.(command.kind)

--- a/apps/web/src/components/spatial-editor/drag-content-preview.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-content-preview.browser.test.tsx
@@ -23,7 +23,12 @@ function Host() {
   const [canvas, setCanvas] = useState<SpatialCanvas>(start)
   return (
     <div style={{ width: 800, height: 600 }}>
-      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
@@ -34,6 +34,7 @@ function makeHost(start: SpatialCanvas) {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -29,6 +29,7 @@ function makeHost() {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -21,7 +21,12 @@ function Host() {
   const [canvas, setCanvas] = useState<SpatialCanvas>(start)
   return (
     <div style={{ width: 800, height: 600 }}>
-      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -32,6 +32,7 @@ function makeHost(initial: SpatialCanvas) {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -31,6 +31,7 @@ function makeHost() {
             setCanvas(next)
           }}
           theme="light"
+          paletteLeading={<span data-testid="host-leading" />}
         />
       </div>
     )
@@ -63,14 +64,22 @@ function drag(root: HTMLElement, from: [number, number], to: [number, number]) {
   })
 }
 
+it('hand is the DEFAULT tool and sits leftmost in the tool group', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const hand = container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement
+  expect(hand.getAttribute('aria-pressed')).toBe('true')
+  const buttons = [...container.querySelectorAll('[data-testid$="-tool-button"]')]
+  expect(buttons[0]?.getAttribute('data-testid')).toBe('hand-tool-button')
+})
+
 it('in hand mode a plain drag pans the viewport — over empty space AND over a node', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 
+  // Hand is already active by default — no tool switch needed.
   const hand = container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement
-  expect(hand).not.toBeNull()
-  fireEvent.click(hand)
   expect(hand.getAttribute('aria-pressed')).toBe('true')
 
   const before = transformOf(container)
@@ -90,12 +99,86 @@ it('in hand mode a plain drag pans the viewport — over empty space AND over a 
   expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
 })
 
-it('switching back to select restores normal behavior (drag on a node selects it)', () => {
+it('hand mode suppresses the long-press context menu — navigation only', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  // Android synthesises a contextmenu from a touch long-press; in hand
+  // mode that must not surface editing affordances.
+  fireEvent.contextMenu(root, { clientX: r.left + 150, clientY: r.top + 130 })
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+
+  fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
+  fireEvent.contextMenu(root, { clientX: r.left + 150, clientY: r.top + 130 })
+  expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+})
+
+it('hand mode swaps the leading history cluster for zoom controls; select mode swaps back', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+
+  // Hand (default): view-only mode — zoom controls, no host history.
+  expect(container.querySelector('[data-testid="host-leading"]')).toBeNull()
+  for (const id of ['zoom-out-button', 'zoom-reset-button', 'zoom-in-button', 'zoom-center-button'])
+    expect(container.querySelector(`[data-testid="${id}"]`)).not.toBeNull()
+
+  fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
+  expect(container.querySelector('[data-testid="host-leading"]')).not.toBeNull()
+  expect(container.querySelector('[data-testid="zoom-in-button"]')).toBeNull()
+})
+
+it('zoom controls: in/out change the scale, reset returns to 100%, center brings content to the middle', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const vt = () =>
+    (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style.transform
+  const zoomOf = (transform: string) => Number(/scale\(([\d.]+)\)/.exec(transform)?.[1])
+
+  fireEvent.click(container.querySelector('[data-testid="zoom-in-button"]') as HTMLElement)
+  expect(zoomOf(vt())).toBeGreaterThan(1)
+  const label = container.querySelector('[data-testid="zoom-reset-button"]') as HTMLElement
+  expect(label.textContent).not.toBe('100%')
+
+  fireEvent.click(label)
+  expect(zoomOf(vt())).toBe(1)
+  expect(label.textContent).toBe('100%')
+
+  fireEvent.click(container.querySelector('[data-testid="zoom-out-button"]') as HTMLElement)
+  expect(zoomOf(vt())).toBeLessThan(1)
+
+  // Center: the lone node's box (100,100 200x80) centers on the 800x600 root.
+  fireEvent.click(container.querySelector('[data-testid="zoom-center-button"]') as HTMLElement)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  const svgRect = (
+    container.querySelector('[data-testid="viewport-transform"] svg rect') as SVGRectElement
+  ).getBoundingClientRect()
+  const cx = svgRect.x + svgRect.width / 2 - r.x
+  const cy = svgRect.y + svgRect.height / 2 - r.y
+  expect(Math.abs(cx - r.width / 2)).toBeLessThan(2)
+  expect(Math.abs(cy - r.height / 2)).toBeLessThan(2)
+})
+
+it('switching tools closes an open context menu — no edit affordance survives into hand mode', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+
+  fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
+  fireEvent.contextMenu(root, { clientX: r.left + 400, clientY: r.top + 300 })
+  expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+
+  fireEvent.click(container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+})
+
+it('switching to select restores normal behavior (press on a node selects it)', () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 
-  fireEvent.click(container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
   fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
 
   const r = root.getBoundingClientRect()

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -33,6 +33,7 @@ function makeHost(initial: SpatialCanvas) {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)
@@ -120,7 +121,12 @@ it('without the storage seam, image affordances hide and non-image drops are ign
     const [canvas, setCanvas] = useState<SpatialCanvas>({ nodes: [], edges: [] })
     return (
       <div style={{ width: 800, height: 600 }}>
-        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
       </div>
     )
   }

--- a/apps/web/src/components/spatial-editor/link-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-embed.browser.test.tsx
@@ -27,7 +27,12 @@ function makeHost(initial: SpatialCanvas) {
     const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
     return (
       <div style={{ width: 1600, height: 600 }}>
-        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
       </div>
     )
   }

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -37,6 +37,7 @@ function makeHost(initial: SpatialCanvas) {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
@@ -26,7 +26,12 @@ function Host() {
   latest = canvas
   return (
     <div style={{ width: 800, height: 600 }}>
-      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
@@ -25,7 +25,12 @@ function Host() {
   latest = canvas
   return (
     <div style={{ width: 800, height: 600 }}>
-      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
     </div>
   )
 }

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -27,6 +27,7 @@ function makeHost() {
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
+          defaultTool="select"
           canvas={canvas}
           onChange={(next, command) => {
             latest.commands.push(command.kind)

--- a/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
@@ -42,6 +42,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     document.documentElement.classList.add('dark')
     const { container } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={twoNodeCanvasWithEdge()}
         onChange={() => {}}
         measure={fakeMeasure}
@@ -67,6 +68,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
   it('renders light-mode chrome with the light palette stroke (#737373)', () => {
     const { container } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={twoNodeCanvasWithEdge()}
         onChange={() => {}}
         measure={fakeMeasure}
@@ -83,6 +85,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
   it('sets the host element fill to the theme text color, the seam markdown body runs inherit', () => {
     const { container } = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={twoNodeCanvasWithEdge()}
         onChange={() => {}}
         measure={fakeMeasure}
@@ -97,6 +100,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
   it('does not change scene geometry between themes — only color attributes differ', () => {
     const light = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={twoNodeCanvasWithEdge()}
         onChange={() => {}}
         measure={fakeMeasure}
@@ -109,6 +113,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     cleanup()
     const dark = render(
       <SpatialEditor
+        defaultTool="select"
         canvas={twoNodeCanvasWithEdge()}
         onChange={() => {}}
         measure={fakeMeasure}

--- a/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-pan-zoom.browser.test.tsx
@@ -20,7 +20,12 @@ function Host() {
   })
   return (
     <div style={{ width: 800, height: 600 }}>
-      <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
     </div>
   )
 }

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -115,6 +115,9 @@ describe('DaemonCanvasPage', () => {
     })
 
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
     // WorkspaceTopBar's canvas switcher shows the current canvas and lists
     // every entry from controller.canvases — this pins the CanvasSummary
     // {slug, updatedAt} -> WorkspaceTopBar CanvasInfo mapping end to end.
@@ -133,6 +136,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
     // The bar's History button is the real versions-capability affordance
     // now that WorkspaceTopBar owns it (see WorkspaceTopBar.tsx).
     expect(screen.getByRole('button', { name: /history/i })).toBeTruthy()
@@ -159,6 +165,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
       expect(Array.from(workspaceSelect.options).map((o) => o.value)).toEqual(['w1', 'w2'])
@@ -187,6 +196,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
       expect(createdBackends).toHaveLength(1)
       expect(createdBackends[0]?.workspaceId).toBe('w1')
 
@@ -225,6 +237,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
       await act(async () => {
@@ -255,6 +270,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
       expect(createdBackends).toHaveLength(1)
 
       mockListCanvases.mockRejectedValueOnce(new Error('daemon unreachable'))
@@ -294,6 +312,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByLabelText('Workspaces')).toBeNull()
       const teaser = screen.getByText('Workspaces')
@@ -309,6 +330,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
 
     const oldBackend = createdBackends[0]!
 
@@ -331,6 +355,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
     // Healthy session: the chip reads Synced.
     expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
 
@@ -361,6 +388,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
 
     expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
 
@@ -394,6 +424,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
@@ -424,6 +457,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
@@ -454,6 +490,9 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
@@ -552,6 +591,9 @@ describe('DaemonCanvasPage', () => {
       'brand-new',
     )
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Hand (view-only) is the default tool; the host history cluster only
+    // docks in Select mode, so tests exercising it switch first.
+    fireEvent.click(await screen.findByTestId('select-tool-button'))
   })
 
   it('shows the createError alert in the empty-canvases state when creation fails', async () => {
@@ -626,6 +668,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       toggleHistoryPanel()
       const saveButton = await screen.findByRole('button', { name: 'Save version' })
@@ -690,6 +735,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       // Dirty the doc via a remote update, exactly like the "drives
       // HeaderSaveDot dirty/clean" test does, so this test isolates the
@@ -760,6 +808,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       toggleHistoryPanel()
       const saveButton = await screen.findByRole('button', { name: 'Save version' })
@@ -792,6 +843,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByRole('button', { name: 'Save version' })).toBeNull()
     })
@@ -823,6 +877,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       toggleHistoryPanel()
       const saveButton = await screen.findByRole('button', { name: 'Save version' })
@@ -897,6 +954,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
@@ -949,6 +1009,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
@@ -985,6 +1048,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const versionButton = screen.getByRole('button', { name: 'Version history' })
       // The static CapabilityTeaser renders aria-disabled; the real toggle
@@ -1040,6 +1106,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const toggle = screen.getByRole('button', { name: 'Version history' })
       await act(async () => {
@@ -1134,6 +1203,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       await waitFor(() => expect(screen.getByTestId('header-branch-chip')).toBeTruthy())
       await waitFor(() => {
@@ -1170,6 +1242,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByTestId('header-branch-chip')).toBeNull()
       expect(screen.getByText('Variations')).toBeTruthy()
@@ -1190,6 +1265,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
       await waitFor(() => expect(screen.getByTestId('header-branch-chip')).toBeTruthy())
 
       const branchCallCountBefore = fetchMock.mock.calls.filter(([reqInput]) =>
@@ -1259,6 +1337,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const banner = await screen.findByTestId('header-branch-banner')
       expect(banner.textContent).toContain('feature-x')
@@ -1326,6 +1407,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByTestId('header-branch-banner')).toBeNull()
 
@@ -1361,6 +1445,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByTestId('merge-toast')).toBeNull()
 
@@ -1392,6 +1479,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       await act(async () => {
         dispatchMergeCommitted()
@@ -1420,6 +1510,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       await act(async () => {
         dispatchMergeCommitted({ preMergeVersionId: 'v-pre' })
@@ -1450,6 +1543,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByRole('button', { name: 'Back to canvas list' })).toBeNull()
     })
@@ -1467,6 +1563,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const button = screen.getByRole('button', { name: 'Back to canvas list' })
       fireEvent.click(button)
@@ -1539,6 +1638,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       await act(async () => {
         fireEvent.keyDown(window, { key: 's', metaKey: true })
@@ -1580,6 +1682,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByTestId('header-save-dot')).toBeNull()
 
@@ -1686,6 +1791,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       const summary = await screen.findByText('Import from this browser')
       fireEvent.click(summary)
@@ -1710,6 +1818,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
       await screen.findByText('Import from this browser')
 
       // <details> only hides collapsed content visually; the section (and its
@@ -1733,6 +1844,9 @@ describe('DaemonCanvasPage', () => {
         )
       })
       await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
 
       expect(screen.queryByText('Import from this browser')).toBeNull()
     })


### PR DESCRIPTION
## Summary

User feedback from mobile dogfooding, two parts:

**Hand is the default tool, leftmost in the dock.** A canvas now opens in navigation mode — the natural first act on a phone is looking around, not editing. `SpatialEditor` gains a `defaultTool` prop (product default `'hand'`; test harnesses exercising editing flows pass `'select'`).

**Hand mode is consistently view-only.** The reported inconsistency — long-press dropping into edit affordances mid-pan — is closed from three sides:

- The touch long-press `contextmenu` is suppressed in hand mode (switching to Select is the explicit gate into editing).
- Switching tools closes an open context menu, so no edit menu survives into hand mode (caught live during verification).
- The dock's leading slot swaps the host history cluster (edit chrome with nothing to act on in a mode where no press can change the canvas) for **view controls**: zoom out, a % readout that resets to 100%, zoom in, and center-content.

Select restores every editing affordance unchanged. Two-finger pan/pinch stays available in every mode.

## Visual repro

Hand mode (default) — zoom cluster docked left of the tools, hand active:

![hand-default-zoom-cluster.jpg](https://github.com/user-attachments/assets/4e9c54f0-ba8a-4de2-8b82-9f824453b152)

Live-verified in Chrome: hand default + leftmost order, zoom in ×2 → 156% readout, reset → 100%, center-content pans the union of nodes into view, long-press contextmenu suppressed in hand / working in Select, history cluster returns in Select.

## Test plan

- [x] `hand-tool.browser.test.tsx` (7): default+leftmost, drag-pans (empty AND over a node, zero commands), long-press suppression, zoom cluster swap, zoom in/out/reset/center math, menu-closes-on-tool-switch, select restores selection
- [x] `bottom-dock.browser.test.tsx`: hand mode's wider zoom cluster still fits a 375px phone in one row (real stylesheet)
- [x] Full suites: web-browser 283 / jsdom 1445 all green; `tsc --noEmit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Hand mode as the default Spatial Editor tool for navigating the canvas without selecting or modifying content.
  - Pan across empty space and nodes, with context menus suppressed while navigating.
  - Added viewport controls for zooming, resetting the view, and centering content.
  - Switch between Hand, Select, and Connect tools from the tool palette.
  - Added configuration to choose the editor’s initial tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->