### PR TITLE
feat: Cloudflare Pages header parity in local dev

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build && node scripts/copy-into-mcp-dist.mjs",
     "preview": "vite preview",
+    "preview:pages": "pnpm build && wrangler pages dev dist",
     "test": "vitest run && vitest run --config vitest.node.config.ts",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "docs:snapshots": "vitest run --config vitest.docs-snapshots.config.ts",

--- a/apps/web/vite-dev-headers.test.ts
+++ b/apps/web/vite-dev-headers.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { devHeadersFromCloudflareHeaders } from './vite-dev-headers.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const headersText = readFileSync(resolve(__dirname, 'public/_headers'), 'utf8')
+
+// The production `_headers` file only ships on Cloudflare Pages, so a CSP
+// mistake there is invisible in local dev (the frame-src gap shipped
+// exactly this way). These pin the dev server's parity layer: the global
+// block is applied to dev responses, with the ONE documented dev-only
+// amendment (inline scripts for the React fast-refresh preamble).
+describe('devHeadersFromCloudflareHeaders', () => {
+  const dev = devHeadersFromCloudflareHeaders(headersText)
+
+  it('applies the global security headers to dev responses verbatim', () => {
+    expect(dev.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(dev.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin')
+  })
+
+  it('keeps the production CSP resource policy — the frame-src gap must reproduce in dev', () => {
+    const csp = dev.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain('frame-src https:')
+    expect(csp).toContain("default-src 'self'")
+    expect(csp).toContain("worker-src 'self'")
+  })
+
+  it("amends script-src with 'unsafe-inline' ONLY (the react-refresh preamble is inline in dev)", () => {
+    const csp = dev.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'")
+    // The amendment is surgical: nothing else gains unsafe-inline.
+    expect(csp.match(/'unsafe-inline'/g)).toHaveLength(
+      (readFileSync(resolve(__dirname, 'public/_headers'), 'utf8').match(/'unsafe-inline'/g)
+        ?.length ?? 0) + 1,
+    )
+  })
+
+  it('never applies path-scoped blocks (sw.js cache rules are not dev concerns)', () => {
+    expect(dev.get('Cache-Control')).toBeUndefined()
+  })
+})

--- a/apps/web/vite-dev-headers.ts
+++ b/apps/web/vite-dev-headers.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Plugin } from 'vite'
+
+/**
+ * Dev-server parity for the Cloudflare Pages `_headers` file.
+ *
+ * Pages is the only place `public/_headers` is ever served, so a policy
+ * mistake there (a missing CSP directive, say) is invisible in local dev
+ * and first surfaces on the deployed origin. This plugin applies the
+ * file's global (`/*`) block to every dev/preview response so the
+ * production resource policy is exercised in the everyday dev loop.
+ *
+ * One deliberate dev-only amendment: `script-src` gains
+ * `'unsafe-inline'`, because @vitejs/plugin-react injects its
+ * fast-refresh preamble as an inline script in dev. Everything else —
+ * including what the policy BLOCKS — is verbatim, which is the point.
+ * Path-scoped blocks (sw.js cache rules) are deploy concerns and are not
+ * applied.
+ *
+ * For byte-exact Pages behavior (path blocks, redirects), use
+ * `pnpm preview:pages`, which serves the real build through wrangler.
+ */
+export function devHeadersFromCloudflareHeaders(headersText: string): Map<string, string> {
+  const headers = new Map<string, string>()
+  let currentPath: string | null = null
+  for (const rawLine of headersText.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+    if (line.startsWith('/')) {
+      currentPath = line
+      continue
+    }
+    if (currentPath !== '/*') continue
+    const separatorIndex = line.indexOf(':')
+    if (separatorIndex === -1) continue
+    const key = line.slice(0, separatorIndex).trim()
+    const value = line.slice(separatorIndex + 1).trim()
+    headers.set(key, value)
+  }
+  const csp = headers.get('Content-Security-Policy')
+  if (csp !== undefined) {
+    headers.set(
+      'Content-Security-Policy',
+      csp.replace(/script-src ([^;]*)/, "script-src $1 'unsafe-inline'"),
+    )
+  }
+  return headers
+}
+
+export function cloudflareDevHeadersPlugin(): Plugin {
+  const headersPath = resolve(dirname(fileURLToPath(import.meta.url)), 'public/_headers')
+  const applyTo = (server: {
+    middlewares: {
+      use: (fn: (req: unknown, res: unknown, next: () => void) => void) => void
+    }
+  }) => {
+    // Re-read per request: an edit to _headers takes effect on reload
+    // without restarting the dev server (the file is tiny).
+    server.middlewares.use((_req, res, next) => {
+      const headers = devHeadersFromCloudflareHeaders(readFileSync(headersPath, 'utf8'))
+      for (const [key, value] of headers) {
+        ;(res as { setHeader: (k: string, v: string) => void }).setHeader(key, value)
+      }
+      next()
+    })
+  }
+  return {
+    name: 'whiteboard:cloudflare-dev-headers',
+    configureServer: applyTo,
+    configurePreviewServer: applyTo,
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
+import { cloudflareDevHeadersPlugin } from './vite-dev-headers.js'
 import { stripWasmSourceMapPlugin } from './vite-plugin-strip-wasm-sourcemap.js'
 import { pwaOptions } from './vite-pwa-options.js'
 
@@ -104,6 +105,9 @@ export default defineConfig({
     // VitePWA hashes dist/ contents for the precache manifest in closeBundle,
     // so the wasm bytes must already be stripped when that hook runs.
     stripWasmSourceMapPlugin(),
+    // Production _headers parity in dev/preview responses — a CSP gap must
+    // reproduce locally, not first on the deployed Pages origin.
+    cloudflareDevHeadersPlugin(),
     VitePWA(pwaOptions),
   ],
 })

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: [
       'vite-pwa-options.test.ts',
       'public-headers.test.ts',
+      'vite-dev-headers.test.ts',
       'vite-plugin-strip-wasm-sourcemap.test.ts',
       'scripts/**/*.test.ts',
     ],

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -156,6 +156,23 @@ If behavior diverges, fall back to renaming `.mcp.json` to `.mcp.json.published`
 
 This does not affect normal published usage through `npx -y @kamiazya/whiteboard-mcp@latest`, because each launch is a fresh spawn.
 
+## Cloudflare Pages header parity in local dev
+
+`apps/web/public/_headers` (security headers, CSP) is only served by
+Cloudflare Pages, so a policy mistake there used to be invisible until the
+deployed origin broke (the missing `frame-src` shipped exactly this way).
+Two layers close that gap:
+
+- **Every `vite` dev/preview response** carries the `_headers` global block
+  via `apps/web/vite-dev-headers.ts`. The one dev-only amendment is
+  `script-src … 'unsafe-inline'` (the react-refresh preamble is inline);
+  everything else — including what the CSP blocks — matches production. A
+  CSP violation during normal dogfooding is therefore a real production
+  bug, not dev noise.
+- **Byte-exact Pages behavior** (path-scoped blocks, redirects):
+  `pnpm --filter @kamiazya/whiteboard-web preview:pages` builds and serves
+  `dist/` through `wrangler pages dev`.
+
 ## Test commands
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up to #484, answering "can header problems be caught locally?" — yes, two layers:

- **vite dev/preview parity** (`apps/web/vite-dev-headers.ts`): every dev response now carries the `public/_headers` global block. One documented dev-only amendment: `script-src` gains `'unsafe-inline'` (the react-refresh preamble is inline in dev). Everything else — including what the CSP *blocks* — is verbatim, so a CSP violation during normal dogfooding is a real production bug, not dev noise. The file is re-read per request, so `_headers` edits take effect on reload.
- **Byte-exact Pages behavior**: `pnpm --filter @kamiazya/whiteboard-web preview:pages` builds and serves `dist/` through `wrangler pages dev` (wrangler was already a devDependency), for path-scoped blocks and redirects.

Assessment of [vercel-labs/portless](https://github.com/vercel-labs/portless) (user suggestion): it provides stable `https://<name>.localhost` origins with real TLS, but does not emulate Pages `_headers` — it complements (nicer origins, https-only behaviors) rather than replaces this. Not wired in this PR; can be layered later if we want https-origin parity too.

## Test plan

- [x] `vite-dev-headers.test.ts` (web-node project, red-first): global headers verbatim, `frame-src https:` preserved (the #484 gap must reproduce in dev), surgical single `'unsafe-inline'` amendment, path-scoped blocks not applied (4 passed)
- [x] Live: dev server on :5199 serves the production CSP (+amendment); the app mounts, renders, and logs zero CSP violations under it
- [x] `tsc --noEmit` clean; docs updated (`docs/contributing/development.md`)