### PR TITLE
test(web): give the export waits a budget matched to the work they wait on

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -82,6 +82,19 @@ async function openExportMenuItem(label: string): Promise<HTMLElement> {
   return item
 }
 
+/**
+ * Budget for an export to reach the download anchor. This is NOT papering
+ * over a race: the wait is already on the terminal signal (the anchor
+ * click), and the work in between is irreducibly asynchronous — lay out the
+ * scene, serialise SVG, and for PNG additionally decode it through a real
+ * <img> and encode a bitmap via canvas.toBlob. testing-library's default
+ * 1000ms was simply too small a budget for that on a loaded CI runner, and
+ * the PNG case (the heaviest of the two) is what failed there on
+ * 2026-08-09. The rest of this file already uses explicit budgets for the
+ * same reason.
+ */
+const EXPORT_TIMEOUT_MS = 15_000
+
 describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Excalidraw)', () => {
   beforeEach(async () => {
     await clearDb()
@@ -100,7 +113,7 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
     const svgItem = await openExportMenuItem('Export as SVG')
     fireEvent.pointerUp(svgItem)
 
-    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled(), { timeout: EXPORT_TIMEOUT_MS })
     expect(blobs).toHaveLength(1)
     const blob = blobs[0]
     expect(blob.type).toBe('image/svg+xml')
@@ -116,7 +129,7 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
     const pngItem = await openExportMenuItem('Export as PNG')
     fireEvent.pointerUp(pngItem)
 
-    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled(), { timeout: EXPORT_TIMEOUT_MS })
     // rasterizeSvgToPng creates its own intermediate object URL (the
     // rendered SVG fed into a real <img>) ahead of the final downloaded
     // blob, so the last captured blob is the one under test here.


### PR DESCRIPTION
The PNG export test failed on CI (2026-08-09) with `expected "click" to be called at least once`, after 1.7s — testing-library's default 1000ms wait expiring, not the export breaking. It passes 3/3 locally.

## Why this one is a budget, not a race

I fixed a different flake earlier today (#502) by making a wait deterministic rather than longer, so it is worth being explicit about why this case is the opposite.

There, the test was racing a lazy module load that could be made instant — the wait had a deterministic fix, and a bigger timeout would have hidden it.

Here the wait is **already on the terminal signal** (the download anchor's `click`), and the work in between is irreducibly asynchronous: lay out the scene, serialise SVG, and for PNG additionally decode it through a real `<img>` and encode a bitmap via `canvas.toBlob`. Nothing about that can be made synchronous, and the test's claim was never "this finishes within one second". The default budget was simply too small for that work on a loaded runner, which is why the PNG case — the heavier of the two — is the one that lost. The rest of this file already uses explicit budgets (5000ms, 1500ms) for the same reason.

## Guarding against a vacuous assertion

A longer timeout is only safe if the test still fails when the thing under test breaks. Mutation-checked: making `rasterizeSvgToPng` return null (no PNG, so no download) still fails the test.

## Test plan

- [x] `BrowserLocalCanvasPage.export.browser.test.tsx` 3 passed, locally 3/3 before and after
- [x] Mutation-checked: breaking PNG rasterisation fails the test even with the larger budget
- [x] Applied to the SVG case too — same shape, merely faster today, and one loaded runner away from the same failure
