### PR TITLE
docs: correct the editor capability contract and publish the shortcut reference

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -37,10 +37,16 @@
  * gesture calls `onChange(next, command)` with a brand-new `SpatialCanvas`
  * value (see `commands.ts`) — it never mutates the `canvas` prop.
  *
+ * Also supported: the clipboard family — copy/cut/paste over the native
+ * clipboard events (fragment JSON in `text/plain`, foreign text degrading
+ * to a note), duplicate (Cmd/Ctrl+D), select-all, z-order moves, and
+ * viewport framing (zoom to fit / to selection). Every one has a
+ * context-menu or dock twin; every binding is declared in `shortcuts.ts`.
+ *
  * NOT yet supported (see `SPATIAL_EDITOR_UNSUPPORTED`): freehand drawing
  * and shape tools (`x-whiteboard` extension authoring — its own slice),
- * grouping, undo/redo, snapping,
- * persistence, and sync. Those are later phases.
+ * snapping, alignment/distribution, persistence, and sync. Those are
+ * later phases.
  */
 import type {
   CanvasColor,
@@ -145,9 +151,8 @@ import {
 export const SPATIAL_EDITOR_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
-  'grouping',
-  'undo-redo',
   'snapping',
+  'align-distribute',
   'persistence',
   'sync',
 ] as const

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { SPATIAL_EDITOR_UNSUPPORTED } from './SpatialEditor.js'
 
+// Grouping (J4) and undo/redo (the LoroDoc UndoManager behind the dock's
+// history cluster) both shipped and left this list; alignment/distribution
+// joined it as the next explicitly-deferred gap.
 const REQUIRED_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
-  'grouping',
-  'undo-redo',
   'snapping',
+  'align-distribute',
   'persistence',
   'sync',
 ]
@@ -24,6 +26,15 @@ describe('SPATIAL_EDITOR_UNSUPPORTED', () => {
     const docComment = source.match(/^\/\*\*[\s\S]*?\*\//)?.[0]
     expect(docComment).toBeDefined()
     expect(docComment).toContain('SPATIAL_EDITOR_UNSUPPORTED')
+  })
+
+  it('never lists a capability the editor actually ships', async () => {
+    // The list is a promise to the reader; a stale entry is worse than no
+    // list. These four all ship today (J4 groups, the history cluster's
+    // undo/redo, and the slice-4/5 clipboard family).
+    for (const shipped of ['grouping', 'undo-redo', 'clipboard', 'duplicate']) {
+      expect(SPATIAL_EDITOR_UNSUPPORTED).not.toContain(shipped)
+    }
   })
 
   it('documents creation and deletion as SUPPORTED, and neither is listed as an unsupported gap', async () => {

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -7,6 +7,7 @@ it when you already know what you are doing and need exact details.
 Reference pages:
 
 - **[configuration](configuration.md)** — runtime environment variables and storage layout.
+- **[keyboard shortcuts](keyboard-shortcuts.md)** — every canvas-editor binding and its pointer equivalent.
 - **[export formats](export-formats.md)** — SVG / OKF Markdown / JSON Canvas via `canvas_render_svg` / `canvas_export_okf` / `canvas_export_json_canvas`.
 - **MCP tools** — the tools the MCP server exposes (entry point to the live `tools/list`) _(planned)_.
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -1,0 +1,93 @@
+# Keyboard shortcuts
+
+Every shortcut below works on the spatial canvas editor. `Cmd` is the macOS
+modifier; use `Ctrl` everywhere else — both satisfy the same binding.
+
+Two rules hold for the whole table:
+
+- **Every shortcut has a pointer path too.** Anything you can do with the
+  keyboard is also reachable from an object's right-click menu, the
+  empty-space menu, or the bottom dock — a shortcut is an accelerator,
+  never the only way in.
+- **Shortcuts never fire while you are typing.** Inside a node's text
+  editor or a dialog field, the keys belong to the text.
+
+## Tools
+
+| Shortcut | Action |
+|---|---|
+| — | Hand (pan) — the tool a canvas opens in; drag anywhere to pan |
+| — | Select — click to select, drag to marquee |
+| — | Connect — click one node, then another, to draw an edge |
+| `Space` + drag | Pan from any tool, without leaving it |
+
+The three tools live in the bottom dock. On touch, two-finger drag pans and
+pinch zooms in every tool.
+
+## Selection and editing
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + A` | Select every node |
+| `Shift` + click | Add or remove a node from the selection |
+| Arrow keys | Nudge the whole selection (`Shift` for a larger step) |
+| `Delete` / `Backspace` | Delete the selected nodes, or the selected edge |
+| Double-click | Edit a node's text, an edge's label, or a group's label |
+| `Esc` | Cancel the current gesture or clear the selection |
+
+## Clipboard
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + C` | Copy the selection |
+| `Cmd/Ctrl + X` | Cut the selection |
+| `Cmd/Ctrl + V` | Paste |
+| `Cmd/Ctrl + D` | Duplicate the selection in place |
+
+Copy puts the selection on your system clipboard as JSON, so a paste works
+in another canvas, another tab, or after a reload. Pasting content from
+elsewhere follows what it finds: an image becomes an image node, our own
+copied JSON becomes the nodes it describes, and any other text becomes a
+note. Edges come along whenever both of their endpoints are selected.
+
+Right-click empty space and choose **Paste here** to place the pasted
+content at that exact point instead of the default offset.
+
+## Arranging
+
+| Shortcut | Action |
+|---|---|
+| `]` | Bring forward |
+| `[` | Send backward |
+| `Shift + ]` | Bring to front |
+| `Shift + [` | Send to back |
+
+Forward and backward step over the nearest node the selection actually
+overlaps — stepping past something you do not overlap would change nothing
+on screen. The same four moves sit in a node's right-click menu under
+**Order**.
+
+## Viewport
+
+| Shortcut | Action |
+|---|---|
+| `Shift + 1` | Zoom to fit all content |
+| `Shift + 2` | Zoom to the selection |
+| `Cmd/Ctrl` + scroll | Zoom under the pointer |
+| Scroll / two-finger drag | Pan |
+
+In Hand mode the dock shows zoom out, the current zoom (click to reset to
+100%), zoom in, and zoom to fit.
+
+## History
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + Z` | Undo |
+| `Cmd/Ctrl + Shift + Z` | Redo |
+| `Cmd/Ctrl + S` | Save a version |
+
+One action is one undo step: pasting twenty nodes, duplicating a
+selection, or nudging several nodes each undo in a single press.
+
+← Back to [reference](README.md)


### PR DESCRIPTION
## Summary

Slice 8 — the last slice of the editor-completeness plan, closing the honesty gap the earlier slices opened.

**`SPATIAL_EDITOR_UNSUPPORTED` was stale.** It still named `grouping` and `undo-redo` as missing long after both shipped (J4 groups; the LoroDoc UndoManager behind the dock's history cluster). A stale promise is worse than no list, so both leave it; `align-distribute` joins it as the next explicitly-deferred gap. The source doc comment gains the capabilities this initiative added (clipboard family, duplicate, select-all, z-order, viewport framing) and the note that every one has a menu or dock twin.

**`doc-contract.test.ts` gains the direction it lacked**: previously it only checked the list matched a hardcoded expectation — it could not catch a shipped feature still being listed. It now also asserts that no shipped capability (`grouping`, `undo-redo`, `clipboard`, `duplicate`) appears in the list at all.

**`docs/reference/keyboard-shortcuts.md`** is the user-facing counterpart to `shortcuts.ts`: every binding with its pointer equivalent, grouped by tools / selection / clipboard / arranging / viewport / history, plus the two rules that hold across the whole table (every shortcut has a menu-or-dock path; none fire while typing). Linked from the reference index.

## Test plan

- [x] `doc-contract.test.ts` red-first for both the corrected list and the new no-shipped-capability direction (4 passed)
- [x] Full suites on this content: web-browser 313/59, jsdom 1476/123; typecheck 0

---

This completes slices 0a → 8. The initiative's deferred backlog (align/distribute, snapping, lock, flip, style-copy, minimap) stays explicitly out of scope, each gated by its own decision.