### PR TITLE
feat: shortcut catalog gains explicit mod/alt modifier claims

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -98,6 +98,13 @@ Z-order uses the tldraw combos: `]` / `[` step forward/backward,
 mutates the canvas also has a touch path (the context menu's Order row,
 here) — a shortcut is an accelerator, never the only way.
 
+Modifier policy: a spec claims the platform command chord with
+`mod: true` (Cmd on macOS or Ctrl elsewhere — either satisfies it) and
+Alt with `alt: true`; a held modifier suppresses every spec that does
+not claim it, so browser combos stay the browser's until a catalog
+entry explicitly takes one. Command chords still never fire from a
+text-entry surface.
+
 ## Canvas theme boundary
 
 Canvas rendering (nodes/edges/selection) is themed by canvas-render's

--- a/apps/web/src/components/spatial-editor/shortcuts.test.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.test.ts
@@ -1,0 +1,107 @@
+// Matcher semantics for the shortcut catalog (shortcuts.ts). Slice 0a of
+// the editor-completeness plan: specs can now claim a Cmd/Ctrl ("mod") or
+// Alt modifier explicitly — the capability every clipboard-family binding
+// needs. No product binding uses it yet in this slice, so the cases run
+// against synthetic specs via the exported matcher.
+import { describe, expect, it } from 'vitest'
+import { EDITOR_SHORTCUTS, findShortcutIn, type ShortcutSpec } from './shortcuts.js'
+
+const KEY_C = { code: 'KeyC', key: 'c' }
+
+function event(over: Partial<KeyEventLike>): KeyEventLike {
+  return {
+    code: '',
+    key: '',
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    target: null,
+    ...over,
+  }
+}
+interface KeyEventLike {
+  readonly code: string
+  readonly key: string
+  readonly shiftKey: boolean
+  readonly altKey: boolean
+  readonly metaKey: boolean
+  readonly ctrlKey: boolean
+  readonly target: EventTarget | null
+}
+
+const MOD_SPEC: ShortcutSpec = {
+  id: 'reorder-forward', // any table id — the matcher only reads matching fields
+  keys: ['c'],
+  mod: true,
+  display: 'Cmd+C',
+  description: 'test spec',
+}
+
+const PLAIN_SPEC: ShortcutSpec = {
+  id: 'reorder-backward',
+  codes: ['BracketLeft'],
+  shift: false,
+  display: '[',
+  description: 'test spec',
+}
+
+describe('findShortcutIn modifier semantics', () => {
+  it('a mod:true spec fires on Cmd (metaKey) AND on Ctrl (ctrlKey), never on a plain press', () => {
+    const specs = [MOD_SPEC]
+    expect(findShortcutIn(specs, event({ ...KEY_C, metaKey: true }), 'select')).toBe(MOD_SPEC)
+    expect(findShortcutIn(specs, event({ ...KEY_C, ctrlKey: true }), 'select')).toBe(MOD_SPEC)
+    expect(findShortcutIn(specs, event({ ...KEY_C }), 'select')).toBeUndefined()
+  })
+
+  it('a mod:true spec still rejects a stray Alt, and alt:true requires Alt', () => {
+    const specs = [MOD_SPEC]
+    expect(
+      findShortcutIn(specs, event({ ...KEY_C, metaKey: true, altKey: true }), 'select'),
+    ).toBeUndefined()
+
+    const altSpec: ShortcutSpec = { ...MOD_SPEC, mod: undefined, alt: true, display: 'Alt+C' }
+    expect(findShortcutIn([altSpec], event({ ...KEY_C, altKey: true }), 'select')).toBe(altSpec)
+    expect(findShortcutIn([altSpec], event({ ...KEY_C }), 'select')).toBeUndefined()
+  })
+
+  it('a spec WITHOUT mod keeps the historic behavior: any held meta/ctrl/alt suppresses it', () => {
+    const specs = [PLAIN_SPEC]
+    const plain = event({ code: 'BracketLeft', key: '[' })
+    expect(findShortcutIn(specs, plain, 'select')).toBe(PLAIN_SPEC)
+    for (const modifier of ['metaKey', 'ctrlKey', 'altKey'] as const) {
+      expect(
+        findShortcutIn(specs, event({ code: 'BracketLeft', key: '[', [modifier]: true }), 'select'),
+      ).toBeUndefined()
+    }
+  })
+
+  it('mod matching stays case-insensitive on key (Shift+Cmd chords report uppercase keys)', () => {
+    expect(
+      findShortcutIn(
+        [MOD_SPEC],
+        event({ code: 'KeyC', key: 'C', metaKey: true, shiftKey: true }),
+        'select',
+      ),
+    ).toBe(MOD_SPEC)
+  })
+
+  it('never fires from a text-entry surface, mod or not', () => {
+    const textarea = document.createElement('textarea')
+    expect(
+      findShortcutIn([MOD_SPEC], event({ ...KEY_C, metaKey: true, target: textarea }), 'select'),
+    ).toBeUndefined()
+  })
+
+  it('tool scoping applies to mod specs like any other', () => {
+    const scoped: ShortcutSpec = { ...MOD_SPEC, tools: ['select'] }
+    expect(findShortcutIn([scoped], event({ ...KEY_C, metaKey: true }), 'hand')).toBeUndefined()
+  })
+
+  it('regression: no existing catalog entry declares mod/alt, so the table is unaffected', () => {
+    for (const spec of EDITOR_SHORTCUTS) {
+      expect(spec.mod).toBeUndefined()
+      expect(spec.alt).toBeUndefined()
+    }
+  })
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -35,6 +35,15 @@ export interface ShortcutSpec {
   readonly keys?: readonly string[]
   /** Required shift state; absent = either. */
   readonly shift?: boolean
+  /**
+   * Requires the platform command modifier — Cmd (metaKey) on macOS or
+   * Ctrl (ctrlKey) elsewhere; either satisfies it. Absent = the spec never
+   * fires while meta/ctrl is held (the historic default: browser combos
+   * stay the browser's until a spec explicitly claims one).
+   */
+  readonly mod?: boolean
+  /** Requires Alt/Option held. Absent = never fires while Alt is held. */
+  readonly alt?: boolean
   /** Human-readable combo for menus and a future help sheet. */
   readonly display: string
   readonly description: string
@@ -128,19 +137,39 @@ interface KeyEventLike {
 
 /**
  * The first table-dispatched shortcut matching the event in `tool`, or
- * undefined. Never fires while typing, and never matches when a
- * meta/ctrl/alt modifier is held — those combos belong to the browser
- * until a spec explicitly claims one.
+ * undefined. Never fires while typing. Modifier policy: a held meta/ctrl
+ * suppresses every spec except one declaring `mod: true` (which requires
+ * it — Cmd or Ctrl, either platform's command chord); a held Alt likewise
+ * belongs only to specs declaring `alt: true`. Combos a spec does not
+ * claim stay the browser's.
  */
 export function findShortcut(e: KeyEventLike, tool: EditorTool): ShortcutSpec | undefined {
-  if (e.metaKey || e.ctrlKey || e.altKey) return undefined
+  return findShortcutIn(EDITOR_SHORTCUTS, e, tool)
+}
+
+/** `findShortcut` over an explicit spec list — the testable pure core. */
+export function findShortcutIn(
+  specs: readonly ShortcutSpec[],
+  e: KeyEventLike,
+  tool: EditorTool,
+): ShortcutSpec | undefined {
   if (isTextEntryEvent(e)) return undefined
-  return EDITOR_SHORTCUTS.find((spec) => {
+  const hasMod = e.metaKey || e.ctrlKey
+  return specs.find((spec) => {
     if (spec.handledInline === true) return false
     if (spec.tools !== undefined && !spec.tools.includes(tool)) return false
+    if ((spec.mod === true) !== hasMod) return false
+    if ((spec.alt === true) !== e.altKey) return false
     if (spec.shift !== undefined && spec.shift !== e.shiftKey) return false
     if (spec.codes !== undefined && !spec.codes.includes(e.code)) return false
-    if (spec.keys !== undefined && !spec.keys.includes(e.key)) return false
+    // Case-insensitive on key: shifted command chords (Cmd+Shift+C) report
+    // an uppercase key while the spec declares the plain character.
+    if (
+      spec.keys !== undefined &&
+      !spec.keys.some((key) => key.toLowerCase() === e.key.toLowerCase())
+    ) {
+      return false
+    }
     return spec.codes !== undefined || spec.keys !== undefined
   })
 }


### PR DESCRIPTION
## Summary

Slice 0a of the editor-completeness plan (whiteboard canvas `basic-editing-gap-plan-2026-08-09`), the root blocker for the whole clipboard family: `findShortcut` hard-bailed on any held meta/ctrl/alt, so no Cmd/Ctrl chord could ever be expressed in the catalog.

- `ShortcutSpec` gains `mod?: boolean` (the platform command chord — Cmd on macOS or Ctrl elsewhere, either satisfies it) and `alt?: boolean`.
- A held modifier still suppresses every spec that does not claim it — browser combos stay the browser's until a catalog entry explicitly takes one; the never-in-text-entry guard is unchanged.
- Key matching is case-insensitive so shifted chords (Cmd+Shift+C reports `'C'`) keep matching.
- The matcher core is extracted as `findShortcutIn(specs, e, tool)` so it unit-tests directly against synthetic specs; `findShortcut` delegates over the catalog.
- **No product binding uses the capability yet** — a regression case pins that every current catalog entry declares neither `mod` nor `alt`, and plain-spec behavior under held modifiers is byte-identical to before (explicit per-modifier cases).

Copy/cut/paste/duplicate/select-all land in later slices on top of this.

## Test plan

- [x] `shortcuts.test.ts` (new, jsdom, red-first): mod fires on Cmd AND Ctrl but never plain; stray Alt rejected; `alt:true` requires Alt; plain specs unaffected by each held modifier; case-insensitive key; text-entry suppression; tool scoping; catalog-unchanged regression (7 passed)
- [x] Full suites: web-browser z-order/hand-tool 12 passed; jsdom 1460/122 all green; typecheck exit 0; knip clean