### PR TITLE
feat: duplicate selection via Cmd/Ctrl+D and the context menu

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,6 +50,7 @@ import {
   BringToFront,
   ChevronDown,
   ChevronUp,
+  Copy as CopyIcon,
   ExternalLink,
   FileBox,
   Focus,
@@ -80,6 +81,7 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { extractClipboardFragment, remintClipboardFragment } from '../../lib/clipboard-fragment.js'
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
@@ -227,6 +229,9 @@ const DOUBLE_PRESS_WINDOW_MS = 400
 
 /** One click of the hand-mode zoom buttons scales by this factor. */
 const ZOOM_STEP_FACTOR = 1.25
+
+/** Duplicated copies land offset by this much, cascading on repeat. */
+const DUPLICATE_OFFSET_PX = 16
 const ZOOM_WHEEL_FACTOR = 1.1
 /** Canvas-space px per arrow-key nudge on a focused resize handle; Shift multiplies by 4. */
 const RESIZE_KEYBOARD_STEP = 8
@@ -1081,9 +1086,60 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return true
     }
 
+    /**
+     * Clones the selection as ONE batch command (one undo step): reminted
+     * ids via the clipboard-fragment helpers, +16px offset (the standard
+     * duplicate-again cascade), edges kept only when both endpoints are
+     * selected — with their properties. The copies become the selection.
+     */
+    const duplicateSelection = (): boolean => {
+      if (selection === undefined) return false
+      const current = canvasRef.current
+      const fragment = extractClipboardFragment(current, new Set([selection.id, ...extraIds]))
+      if (fragment.nodes.length === 0) return false
+      const existingIds = new Set([
+        ...current.nodes.map((node) => node.id),
+        ...current.edges.map((edge) => edge.id),
+      ])
+      const reminted = remintClipboardFragment(
+        fragment,
+        () => createId?.() ?? crypto.randomUUID(),
+        existingIds,
+      )
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: [
+          ...reminted.nodes.map(
+            (node) =>
+              ({
+                kind: 'create-node',
+                node: {
+                  ...node,
+                  x: node.x + DUPLICATE_OFFSET_PX,
+                  y: node.y + DUPLICATE_OFFSET_PX,
+                },
+              }) as const,
+          ),
+          ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
+        ],
+      }
+      const running = applyCommand(current, command)
+      if (running === current) return false
+      onChange(running, command)
+      const [first, ...rest] = reminted.nodes.map((node) => node.id)
+      if (first !== undefined) {
+        setSelectedId(first)
+        setExtraIds(new Set(rest))
+        setSelectedEdgeId(null)
+      }
+      return true
+    }
+
     /** Table-dispatched shortcut handlers, keyed by the catalog's ids. */
     const runShortcut = (id: ShortcutId): boolean => {
       switch (id) {
+        case 'duplicate-selection':
+          return duplicateSelection()
         case 'reorder-forward':
           return reorderSelection('forward')
         case 'reorder-backward':
@@ -2040,6 +2096,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 // entry sits in its own section.
                 items.push({ kind: 'separator' })
               }
+              // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
+              // right-click already made this node the primary selection,
+              // so the shared handler clones the full multi-selection.
+              items.push({
+                label: 'Duplicate',
+                icon: <CopyIcon />,
+                onSelect: () => {
+                  duplicateSelection()
+                },
+              })
               items.push(
                 colorRow(node.color, (color) =>
                   applyResult({

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -563,3 +563,44 @@ describe('batch', () => {
     ).toBe(canvas)
   })
 })
+
+// create-edge (slice 3): duplicate/paste re-create edges WITH their
+// properties (sides/ends/color/label) — connect-nodes only carries
+// endpoints, so a full-edge creation command is needed.
+describe('create-edge', () => {
+  const fullEdge = {
+    id: 'e-dup',
+    fromNode: 'a',
+    toNode: 'b',
+    fromSide: 'right',
+    toSide: 'left',
+    fromEnd: 'arrow',
+    label: 'kept',
+    color: '3',
+  } as const
+
+  it('appends the edge verbatim, preserving every optional property', () => {
+    const canvas = baseCanvas()
+    const next = applyCommand(canvas, { kind: 'create-edge', edge: fullEdge })
+    expect(next.edges).toEqual([fullEdge])
+    expect(next.nodes).toBe(canvas.nodes)
+    expect(spatialCanvasSchema.safeParse(next).success).toBe(true)
+  })
+
+  it('is total: duplicate edge id, missing endpoint, and self-loop are no-ops returning the input', () => {
+    const canvas = applyCommand(baseCanvas(), { kind: 'create-edge', edge: fullEdge })
+    expect(applyCommand(canvas, { kind: 'create-edge', edge: fullEdge })).toBe(canvas)
+    expect(
+      applyCommand(canvas, {
+        kind: 'create-edge',
+        edge: { ...fullEdge, id: 'x', toNode: 'ghost' },
+      }),
+    ).toBe(canvas)
+    expect(
+      applyCommand(canvas, {
+        kind: 'create-edge',
+        edge: { ...fullEdge, id: 'y', fromNode: 'a', toNode: 'a' },
+      }),
+    ).toBe(canvas)
+  })
+})

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -46,6 +46,16 @@ export type EditorLeafCommand =
   | { readonly kind: 'delete-node'; readonly id: string }
   | {
       /**
+       * Appends a full edge verbatim (sides/ends/color/label preserved) —
+       * what duplicate/paste re-create edges with; `connect-nodes` only
+       * carries endpoints. Total: duplicate id, missing endpoint, and
+       * self-loop are no-ops.
+       */
+      readonly kind: 'create-edge'
+      readonly edge: CanvasEdge
+    }
+  | {
+      /**
        * Z-order move. Array order IS z-order in JSON Canvas (last = topmost),
        * so this is a pure permutation of `nodes`. A multi-selection moves as
        * ONE block preserving its relative order; forward/backward step the
@@ -391,11 +401,21 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return deleteNode(canvas, command.id)
     case 'reorder-nodes':
       return reorderNodes(canvas, command.ids, command.placement)
+    case 'create-edge':
+      return createEdge(canvas, command.edge)
     case 'batch':
       // Pure fold; a batch of no-ops folds back to the input reference,
       // preserving the union-wide "nothing changed → same object" contract.
       return command.commands.reduce(applyCommand, canvas)
   }
+}
+
+function createEdge(canvas: SpatialCanvas, edge: CanvasEdge): SpatialCanvas {
+  if (canvas.edges.some((existing) => existing.id === edge.id)) return canvas
+  if (edge.fromNode === edge.toNode) return canvas
+  const nodeIds = new Set(canvas.nodes.map((node) => node.id))
+  if (!nodeIds.has(edge.fromNode) || !nodeIds.has(edge.toNode)) return canvas
+  return { ...canvas, edges: [...canvas.edges, edge] }
 }
 
 /** Strict bbox intersection — flush-touching edges are NOT overlap. */

--- a/apps/web/src/components/spatial-editor/duplicate.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/duplicate.browser.test.tsx
@@ -1,0 +1,141 @@
+// Duplicate (editor-completeness slice 3): Cmd/Ctrl+D and the context
+// menu's Duplicate item clone the selection as ONE batch command —
+// reminted ids, +16px offset, edge properties preserved, copies selected.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import type { EditorCommand } from './commands.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 160, height: 80, text: 'A' },
+    { id: 'b', type: 'text', x: 320, y: 40, width: 160, height: 80, text: 'B' },
+  ],
+  edges: [
+    {
+      id: 'ab',
+      fromNode: 'a',
+      toNode: 'b',
+      fromSide: 'right',
+      toSide: 'left',
+      label: 'kept-label',
+      color: '3',
+    },
+  ],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: initial,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function selectNode(root: HTMLElement, x: number, y: number, shift = false) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+}
+
+it('Cmd+D duplicates the selected node as ONE batch command, offset and selected', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  selectNode(root, 120, 80)
+
+  fireEvent.keyDown(root, { code: 'KeyD', key: 'd', metaKey: true })
+
+  expect(latest.canvas.nodes).toHaveLength(3)
+  const copy = latest.canvas.nodes[2]
+  expect(copy.id).not.toBe('a')
+  expect(copy).toMatchObject({ type: 'text', text: 'A', x: 40 + 16, y: 40 + 16 })
+  // One batch command = one undo step at the sync layer.
+  const last = latest.commands.at(-1)
+  expect(last?.kind).toBe('batch')
+  // The copy is now the selection (duplicate-again chains).
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+  fireEvent.keyDown(root, { code: 'KeyD', key: 'd', ctrlKey: true })
+  expect(latest.canvas.nodes).toHaveLength(4)
+  expect(latest.canvas.nodes[3]).toMatchObject({ x: 40 + 32, y: 40 + 32 })
+})
+
+it('duplicating a multi-selection keeps the connecting edge WITH its properties, endpoints remapped', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  selectNode(root, 120, 80)
+  selectNode(root, 400, 80, true)
+
+  fireEvent.keyDown(root, { code: 'KeyD', key: 'd', metaKey: true })
+
+  expect(latest.canvas.nodes).toHaveLength(4)
+  expect(latest.canvas.edges).toHaveLength(2)
+  const copyIds = new Set(latest.canvas.nodes.slice(2).map((n) => n.id))
+  const copiedEdge = latest.canvas.edges[1]
+  expect(copiedEdge.id).not.toBe('ab')
+  expect(copyIds.has(copiedEdge.fromNode)).toBe(true)
+  expect(copyIds.has(copiedEdge.toNode)).toBe(true)
+  expect(copiedEdge).toMatchObject({
+    fromSide: 'right',
+    toSide: 'left',
+    label: 'kept-label',
+    color: '3',
+  })
+})
+
+it('the context menu offers Duplicate as the touch path', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+
+  fireEvent.contextMenu(root, { clientX: r.left + 120, clientY: r.top + 80 })
+  const item = [...container.querySelectorAll('[data-testid="context-menu"] *')].find(
+    (el) => el.textContent === 'Duplicate' && el.tagName === 'BUTTON',
+  ) as HTMLElement
+  expect(item).toBeDefined()
+  fireEvent.click(item)
+  expect(latest.canvas.nodes).toHaveLength(3)
+})
+
+it('Cmd+D without a selection does nothing (and typing d in the editor never duplicates)', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  fireEvent.keyDown(root, { code: 'KeyD', key: 'd', metaKey: true })
+  expect(latest.canvas.nodes).toHaveLength(2)
+  expect(latest.commands).toHaveLength(0)
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.test.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.test.ts
@@ -98,10 +98,25 @@ describe('findShortcutIn modifier semantics', () => {
     expect(findShortcutIn([scoped], event({ ...KEY_C, metaKey: true }), 'hand')).toBeUndefined()
   })
 
-  it('regression: no existing catalog entry declares mod/alt, so the table is unaffected', () => {
-    for (const spec of EDITOR_SHORTCUTS) {
-      expect(spec.mod).toBeUndefined()
-      expect(spec.alt).toBeUndefined()
+  it('regression: the pre-modifier catalog entries still declare neither mod nor alt', () => {
+    // The z-order and inline-handled bindings predate modifier support and
+    // must keep firing exactly as before; only chords added SINCE (e.g.
+    // duplicate-selection) may claim a modifier.
+    const preModifierIds = [
+      'reorder-forward',
+      'reorder-backward',
+      'reorder-front',
+      'reorder-back',
+      'delete-selection',
+      'cancel',
+      'space-pan',
+      'nudge-selection',
+    ]
+    for (const id of preModifierIds) {
+      const spec = EDITOR_SHORTCUTS.find((entry) => entry.id === id)
+      expect(spec).toBeDefined()
+      expect(spec?.mod).toBeUndefined()
+      expect(spec?.alt).toBeUndefined()
     }
   })
 })

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -15,6 +15,7 @@
 import type { EditorTool } from './ToolPalette.js'
 
 export type ShortcutId =
+  | 'duplicate-selection'
   | 'reorder-forward'
   | 'reorder-backward'
   | 'reorder-front'
@@ -54,6 +55,14 @@ export interface ShortcutSpec {
 }
 
 export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
+  {
+    id: 'duplicate-selection',
+    keys: ['d'],
+    mod: true,
+    display: 'Cmd+D',
+    description: 'Duplicate the selection',
+    tools: ['select'],
+  },
   // Z-order (tldraw parity). Array order is z-order, last = topmost.
   {
     id: 'reorder-forward',

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -212,6 +212,8 @@ function isBatchWritable(command: EditorLeafCommand, next: SpatialCanvas): boole
       return next.nodes.some((n) => n.id === command.node.id)
     case 'connect-nodes':
       return next.edges.some((e) => e.id === command.edgeId)
+    case 'create-edge':
+      return next.edges.some((e) => e.id === command.edge.id)
     case 'delete-node':
     case 'delete-edge':
       // Deletes are no-ops for absent ids — always writable.
@@ -241,6 +243,11 @@ function writeSubCommand(
     }
     case 'connect-nodes': {
       const edge = next.edges.find((e) => e.id === command.edgeId)
+      if (edge) writer.writeEdge(edge)
+      return
+    }
+    case 'create-edge': {
+      const edge = next.edges.find((e) => e.id === command.edge.id)
       if (edge) writer.writeEdge(edge)
       return
     }


### PR DESCRIPTION
## Summary

Slice 3 of the editor-completeness plan — the first user-visible consumer of all three foundations: the modifier-aware shortcut catalog (#490), the clipboard-fragment remint helpers (#491), and the undo-batching seam (#492).

- **Cmd/Ctrl+D** (Select mode, catalog entry `duplicate-selection`) clones the selection as **ONE batch command → one Loro commit → one undo step**. Live-verified: duplicate on the real page, then a single Undo click removes every copied node and edge.
- Copies land **+16px offset** (cascading on repeat) and become the selection, so duplicate-again chains.
- **Edges keep their properties**: a new total `create-edge` leaf command appends a full edge verbatim (sides/ends/color/label) — `connect-nodes` only carries endpoints and would have dropped them. Duplicate id / missing endpoint / self-loop are no-ops; `create-edge` joins the batch-writable set in canvas-sync-session.
- **Context menu gains Duplicate** as the touch path (every keyboard action has one).
- Cmd+D with no selection returns false → no preventDefault → the browser keeps its bookmark shortcut.

## Test plan

- [x] `commands.test.ts`: create-edge verbatim append + totality (42 passed)
- [x] `duplicate.browser.test.tsx` (red-first, real Chromium): Cmd+D and Ctrl+D duplicate + offset cascade + batch command shape + copies-selected; multi-selection keeps the connecting edge with properties, endpoints remapped; menu Duplicate; no-selection no-op (4 passed)
- [x] Live in Chrome: Cmd+D duplicates 'Release plan', ONE Undo click reverts the whole action (the slice-1 batching guarantee, observed end-to-end)
- [x] Full suites: web-browser 292/55, jsdom 1474/123; typecheck 0; root knip clean (the 0a 'no mod entries' regression test updated to pin only the pre-modifier bindings — Cmd+D is the first legitimate mod entry)