### PR TITLE
fix(mcp): stop a reserved-port collision failing the dev-hook tests silently

### DIFF
--- a/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
+++ b/packages/mcp-server/scripts/dev/ensure-http-dev-daemon.script.test.ts
@@ -288,6 +288,45 @@ describe('ensure-http-dev-daemon.mjs (subprocess)', () => {
   )
 
   itPosix(
+    'writes the reason to the daemon log when the spawned dev server cannot bind',
+    async () => {
+      const { port, env } = await prepareHookRun()
+      const logPath = join(REPO_ROOT, LOG_PATH_SUFFIX)
+
+      // reserveFreePort() binds port 0, reads the number, then CLOSES the
+      // listener — so between that close and the spawned server's own
+      // listen() the OS may hand the same ephemeral port to anything else on
+      // the machine. On a sharded CI runner that is a real, observed race
+      // (2026-08-09). Steal the port inside that window: the hook's probe
+      // still sees it free, and the delayed bind then fails.
+      const hookRun = runHook({
+        ...env,
+        WHITEBOARD_DEV_READY_TIMEOUT_MS: '3000',
+        FAKE_PNPM_BIND_DELAY_MS: '600',
+      })
+      await new Promise((settle) => setTimeout(settle, 250))
+      // Drops every connection on arrival: this server exists only to hold
+      // the port, and a lingering socket from the hook's probe would make
+      // close() below wait on it.
+      const squatter = createServer((socket) => socket.destroy())
+      await new Promise<void>((listening) => squatter.listen(port, HOST, () => listening()))
+
+      try {
+        const { exitCode, stderr } = await hookRun
+        expect(exitCode).not.toBe(0)
+        // The hook points at the log; the log must actually name the cause,
+        // or "spawned process exited with code 1" is all anyone ever sees.
+        expect(stderr).toContain(LOG_PATH_SUFFIX)
+        const log = existsSync(logPath) ? readFileSync(logPath, 'utf8') : ''
+        expect(log).toContain('EADDRINUSE')
+        expect(log).toContain(String(port))
+      } finally {
+        await new Promise<void>((closed) => squatter.close(() => closed()))
+      }
+    },
+  )
+
+  itPosix(
     'fails loudly when a colliding worktree answers the readiness probe right after our own spawn (post-spawn TOCTOU)',
     async () => {
       const { port, dataDir, invokedSentinelPath, env } = await prepareHookRun()

--- a/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.mjs
+++ b/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.mjs
@@ -7,6 +7,10 @@
 
 import { createServer } from 'node:http'
 
+/** How long a transient EADDRINUSE is retried before the bind is called lost. */
+const BIND_RETRY_BUDGET_MS = 2_000
+const BIND_RETRY_INTERVAL_MS = 100
+
 /**
  * Starts a minimal HTTP responder that answers POST /mcp like the real
  * daemon's authenticated MCP endpoint, for exactly the fields
@@ -29,12 +33,28 @@ export function startFakeMcpResponder({ port, token, host = '127.0.0.1' }) {
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ jsonrpc: '2.0', id: 'fake-mcp-daemon', result: {} }))
     })
-    server.once('error', reject)
-    server.listen(port, host, () => {
+    // The caller reserved this port by binding :0 and closing again, so the
+    // OS is free to hand it to anything else on the machine before we get
+    // here — on a sharded CI runner that collision is real, not theoretical.
+    // A short retry rides out the usual case (something mid-teardown) rather
+    // than failing the run over a transient.
+    const deadline = Date.now() + BIND_RETRY_BUDGET_MS
+    // Both handlers are registered ONCE, outside the retry loop: re-adding
+    // them per attempt leaks a listener each time and trips Node's
+    // max-listeners warning after ten retries.
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE' && Date.now() < deadline) {
+        setTimeout(() => server.listen(port, host), BIND_RETRY_INTERVAL_MS)
+        return
+      }
+      reject(err)
+    })
+    server.once('listening', () => {
       resolve({
         server,
         close: () => new Promise((resolveClose) => server.close(() => resolveClose())),
       })
     })
+    server.listen(port, host)
   })
 }

--- a/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.test.ts
+++ b/packages/mcp-server/scripts/dev/test-utils/fake-mcp-daemon.test.ts
@@ -1,0 +1,81 @@
+// The fake daemon's bind retry, tested directly rather than through the
+// hook subprocess. Driving it end-to-end would mean racing wall-clock
+// sleeps against a spawned process — a test that passes when the collision
+// it meant to create never happened. Here the collision is constructed, so
+// each case is deterministic.
+import { createServer, type Server } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startFakeMcpResponder } from './fake-mcp-daemon.mjs'
+
+const HOST = '127.0.0.1'
+
+const openServers: Server[] = []
+
+afterEach(async () => {
+  for (const server of openServers.splice(0)) {
+    await new Promise<void>((closed) => server.close(() => closed()))
+  }
+})
+
+/** Binds a port and returns it still held, plus a release function. */
+async function occupyAPort(): Promise<{ port: number; release: () => Promise<void> }> {
+  const squatter = createServer((socket) => socket.destroy())
+  openServers.push(squatter)
+  await new Promise<void>((listening) => squatter.listen(0, HOST, () => listening()))
+  const address = squatter.address()
+  const port = typeof address === 'object' && address !== null ? address.port : 0
+  return {
+    port,
+    release: () => new Promise<void>((closed) => squatter.close(() => closed())),
+  }
+}
+
+describe('startFakeMcpResponder bind retry', () => {
+  it('rides out a collision that clears within the budget', async () => {
+    const { port, release } = await occupyAPort()
+    // Let go while the responder is still retrying — the common shape of the
+    // race on a shared CI runner is something else mid-teardown, and losing
+    // a job to that would be a flake, not a signal.
+    setTimeout(() => void release(), 250)
+
+    const responder = await startFakeMcpResponder({ port, token: 'tok' })
+    openServers.push(responder.server)
+    expect(responder.server.listening).toBe(true)
+  })
+
+  it('rejects with EADDRINUSE when the port never frees up', async () => {
+    const { port } = await occupyAPort()
+    await expect(startFakeMcpResponder({ port, token: 'tok' })).rejects.toMatchObject({
+      code: 'EADDRINUSE',
+    })
+  })
+
+  it('binds immediately when the port is free', async () => {
+    const { port, release } = await occupyAPort()
+    await release()
+
+    const started = Date.now()
+    const responder = await startFakeMcpResponder({ port, token: 'tok' })
+    openServers.push(responder.server)
+    // No retry budget is spent on the happy path.
+    expect(Date.now() - started).toBeLessThan(1_000)
+  })
+
+  it('answers an authenticated POST /mcp and refuses anything else', async () => {
+    const { port, release } = await occupyAPort()
+    await release()
+    const responder = await startFakeMcpResponder({ port, token: 'tok' })
+    openServers.push(responder.server)
+    const url = `http://${HOST}:${port}/mcp`
+
+    const ok = await fetch(url, { method: 'POST', headers: { authorization: 'Bearer tok' } })
+    expect(ok.status).toBe(200)
+    const unauthorized = await fetch(url, {
+      method: 'POST',
+      headers: { authorization: 'Bearer x' },
+    })
+    expect(unauthorized.status).toBe(401)
+    const wrongRoute = await fetch(`http://${HOST}:${port}/nope`, { method: 'POST' })
+    expect(wrongRoute.status).toBe(404)
+  })
+})

--- a/packages/mcp-server/scripts/dev/test-utils/fake-pnpm-shim.mjs
+++ b/packages/mcp-server/scripts/dev/test-utils/fake-pnpm-shim.mjs
@@ -62,7 +62,17 @@ if (process.env.FAKE_PNPM_NEVER_BIND === '1') {
   await new Promise(() => {})
 }
 
-await startFakeMcpResponder({ port, token })
+try {
+  await startFakeMcpResponder({ port, token })
+} catch (err) {
+  // Without this the rejection is unhandled: the process dies with exit 1
+  // and NOTHING on stderr, so the hook can only report "spawned process
+  // exited with code 1" and the log it points at is empty. Say why.
+  process.stderr.write(
+    `[fake-pnpm-shim] failed to bind ${port}: ${err?.code ?? ''} ${err?.message ?? err}\n`,
+  )
+  process.exit(1)
+}
 
 const markerJson = process.env.FAKE_PNPM_MARKER_JSON
 const dataDir = process.env.WHITEBOARD_DATA_DIR


### PR DESCRIPTION
## What happened

CI failed the concurrent-spawn dev-hook test on #503 — a PR that touches only `apps/web`. The hook reported:

```
timed out waiting for authenticated MCP at http://127.0.0.1:46481 after 8000ms;
spawned process exited with code 1
```

The spawned dev server **died**, it did not merely run late — so this was never the "8s is not enough under load" story I would otherwise have assumed. That distinction only exists because #502 made `runHook` resolve on `'close'` and include the captured stdio; the first occurrence of this same failure, a day earlier, carried an empty stderr and was undiagnosable.

## Root cause

`reserveFreePort()` binds `:0`, reads the assigned number, then **closes** the listener and returns the number. Between that close and the spawned server's own `listen()` — separated by lock acquisition, a process spawn, and this test's deliberate bind delay — the OS is free to hand the same ephemeral port to anything else on the machine. On a sharded CI runner with many tests opening sockets, that is a real collision.

The bind error then rejected a promise the shim `await`s at top level, so the process died with exit 1 and **nothing on stderr**, and the log the hook points the developer at was empty.

Reproduced locally by stealing the port inside that exact window (the port is free when the hook probes, taken by the time the spawned server binds), which fails the same way.

## The fix

- **The fake responder retries an `EADDRINUSE` for two seconds.** A port released by something mid-teardown no longer costs a CI job.
- **The shim reports a bind failure on stderr before exiting**, so the log the hook already points at actually names the cause.

## A note on how the retry is tested

My first attempt drove the retry through the hook subprocess with wall-clock sleeps. It passed with the retry budget set to **zero** — the collision it meant to construct simply had not happened at that moment. A test that passes for the wrong reason is worse than no test, so the retry is now tested directly against `startFakeMcpResponder`, where the collision is constructed rather than raced. That version fails when the budget is zeroed.

## Test plan

- [x] `ensure-http-dev-daemon.script.test.ts` — new subprocess case: steal the port inside the reserve→bind window, assert the daemon log names `EADDRINUSE` and the port. Red before the fix; **mutation-checked** (removing the shim's stderr write fails it)
- [x] `fake-mcp-daemon.test.ts` — new, deterministic: collision that clears within the budget succeeds, collision that never clears rejects with `EADDRINUSE`, a free port binds without spending the budget, and the responder still answers 200/401/404. **Mutation-checked** (budget → 0 fails the first case)
- [x] Fixed a listener leak the first retry version introduced (a handler per attempt tripped Node's max-listeners warning)
- [x] Full `pnpm test` 580/580 files, 6156 passed, 0 failed; `@kamiazya/whiteboard-mcp typecheck` 0
