### PR TITLE
test(mcp): pin lock persistence on the daemon's own canvas path

### DIFF
--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -90,6 +90,33 @@ describe('saveCanvas / loadCanvas', () => {
     expect(elements[0].x).toBe(100)
   })
 
+  // Daemon mode persists a canvas through THIS path, not through
+  // canvasDocStore — a separate implementation, so the sidecar-map contract
+  // node/edge lock relies on has to be pinned here too. It holds because
+  // saveCanvas writes doc.export({ mode: 'snapshot' }) verbatim rather than
+  // re-serializing through readSpatialCanvas, which would drop everything
+  // outside the canvas value.
+  it('round-trips node and edge locks, which live outside the canvas value', async () => {
+    const { setEdgeLock, setNodeLock, readEdgeLocks, readNodeLocks, writeSpatialCanvas } =
+      await import('@kamiazya/whiteboard-canvas-workspace')
+    const doc = new LoroDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' },
+        { id: 'n2', type: 'text', x: 200, y: 0, width: 100, height: 50, text: 'b' },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    setNodeLock(doc, 'n1', true)
+    setEdgeLock(doc, 'e1', true)
+
+    await saveCanvas('session1', 'locked', doc)
+    const loaded = await loadCanvas('session1', 'locked')
+
+    expect(readNodeLocks(loaded)).toEqual(new Set(['n1']))
+    expect(readEdgeLocks(loaded)).toEqual(new Set(['e1']))
+  })
+
   it('returns an empty LoroDoc for a missing canvas', async () => {
     const doc = await loadCanvas('session1', 'nonexistent')
     expect(doc.getMovableList('elements').length).toBe(0)


### PR DESCRIPTION
Third item from the recommended order, and the last disclosed gap from the lock work: #499 shipped with "daemon-mode persistence is unverified" in its body, and #501 inherited that for edge lock.

## Why this needed its own guard

Daemon mode does not persist through `canvasDocStore` — it goes through `saveCanvas`/`loadCanvas` in `canvas-store.ts`, a **separate implementation**. The sidecar-map contract that node and edge lock depend on (durable, peer-synced, invisible to `readSpatialCanvas`) was only pinned on the store the MCP tools use, so extending the claim to the daemon would have been an argument by analogy rather than a verified one.

It turns out to hold, for a reason worth writing down: `saveCanvas` writes `doc.export({ mode: 'snapshot' })` **verbatim**. A future change that re-serialised through `readSpatialCanvas` — a natural-looking refactor, since that is how the rest of the codebase turns a doc into a canvas — would silently drop every lock, and everything else living outside the canvas value.

That is exactly what the test guards, so it is mutation-checked against that specific rewrite: rebuilding the doc from `readSpatialCanvas` before export loses both locks and fails.

## Why a test rather than a manual daemon dogfood

The gap was recorded as "unverified", and a one-off manual check would have converted it to "verified once". A test on the real save/load pair converts it to "verified continuously", is deterministic, and runs in the existing `mcp-node` project with no daemon, pairing flow, or browser involved.

## Test plan

- [x] `canvas-store.test.ts`: a doc carrying both a node lock and an edge lock round-trips through `saveCanvas` → `loadCanvas` with both sets intact
- [x] Mutation-checked: making `saveCanvas` rebuild the doc from `readSpatialCanvas` fails it (`expected Set{} to deeply equal Set{ 'n1' }`)
- [x] Whole `canvas-store.test.ts` 54 passed; `@kamiazya/whiteboard-mcp typecheck` 0
