### PR TITLE
feat: undo-batching seam — one action, one Loro commit

### DIFF
--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -528,3 +528,38 @@ describe('applyCommand', () => {
     })
   })
 })
+
+// Compound batch command (editor-completeness slice 1): one user action
+// composed of N leaf commands applies as a pure fold. The undo guarantee
+// (one Loro commit) lives at the sync layer; here batch is just sequential
+// application with the same totality conventions as every other kind.
+describe('batch', () => {
+  it('applies member commands in order as a pure fold', () => {
+    const canvas = baseCanvas()
+    const next = applyCommand(canvas, {
+      kind: 'batch',
+      commands: [
+        { kind: 'move-node', id: 'a', x: 10, y: 20 },
+        { kind: 'set-text', id: 'a', text: 'batched' },
+        { kind: 'connect-nodes', edgeId: 'e9', fromNode: 'a', toNode: 'b' },
+      ],
+    })
+    expect(next.nodes[0]).toMatchObject({ x: 10, y: 20, text: 'batched' })
+    expect(next.edges).toEqual([{ id: 'e9', fromNode: 'a', toNode: 'b' }])
+    expect(spatialCanvasSchema.safeParse(next).success).toBe(true)
+  })
+
+  it('an empty batch, or a batch of pure no-ops, returns the input canvas reference', () => {
+    const canvas = baseCanvas()
+    expect(applyCommand(canvas, { kind: 'batch', commands: [] })).toBe(canvas)
+    expect(
+      applyCommand(canvas, {
+        kind: 'batch',
+        commands: [
+          { kind: 'move-node', id: 'missing', x: 1, y: 1 },
+          { kind: 'delete-node', id: 'missing' },
+        ],
+      }),
+    ).toBe(canvas)
+  })
+})

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -25,7 +25,7 @@ import type {
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
 
-export type EditorCommand =
+export type EditorLeafCommand =
   | { readonly kind: 'move-node'; readonly id: string; readonly x: number; readonly y: number }
   | {
       readonly kind: 'resize-node'
@@ -109,6 +109,17 @@ export type EditorCommand =
       // undefined returns the endpoint to derived (auto) routing.
       readonly side: 'top' | 'right' | 'bottom' | 'left' | undefined
     }
+
+/**
+ * One user action composed of N leaf commands (paste, duplicate,
+ * multi-delete). The two-type split (rather than a self-referential union)
+ * type-forbids nested batches, mirroring the sync layer's one-commit rule.
+ * Application is a pure fold; the one-Loro-commit/one-undo-step guarantee
+ * lives in canvas-sync-session's batch write path, not here.
+ */
+export type EditorCommand =
+  | EditorLeafCommand
+  | { readonly kind: 'batch'; readonly commands: readonly EditorLeafCommand[] }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -380,6 +391,10 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return deleteNode(canvas, command.id)
     case 'reorder-nodes':
       return reorderNodes(canvas, command.ids, command.placement)
+    case 'batch':
+      // Pure fold; a batch of no-ops folds back to the input reference,
+      // preserving the union-wide "nothing changed → same object" contract.
+      return command.commands.reduce(applyCommand, canvas)
   }
 }
 

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -6,7 +6,7 @@
  * OpenCanvas-shaped surface this session now owns.
  */
 
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import type {
   CanvasBackend,
@@ -819,5 +819,117 @@ describe('createCanvasSyncSession', () => {
         }
       },
     )
+  })
+
+  // Batch commands (editor-completeness slice 1): one user action of N leaf
+  // commands = ONE Loro commit via canvas-workspace's withSpatialBatch, so
+  // one session.undo() reverts the whole action.
+  describe('batch commands', () => {
+    it('a batch of create+connect+delete lands as ONE update payload and ONE undo step', async () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+      const created: SpatialNode = {
+        id: 'n-new',
+        type: 'text',
+        x: 500,
+        y: 0,
+        width: 100,
+        height: 50,
+        text: 'pasted',
+      }
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: [
+          { kind: 'create-node', node: created },
+          { kind: 'connect-nodes', edgeId: 'e-new', fromNode: 'n-a', toNode: 'n-new' },
+          { kind: 'delete-node', id: 'n-b' },
+        ],
+      }
+      const next = applyCommand(twoNodeCanvas(), command)
+      session.onChange(next, command)
+      await vi.advanceTimersByTimeAsync(300)
+
+      // One flush of one batch → exactly one pushed payload.
+      expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+      expect(session.getCanvas()).toEqual(next)
+
+      // One undo step reverts the WHOLE action.
+      expect(session.undo()).toBe(true)
+      expect(session.getCanvas()).toEqual(twoNodeCanvas())
+      expect(session.canUndo()).toBe(false)
+    })
+
+    it('a batch containing an unsupported member kind falls back to a full resync — still one undo step, converged on next', async () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      const snapshotBytes = makeSnapshot(twoNodeCanvas())
+      backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: [
+          { kind: 'move-node', id: 'n-a', x: 42, y: 24 },
+          // reorder-nodes is not batch-writable → whole batch takes the
+          // full-resync path (one commit, whole-canvas granularity).
+          { kind: 'reorder-nodes', ids: ['n-a'], placement: 'front' },
+        ],
+      }
+      const next = applyCommand(twoNodeCanvas(), command)
+      session.onChange(next, command)
+      await vi.advanceTimersByTimeAsync(300)
+
+      const doc = new LoroDoc()
+      doc.import(snapshotBytes)
+      for (const bytes of backend._ctrl.pushLocalUpdateCalls) doc.import(bytes)
+      const converged = readSpatialCanvas(doc)
+      expect(converged.nodes.find((n) => n.id === 'n-a')).toMatchObject({ x: 42, y: 24 })
+
+      expect(session.undo()).toBe(true)
+      expect(session.getCanvas()).toEqual(twoNodeCanvas())
+      expect(session.canUndo()).toBe(false)
+    })
+
+    it('a batched delete-edge removes exactly that edge (fine-grained, peer edits survive)', async () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      const base = applyCommand(twoNodeCanvas(), {
+        kind: 'connect-nodes',
+        edgeId: 'e-1',
+        fromNode: 'n-a',
+        toNode: 'n-b',
+      })
+      const snapshotBytes = makeSnapshot(base)
+      backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: [{ kind: 'delete-edge', id: 'e-1' }],
+      }
+      const next = applyCommand(base, command)
+      session.onChange(next, command)
+      await vi.advanceTimersByTimeAsync(300)
+
+      // Peer concurrently edits node B from the same lineage; the batched
+      // fine-grained delete must not clobber it (a full resync would).
+      const peerDoc = new LoroDoc()
+      peerDoc.import(snapshotBytes)
+      writeSpatialCanvas(peerDoc, {
+        ...base,
+        nodes: [TEXT_NODE_A, { ...TEXT_NODE_B, text: 'renamed-by-peer' }],
+      })
+      const merged = new LoroDoc()
+      merged.import(snapshotBytes)
+      for (const bytes of backend._ctrl.pushLocalUpdateCalls) merged.import(bytes)
+      merged.import(peerDoc.export({ mode: 'update' }))
+
+      const result = readSpatialCanvas(merged)
+      expect(result.edges).toEqual([])
+      expect(result.nodes.find((n) => n.id === 'n-b')).toMatchObject({ text: 'renamed-by-peer' })
+    })
   })
 })

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -2,6 +2,8 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import {
   deleteSpatialNode,
   readSpatialCanvas,
+  type SpatialBatchWriter,
+  withSpatialBatch,
   writeSpatialCanvas,
   writeSpatialEdge,
   writeSpatialNode,
@@ -10,7 +12,7 @@ import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { exportResponseMessageSchema } from '@kamiazya/whiteboard-mcp/browser-shared'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import type { z } from 'zod'
-import type { EditorCommand } from '../components/spatial-editor/commands.js'
+import type { EditorCommand, EditorLeafCommand } from '../components/spatial-editor/commands.js'
 import { getAppLogger } from './app-logger.js'
 import {
   type ExportRequestHandlerDeps,
@@ -51,6 +53,10 @@ function commandTargetKey(command: EditorCommand): string {
       return `edge:${command.edgeId}`
     case 'create-node':
       return `node:${command.node.id}`
+    case 'batch':
+      // Mapped in writeCommandTarget (unlike the default arm), but each
+      // batch is one distinct user action — never deduped against another.
+      return `batch:${++unmappedCommandCounter}`
     default:
       return `unmapped:${++unmappedCommandCounter}`
   }
@@ -174,8 +180,80 @@ function writeCommandTarget(doc: LoroDoc, next: SpatialCanvas, command: EditorCo
       // exist in `next` to know what to write).
       deleteSpatialNode(doc, command.id)
       return true
+    case 'batch': {
+      // Pre-validate BEFORE any write: a batch is all-or-nothing at this
+      // layer. One unsupported member (or a missing target) sends the WHOLE
+      // batch down the full-resync fallback — still exactly one commit and
+      // one undo step, just with whole-canvas granularity.
+      if (!command.commands.every((sub) => isBatchWritable(sub, next))) return false
+      withSpatialBatch(doc, (writer) => {
+        for (const sub of command.commands) writeSubCommand(writer, next, sub)
+      })
+      return true
+    }
     default:
       return false
+  }
+}
+
+/**
+ * The leaf kinds a batch can write fine-grained: exactly the operations
+ * `SpatialBatchWriter` exposes. `delete-edge` is deliberately included here
+ * even though the non-batch path has no case for it (multi-delete needs
+ * it); the other kinds fall back to the full resync as a whole batch.
+ */
+function isBatchWritable(command: EditorLeafCommand, next: SpatialCanvas): boolean {
+  switch (command.kind) {
+    case 'move-node':
+    case 'resize-node':
+    case 'set-text':
+      return next.nodes.some((n) => n.id === command.id)
+    case 'create-node':
+      return next.nodes.some((n) => n.id === command.node.id)
+    case 'connect-nodes':
+      return next.edges.some((e) => e.id === command.edgeId)
+    case 'delete-node':
+    case 'delete-edge':
+      // Deletes are no-ops for absent ids — always writable.
+      return true
+    default:
+      return false
+  }
+}
+
+function writeSubCommand(
+  writer: SpatialBatchWriter,
+  next: SpatialCanvas,
+  command: EditorLeafCommand,
+): void {
+  switch (command.kind) {
+    case 'move-node':
+    case 'resize-node':
+    case 'set-text': {
+      const node = next.nodes.find((n) => n.id === command.id)
+      if (node) writer.writeNode(node)
+      return
+    }
+    case 'create-node': {
+      const node = next.nodes.find((n) => n.id === command.node.id)
+      if (node) writer.writeNode(node)
+      return
+    }
+    case 'connect-nodes': {
+      const edge = next.edges.find((e) => e.id === command.edgeId)
+      if (edge) writer.writeEdge(edge)
+      return
+    }
+    case 'delete-node':
+      writer.deleteNode(command.id)
+      return
+    case 'delete-edge':
+      writer.deleteEdge(command.id)
+      return
+    default:
+      // Unreachable behind isBatchWritable; a miss here writes nothing and
+      // the batch still commits what the other members wrote.
+      return
   }
 }
 

--- a/packages/canvas-workspace/src/index.ts
+++ b/packages/canvas-workspace/src/index.ts
@@ -15,6 +15,8 @@ export {
   readCoreFacets,
   readFacets,
   readSpatialCanvas,
+  type SpatialBatchWriter,
+  withSpatialBatch,
   writeCoreFacets,
   writeFacets,
   writeSpatialCanvas,

--- a/packages/canvas-workspace/src/loro-bridge.property.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.property.test.ts
@@ -6,7 +6,16 @@ import {
 } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect } from 'vitest'
-import { readFacets, readSpatialCanvas, writeFacets, writeSpatialCanvas } from './loro-bridge.js'
+import {
+  deleteSpatialEdge,
+  deleteSpatialNode,
+  readFacets,
+  readSpatialCanvas,
+  withSpatialBatch,
+  writeFacets,
+  writeSpatialCanvas,
+  writeSpatialNode,
+} from './loro-bridge.js'
 import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
 
 /**
@@ -82,6 +91,93 @@ describe('loro-bridge properties', () => {
       // Loro normalizes -0 to 0 during storage; JSON.parse(JSON.stringify())
       // applies the same normalization so we compare against that.
       expect(result).toEqual(JSON.parse(JSON.stringify(facets)))
+    },
+  )
+})
+
+// withSpatialBatch equivalence (editor-completeness slice 1): for ANY
+// command list drawn from the writer's four operations, one batch produces
+// the same readSpatialCanvas state as the sequential committing helpers,
+// and (when anything was written) exactly one undo step.
+type BatchOp =
+  | { readonly kind: 'writeNode'; readonly index: number }
+  | { readonly kind: 'deleteNode'; readonly index: number }
+  | { readonly kind: 'deleteEdge'; readonly index: number }
+
+describe('withSpatialBatch equivalence property', () => {
+  fcTest.prop(
+    [
+      spatialCanvasArbitrary,
+      fc.array(
+        fc.record({
+          kind: fc.constantFrom<'writeNode' | 'deleteNode' | 'deleteEdge'>(
+            'writeNode',
+            'deleteNode',
+            'deleteEdge',
+          ),
+          index: fc.nat({ max: 7 }),
+        }),
+        { maxLength: 6 },
+      ),
+    ],
+    withDefaults(),
+  )(
+    'one batch ≡ sequential helpers on state, and at most one undo step',
+    async (canvas, opSpecs) => {
+      const { UndoManager } = await import('loro-crdt')
+      const ops: BatchOp[] = opSpecs
+      const apply = {
+        writeNode: (index: number) => canvas.nodes[index % Math.max(1, canvas.nodes.length)],
+        deleteNode: (index: number) => canvas.nodes[index % Math.max(1, canvas.nodes.length)]?.id,
+        deleteEdge: (index: number) => canvas.edges[index % Math.max(1, canvas.edges.length)]?.id,
+      }
+
+      const sequential = new LoroDoc()
+      writeSpatialCanvas(sequential, canvas)
+      const batched = new LoroDoc()
+      batched.import(sequential.export({ mode: 'snapshot' }))
+
+      for (const op of ops) {
+        if (op.kind === 'writeNode') {
+          const node = apply.writeNode(op.index)
+          if (node !== undefined) writeSpatialNode(sequential, { ...node, x: node.x + 1 })
+        } else if (op.kind === 'deleteNode') {
+          const id = apply.deleteNode(op.index)
+          if (id !== undefined) deleteSpatialNode(sequential, id)
+        } else {
+          const id = apply.deleteEdge(op.index)
+          if (id !== undefined) deleteSpatialEdge(sequential, id)
+        }
+      }
+
+      const undo = new UndoManager(batched, { mergeInterval: 0 })
+      withSpatialBatch(batched, (writer) => {
+        for (const op of ops) {
+          if (op.kind === 'writeNode') {
+            const node = apply.writeNode(op.index)
+            if (node !== undefined) writer.writeNode({ ...node, x: node.x + 1 })
+          } else if (op.kind === 'deleteNode') {
+            const id = apply.deleteNode(op.index)
+            if (id !== undefined) writer.deleteNode(id)
+          } else {
+            const id = apply.deleteEdge(op.index)
+            if (id !== undefined) writer.deleteEdge(id)
+          }
+        }
+      })
+
+      const stateOf = (doc: LoroDoc) => {
+        const value = readSpatialCanvas(doc)
+        return {
+          nodes: [...value.nodes].sort((a, b) => a.id.localeCompare(b.id)),
+          edges: [...value.edges].sort((a, b) => a.id.localeCompare(b.id)),
+        }
+      }
+      expect(stateOf(batched)).toEqual(stateOf(sequential))
+      if (undo.canUndo()) {
+        undo.undo()
+        expect(undo.canUndo()).toBe(false)
+      }
     },
   )
 })

--- a/packages/canvas-workspace/src/loro-bridge.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   readCoreFacets,
   readFacets,
   readSpatialCanvas,
+  withSpatialBatch,
   writeCoreFacets,
   writeFacets,
   writeSpatialCanvas,
@@ -560,5 +561,121 @@ describe('core facets bridge', () => {
     doc.commit()
 
     expect(readCoreFacets(doc)).toBeUndefined()
+  })
+})
+
+// withSpatialBatch (editor-completeness slice 1): N writes inside ONE Loro
+// commit — one UndoManager step, with the N=1 path byte-identical to the
+// corresponding single committing helper. Spike verdict 2026-08-09 (option
+// C); Loro's UndoManager.groupStart()/groupEnd() was considered and
+// rejected — a remote import mid-group can split the group, while a single
+// commit is indivisible.
+describe('withSpatialBatch', () => {
+  const seeded = () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
+    return doc
+  }
+
+  test('a batch of one writeNode is byte-identical to writeSpatialNode', () => {
+    const a = new LoroDoc()
+    a.setPeerId(1n)
+    const b = new LoroDoc()
+    b.setPeerId(1n)
+    writeSpatialNode(a, TEXT_NODE)
+    withSpatialBatch(b, (w) => w.writeNode(TEXT_NODE))
+    expect(b.export({ mode: 'update' })).toEqual(a.export({ mode: 'update' }))
+  })
+
+  test('a batch of one writeEdge / deleteNode / deleteEdge each mirrors its helper byte-for-byte', () => {
+    const base = new LoroDoc()
+    base.setPeerId(9n)
+    writeSpatialCanvas(base, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
+    const snapshot = base.export({ mode: 'snapshot' })
+    const pair = () => {
+      const a = new LoroDoc()
+      a.import(snapshot)
+      a.setPeerId(1n)
+      const b = new LoroDoc()
+      b.import(snapshot)
+      b.setPeerId(1n)
+      return { a, b }
+    }
+
+    const edgePair = pair()
+    writeSpatialEdge(edgePair.a, { ...EDGE, label: 'renamed' })
+    withSpatialBatch(edgePair.b, (w) => w.writeEdge({ ...EDGE, label: 'renamed' }))
+    expect(edgePair.b.export({ mode: 'update' })).toEqual(edgePair.a.export({ mode: 'update' }))
+
+    const delNodePair = pair()
+    deleteSpatialNode(delNodePair.a, TEXT_NODE.id)
+    withSpatialBatch(delNodePair.b, (w) => w.deleteNode(TEXT_NODE.id))
+    expect(delNodePair.b.export({ mode: 'update' })).toEqual(
+      delNodePair.a.export({ mode: 'update' }),
+    )
+
+    const delEdgePair = pair()
+    deleteSpatialEdge(delEdgePair.a, EDGE.id)
+    withSpatialBatch(delEdgePair.b, (w) => w.deleteEdge(EDGE.id))
+    expect(delEdgePair.b.export({ mode: 'update' })).toEqual(
+      delEdgePair.a.export({ mode: 'update' }),
+    )
+  })
+
+  test('deleting an ABSENT id inside a batch preserves the helper no-op: no ops, no undo step', async () => {
+    const { UndoManager } = await import('loro-crdt')
+    const doc = seeded()
+    const undoManager = new UndoManager(doc, { mergeInterval: 0 })
+    expect(undoManager.canUndo()).toBe(false)
+    withSpatialBatch(doc, (w) => {
+      w.deleteNode('ghost')
+      w.deleteEdge('ghost-edge')
+    })
+    expect(undoManager.canUndo()).toBe(false)
+    expect(readSpatialCanvas(doc).nodes).toHaveLength(2)
+  })
+
+  test('one batch of N writes = exactly one undo step (mergeInterval 0 so timing cannot mask it)', async () => {
+    const { UndoManager } = await import('loro-crdt')
+    const doc = seeded()
+    const before = readSpatialCanvas(doc)
+    const undoManager = new UndoManager(doc, { mergeInterval: 0 })
+    expect(undoManager.canUndo()).toBe(false)
+    withSpatialBatch(doc, (w) => {
+      w.writeNode(LINK_NODE)
+      w.writeNode(GROUP_NODE)
+      w.deleteNode(TEXT_NODE.id)
+    })
+    expect(
+      readSpatialCanvas(doc)
+        .nodes.map((n) => n.id)
+        .sort(),
+    ).toEqual(['node-2', 'node-3', 'node-4'].sort())
+    undoManager.undo()
+    expect(readSpatialCanvas(doc)).toEqual(before)
+    expect(undoManager.canUndo()).toBe(false)
+  })
+
+  test('error contract: a mid-batch throw commits NOTHING; the partial ops stay pending until a later committing write converges the doc', async () => {
+    const { UndoManager } = await import('loro-crdt')
+    const doc = seeded()
+    const undoManager = new UndoManager(doc, { mergeInterval: 0 })
+    expect(() =>
+      withSpatialBatch(doc, (w) => {
+        w.writeNode(LINK_NODE)
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+    // Commit is an undo/sync boundary, not a visibility boundary: the
+    // partial write IS visible to readers, but no undo step exists.
+    expect(undoManager.canUndo()).toBe(false)
+    expect(readSpatialCanvas(doc).nodes.map((n) => n.id)).toContain(LINK_NODE.id)
+    // The session-layer fallback (writeSpatialCanvas to the intended next
+    // state) absorbs the pending ops into ONE converged commit/undo step.
+    const next: SpatialCanvas = { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] }
+    writeSpatialCanvas(doc, next)
+    expect(readSpatialCanvas(doc)).toEqual(next)
+    undoManager.undo()
+    expect(undoManager.canUndo()).toBe(false)
   })
 })

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -95,6 +95,42 @@ export function writeSpatialCanvas(doc: LoroDoc, canvas: SpatialCanvas): void {
   doc.commit()
 }
 
+// Non-committing internals shared by the single committing helpers below
+// and `withSpatialBatch`'s writer, so field projection and the delete
+// cascade can never drift between the two paths.
+function writeNodeInto(doc: LoroDoc, node: SpatialNode): void {
+  doc.getMap(NODES_KEY).set(node.id, nodeToFields(node))
+}
+
+function writeEdgeInto(doc: LoroDoc, edge: CanvasEdge): void {
+  doc.getMap(EDGES_KEY).set(edge.id, edgeToFields(edge))
+}
+
+/** Returns false (writing nothing) when the node id is absent. */
+function deleteNodeCascadeInto(doc: LoroDoc, nodeId: string): boolean {
+  const nodesMap = doc.getMap(NODES_KEY)
+  const edgesMap = doc.getMap(EDGES_KEY)
+  if (!nodesMap.keys().includes(nodeId)) return false
+
+  nodesMap.delete(nodeId)
+  for (const edgeId of edgesMap.keys()) {
+    const raw = edgesMap.get(edgeId)
+    const parsed = canvasEdgeSchema.safeParse(raw)
+    if (parsed.success && (parsed.data.fromNode === nodeId || parsed.data.toNode === nodeId)) {
+      edgesMap.delete(edgeId)
+    }
+  }
+  return true
+}
+
+/** Returns false (writing nothing) when the edge id is absent. */
+function deleteEdgeInto(doc: LoroDoc, edgeId: string): boolean {
+  const edgesMap = doc.getMap(EDGES_KEY)
+  if (!edgesMap.keys().includes(edgeId)) return false
+  edgesMap.delete(edgeId)
+  return true
+}
+
 /**
  * Writes exactly one node's LoroMap entry, leaving every other node/edge in
  * the doc untouched. This is the node-level CRDT merge granularity a full
@@ -105,7 +141,7 @@ export function writeSpatialCanvas(doc: LoroDoc, canvas: SpatialCanvas): void {
  * the full-resync encoding.
  */
 export function writeSpatialNode(doc: LoroDoc, node: SpatialNode): void {
-  doc.getMap(NODES_KEY).set(node.id, nodeToFields(node))
+  writeNodeInto(doc, node)
   doc.commit()
 }
 
@@ -113,7 +149,7 @@ export function writeSpatialNode(doc: LoroDoc, node: SpatialNode): void {
  * Edge counterpart to `writeSpatialNode` — see its doc comment.
  */
 export function writeSpatialEdge(doc: LoroDoc, edge: CanvasEdge): void {
-  doc.getMap(EDGES_KEY).set(edge.id, edgeToFields(edge))
+  writeEdgeInto(doc, edge)
   doc.commit()
 }
 
@@ -127,19 +163,7 @@ export function writeSpatialEdge(doc: LoroDoc, edge: CanvasEdge): void {
  * Idempotent and a no-op (no commit) for an id absent from the doc.
  */
 export function deleteSpatialNode(doc: LoroDoc, nodeId: string): void {
-  const nodesMap = doc.getMap(NODES_KEY)
-  const edgesMap = doc.getMap(EDGES_KEY)
-  if (!nodesMap.keys().includes(nodeId)) return
-
-  nodesMap.delete(nodeId)
-  for (const edgeId of edgesMap.keys()) {
-    const raw = edgesMap.get(edgeId)
-    const parsed = canvasEdgeSchema.safeParse(raw)
-    if (parsed.success && (parsed.data.fromNode === nodeId || parsed.data.toNode === nodeId)) {
-      edgesMap.delete(edgeId)
-    }
-  }
-  doc.commit()
+  if (deleteNodeCascadeInto(doc, nodeId)) doc.commit()
 }
 
 /**
@@ -147,10 +171,59 @@ export function deleteSpatialNode(doc: LoroDoc, nodeId: string): void {
  * cascade needed since an edge has no dependents of its own.
  */
 export function deleteSpatialEdge(doc: LoroDoc, edgeId: string): void {
-  const edgesMap = doc.getMap(EDGES_KEY)
-  if (!edgesMap.keys().includes(edgeId)) return
-  edgesMap.delete(edgeId)
-  doc.commit()
+  if (deleteEdgeInto(doc, edgeId)) doc.commit()
+}
+
+/** Uncommitted spatial writes scoped to one `withSpatialBatch` call. */
+export interface SpatialBatchWriter {
+  writeNode(node: SpatialNode): void
+  writeEdge(edge: CanvasEdge): void
+  /** Same edge-cascade as `deleteSpatialNode`; absent ids write nothing. */
+  deleteNode(nodeId: string): void
+  deleteEdge(edgeId: string): void
+}
+
+/**
+ * Runs every write in `fn` inside ONE Loro commit — one `UndoManager`
+ * step, one local-update payload. N=1 is byte-identical to the
+ * corresponding single committing helper, and a batch that writes nothing
+ * (all deletes of absent ids) commits nothing, preserving the helpers'
+ * no-op semantics. (Loro's `UndoManager.groupStart()/groupEnd()` was
+ * considered and rejected: a remote import received mid-group can split
+ * the group, while a single commit is indivisible.)
+ *
+ * Error contract (matching this bridge's commit-last convention): if `fn`
+ * throws, NOTHING is committed — the error is rethrown and the partial
+ * uncommitted ops stay pending on the doc (visible to readers; commit is
+ * an undo/sync boundary, not a visibility boundary). The caller must then
+ * converge with a committing write — canvas-sync-session's documented
+ * fallback (`writeSpatialCanvas(doc, next)`) does exactly this, absorbing
+ * the pending ops into one converged commit. Never follow a thrown batch
+ * with an UNRELATED commit on the same doc: the pending ops would be
+ * silently absorbed into that step.
+ */
+export function withSpatialBatch(doc: LoroDoc, fn: (writer: SpatialBatchWriter) => void): void {
+  let wrote = false
+  const writer: SpatialBatchWriter = {
+    writeNode(node) {
+      writeNodeInto(doc, node)
+      wrote = true
+    },
+    writeEdge(edge) {
+      writeEdgeInto(doc, edge)
+      wrote = true
+    },
+    deleteNode(nodeId) {
+      if (deleteNodeCascadeInto(doc, nodeId)) wrote = true
+    },
+    deleteEdge(edgeId) {
+      if (deleteEdgeInto(doc, edgeId)) wrote = true
+    },
+  }
+  fn(writer)
+  // Success path only — a finally-commit would break the error contract
+  // above (the session fallback's own commit must stay the only one).
+  if (wrote) doc.commit()
 }
 
 export function readSpatialCanvas(doc: LoroDoc): SpatialCanvas {


### PR DESCRIPTION
## Summary

Slice 1 of the editor-completeness plan. Spike verdict (option C, adversarially reviewed over 3 rounds — the design survived; four test-spec corrections from the skeptic panel are folded in below): multi-object actions (paste, duplicate, multi-delete) must land N writes as **one Loro commit = one UndoManager step**, instead of riding the 500ms merge-timing heuristic.

**canvas-workspace — `withSpatialBatch(doc, fn)`**: every write in `fn`'s `SpatialBatchWriter` (writeNode/writeEdge/deleteNode-cascade/deleteEdge) lands in ONE commit.
- N=1 is **byte-identical** to the single committing helper — helper bodies are extracted into shared non-committing internals so field projection and the delete cascade cannot drift (pinned by export-bytes equality tests per operation).
- A batch that writes nothing (deletes of absent ids) commits nothing — preserving the helpers' documented no-op semantics (skeptic correction #2).
- Error contract: a thrown `fn` commits NOTHING; partial ops stay pending and **visible** (commit is an undo/sync boundary, not a visibility boundary — skeptic correction #1) until the caller's converging committing write absorbs them, which is exactly canvas-sync-session's existing fallback. Pinned by test.
- Loro's `UndoManager.groupStart/groupEnd` (present in the resolved loro-crdt **1.13.6** — skeptic correction #3) was considered and rejected: a remote import mid-group can split the group; a single commit is indivisible.
- fast-check property: any generated op list — one batch ≡ the sequential committing helpers on `readSpatialCanvas` state, and at most one undo step under `mergeInterval: 0`.

**apps/web**: `EditorCommand` gains `{kind:'batch', commands: EditorLeafCommand[]}` (two-type split forbids nesting), applied as a pure fold — empty/no-op batches return the input reference. `canvas-sync-session` maps batch to `withSpatialBatch` with all-or-nothing pre-validation: one unsupported member sends the whole batch down the full-resync fallback (still one commit / one undo step, whole-canvas granularity); `delete-edge` joins the batch-writable set using its `id` field (skeptic correction #4). Each batch gets a fresh debounce key — never deduped against another action.

Slice 3 (Cmd+D duplicate) and 4 (paste) call this next.

## Test plan

- [x] `loro-bridge.test.ts` (red-first): N=1 byte-identity ×4 ops, absent-id no-op (no undo step), N writes = exactly one undo step (`mergeInterval: 0`), error contract incl. fallback convergence (48 passed)
- [x] `loro-bridge.property.test.ts`: batch ≡ sequential equivalence property
- [x] `commands.test.ts`: batch fold + empty/no-op identity (40 passed)
- [x] `canvas-sync-session.test.ts` (red-first): one payload + one undo for create+connect+delete; unsupported-member fallback still one undo step; batched delete-edge keeps fine-grained granularity (peer edit survives merge) (28 passed)
- [x] Full: canvas-workspace-node 104 / apps/web jsdom 1472; typecheck exit 0 (both packages); root knip clean