### PR TITLE
fix(web): key the daemon connection on the canvas, not on the injected factory

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.backend-identity.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.backend-identity.browser.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * The sync session's lifetime is the backend object's identity, so whatever
+ * the backend memo depends on becomes the session's lifetime. Only values
+ * that define the connection may appear there: a rebuild means a fresh
+ * hydrate and a cleared undo history for a canvas the user never left.
+ *
+ * This pins that for the browser-local page, where the injected `store` and
+ * `loro` props are the tempting things to add.
+ */
+
+import type { CanvasBackendHandlers } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { clearWhiteboardDb } from '../test-utils/browser-local-canvas.js'
+import '../index.css'
+
+const constructedFor: string[] = []
+const connectedFor: string[] = []
+
+vi.mock('../lib/browser-local-backend.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/browser-local-backend.js')>(
+    '../lib/browser-local-backend.js',
+  )
+  class RecordingBackend extends actual.BrowserLocalBackend {
+    constructor(canvasId: string) {
+      super(canvasId)
+      constructedFor.push(canvasId)
+    }
+    connect(handlers: CanvasBackendHandlers) {
+      connectedFor.push('connect')
+      return super.connect(handlers)
+    }
+  }
+  return { ...actual, BrowserLocalBackend: RecordingBackend }
+})
+
+const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+beforeEach(async () => {
+  await clearWhiteboardDb()
+  constructedFor.length = 0
+  connectedFor.length = 0
+})
+
+afterEach(cleanup)
+
+it('opens exactly one connection per canvas, and keeps it across a re-render', async () => {
+  const { rerender } = render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+  await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(), {
+    timeout: 5000,
+  })
+  await waitFor(() => expect(constructedFor).toHaveLength(1), { timeout: 5000 })
+
+  // A parent re-render handing over a fresh store instance — the injected
+  // seam a future change would be tempted to key the backend on.
+  await act(async () => {
+    rerender(
+      <div style={{ height: '100vh' }}>
+        <MemoryRouter initialEntries={['/']}>
+          <BrowserLocalCanvasPage store={new IndexedDBStore()} />
+        </MemoryRouter>
+      </div>,
+    )
+  })
+
+  expect(constructedFor).toHaveLength(1)
+  expect(connectedFor).toHaveLength(1)
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.create-delete-node.browser.test.tsx
@@ -81,10 +81,11 @@ describe('BrowserLocalCanvasPage create/delete-node reload persistence (browser 
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const created = textNodeCanvas('undo-probe-node', 20, 20)
-    // Retried like the neighboring tests: right after hydrate the page can
-    // swap backend identity (fresh canvas creation), so the first captured
-    // onChange may belong to a torn-down session. Re-sending an identical
-    // canvas is a no-op on the doc, so retries never stack extra undo steps.
+    // Retried like the neighboring tests: the editor renders as soon as the
+    // canvas metadata loads, which is before the session has hydrated, so an
+    // early onChange lands on a doc that is not ready to commit it.
+    // Re-sending an identical canvas is a no-op on the doc, so retries never
+    // stack extra undo steps.
     const undoButton = screen.getByRole('button', { name: 'Undo' })
     await waitFor(
       () => {

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -128,6 +128,31 @@ describe('DaemonCanvasPage', () => {
     expect(createdBackends[0]?.connectCount).toBe(1)
   })
 
+  it('keeps one live connection when the parent re-renders with a fresh createBackend', async () => {
+    // A parent that writes `createBackend={(w, s) => …}` inline — the
+    // natural thing to write — hands this page a new function identity on
+    // every render. The connection is defined by (workspace, slug, daemon),
+    // not by that function's identity, so the session must survive it:
+    // rebuilding tears down the WebSocket, re-hydrates, and drops the undo
+    // history for a canvas the user never left.
+    const { rerender } = render(
+      <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+      { container: document.body },
+    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    expect(createdBackends).toHaveLength(1)
+
+    await act(async () => {
+      rerender(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+      )
+    })
+
+    expect(createdBackends).toHaveLength(1)
+    expect(createdBackends[0]?.disconnectCount).toBe(0)
+    expect(createdBackends[0]?.connectCount).toBe(1)
+  })
+
   it('renders capability badges from LOCAL_DAEMON_CAPABILITIES', async () => {
     await act(async () => {
       render(

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -85,12 +85,21 @@ export function DaemonCanvasPage({
   // buildWhiteboardWsUrl), so it must be the daemon's own origin — a hosted
   // web app paired to a loopback daemon must not open the socket against its
   // own page origin.
-  const resolvedCreateBackend = useMemo(
-    () =>
-      createBackend ??
-      ((workspaceId: string, slug: string, daemonFetch: typeof fetch): CanvasBackend =>
-        new DaemonBackend(workspaceId, slug, daemonBaseUrl, { fetch: daemonFetch })),
-    [createBackend, daemonBaseUrl],
+  // The injected factory is held in a ref rather than carried in the backend
+  // memo's dependencies: it customises HOW a connection is built, it does not
+  // say WHICH connection this is. A parent writing the natural
+  // `createBackend={(w, s) => …}` hands this page a new function identity on
+  // every one of its own renders, and anything the backend memo depends on
+  // becomes the session's lifetime — so that alone would tear down the
+  // socket, re-hydrate, and drop the undo history for a canvas the user
+  // never left. Only values that define the connection belong in those deps.
+  const createBackendRef = useRef(createBackend)
+  createBackendRef.current = createBackend
+  const resolvedCreateBackend = useCallback(
+    (workspaceId: string, slug: string, daemonFetch: typeof fetch): CanvasBackend =>
+      createBackendRef.current?.(workspaceId, slug, daemonFetch) ??
+      new DaemonBackend(workspaceId, slug, daemonBaseUrl, { fetch: daemonFetch }),
+    [daemonBaseUrl],
   )
 
   const controller = useDaemonCanvasController({ daemonBaseUrl, workspaceId, slug, daemonFetch })


### PR DESCRIPTION
## Why

The sync session's lifetime is the backend object's identity — `useCanvasSync` tears down and rebuilds on every change of it. So whatever the backend memo depends on silently becomes the session's lifetime, and a rebuild is not free: new WebSocket, fresh hydrate, undo history gone, for a canvas the user never left.

`DaemonCanvasPage` had `createBackend` in those dependencies, and `createBackend` is a **prop**. A parent writing the natural `createBackend={(w, s) => …}` hands the page a new function identity on every one of its own renders. Measured, not assumed: a re-render with an equivalent inline factory constructed a second backend and reconnected.

That factory customises *how* a connection is built; it does not say *which* connection this is. It now lives in a ref — the same latest-wins treatment `useCanvasSync` already gives `options` — so only values that actually define the connection (workspace, slug, daemon origin, fetch) decide when to reconnect.

## What I checked and did not change

The browser-local page was already correct: its memo depends on `[canvasId, canvasKind]`, both plain values. I measured a plain mount to be sure — exactly one backend constructed, one connect. A comment in two page tests claimed the page "swaps backend identity right after hydrate (fresh canvas creation)"; that is not true of the current code, and it sent me down the wrong path while chasing an unrelated bug, so it is corrected to what actually happens (the editor renders once the metadata loads, before the session has hydrated).

## Test plan

- [x] `DaemonCanvasPage.test.tsx` — a parent re-render with a fresh `createBackend` keeps one live connection: no second construction, no disconnect, connect count still 1. Red before the fix (2 backends), green after — 46 passed
- [x] `BrowserLocalCanvasPage.backend-identity.browser.test.tsx` (real IndexedDB) — one connection per canvas, held across a re-render that hands over a fresh `store`. Mutation-checked: adding `store` to that page's backend memo deps fails it with 2 constructions
- [x] `pnpm -r typecheck` 0; knip clean
