### PR TITLE
feat: in-app copy/cut/paste over a shared clipboard slot

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -50,6 +50,7 @@ import {
   BringToFront,
   ChevronDown,
   ChevronUp,
+  ClipboardPaste,
   Copy as CopyIcon,
   ExternalLink,
   FileBox,
@@ -62,6 +63,7 @@ import {
   PanelRight,
   PanelTop,
   Pencil,
+  Scissors,
   SendToBack,
   SquareDashed,
   StickyNote,
@@ -82,6 +84,11 @@ import {
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { extractClipboardFragment, remintClipboardFragment } from '../../lib/clipboard-fragment.js'
+import {
+  hasClipboardFragment,
+  readClipboardFragment,
+  writeClipboardFragment,
+} from '../../lib/clipboard-store.js'
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
@@ -1135,9 +1142,94 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return true
     }
 
+    /** Copy the selection into the in-app clipboard slot. No mutation. */
+    const copySelection = (): boolean => {
+      if (selection === undefined) return false
+      const fragment = extractClipboardFragment(
+        canvasRef.current,
+        new Set([selection.id, ...extraIds]),
+      )
+      if (fragment.nodes.length === 0) return false
+      writeClipboardFragment(fragment)
+      return true
+    }
+
+    /** Copy, then remove the selection as ONE batch (one undo step). */
+    const cutSelection = (): boolean => {
+      if (!copySelection() || selection === undefined) return false
+      const ids = [selection.id, ...extraIds]
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: ids.map((id) => ({ kind: 'delete-node', id }) as const),
+      }
+      const running = applyCommand(canvasRef.current, command)
+      if (running !== canvasRef.current) onChange(running, command)
+      setSelectedId(null)
+      setExtraIds(new Set())
+      setSelectedEdgeId(null)
+      return true
+    }
+
+    /**
+     * Paste the stored fragment as ONE batch: reminted ids, edges remapped.
+     * With an anchor point (the empty-space menu's "Paste here") the
+     * fragment's bounding box centers on it; without one (Cmd+V) copies
+     * land +16px from their source coordinates, cascading like duplicate.
+     */
+    const pasteClipboard = (at?: Point): boolean => {
+      const fragment = readClipboardFragment()
+      if (fragment === null || fragment.nodes.length === 0) return false
+      const current = canvasRef.current
+      const existingIds = new Set([
+        ...current.nodes.map((node) => node.id),
+        ...current.edges.map((edge) => edge.id),
+      ])
+      const reminted = remintClipboardFragment(
+        fragment,
+        () => createId?.() ?? crypto.randomUUID(),
+        existingIds,
+      )
+      let dx = DUPLICATE_OFFSET_PX
+      let dy = DUPLICATE_OFFSET_PX
+      if (at !== undefined) {
+        const minX = Math.min(...reminted.nodes.map((node) => node.x))
+        const minY = Math.min(...reminted.nodes.map((node) => node.y))
+        const maxX = Math.max(...reminted.nodes.map((node) => node.x + node.width))
+        const maxY = Math.max(...reminted.nodes.map((node) => node.y + node.height))
+        dx = Math.round(at.x - (minX + maxX) / 2)
+        dy = Math.round(at.y - (minY + maxY) / 2)
+      }
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: [
+          ...reminted.nodes.map(
+            (node) =>
+              ({ kind: 'create-node', node: { ...node, x: node.x + dx, y: node.y + dy } }) as const,
+          ),
+          ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
+        ],
+      }
+      const running = applyCommand(current, command)
+      if (running === current) return false
+      onChange(running, command)
+      const [first, ...rest] = reminted.nodes.map((node) => node.id)
+      if (first !== undefined) {
+        setSelectedId(first)
+        setExtraIds(new Set(rest))
+        setSelectedEdgeId(null)
+      }
+      return true
+    }
+
     /** Table-dispatched shortcut handlers, keyed by the catalog's ids. */
     const runShortcut = (id: ShortcutId): boolean => {
       switch (id) {
+        case 'copy-selection':
+          return copySelection()
+        case 'cut-selection':
+          return cutSelection()
+        case 'paste-clipboard':
+          return pasteClipboard()
         case 'duplicate-selection':
           return duplicateSelection()
         case 'reorder-forward':
@@ -1990,6 +2082,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 // the click point — "here" is exactly the information the
                 // bottom dock cannot express.
                 const emptyItems: ContextMenuItem[] = [
+                  ...(hasClipboardFragment()
+                    ? [
+                        {
+                          label: 'Paste here',
+                          icon: <ClipboardPaste />,
+                          onSelect: () => {
+                            pasteClipboard(contextMenu.point)
+                          },
+                        },
+                        { kind: 'separator' } as const,
+                      ]
+                    : []),
                   {
                     label: 'Add note here',
                     icon: <StickyNote />,
@@ -2099,6 +2203,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
               // right-click already made this node the primary selection,
               // so the shared handler clones the full multi-selection.
+              items.push({
+                label: 'Copy',
+                icon: <CopyIcon />,
+                onSelect: () => {
+                  copySelection()
+                },
+              })
+              items.push({
+                label: 'Cut',
+                icon: <Scissors />,
+                onSelect: () => {
+                  cutSelection()
+                },
+              })
               items.push({
                 label: 'Duplicate',
                 icon: <CopyIcon />,

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -1,0 +1,170 @@
+// In-app copy/cut/paste (editor-completeness slice 4): Cmd/Ctrl+C/X/V over
+// the module-level clipboard store — cross-canvas within the tab, every
+// mutation ONE batch command (one undo step), reminted ids on every paste.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+import { clearClipboardFragmentForTests } from '../../lib/clipboard-store.js'
+import type { EditorCommand } from './commands.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+beforeEach(clearClipboardFragmentForTests)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 160, height: 80, text: 'A' },
+    { id: 'b', type: 'text', x: 320, y: 40, width: 160, height: 80, text: 'B' },
+  ],
+  edges: [{ id: 'ab', fromNode: 'a', toNode: 'b', label: 'kept' }],
+}
+
+function makeHost(start: SpatialCanvas = initial) {
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: start,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function selectAt(root: HTMLElement, x: number, y: number, shift = false) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+it('copy then paste clones the selection with reminted ids, offset, as ONE batch', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+  // Copy never mutates the canvas.
+  expect(latest.commands).toHaveLength(0)
+
+  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  expect(latest.canvas.nodes).toHaveLength(3)
+  const copy = latest.canvas.nodes[2]
+  expect(copy.id).not.toBe('a')
+  expect(copy).toMatchObject({ text: 'A', x: 40 + 16, y: 40 + 16 })
+  expect(latest.commands.at(-1)?.kind).toBe('batch')
+
+  // Paste again: reminted afresh, cascading offset from the ORIGINAL copy.
+  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', ctrlKey: true })
+  expect(latest.canvas.nodes).toHaveLength(4)
+  expect(new Set(latest.canvas.nodes.map((n) => n.id)).size).toBe(4)
+})
+
+it('cut removes the selection as ONE batch and paste restores a reminted copy', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  fireEvent.keyDown(root, { code: 'KeyX', key: 'x', metaKey: true })
+  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
+  // The edge cascaded away with its endpoint.
+  expect(latest.canvas.edges).toEqual([])
+  expect(latest.commands.at(-1)?.kind).toBe('batch')
+
+  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  expect(latest.canvas.nodes).toHaveLength(2)
+  expect(latest.canvas.nodes[1]).toMatchObject({ text: 'A' })
+})
+
+it('a multi-selection copy carries the internal edge with properties; paste remaps endpoints', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  selectAt(root, 400, 80, true)
+
+  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+
+  expect(latest.canvas.nodes).toHaveLength(4)
+  expect(latest.canvas.edges).toHaveLength(2)
+  const pastedIds = new Set(latest.canvas.nodes.slice(2).map((n) => n.id))
+  const pastedEdge = latest.canvas.edges[1]
+  expect(pastedEdge.label).toBe('kept')
+  expect(pastedIds.has(pastedEdge.fromNode)).toBe(true)
+  expect(pastedIds.has(pastedEdge.toNode)).toBe(true)
+})
+
+it('the clipboard is shared across editor mounts — cross-canvas paste within the tab', () => {
+  const a = makeHost()
+  const first = render(<a.Host />)
+  selectAt(rootOf(first.container), 120, 80)
+  fireEvent.keyDown(rootOf(first.container), { code: 'KeyC', key: 'c', metaKey: true })
+  first.unmount()
+
+  const empty: SpatialCanvas = { nodes: [], edges: [] }
+  const b = makeHost(empty)
+  const second = render(<b.Host />)
+  fireEvent.keyDown(rootOf(second.container), { code: 'KeyV', key: 'v', metaKey: true })
+  expect(b.latest.canvas.nodes).toHaveLength(1)
+  expect(b.latest.canvas.nodes[0]).toMatchObject({ text: 'A' })
+})
+
+it("the empty-space context menu offers 'Paste here', centering the fragment at the click point", () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 600, clientY: r.top + 400 })
+  const item = [...container.querySelectorAll('[data-testid="context-menu"] button')].find(
+    (el) => el.textContent === 'Paste here',
+  ) as HTMLElement
+  expect(item).toBeDefined()
+  fireEvent.click(item)
+
+  const pasted = latest.canvas.nodes[2]
+  // Centered on the click point (identity viewport): 600-80, 400-40.
+  expect(pasted).toMatchObject({ x: 600 - 80, y: 400 - 40 })
+})
+
+it('Cmd+C or Cmd+V with nothing to act on stays inert (browser keeps its own copy/paste)', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  expect(latest.commands).toHaveLength(0)
+  expect(latest.canvas.nodes).toHaveLength(2)
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -15,6 +15,9 @@
 import type { EditorTool } from './ToolPalette.js'
 
 export type ShortcutId =
+  | 'copy-selection'
+  | 'cut-selection'
+  | 'paste-clipboard'
   | 'duplicate-selection'
   | 'reorder-forward'
   | 'reorder-backward'
@@ -55,6 +58,33 @@ export interface ShortcutSpec {
 }
 
 export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
+  // Clipboard family. With nothing to act on the handlers return false and
+  // the event falls through, so the browser keeps its own copy/paste for
+  // text selections.
+  {
+    id: 'copy-selection',
+    keys: ['c'],
+    mod: true,
+    display: 'Cmd+C',
+    description: 'Copy the selection',
+    tools: ['select'],
+  },
+  {
+    id: 'cut-selection',
+    keys: ['x'],
+    mod: true,
+    display: 'Cmd+X',
+    description: 'Cut the selection',
+    tools: ['select'],
+  },
+  {
+    id: 'paste-clipboard',
+    keys: ['v'],
+    mod: true,
+    display: 'Cmd+V',
+    description: 'Paste the copied nodes',
+    tools: ['select'],
+  },
   {
     id: 'duplicate-selection',
     keys: ['d'],

--- a/apps/web/src/lib/clipboard-store.ts
+++ b/apps/web/src/lib/clipboard-store.ts
@@ -1,0 +1,33 @@
+/**
+ * In-app clipboard (editor-completeness slice 4): one module-level slot
+ * holding the last copied fragment, shared by every editor mount in the
+ * tab — which is exactly what makes cross-canvas paste work (navigate to
+ * another canvas, Cmd+V). Deliberately NOT the OS clipboard: that
+ * integration (slice 5) layers on top of this store, and an in-memory
+ * slot needs no permissions and cannot race an unmount.
+ *
+ * File-node references travel by reference, not inline bytes: in
+ * browser-local mode the asset store is origin-global, so a same-tab
+ * cross-canvas paste resolves them as-is. Inline `files` assets are the
+ * OS-clipboard slice's concern.
+ */
+import type { ClipboardFragment } from '@kamiazya/whiteboard-canvas-model'
+
+let current: ClipboardFragment | null = null
+
+export function writeClipboardFragment(fragment: ClipboardFragment): void {
+  current = fragment
+}
+
+export function readClipboardFragment(): ClipboardFragment | null {
+  return current
+}
+
+export function hasClipboardFragment(): boolean {
+  return current !== null && current.nodes.length > 0
+}
+
+/** Test isolation only — production never clears the slot. */
+export function clearClipboardFragmentForTests(): void {
+  current = null
+}


### PR DESCRIPTION
## Summary

Slice 4 of the editor-completeness plan — the clipboard family proper, on top of #490/#491/#492/#493.

- **Cmd/Ctrl+C** copies the selection into a module-level fragment slot shared by every editor mount in the tab — which is exactly what makes **cross-canvas paste** work (navigate to another canvas, Cmd+V). File-node references travel by reference (browser-local assets are origin-global); inline `files` assets stay the OS-clipboard slice's concern.
- **Cmd/Ctrl+V** pastes with reminted ids and remapped edges as **ONE batch → one undo step**; +16px offset cascades like duplicate. The empty-space context menu gains **'Paste here'** (only when a fragment exists), centering the fragment's bounding box on the click point — position is exactly what the keyboard cannot express.
- **Cmd/Ctrl+X** is copy + one batched delete (edge cascade included).
- Node context menu gains **Copy / Cut** as the touch path; with nothing to act on every handler returns false, so the browser keeps its own text copy/paste behavior.

## Test plan

- [x] `clipboard.browser.test.tsx` (red-first, real Chromium, 6): copy→paste reminted+offset+batch; repeat-paste unique ids; cut one-batch + paste restores; multi-selection edge kept with properties, endpoints remapped; cross-mount (cross-canvas) paste; Paste-here centering; no-op inertness
- [x] Live in Chrome: Cmd+C → Cmd+V on 'Release plan' (copy appears), empty-space 'Paste here' pastes at the click point, each paste reverts with ONE Undo click
- [x] Full suites: web-browser 298/56, jsdom 1475/123; typecheck 0; root knip clean