### PR TITLE
fix: entering hand mode drops selection, open editors, and armed connects

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1687,6 +1687,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             // opened in — switching tools (especially into view-only hand
             // mode) must not leave it floating.
             setContextMenu(null)
+            // Entering hand mode drops EVERY edit affordance, not just the
+            // menu: a surviving selection would keep Delete/resize/connect
+            // handles live, an open editor would keep accepting text, and
+            // an armed connect could still complete — all edits in a mode
+            // whose contract is "no press can change the canvas". The
+            // in-flight gesture is cancelled like Escape (uncommitted text
+            // is discarded, not committed).
+            if (next === 'hand') {
+              if (gestureState.kind !== 'idle') {
+                applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+              }
+              setSelectedId(null)
+              setExtraIds(new Set())
+              setSelectedEdgeId(null)
+              setEdgeLabelEditId(null)
+              setGroupLabelEditId(null)
+              setMarquee(null)
+            }
           }}
         />
         {onAddImage !== undefined && (

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -4,7 +4,8 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
-import { afterEach, expect, it } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -172,6 +173,50 @@ it('switching tools closes an open context menu — no edit affordance survives 
 
   fireEvent.click(container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
   expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+})
+
+it('entering hand mode clears edit state: selection, open text editor, armed connect', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  const selectBtn = container.querySelector('[data-testid="select-tool-button"]') as HTMLElement
+  const handBtn = container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement
+
+  // Selection does not survive into hand mode, so Delete cannot mutate.
+  fireEvent.click(selectBtn)
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 150,
+    clientY: r.top + 130,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 150, clientY: r.top + 130 })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+  fireEvent.click(handBtn)
+  expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+  fireEvent.keyDown(root, { key: 'Delete' })
+  expect(latest.canvas.nodes).toHaveLength(1)
+
+  // An open text editor closes (uncommitted text is discarded, like Escape).
+  fireEvent.click(selectBtn)
+  await userEvent.dblClick(root, { position: { x: 150, y: 130 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  fireEvent.click(handBtn)
+  expect(container.querySelector('textarea')).toBeNull()
+
+  // An armed connect never completes across the mode switch.
+  fireEvent.click(container.querySelector('[data-testid="connect-tool-button"]') as HTMLElement)
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + 150,
+    clientY: r.top + 130,
+  })
+  fireEvent.click(handBtn)
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + 150, clientY: r.top + 130 })
+  expect(latest.canvas.edges).toHaveLength(0)
+  expect(latest.commands).not.toContain('connect-nodes')
 })
 
 it('switching to select restores normal behavior (press on a node selects it)', () => {


### PR DESCRIPTION
## Summary

Triage of the CodeRabbit Major on #485 (surfaced after merge), verified real against the code: switching to hand only closed the context menu. A surviving selection kept Delete / resize / connect handles live, an open text editor kept accepting input, and an armed connect could still complete — all edits inside the mode whose contract is "no press can change the canvas".

Entering hand now:

- cancels the in-flight gesture with Escape semantics (move/resize/connect torn down; uncommitted editor text is discarded, not committed),
- clears the node/edge selection, both label editors, and the marquee.

Leaving hand is untouched — Select restores a clean editing surface.

## Test plan

- [x] `hand-tool.browser.test.tsx` red-first addition: select→hand clears the selection overlay and Delete no-ops; an open text editor closes; an armed connect never completes across the switch (8 passed)
- [x] Full suites: web-browser 284 / jsdom 1445 all green