### PR TITLE
feat: z-order shortcuts and menu row via a declarative shortcut catalog

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -81,6 +81,23 @@ and scrolling clips popovers anchored inside the dock (version history,
 the + menu). Opening the + menu focuses its first entry (keyboard path:
 Enter, Enter).
 
+## Keyboard shortcuts: one catalog
+
+Every editor keyboard binding is declared in
+`src/components/spatial-editor/shortcuts.ts` (user decision 2026-08-09) —
+ids, combos, display strings, and mode scoping in one table. New
+shortcuts are added there and dispatched by `handleKeyDown`'s table
+lookup; an ad-hoc `e.key === …` branch in a component is the drift this
+catalog exists to prevent. Bindings that predate the table are declared
+with `handledInline: true` so the catalog stays complete while their
+bespoke branches migrate over time.
+
+Z-order uses the tldraw combos: `]` / `[` step forward/backward,
+`Shift+]` / `Shift+[` go to front/back — matched on `KeyboardEvent.code`
+(physical bracket keys, layout-stable). Every keyboard action that
+mutates the canvas also has a touch path (the context menu's Order row,
+here) — a shortcut is an accelerator, never the only way.
+
 ## Canvas theme boundary
 
 Canvas rendering (nodes/edges/selection) is themed by canvas-render's

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -47,6 +47,9 @@ import type { MeasureText, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-
 import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
+  BringToFront,
+  ChevronDown,
+  ChevronUp,
   ExternalLink,
   FileBox,
   Focus,
@@ -58,6 +61,7 @@ import {
   PanelRight,
   PanelTop,
   Pencil,
+  SendToBack,
   SquareDashed,
   StickyNote,
   Tag,
@@ -99,6 +103,7 @@ import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
+import { findShortcut, type ShortcutId } from './shortcuts.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
@@ -1057,7 +1062,49 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
     }
 
+    /**
+     * The selection as reorder targets, primary + extras, deduped. The
+     * command treats ids as a set and takes relative order from the canvas.
+     */
+    const reorderSelection = (placement: 'forward' | 'backward' | 'front' | 'back') => {
+      if (selection === undefined) return false
+      const command: EditorCommand = {
+        kind: 'reorder-nodes',
+        ids: [selection.id, ...extraIds],
+        placement,
+      }
+      // `running` is the purity-guard-approved onChange argument shape: the
+      // canvas produced by applyCommand, never a hand-built object.
+      const running = applyCommand(canvasRef.current, command)
+      // Total command: extremes return the input — emit no empty history step.
+      if (running !== canvasRef.current) onChange(running, command)
+      return true
+    }
+
+    /** Table-dispatched shortcut handlers, keyed by the catalog's ids. */
+    const runShortcut = (id: ShortcutId): boolean => {
+      switch (id) {
+        case 'reorder-forward':
+          return reorderSelection('forward')
+        case 'reorder-backward':
+          return reorderSelection('backward')
+        case 'reorder-front':
+          return reorderSelection('front')
+        case 'reorder-back':
+          return reorderSelection('back')
+        default:
+          // Inline-handled ids never reach here (findShortcut skips them).
+          return false
+      }
+    }
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // Declarative shortcuts first — see shortcuts.ts, the single catalog.
+      const shortcut = findShortcut(e.nativeEvent, tool)
+      if (shortcut !== undefined && runShortcut(shortcut.id)) {
+        e.preventDefault()
+        return
+      }
       // Keyboard equivalent of pointercancel: discards an in-flight
       // resize/move/connect gesture without committing it.
       if (e.key === 'Escape' && selectedEdgeId !== null) {
@@ -2001,6 +2048,43 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   }),
                 ),
               )
+              // Z-order as one-tap options — the touch path to the [ / ]
+              // keyboard shortcuts (see shortcuts.ts). Not a picker: no
+              // option is ever "selected", each tap applies a move.
+              items.push({
+                kind: 'options',
+                label: 'Order',
+                options: [
+                  {
+                    label: 'back',
+                    ariaLabel: 'Send to back',
+                    icon: <SendToBack />,
+                    selected: false,
+                    onSelect: () => reorderSelection('back'),
+                  },
+                  {
+                    label: 'backward',
+                    ariaLabel: 'Send backward',
+                    icon: <ChevronDown />,
+                    selected: false,
+                    onSelect: () => reorderSelection('backward'),
+                  },
+                  {
+                    label: 'forward',
+                    ariaLabel: 'Bring forward',
+                    icon: <ChevronUp />,
+                    selected: false,
+                    onSelect: () => reorderSelection('forward'),
+                  },
+                  {
+                    label: 'front',
+                    ariaLabel: 'Bring to front',
+                    icon: <BringToFront />,
+                    selected: false,
+                    onSelect: () => reorderSelection('front'),
+                  },
+                ],
+              })
               items.push({ kind: 'separator' })
               items.push({
                 label: 'Delete',

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -389,4 +389,92 @@ describe('applyCommand', () => {
     const deleted = applyCommand(created, { kind: 'delete-node', id: node.id })
     expect(deleted).toEqual(canvas)
   })
+
+  // Array order IS z-order in JSON Canvas (last = topmost), so reorder is a
+  // pure array permutation: node objects stay reference-equal.
+  describe('reorder-nodes', () => {
+    function orderedCanvas(): SpatialCanvas {
+      return {
+        nodes: (['a', 'b', 'c', 'd'] as const).map((id, index) => ({
+          id,
+          type: 'text',
+          x: index * 100,
+          y: 0,
+          width: 80,
+          height: 40,
+          text: id,
+        })),
+        edges: [],
+      }
+    }
+    const orderOf = (canvas: SpatialCanvas) => canvas.nodes.map((node) => node.id)
+
+    it('forward swaps toward the top; backward toward the bottom', () => {
+      const canvas = orderedCanvas()
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'forward' })),
+      ).toEqual(['a', 'c', 'b', 'd'])
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'backward' })),
+      ).toEqual(['b', 'a', 'c', 'd'])
+      // The moved node object itself is reference-equal.
+      const next = applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'forward' })
+      expect(next.nodes[2]).toBe(canvas.nodes[1])
+      expect(next.edges).toBe(canvas.edges)
+    })
+
+    it('front moves to the end of the array; back to the start', () => {
+      const canvas = orderedCanvas()
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'front' })),
+      ).toEqual(['a', 'c', 'd', 'b'])
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['c'], placement: 'back' })),
+      ).toEqual(['c', 'a', 'b', 'd'])
+    })
+
+    it('a multi-selection moves as ONE block preserving its relative order', () => {
+      const canvas = orderedCanvas()
+      expect(
+        orderOf(
+          applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d', 'a'], placement: 'front' }),
+        ),
+      ).toEqual(['b', 'c', 'a', 'd'])
+      expect(
+        orderOf(
+          applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a', 'c'], placement: 'back' }),
+        ),
+      ).toEqual(['a', 'c', 'b', 'd'])
+      // Forward steps the block over the next non-member; backward mirrors.
+      expect(
+        orderOf(
+          applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a', 'b'], placement: 'forward' }),
+        ),
+      ).toEqual(['c', 'a', 'b', 'd'])
+      expect(
+        orderOf(
+          applyCommand(canvas, { kind: 'reorder-nodes', ids: ['c', 'd'], placement: 'backward' }),
+        ),
+      ).toEqual(['a', 'c', 'd', 'b'])
+    })
+
+    it('is total: extremes, unknown ids, and empty selections are no-ops returning the input', () => {
+      const canvas = orderedCanvas()
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d'], placement: 'forward' }),
+      ).toBe(canvas)
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a'], placement: 'backward' }),
+      ).toBe(canvas)
+      expect(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d'], placement: 'front' })).toBe(
+        canvas,
+      )
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['zzz'], placement: 'front' }),
+      ).toBe(canvas)
+      expect(applyCommand(canvas, { kind: 'reorder-nodes', ids: [], placement: 'front' })).toBe(
+        canvas,
+      )
+    })
+  })
 })

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -44,6 +44,17 @@ export type EditorCommand =
     }
   | { readonly kind: 'create-node'; readonly node: SpatialNode }
   | { readonly kind: 'delete-node'; readonly id: string }
+  | {
+      /**
+       * Z-order move. Array order IS z-order in JSON Canvas (last = topmost),
+       * so this is a pure permutation of `nodes`. A multi-selection moves as
+       * ONE block preserving its relative order; forward/backward step the
+       * block over the nearest non-member above/below it.
+       */
+      readonly kind: 'reorder-nodes'
+      readonly ids: readonly string[]
+      readonly placement: 'forward' | 'backward' | 'front' | 'back'
+    }
   | { readonly kind: 'delete-edge'; readonly id: string }
   | { readonly kind: 'set-edge-label'; readonly id: string; readonly label: string }
   | {
@@ -367,5 +378,50 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setGroupLabel(canvas, command.id, command.label)
     case 'delete-node':
       return deleteNode(canvas, command.id)
+    case 'reorder-nodes':
+      return reorderNodes(canvas, command.ids, command.placement)
   }
+}
+
+function reorderNodes(
+  canvas: SpatialCanvas,
+  ids: readonly string[],
+  placement: 'forward' | 'backward' | 'front' | 'back',
+): SpatialCanvas {
+  const members = new Set(ids)
+  const block = canvas.nodes.filter((node) => members.has(node.id))
+  if (block.length === 0) return canvas
+  const rest = canvas.nodes.filter((node) => !members.has(node.id))
+
+  let insertAt: number
+  switch (placement) {
+    case 'front':
+      insertAt = rest.length
+      break
+    case 'back':
+      insertAt = 0
+      break
+    case 'forward': {
+      // Step the block over the nearest non-member ABOVE its topmost member.
+      const top = canvas.nodes.findLastIndex((node) => members.has(node.id))
+      const over = canvas.nodes.slice(top + 1).find((node) => !members.has(node.id))
+      if (over === undefined) return canvas
+      insertAt = rest.indexOf(over) + 1
+      break
+    }
+    case 'backward': {
+      // Mirror: step under the nearest non-member BELOW its bottom member.
+      const bottom = canvas.nodes.findIndex((node) => members.has(node.id))
+      const under = canvas.nodes.slice(0, bottom).findLast((node) => !members.has(node.id))
+      if (under === undefined) return canvas
+      insertAt = rest.indexOf(under)
+      break
+    }
+  }
+
+  const next = [...rest.slice(0, insertAt), ...block, ...rest.slice(insertAt)]
+  // No-op permutations return the input so callers can cheaply detect "did
+  // anything move" (and undo history stays free of empty steps).
+  if (next.every((node, index) => node === canvas.nodes[index])) return canvas
+  return { ...canvas, nodes: next }
 }

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -403,7 +403,15 @@ function reorderNodes(
       break
     case 'forward': {
       // Step the block over the nearest non-member ABOVE its topmost member.
-      const top = canvas.nodes.findLastIndex((node) => members.has(node.id))
+      // (Index loops, not findLast/findLastIndex — the tsconfig lib target
+      // predates es2023.)
+      let top = -1
+      for (let i = canvas.nodes.length - 1; i >= 0; i--) {
+        if (members.has(canvas.nodes[i].id)) {
+          top = i
+          break
+        }
+      }
       const over = canvas.nodes.slice(top + 1).find((node) => !members.has(node.id))
       if (over === undefined) return canvas
       insertAt = rest.indexOf(over) + 1
@@ -412,7 +420,13 @@ function reorderNodes(
     case 'backward': {
       // Mirror: step under the nearest non-member BELOW its bottom member.
       const bottom = canvas.nodes.findIndex((node) => members.has(node.id))
-      const under = canvas.nodes.slice(0, bottom).findLast((node) => !members.has(node.id))
+      let under: SpatialCanvas['nodes'][number] | undefined
+      for (let i = bottom - 1; i >= 0; i--) {
+        if (!members.has(canvas.nodes[i].id)) {
+          under = canvas.nodes[i]
+          break
+        }
+      }
       if (under === undefined) return canvas
       insertAt = rest.indexOf(under)
       break

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -1,0 +1,146 @@
+/**
+ * The editor's keyboard shortcut catalog — the ONE place every binding is
+ * declared (user decision 2026-08-09). A future help sheet or settings
+ * surface reads this table; ad-hoc `e.key === …` checks in components are
+ * the drift this file exists to prevent.
+ *
+ * Two kinds of entries:
+ * - Table-dispatched: `handleKeyDown` matches the event against this table
+ *   and routes to a handler keyed by `id` (all new shortcuts land here).
+ * - `handledInline: true`: bindings that predate the table and still live
+ *   as bespoke branches in `handleKeyDown` (their guards are deeply
+ *   stateful). They are declared here so the catalog stays complete, and
+ *   the matcher deliberately skips them.
+ */
+import type { EditorTool } from './ToolPalette.js'
+
+export type ShortcutId =
+  | 'reorder-forward'
+  | 'reorder-backward'
+  | 'reorder-front'
+  | 'reorder-back'
+  | 'delete-selection'
+  | 'cancel'
+  | 'space-pan'
+  | 'nudge-selection'
+
+export interface ShortcutSpec {
+  readonly id: ShortcutId
+  /**
+   * Physical-key match (`KeyboardEvent.code`) — used for punctuation keys
+   * like the brackets, whose `key` value shifts with layout and modifiers.
+   */
+  readonly codes?: readonly string[]
+  /** Logical-key match (`KeyboardEvent.key`). */
+  readonly keys?: readonly string[]
+  /** Required shift state; absent = either. */
+  readonly shift?: boolean
+  /** Human-readable combo for menus and a future help sheet. */
+  readonly display: string
+  readonly description: string
+  /** Tools the shortcut is live in; absent = every tool. */
+  readonly tools?: readonly EditorTool[]
+  /** Declared-only: handled by a bespoke branch in handleKeyDown. */
+  readonly handledInline?: boolean
+}
+
+export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
+  // Z-order (tldraw parity). Array order is z-order, last = topmost.
+  {
+    id: 'reorder-forward',
+    codes: ['BracketRight'],
+    shift: false,
+    display: ']',
+    description: 'Bring forward',
+    tools: ['select'],
+  },
+  {
+    id: 'reorder-backward',
+    codes: ['BracketLeft'],
+    shift: false,
+    display: '[',
+    description: 'Send backward',
+    tools: ['select'],
+  },
+  {
+    id: 'reorder-front',
+    codes: ['BracketRight'],
+    shift: true,
+    display: 'Shift+]',
+    description: 'Bring to front',
+    tools: ['select'],
+  },
+  {
+    id: 'reorder-back',
+    codes: ['BracketLeft'],
+    shift: true,
+    display: 'Shift+[',
+    description: 'Send to back',
+    tools: ['select'],
+  },
+  // Pre-table bindings, declared for catalog completeness.
+  {
+    id: 'delete-selection',
+    keys: ['Delete', 'Backspace'],
+    display: 'Delete',
+    description: 'Delete the selected node(s) or edge',
+    handledInline: true,
+  },
+  {
+    id: 'cancel',
+    keys: ['Escape'],
+    display: 'Esc',
+    description: 'Cancel the gesture / clear the selection',
+    handledInline: true,
+  },
+  {
+    id: 'space-pan',
+    keys: [' '],
+    display: 'Space+drag',
+    description: 'Pan while held',
+    handledInline: true,
+  },
+  {
+    id: 'nudge-selection',
+    keys: ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'],
+    display: 'Arrows',
+    description: 'Nudge the selected node (Shift: larger step)',
+    handledInline: true,
+  },
+]
+
+/** True when the event originates in a surface that consumes typing. */
+export function isTextEntryEvent(e: { readonly target: EventTarget | null }): boolean {
+  const target = e.target
+  if (!(target instanceof HTMLElement)) return false
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
+}
+
+interface KeyEventLike {
+  readonly code: string
+  readonly key: string
+  readonly shiftKey: boolean
+  readonly altKey: boolean
+  readonly metaKey: boolean
+  readonly ctrlKey: boolean
+  readonly target: EventTarget | null
+}
+
+/**
+ * The first table-dispatched shortcut matching the event in `tool`, or
+ * undefined. Never fires while typing, and never matches when a
+ * meta/ctrl/alt modifier is held — those combos belong to the browser
+ * until a spec explicitly claims one.
+ */
+export function findShortcut(e: KeyEventLike, tool: EditorTool): ShortcutSpec | undefined {
+  if (e.metaKey || e.ctrlKey || e.altKey) return undefined
+  if (isTextEntryEvent(e)) return undefined
+  return EDITOR_SHORTCUTS.find((spec) => {
+    if (spec.handledInline === true) return false
+    if (spec.tools !== undefined && !spec.tools.includes(tool)) return false
+    if (spec.shift !== undefined && spec.shift !== e.shiftKey) return false
+    if (spec.codes !== undefined && !spec.codes.includes(e.code)) return false
+    if (spec.keys !== undefined && !spec.keys.includes(e.key)) return false
+    return spec.codes !== undefined || spec.keys !== undefined
+  })
+}

--- a/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
@@ -1,0 +1,143 @@
+// Z-order manipulation: [ / ] / Shift+[ / Shift+] via the shortcut catalog
+// (shortcuts.ts), and the context menu's Order row as the touch path.
+// Array order IS z-order — assertions read the canvas node order directly.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: (['a', 'b', 'c'] as const).map((id, index) => ({
+    id,
+    type: 'text',
+    x: index * 220,
+    y: 100,
+    width: 200,
+    height: 80,
+    text: id,
+  })),
+  edges: [],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function selectNodeB(container: HTMLElement): HTMLElement {
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  // Node b spans x 220..420 at identity viewport.
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 320,
+    clientY: r.top + 140,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 320, clientY: r.top + 140 })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+  return root
+}
+
+const orderOf = (canvas: SpatialCanvas) => canvas.nodes.map((node) => node.id)
+
+it('bracket shortcuts reorder the selected node through all four placements', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = selectNodeB(container)
+
+  fireEvent.keyDown(root, { code: 'BracketRight', key: ']' })
+  expect(orderOf(latest.canvas)).toEqual(['a', 'c', 'b'])
+
+  fireEvent.keyDown(root, { code: 'BracketLeft', key: '[' })
+  expect(orderOf(latest.canvas)).toEqual(['a', 'b', 'c'])
+
+  fireEvent.keyDown(root, { code: 'BracketRight', key: '}', shiftKey: true })
+  expect(orderOf(latest.canvas)).toEqual(['a', 'c', 'b'])
+
+  fireEvent.keyDown(root, { code: 'BracketLeft', key: '{', shiftKey: true })
+  expect(orderOf(latest.canvas)).toEqual(['b', 'a', 'c'])
+
+  // Extremes are total no-ops (already at back).
+  fireEvent.keyDown(root, { code: 'BracketLeft', key: '[' })
+  expect(orderOf(latest.canvas)).toEqual(['b', 'a', 'c'])
+})
+
+it('never fires from a text-entry surface or with a browser modifier held', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = selectNodeB(container)
+
+  fireEvent.keyDown(root, { code: 'BracketRight', key: ']', metaKey: true })
+  expect(orderOf(latest.canvas)).toEqual(['a', 'b', 'c'])
+
+  // Typing a bracket inside the node text editor must not reorder.
+  fireEvent.pointerDown(root, { button: 0, pointerId: 2, clientX: 320, clientY: 140 })
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: 320, clientY: 140 })
+  fireEvent.pointerDown(root, { button: 0, pointerId: 3, clientX: 320, clientY: 140 })
+  fireEvent.pointerUp(root, { pointerId: 3, clientX: 320, clientY: 140 })
+  const textarea = container.querySelector('textarea')
+  if (textarea !== null) {
+    fireEvent.keyDown(textarea, { code: 'BracketRight', key: ']' })
+    expect(orderOf(latest.canvas)).toEqual(['a', 'b', 'c'])
+  }
+})
+
+it("the node context menu's Order row applies each placement in one tap", () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+
+  fireEvent.contextMenu(root, { clientX: r.left + 320, clientY: r.top + 140 })
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(menu).not.toBeNull()
+  fireEvent.click(menu.querySelector('[aria-label="Bring to front"]') as HTMLElement)
+  expect(orderOf(latest.canvas)).toEqual(['a', 'c', 'b'])
+
+  fireEvent.contextMenu(root, { clientX: r.left + 320, clientY: r.top + 140 })
+  const menu2 = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  fireEvent.click(menu2.querySelector('[aria-label="Send to back"]') as HTMLElement)
+  expect(orderOf(latest.canvas)).toEqual(['b', 'a', 'c'])
+})
+
+it('a multi-selection reorders as one block', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = selectNodeB(container)
+  const r = root.getBoundingClientRect()
+  // Shift-click node a to build {b, a}.
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 4,
+    shiftKey: true,
+    clientX: r.left + 100,
+    clientY: r.top + 140,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 4,
+    shiftKey: true,
+    clientX: r.left + 100,
+    clientY: r.top + 140,
+  })
+
+  fireEvent.keyDown(root, { code: 'BracketRight', key: '}', shiftKey: true })
+  expect(orderOf(latest.canvas)).toEqual(['c', 'a', 'b'])
+})

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -107,11 +107,6 @@
     // imports, only JS/TS module graphs.
     "tailwindcss",
     "tw-animate-css",
-    // apps/web/wrangler.toml drives Cloudflare Pages preview deploys; CI
-    // invokes wrangler via `npx wrangler@<pinned>` / cloudflare/wrangler-action
-    // rather than this package.json's own devDependency. Kept so a local
-    // `pnpm --filter web exec wrangler ...` matches the CI-pinned version.
-    "wrangler",
     // Not imported directly anywhere in src — @libsql/kysely-libsql pulls it
     // in transitively — but the direct pin here forces the whole workspace
     // onto a newer @libsql/client (^0.17.3) than kysely-libsql's own range


### PR DESCRIPTION
## Summary

User request: z-order manipulation shortcuts, plus a mechanism that centralizes shortcut management.

**`reorder-nodes` command** — array order IS z-order in JSON Canvas (last = topmost), so reorder is a pure permutation: a multi-selection moves as ONE block preserving relative order, `forward`/`backward` step the block over the nearest non-member above/below, `front`/`back` move it to the array ends. Total: extremes, unknown ids, and empty selections return the input, so no empty undo steps are emitted.

**Shortcut catalog (`shortcuts.ts`)** — the new single place every editor binding is declared (ids, combos, display strings, mode scoping). `handleKeyDown` dispatches table-matched shortcuts first; bindings that predate the table (Delete, Escape, Space-pan, arrows) are declared with `handledInline: true` so the catalog stays complete while their bespoke branches migrate over time. The matcher never fires from text-entry surfaces and never claims meta/ctrl/alt combos. Documented in `DESIGN.md`.

**Bindings** (tldraw parity, matched on `KeyboardEvent.code` so the physical bracket keys survive layout/modifier shifts; Select mode only):

| combo | action |
|---|---|
| `]` | Bring forward |
| `[` | Send backward |
| `Shift+]` | Bring to front |
| `Shift+[` | Send to back |

**Context menu Order row** — the touch path to the same commands (a shortcut is an accelerator, never the only way):

![z-order-menu.jpg](https://github.com/user-attachments/assets/a7f40152-b648-4dd5-b531-a8131ae00a97)

Also: `wrangler` leaves knip's `ignoreDependencies` — `preview:pages` (#486) now uses the devDependency directly.

## Test plan

- [x] `commands.test.ts` (red-first): all four placements, multi-selection block semantics, totality (extremes/unknown/empty → input reference), node reference equality (36 passed)
- [x] `z-order.browser.test.tsx` (real Chromium): all four bracket shortcuts against the canvas order, meta-modifier and text-entry suppression, Order-row taps, multi-selection block move (4 passed)
- [x] Live in Chrome: keyboard front/back verified against the real canvas (`Shift+[` → bottom, `Shift+]` → top), Order row applies on tap
- [x] Full suites: web-browser 288 / jsdom 1451 (incl. the purity-guard call-site rule) all green; `pnpm knip` clean; typecheck clean
