### PR TITLE
feat: typed clipboard fragment schema + id-remint helpers

### DIFF
--- a/apps/web/src/lib/clipboard-fragment.test.ts
+++ b/apps/web/src/lib/clipboard-fragment.test.ts
@@ -1,0 +1,101 @@
+// Pure clipboard-fragment helpers (editor-completeness slice 2): extract a
+// self-contained fragment from a selection, and remint ids on paste so a
+// fragment can land any number of times in any canvas without colliding.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { clipboardFragmentSchema } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { extractClipboardFragment, remintClipboardFragment } from './clipboard-fragment.js'
+
+const canvas: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' },
+    { id: 'b', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'b' },
+    { id: 'c', type: 'text', x: 400, y: 0, width: 100, height: 50, text: 'c' },
+  ],
+  edges: [
+    { id: 'ab', fromNode: 'a', toNode: 'b' },
+    { id: 'bc', fromNode: 'b', toNode: 'c' },
+  ],
+}
+
+describe('extractClipboardFragment', () => {
+  it('keeps selected nodes in canvas (z) order and only fully-selected edges', () => {
+    const fragment = extractClipboardFragment(canvas, new Set(['b', 'a']))
+    expect(fragment.nodes.map((node) => node.id)).toEqual(['a', 'b'])
+    // 'bc' has an unselected endpoint and is dropped.
+    expect(fragment.edges.map((edge) => edge.id)).toEqual(['ab'])
+    expect(fragment.type).toBe('whiteboard/clipboard')
+    expect(clipboardFragmentSchema.safeParse(fragment).success).toBe(true)
+  })
+
+  it('an empty or unknown selection yields an empty (still valid) fragment', () => {
+    const fragment = extractClipboardFragment(canvas, new Set(['ghost']))
+    expect(fragment.nodes).toEqual([])
+    expect(fragment.edges).toEqual([])
+    expect(clipboardFragmentSchema.safeParse(fragment).success).toBe(true)
+  })
+})
+
+describe('remintClipboardFragment', () => {
+  const seq = () => {
+    let n = 0
+    return () => `minted-${++n}`
+  }
+
+  it('remints every node id, remaps edge endpoints, and avoids the blocklist', () => {
+    const fragment = extractClipboardFragment(canvas, new Set(['a', 'b']))
+    const { nodes, edges } = remintClipboardFragment(fragment, seq(), new Set(['a', 'b', 'c']))
+    expect(nodes.map((node) => node.id)).toEqual(['minted-1', 'minted-2'])
+    expect(edges).toHaveLength(1)
+    expect(edges[0].fromNode).toBe('minted-1')
+    expect(edges[0].toNode).toBe('minted-2')
+    expect(edges[0].id).not.toBe('ab')
+    // Non-id fields survive untouched.
+    expect(nodes[0]).toMatchObject({ type: 'text', text: 'a', x: 0, y: 0 })
+  })
+
+  it('skips createId values already present in the blocklist or the minted set', () => {
+    const fragment = extractClipboardFragment(canvas, new Set(['a']))
+    let calls = 0
+    const collidingThenFresh = () => {
+      calls += 1
+      return calls === 1 ? 'taken' : 'fresh'
+    }
+    const { nodes } = remintClipboardFragment(fragment, collidingThenFresh, new Set(['taken']))
+    expect(nodes[0].id).toBe('fresh')
+  })
+
+  it('drops edges whose endpoints are not both present in the fragment (defensive on foreign input)', () => {
+    const foreign = {
+      ...extractClipboardFragment(canvas, new Set(['a'])),
+      edges: [{ id: 'x', fromNode: 'a', toNode: 'ghost' }],
+    }
+    const { edges } = remintClipboardFragment(foreign, seq(), new Set())
+    expect(edges).toEqual([])
+  })
+
+  fcTest.prop(
+    [fc.subarray(['a', 'b', 'c'] as const, { minLength: 0 }), fc.integer({ min: 0, max: 20 })],
+    withDefaults(),
+  )(
+    'extract-then-remint: node count preserved, endpoints resolve, no collisions',
+    (picked, seed) => {
+      const fragment = extractClipboardFragment(canvas, new Set(picked))
+      let n = seed
+      const { nodes, edges } = remintClipboardFragment(
+        fragment,
+        () => `id-${++n}`,
+        new Set(canvas.nodes.map((node) => node.id)),
+      )
+      expect(nodes).toHaveLength(fragment.nodes.length)
+      const minted = new Set(nodes.map((node) => node.id))
+      expect(minted.size).toBe(nodes.length)
+      for (const id of minted) expect(['a', 'b', 'c']).not.toContain(id)
+      for (const edge of edges) {
+        expect(minted.has(edge.fromNode)).toBe(true)
+        expect(minted.has(edge.toNode)).toBe(true)
+      }
+    },
+  )
+})

--- a/apps/web/src/lib/clipboard-fragment.ts
+++ b/apps/web/src/lib/clipboard-fragment.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure clipboard-fragment helpers (editor-completeness slice 2). The
+ * fragment format itself is canvas-model's `clipboardFragmentSchema`;
+ * these two functions are the only bridge between a live canvas and that
+ * envelope:
+ *
+ * - `extractClipboardFragment` builds a SELF-CONTAINED fragment from a
+ *   selection — nodes in canvas (z) order, edges only when both
+ *   endpoints are selected, so the result always parses.
+ * - `remintClipboardFragment` makes a paste collision-free — every node
+ *   id is reminted via the injected id factory (never colliding with the
+ *   target canvas's ids or each other), edge endpoints are remapped, and
+ *   edges whose endpoints are not both in the fragment are dropped
+ *   (defensive against hand-built foreign input that skipped the schema).
+ */
+import type {
+  CanvasEdge,
+  ClipboardFragment,
+  SpatialCanvas,
+  SpatialNode,
+} from '@kamiazya/whiteboard-canvas-model'
+
+export function extractClipboardFragment(
+  canvas: SpatialCanvas,
+  selectedIds: ReadonlySet<string>,
+): ClipboardFragment {
+  const nodes = canvas.nodes.filter((node) => selectedIds.has(node.id))
+  const included = new Set(nodes.map((node) => node.id))
+  const edges = canvas.edges.filter(
+    (edge) => included.has(edge.fromNode) && included.has(edge.toNode),
+  )
+  return { type: 'whiteboard/clipboard', version: 1, nodes, edges }
+}
+
+export interface RemintedFragment {
+  readonly nodes: readonly SpatialNode[]
+  readonly edges: readonly CanvasEdge[]
+}
+
+export function remintClipboardFragment(
+  fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
+  createId: () => string,
+  existingIds: ReadonlySet<string>,
+): RemintedFragment {
+  const taken = new Set(existingIds)
+  const freshId = () => {
+    let id = createId()
+    while (taken.has(id)) id = createId()
+    taken.add(id)
+    return id
+  }
+
+  const idMap = new Map<string, string>()
+  const nodes = fragment.nodes.map((node) => {
+    const id = freshId()
+    idMap.set(node.id, id)
+    return { ...node, id }
+  })
+  const edges = fragment.edges.flatMap((edge) => {
+    const fromNode = idMap.get(edge.fromNode)
+    const toNode = idMap.get(edge.toNode)
+    if (fromNode === undefined || toNode === undefined) return []
+    return [{ ...edge, id: freshId(), fromNode, toNode }]
+  })
+  return { nodes, edges }
+}

--- a/packages/canvas-model/src/clipboard.test.ts
+++ b/packages/canvas-model/src/clipboard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { clipboardFragmentSchema } from './clipboard.js'
+
+const NODE = { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }
+const NODE2 = { id: 'n2', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'yo' }
+
+describe('clipboardFragmentSchema', () => {
+  it('accepts a typed fragment of nodes, edges, and inline file assets', () => {
+    const fragment = {
+      type: 'whiteboard/clipboard',
+      version: 1,
+      nodes: [
+        NODE,
+        NODE2,
+        { id: 'n3', type: 'file', x: 400, y: 0, width: 100, height: 50, file: 'asset:img' },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+      files: {
+        'asset:img': { mimeType: 'image/png', dataBase64: 'iVBORw0KGgo=' },
+      },
+    }
+    const parsed = clipboardFragmentSchema.parse(fragment)
+    expect(parsed).toEqual(fragment)
+  })
+
+  it('accepts a minimal fragment without files', () => {
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 1,
+        nodes: [NODE],
+        edges: [],
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a wrong or missing discriminant/version (foreign JSON must not parse)', () => {
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'excalidraw/clipboard',
+        version: 1,
+        nodes: [],
+        edges: [],
+      }).success,
+    ).toBe(false)
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 2,
+        nodes: [],
+        edges: [],
+      }).success,
+    ).toBe(false)
+    expect(clipboardFragmentSchema.safeParse({ nodes: [], edges: [] }).success).toBe(false)
+  })
+
+  it('rejects duplicate node ids and edges with endpoints missing from the fragment', () => {
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 1,
+        nodes: [NODE, { ...NODE2, id: 'n1' }],
+        edges: [],
+      }).success,
+    ).toBe(false)
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 1,
+        nodes: [NODE],
+        edges: [{ id: 'e1', fromNode: 'n1', toNode: 'ghost' }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects extra keys and malformed file assets (strict envelope)', () => {
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 1,
+        nodes: [],
+        edges: [],
+        surprise: true,
+      }).success,
+    ).toBe(false)
+    expect(
+      clipboardFragmentSchema.safeParse({
+        type: 'whiteboard/clipboard',
+        version: 1,
+        nodes: [],
+        edges: [],
+        files: { k: { mimeType: '', dataBase64: 'x' } },
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/packages/canvas-model/src/clipboard.ts
+++ b/packages/canvas-model/src/clipboard.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod'
+import { canvasEdgeSchema, spatialNodeSchema } from './spatial.js'
+
+/**
+ * The typed clipboard envelope for copy/paste of canvas fragments
+ * (editor-completeness plan, user decisions 2026-08-09): a FULL
+ * spatialCanvasSchema-shaped subset plus inline file assets, so a
+ * cross-canvas paste can re-materialize images instead of carrying
+ * dangling references (Excalidraw's elements+files precedent). The
+ * discriminant `type` keeps foreign JSON from parsing as ours, and
+ * `version` is a literal so a future breaking change is a new literal
+ * union member, not a silent drift.
+ */
+export const clipboardFileAssetSchema = z
+  .object({
+    mimeType: z.string().min(1),
+    dataBase64: z.string(),
+  })
+  .strict()
+
+export type ClipboardFileAsset = z.infer<typeof clipboardFileAssetSchema>
+
+export const clipboardFragmentSchema = z
+  .object({
+    type: z.literal('whiteboard/clipboard'),
+    version: z.literal(1),
+    nodes: z.array(spatialNodeSchema),
+    edges: z.array(canvasEdgeSchema),
+    /** Inline assets keyed by the file-node `file` reference they carry. */
+    files: z.record(z.string(), clipboardFileAssetSchema).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    // Same integrity rules as spatialCanvasSchema: unique ids, and every
+    // edge endpoint present IN THE FRAGMENT (a fragment is self-contained
+    // by construction — the copy builder only includes fully-selected
+    // edges, and paste remints against exactly this node set).
+    const seen = new Set<string>()
+    for (const node of value.nodes) {
+      if (seen.has(node.id)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `duplicate node id "${node.id}"`,
+          path: ['nodes'],
+        })
+        break
+      }
+      seen.add(node.id)
+    }
+    const edgeIds = new Set<string>()
+    value.edges.forEach((edge, index) => {
+      if (edgeIds.has(edge.id)) {
+        ctx.addIssue({ code: 'custom', message: `duplicate edge id "${edge.id}"`, path: ['edges'] })
+      }
+      edgeIds.add(edge.id)
+      if (!seen.has(edge.fromNode)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `edge "${edge.id}" references fromNode "${edge.fromNode}" outside the fragment`,
+          path: ['edges', index, 'fromNode'],
+        })
+      }
+      if (!seen.has(edge.toNode)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `edge "${edge.id}" references toNode "${edge.toNode}" outside the fragment`,
+          path: ['edges', index, 'toNode'],
+        })
+      }
+    })
+  })
+
+export type ClipboardFragment = z.infer<typeof clipboardFragmentSchema>

--- a/packages/canvas-model/src/index.ts
+++ b/packages/canvas-model/src/index.ts
@@ -1,3 +1,4 @@
+export * from './clipboard.js'
 export * from './facets.js'
 export * from './ids.js'
 export * from './markdown.js'


### PR DESCRIPTION
## Summary

Slice 2 of the editor-completeness plan (user decisions: **full spatialCanvasSchema-shaped fragment WITH inline file assets**, Excalidraw's elements+files precedent). Pure data layer only — no UI changes; slices 3–5 (duplicate, copy/cut/paste, OS interop) consume these.

**canvas-model — `clipboardFragmentSchema`**: `.strict()` envelope with discriminant `type: 'whiteboard/clipboard'` + literal `version: 1` (foreign JSON never parses as ours; a future break is a new union member, not silent drift). `nodes`/`edges` reuse the existing spatial schemas by import; optional `files` record maps a file-node reference to an inline `{mimeType, dataBase64}` asset so cross-canvas image paste can re-materialize. Same integrity refinements as `spatialCanvasSchema` (unique ids, edge endpoints inside the fragment).

**apps/web — pure helpers** (`src/lib/clipboard-fragment.ts`):
- `extractClipboardFragment(canvas, selectedIds)` — nodes in canvas (z) order, edges only when both endpoints selected → the result always parses.
- `remintClipboardFragment(fragment, createId, existingIds)` — collision-free reminted ids (injected factory + blocklist + intra-batch dedup), edge endpoints remapped, dangling foreign edges dropped.

## Test plan

- [x] `clipboard.test.ts` (canvas-model, red-first): accept full/minimal, reject foreign discriminant / wrong version / duplicate ids / outside-fragment endpoints / extra keys / malformed assets (5 passed)
- [x] `clipboard-fragment.test.ts` (apps/web, red-first): extraction order + edge filtering, remint + remap + blocklist skip, foreign-edge drop, fast-check property (extract→remint preserves counts, endpoints resolve, no collisions) (6 passed)
- [x] Full: canvas-model-node 158 / apps/web jsdom 1460; typecheck exit 0 both packages; root knip clean