### PR TITLE
feat: overlap-aware bring-forward / send-backward

### DIFF
--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -392,13 +392,18 @@ describe('applyCommand', () => {
 
   // Array order IS z-order in JSON Canvas (last = topmost), so reorder is a
   // pure array permutation: node objects stay reference-equal.
+  // forward/backward are OVERLAP-aware (user feedback 2026-08-09, tldraw
+  // semantics): the block steps over the nearest node it visually overlaps,
+  // because stepping over a non-overlapping neighbor changes nothing on
+  // screen and reads as the shortcut "not working".
   describe('reorder-nodes', () => {
-    function orderedCanvas(): SpatialCanvas {
+    /** Four nodes stacked on the same spot — everything overlaps. */
+    function stackedCanvas(): SpatialCanvas {
       return {
-        nodes: (['a', 'b', 'c', 'd'] as const).map((id, index) => ({
+        nodes: (['a', 'b', 'c', 'd'] as const).map((id) => ({
           id,
           type: 'text',
-          x: index * 100,
+          x: 0,
           y: 0,
           width: 80,
           height: 40,
@@ -409,8 +414,8 @@ describe('applyCommand', () => {
     }
     const orderOf = (canvas: SpatialCanvas) => canvas.nodes.map((node) => node.id)
 
-    it('forward swaps toward the top; backward toward the bottom', () => {
-      const canvas = orderedCanvas()
+    it('forward steps over the nearest overlapping node above; backward mirrors', () => {
+      const canvas = stackedCanvas()
       expect(
         orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'forward' })),
       ).toEqual(['a', 'c', 'b', 'd'])
@@ -423,8 +428,52 @@ describe('applyCommand', () => {
       expect(next.edges).toBe(canvas.edges)
     })
 
-    it('front moves to the end of the array; back to the start', () => {
-      const canvas = orderedCanvas()
+    it('forward/backward SKIP non-overlapping neighbors and land past the overlapping one', () => {
+      // z-order a < b < c < d; spatially only a and d overlap (b, c live
+      // far away). Forward from a must step over d directly — hopping over
+      // b or c would change nothing visible.
+      const canvas: SpatialCanvas = {
+        nodes: [
+          { id: 'a', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'a' },
+          { id: 'b', type: 'text', x: 500, y: 500, width: 80, height: 40, text: 'b' },
+          { id: 'c', type: 'text', x: 700, y: 500, width: 80, height: 40, text: 'c' },
+          { id: 'd', type: 'text', x: 40, y: 20, width: 80, height: 40, text: 'd' },
+        ],
+        edges: [],
+      }
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a'], placement: 'forward' })),
+      ).toEqual(['b', 'c', 'd', 'a'])
+      expect(
+        orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d'], placement: 'backward' })),
+      ).toEqual(['d', 'a', 'b', 'c'])
+      // No overlapping node in the step direction → visually already on
+      // top/bottom of its pile → no-op, even with array neighbors present.
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d'], placement: 'forward' }),
+      ).toBe(canvas)
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'backward' }),
+      ).toBe(canvas)
+    })
+
+    it('touching edges do not count as overlap', () => {
+      // b sits exactly flush against a's right edge — adjacent, not
+      // overlapping, so forward has nothing to step over.
+      const canvas: SpatialCanvas = {
+        nodes: [
+          { id: 'a', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'a' },
+          { id: 'b', type: 'text', x: 80, y: 0, width: 80, height: 40, text: 'b' },
+        ],
+        edges: [],
+      }
+      expect(
+        applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a'], placement: 'forward' }),
+      ).toBe(canvas)
+    })
+
+    it('front moves to the end of the array; back to the start (position-independent)', () => {
+      const canvas = stackedCanvas()
       expect(
         orderOf(applyCommand(canvas, { kind: 'reorder-nodes', ids: ['b'], placement: 'front' })),
       ).toEqual(['a', 'c', 'd', 'b'])
@@ -434,7 +483,7 @@ describe('applyCommand', () => {
     })
 
     it('a multi-selection moves as ONE block preserving its relative order', () => {
-      const canvas = orderedCanvas()
+      const canvas = stackedCanvas()
       expect(
         orderOf(
           applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d', 'a'], placement: 'front' }),
@@ -445,7 +494,8 @@ describe('applyCommand', () => {
           applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a', 'c'], placement: 'back' }),
         ),
       ).toEqual(['a', 'c', 'b', 'd'])
-      // Forward steps the block over the next non-member; backward mirrors.
+      // Forward steps the block over the next overlapping non-member (a
+      // member overlaps when ANY of its nodes intersects the candidate).
       expect(
         orderOf(
           applyCommand(canvas, { kind: 'reorder-nodes', ids: ['a', 'b'], placement: 'forward' }),
@@ -459,7 +509,7 @@ describe('applyCommand', () => {
     })
 
     it('is total: extremes, unknown ids, and empty selections are no-ops returning the input', () => {
-      const canvas = orderedCanvas()
+      const canvas = stackedCanvas()
       expect(
         applyCommand(canvas, { kind: 'reorder-nodes', ids: ['d'], placement: 'forward' }),
       ).toBe(canvas)

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -383,6 +383,20 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
   }
 }
 
+/** Strict bbox intersection — flush-touching edges are NOT overlap. */
+function overlapsAny(
+  candidate: SpatialCanvas['nodes'][number],
+  block: readonly SpatialCanvas['nodes'][number][],
+): boolean {
+  return block.some(
+    (member) =>
+      candidate.x < member.x + member.width &&
+      member.x < candidate.x + candidate.width &&
+      candidate.y < member.y + member.height &&
+      member.y < candidate.y + candidate.height,
+  )
+}
+
 function reorderNodes(
   canvas: SpatialCanvas,
   ids: readonly string[],
@@ -402,9 +416,13 @@ function reorderNodes(
       insertAt = 0
       break
     case 'forward': {
-      // Step the block over the nearest non-member ABOVE its topmost member.
-      // (Index loops, not findLast/findLastIndex — the tsconfig lib target
-      // predates es2023.)
+      // Step the block over the nearest OVERLAPPING non-member above its
+      // topmost member (tldraw semantics, user feedback 2026-08-09):
+      // hopping over a node the selection does not visually overlap
+      // changes nothing on screen and reads as the shortcut "not working".
+      // No overlapping node above → the block is already visually on top
+      // of its pile → no-op. (Index loops, not findLast/findLastIndex —
+      // the tsconfig lib target predates es2023.)
       let top = -1
       for (let i = canvas.nodes.length - 1; i >= 0; i--) {
         if (members.has(canvas.nodes[i].id)) {
@@ -412,18 +430,22 @@ function reorderNodes(
           break
         }
       }
-      const over = canvas.nodes.slice(top + 1).find((node) => !members.has(node.id))
+      const over = canvas.nodes
+        .slice(top + 1)
+        .find((node) => !members.has(node.id) && overlapsAny(node, block))
       if (over === undefined) return canvas
       insertAt = rest.indexOf(over) + 1
       break
     }
     case 'backward': {
-      // Mirror: step under the nearest non-member BELOW its bottom member.
+      // Mirror: step under the nearest overlapping non-member below the
+      // bottom member.
       const bottom = canvas.nodes.findIndex((node) => members.has(node.id))
       let under: SpatialCanvas['nodes'][number] | undefined
       for (let i = bottom - 1; i >= 0; i--) {
-        if (!members.has(canvas.nodes[i].id)) {
-          under = canvas.nodes[i]
+        const node = canvas.nodes[i]
+        if (!members.has(node.id) && overlapsAny(node, block)) {
+          under = node
           break
         }
       }

--- a/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
@@ -9,11 +9,13 @@ import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
 
+// An overlapping chain (a∩b, b∩c, a∦c): forward/backward are
+// overlap-aware, so the fixture must actually overlap for them to move.
 const initial: SpatialCanvas = {
   nodes: (['a', 'b', 'c'] as const).map((id, index) => ({
     id,
     type: 'text',
-    x: index * 220,
+    x: index * 150,
     y: 100,
     width: 200,
     height: 80,
@@ -44,14 +46,14 @@ function makeHost() {
 function selectNodeB(container: HTMLElement): HTMLElement {
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   const r = root.getBoundingClientRect()
-  // Node b spans x 220..420 at identity viewport.
+  // x 250 lands on b ONLY (a ends at 200, c starts at 300).
   fireEvent.pointerDown(root, {
     button: 0,
     pointerId: 1,
-    clientX: r.left + 320,
+    clientX: r.left + 250,
     clientY: r.top + 140,
   })
-  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 320, clientY: r.top + 140 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 250, clientY: r.top + 140 })
   expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
   return root
 }
@@ -106,13 +108,13 @@ it("the node context menu's Order row applies each placement in one tap", () => 
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   const r = root.getBoundingClientRect()
 
-  fireEvent.contextMenu(root, { clientX: r.left + 320, clientY: r.top + 140 })
+  fireEvent.contextMenu(root, { clientX: r.left + 250, clientY: r.top + 140 })
   const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
   expect(menu).not.toBeNull()
   fireEvent.click(menu.querySelector('[aria-label="Bring to front"]') as HTMLElement)
   expect(orderOf(latest.canvas)).toEqual(['a', 'c', 'b'])
 
-  fireEvent.contextMenu(root, { clientX: r.left + 320, clientY: r.top + 140 })
+  fireEvent.contextMenu(root, { clientX: r.left + 250, clientY: r.top + 140 })
   const menu2 = container.querySelector('[data-testid="context-menu"]') as HTMLElement
   fireEvent.click(menu2.querySelector('[aria-label="Send to back"]') as HTMLElement)
   expect(orderOf(latest.canvas)).toEqual(['b', 'a', 'c'])


### PR DESCRIPTION
## Summary

User feedback while dogfooding #488: strict one-array-step forward/backward often hops over a node the selection does not visually overlap — nothing changes on screen and the shortcut reads as broken.

`forward`/`backward` now step over the nearest **overlapping** non-member (tldraw semantics): the reordered block lands just past the closest node it actually intersects in the step direction. With no overlapping node in that direction the block is already visually on top/bottom of its pile, so the command is a total no-op (no empty undo step). Flush-touching edges do not count as overlap; a multi-selection block overlaps when ANY member intersects the candidate. `front`/`back` stay position-independent.

## Test plan

- [x] `commands.test.ts` (red-first): overlap-skip past non-overlapping array neighbors, no-op when nothing overlaps in the step direction, flush-edge non-overlap, stacked-pile stepping, multi-selection block, totality — 38 passed
- [x] `z-order.browser.test.tsx` re-fixtured to an overlapping chain; all 4 pass
- [x] Live in Chrome: two overlapping notes — `[` steps under, `]` restores; an isolated node's `]` is a no-op
- [x] Full suites: web-browser 288 / jsdom 1453; typecheck exit 0 (checked the exit code this time — the #488 lesson)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spatial editor reordering to move selected items only across visually overlapping items.
  * Prevented reordering when items merely touch edges or have no overlap.
  * Applied consistent overlap-aware behavior to forward, backward, and multi-selection movements.
  * Updated z-order interactions to reflect the corrected positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->