### PR TITLE
feat: select-all and whole-selection arrow nudge

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1221,9 +1221,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return true
     }
 
+    /** Select every node; the first becomes primary, the rest extras. */
+    const selectAllNodes = (): boolean => {
+      const [first, ...rest] = canvasRef.current.nodes.map((node) => node.id)
+      if (first === undefined) return false
+      setSelectedId(first)
+      setExtraIds(new Set(rest))
+      setSelectedEdgeId(null)
+      return true
+    }
+
     /** Table-dispatched shortcut handlers, keyed by the catalog's ids. */
     const runShortcut = (id: ShortcutId): boolean => {
       switch (id) {
+        case 'select-all':
+          return selectAllNodes()
         case 'copy-selection':
           return copySelection()
         case 'cut-selection':
@@ -1316,22 +1328,26 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       ) {
         e.preventDefault()
         const step = e.shiftKey ? RESIZE_KEYBOARD_STEP_LARGE : RESIZE_KEYBOARD_STEP
-        // Read the node's position from canvasRef, not the render closure:
-        // key auto-repeat delivers keydowns faster than commits re-render,
-        // and a stale base makes each repeat clobber the previous nudge.
-        const current = canvasRef.current.nodes.find((n) => n.id === selectedNode.id)
-        if (current === undefined) return
-        applyResult({
-          state: gestureState,
-          commands: [
+        // Nudge the WHOLE selection, not just the primary: a multi-selection
+        // that tore apart under the arrow keys was a latent bug select-all
+        // makes trivial to hit. Positions are read from canvasRef, not the
+        // render closure — key auto-repeat delivers keydowns faster than
+        // commits re-render, and a stale base clobbers the previous nudge.
+        const ids = [selectedNode.id, ...extraIds]
+        const moves = ids.flatMap((id) => {
+          const current = canvasRef.current.nodes.find((n) => n.id === id)
+          if (current === undefined) return []
+          return [
             {
-              kind: 'move-node',
+              kind: 'move-node' as const,
               id: current.id,
               x: current.x + nudge.dx * step,
               y: current.y + nudge.dy * step,
             },
-          ],
+          ]
         })
+        if (moves.length === 0) return
+        applyResult({ state: gestureState, commands: moves })
         return
       }
       if (

--- a/apps/web/src/components/spatial-editor/select-all-nudge.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/select-all-nudge.browser.test.tsx
@@ -1,0 +1,108 @@
+// Select-all (Cmd/Ctrl+A) + multi-selection nudge parity (editor-
+// completeness slice 6). The nudge fix closes a latent bug select-all
+// makes immediately visible: arrow keys moved only the PRIMARY node,
+// tearing a multi-selection apart.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 160, height: 80, text: 'A' },
+    { id: 'b', type: 'text', x: 320, y: 40, width: 160, height: 80, text: 'B' },
+    { id: 'c', type: 'text', x: 40, y: 240, width: 160, height: 80, text: 'C' },
+  ],
+  edges: [],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+function selectAt(root: HTMLElement, x: number, y: number, shift = false) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    shiftKey: shift,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+}
+
+it('Cmd/Ctrl+A selects every node; Delete then removes them all', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  fireEvent.keyDown(root, { code: 'KeyA', key: 'a', metaKey: true })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+
+  fireEvent.keyDown(root, { key: 'Delete' })
+  expect(latest.canvas.nodes).toEqual([])
+})
+
+it('arrow-key nudge moves the WHOLE multi-selection by the same delta', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  selectAt(root, 400, 80, true)
+
+  fireEvent.keyDown(root, { key: 'ArrowRight' })
+  const a = latest.canvas.nodes.find((n) => n.id === 'a')
+  const b = latest.canvas.nodes.find((n) => n.id === 'b')
+  const c = latest.canvas.nodes.find((n) => n.id === 'c')
+  expect(a?.x).toBeGreaterThan(40)
+  expect(b?.x ?? 0).toBe(320 + ((a?.x ?? 0) - 40))
+  // The unselected node never moves.
+  expect(c).toMatchObject({ x: 40, y: 240 })
+})
+
+it('Cmd+A on an empty canvas stays inert', () => {
+  const empty: SpatialCanvas = { nodes: [], edges: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(empty)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  fireEvent.keyDown(rootOf(container), { code: 'KeyA', key: 'a', metaKey: true })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -15,6 +15,7 @@
 import type { EditorTool } from './ToolPalette.js'
 
 export type ShortcutId =
+  | 'select-all'
   | 'copy-selection'
   | 'cut-selection'
   | 'paste-clipboard'
@@ -58,6 +59,14 @@ export interface ShortcutSpec {
 }
 
 export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
+  {
+    id: 'select-all',
+    keys: ['a'],
+    mod: true,
+    display: 'Cmd+A',
+    description: 'Select every node',
+    tools: ['select'],
+  },
   // Clipboard family. With nothing to act on the handlers return false and
   // the event falls through, so the browser keeps its own copy/paste for
   // text selections.


### PR DESCRIPTION
## Summary

Slice 6 of the editor-completeness plan.

- **Cmd/Ctrl+A** selects every node (first becomes primary, the rest extras), so Delete, copy/cut, duplicate, and the z-order commands all act on the whole canvas. Inert on an empty canvas.
- **Arrow-key nudge now moves the WHOLE selection** by the same delta. Previously only the primary node moved — a latent bug that tore a multi-selection apart, which select-all makes trivial to hit. Unselected nodes never move; positions are still read from `canvasRef` so key auto-repeat cannot clobber the previous nudge.

## Test plan

- [x] `select-all-nudge.browser.test.tsx` (red-first, real Chromium): Cmd+A then Delete empties the canvas; arrow nudge moves both selected nodes by an equal delta while the unselected one stays put; Cmd+A on an empty canvas is inert (3 passed)
- [x] Full suites: web-browser 301/57, jsdom 1475/123; typecheck 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cmd/Ctrl+A support to select all nodes in the spatial editor.
  - Arrow-key nudging now moves all selected nodes together while preserving their relative positions.
  - The first selected node remains the primary selection.

- **Bug Fixes**
  - Delete now correctly removes all selected nodes.
  - Select-all has no effect when the canvas is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->