### PR TITLE
feat: zoom to fit / zoom to selection, plus two review fixes

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -98,6 +98,11 @@ Z-order uses the tldraw combos: `]` / `[` step forward/backward,
 mutates the canvas also has a touch path (the context menu's Order row,
 here) — a shortcut is an accelerator, never the only way.
 
+Bindings today: `Cmd/Ctrl+A` select all, `Cmd/Ctrl+C/X/V` copy/cut/paste,
+`Cmd/Ctrl+D` duplicate, `]`/`[`/`Shift+]`/`Shift+[` z-order,
+`Shift+1`/`Shift+2` zoom to fit / to selection, plus the inline-handled
+Delete / Esc / Space-pan / arrows.
+
 Modifier policy: a spec claims the platform command chord with
 `mod: true` (Cmd on macOS or Ctrl elsewhere — either satisfies it) and
 Alt with `alt: true`; a held modifier suppresses every spec that does

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -118,6 +118,7 @@ import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.j
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   canvasToScreen,
+  clampZoom,
   fitViewportToBoxes,
   IDENTITY_VIEWPORT,
   type Point,
@@ -239,6 +240,9 @@ const ZOOM_STEP_FACTOR = 1.25
 
 /** Duplicated copies land offset by this much, cascading on repeat. */
 const DUPLICATE_OFFSET_PX = 16
+
+/** Breathing room kept around framed content (zoom to fit / selection). */
+const FRAME_MARGIN_PX = 24
 const ZOOM_WHEEL_FACTOR = 1.1
 /** Canvas-space px per arrow-key nudge on a focused resize handle; Shift multiplies by 4. */
 const RESIZE_KEYBOARD_STEP = 8
@@ -1234,6 +1238,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /** Table-dispatched shortcut handlers, keyed by the catalog's ids. */
     const runShortcut = (id: ShortcutId): boolean => {
       switch (id) {
+        case 'zoom-to-fit':
+          return frameContent()
+        case 'zoom-to-selection':
+          return frameSelection()
         case 'select-all':
           return selectAllNodes()
         case 'copy-selection':
@@ -1509,27 +1517,63 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * keeping the current zoom (the hand-mode "where did my content go"
      * recovery). No boxes → no-op.
      */
-    const centerContentInViewport = () => {
-      if (boxes.length === 0) return
+    /** Union of the given nodes' boxes, or undefined when there is none. */
+    const contentBounds = (ids?: ReadonlySet<string>) => {
       let minX = Number.POSITIVE_INFINITY
       let minY = Number.POSITIVE_INFINITY
       let maxX = Number.NEGATIVE_INFINITY
       let maxY = Number.NEGATIVE_INFINITY
-      for (const { box } of boxes) {
+      for (const { id, box } of boxes) {
+        if (ids !== undefined && !ids.has(id)) continue
         if (!Number.isFinite(box.x) || !Number.isFinite(box.y)) continue
         minX = Math.min(minX, box.x)
         minY = Math.min(minY, box.y)
         maxX = Math.max(maxX, box.x + box.width)
         maxY = Math.max(maxY, box.y + box.height)
       }
-      if (!Number.isFinite(minX) || !Number.isFinite(minY)) return
-      const contentCenter = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+      if (!Number.isFinite(minX) || !Number.isFinite(minY)) return undefined
+      return { minX, minY, maxX, maxY }
+    }
+
+    /**
+     * Frames the given content: pans so its center sits at the viewport
+     * center, and zooms so the whole box fits with a small margin —
+     * magnifying a small selection as readily as it shrinks an oversized
+     * canvas, which is the whole point of zoom-to-selection. Never
+     * magnifies past 1:1 (a two-word note would otherwise fill the screen)
+     * and stays inside the viewport module's own [MIN_ZOOM, MAX_ZOOM].
+     */
+    const frameContent = (ids?: ReadonlySet<string>) => {
+      const bounds = contentBounds(ids)
+      if (bounds === undefined) return false
+      const root = rootRef.current
       const center = viewportCenterScreen()
-      setViewport((vp) => ({
-        zoom: vp.zoom,
-        x: contentCenter.x - center.x / vp.zoom,
-        y: contentCenter.y - center.y / vp.zoom,
-      }))
+      const contentCenter = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      }
+      const width = Math.max(1, bounds.maxX - bounds.minX)
+      const height = Math.max(1, bounds.maxY - bounds.minY)
+      setViewport((vp) => {
+        let zoom = vp.zoom
+        if (root !== null) {
+          const usableWidth = Math.max(1, root.clientWidth - FRAME_MARGIN_PX * 2)
+          const usableHeight = Math.max(1, root.clientHeight - FRAME_MARGIN_PX * 2)
+          zoom = clampZoom(Math.min(1, usableWidth / width, usableHeight / height))
+        }
+        return {
+          zoom,
+          x: contentCenter.x - center.x / zoom,
+          y: contentCenter.y - center.y / zoom,
+        }
+      })
+      return true
+    }
+
+    /** Frames the selection, or everything when nothing is selected. */
+    const frameSelection = (): boolean => {
+      if (selection === undefined) return frameContent()
+      return frameContent(new Set([selection.id, ...extraIds]))
     }
 
     const createNodeAtViewportCenter = () => {
@@ -1865,9 +1909,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 </button>
                 <button
                   type="button"
-                  data-testid="zoom-center-button"
-                  aria-label="Center content"
-                  onClick={centerContentInViewport}
+                  data-testid="zoom-fit-button"
+                  aria-label="Zoom to fit"
+                  onClick={() => {
+                    frameContent()
+                  }}
                   className={TOOL_BUTTON_CLASS}
                 >
                   <Focus aria-hidden="true" className="size-4" />

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1225,10 +1225,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return true
     }
 
-    /** Select every node; the first becomes primary, the rest extras. */
+    /**
+     * Select every node; the first becomes primary, the rest extras.
+     * Always returns true, INCLUDING on an empty canvas: returning false
+     * would let the chord fall through to the browser's own select-all,
+     * highlighting the whole page. A handled no-op still consumes it.
+     */
     const selectAllNodes = (): boolean => {
       const [first, ...rest] = canvasRef.current.nodes.map((node) => node.id)
-      if (first === undefined) return false
+      if (first === undefined) return true
       setSelectedId(first)
       setExtraIds(new Set(rest))
       setSelectedEdgeId(null)
@@ -1355,7 +1360,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           ]
         })
         if (moves.length === 0) return
-        applyResult({ state: gestureState, commands: moves })
+        // ONE batch, not N commands: a multi-node nudge is one user action
+        // and must undo as one step (N separate commits would only group by
+        // the UndoManager's merge-timing heuristic).
+        applyResult({ state: gestureState, commands: [{ kind: 'batch', commands: moves }] })
         return
       }
       if (

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -121,7 +121,7 @@ it('hand mode swaps the leading history cluster for zoom controls; select mode s
 
   // Hand (default): view-only mode — zoom controls, no host history.
   expect(container.querySelector('[data-testid="host-leading"]')).toBeNull()
-  for (const id of ['zoom-out-button', 'zoom-reset-button', 'zoom-in-button', 'zoom-center-button'])
+  for (const id of ['zoom-out-button', 'zoom-reset-button', 'zoom-in-button', 'zoom-fit-button'])
     expect(container.querySelector(`[data-testid="${id}"]`)).not.toBeNull()
 
   fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
@@ -129,7 +129,7 @@ it('hand mode swaps the leading history cluster for zoom controls; select mode s
   expect(container.querySelector('[data-testid="zoom-in-button"]')).toBeNull()
 })
 
-it('zoom controls: in/out change the scale, reset returns to 100%, center brings content to the middle', () => {
+it('zoom controls: in/out change the scale, reset returns to 100%, zoom-to-fit frames content in the middle', () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
   const vt = () =>
@@ -149,7 +149,7 @@ it('zoom controls: in/out change the scale, reset returns to 100%, center brings
   expect(zoomOf(vt())).toBeLessThan(1)
 
   // Center: the lone node's box (100,100 200x80) centers on the 800x600 root.
-  fireEvent.click(container.querySelector('[data-testid="zoom-center-button"]') as HTMLElement)
+  fireEvent.click(container.querySelector('[data-testid="zoom-fit-button"]') as HTMLElement)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   const r = root.getBoundingClientRect()
   const svgRect = (

--- a/apps/web/src/components/spatial-editor/select-all-nudge.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/select-all-nudge.browser.test.tsx
@@ -6,6 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it } from 'vitest'
+import type { EditorCommand } from './commands.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -20,7 +21,10 @@ const initial: SpatialCanvas = {
 }
 
 function makeHost() {
-  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: initial,
+    commands: [],
+  }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
     latest.canvas = canvas
@@ -29,7 +33,10 @@ function makeHost() {
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
-          onChange={(next) => setCanvas(next)}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
           theme="light"
         />
       </div>
@@ -77,7 +84,11 @@ it('arrow-key nudge moves the WHOLE multi-selection by the same delta', () => {
   selectAt(root, 120, 80)
   selectAt(root, 400, 80, true)
 
+  const commandsBefore = latest.commands.length
   fireEvent.keyDown(root, { key: 'ArrowRight' })
+  // ONE batch command, not one per node: the whole nudge is one undo step.
+  expect(latest.commands.length).toBe(commandsBefore + 1)
+  expect(latest.commands.at(-1)?.kind).toBe('batch')
   const a = latest.canvas.nodes.find((n) => n.id === 'a')
   const b = latest.canvas.nodes.find((n) => n.id === 'b')
   const c = latest.canvas.nodes.find((n) => n.id === 'c')
@@ -87,7 +98,16 @@ it('arrow-key nudge moves the WHOLE multi-selection by the same delta', () => {
   expect(c).toMatchObject({ x: 40, y: 240 })
 })
 
-it('Cmd+A on an empty canvas stays inert', () => {
+it('Cmd+A always consumes the event, so the browser never runs its own select-all', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const withNodes = fireEvent.keyDown(root, { code: 'KeyA', key: 'a', metaKey: true })
+  // fireEvent returns false when preventDefault() was called.
+  expect(withNodes).toBe(false)
+})
+
+it('Cmd+A on an empty canvas selects nothing but still consumes the event', () => {
   const empty: SpatialCanvas = { nodes: [], edges: [] }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(empty)
@@ -103,6 +123,9 @@ it('Cmd+A on an empty canvas stays inert', () => {
     )
   }
   const { container } = render(<Host />)
-  fireEvent.keyDown(rootOf(container), { code: 'KeyA', key: 'a', metaKey: true })
+  const consumed = fireEvent.keyDown(rootOf(container), { code: 'KeyA', key: 'a', metaKey: true })
   expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+  // Native select-all would highlight the whole page — a handled no-op
+  // still has to swallow the chord.
+  expect(consumed).toBe(false)
 })

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -15,6 +15,8 @@
 import type { EditorTool } from './ToolPalette.js'
 
 export type ShortcutId =
+  | 'zoom-to-fit'
+  | 'zoom-to-selection'
   | 'select-all'
   | 'copy-selection'
   | 'cut-selection'
@@ -59,6 +61,22 @@ export interface ShortcutSpec {
 }
 
 export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
+  // Viewport framing (tldraw combos). Live in every tool — navigation is
+  // never mode-gated.
+  {
+    id: 'zoom-to-fit',
+    codes: ['Digit1'],
+    shift: true,
+    display: 'Shift+1',
+    description: 'Zoom to fit all content',
+  },
+  {
+    id: 'zoom-to-selection',
+    codes: ['Digit2'],
+    shift: true,
+    display: 'Shift+2',
+    description: 'Zoom to the selection',
+  },
   {
     id: 'select-all',
     keys: ['a'],

--- a/apps/web/src/components/spatial-editor/zoom-to-fit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/zoom-to-fit.browser.test.tsx
@@ -1,0 +1,118 @@
+// Zoom to fit / zoom to selection (editor-completeness slice 7): surface
+// the viewport framing the editor could already compute. Shift+1 frames
+// everything, Shift+2 frames the selection; the hand-mode dock's framing
+// button is the touch path.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// Content far wider than the 800x600 host, so fitting MUST zoom out.
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 400, height: 200, text: 'A' },
+    { id: 'b', type: 'text', x: 2000, y: 1200, width: 400, height: 200, text: 'B' },
+  ],
+  edges: [],
+}
+
+function makeHost() {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+const zoomOf = (container: HTMLElement) => {
+  const vt = container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+  return Number(/scale\(([\d.]+)\)/.exec(vt.style.transform)?.[1])
+}
+
+/** Every node's on-screen box, relative to the editor root. */
+function nodeBoxes(container: HTMLElement) {
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  return [...container.querySelectorAll('[data-testid="viewport-transform"] svg rect')]
+    .map((el) => el.getBoundingClientRect())
+    .filter((b) => b.width > 20)
+    .map((b) => ({
+      left: b.x - r.x,
+      top: b.y - r.y,
+      right: b.x + b.width - r.x,
+      bottom: b.y + b.height - r.y,
+    }))
+}
+
+it('Shift+1 frames ALL content inside the viewport (zooming out when it does not fit)', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  expect(zoomOf(container)).toBe(1)
+
+  fireEvent.keyDown(root, { code: 'Digit1', key: '!', shiftKey: true })
+
+  expect(zoomOf(container)).toBeLessThan(1)
+  const r = root.getBoundingClientRect()
+  for (const box of nodeBoxes(container)) {
+    expect(box.left).toBeGreaterThanOrEqual(-1)
+    expect(box.top).toBeGreaterThanOrEqual(-1)
+    expect(box.right).toBeLessThanOrEqual(r.width + 1)
+    expect(box.bottom).toBeLessThanOrEqual(r.height + 1)
+  }
+})
+
+it('Shift+2 frames only the SELECTION, filling more of the viewport than fit-all', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.keyDown(root, { code: 'Digit1', key: '!', shiftKey: true })
+  const fitAllZoom = zoomOf(container)
+
+  // Select node A at its ACTUAL rendered position after the fit (the
+  // framed layout is what a user would be clicking).
+  const first = nodeBoxes(container)[0]
+  const cx = r.left + (first.left + first.right) / 2
+  const cy = r.top + (first.top + first.bottom) / 2
+  fireEvent.pointerDown(root, { button: 0, pointerId: 1, clientX: cx, clientY: cy })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: cx, clientY: cy })
+  expect(container.querySelector('[data-testid="selection-overlay"]')).not.toBeNull()
+
+  fireEvent.keyDown(root, { code: 'Digit2', key: '@', shiftKey: true })
+  expect(zoomOf(container)).toBeGreaterThan(fitAllZoom)
+})
+
+it('Shift+2 without a selection falls back to framing everything', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  fireEvent.keyDown(root, { code: 'Digit2', key: '@', shiftKey: true })
+  expect(zoomOf(container)).toBeLessThan(1)
+})
+
+it("hand mode's dock button frames the content as the touch path", () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  fireEvent.click(container.querySelector('[data-testid="hand-tool-button"]') as HTMLElement)
+  const button = container.querySelector('[data-testid="zoom-fit-button"]') as HTMLElement
+  expect(button).not.toBeNull()
+  fireEvent.click(button)
+  expect(zoomOf(container)).toBeLessThan(1)
+})


### PR DESCRIPTION
## Summary

Slice 7 of the editor-completeness plan, plus the two CodeRabbit findings from #495 (both verified real against the code).

**Zoom to fit / to selection** — `frameContent(ids?)` pans the content center to the viewport center AND scales so the box fits with a 24px margin, magnifying a small selection as readily as it shrinks an oversized canvas. Capped at 1:1 (a two-word note must not fill the screen) and clamped by the viewport module's own `[MIN_ZOOM, MAX_ZOOM]`.

| combo | action |
|---|---|
| `Shift+1` | Zoom to fit all content |
| `Shift+2` | Zoom to the selection (falls back to fit-all with no selection) |

Live in every tool — navigation is never mode-gated. The hand-mode dock's framing button becomes **Zoom to fit** (it previously only recentered at the current zoom) and is the touch path.

**Review fixes from #495**
- `Cmd/Ctrl+A` returned false on an empty canvas, so `handleKeyDown` skipped `preventDefault` and the browser ran its own select-all, highlighting the page. A handled no-op still has to swallow the chord.
- The widened arrow nudge emitted one command per selected node, so an N-node nudge undid in N steps (grouped only by the UndoManager's merge-timing heuristic). It now emits **ONE batch command**, matching every other multi-object action.

## Test plan

- [x] `zoom-to-fit.browser.test.tsx` (red-first, 4): Shift+1 zooms out and every node lands inside the viewport; Shift+2 magnifies past fit-all; no-selection fallback; dock button touch path
- [x] `select-all-nudge.browser.test.tsx` (red-first for both fixes, 4): the chord is consumed with AND without nodes; the multi-node nudge emits exactly one `batch` command
- [x] `hand-tool.browser.test.tsx` updated for the renamed/​upgraded dock button
- [x] Live in Chrome: Shift+1 framed all 16 nodes inside the viewport (zoom 1 → 0.516, every box inside), Shift+2 on a selection magnified to 1:1, Cmd+A selected everything and consumed the event
- [x] Full suites: web-browser 306/58, jsdom 1475/123; typecheck 0; root knip clean