### PR TITLE
feat: OS-clipboard interop for copy/cut/paste

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -103,6 +103,14 @@ Bindings today: `Cmd/Ctrl+A` select all, `Cmd/Ctrl+C/X/V` copy/cut/paste,
 `Shift+1`/`Shift+2` zoom to fit / to selection, plus the inline-handled
 Delete / Esc / Space-pan / arrows.
 
+The clipboard family (`Cmd+C/X/V`) is declared in the catalog but
+`handledInline` on purpose: it rides the NATIVE copy/cut/paste DOM
+events, because a keydown `preventDefault` on the chord suppresses the
+very event carrying `clipboardData` — the payload that crosses tabs and
+that lets foreign text degrade into a note. Paste follows a content
+cascade (image file → our `whiteboard/clipboard` JSON → any other text
+as a note → in-app slot fallback).
+
 Modifier policy: a spec claims the platform command chord with
 `mod: true` (Cmd on macOS or Ctrl elsewhere — either satisfies it) and
 Alt with `alt: true`; a held modifier suppresses every spec that does

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -42,7 +42,12 @@
  * grouping, undo/redo, snapping,
  * persistence, and sync. Those are later phases.
  */
-import type { CanvasColor, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type {
+  CanvasColor,
+  ClipboardFragment,
+  SpatialCanvas,
+  SpatialNode,
+} from '@kamiazya/whiteboard-canvas-model'
 import type { MeasureText, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
 import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
@@ -83,7 +88,11 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
-import { extractClipboardFragment, remintClipboardFragment } from '../../lib/clipboard-fragment.js'
+import {
+  extractClipboardFragment,
+  parseClipboardText,
+  remintClipboardFragment,
+} from '../../lib/clipboard-fragment.js'
 import {
   hasClipboardFragment,
   readClipboardFragment,
@@ -112,7 +121,7 @@ import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
-import { findShortcut, type ShortcutId } from './shortcuts.js'
+import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
@@ -1146,32 +1155,58 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return true
     }
 
-    /** Copy the selection into the in-app clipboard slot. No mutation. */
-    const copySelection = (): boolean => {
-      if (selection === undefined) return false
+    /**
+     * Copy the selection into the in-app clipboard slot, returning the
+     * fragment so the caller can also hand it to the OS clipboard. null
+     * when there is nothing to copy.
+     */
+    const copySelection = (): ClipboardFragment | null => {
+      if (selection === undefined) return null
       const fragment = extractClipboardFragment(
         canvasRef.current,
         new Set([selection.id, ...extraIds]),
       )
-      if (fragment.nodes.length === 0) return false
+      if (fragment.nodes.length === 0) return null
       writeClipboardFragment(fragment)
-      return true
+      return fragment
     }
 
-    /** Copy, then remove the selection as ONE batch (one undo step). */
-    const cutSelection = (): boolean => {
-      if (!copySelection() || selection === undefined) return false
+    /** Remove the selection as ONE batch (one undo step). */
+    const deleteSelectionAsBatch = (): boolean => {
+      if (selection === undefined) return false
       const ids = [selection.id, ...extraIds]
       const command: EditorCommand = {
         kind: 'batch',
         commands: ids.map((id) => ({ kind: 'delete-node', id }) as const),
       }
       const running = applyCommand(canvasRef.current, command)
-      if (running !== canvasRef.current) onChange(running, command)
+      if (running === canvasRef.current) return false
+      onChange(running, command)
       setSelectedId(null)
       setExtraIds(new Set())
       setSelectedEdgeId(null)
       return true
+    }
+
+    /** A note carrying pasted foreign text, at the viewport center. */
+    const createTextNodeAtViewportCenter = (text: string): void => {
+      const point = screenToCanvas(viewportCenterScreen(), viewport)
+      const node: SpatialNode = {
+        id: createId?.() ?? crypto.randomUUID(),
+        type: 'text',
+        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+        y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
+        width: NEW_NODE_WIDTH,
+        height: NEW_NODE_HEIGHT,
+        text,
+      }
+      const command: EditorCommand = { kind: 'create-node', node }
+      const running = applyCommand(canvasRef.current, command)
+      if (running === canvasRef.current) return
+      onChange(running, command)
+      setSelectedId(node.id)
+      setExtraIds(new Set())
+      setSelectedEdgeId(null)
     }
 
     /**
@@ -1182,7 +1217,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const pasteClipboard = (at?: Point): boolean => {
       const fragment = readClipboardFragment()
-      if (fragment === null || fragment.nodes.length === 0) return false
+      if (fragment === null) return false
+      return pasteFragment(fragment, at)
+    }
+
+    /** Paste an explicit fragment (in-app slot, or one parsed off the OS clipboard). */
+    const pasteFragment = (
+      fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
+      at?: Point,
+    ): boolean => {
+      if (fragment.nodes.length === 0) return false
       const current = canvasRef.current
       const existingIds = new Set([
         ...current.nodes.map((node) => node.id),
@@ -1249,12 +1293,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           return frameSelection()
         case 'select-all':
           return selectAllNodes()
-        case 'copy-selection':
-          return copySelection()
-        case 'cut-selection':
-          return cutSelection()
-        case 'paste-clipboard':
-          return pasteClipboard()
         case 'duplicate-selection':
           return duplicateSelection()
         case 'reorder-forward':
@@ -1860,12 +1898,53 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           const local = clientPointToRootLocal(e, root)
           addImageFile(file, screenToCanvas(local, viewport))
         }}
-        onPaste={(e) => {
-          if (onAddImage === undefined) return
-          const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith('image/'))
-          if (file === undefined) return
+        // The clipboard family rides the NATIVE events, not keydown: a
+        // keydown preventDefault on Cmd+C/X/V suppresses the very event
+        // carrying `clipboardData`, and that data is what crosses tabs and
+        // what lets foreign text degrade into a note.
+        onCopy={(e) => {
+          if (isTextEntryEvent(e.nativeEvent)) return
+          const fragment = copySelection()
+          if (fragment === null) return
           e.preventDefault()
-          addImageFile(file)
+          e.clipboardData?.setData('text/plain', JSON.stringify(fragment))
+        }}
+        onCut={(e) => {
+          if (isTextEntryEvent(e.nativeEvent)) return
+          const fragment = copySelection()
+          if (fragment === null) return
+          e.preventDefault()
+          e.clipboardData?.setData('text/plain', JSON.stringify(fragment))
+          deleteSelectionAsBatch()
+        }}
+        onPaste={(e) => {
+          if (isTextEntryEvent(e.nativeEvent)) return
+          // Content cascade (Excalidraw's shape): image file, then our own
+          // JSON, then any other text as a note. Only a completely empty
+          // clipboard falls through untouched.
+          const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith('image/'))
+          if (file !== undefined) {
+            if (onAddImage === undefined) return
+            e.preventDefault()
+            addImageFile(file)
+            return
+          }
+          const text = e.clipboardData?.getData('text/plain') ?? ''
+          const parsed = parseClipboardText(text)
+          if (parsed !== null) {
+            e.preventDefault()
+            pasteFragment(parsed)
+            return
+          }
+          if (text.trim() !== '') {
+            e.preventDefault()
+            createTextNodeAtViewportCenter(text)
+            return
+          }
+          // Nothing recognizable in the event — fall back to the in-app
+          // slot, which is what a same-tab Cmd+V carries in browsers that
+          // hand us an empty clipboardData for a canvas paste.
+          if (pasteClipboard()) e.preventDefault()
         }}
         onKeyUp={(e) => {
           if (e.key === ' ') spaceDownRef.current = false
@@ -2284,7 +2363,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 label: 'Cut',
                 icon: <Scissors />,
                 onSelect: () => {
-                  cutSelection()
+                  // Menu path mirrors the native cut: copy, then remove.
+                  if (copySelection() !== null) deleteSelectionAsBatch()
                 },
               })
               items.push({

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -65,17 +65,26 @@ function selectAt(root: HTMLElement, x: number, y: number, shift = false) {
 const rootOf = (container: HTMLElement) =>
   container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 
+/**
+ * Cmd+C/X/V reach the editor as NATIVE clipboard events (see
+ * os-clipboard.browser.test.tsx) — with no clipboardData the handlers fall
+ * back to the in-app slot, which is what these same-tab cases exercise.
+ */
+function clip(root: HTMLElement, type: 'copy' | 'cut' | 'paste'): void {
+  fireEvent(root, new ClipboardEvent(type, { bubbles: true, cancelable: true }))
+}
+
 it('copy then paste clones the selection with reminted ids, offset, as ONE batch', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
   const root = rootOf(container)
   selectAt(root, 120, 80)
 
-  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+  clip(root, 'copy')
   // Copy never mutates the canvas.
   expect(latest.commands).toHaveLength(0)
 
-  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  clip(root, 'paste')
   expect(latest.canvas.nodes).toHaveLength(3)
   const copy = latest.canvas.nodes[2]
   expect(copy.id).not.toBe('a')
@@ -83,7 +92,7 @@ it('copy then paste clones the selection with reminted ids, offset, as ONE batch
   expect(latest.commands.at(-1)?.kind).toBe('batch')
 
   // Paste again: reminted afresh, cascading offset from the ORIGINAL copy.
-  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', ctrlKey: true })
+  clip(root, 'paste')
   expect(latest.canvas.nodes).toHaveLength(4)
   expect(new Set(latest.canvas.nodes.map((n) => n.id)).size).toBe(4)
 })
@@ -94,13 +103,13 @@ it('cut removes the selection as ONE batch and paste restores a reminted copy', 
   const root = rootOf(container)
   selectAt(root, 120, 80)
 
-  fireEvent.keyDown(root, { code: 'KeyX', key: 'x', metaKey: true })
+  clip(root, 'cut')
   expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
   // The edge cascaded away with its endpoint.
   expect(latest.canvas.edges).toEqual([])
   expect(latest.commands.at(-1)?.kind).toBe('batch')
 
-  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  clip(root, 'paste')
   expect(latest.canvas.nodes).toHaveLength(2)
   expect(latest.canvas.nodes[1]).toMatchObject({ text: 'A' })
 })
@@ -112,8 +121,8 @@ it('a multi-selection copy carries the internal edge with properties; paste rema
   selectAt(root, 120, 80)
   selectAt(root, 400, 80, true)
 
-  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
-  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  clip(root, 'copy')
+  clip(root, 'paste')
 
   expect(latest.canvas.nodes).toHaveLength(4)
   expect(latest.canvas.edges).toHaveLength(2)
@@ -128,13 +137,13 @@ it('the clipboard is shared across editor mounts — cross-canvas paste within t
   const a = makeHost()
   const first = render(<a.Host />)
   selectAt(rootOf(first.container), 120, 80)
-  fireEvent.keyDown(rootOf(first.container), { code: 'KeyC', key: 'c', metaKey: true })
+  clip(rootOf(first.container), 'copy')
   first.unmount()
 
   const empty: SpatialCanvas = { nodes: [], edges: [] }
   const b = makeHost(empty)
   const second = render(<b.Host />)
-  fireEvent.keyDown(rootOf(second.container), { code: 'KeyV', key: 'v', metaKey: true })
+  clip(rootOf(second.container), 'paste')
   expect(b.latest.canvas.nodes).toHaveLength(1)
   expect(b.latest.canvas.nodes[0]).toMatchObject({ text: 'A' })
 })
@@ -144,7 +153,7 @@ it("the empty-space context menu offers 'Paste here', centering the fragment at 
   const { container } = render(<Host />)
   const root = rootOf(container)
   selectAt(root, 120, 80)
-  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
+  clip(root, 'copy')
 
   const r = root.getBoundingClientRect()
   fireEvent.contextMenu(root, { clientX: r.left + 600, clientY: r.top + 400 })
@@ -163,8 +172,8 @@ it('Cmd+C or Cmd+V with nothing to act on stays inert (browser keeps its own cop
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
   const root = rootOf(container)
-  fireEvent.keyDown(root, { code: 'KeyC', key: 'c', metaKey: true })
-  fireEvent.keyDown(root, { code: 'KeyV', key: 'v', metaKey: true })
+  clip(root, 'copy')
+  clip(root, 'paste')
   expect(latest.commands).toHaveLength(0)
   expect(latest.canvas.nodes).toHaveLength(2)
 })

--- a/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
@@ -1,0 +1,172 @@
+// OS-clipboard interop (editor-completeness slice 5). The clipboard family
+// rides the NATIVE copy/cut/paste events rather than keydown, because a
+// keydown preventDefault would suppress the very event that carries
+// `clipboardData` — and that data is what lets a fragment cross tabs and
+// what lets foreign text degrade into a note.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+import { clearClipboardFragmentForTests } from '../../lib/clipboard-store.js'
+import type { EditorCommand } from './commands.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+beforeEach(clearClipboardFragmentForTests)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 40, y: 40, width: 160, height: 80, text: 'A' }],
+  edges: [],
+}
+
+function makeHost(start: SpatialCanvas = initial) {
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: start,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+function selectFirst(root: HTMLElement) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 120,
+    clientY: r.top + 80,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 120, clientY: r.top + 80 })
+}
+
+/**
+ * Real Chromium refuses a plain object for `clipboardData`, so these use a
+ * genuine DataTransfer + ClipboardEvent — the same objects the browser
+ * hands the handler for an OS copy/paste.
+ */
+function clipboardWith(text = ''): DataTransfer {
+  const data = new DataTransfer()
+  if (text !== '') data.setData('text/plain', text)
+  return data
+}
+
+function dispatchClipboard(
+  root: HTMLElement,
+  type: 'copy' | 'cut' | 'paste',
+  clipboardData: DataTransfer | null,
+): void {
+  // fireEvent (not raw dispatchEvent) so React flushes the resulting state
+  // updates inside act before the assertions run.
+  fireEvent(root, new ClipboardEvent(type, { bubbles: true, cancelable: true, clipboardData }))
+}
+
+it('a native copy writes the fragment as JSON into text/plain', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectFirst(root)
+
+  const clipboardData = clipboardWith()
+  dispatchClipboard(root, 'copy', clipboardData)
+
+  const written = clipboardData.getData('text/plain')
+  const parsed = JSON.parse(written)
+  expect(parsed.type).toBe('whiteboard/clipboard')
+  expect(parsed.nodes).toHaveLength(1)
+  expect(parsed.nodes[0].text).toBe('A')
+})
+
+it('pasting our JSON from another tab recreates the nodes with reminted ids', () => {
+  const fragment = {
+    type: 'whiteboard/clipboard',
+    version: 1,
+    nodes: [{ id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'from-other-tab' }],
+    edges: [],
+  }
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  dispatchClipboard(root, 'paste', clipboardWith(JSON.stringify(fragment)))
+
+  expect(latest.canvas.nodes).toHaveLength(1)
+  expect(latest.canvas.nodes[0]).toMatchObject({ text: 'from-other-tab' })
+  expect(latest.canvas.nodes[0].id).not.toBe('a')
+  expect(latest.commands.at(-1)?.kind).toBe('batch')
+})
+
+it('pasting arbitrary text degrades to a text node instead of doing nothing', () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  dispatchClipboard(root, 'paste', clipboardWith('hello from a web page'))
+
+  expect(latest.canvas.nodes).toHaveLength(1)
+  expect(latest.canvas.nodes[0]).toMatchObject({ type: 'text', text: 'hello from a web page' })
+})
+
+it('foreign JSON is treated as plain text, never as a fragment', () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const foreign = JSON.stringify({ type: 'excalidraw/clipboard', elements: [] })
+
+  dispatchClipboard(root, 'paste', clipboardWith(foreign))
+
+  expect(latest.canvas.nodes).toHaveLength(1)
+  expect(latest.canvas.nodes[0]).toMatchObject({ type: 'text', text: foreign })
+})
+
+it('an empty clipboard paste is a no-op', () => {
+  const { Host, latest } = makeHost({ nodes: [], edges: [] })
+  const { container } = render(<Host />)
+  dispatchClipboard(rootOf(container), 'paste', clipboardWith('   '))
+  expect(latest.commands).toHaveLength(0)
+})
+
+it('a native cut copies to the OS clipboard AND removes the selection in one batch', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectFirst(root)
+
+  const clipboardData = clipboardWith()
+  dispatchClipboard(root, 'cut', clipboardData)
+
+  expect(JSON.parse(clipboardData.getData('text/plain') || '{}').nodes).toHaveLength(1)
+  expect(latest.canvas.nodes).toEqual([])
+  expect(latest.commands.at(-1)?.kind).toBe('batch')
+})
+
+it('the in-app store still round-trips when the event carries no clipboardData', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectFirst(root)
+
+  dispatchClipboard(root, 'copy', null)
+  dispatchClipboard(root, 'paste', null)
+
+  expect(latest.canvas.nodes).toHaveLength(2)
+  expect(latest.canvas.nodes[1]).toMatchObject({ text: 'A' })
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -85,9 +85,11 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     description: 'Select every node',
     tools: ['select'],
   },
-  // Clipboard family. With nothing to act on the handlers return false and
-  // the event falls through, so the browser keeps its own copy/paste for
-  // text selections.
+  // Clipboard family — declared here for catalog completeness, but handled
+  // by the NATIVE copy/cut/paste DOM events (handledInline): a keydown
+  // preventDefault on the chord would suppress the very event that carries
+  // `clipboardData`, which is what crosses tabs and what lets foreign text
+  // degrade into a note.
   {
     id: 'copy-selection',
     keys: ['c'],
@@ -95,6 +97,7 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     display: 'Cmd+C',
     description: 'Copy the selection',
     tools: ['select'],
+    handledInline: true,
   },
   {
     id: 'cut-selection',
@@ -103,6 +106,7 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     display: 'Cmd+X',
     description: 'Cut the selection',
     tools: ['select'],
+    handledInline: true,
   },
   {
     id: 'paste-clipboard',
@@ -111,6 +115,7 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     display: 'Cmd+V',
     description: 'Paste the copied nodes',
     tools: ['select'],
+    handledInline: true,
   },
   {
     id: 'duplicate-selection',

--- a/apps/web/src/lib/clipboard-fragment.ts
+++ b/apps/web/src/lib/clipboard-fragment.ts
@@ -19,6 +19,23 @@ import type {
   SpatialCanvas,
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
+import { clipboardFragmentSchema } from '@kamiazya/whiteboard-canvas-model'
+
+/**
+ * Our fragment parsed out of clipboard TEXT, or null for anything else —
+ * non-JSON, foreign JSON (a different `type` discriminant), or a shape the
+ * schema rejects. Callers degrade a null to a plain-text note, so this must
+ * never throw.
+ */
+export function parseClipboardText(text: string): ClipboardFragment | null {
+  if (text.trim() === '') return null
+  try {
+    const parsed = clipboardFragmentSchema.safeParse(JSON.parse(text))
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
 
 export function extractClipboardFragment(
   canvas: SpatialCanvas,


### PR DESCRIPTION
## Summary

Slice 5 of the editor-completeness plan — the last clipboard slice (user decision: **degrade unrecognized content to a text node**).

**The chords move from keydown to the NATIVE copy/cut/paste events.** A keydown `preventDefault` on Cmd+C/X/V suppresses the very event that carries `clipboardData` — the payload that crosses tabs and that lets foreign text degrade into a note. The chords stay declared in the catalog as `handledInline: true`, which is exactly what that flag is for, so the catalog remains complete.

- **Copy / cut** serialize the fragment as JSON into the **`text/plain`** slot (Excalidraw's precedent — `application/json` is unreliable across browsers) alongside the in-app slot write, so a fragment now survives a tab reload or a second window.
- **Paste runs a content cascade**: image file → our typed JSON (schema-validated, so foreign JSON never parses as ours) → any other non-empty text as a note at the viewport center → the in-app slot when the event carries no data at all.
- `parseClipboardText` is a pure total helper: malformed JSON and foreign payloads both return `null` rather than throwing.

## Test plan

- [x] `os-clipboard.browser.test.tsx` (red-first, real Chromium with genuine `DataTransfer`/`ClipboardEvent`, 7): copy writes fragment JSON; cross-tab JSON paste remints ids into one batch; arbitrary text degrades to a note; foreign JSON is treated as text, never a fragment; whitespace-only clipboard is a no-op; cut writes AND deletes in one batch; the in-app slot still round-trips when the event carries no clipboardData
- [x] `clipboard.browser.test.tsx` migrated to the native events (6) — same-tab and cross-canvas behavior unchanged
- [x] Live in Chrome: native copy produced a 1-node fragment, pasting that JSON duplicated the node, arbitrary text became a note, two Undo clicks reverted both
- [x] Full suites: web-browser 313/59, jsdom 1475/123; typecheck 0; knip clean