### PR TITLE
test: fix the /pair consent flake at its root and stop a hook test discarding its own evidence

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -5,6 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
+// App reaches every page through React.lazy(), so a page renders only once
+// its dynamic import resolves. The other three pages are vi.mock'd below, so
+// their imports are already trivial; PairConsentPage is the one this file
+// loads for real, and under a full-suite run the dev server served that
+// chunk slowly enough to outlast the assertion's retry budget. Importing it
+// here — before any test runs, with nothing competing — puts it in the ESM
+// cache, so lazy() settles in a microtask and the render is deterministic
+// rather than a race the assertion usually wins. Side-effect import: the
+// component is reached through App, never referenced directly.
+import './pages/PairConsentPage.js'
 import {
   BROWSER_LOCAL_CAPABILITIES,
   type ProviderState,
@@ -269,7 +279,10 @@ describe('/pair consent route', () => {
     expect(search.get('origin')).toBe('https://example.com')
     expect(search.get('challenge')).toBe('chal')
     expect(search.get('state')).toBe('st')
-    await screen.findByText(/allow this web app to use your local daemon/i)
+    // Synchronous on purpose: the page module is preloaded at the top of this
+    // file, so nothing here waits on a chunk. If that preload is ever dropped
+    // this fails immediately instead of flaking under load.
+    screen.getByText(/allow this web app to use your local daemon/i)
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
   })
 })

--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
@@ -65,6 +65,7 @@ function runHook(env: NodeJS.ProcessEnv): Promise<{
   exitCode: number | null
   exitedAt: number
   stderr: string
+  stdout: string
 }> {
   return new Promise((resolveRun) => {
     const child: ChildProcessWithoutNullStreams = spawn(
@@ -73,11 +74,21 @@ function runHook(env: NodeJS.ProcessEnv): Promise<{
       { cwd: REPO_ROOT, env },
     )
     let stderr = ''
+    let stdout = ''
     child.stderr.on('data', (chunk) => {
       stderr += String(chunk)
     })
-    child.once('exit', (exitCode) => {
-      resolveRun({ exitCode, exitedAt: Date.now(), stderr })
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    // 'close', not 'exit': 'exit' fires when the process terminates, while
+    // its stdio may still have buffered data to deliver. Resolving there
+    // discards whatever the hook printed on its way out — which is how a
+    // failing run once reported "exit 1" with an empty stderr, throwing away
+    // the only evidence of why it failed. 'close' fires after every stdio
+    // stream has ended, so the captured output is complete.
+    child.once('close', (exitCode) => {
+      resolveRun({ exitCode, exitedAt: Date.now(), stderr, stdout })
     })
   })
 }
@@ -260,8 +271,14 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
 
       const [first, second] = await Promise.all([runHook(runEnv), runHook(runEnv)])
 
-      expect(first.exitCode, `hook 1 stderr:\n${first.stderr}`).toBe(0)
-      expect(second.exitCode, `hook 2 stderr:\n${second.stderr}`).toBe(0)
+      expect(
+        first.exitCode,
+        `hook 1 stderr:\n${first.stderr}\nhook 1 stdout:\n${first.stdout}`,
+      ).toBe(0)
+      expect(
+        second.exitCode,
+        `hook 2 stderr:\n${second.stderr}\nhook 2 stdout:\n${second.stdout}`,
+      ).toBe(0)
       // The discriminating assertion: exactly one process was ever spawned.
       // On unpatched main, both hooks observe the port free and both spawn.
       expect(countSpawns()).toBe(1)


### PR DESCRIPTION
## The noise

`App.test.tsx > /pair consent route` failed in **all three** full `pnpm test` runs on 2026-08-09, on branches that touch nothing on that route, and passed every time the file ran alone.

## Root cause, confirmed by experiment rather than inferred

App reaches every page through `React.lazy()`, so the consent page renders only once its dynamic import resolves. Narrowing the assertion's retry budget to 50ms made the failure **deterministic**, which pins it: the assertion was racing the chunk, and under a full-suite run the dev server served it slowly enough to lose.

## The fix

Import the page module at the top of the test file — before any test runs, with nothing competing — so it is in the ESM cache and `lazy()` settles in a microtask.

What makes this a fix rather than a bigger timeout: the assertion is now **synchronous**. There is no retry budget left to exhaust, so the test cannot flake on timing at all, and if the preload is ever dropped it fails immediately instead of flaking. Mutation-checked both ways.

The other three pages App lazy-loads are `vi.mock`'d in this file, so this was the only one ever loaded for real — preloading them too would have been noise.

## The second suspect, handled honestly

`ensure-http-dev-daemon.script.test.ts`'s concurrent-spawn test flaked once in the same window. It does **not** reproduce in isolation (3/3 runs pass), and its failure read `exit 1` with an **empty stderr** — no evidence at all.

That empty stderr turned out to be a harness defect worth fixing on its own: `runHook` resolved on `'exit'`, which fires when the process terminates while its stdio may still have buffered data to deliver, so whatever the hook printed on its way out was dropped. It now resolves on `'close'` and captures stdout alongside stderr.

This does not claim to fix that race — I could not reproduce it, and guessing at a fix would be worse than leaving it diagnosable. The next occurrence will carry the reason with it. Tracked in the local backlog.

## Test plan

- [x] Probe: 50ms retry budget → deterministic failure, confirming the race
- [x] Fix applied → passes at that same 50ms budget, then converted to a synchronous assertion
- [x] Mutation-check: removing the preload fails the test immediately
- [x] `ensure-http-dev-daemon.script.test.ts` 6 passed; `@kamiazya/whiteboard-mcp typecheck` 0
- [x] **Full `pnpm test` twice, back to back: 579/579 files, 6151 passed, 0 failed** — previously 1–3 failures per run
