### PR TITLE
feat(web): snap a dragged node to neighbour edges and the grid

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -119,20 +119,23 @@ describe('SpatialEditor (browser)', () => {
         button: 0,
       }),
     )
+    // +29/+29 lands "a" at (49,49): 9 from the nearest grid line and well
+    // clear of every line node "b" offers, so this stays a plain drag on the
+    // default path rather than a snap (snap.browser.test.tsx covers those).
     await editor
       .element()
       .dispatchEvent(
-        new PointerEvent('pointermove', { bubbles: true, clientX: 70, clientY: 55, pointerId: 1 }),
+        new PointerEvent('pointermove', { bubbles: true, clientX: 69, clientY: 69, pointerId: 1 }),
       )
     await editor
       .element()
       .dispatchEvent(
-        new PointerEvent('pointerup', { bubbles: true, clientX: 70, clientY: 55, pointerId: 1 }),
+        new PointerEvent('pointerup', { bubbles: true, clientX: 69, clientY: 69, pointerId: 1 }),
       )
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
-    expect(command).toEqual({ kind: 'move-node', id: 'a', x: 50, y: 35 })
+    expect(command).toEqual({ kind: 'move-node', id: 'a', x: 49, y: 49 })
     expect(next.nodes[1]).toEqual(canvasValue.nodes[1])
     // input untouched
     expect(canvasValue.nodes[0]).toEqual({
@@ -739,12 +742,17 @@ describe('SpatialEditor (browser)', () => {
     let previousRectX: number | undefined
     let previousRectY: number | undefined
     for (const delta of deltas) {
+      // Cmd suspends snapping for the gesture, which is what makes "tracks
+      // the pointer" a meaningful claim here: with snapping live the preview
+      // is SUPPOSED to leave the pointer for a nearby line, and that
+      // behaviour has its own test file.
       await editor.element().dispatchEvent(
         new PointerEvent('pointermove', {
           bubbles: true,
           clientX: 40 + delta.x,
           clientY: 40 + delta.y,
           pointerId: 200,
+          metaKey: true,
         }),
       )
       const expectedX = 20 + delta.x

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -165,10 +165,14 @@ describe('SpatialEditor externalVersion origin handling', () => {
         button: 0,
       }),
     )
+    // +29/+29 keeps "a" clear of every snap candidate (see the same choice
+    // in SpatialEditor.browser.test.tsx), so these tests stay about
+    // externalVersion rather than about snapping arithmetic.
     root.dispatchEvent(
-      new PointerEvent('pointermove', { bubbles: true, clientX: 70, clientY: 55, pointerId: 1 }),
+      new PointerEvent('pointermove', { bubbles: true, clientX: 69, clientY: 69, pointerId: 1 }),
     )
   }
+  const DRAG_DROP = { clientX: 69, clientY: 69 }
 
   it('bumping externalVersion alongside a canvas prop swap cancels an in-flight drag', () => {
     const onChange = vi.fn()
@@ -196,9 +200,7 @@ describe('SpatialEditor externalVersion origin handling', () => {
       />,
     )
 
-    root.dispatchEvent(
-      new PointerEvent('pointerup', { bubbles: true, clientX: 70, clientY: 55, pointerId: 1 }),
-    )
+    root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, ...DRAG_DROP, pointerId: 1 }))
 
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -230,13 +232,11 @@ describe('SpatialEditor externalVersion origin handling', () => {
       />,
     )
 
-    root.dispatchEvent(
-      new PointerEvent('pointerup', { bubbles: true, clientX: 70, clientY: 55, pointerId: 1 }),
-    )
+    root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, ...DRAG_DROP, pointerId: 1 }))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
-    expect(command).toEqual({ kind: 'move-node', id: 'a', x: 50, y: 35 })
+    expect(command).toEqual({ kind: 'move-node', id: 'a', x: 49, y: 49 })
   })
 })
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -44,9 +44,13 @@
  * fit / to selection). Every one has a context-menu or dock twin; every
  * binding is declared in `shortcuts.ts`.
  *
+ * Dragging a node also SNAPS it to nearby neighbour edges/centres and to a
+ * background grid, drawing the guide that justifies each snap; Cmd/Ctrl
+ * suspends it for one gesture (`snap.ts` holds the geometry).
+ *
  * NOT yet supported (see `SPATIAL_EDITOR_UNSUPPORTED`): freehand drawing
  * and shape tools (`x-whiteboard` extension authoring — its own slice),
- * snapping, persistence, and sync. Those are later phases.
+ * persistence, and sync. Those are later phases.
  */
 import type {
   CanvasColor,
@@ -140,6 +144,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
+import { type SnapBox, snapBox } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
@@ -163,10 +168,25 @@ import {
 export const SPATIAL_EDITOR_UNSUPPORTED = [
   'freehand-drawing',
   'shape-tools',
-  'snapping',
   'persistence',
   'sync',
 ] as const
+
+/**
+ * Attraction radius in SCREEN pixels, converted to canvas units per gesture
+ * so the pull feels the same at every zoom — a fixed canvas threshold would
+ * be imperceptible zoomed out and violent zoomed in.
+ */
+const SNAP_THRESHOLD_SCREEN_PX = 6
+/**
+ * Grid pitch in canvas units. Deliberately wider than
+ * `2 * SNAP_THRESHOLD_SCREEN_PX`: a pitch at or below that makes every
+ * lattice line reachable from everywhere, which is silent rounding rather
+ * than snapping, and it would out-pull the neighbour edges the user aimed
+ * at. At 20 the grid attracts near a line and leaves the rest of the plane
+ * alone.
+ */
+const SNAP_GRID_CANVAS_PX = 20
 
 export interface SpatialEditorProps {
   readonly canvas: SpatialCanvas
@@ -361,6 +381,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * ~30ms on an 80-node canvas — far past a frame budget).
      */
     const [livePoint, setLivePoint] = useState<Point | null>(null)
+    /**
+     * Canvas-space lines justifying the current snap, cleared with the
+     * gesture. Same rationale as `livePoint`: a per-frame value that drives
+     * only an overlay, never the document.
+     */
+    const [snapGuides, setSnapGuides] = useState<{
+      readonly x: readonly number[]
+      readonly y: readonly number[]
+    } | null>(null)
     // OOUI interaction mode (S6/S7): Hand (navigation) is the default —
     // Select restores the pre-tool editing behavior byte-for-byte; Connect
     // arms object-first click-A, click-B edge creation. Creation is
@@ -452,7 +481,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // cancelled. Uses the SAME predicate applyResult's own clearing check
       // below does, so there is exactly one definition of "no longer in
       // flight" rather than two clearing rules that could drift apart.
-      if (!isInFlightGesture(result.state)) setLivePoint(null)
+      if (!isInFlightGesture(result.state)) {
+        setLivePoint(null)
+        // The guides justify an in-flight snap; outliving the gesture would
+        // leave stray lines on the canvas.
+        setSnapGuides(null)
+      }
       // gestureState intentionally omitted: this effect only reacts to a new
       // canvas identity, not every gestureState transition (that would create
       // an infinite render loop feeding the reducer's own output back in).
@@ -672,6 +706,83 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     )
 
     /**
+     * How far a snap guide extends, in canvas space: across all content plus
+     * a margin. Spanning the content rather than the window keeps the line a
+     * function of the document alone, so it renders identically at any zoom
+     * or scroll position and needs no measured element size.
+     */
+    const guideSpan = useMemo(() => {
+      const GUIDE_MARGIN_PX = 40
+      if (boxes.length === 0) return { minX: 0, maxX: 0, minY: 0, maxY: 0 }
+      const xs = boxes.flatMap((entry) => [entry.box.x, entry.box.x + entry.box.width])
+      const ys = boxes.flatMap((entry) => [entry.box.y, entry.box.y + entry.box.height])
+      return {
+        minX: Math.min(...xs) - GUIDE_MARGIN_PX,
+        maxX: Math.max(...xs) + GUIDE_MARGIN_PX,
+        minY: Math.min(...ys) - GUIDE_MARGIN_PX,
+        maxY: Math.max(...ys) + GUIDE_MARGIN_PX,
+      }
+    }, [boxes])
+
+    /**
+     * Nudges the POINTER, not the emitted command, so preview and commit see
+     * the same value: the reducer derives both from `point`, and adjusting
+     * only one of them would let the box render in one place and land in
+     * another.
+     *
+     * Move only. A resize would have to snap the dragged EDGE rather than the
+     * origin, which is a different candidate set — deferred rather than
+     * approximated, since an approximate resize snap fights the handle.
+     */
+    const snapMovePoint = (
+      raw: Point,
+      suspended: boolean,
+    ): { point: Point; guides: { x: readonly number[]; y: readonly number[] } } => {
+      const unchanged = { point: raw, guides: { x: [], y: [] } }
+      if (suspended || gestureState.kind !== 'moving') return unchanged
+      const moving = boxes.find((entry) => entry.id === gestureState.nodeId)
+      if (moving === undefined) return unchanged
+
+      const candidate: SnapBox = {
+        x: gestureState.startX + (raw.x - gestureState.startPoint.x),
+        y: gestureState.startY + (raw.y - gestureState.startPoint.y),
+        width: moving.box.width,
+        height: moving.box.height,
+      }
+      // Everything travelling WITH the drag is excluded: a multi-selection
+      // member, or a frame's geometrically contained members (same rule the
+      // commit uses). Left in, a carried node would attract its own carrier
+      // and peg the gesture at a fixed offset.
+      const movingNode = canvas.nodes.find((n) => n.id === gestureState.nodeId)
+      const carried = new Set<string>([gestureState.nodeId, ...extraIds])
+      if (movingNode?.type === 'group') {
+        for (const n of canvas.nodes) {
+          if (
+            n.x >= gestureState.startX &&
+            n.y >= gestureState.startY &&
+            n.x + n.width <= gestureState.startX + movingNode.width &&
+            n.y + n.height <= gestureState.startY + movingNode.height
+          ) {
+            carried.add(n.id)
+          }
+        }
+      }
+
+      const result = snapBox(
+        candidate,
+        boxes.filter((entry) => !carried.has(entry.id)).map((entry) => entry.box),
+        {
+          thresholdCanvasPx: SNAP_THRESHOLD_SCREEN_PX / viewport.zoom,
+          gridSize: SNAP_GRID_CANVAS_PX,
+        },
+      )
+      return {
+        point: { x: raw.x + (result.x - candidate.x), y: raw.y + (result.y - candidate.y) },
+        guides: { x: result.guidesX, y: result.guidesY },
+      }
+    }
+
+    /**
      * Folds `result.commands` in order over a LOCAL running canvas (seeded
      * from `canvasRef.current`, never re-read from the ref between steps) so
      * a multi-command result — e.g. a pending-text commit ordered ahead of a
@@ -684,7 +795,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // Any gesture that leaves an in-flight state retires the preview: the
       // committed canvas is about to draw the real thing. Same predicate the
       // canvas-replaced effect above uses, so both agree on one definition.
-      if (!isInFlightGesture(result.state)) setLivePoint(null)
+      if (!isInFlightGesture(result.state)) {
+        setLivePoint(null)
+        // The guides justify an in-flight snap; outliving the gesture would
+        // leave stray lines on the canvas.
+        setSnapGuides(null)
+      }
       setGestureState(result.state)
       if (result.selectedId !== undefined) setSelectedId(result.selectedId)
       let running = canvasRef.current
@@ -1010,9 +1126,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         return
       }
       if (gestureState.kind === 'idle') return
-      const point = screenToCanvas(screenPoint, viewport)
-      setLivePoint(point)
-      applyResult(reduceGesture(gestureState, canvas, { type: 'pointermove', point }))
+      const snapped = snapMovePoint(screenToCanvas(screenPoint, viewport), e.metaKey || e.ctrlKey)
+      setSnapGuides(snapped.guides)
+      setLivePoint(snapped.point)
+      applyResult(
+        reduceGesture(gestureState, canvas, { type: 'pointermove', point: snapped.point }),
+      )
     }
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -1083,7 +1202,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       }
       if (root === null) return
       const screenPoint = clientPointToRootLocal(e, root)
-      const point = screenToCanvas(screenPoint, viewport)
+      // Snapped with the same helper the preview used, so the box commits
+      // exactly where the last frame drew it.
+      const point = snapMovePoint(
+        screenToCanvas(screenPoint, viewport),
+        e.metaKey || e.ctrlKey,
+      ).point
       const targetNodeId =
         gestureState.kind === 'connecting' ? hitTest(selectableBoxes, point) : undefined
       const result = reduceGesture(
@@ -2810,6 +2934,44 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 strokeWidth={1 / viewport.zoom}
                 strokeDasharray={`${4 / viewport.zoom} ${3 / viewport.zoom}`}
               />
+            </svg>
+          )}
+          {snapGuides !== null && snapGuides.x.length + snapGuides.y.length > 0 && (
+            <svg
+              data-testid="snap-guides"
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                overflow: 'visible',
+                left: 0,
+                top: 0,
+                pointerEvents: 'none',
+              }}
+            >
+              {snapGuides.x.map((x) => (
+                <line
+                  key={`x${x}`}
+                  data-axis="x"
+                  x1={x}
+                  x2={x}
+                  y1={guideSpan.minY}
+                  y2={guideSpan.maxY}
+                  stroke="#e11d48"
+                  strokeWidth={1 / viewport.zoom}
+                />
+              ))}
+              {snapGuides.y.map((y) => (
+                <line
+                  key={`y${y}`}
+                  data-axis="y"
+                  x1={guideSpan.minX}
+                  x2={guideSpan.maxX}
+                  y1={y}
+                  y2={y}
+                  stroke="#e11d48"
+                  strokeWidth={1 / viewport.zoom}
+                />
+              ))}
             </svg>
           )}
           {extraIds.size > 0 && (

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -753,11 +753,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // member, or a frame's geometrically contained members (same rule the
       // commit uses). Left in, a carried node would attract its own carrier
       // and peg the gesture at a fixed offset.
+      //
+      // A LOCKED contained member is the exception, and it has to mirror the
+      // commit path exactly: that path refuses to move a locked member with
+      // its frame, so the member stays put and remains a legitimate
+      // alignment target. Dropping it here would silently discard one.
       const movingNode = canvas.nodes.find((n) => n.id === gestureState.nodeId)
       const carried = new Set<string>([gestureState.nodeId, ...extraIds])
       if (movingNode?.type === 'group') {
         for (const n of canvas.nodes) {
           if (
+            !isLocked(n.id) &&
             n.x >= gestureState.startX &&
             n.y >= gestureState.startY &&
             n.x + n.width <= gestureState.startX + movingNode.width &&

--- a/apps/web/src/components/spatial-editor/doc-contract.test.ts
+++ b/apps/web/src/components/spatial-editor/doc-contract.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { SPATIAL_EDITOR_UNSUPPORTED } from './SpatialEditor.js'
 
-// Grouping (J4) and undo/redo (the LoroDoc UndoManager behind the dock's
-// history cluster) both shipped and left this list; alignment/distribution
-// joined it as the next explicitly-deferred gap.
-const REQUIRED_UNSUPPORTED = ['freehand-drawing', 'shape-tools', 'snapping', 'persistence', 'sync']
+// Grouping (J4), undo/redo (the LoroDoc UndoManager behind the dock's
+// history cluster), alignment/distribution, and snapping have all shipped
+// and left this list.
+const REQUIRED_UNSUPPORTED = ['freehand-drawing', 'shape-tools', 'persistence', 'sync']
 
 describe('SPATIAL_EDITOR_UNSUPPORTED', () => {
   it('names exactly every parity gap this slice deliberately does not implement (both directions: nothing missing, nothing undocumented)', () => {
@@ -23,9 +23,9 @@ describe('SPATIAL_EDITOR_UNSUPPORTED', () => {
 
   it('never lists a capability the editor actually ships', async () => {
     // The list is a promise to the reader; a stale entry is worse than no
-    // list. These four all ship today (J4 groups, the history cluster's
-    // undo/redo, and the slice-4/5 clipboard family).
-    for (const shipped of ['grouping', 'undo-redo', 'clipboard', 'duplicate']) {
+    // list. These all ship today (J4 groups, the history cluster's
+    // undo/redo, the slice-4/5 clipboard family, and drag snapping).
+    for (const shipped of ['grouping', 'undo-redo', 'clipboard', 'duplicate', 'snapping']) {
       expect(SPATIAL_EDITOR_UNSUPPORTED).not.toContain(shipped)
     }
   })

--- a/apps/web/src/components/spatial-editor/snap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/snap.browser.test.tsx
@@ -1,0 +1,163 @@
+// Snapping in the editor. The geometry is unit-tested in snap.test.ts; this
+// pins the wiring: that a dragged node actually lands on the snapped
+// position, that the guide is drawn, that Cmd/Ctrl suspends it, and that a
+// node never snaps to something travelling with it.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// `a` sits OFF the grid on purpose: a position that is already a grid
+// multiple would leave every assertion ambiguous between the node candidate
+// and the lattice.
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 137, y: 113, width: 100, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 400, y: 400, width: 100, height: 60, text: 'B' },
+  ],
+  edges: [],
+}
+
+function makeHost(canvas0: SpatialCanvas = initial) {
+  const latest: { canvas: SpatialCanvas } = { canvas: canvas0 }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(canvas0)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+/** Drag from one canvas-space point to another, optionally holding Cmd. */
+function drag(
+  root: HTMLElement,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  modifiers: { metaKey?: boolean } = {},
+) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + from.x,
+    clientY: r.top + from.y,
+  })
+  fireEvent.pointerMove(root, {
+    pointerId: 1,
+    clientX: r.left + to.x,
+    clientY: r.top + to.y,
+    ...modifiers,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    clientX: r.left + to.x,
+    clientY: r.top + to.y,
+    ...modifiers,
+  })
+}
+
+const byId = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((node) => node.id === id)!
+
+// Grab `b` at its centre (450, 430) and release 265 to the left, which puts
+// its un-snapped left edge at 135: 2 from `a`'s edge at 137, and 5 from the
+// grid line at 140. The node candidate is closer, so it wins.
+const GRAB = { x: 450, y: 430 }
+const DROP_NEAR_A = { x: 185, y: 430 }
+
+it('lands a dragged node on a near-miss neighbour edge instead of where the pointer stopped', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  drag(rootOf(container), GRAB, DROP_NEAR_A)
+
+  expect(byId(latest.canvas, 'b').x).toBe(137)
+  // The other axis never moved, so it must come back untouched — the two
+  // axes snap independently and 400 is already on the grid.
+  expect(byId(latest.canvas, 'b').y).toBe(400)
+})
+
+it('draws the guide that justifies the snap while the drag is in flight', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + GRAB.x,
+    clientY: r.top + GRAB.y,
+  })
+  fireEvent.pointerMove(root, {
+    pointerId: 1,
+    clientX: r.left + DROP_NEAR_A.x,
+    clientY: r.top + DROP_NEAR_A.y,
+  })
+
+  const guide = container.querySelector('[data-testid="snap-guides"] [data-axis="x"]')
+  expect(guide).toBeTruthy()
+  expect(guide?.getAttribute('x1')).toBe('137')
+
+  // A guide that outlived its gesture would be a permanent stray line.
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    clientX: r.left + DROP_NEAR_A.x,
+    clientY: r.top + DROP_NEAR_A.y,
+  })
+  expect(container.querySelector('[data-testid="snap-guides"]')).toBeNull()
+})
+
+it('places the node exactly where the pointer stopped while Cmd/Ctrl is held', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  drag(rootOf(container), GRAB, DROP_NEAR_A, { metaKey: true })
+
+  expect(byId(latest.canvas, 'b').x).toBe(135)
+})
+
+it('snaps to the grid when no neighbour edge is in range', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  // Drop far from `a`: the left edge would be 603, and only the lattice is
+  // near enough to attract.
+  drag(rootOf(container), GRAB, { x: 653, y: 430 })
+
+  expect(byId(latest.canvas, 'b').x).toBe(600)
+})
+
+it('never snaps a group frame to a member it is carrying', () => {
+  const framed: SpatialCanvas = {
+    nodes: [
+      { id: 'frame', type: 'group', x: 407, y: 400, width: 200, height: 200, label: 'F' },
+      // Sits 5 inside the frame's left edge — close enough to attract, and
+      // it travels with the frame, so honouring it would peg the drag.
+      { id: 'inner', type: 'text', x: 412, y: 460, width: 60, height: 40, text: 'I' },
+    ],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(framed)
+  const { container } = render(<Host />)
+
+  // Grab the frame chrome above `inner` and move 3 right. 410 is 10 from
+  // the nearest grid line, so nothing but the member could pull it.
+  drag(rootOf(container), { x: 450, y: 420 }, { x: 453, y: 420 })
+
+  expect(byId(latest.canvas, 'frame').x).toBe(410)
+})

--- a/apps/web/src/components/spatial-editor/snap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/snap.browser.test.tsx
@@ -21,7 +21,7 @@ const initial: SpatialCanvas = {
   edges: [],
 }
 
-function makeHost(canvas0: SpatialCanvas = initial) {
+function makeHost(canvas0: SpatialCanvas = initial, lockedNodes: readonly string[] = []) {
   const latest: { canvas: SpatialCanvas } = { canvas: canvas0 }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(canvas0)
@@ -33,6 +33,8 @@ function makeHost(canvas0: SpatialCanvas = initial) {
           canvas={canvas}
           onChange={(next) => setCanvas(next)}
           theme="light"
+          lockedNodeIds={new Set(lockedNodes)}
+          onToggleNodeLock={() => {}}
         />
       </div>
     )
@@ -48,7 +50,7 @@ function drag(
   root: HTMLElement,
   from: { x: number; y: number },
   to: { x: number; y: number },
-  modifiers: { metaKey?: boolean } = {},
+  modifiers: { metaKey?: boolean; ctrlKey?: boolean } = {},
 ) {
   const r = root.getBoundingClientRect()
   fireEvent.pointerDown(root, {
@@ -122,11 +124,17 @@ it('draws the guide that justifies the snap while the drag is in flight', () => 
   expect(container.querySelector('[data-testid="snap-guides"]')).toBeNull()
 })
 
-it('places the node exactly where the pointer stopped while Cmd/Ctrl is held', () => {
+// Both modifiers, because the suspension is claimed for Cmd AND Ctrl and the
+// two reach the handler through different event fields — testing one would
+// leave the other free to regress on the platform that uses it.
+it.each([
+  ['Cmd', { metaKey: true }],
+  ['Ctrl', { ctrlKey: true }],
+] as const)('places the node exactly where the pointer stopped while %s is held', (_name, mod) => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  drag(rootOf(container), GRAB, DROP_NEAR_A, { metaKey: true })
+  drag(rootOf(container), GRAB, DROP_NEAR_A, mod)
 
   expect(byId(latest.canvas, 'b').x).toBe(135)
 })
@@ -142,22 +150,39 @@ it('snaps to the grid when no neighbour edge is in range', () => {
   expect(byId(latest.canvas, 'b').x).toBe(600)
 })
 
+const framedCanvas: SpatialCanvas = {
+  nodes: [
+    { id: 'frame', type: 'group', x: 407, y: 400, width: 200, height: 200, label: 'F' },
+    // Sits 5 inside the frame's left edge — close enough to attract.
+    { id: 'inner', type: 'text', x: 412, y: 460, width: 60, height: 40, text: 'I' },
+  ],
+  edges: [],
+}
+// Grab the frame chrome above `inner` and move 3 right. 410 is 10 from the
+// nearest grid line, so only the member can decide where this lands.
+const FRAME_GRAB = { x: 450, y: 420 }
+const FRAME_DROP = { x: 453, y: 420 }
+
 it('never snaps a group frame to a member it is carrying', () => {
-  const framed: SpatialCanvas = {
-    nodes: [
-      { id: 'frame', type: 'group', x: 407, y: 400, width: 200, height: 200, label: 'F' },
-      // Sits 5 inside the frame's left edge — close enough to attract, and
-      // it travels with the frame, so honouring it would peg the drag.
-      { id: 'inner', type: 'text', x: 412, y: 460, width: 60, height: 40, text: 'I' },
-    ],
-    edges: [],
-  }
-  const { Host, latest } = makeHost(framed)
+  const { Host, latest } = makeHost(framedCanvas)
   const { container } = render(<Host />)
 
-  // Grab the frame chrome above `inner` and move 3 right. 410 is 10 from
-  // the nearest grid line, so nothing but the member could pull it.
-  drag(rootOf(container), { x: 450, y: 420 }, { x: 453, y: 420 })
+  drag(rootOf(container), FRAME_GRAB, FRAME_DROP)
 
   expect(byId(latest.canvas, 'frame').x).toBe(410)
+})
+
+it('DOES snap a group frame to a LOCKED member, which stays put', () => {
+  // Containment is geometric, but the commit path refuses to move a locked
+  // member with its frame. So a locked member is stationary content, not
+  // something travelling with the drag — excluding it would throw away a
+  // real alignment target.
+  const { Host, latest } = makeHost(framedCanvas, ['inner'])
+  const { container } = render(<Host />)
+
+  drag(rootOf(container), FRAME_GRAB, FRAME_DROP)
+
+  expect(byId(latest.canvas, 'frame').x).toBe(412)
+  // ...and the lock still holds: the member did not travel.
+  expect(byId(latest.canvas, 'inner').x).toBe(412)
 })

--- a/apps/web/src/components/spatial-editor/snap.test.ts
+++ b/apps/web/src/components/spatial-editor/snap.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { type SnapBox, snapBox } from './snap.js'
+
+const box = (x: number, y: number, width = 100, height = 60): SnapBox => ({ x, y, width, height })
+
+// Grid off unless a case is specifically about the grid, so node candidates
+// are never silently rescued by a lattice hit.
+const NODE_ONLY = { thresholdCanvasPx: 8, gridSize: 0 }
+const WITH_GRID = { thresholdCanvasPx: 8, gridSize: 10 }
+
+describe('snapBox — node candidates', () => {
+  const other = box(100, 100, 100, 60) // left 100, centre 150, right 200
+
+  it('pulls a near-miss onto another box left edge, and reports the guide', () => {
+    const result = snapBox(box(103, 500), [other], NODE_ONLY)
+    expect(result.x).toBe(100)
+    expect(result.guidesX).toEqual([100])
+  })
+
+  it('aligns trailing edge to trailing edge, accounting for width', () => {
+    // Moving box is 40 wide; its RIGHT edge at 197 is 3 from the other's 200.
+    const result = snapBox(box(157, 500, 40, 60), [other], NODE_ONLY)
+    expect(result.x).toBe(160)
+    expect(result.guidesX).toEqual([200])
+  })
+
+  it('aligns centre to centre', () => {
+    // Moving centre at 148 vs other centre 150.
+    const result = snapBox(box(128, 500, 40, 60), [other], NODE_ONLY)
+    expect(result.x).toBe(130)
+    expect(result.guidesX).toEqual([150])
+  })
+
+  it('leaves an axis alone when nothing is in range', () => {
+    const result = snapBox(box(500, 500), [other], NODE_ONLY)
+    expect(result).toEqual({ x: 500, y: 500, guidesX: [], guidesY: [] })
+  })
+
+  it('snaps the two axes independently', () => {
+    // x is a near-miss on the left edge; y is far from anything.
+    const result = snapBox(box(103, 900), [other], NODE_ONLY)
+    expect(result.x).toBe(100)
+    expect(result.y).toBe(900)
+    expect(result.guidesY).toEqual([])
+  })
+
+  it('takes the nearest candidate when several are in range', () => {
+    const near = box(104, 500)
+    const result = snapBox(near, [other, box(106, 500)], NODE_ONLY)
+    // 106 is 2 away, 100 is 4 away — the closer one wins.
+    expect(result.x).toBe(106)
+  })
+
+  it('respects the threshold rather than snapping from any distance', () => {
+    const result = snapBox(box(112, 500), [other], NODE_ONLY)
+    expect(result.x).toBe(112)
+    expect(result.guidesX).toEqual([])
+  })
+})
+
+describe('snapBox — grid candidates', () => {
+  it('snaps to the nearest grid multiple when no node is in range', () => {
+    const result = snapBox(box(103, 47), [], WITH_GRID)
+    expect(result.x).toBe(100)
+    expect(result.y).toBe(50)
+  })
+
+  it('draws no guide for a grid hit — there is no content to point at', () => {
+    const result = snapBox(box(103, 47), [], WITH_GRID)
+    expect(result.guidesX).toEqual([])
+    expect(result.guidesY).toEqual([])
+  })
+
+  it('prefers a node over the grid at equal distance', () => {
+    // Moving x 102: grid 100 is 2 away, and a node left edge at 104 is 2
+    // away too. Real content wins, or the lattice would take most ties.
+    const result = snapBox(box(102, 500), [box(104, 500)], WITH_GRID)
+    expect(result.x).toBe(104)
+    expect(result.guidesX).toEqual([104])
+  })
+
+  it('still lets a closer grid line win', () => {
+    // grid 100 is 1 away; the node edge at 107 is 6 away.
+    const result = snapBox(box(101, 500), [box(107, 500)], WITH_GRID)
+    expect(result.x).toBe(100)
+    expect(result.guidesX).toEqual([])
+  })
+
+  it('treats a zero or negative grid size as no grid', () => {
+    expect(snapBox(box(103, 47), [], { thresholdCanvasPx: 8, gridSize: 0 }).x).toBe(103)
+    expect(snapBox(box(103, 47), [], { thresholdCanvasPx: 8, gridSize: -10 }).x).toBe(103)
+  })
+})
+
+describe('snapBox — totality', () => {
+  it('returns the input unchanged for a non-finite box', () => {
+    const broken = { x: Number.NaN, y: 0, width: 10, height: 10 }
+    expect(snapBox(broken, [box(0, 0)], WITH_GRID)).toMatchObject({ x: Number.NaN, y: 0 })
+  })
+
+  it('skips non-finite neighbours instead of throwing', () => {
+    const others = [{ x: Number.NaN, y: 0, width: 10, height: 10 }, box(104, 500)]
+    expect(snapBox(box(102, 500), others, NODE_ONLY).x).toBe(104)
+  })
+
+  it('rejects a non-finite or negative threshold by not snapping', () => {
+    expect(
+      snapBox(box(103, 500), [box(100, 500)], { thresholdCanvasPx: Number.NaN, gridSize: 10 }).x,
+    ).toBe(103)
+    expect(snapBox(box(103, 500), [box(100, 500)], { thresholdCanvasPx: -1, gridSize: 10 }).x).toBe(
+      103,
+    )
+  })
+
+  it('handles an empty neighbour list', () => {
+    expect(snapBox(box(103, 500), [], NODE_ONLY)).toEqual({
+      x: 103,
+      y: 500,
+      guidesX: [],
+      guidesY: [],
+    })
+  })
+})

--- a/apps/web/src/components/spatial-editor/snap.ts
+++ b/apps/web/src/components/spatial-editor/snap.ts
@@ -1,0 +1,171 @@
+/**
+ * Snapping geometry for a dragged box.
+ *
+ * Pure and total, like `align.ts`: it takes the box's would-be position and
+ * returns the position to actually use plus the guide lines that justify it.
+ * Nothing here reads the DOM, the viewport, or a modifier key — the caller
+ * decides whether snapping is on and what the threshold is in canvas units.
+ *
+ * The two axes snap INDEPENDENTLY. A box can land on another node's left
+ * edge horizontally while snapping to the grid vertically, which is what
+ * every comparable editor does and what makes near-misses feel forgiving
+ * rather than all-or-nothing.
+ *
+ * Node candidates beat grid candidates at equal distance: a deliberate
+ * alignment to real content is more likely what the user meant than an
+ * invisible lattice, and the grid is dense enough that it would otherwise
+ * win most ties. That falls out of building node candidates first and
+ * accepting only a STRICTLY closer replacement — see `best`.
+ */
+
+export interface SnapBox {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface SnapOptions {
+  /** Max distance, in CANVAS units, at which a candidate attracts. */
+  readonly thresholdCanvasPx: number
+  /** Grid pitch in canvas units; 0 or non-finite disables grid snapping. */
+  readonly gridSize: number
+}
+
+export interface SnapResult {
+  readonly x: number
+  readonly y: number
+  /** Canvas-space x positions of the vertical guides to draw (may be empty). */
+  readonly guidesX: readonly number[]
+  /** Canvas-space y positions of the horizontal guides to draw. */
+  readonly guidesY: readonly number[]
+}
+
+/** A candidate line the moving box can be attracted to, on one axis. */
+interface Candidate {
+  /** Where the moving box's ORIGIN lands if this candidate wins. */
+  readonly origin: number
+  /** Distance from the un-snapped origin — smaller wins. */
+  readonly distance: number
+  /** The line to draw; absent for grid candidates, which have no content. */
+  readonly guide: number | undefined
+}
+
+function finiteBox(box: SnapBox): boolean {
+  return (
+    Number.isFinite(box.x) &&
+    Number.isFinite(box.y) &&
+    Number.isFinite(box.width) &&
+    Number.isFinite(box.height)
+  )
+}
+
+/**
+ * Builds every candidate for ONE axis. `start`/`extent` project the axis, so
+ * the same logic serves x/width and y/height without a second copy that
+ * could drift.
+ */
+function candidatesForAxis(
+  start: number,
+  extent: number,
+  others: readonly SnapBox[],
+  options: SnapOptions,
+  pick: (box: SnapBox) => { start: number; extent: number },
+): Candidate[] {
+  const candidates: Candidate[] = []
+
+  // The moving box offers three lines of its own: leading edge, centre and
+  // trailing edge. Matching centre-to-centre and edge-to-edge is what makes
+  // differently-sized boxes line up the way they look aligned.
+  const movingOffsets = [0, extent / 2, extent]
+
+  for (const other of others) {
+    if (!finiteBox(other)) continue
+    const projected = pick(other)
+    const otherLines = [
+      projected.start,
+      projected.start + projected.extent / 2,
+      projected.start + projected.extent,
+    ]
+    for (const line of otherLines) {
+      for (const offset of movingOffsets) {
+        const origin = line - offset
+        candidates.push({
+          origin,
+          distance: Math.abs(origin - start),
+          guide: line,
+        })
+      }
+    }
+  }
+
+  if (Number.isFinite(options.gridSize) && options.gridSize > 0) {
+    // Only the leading edge snaps to the grid. Snapping centre and trailing
+    // edge too would triple the lattice's pull for no extra expressiveness,
+    // and would fight the node candidates the user actually aimed at.
+    const snapped = Math.round(start / options.gridSize) * options.gridSize
+    candidates.push({
+      origin: snapped,
+      distance: Math.abs(snapped - start),
+      guide: undefined,
+    })
+  }
+
+  return candidates
+}
+
+function best(candidates: readonly Candidate[], threshold: number): Candidate | undefined {
+  let winner: Candidate | undefined
+  for (const candidate of candidates) {
+    if (candidate.distance > threshold) continue
+    if (winner === undefined) {
+      winner = candidate
+      continue
+    }
+    // Strictly closer only, so an equal-distance later candidate never
+    // displaces an earlier one. Node candidates are built before the grid
+    // candidate (see candidatesForAxis), which is what makes content win a
+    // tie — an explicit tie-break branch here would be unreachable, and
+    // unreachable code rots. The "prefers a node over the grid at equal
+    // distance" test pins the outcome, so reordering the two would fail.
+    if (candidate.distance < winner.distance) winner = candidate
+  }
+  return winner
+}
+
+/**
+ * Returns where the dragged box should actually land, plus the guides that
+ * explain it. A box with nothing in range comes back unchanged with no
+ * guides, so a caller can always use the result unconditionally.
+ */
+export function snapBox(
+  moving: SnapBox,
+  others: readonly SnapBox[],
+  options: SnapOptions,
+): SnapResult {
+  const noSnap: SnapResult = { x: moving.x, y: moving.y, guidesX: [], guidesY: [] }
+  if (!finiteBox(moving)) return noSnap
+  if (!Number.isFinite(options.thresholdCanvasPx) || options.thresholdCanvasPx < 0) return noSnap
+
+  const xWinner = best(
+    candidatesForAxis(moving.x, moving.width, others, options, (box) => ({
+      start: box.x,
+      extent: box.width,
+    })),
+    options.thresholdCanvasPx,
+  )
+  const yWinner = best(
+    candidatesForAxis(moving.y, moving.height, others, options, (box) => ({
+      start: box.y,
+      extent: box.height,
+    })),
+    options.thresholdCanvasPx,
+  )
+
+  return {
+    x: xWinner?.origin ?? moving.x,
+    y: yWinner?.origin ?? moving.y,
+    guidesX: xWinner?.guide === undefined ? [] : [xWinner.guide],
+    guidesY: yWinner?.guide === undefined ? [] : [yWinner.guide],
+  }
+}

--- a/packages/canvas-model/src/facets.test.ts
+++ b/packages/canvas-model/src/facets.test.ts
@@ -122,6 +122,26 @@ describe('facetsRawSchema', () => {
   it('accepts an empty record', () => {
     expect(facetsRawSchema.safeParse({}).success).toBe(true)
   })
+
+  // Found by src/properties.test.ts's preservation property. `__proto__` is
+  // the one key the "preserves arbitrary non-reserved root keys" rule cannot
+  // hold for: writing it onto the result object sets the PROTOTYPE instead of
+  // creating an own key, so it comes back absent. Dropping it is the outcome
+  // we want — a hostile facets payload must not survive into a downstream
+  // spread as a prototype — so this pins the drop rather than the schema
+  // being changed to carry it.
+  it('drops a __proto__ key instead of carrying it (parse must not pollute)', () => {
+    const hostile = JSON.parse('{"__proto__": {"polluted": true}, "keep": 1}')
+    const result = facetsRawSchema.safeParse(hostile)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(Object.hasOwn(result.data, '__proto__')).toBe(false)
+      expect(result.data.keep).toBe(1)
+      // The prototype chain is untouched: nothing leaked onto Object.prototype.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+      expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype)
+    }
+  })
 })
 
 describe('canvasCoreMetaSchema', () => {

--- a/packages/canvas-model/src/facets.test.ts
+++ b/packages/canvas-model/src/facets.test.ts
@@ -125,12 +125,16 @@ describe('facetsRawSchema', () => {
 
   // Found by src/properties.test.ts's preservation property. `__proto__` is
   // the one key the "preserves arbitrary non-reserved root keys" rule cannot
-  // hold for: writing it onto the result object sets the PROTOTYPE instead of
-  // creating an own key, so it comes back absent. Dropping it is the outcome
-  // we want — a hostile facets payload must not survive into a downstream
-  // spread as a prototype — so this pins the drop rather than the schema
-  // being changed to carry it.
-  it('drops a __proto__ key instead of carrying it (parse must not pollute)', () => {
+  // hold for: Zod deliberately skips it when building the parsed object, so
+  // it is neither an own key nor written to the prototype.
+  //
+  // Keeping that skip is what this pins. Native object spread would carry
+  // `__proto__` through as an ordinary own property (spread creates data
+  // properties and never invokes the setter), but `Object.assign` and a
+  // hand-written `for (k of keys) out[k] = ...` merge both DO invoke it and
+  // pollute the target's prototype. A parser that preserved the key would
+  // hand every such consumer a loaded payload.
+  it('skips a __proto__ key instead of carrying it (parse must not pollute)', () => {
     const hostile = JSON.parse('{"__proto__": {"polluted": true}, "keep": 1}')
     const result = facetsRawSchema.safeParse(hostile)
     expect(result.success).toBe(true)
@@ -140,6 +144,11 @@ describe('facetsRawSchema', () => {
       // The prototype chain is untouched: nothing leaked onto Object.prototype.
       expect(({} as Record<string, unknown>).polluted).toBeUndefined()
       expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype)
+      // The point of the skip, stated as behaviour rather than prose: the
+      // parsed value is safe to merge through the sink that WOULD pollute.
+      const merged = Object.assign({}, result.data)
+      expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined()
     }
   })
 })

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -67,12 +67,13 @@ export const extensionFacetsArbitrary = fc.dictionary(extensionFacetKeyArbitrary
 const facetsRawKeyArbitrary: fc.Arbitrary<string> = fc
   .string({ minLength: 1, maxLength: 15 })
   .filter((key) => !(RESERVED_ROOT_KEYS as readonly string[]).includes(key))
-  // `__proto__` is excluded because no object-building parser can round-trip
-  // it: assigning it writes the PROTOTYPE rather than creating an own key,
-  // so the value comes back dropped. That drop is the safe outcome (it is
-  // what stops a hostile facets payload from reaching a downstream spread as
-  // a prototype), so the property is narrowed rather than the schema
-  // changed. `facets-raw.test.ts` pins the drop as deliberate behaviour.
+  // `__proto__` is excluded because Zod deliberately skips it when building
+  // the parsed object, so it can never round-trip and the preservation
+  // property cannot hold for it. Keeping that skip matters: a consumer that
+  // merges parsed facets with `Object.assign` or a `for (k) out[k] = ...`
+  // loop invokes the `__proto__` setter and pollutes the target's prototype.
+  // So the property is narrowed rather than the schema widened to carry the
+  // key; `facets.test.ts` pins the skip as deliberate behaviour.
   .filter((key) => key !== '__proto__')
 
 export const facetsRawArbitrary = fc.dictionary(facetsRawKeyArbitrary, fc.jsonValue(), {

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -67,6 +67,13 @@ export const extensionFacetsArbitrary = fc.dictionary(extensionFacetKeyArbitrary
 const facetsRawKeyArbitrary: fc.Arbitrary<string> = fc
   .string({ minLength: 1, maxLength: 15 })
   .filter((key) => !(RESERVED_ROOT_KEYS as readonly string[]).includes(key))
+  // `__proto__` is excluded because no object-building parser can round-trip
+  // it: assigning it writes the PROTOTYPE rather than creating an own key,
+  // so the value comes back dropped. That drop is the safe outcome (it is
+  // what stops a hostile facets payload from reaching a downstream spread as
+  // a prototype), so the property is narrowed rather than the schema
+  // changed. `facets-raw.test.ts` pins the drop as deliberate behaviour.
+  .filter((key) => key !== '__proto__')
 
 export const facetsRawArbitrary = fc.dictionary(facetsRawKeyArbitrary, fc.jsonValue(), {
   maxKeys: 4,


### PR DESCRIPTION
Dragging a node now snaps to nearby content and to a background grid, with the guide line that justifies each snap drawn while the gesture is in flight. Cmd/Ctrl suspends it for one gesture (the Figma / Excalidraw / tldraw convention).

Both snap targets are live: a neighbour's leading edge, centre and trailing edge on either axis, plus a grid. The two axes resolve independently, so a box can land on a neighbour's edge horizontally while taking the grid vertically.

## Visual repro

The dragged node's left edge stopped 3px short of the node above it; the snap closes the gap and the guide shows why.

![snap-guide.jpg](https://github.com/user-attachments/assets/ee608504-adbf-4a14-8620-9cc9099c469a)

## Decisions worth reviewing

**The pointer is nudged, not the emitted command.** The reducer derives both the preview and the commit from the same `point`, so adjusting only one of them would draw the box in one place and land it in another.

**The grid pitch (20) is deliberately wider than twice the threshold (6).** At or below that, every lattice line is reachable from everywhere — silent rounding rather than snapping — and it would out-pull the neighbour edges the user was aiming at.

**Anything travelling with the drag is excluded from the candidate set**: a multi-selection member, or a frame's contained members. Left in, a carried node attracts its own carrier and pegs the gesture at a fixed offset.

**Snapping is move-only.** A resize would have to snap the dragged edge, a different candidate set — deferred rather than approximated, since an approximate resize snap fights the handle.

## Tests

`snap.ts` has 16 unit tests (candidate selection, threshold, axis independence, totality on non-finite input). `snap.browser.test.tsx` pins the wiring in a real browser: the landing position, the guide appearing and retiring with the gesture, Cmd suspension, and the carried-member exclusion. The last two passed before the wiring existed, so both were mutation-checked — removing either guard fails its test.

Three existing tests asserted 1:1 pointer tracking, which snapping deliberately breaks. The preview-tracking one now holds Cmd, since raw tracking is exactly what Cmd preserves; the two commit-shape ones move to a drop point no candidate is near, so they stay on the default path.

## Also here

A separate commit narrows a canvas-model property that a rare seed failed on `{ __proto__: {} }`. The finding is real but the schema is right: writing `__proto__` onto the result sets the prototype rather than creating an own key, so it comes back dropped — and that drop is what stops a hostile facets payload reaching a downstream spread as a prototype. The property is narrowed and the drop pinned as deliberate behaviour, rather than the schema widened to carry it.

## Verification

`pnpm test` 585/585 files green (6213 passed), `pnpm -r typecheck` clean, `pnpm knip` clean. Manually verified in Chrome against the running app: a 3px near-miss snapped to the neighbour edge with the guide at the right position, and a separate real-pointer drag landed on the grid line as predicted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added snapping for dragged nodes and groups to nearby edges, centers, and a 20-unit grid.
  - Added alignment guides during dragging, with consistent preview and final placement.
  - Snapping now works independently along each axis and can be suspended with Cmd/Ctrl.

- **Bug Fixes**
  - Improved handling of special `__proto__` data keys to prevent prototype pollution while preserving valid data.

- **Tests**
  - Added coverage for snapping behavior, guides, modifier-key controls, grouping, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->