### PR TITLE
fix: render canvas thumbnails again (CSP, 204 handling, and the missing generator)

### DIFF
--- a/apps/web/public-headers.test.ts
+++ b/apps/web/public-headers.test.ts
@@ -51,6 +51,17 @@ describe('public/_headers', () => {
     expect(csp).toContain("worker-src 'self'")
   })
 
+  it('permits blob: img-src so daemon-fetched images are not blocked by our own CSP', () => {
+    // Images that need an auth header (canvas thumbnails, version
+    // thumbnails, embedded canvas files) cannot be loaded by pointing
+    // `<img src>` at the daemon — the browser sends no Authorization on a
+    // subresource load. They are fetched, turned into a Blob, and rendered
+    // through `URL.createObjectURL`, so every one of them is a `blob:` URL.
+    const globalHeaders = blocks.get('/*')
+    const csp = globalHeaders?.get('Content-Security-Policy') ?? ''
+    expect(csp).toMatch(/img-src[^;]*\bblob:/)
+  })
+
   it('permits https frame-src so link-node iframe embeds are not blocked by our own CSP', () => {
     // Without an explicit frame-src, child iframes fall back to
     // default-src 'self' and every external embed renders as Chrome's

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,7 +3,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; worker-src 'self'; frame-src https:
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; worker-src 'self'; frame-src https:
 
 # Cloudflare Pages applies the most specific matching path, so these two
 # path-scoped rules layer on top of `/*` above rather than replacing it.

--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DaemonApiContext } from '@/contexts/DaemonApiContext'
 import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
@@ -97,6 +97,45 @@ describe('CanvasThumb', () => {
     )
     await vi.waitFor(() => expect(container.querySelector('svg')).not.toBeNull())
     expect(container.querySelector('img')).toBeNull()
+  })
+
+  // "No thumbnail yet" is a 204, not an error status, so `res.ok` is true and
+  // the empty body would become a zero-byte object URL. A plain <img src>
+  // degrades on its own there (the empty body trips onError), but the blob
+  // path has to recognize it: an <img> pointed at a blob that decodes to
+  // nothing renders as a broken image, never firing the fallback.
+  // The placeholder also shows while the fetch is still in flight, so this
+  // asserts only AFTER the response has been consumed — otherwise it passes
+  // on the loading state and guards nothing.
+  async function renderEmptyThumbnailResponse(response: Response) {
+    const daemonFetch = vi.fn().mockResolvedValue(response)
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL: vi.fn() })
+    const { container } = render(
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <CanvasThumb workspaceId="ws-1" slug="a" />
+      </DaemonApiContext.Provider>,
+    )
+    await vi.waitFor(() => expect(daemonFetch).toHaveBeenCalled())
+    // Let the response -> blob -> setState chain settle before asserting.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    return { container, createObjectURL }
+  }
+
+  it('renders the fallback icon when the daemon reports no thumbnail yet (204)', async () => {
+    try {
+      const { container, createObjectURL } = await renderEmptyThumbnailResponse(
+        new Response(null, { status: 204 }),
+      )
+      expect(container.querySelector('img')).toBeNull()
+      expect(container.querySelector('svg')).not.toBeNull()
+      expect(createObjectURL).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('revokes the previous object URL when the slug identity changes', async () => {

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -57,6 +57,14 @@ export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }:
         }
         const blob = await res.blob()
         if (cancelled) return
+        // "No thumbnail yet" arrives as 204 No Content — a success status, so
+        // the `res.ok` check above lets it through. An object URL built from
+        // that empty body renders as a broken image rather than degrading to
+        // the placeholder, because a blob-backed <img> has no src to fail on.
+        if (blob.size === 0) {
+          setFailed(true)
+          return
+        }
         createdUrl = URL.createObjectURL(blob)
         setObjectUrl(createdUrl)
       } catch {

--- a/apps/web/src/components/VersionThumbnail.test.tsx
+++ b/apps/web/src/components/VersionThumbnail.test.tsx
@@ -136,6 +136,21 @@ describe('VersionThumbnail', () => {
     expect(screen.getByTestId('version-thumbnail-placeholder')).toBeTruthy()
   })
 
+  // 204 is a success status, so `res.ok` is true and the empty body would
+  // become a zero-byte object URL that renders as a broken image rather than
+  // reaching the placeholder.
+  it('204 response falls back to the placeholder without creating an objectURL', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+
+    await act(async () => {
+      renderInDaemonMode(fetchMock as unknown as typeof fetch)
+    })
+
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(createObjectURL).not.toHaveBeenCalled()
+    expect(screen.getByTestId('version-thumbnail-placeholder')).toBeTruthy()
+  })
+
   it('a rejected fetch falls back to the placeholder without an unhandled rejection', async () => {
     const fetchMock = vi.fn(async () => {
       throw new Error('network down')

--- a/apps/web/src/components/VersionThumbnail.test.tsx
+++ b/apps/web/src/components/VersionThumbnail.test.tsx
@@ -145,6 +145,15 @@ describe('VersionThumbnail', () => {
     await act(async () => {
       renderInDaemonMode(fetchMock as unknown as typeof fetch)
     })
+    // The placeholder is also what renders while the fetch is in flight, so
+    // wait for the response and flush the blob -> setState chain before
+    // asserting — otherwise every assertion below passes on the loading state
+    // and the test would stay green with the zero-byte guard removed.
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
 
     expect(screen.queryByRole('img')).toBeNull()
     expect(createObjectURL).not.toHaveBeenCalled()

--- a/apps/web/src/components/VersionThumbnail.tsx
+++ b/apps/web/src/components/VersionThumbnail.tsx
@@ -59,6 +59,13 @@ export function VersionThumbnail({
         }
         const blob = await res.blob()
         if (cancelled) return
+        // 204 No Content ("no thumbnail yet") is a success status, so it slips
+        // past the `res.ok` check above. An object URL built from an empty
+        // body renders as a broken image instead of the placeholder.
+        if (blob.size === 0) {
+          setFailed(true)
+          return
+        }
         createdUrl = URL.createObjectURL(blob)
         setObjectUrl(createdUrl)
       } catch {

--- a/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Confirms DaemonCanvasPage supplies WorkspaceTopBar's `getThumbnailBlob`.
+ *
+ * The prop is optional, and `useSaveVersion` silently skips the thumbnail
+ * upload when it is absent — so an unwired page produces a daemon whose
+ * every canvas answers 204 on latest-thumbnail forever, with no error
+ * anywhere to notice. Mirrors DaemonCanvasPage.theme.test.tsx: a per-page
+ * prop-threading test, because a regression here is invisible at runtime.
+ */
+import type {
+  CanvasBackend,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+
+const capturedProps: { getThumbnailBlob?: () => Promise<Blob | null> }[] = []
+
+// DaemonCanvasPage imports this as a DEFAULT export, so overriding only a
+// named one would capture nothing and the test would fail for the wrong
+// reason.
+vi.mock('../components/WorkspaceTopBar.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/WorkspaceTopBar.js')>()
+  const Capturing = (props: Parameters<typeof actual.default>[0]) => {
+    capturedProps.push(props)
+    return <actual.default {...props} />
+  }
+  return { ...actual, default: Capturing }
+})
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listCanvases: vi.fn(),
+    createCanvas: vi.fn(),
+  }
+})
+
+const { DaemonCanvasPage } = await import('./DaemonCanvasPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
+
+class FakeBackend implements CanvasBackend {
+  handlers: CanvasBackendHandlers | null = null
+  connect(handlers: CanvasBackendHandlers): void {
+    this.handlers = handlers
+    handlers.onConnected()
+    const { LoroDoc } = require('loro-crdt') as typeof import('loro-crdt')
+    handlers.onSnapshot(new LoroDoc().export({ mode: 'snapshot' }))
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+describe('DaemonCanvasPage thumbnail wiring', () => {
+  beforeEach(() => {
+    capturedProps.length = 0
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValue({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] })
+  })
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('gives WorkspaceTopBar a getThumbnailBlob so a saved version gets a thumbnail', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    await waitFor(() => expect(capturedProps.length).toBeGreaterThan(0))
+
+    const withThumbnail = capturedProps.filter((p) => typeof p.getThumbnailBlob === 'function')
+    expect(withThumbnail.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -210,6 +210,10 @@ export function DaemonCanvasPage({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const handleOpenSettings = useCallback(() => setSettingsOpen(true), [])
 
+  // PNG, because the daemon's thumbnail endpoint validates a PNG signature
+  // on upload and rejects anything else.
+  const getThumbnailBlob = useCallback(() => exportScene('png'), [exportScene])
+
   const saveVersion = async (): Promise<void> => {
     if (!capabilities.versions || canvas === null || savingVersion) return
     setSavingVersion(true)
@@ -349,6 +353,10 @@ export function DaemonCanvasPage({
               branchRefreshSignal={branchRefreshSignal}
               onNavigateBack={onNavigateBack}
               onExport={exportScene}
+              // Version thumbnails come from the same PNG export path the
+              // user can trigger by hand. Without this the save flow skips
+              // the upload entirely and latest-thumbnail stays 204 forever.
+              getThumbnailBlob={getThumbnailBlob}
               onOpenSettings={handleOpenSettings}
             />
           )}

--- a/apps/web/src/pwa/bootstrap.ts
+++ b/apps/web/src/pwa/bootstrap.ts
@@ -4,8 +4,15 @@ import { setupSwRegistration } from './register-sw.js'
 // the VitePWA plugin is active (real dev/build), so this wiring stays in its
 // own tiny module — kept out of register-sw.ts, which register-sw.test.ts
 // imports directly under plain vitest/jsdom (no VitePWA plugin present).
+// Only the daemon injects `__WHITEBOARD_RUNTIME_CONFIG__` into the shell it
+// serves; the hosted app is plain static HTML, so its presence is what tells
+// these two deployments apart.
+const runtimeConfig = (window as { __WHITEBOARD_RUNTIME_CONFIG__?: unknown })
+  .__WHITEBOARD_RUNTIME_CONFIG__
+
 setupSwRegistration({
   isProd: import.meta.env.PROD,
   hasServiceWorker: typeof navigator !== 'undefined' && 'serviceWorker' in navigator,
+  isDaemonServed: runtimeConfig !== undefined,
   importRegister: () => import('virtual:pwa-register'),
 })

--- a/apps/web/src/pwa/register-sw.test.ts
+++ b/apps/web/src/pwa/register-sw.test.ts
@@ -28,7 +28,12 @@ describe('setupSwRegistration', () => {
     const registerSW = vi.fn()
     const importRegister = vi.fn().mockResolvedValue({ registerSW })
 
-    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
     // Not yet — registration must wait for 'load'.
     expect(importRegister).not.toHaveBeenCalled()
 
@@ -52,7 +57,12 @@ describe('setupSwRegistration', () => {
     const importRegister = vi.fn().mockResolvedValue({ registerSW })
 
     expect(document.readyState).toBe('complete')
-    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
     // NO fireWindowLoad() — load already happened before setup ran.
     await Promise.resolve()
     await Promise.resolve()
@@ -65,7 +75,12 @@ describe('setupSwRegistration', () => {
     const importRegister = vi.fn()
 
     expect(() =>
-      setupSwRegistration({ isProd: true, hasServiceWorker: false, importRegister }),
+      setupSwRegistration({
+        isProd: true,
+        hasServiceWorker: false,
+        isDaemonServed: false,
+        importRegister,
+      }),
     ).not.toThrow()
     fireWindowLoad()
     await Promise.resolve()
@@ -77,7 +92,33 @@ describe('setupSwRegistration', () => {
     Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
     const importRegister = vi.fn()
 
-    setupSwRegistration({ isProd: false, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: false,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
+    fireWindowLoad()
+    await Promise.resolve()
+
+    expect(importRegister).not.toHaveBeenCalled()
+  })
+
+  // The local daemon serves one page (/pair) and redirects every other path
+  // to the hosted app, so `/sw.js` there answers 302 to a different origin.
+  // Registering would make the browser fetch the hosted app's HTML as a
+  // worker script — a request that can never succeed and, under the page's
+  // CSP, never settles either.
+  it('does not register on a daemon-served page', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true })
+    const importRegister = vi.fn()
+
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: true,
+      importRegister,
+    })
     fireWindowLoad()
     await Promise.resolve()
 
@@ -94,7 +135,12 @@ describe('setupSwRegistration', () => {
     window.addEventListener('unhandledrejection', onUnhandledRejection)
 
     try {
-      setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+      setupSwRegistration({
+        isProd: true,
+        hasServiceWorker: true,
+        isDaemonServed: false,
+        importRegister,
+      })
       fireWindowLoad()
       await Promise.resolve()
       await Promise.resolve()
@@ -111,7 +157,12 @@ describe('setupSwRegistration', () => {
     const registerSW = vi.fn()
     const importRegister = vi.fn().mockResolvedValue({ registerSW })
 
-    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
     await Promise.resolve()
     await Promise.resolve()
 
@@ -126,7 +177,12 @@ describe('setupSwRegistration', () => {
     const registerSW = vi.fn()
     const importRegister = vi.fn().mockResolvedValue({ registerSW })
 
-    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
     await Promise.resolve()
     await Promise.resolve()
 
@@ -158,7 +214,12 @@ describe('setupSwRegistration', () => {
     window.addEventListener('unhandledrejection', onUnhandledRejection)
 
     try {
-      setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+      setupSwRegistration({
+        isProd: true,
+        hasServiceWorker: true,
+        isDaemonServed: false,
+        importRegister,
+      })
       await Promise.resolve()
       await Promise.resolve()
 
@@ -188,7 +249,12 @@ describe('setupSwRegistration', () => {
     const registerSW = vi.fn()
     const importRegister = vi.fn().mockResolvedValue({ registerSW })
 
-    setupSwRegistration({ isProd: true, hasServiceWorker: true, importRegister })
+    setupSwRegistration({
+      isProd: true,
+      hasServiceWorker: true,
+      isDaemonServed: false,
+      importRegister,
+    })
     await Promise.resolve()
     await Promise.resolve()
 

--- a/apps/web/src/pwa/register-sw.ts
+++ b/apps/web/src/pwa/register-sw.ts
@@ -10,6 +10,16 @@ type ImportRegisterModule = () => Promise<{
 export interface SetupSwRegistrationOptions {
   isProd: boolean
   hasServiceWorker: boolean
+  /**
+   * True when this document came from the local daemon rather than the hosted
+   * app. The daemon serves exactly one page (/pair) and redirects every other
+   * path to the hosted app, so `/sw.js` there answers 302 to a different
+   * origin: registering makes the browser fetch the hosted app's HTML as a
+   * worker script. That request can never succeed, and under the page's CSP it
+   * is blocked outright and never settles, stranding the dynamic import below.
+   * The PWA is a hosted-app concern; a consent page has nothing to cache.
+   */
+  isDaemonServed: boolean
   importRegister: ImportRegisterModule
 }
 
@@ -23,9 +33,10 @@ export interface SetupSwRegistrationOptions {
 export function setupSwRegistration({
   isProd,
   hasServiceWorker,
+  isDaemonServed,
   importRegister,
 }: SetupSwRegistrationOptions): void {
-  if (!isProd || !hasServiceWorker) return
+  if (!isProd || !hasServiceWorker || isDaemonServed) return
 
   const register = () => {
     void importRegister()

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -1,2 +1,10 @@
 name = "kamiazya-whiteboard"
 pages_build_output_dir = "dist"
+
+# Pin the compatibility date. Left unset, wrangler defaults it to *today*,
+# so `wrangler pages dev` demands a runtime newer than the workerd bundled
+# with the installed wrangler and refuses to start — a local-only failure
+# that arrives on its own the first day the pinned wrangler falls behind
+# the calendar, with nothing in the repo having changed.
+# Raise this together with the wrangler devDependency, never ahead of it.
+compatibility_date = "2026-07-02"

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -215,6 +215,10 @@ describe('createApp daemon mutation auth', () => {
     expect(csp).toContain("base-uri 'none'")
     expect(csp).toContain("object-src 'none'")
     expect(csp).toContain("frame-ancestors 'none'")
+    // A consent page embeds nothing, so it does not inherit the hosted app's
+    // `frame-src https:` — pinned so a later policy edit cannot quietly let
+    // this trust anchor frame remote content.
+    expect(csp).toContain("frame-src 'none'")
     // The daemon-fetched thumbnails this app renders are blob: URLs.
     expect(csp).toMatch(/img-src[^;]*\bblob:/)
   })

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -196,11 +196,56 @@ describe('createApp daemon mutation auth', () => {
     const res = await app.request('/pair')
 
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Security-Policy')).toBe("frame-ancestors 'none'")
     expect(res.headers.get('X-Frame-Options')).toBe('DENY')
     expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
     expect(res.headers.get('Referrer-Policy')).toBe('no-referrer')
     expect(res.headers.get('Cross-Origin-Resource-Policy')).toBe('same-origin')
+  })
+
+  // /pair is the pairing consent trust anchor and the only real page this
+  // daemon serves, so it carries a full page policy rather than the
+  // frame-ancestors-only floor that suits an API JSON response.
+  it('serves /pair under a full page CSP, not the frame-ancestors-only floor', async () => {
+    const app = createApp(createRuntimeOptions('secret'))
+
+    const res = await app.request('/pair')
+
+    const csp = res.headers.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain("default-src 'self'")
+    expect(csp).toContain("base-uri 'none'")
+    expect(csp).toContain("object-src 'none'")
+    expect(csp).toContain("frame-ancestors 'none'")
+    // The daemon-fetched thumbnails this app renders are blob: URLs.
+    expect(csp).toMatch(/img-src[^;]*\bblob:/)
+  })
+
+  it('authorizes the two injected inline scripts on /pair with a per-response nonce', async () => {
+    const app = createApp(createRuntimeOptions('secret'))
+
+    const res = await app.request('/pair')
+
+    const csp = res.headers.get('Content-Security-Policy') ?? ''
+    const nonce = /'nonce-([A-Za-z0-9+/=_-]+)'/.exec(csp)?.[1]
+    expect(nonce).toBeDefined()
+    // Without the nonce on the tags, `script-src 'self'` would block the
+    // runtime-config and token scripts and the pairing page would boot blind.
+    const html = await res.text()
+    expect(html).toContain(`<script nonce="${nonce}">window.__WHITEBOARD_RUNTIME_CONFIG__`)
+    expect(html).toContain(`<script nonce="${nonce}">window.__WHITEBOARD_DAEMON_TOKEN__`)
+    const scriptSrc = /script-src ([^;]*)/.exec(csp)?.[1] ?? ''
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+  })
+
+  it('issues a fresh nonce per /pair response', async () => {
+    const app = createApp(createRuntimeOptions('secret'))
+
+    const first = await app.request('/pair')
+    const second = await app.request('/pair')
+
+    const nonceOf = (res: Response) =>
+      /'nonce-([A-Za-z0-9+/=_-]+)'/.exec(res.headers.get('Content-Security-Policy') ?? '')?.[1]
+    expect(nonceOf(first)).toBeDefined()
+    expect(nonceOf(first)).not.toBe(nonceOf(second))
   })
 
   it('adds the same baseline security headers to API responses', async () => {

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -30,6 +30,7 @@ import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { getLogger, getLogLevel, setLogLevel } from './log.js'
 import { createMcpServer } from './mcp/index.js'
 import { tracingMiddleware } from './observability/http-tracing.js'
+import { createCspNonce, pairPageCsp } from './pair-page-csp.js'
 import { createDaemonAuthMiddleware } from './routes/auth.js'
 import { createBranchesRouter } from './routes/branches.js'
 import { createCanvasRouter } from './routes/canvas.js'
@@ -781,15 +782,18 @@ export function createApp(options: AppOptions) {
         // value is always a loopback origin, even when the daemon binds 0.0.0.0.
         daemonBaseUrl: `http://127.0.0.1:${daemonPort}`,
       })
-      const runtimeConfigScript = `<script>window.__WHITEBOARD_RUNTIME_CONFIG__ = ${runtimeConfigJson}</script>`
+      const nonce = createCspNonce()
+      const runtimeConfigScript = `<script nonce="${nonce}">window.__WHITEBOARD_RUNTIME_CONFIG__ = ${runtimeConfigJson}</script>`
       const tokenScript = token
-        ? `<script>window.__WHITEBOARD_DAEMON_TOKEN__ = ${toInlineScriptJson(token)}</script>`
+        ? `<script nonce="${nonce}">window.__WHITEBOARD_DAEMON_TOKEN__ = ${toInlineScriptJson(token)}</script>`
         : ''
       const injected = `${runtimeConfigScript}${tokenScript}`
       const withRuntimeConfig = html.includes('</head>')
         ? html.replace('</head>', `${injected}</head>`)
         : `${injected}${html}`
-      return c.html(withRuntimeConfig)
+      return c.html(withRuntimeConfig, 200, {
+        'Content-Security-Policy': pairPageCsp(nonce),
+      })
     } catch {
       return c.text('Not found. Run `pnpm build` first.', 404)
     }

--- a/packages/mcp-server/src/server/pair-page-csp.ts
+++ b/packages/mcp-server/src/server/pair-page-csp.ts
@@ -1,0 +1,48 @@
+import { randomBytes } from 'node:crypto'
+
+/**
+ * The Content-Security-Policy for `/pair`, the pairing consent page.
+ *
+ * `setBaselineSecurityHeaders` deliberately applies only
+ * `frame-ancestors 'none'` when a route chose no policy of its own — a floor
+ * that fits an API JSON response but leaves a real HTML page without
+ * `script-src`, `object-src`, or `base-uri`. `/pair` is the one real page
+ * this daemon serves and is the trust anchor a user consents on, so it
+ * declares a full page policy here and the baseline leaves it alone.
+ *
+ * This mirrors the Cloudflare Pages policy in `apps/web/public/_headers`
+ * (the same app shell is served from both origins) with two deliberate
+ * differences:
+ *
+ * - `script-src` carries a per-response nonce. `/pair` is served by
+ *   injecting two inline `<script>` tags into the built shell (runtime
+ *   config and the daemon token), which `'self'` alone would block. A nonce
+ *   authorizes exactly those two tags rather than opening the page to every
+ *   inline script the way `'unsafe-inline'` would.
+ * - `frame-src 'none'`. The hosted app allows `https:` frames for link-node
+ *   embeds; the pairing page embeds nothing, and a consent page that can
+ *   frame arbitrary remote content is needless attack surface.
+ */
+export function createCspNonce(): string {
+  return randomBytes(16).toString('base64')
+}
+
+export function pairPageCsp(nonce: string): string {
+  return [
+    "default-src 'self'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    `script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval'`,
+    "style-src 'self' 'unsafe-inline'",
+    // Thumbnails that need an Authorization header cannot be loaded by
+    // pointing `<img src>` at the daemon, so they are fetched and rendered
+    // through `URL.createObjectURL` — every one of them is a blob: URL.
+    "img-src 'self' data: blob:",
+    // The browser may hold either loopback spelling of this daemon's origin,
+    // and 'self' only covers the one it was served from.
+    "connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*",
+    "worker-src 'self'",
+    "frame-src 'none'",
+  ].join('; ')
+}


### PR DESCRIPTION
Canvas thumbnails did not render on the deployed Pages app while connected to a daemon. Chasing that one symptom surfaced four separate defects plus a local-tooling breakage — one commit each.

## 1. `blob:` images were blocked by our own CSP

Thumbnails that need an `Authorization` header cannot be loaded by pointing `<img src>` at the daemon — the browser sends no `Authorization` on a subresource load. `CanvasThumb` / `VersionThumbnail` / `canvas-embed-content` therefore fetch the bytes, wrap them in a `Blob`, and render `URL.createObjectURL(...)`, so every one of them is a `blob:` URL — which `img-src 'self' data:` blocked.

`blob:` is same-origin and locally created, so unlike an extra remote host it opens no exfiltration path. The alternatives each cost more: `data:` URIs (no revoke, base64 memory), cookie auth on the daemon (needs `img-src http://127.0.0.1:*`, a *broader* allowance, plus CSRF surface), signed query URLs (token in URL, history and logs).

The dev server derives its headers from the same `_headers` file, so this fixes local and deployed together.

## 2. `/pair` had no real CSP

`setBaselineSecurityHeaders` applies only `frame-ancestors 'none'` when a route picks no policy of its own. That floor fits an API JSON response, but `/pair` — the pairing consent trust anchor and the only real page this daemon serves — was left with no `script-src`, `object-src`, or `base-uri`.

`/pair` now declares the hosted app's policy with two deliberate differences: `script-src` carries a **per-response nonce** authorizing exactly the two injected inline scripts (runtime config, daemon token) rather than opening the page to every inline script, and `frame-src` is `'none'` because a consent page embeds nothing. API responses keep the frame-ancestors-only floor unchanged.

## 3. The daemon page registered a service worker that could never work

Fix 2 exposed this. The daemon serves one page and redirects everything else to the hosted app, so `/sw.js`, `/registerSW.js` and `/manifest.webmanifest` all answer 302 to a **different origin** there. Registering made the browser fetch the hosted app's HTML as a worker script — a request that can never succeed, silently failing before and blocked by the new CSP after, stranding the `virtual:pwa-register` dynamic import so `/pair` never reached network idle (this is what failed `verify`).

Only the daemon injects `__WHITEBOARD_RUNTIME_CONFIG__`, so its presence tells the two deployments apart. The PWA is a hosted-app concern; a consent page has nothing to cache.

## 4. "No thumbnail yet" rendered as a broken image

Found by driving the real dogfood loop (preview origin paired with a local dev daemon) after fix 1 landed: no CSP violations remained, yet every card still showed a broken image, and the network trace showed **every `latest-thumbnail` answering 204**.

204 is deliberate — a success status so a plain `<img src>` logs no console error while its empty body trips `onError` into the placeholder. The daemon path does not get that for free: `res.ok` is true for a 204, so the empty body became a zero-byte object URL, and a blob-backed `<img>` has no src left to fail on. Both thumbnail components now treat a zero-byte body as "no thumbnail".

## 5. No thumbnail was ever generated

The reason every canvas answered 204: `WorkspaceTopBar`'s `getThumbnailBlob` is optional and `DaemonCanvasPage` never supplied it, so `useSaveVersion` skipped the upload on every save. Nothing errored anywhere. The PNG producer was already wired for the manual export action, so the thumbnail reuses it.

An unwired optional prop fails silently at runtime, so a per-page prop-threading test guards it — the same shape as `DaemonCanvasPage.theme.test.tsx`.

## 6. `wrangler pages dev` could not start

`apps/web/wrangler.toml` set no `compatibility_date`, and wrangler defaults it to *today*:

```
This Worker requires compatibility date "2026-08-09",
but the newest date supported by this server binary is "2026-07-02".
```

So local Pages preview breaks on its own the first day the pinned wrangler falls behind the calendar, with nothing in the repo having changed. Raise the pin together with the wrangler devDependency, never ahead of it.

## Verification

Red-first throughout: every fix has a test confirmed failing before the change (7 tests across `public-headers`, `app`, `register-sw`, `CanvasThumb`, `VersionThumbnail`, and the new `DaemonCanvasPage.thumbnail` wiring test). Fixes 3 and 5 were additionally mutation-checked — reverting the production change alone turns the guard red.

Real-browser checks, not just unit tests:

- Fix 1, against the wrangler-served production build. Reverting only the `_headers` line reproduces the reported failure verbatim: `Loading the image 'blob:…' violates the following Content Security Policy directive: "img-src 'self' data:"`.
- Fixes 3–5, by pairing the Cloudflare preview origin with a local dev daemon and inspecting console, network and DOM.
- `smoke:daemon-origin` (7 real-browser assertions) passes.

Suite: `pnpm -r typecheck` clean, `pnpm test` 584 files / 6197 tests passing, `pnpm lint` and `pnpm knip` clean.

## Known issue, not addressed here

On a paired hosted origin the canvas WebSocket fails its handshake (`ws://127.0.0.1:3099/ws/…`) while the UI still reports "Synced". `DaemonBackend` authenticates the socket with the injected daemon token, which only exists on the daemon-served page; the ticket path (`POST /api/ws-ticket`, ADR-0005) exists server-side but the client never calls it. Separate from this PR's scope — it needs an auth-design decision — and tracked separately.
