### PR TITLE
feat(web): align and distribute a multi-node selection

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -39,14 +39,14 @@
  *
  * Also supported: the clipboard family — copy/cut/paste over the native
  * clipboard events (fragment JSON in `text/plain`, foreign text degrading
- * to a note), duplicate (Cmd/Ctrl+D), select-all, z-order moves, and
- * viewport framing (zoom to fit / to selection). Every one has a
- * context-menu or dock twin; every binding is declared in `shortcuts.ts`.
+ * to a note), duplicate (Cmd/Ctrl+D), select-all, z-order moves,
+ * align/distribute over a multi-selection, and viewport framing (zoom to
+ * fit / to selection). Every one has a context-menu or dock twin; every
+ * binding is declared in `shortcuts.ts`.
  *
  * NOT yet supported (see `SPATIAL_EDITOR_UNSUPPORTED`): freehand drawing
  * and shape tools (`x-whiteboard` extension authoring — its own slice),
- * snapping, alignment/distribution, persistence, and sync. Those are
- * later phases.
+ * snapping, persistence, and sync. Those are later phases.
  */
 import type {
   CanvasColor,
@@ -58,6 +58,14 @@ import type { MeasureText, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-
 import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
+  AlignCenterHorizontal,
+  AlignCenterVertical,
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignHorizontalDistributeCenter,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  AlignVerticalDistributeCenter,
   BringToFront,
   ChevronDown,
   ChevronUp,
@@ -106,6 +114,8 @@ import {
   readClipboardFragment,
   writeClipboardFragment,
 } from '../../lib/clipboard-store.js'
+import type { AlignableBox, BoxMove } from './align.js'
+import { alignBoxes, distributeBoxes } from './align.js'
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
@@ -154,7 +164,6 @@ export const SPATIAL_EDITOR_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
   'snapping',
-  'align-distribute',
   'persistence',
   'sync',
 ] as const
@@ -1197,6 +1206,37 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // canvas produced by applyCommand, never a hand-built object.
       const running = applyCommand(canvasRef.current, command)
       // Total command: extremes return the input — emit no empty history step.
+      if (running !== canvasRef.current) onChange(running, command)
+      return true
+    }
+
+    /**
+     * The selected nodes as align/distribute inputs, read from canvasRef so
+     * a menu action never computes against a stale render closure. Locked
+     * nodes cannot be in a selection (see the pruning effect above), so they
+     * are absent here too — neither moved nor counted toward the bounds.
+     */
+    const selectedAlignableBoxes = (): AlignableBox[] => {
+      if (selection === undefined) return []
+      const ids = new Set([selection.id, ...extraIds])
+      return canvasRef.current.nodes
+        .filter((node) => ids.has(node.id))
+        .map(({ id, x, y, width, height }) => ({ id, x, y, width, height }))
+    }
+
+    /**
+     * Applies a set of moves as ONE batch command — an align is one user
+     * action and must undo as one step. An empty move list (already aligned)
+     * emits nothing rather than an empty history entry, matching
+     * `reorderSelection`'s totality contract.
+     */
+    const applyBoxMoves = (moves: readonly BoxMove[]): boolean => {
+      if (moves.length === 0) return true
+      const command: EditorCommand = {
+        kind: 'batch',
+        commands: moves.map((move) => ({ kind: 'move-node' as const, ...move })),
+      }
+      const running = applyCommand(canvasRef.current, command)
       if (running !== canvasRef.current) onChange(running, command)
       return true
     }
@@ -2579,6 +2619,58 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   },
                 ],
               })
+              // Align needs a second box to align TO, and distribute needs a
+              // middle one to place — so each row appears only once its
+              // action means something, rather than sitting there inert.
+              const alignableCount = extraIds.size + 1
+              if (alignableCount >= 2) {
+                items.push({
+                  kind: 'options',
+                  label: 'Align',
+                  options: (
+                    [
+                      ['left', 'Align left', <AlignStartVertical key="l" />],
+                      ['center-x', 'Align centre horizontally', <AlignCenterVertical key="cx" />],
+                      ['right', 'Align right', <AlignEndVertical key="r" />],
+                      ['top', 'Align top', <AlignStartHorizontal key="t" />],
+                      ['center-y', 'Align centre vertically', <AlignCenterHorizontal key="cy" />],
+                      ['bottom', 'Align bottom', <AlignEndHorizontal key="b" />],
+                    ] as const
+                  ).map(([mode, ariaLabel, icon]) => ({
+                    label: mode,
+                    ariaLabel,
+                    icon,
+                    selected: false,
+                    onSelect: () => applyBoxMoves(alignBoxes(selectedAlignableBoxes(), mode)),
+                  })),
+                })
+              }
+              if (alignableCount >= 3) {
+                items.push({
+                  kind: 'options',
+                  label: 'Distribute',
+                  options: (
+                    [
+                      [
+                        'horizontal',
+                        'Distribute horizontally',
+                        <AlignHorizontalDistributeCenter key="h" />,
+                      ],
+                      [
+                        'vertical',
+                        'Distribute vertically',
+                        <AlignVerticalDistributeCenter key="v" />,
+                      ],
+                    ] as const
+                  ).map(([axis, ariaLabel, icon]) => ({
+                    label: axis,
+                    ariaLabel,
+                    icon,
+                    selected: false,
+                    onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
+                  })),
+                })
+              }
               if (lockEnabled) {
                 items.push({
                   label: 'Lock',

--- a/apps/web/src/components/spatial-editor/align.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/align.browser.test.tsx
@@ -1,0 +1,230 @@
+// Align/distribute in the editor. The geometry itself is unit-tested in
+// align.test.ts; this pins the wiring: which selections get the affordance,
+// that one action is one undo step, and that a locked node is never moved
+// by it.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import type { EditorCommand } from './commands.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// Three different-sized boxes, none of them aligned, laid out so a marquee
+// from the top-left can sweep all three.
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 220, y: 160, width: 80, height: 100, text: 'B' },
+    { id: 'c', type: 'text', x: 420, y: 260, width: 60, height: 40, text: 'C' },
+  ],
+  edges: [],
+}
+
+function makeHost(lockedNodes: readonly string[] = []) {
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: initial,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
+          theme="light"
+          lockedNodeIds={new Set(lockedNodes)}
+          onToggleNodeLock={() => {}}
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+/** Marquee from empty space across every node. */
+function selectAll(root: HTMLElement) {
+  fireEvent.keyDown(root, { code: 'KeyA', key: 'a', metaKey: true })
+}
+
+function openMenuOn(root: HTMLElement, x: number, y: number) {
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + x, clientY: r.top + y })
+}
+
+function clickOption(container: HTMLElement, ariaLabel: string) {
+  const button = container.querySelector(
+    `[data-testid="context-menu"] [aria-label="${ariaLabel}"]`,
+  ) as HTMLElement
+  expect(button, `no menu option labelled ${ariaLabel}`).toBeTruthy()
+  fireEvent.click(button)
+}
+
+const byId = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((node) => node.id === id)!
+
+it('aligns the whole selection to its left edge in one undo step', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70) // over node 'a', which is in the selection
+  latest.commands.length = 0
+  clickOption(container, 'Align left')
+
+  expect(byId(latest.canvas, 'a').x).toBe(40)
+  expect(byId(latest.canvas, 'b').x).toBe(40)
+  expect(byId(latest.canvas, 'c').x).toBe(40)
+  // One batch, not three moves: an align is one user action.
+  expect(latest.commands).toHaveLength(1)
+  expect(latest.commands[0]).toMatchObject({ kind: 'batch' })
+})
+
+it('aligns to the bottom edge, accounting for differing heights', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Align bottom')
+
+  // Bottom-most edge is c's 260 + 40 = 300 — the shortest node, not the
+  // lowest-positioned one, so aligning by y alone would land elsewhere.
+  expect(byId(latest.canvas, 'a').y).toBe(240)
+  expect(byId(latest.canvas, 'b').y).toBe(200)
+  expect(byId(latest.canvas, 'c').y).toBe(260)
+})
+
+it('distributes the middle node so the gaps are equal', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Distribute horizontally')
+
+  // Span 40..480 = 440, widths 260 → gap 90; b lands at 40+120+90 = 250.
+  expect(byId(latest.canvas, 'a').x).toBe(40)
+  expect(byId(latest.canvas, 'b').x).toBe(250)
+  expect(byId(latest.canvas, 'c').x).toBe(420)
+})
+
+it('offers neither row for a single-node selection', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 100,
+    clientY: r.top + 70,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 100, clientY: r.top + 70 })
+  openMenuOn(root, 100, 70)
+
+  const labels = [...container.querySelectorAll('[data-testid="context-menu"]')].map(
+    (el) => el.textContent ?? '',
+  )
+  expect(labels.join(' ')).not.toContain('Align')
+  expect(labels.join(' ')).not.toContain('Distribute')
+})
+
+it('hides only Distribute when the selection has exactly two nodes', () => {
+  const two: SpatialCanvas = { nodes: initial.nodes.slice(0, 2), edges: [] }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(two)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  const text = (container.querySelector('[data-testid="context-menu"]')?.textContent ??
+    '') as string
+  expect(text).toContain('Align')
+  expect(text).not.toContain('Distribute')
+})
+
+it('never moves a locked node, and never counts it toward the bounds', () => {
+  // 'c' is locked, so select-all skips it — the alignment must be computed
+  // from a and b alone, leaving c exactly where it was.
+  const { Host, latest } = makeHost(['c'])
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Align left')
+
+  expect(byId(latest.canvas, 'a').x).toBe(40)
+  expect(byId(latest.canvas, 'b').x).toBe(40)
+  expect(byId(latest.canvas, 'c')).toMatchObject({ x: 420, y: 260 })
+})
+
+it('emits nothing when the selection is already aligned', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Align left')
+  latest.commands.length = 0
+
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Align left')
+  // Already flush: no second undo step to step back through.
+  expect(latest.commands).toHaveLength(0)
+})
+
+it('leaves edges alone — align moves nodes only', () => {
+  const withEdge: SpatialCanvas = { ...initial, edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }] }
+  const seen = vi.fn()
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(withEdge)
+    seen(canvas)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickOption(container, 'Align left')
+
+  const latest = seen.mock.calls.at(-1)?.[0] as SpatialCanvas
+  expect(latest.edges).toEqual(withEdge.edges)
+})

--- a/apps/web/src/components/spatial-editor/align.test.ts
+++ b/apps/web/src/components/spatial-editor/align.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { type AlignableBox, alignBoxes, distributeBoxes } from './align.js'
+
+const box = (id: string, x: number, y: number, width = 100, height = 50): AlignableBox => ({
+  id,
+  x,
+  y,
+  width,
+  height,
+})
+
+describe('alignBoxes', () => {
+  // Three boxes of DIFFERENT sizes: an implementation that aligns by
+  // position alone passes 'left' but fails 'right' and 'center-x'.
+  const spread = [box('a', 0, 0, 100, 50), box('b', 40, 200, 60, 80), box('c', 300, 90, 20, 20)]
+
+  it('aligns to the leftmost edge', () => {
+    expect(alignBoxes(spread, 'left')).toEqual([
+      { id: 'b', x: 0, y: 200 },
+      { id: 'c', x: 0, y: 90 },
+    ])
+  })
+
+  it('aligns to the rightmost edge, accounting for width', () => {
+    // Rightmost edge is c's 300 + 20 = 320.
+    expect(alignBoxes(spread, 'right')).toEqual([
+      { id: 'a', x: 220, y: 0 },
+      { id: 'b', x: 260, y: 200 },
+    ])
+  })
+
+  it('centres on the selection bounding box, accounting for width', () => {
+    // Bounds 0..320 → centre 160; each box lands at 160 - width/2.
+    expect(alignBoxes(spread, 'center-x')).toEqual([
+      { id: 'a', x: 110, y: 0 },
+      { id: 'b', x: 130, y: 200 },
+      { id: 'c', x: 150, y: 90 },
+    ])
+  })
+
+  it('aligns to the top edge', () => {
+    expect(alignBoxes(spread, 'top')).toEqual([
+      { id: 'b', x: 40, y: 0 },
+      { id: 'c', x: 300, y: 0 },
+    ])
+  })
+
+  it('aligns to the bottom edge, accounting for height', () => {
+    // Bottom-most edge is b's 200 + 80 = 280.
+    expect(alignBoxes(spread, 'bottom')).toEqual([
+      { id: 'a', x: 0, y: 230 },
+      { id: 'c', x: 300, y: 260 },
+    ])
+  })
+
+  it('centres vertically on the selection bounding box', () => {
+    // Bounds 0..280 → centre 140.
+    expect(alignBoxes(spread, 'center-y')).toEqual([
+      { id: 'a', x: 0, y: 115 },
+      { id: 'b', x: 40, y: 100 },
+      { id: 'c', x: 300, y: 130 },
+    ])
+  })
+
+  it('reports only the boxes that actually move', () => {
+    // 'a' is already flush left, so it must not appear — an empty batch is
+    // what keeps an already-aligned selection out of the undo history.
+    const moves = alignBoxes(spread, 'left')
+    expect(moves.map((move) => move.id)).not.toContain('a')
+  })
+
+  it('is a no-op on an already-aligned selection', () => {
+    const aligned = [box('a', 10, 0), box('b', 10, 100)]
+    expect(alignBoxes(aligned, 'left')).toEqual([])
+  })
+
+  it('needs two boxes: fewer is a no-op, never a throw', () => {
+    expect(alignBoxes([], 'left')).toEqual([])
+    expect(alignBoxes([box('a', 5, 5)], 'left')).toEqual([])
+  })
+
+  it('rounds to integers, matching the canvas schema', () => {
+    // Bounds 0..101 → centre 50.5; a 3-wide box wants 49, not 49.
+    const odd = [box('a', 0, 0, 3, 3), box('b', 98, 50, 3, 3)]
+    for (const move of alignBoxes(odd, 'center-x')) {
+      expect(Number.isInteger(move.x)).toBe(true)
+      expect(Number.isInteger(move.y)).toBe(true)
+    }
+  })
+})
+
+describe('distributeBoxes', () => {
+  it('equalises the GAPS between boxes, not their centres', () => {
+    // Widths 100/60/20, span 0..320 → free = 320 - 180 = 140, gap = 70.
+    // a stays at 0; b at 100+70=170; c at 170+60+70=300 (already there).
+    const boxes = [box('a', 0, 0, 100, 50), box('b', 40, 0, 60, 50), box('c', 300, 0, 20, 50)]
+    expect(distributeBoxes(boxes, 'horizontal')).toEqual([{ id: 'b', x: 170, y: 0 }])
+  })
+
+  it('distributes vertically the same way', () => {
+    const boxes = [box('a', 0, 0, 50, 100), box('b', 0, 30, 50, 60), box('c', 0, 300, 50, 20)]
+    // span 0..320, free = 320 - 180 = 140, gap = 70 → b at 100+70 = 170.
+    expect(distributeBoxes(boxes, 'vertical')).toEqual([{ id: 'b', x: 0, y: 170 }])
+  })
+
+  it('orders by position, not by the order the ids arrive in', () => {
+    const shuffled = [box('c', 300, 0, 20, 50), box('a', 0, 0, 100, 50), box('b', 40, 0, 60, 50)]
+    expect(distributeBoxes(shuffled, 'horizontal')).toEqual([{ id: 'b', x: 170, y: 0 }])
+  })
+
+  it('leaves the two outermost boxes where they are', () => {
+    const boxes = [box('a', 0, 0), box('b', 10, 0), box('c', 500, 0)]
+    const moved = distributeBoxes(boxes, 'horizontal').map((move) => move.id)
+    expect(moved).not.toContain('a')
+    expect(moved).not.toContain('c')
+  })
+
+  it('needs three boxes: fewer is a no-op, never a throw', () => {
+    expect(distributeBoxes([], 'horizontal')).toEqual([])
+    expect(distributeBoxes([box('a', 0, 0)], 'horizontal')).toEqual([])
+    expect(distributeBoxes([box('a', 0, 0), box('b', 100, 0)], 'horizontal')).toEqual([])
+  })
+
+  it('stays total when the boxes overlap more than the span allows', () => {
+    // Sum of widths (300) exceeds the span (0..100 = 100+width) — the gap
+    // goes negative rather than the function throwing or bailing.
+    const crowded = [box('a', 0, 0, 100, 50), box('b', 0, 0, 100, 50), box('c', 0, 0, 100, 50)]
+    const moves = distributeBoxes(crowded, 'horizontal')
+    for (const move of moves) expect(Number.isFinite(move.x)).toBe(true)
+  })
+})

--- a/apps/web/src/components/spatial-editor/align.ts
+++ b/apps/web/src/components/spatial-editor/align.ts
@@ -1,0 +1,133 @@
+/**
+ * Align and distribute geometry for a multi-node selection.
+ *
+ * Pure and total by construction: every entry point returns a (possibly
+ * empty) list of moves and never throws, so one degenerate selection can
+ * never abort an editor gesture. Both functions report ONLY the boxes that
+ * actually move — an already-aligned selection produces an empty list, which
+ * is what keeps a no-op action out of the undo history.
+ *
+ * Coordinates are rounded here rather than left to `applyCommand`'s own
+ * rounding, so the no-op filter compares the value that will actually be
+ * stored.
+ */
+
+export interface AlignableBox {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface BoxMove {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+}
+
+export type AlignMode = 'left' | 'center-x' | 'right' | 'top' | 'center-y' | 'bottom'
+export type DistributeAxis = 'horizontal' | 'vertical'
+
+/** Drops anything the canvas schema would never produce, so the maths below
+ *  can assume finite numbers without guarding at every step. */
+function usable(boxes: readonly AlignableBox[]): AlignableBox[] {
+  return boxes.filter(
+    (box) =>
+      Number.isFinite(box.x) &&
+      Number.isFinite(box.y) &&
+      Number.isFinite(box.width) &&
+      Number.isFinite(box.height),
+  )
+}
+
+function moved(box: AlignableBox, x: number, y: number): BoxMove | null {
+  const nextX = Math.round(x)
+  const nextY = Math.round(y)
+  if (nextX === box.x && nextY === box.y) return null
+  return { id: box.id, x: nextX, y: nextY }
+}
+
+/**
+ * Aligns every box to one edge (or centre line) of the selection's own
+ * bounding box. The bounding box — not the primary selection — is the
+ * reference, so the result does not depend on which node was clicked first.
+ */
+export function alignBoxes(boxes: readonly AlignableBox[], mode: AlignMode): readonly BoxMove[] {
+  const usableBoxes = usable(boxes)
+  if (usableBoxes.length < 2) return []
+
+  const left = Math.min(...usableBoxes.map((box) => box.x))
+  const right = Math.max(...usableBoxes.map((box) => box.x + box.width))
+  const top = Math.min(...usableBoxes.map((box) => box.y))
+  const bottom = Math.max(...usableBoxes.map((box) => box.y + box.height))
+
+  const moves: BoxMove[] = []
+  for (const box of usableBoxes) {
+    let { x, y } = box
+    switch (mode) {
+      case 'left':
+        x = left
+        break
+      case 'right':
+        x = right - box.width
+        break
+      case 'center-x':
+        x = (left + right) / 2 - box.width / 2
+        break
+      case 'top':
+        y = top
+        break
+      case 'bottom':
+        y = bottom - box.height
+        break
+      case 'center-y':
+        y = (top + bottom) / 2 - box.height / 2
+        break
+    }
+    const move = moved(box, x, y)
+    if (move !== null) moves.push(move)
+  }
+  return moves
+}
+
+/**
+ * Spreads the boxes so the GAPS between them are equal — the behaviour a
+ * single "distribute" action is expected to have, and the one that stays
+ * sensible when the boxes are different sizes (equalising centres instead
+ * would leave visibly uneven gaps around a wide box).
+ *
+ * The two outermost boxes anchor the span and never move. A selection whose
+ * widths exceed that span yields a negative gap: the boxes overlap evenly
+ * rather than the function bailing, which keeps it total.
+ */
+export function distributeBoxes(
+  boxes: readonly AlignableBox[],
+  axis: DistributeAxis,
+): readonly BoxMove[] {
+  const usableBoxes = usable(boxes)
+  // Two boxes are already "evenly spaced" by definition, so there is
+  // nothing to distribute until there is a middle.
+  if (usableBoxes.length < 3) return []
+
+  const horizontal = axis === 'horizontal'
+  const start = (box: AlignableBox) => (horizontal ? box.x : box.y)
+  const extent = (box: AlignableBox) => (horizontal ? box.width : box.height)
+
+  const ordered = [...usableBoxes].sort((a, b) => start(a) - start(b))
+  const first = ordered[0]
+  const last = ordered[ordered.length - 1]
+  const span = start(last) + extent(last) - start(first)
+  const totalExtent = ordered.reduce((sum, box) => sum + extent(box), 0)
+  const gap = (span - totalExtent) / (ordered.length - 1)
+
+  const moves: BoxMove[] = []
+  let cursor = start(first) + extent(first) + gap
+  // Endpoints anchor the span; only the middle boxes are repositioned.
+  for (const box of ordered.slice(1, -1)) {
+    const move = horizontal ? moved(box, cursor, box.y) : moved(box, box.x, cursor)
+    if (move !== null) moves.push(move)
+    cursor += extent(box) + gap
+  }
+  return moves
+}

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -4,14 +4,7 @@ import { SPATIAL_EDITOR_UNSUPPORTED } from './SpatialEditor.js'
 // Grouping (J4) and undo/redo (the LoroDoc UndoManager behind the dock's
 // history cluster) both shipped and left this list; alignment/distribution
 // joined it as the next explicitly-deferred gap.
-const REQUIRED_UNSUPPORTED = [
-  'freehand-drawing',
-  'shape-tools',
-  'snapping',
-  'align-distribute',
-  'persistence',
-  'sync',
-]
+const REQUIRED_UNSUPPORTED = ['freehand-drawing', 'shape-tools', 'snapping', 'persistence', 'sync']
 
 describe('SPATIAL_EDITOR_UNSUPPORTED', () => {
   it('names exactly every parity gap this slice deliberately does not implement (both directions: nothing missing, nothing undocumented)', () => {

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -36,6 +36,14 @@ pinch zooms in every tool.
 | `Cmd/Ctrl + Shift + L` | Lock or unlock the selection |
 | `Esc` | Cancel the current gesture or clear the selection |
 
+**Align and distribute** have no shortcut — they live in the right-click
+menu of a multi-node selection, as **Align** (six edges and centre lines)
+and **Distribute** (horizontal, vertical). Align appears once two nodes are
+selected; distribute once there are three, because it repositions the
+middle ones and leaves the outermost two anchoring the span. Both align to
+the selection's own bounding box, so the result does not depend on which
+node you clicked first, and each is a single undo step.
+
 A locked node or edge cannot be selected, moved, restyled, or deleted, and
 MCP tools refuse to patch it too. Right-click it and choose **Unlock** to
 release it. Nodes and edges lock independently: locking a node does not


### PR DESCRIPTION
First slice of the follow-up editor initiative the basic-editing plan explicitly carved out (align/distribute/snap/flip/style-copy/minimap). Align and distribute were the two that plan named first, and they compose directly with the batch-undo seam and multi-selection already shipped.

## Design decisions worth reviewing

**Align uses the selection's bounding box, not the primary node.** So the result never depends on which node you happened to click first — a reference that would be invisible in the UI and surprising when it moved things the "wrong" way.

**Align accounts for size.** Aligning right or bottom uses each box's far edge, not its stored x/y. The unit tests use three deliberately different-sized boxes precisely so an implementation that aligns by position alone fails.

**Distribute equalises the GAPS, not the centres.** Equal centres leave visibly uneven gaps around a wide box; equal gaps is what a single "distribute" action is expected to do. The two outermost boxes anchor the span and never move.

**No keyboard shortcut.** Eight operations would crowd the chord space for something reached from a selection that is already under the pointer. The repo rule is that every shortcut needs a menu twin, not that every action needs a shortcut.

**Row visibility follows meaning.** Align appears at two nodes (it needs something to align *to*); Distribute at three (it needs a middle one to place). An inert row would be worse than no row.

**Group members are NOT carried along.** This follows the arrow-key nudge precedent — a discrete command moves exactly the selection — rather than the pointer-drag one, which carries a frame's geometrically-contained members. Both discrete paths now agree; if that convention should change, it should change for nudge and align together, which is a separate decision.

## Test plan

- [x] `align.test.ts` (16): each of the six align modes against different-sized boxes, gap-equalising distribute, position-ordering independent of argument order, endpoints anchored, no-op filtering, integer rounding, and totality on under-sized/overlapping selections
- [x] **Mutation-checked**: making align-right ignore width, and distribute equalise spans instead of gaps, each fails the tests that name that behaviour (4 failures)
- [x] `align.browser.test.tsx` (8, real Chromium, red-first): menu wiring, one-batch-per-action, bottom-align across differing heights, row visibility at 1/2/3 nodes, locked nodes neither moved nor counted, already-aligned emits nothing, edges untouched
- [x] `doc-contract.test.ts`: `align-distribute` removed from the machine-checked unsupported list (the test is what forced this to stay honest)
- [x] Manual: select-all → Align top on a real canvas, confirmed every node's top edge lands flush and **one** Cmd+Z restores all of them
- [x] Full `pnpm test` 581/581 files, 6177 passed, 0 failed; `pnpm -r typecheck` 0; knip clean

## Visual repro

Align and Distribute rows on a multi-node selection, below Order:

![align-distribute-menu.jpg](https://github.com/user-attachments/assets/95ed0a6a-51f4-4f86-b099-f3a37761dc50)
