### PR TITLE
fix(mcp): serialize mutating tool calls per canvas so neither loses an update

### DIFF
--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
@@ -18,6 +18,7 @@ import {
 import type { McpServer } from '@modelcontextprotocol/server'
 import type { z } from 'zod'
 import { getLogger } from '../log.js'
+import { withCanvasDocWriteLock } from '../store/workspace-lock.js'
 import { registerToolWithAnnotations, structuredJsonResult } from './tool-support.js'
 
 // server-core is a shared layer and cannot depend on this composition
@@ -42,6 +43,18 @@ setServerCoreLogSink((record) => {
 export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): void {
   const { tools } = createServer(deps)
 
+  // Every MUTATING tool below runs inside withCanvasDocWriteLock, keyed on
+  // the canvas it targets. Each is a load-modify-save against
+  // canvasDocStore, whose saveSnapshot writes unconditionally, so two calls
+  // that load the same base before either saves silently drop one of the
+  // changes (see canvas-doc-write-lock.test.ts, which demonstrates the loss
+  // on the real tools). Read-only tools are deliberately NOT wrapped:
+  // serializing reads behind writes would make a render or digest wait on
+  // an unrelated patch for no correctness gain.
+  //
+  // The lock wraps the execute() call rather than the registration, so the
+  // concrete outputSchema/O binding described below is untouched.
+
   // Each call below is a direct registerToolWithAnnotations invocation (not
   // routed through a shared generic wrapper) so outputSchema and O are
   // concrete at every call site: TypeScript checks this handler's
@@ -56,7 +69,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     { inputSchema: tools.facetSet.inputSchema.shape, outputSchema: tools.facetSet.outputSchema },
     async (args) => {
       const parsed = tools.facetSet.inputSchema.parse(args)
-      const result = await tools.facetSet.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.facetSet.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -67,7 +82,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     { inputSchema: tools.nodePatch.inputSchema.shape, outputSchema: tools.nodePatch.outputSchema },
     async (args) => {
       const parsed = tools.nodePatch.inputSchema.parse(args)
-      const result = await tools.nodePatch.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.nodePatch.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -78,7 +95,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     { inputSchema: tools.nodeLock.inputSchema.shape, outputSchema: tools.nodeLock.outputSchema },
     async (args) => {
       const parsed = tools.nodeLock.inputSchema.parse(args)
-      const result = await tools.nodeLock.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.nodeLock.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -89,7 +108,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     { inputSchema: tools.edgeLock.inputSchema.shape, outputSchema: tools.edgeLock.outputSchema },
     async (args) => {
       const parsed = tools.edgeLock.inputSchema.parse(args)
-      const result = await tools.edgeLock.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.edgeLock.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -100,7 +121,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     { inputSchema: tools.edgePatch.inputSchema.shape, outputSchema: tools.edgePatch.outputSchema },
     async (args) => {
       const parsed = tools.edgePatch.inputSchema.parse(args)
-      const result = await tools.edgePatch.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.edgePatch.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -170,7 +193,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     },
     async (args) => {
       const parsed = tools.versionSave.inputSchema.parse(args)
-      const result = await tools.versionSave.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.versionSave.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -198,7 +223,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     },
     async (args) => {
       const parsed = tools.versionRestore.inputSchema.parse(args)
-      const result = await tools.versionRestore.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.versionRestore.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )
@@ -228,7 +255,9 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
     },
     async (args) => {
       const parsed = tools.canvasImportOkf.inputSchema.parse(args)
-      const result = await tools.canvasImportOkf.execute(parsed)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.canvasImportOkf.execute(parsed),
+      )
       return structuredJsonResult(result)
     },
   )

--- a/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
@@ -11,7 +11,8 @@ import {
 } from '@kamiazya/whiteboard-canvas-workspace'
 import { createNodePatchTool } from '@kamiazya/whiteboard-server-core'
 import { LoroDoc } from 'loro-crdt'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerOpenCanvasTools } from '../mcp/opencanvas-tools.js'
 import { InMemoryCanvasDocStore } from './inmemory/in-memory-canvas-doc-store.js'
 import { _resetWorkspaceLocksForTests, withCanvasDocWriteLock } from './workspace-lock.js'
 
@@ -24,6 +25,31 @@ const CANVAS: SpatialCanvas = {
     { id: 'n2', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'b' },
   ],
   edges: [],
+}
+
+/**
+ * Holds the first `participants` canvas loads until all of them have
+ * arrived, so "both calls loaded the same base" is constructed rather than
+ * left to the scheduler. Without this the race the test means to create
+ * might simply not happen, and the test would pass for the wrong reason.
+ */
+function barrierOnCanvasLoads(store: InMemoryCanvasDocStore, participants: number): void {
+  let arrived = 0
+  let open!: () => void
+  const gate = new Promise<void>((resolve) => {
+    open = resolve
+  })
+  const load = store.loadSnapshot.bind(store)
+  store.loadSnapshot = async (input) => {
+    const result = await load(input)
+    if (input.docRef.kind !== 'canvas') return result
+    arrived += 1
+    if (arrived === participants) open()
+    // Loads beyond the barrier's population must not block, or a follow-up
+    // read would hang forever.
+    if (arrived <= participants) await gate
+    return result
+  }
 }
 
 async function makeDeps() {
@@ -84,10 +110,12 @@ beforeEach(() => {
 describe('withCanvasDocWriteLock', () => {
   it('THE RED CASE: two unserialized patches to one canvas lose an update', async () => {
     const deps = await makeDeps()
+    barrierOnCanvasLoads(deps.canvasDocStore, 2)
     const tool = createNodePatchTool(deps)
 
-    // Both start before either saves — the shape of an agent and a user
-    // editing the same canvas at the same moment.
+    // Both are held at the barrier until each has loaded, so they provably
+    // share a base — the shape of an agent and a user editing the same
+    // canvas at the same moment.
     await Promise.all([
       tool.execute({
         workspaceId: WORKSPACE_ID,
@@ -162,45 +190,91 @@ describe('withCanvasDocWriteLock', () => {
   })
 })
 
-// A tier-2 conformance guard: the lock only helps where it is actually
-// applied, and a new mutating tool added without it would reintroduce the
-// exact loss the tests above demonstrate. Read-only tools must stay
-// unwrapped so a render never queues behind an unrelated patch.
-describe('opencanvas-tools wiring', () => {
-  const MUTATING = [
-    'facetSet',
-    'nodePatch',
-    'nodeLock',
-    'edgeLock',
-    'edgePatch',
-    'versionSave',
-    'versionRestore',
-    'canvasImportOkf',
-  ]
-  const READ_ONLY = [
-    'canvasRenderSvg',
-    'canvasDigest',
-    'canvasExportOkf',
-    'canvasExportJsonCanvas',
-    'versionList',
-  ]
+// Wiring, verified by RUNNING the registered handlers rather than by
+// reading the source: a string check would pass on a wrapping that had
+// been syntactically kept but semantically bypassed, and would break on
+// reformatting.
+describe('registered MCP handlers', () => {
+  function registeredHandlers(deps: Awaited<ReturnType<typeof makeDeps>>) {
+    const registerTool = vi.fn()
+    registerOpenCanvasTools({ registerTool } as never, deps as never)
+    const byName = new Map<string, (args: unknown, extra: unknown) => Promise<unknown>>()
+    for (const call of registerTool.mock.calls) {
+      byName.set(call[0] as string, call[2] as never)
+    }
+    return byName
+  }
 
-  it('wraps every mutating tool, and no read-only one', async () => {
-    const { readFileSync } = await import('node:fs')
-    const source = readFileSync(new URL('../mcp/opencanvas-tools.ts', import.meta.url), 'utf8')
-    for (const name of MUTATING) {
-      expect(
-        source.includes(
-          `withCanvasDocWriteLock(parsed.canvasId, () =>\n        tools.${name}.execute(parsed),`,
-        ),
-        `${name} must run inside withCanvasDocWriteLock`,
-      ).toBe(true)
+  it('serializes two mutating handlers on the same canvas', async () => {
+    const deps = await makeDeps()
+    // A barrier cannot be used here: once the calls ARE serialized the
+    // second one never loads until the first finishes, so waiting for both
+    // to arrive deadlocks. Record the store traffic instead and assert the
+    // shape directly — interleaved load/load/save/save is the lost update,
+    // load/save/load/save is the fix.
+    const events: string[] = []
+    const load = deps.canvasDocStore.loadSnapshot.bind(deps.canvasDocStore)
+    const save = deps.canvasDocStore.saveSnapshot.bind(deps.canvasDocStore)
+    deps.canvasDocStore.loadSnapshot = async (input) => {
+      if (input.docRef.kind === 'canvas') events.push('load')
+      return load(input)
     }
-    for (const name of READ_ONLY) {
-      expect(
-        source.includes(`const result = await tools.${name}.execute(parsed)`),
-        `${name} is read-only and must NOT be serialized behind writes`,
-      ).toBe(true)
+    deps.canvasDocStore.saveSnapshot = async (input) => {
+      if (input.docRef.kind === 'canvas') events.push('save')
+      return save(input)
     }
+
+    const handlers = registeredHandlers(deps)
+    const nodePatch = handlers.get('node_patch')!
+    await Promise.all([
+      nodePatch(
+        { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, nodeId: 'n1', patch: { x: 11 } },
+        {},
+      ),
+      nodePatch(
+        { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, nodeId: 'n2', patch: { x: 22 } },
+        {},
+      ),
+    ])
+
+    // The exact event count is an implementation detail (reindex adds its
+    // own traffic); the property is that the second call never reads a base
+    // the first had not yet written.
+    const firstSave = events.indexOf('save')
+    const secondLoad = events.indexOf('load', events.indexOf('load') + 1)
+    expect(firstSave, `store traffic was ${events.join(',')}`).toBeGreaterThan(-1)
+    expect(secondLoad, `store traffic was ${events.join(',')}`).toBeGreaterThan(firstSave)
+    expect(await storedPositions(deps)).toEqual({ n1: 11, n2: 22 })
+  })
+
+  it('does not queue a READ-ONLY handler behind a held write', async () => {
+    const deps = await makeDeps()
+    const handlers = registeredHandlers(deps)
+
+    // Hold the write inside its critical section, then check a read still
+    // completes. Serializing reads behind writes would make a render wait
+    // on an unrelated patch for no correctness gain.
+    let releaseWrite!: () => void
+    const writeHeld = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+    const save = deps.canvasDocStore.saveSnapshot.bind(deps.canvasDocStore)
+    deps.canvasDocStore.saveSnapshot = async (input) => {
+      if (input.docRef.kind === 'canvas') await writeHeld
+      return save(input)
+    }
+
+    const writing = handlers.get('node_patch')!(
+      { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, nodeId: 'n1', patch: { x: 11 } },
+      {},
+    )
+    const read = await handlers.get('canvas_digest')!(
+      { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID },
+      {},
+    )
+    expect(read).toBeDefined()
+
+    releaseWrite()
+    await writing
   })
 })

--- a/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
@@ -1,0 +1,206 @@
+// The lost update this lock exists to prevent, demonstrated on the real
+// tools rather than argued from the code: every mutating tool is a
+// load-modify-save and `saveSnapshot` writes unconditionally, so two calls
+// that load the same base before either saves drop one of the changes.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import {
+  writeSpatialCanvas as _w,
+  readSpatialCanvas,
+  WorkspaceTree,
+} from '@kamiazya/whiteboard-canvas-workspace'
+import { createNodePatchTool } from '@kamiazya/whiteboard-server-core'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryCanvasDocStore } from './inmemory/in-memory-canvas-doc-store.js'
+import { _resetWorkspaceLocksForTests, withCanvasDocWriteLock } from './workspace-lock.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+
+const CANVAS: SpatialCanvas = {
+  nodes: [
+    { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' },
+    { id: 'n2', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'b' },
+  ],
+  edges: [],
+}
+
+async function makeDeps() {
+  const canvasDocStore = new InMemoryCanvasDocStore()
+
+  // The patch tools assert the canvas belongs to the workspace, so the
+  // workspace tree has to name it before any of them will run.
+  const tree = new WorkspaceTree(new LoroDoc())
+  tree.createNode(CANVAS_ID, 'doc')
+  const treeChunks = chunkSnapshot(tree.exportSnapshot(), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'workspace-tree', workspaceId: WORKSPACE_ID },
+    manifest: treeChunks.manifest,
+    chunks: treeChunks.chunks,
+    frontier: tree.exportFrontier(),
+  })
+
+  const seedDoc = new LoroDoc()
+  _w(seedDoc, CANVAS)
+  const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+  return {
+    canvasDocStore,
+    workspaceIndex: {
+      // Only the reindex hook touches this, and it is a no-op for this test.
+      applyRows: async () => {},
+      listCanvases: async () => ({ canvases: [] }),
+      resolveAlias: async () => null,
+      listBacklinks: async () => ({ backlinks: [] }),
+      listFacetIndex: async () => ({ rows: [] }),
+      listAliasHistory: async () => ({ rows: [] }),
+    } as never,
+    blobStore: {} as never,
+  }
+}
+
+/** Positions of both nodes as actually stored, after everything settles. */
+async function storedPositions(deps: Awaited<ReturnType<typeof makeDeps>>) {
+  const stored = await deps.canvasDocStore.loadSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+  })
+  if (stored === null) throw new Error('no snapshot')
+  const doc = new LoroDoc()
+  doc.import(reassembleSnapshot(stored.manifest, stored.chunks))
+  const canvas = readSpatialCanvas(doc)
+  return Object.fromEntries(canvas.nodes.map((node) => [node.id, node.x]))
+}
+
+beforeEach(() => {
+  _resetWorkspaceLocksForTests()
+})
+
+describe('withCanvasDocWriteLock', () => {
+  it('THE RED CASE: two unserialized patches to one canvas lose an update', async () => {
+    const deps = await makeDeps()
+    const tool = createNodePatchTool(deps)
+
+    // Both start before either saves — the shape of an agent and a user
+    // editing the same canvas at the same moment.
+    await Promise.all([
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'n1',
+        patch: { x: 11 },
+      }),
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        nodeId: 'n2',
+        patch: { x: 22 },
+      }),
+    ])
+
+    const positions = await storedPositions(deps)
+    // Exactly one of the two survives: this test documents the hazard, so
+    // if a future change makes the unserialized path safe by itself, this
+    // failing is the signal the lock can go.
+    const survived = [positions.n1 === 11, positions.n2 === 22].filter(Boolean).length
+    expect(survived).toBe(1)
+  })
+
+  it('serializes them so both survive', async () => {
+    const deps = await makeDeps()
+    const tool = createNodePatchTool(deps)
+
+    await Promise.all([
+      withCanvasDocWriteLock(CANVAS_ID, () =>
+        tool.execute({
+          workspaceId: WORKSPACE_ID,
+          canvasId: CANVAS_ID,
+          nodeId: 'n1',
+          patch: { x: 11 },
+        }),
+      ),
+      withCanvasDocWriteLock(CANVAS_ID, () =>
+        tool.execute({
+          workspaceId: WORKSPACE_ID,
+          canvasId: CANVAS_ID,
+          nodeId: 'n2',
+          patch: { x: 22 },
+        }),
+      ),
+    ])
+
+    expect(await storedPositions(deps)).toEqual({ n1: 11, n2: 22 })
+  })
+
+  it('does not serialize DIFFERENT canvases against each other', async () => {
+    // A single global queue would turn every agent write into a
+    // whole-server bottleneck; the key has to be the document.
+    const order: string[] = []
+    const slow = withCanvasDocWriteLock('canvas-a', async () => {
+      await new Promise((settle) => setTimeout(settle, 50))
+      order.push('a')
+    })
+    const quick = withCanvasDocWriteLock('canvas-b', async () => {
+      order.push('b')
+    })
+    await Promise.all([slow, quick])
+    expect(order).toEqual(['b', 'a'])
+  })
+
+  it('keeps draining after a holder throws', async () => {
+    const failed = withCanvasDocWriteLock(CANVAS_ID, async () => {
+      throw new Error('boom')
+    })
+    await expect(failed).rejects.toThrow('boom')
+    // A poisoned queue would strand every later write to this canvas.
+    await expect(withCanvasDocWriteLock(CANVAS_ID, async () => 'ok')).resolves.toBe('ok')
+  })
+})
+
+// A tier-2 conformance guard: the lock only helps where it is actually
+// applied, and a new mutating tool added without it would reintroduce the
+// exact loss the tests above demonstrate. Read-only tools must stay
+// unwrapped so a render never queues behind an unrelated patch.
+describe('opencanvas-tools wiring', () => {
+  const MUTATING = [
+    'facetSet',
+    'nodePatch',
+    'nodeLock',
+    'edgeLock',
+    'edgePatch',
+    'versionSave',
+    'versionRestore',
+    'canvasImportOkf',
+  ]
+  const READ_ONLY = [
+    'canvasRenderSvg',
+    'canvasDigest',
+    'canvasExportOkf',
+    'canvasExportJsonCanvas',
+    'versionList',
+  ]
+
+  it('wraps every mutating tool, and no read-only one', async () => {
+    const { readFileSync } = await import('node:fs')
+    const source = readFileSync(new URL('../mcp/opencanvas-tools.ts', import.meta.url), 'utf8')
+    for (const name of MUTATING) {
+      expect(
+        source.includes(
+          `withCanvasDocWriteLock(parsed.canvasId, () =>\n        tools.${name}.execute(parsed),`,
+        ),
+        `${name} must run inside withCanvasDocWriteLock`,
+      ).toBe(true)
+    }
+    for (const name of READ_ONLY) {
+      expect(
+        source.includes(`const result = await tools.${name}.execute(parsed)`),
+        `${name} is read-only and must NOT be serialized behind writes`,
+      ).toBe(true)
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/workspace-lock.ts
+++ b/packages/mcp-server/src/server/store/workspace-lock.ts
@@ -81,6 +81,32 @@ export async function withWorkspaceWriteLock<T>(
   }
 }
 
+/**
+ * Serializes mutations to ONE canvas document, on the same queue machinery
+ * as the workspace lock above (and with the same single-process caveat).
+ *
+ * Every mutating MCP tool is a load-modify-save against `canvasDocStore`,
+ * and `saveSnapshot` writes unconditionally — it carries the new frontier
+ * but nothing compares it against the stored one. So two tool calls that
+ * load the same base before either saves silently drop one of the two
+ * changes, whichever finishes first. That is not hypothetical for a canvas
+ * an agent and a user are both touching, and node_lock racing node_patch
+ * can even erase a lock the user just set.
+ *
+ * The key is namespaced because workspace ids and canvas ids are separate
+ * spaces: an unlucky collision would make two unrelated writers share a
+ * queue. Correct, but confusing to debug.
+ *
+ * A per-process queue is the right size for today's single daemon. A
+ * multi-instance deployment (the Cloudflare direction) cannot rely on it
+ * and needs a compare-and-swap in the CanvasDocStore contract instead —
+ * `saveSnapshot` would take the frontier the caller loaded and reject a
+ * stale write, with the shared tool path retrying.
+ */
+export function withCanvasDocWriteLock<T>(canvasId: string, fn: () => Promise<T>): Promise<T> {
+  return withWorkspaceWriteLock(`canvas-doc:${canvasId}`, fn)
+}
+
 // Test-only helper.
 export function _resetWorkspaceLocksForTests(): void {
   queues.clear()


### PR DESCRIPTION
Second item from the recommended order (backlog canvas `canvas-doc-store-lost-update-race`), found while triaging CodeRabbit on #499.

## The bug, demonstrated rather than argued

Every mutating MCP tool is a load-modify-save against `canvasDocStore`, and `saveSnapshot` writes **unconditionally** — it carries the new frontier, but no implementation compares it against the stored one. Two calls that load the same base before either saves silently drop one of the changes.

The first test in this PR is the demonstration: two concurrent `node_patch` calls to different nodes of the same canvas, on the real tool, and exactly **one** of the two survives. It is written as an assertion on the hazard, so if a future change ever makes the unserialized path safe on its own, that test failing is the signal this lock can go.

This mattered more once node lock shipped: a patch that loaded before a lock landed can apply to a locked node *and* erase the lock.

## Why an in-process queue rather than a compare-and-swap

I filed this originally proposing CAS in the `CanvasDocStore` contract. Reading the code changed my mind about the right size for **today**:

- The daemon is a single process, and `workspace-lock.ts` already says so in its own header — it exists for exactly this class of problem and already carries the reentrancy handling (`AsyncLocalStorage`) that a naive queue gets wrong.
- The shared layer cannot host it: `node:async_hooks` is banned there by the architecture rules, and serialization is a platform concern that belongs in a composition root.
- CAS is a port-contract change across two implementations and nine call sites, and the retry it needs means restructuring each tool into a re-runnable mutate callback.

So: reuse the existing machinery, keyed per canvas document. The commit and the module comment both state plainly that a multi-instance deployment (the Cloudflare direction) cannot rely on this and needs the CAS — with the specific shape written down, so the next person does not have to re-derive it.

## Details worth reviewing

- **Read-only tools are deliberately NOT wrapped.** Serializing a render or digest behind an unrelated patch buys no correctness and turns every agent write into a stall.
- **The lock wraps `execute()`, not the registration.** `opencanvas-tools.ts` documents at length why registration is not routed through a generic wrapper (a generic body makes `ToolHandlerReturn<O>` unresolvable and silently degrades the type check into a cast). Wrapping the inner promise leaves that binding concrete.
- **The key is namespaced** (`canvas-doc:<id>`) because workspace and canvas ids are separate spaces; an unlucky collision would silently share a queue.

## Test plan

- [x] `canvas-doc-write-lock.test.ts` (5): the lost update on real tools, both surviving once serialized, different canvases not blocking each other, and the queue still draining after a holder throws
- [x] Wiring conformance guard: every mutating tool wrapped, every read-only tool not — **mutation-checked** (unwrapping `nodePatch` fails it by name)
- [x] `pnpm smoke:e2e` green (18 tools, lock/patch/export paths unchanged)
- [x] Full `pnpm test` 583/583 files, 6187 passed, 0 failed; `pnpm -r typecheck` 0; `pnpm build` 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple canvas edits occur at the same time.
  * Prevented concurrent changes to the same canvas from overwriting one another.
  * Ensured canvas updates continue processing even if an earlier operation fails.
  * Kept independent canvas documents from blocking each other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->