### PR TITLE
feat(web): make canvas embeds and image nodes work in daemon mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,10 @@ This is not yet enforced as a hard CI gate because the existing codebase still h
 
 [Lefthook](https://lefthook.dev) installs git hooks automatically on `pnpm install` (via the `prepare` script):
 
-- **pre-commit** (fast, non-blocking): formats the staged files with Biome and re-stages them. It deliberately does NOT run lint/typecheck/tests, so it never slows the many automated commits the dev flow makes.
-- **pre-push** (the gate): runs `pnpm -r typecheck`, `pnpm test --project mcp-node`, and `pnpm lint:noconsole` in parallel — mirroring CI so a broken build, failing test, or stray `console.*` in server code is caught before it leaves your machine.
+- **pre-commit** (fast): formats the staged files with Biome and re-stages them, then runs **secretlint**, which BLOCKS the commit on a secret or an absolute home-dir path. It deliberately does NOT run lint/typecheck/tests, so it never slows the many automated commits the dev flow makes.
+- **pre-push** (the gate): runs `pnpm -r typecheck`, `pnpm test --project mcp-node`, `pnpm lint:noconsole`, `pnpm lint`, and `pnpm verify:git-hooks` in parallel — mirroring CI so a broken build, failing test, or stray `console.*` in server code is caught before it leaves your machine.
+
+`pnpm verify:git-hooks` checks the hooks themselves rather than your code. A tool that appends its own block to `.git/hooks/<name>` — several editor and code-intelligence integrations install that way — makes *its* exit status the script's, which silently reduces every lefthook command above to advisory while still printing failures as if they blocked. Run `pnpm verify:git-hooks --fix` to move an appended block ahead of lefthook's invocation.
 
 Hooks are a local safety net, **not** a replacement for CI (the authoritative gate). Bypass a run when you must with `LEFTHOOK=0 git …` or `git push --no-verify` (e.g. a docs-only push). If the hooks didn't install, run `pnpm lefthook install`.
 

--- a/apps/web/src/hooks/use-canvas-file-seams.test.tsx
+++ b/apps/web/src/hooks/use-canvas-file-seams.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * The backend-agnostic half of the editor's file seams. This logic used to
+ * live inline in BrowserLocalCanvasPage, which is why the daemon page shipped
+ * without any of it; the caching rules below (staleness stamps, the
+ * same-instance guard, URL revocation) are subtle enough that a second
+ * hand-written copy is exactly what should not happen.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type CanvasFileAdapter, useCanvasFileSeams } from './use-canvas-file-seams.js'
+
+const canvasWith = (...files: string[]): SpatialCanvas => ({
+  nodes: files.map((file, i) => ({
+    id: `n${i}`,
+    type: 'file' as const,
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    file,
+  })),
+  edges: [],
+})
+
+const embedded = (text: string): SpatialCanvas => ({
+  nodes: [{ id: 'e', type: 'text', x: 0, y: 0, width: 1, height: 1, text }],
+  edges: [],
+})
+
+function makeAdapter(overrides: Partial<CanvasFileAdapter> = {}) {
+  const adapter: CanvasFileAdapter = {
+    isImageRef: (file) => file.startsWith('asset:'),
+    loadCanvas: vi.fn(async (ref: string) => embedded(ref)),
+    loadImageUrl: vi.fn(async (ref: string) => `blob:${ref}`),
+    storeImage: vi.fn(async () => 'asset:new'),
+    ...overrides,
+  }
+  return adapter
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useCanvasFileSeams', () => {
+  it('resolves a referenced canvas once it has been pre-fetched', async () => {
+    const adapter = makeAdapter()
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('other'), adapter, stampOf: new Map() }),
+    )
+
+    // The editor's seam is synchronous, so nothing is available on the first
+    // render — the point of the pre-fetch.
+    expect(result.current.resolveFileCanvas('other')).toBeUndefined()
+    await waitFor(() => expect(result.current.resolveFileCanvas('other')).toBeDefined())
+    expect(result.current.resolveFileCanvas('other')).toEqual(embedded('other'))
+  })
+
+  it('routes image refs to the image loader and canvas refs to the canvas loader', async () => {
+    const adapter = makeAdapter()
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({
+        canvas: canvasWith('asset:pic', 'sibling'),
+        adapter,
+        stampOf: new Map(),
+      }),
+    )
+
+    await waitFor(() => expect(result.current.resolveFileImage('asset:pic')).toBeDefined())
+    expect(result.current.resolveFileImage('asset:pic')).toEqual({ href: 'blob:asset:pic' })
+    expect(adapter.loadCanvas).toHaveBeenCalledWith('sibling')
+    expect(adapter.loadCanvas).not.toHaveBeenCalledWith('asset:pic')
+    expect(adapter.loadImageUrl).not.toHaveBeenCalledWith('sibling')
+  })
+
+  it('re-fetches a referenced canvas only when its stamp moves', async () => {
+    const adapter = makeAdapter()
+    const canvas = canvasWith('other')
+    const { result, rerender } = renderHook(
+      ({ stampOf }: { stampOf: ReadonlyMap<string, string> }) =>
+        useCanvasFileSeams({ canvas, adapter, stampOf }),
+      { initialProps: { stampOf: new Map([['other', 'v1']]) as ReadonlyMap<string, string> } },
+    )
+    await waitFor(() => expect(result.current.resolveFileCanvas('other')).toBeDefined())
+    expect(adapter.loadCanvas).toHaveBeenCalledTimes(1)
+
+    // Same stamp, new map identity: a re-render must not re-fetch.
+    rerender({ stampOf: new Map([['other', 'v1']]) })
+    expect(adapter.loadCanvas).toHaveBeenCalledTimes(1)
+
+    // Moved stamp: the referenced canvas was edited elsewhere.
+    rerender({ stampOf: new Map([['other', 'v2']]) })
+    await waitFor(() => expect(adapter.loadCanvas).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not spin when every image load fails', async () => {
+    const loadImageUrl = vi.fn(async () => undefined)
+    const adapter = makeAdapter({ loadImageUrl })
+    renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('asset:gone'), adapter, stampOf: new Map() }),
+    )
+
+    // A fresh-but-equal map would re-trigger the effect and retry forever.
+    // Settling at one attempt is the property; the count is the evidence.
+    await waitFor(() => expect(loadImageUrl).toHaveBeenCalled())
+    await new Promise((settle) => setTimeout(settle, 50))
+    expect(loadImageUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('revokes every object URL it created when the page unmounts', async () => {
+    const revoke = vi.fn()
+    vi.stubGlobal('URL', { ...URL, revokeObjectURL: revoke, createObjectURL: () => 'blob:x' })
+    const adapter = makeAdapter()
+    const { result, unmount } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('asset:pic'), adapter, stampOf: new Map() }),
+    )
+    await waitFor(() => expect(result.current.resolveFileImage('asset:pic')).toBeDefined())
+
+    unmount()
+
+    // Leaking these keeps the decoded image alive for the tab's lifetime.
+    expect(revoke).toHaveBeenCalledWith('blob:asset:pic')
+    vi.unstubAllGlobals()
+  })
+
+  it('delegates adding an image to the adapter', async () => {
+    const adapter = makeAdapter()
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith(), adapter, stampOf: new Map() }),
+    )
+
+    const file = new File(['x'], 'x.png', { type: 'image/png' })
+    const ref = await result.current.onAddImage(file)
+
+    expect(adapter.storeImage).toHaveBeenCalledWith(file)
+    expect(ref).toBe('asset:new')
+  })
+
+  it('exposes the adapter image-ref predicate to the editor', () => {
+    const adapter = makeAdapter()
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith(), adapter, stampOf: new Map() }),
+    )
+
+    expect(result.current.isImageFileRef('asset:pic')).toBe(true)
+    expect(result.current.isImageFileRef('sibling')).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/use-canvas-file-seams.ts
+++ b/apps/web/src/hooks/use-canvas-file-seams.ts
@@ -1,0 +1,145 @@
+/**
+ * The editor's four file seams — referenced-canvas embeds (J5a) and image
+ * nodes (J5b) — with the backend factored out behind `CanvasFileAdapter`.
+ *
+ * This exists because the logic was written inline in one page, so the other
+ * page shipped without any of it: canvas embeds and image nodes worked in
+ * browser-local mode and silently did nothing in daemon mode. The caching
+ * rules here (staleness stamps, the same-instance guard, URL revocation) are
+ * subtle enough that a second hand-written copy is the wrong answer.
+ *
+ * `resolveFileCanvas`/`resolveFileImage` are SYNCHRONOUS by the editor's
+ * contract, so both are cache lookups over content this hook pre-fetches.
+ * Totality mirrors the layout seam: any load failure resolves to `undefined`
+ * and the editor keeps the card — a broken reference never takes down a page.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { collectFileRefs } from '../lib/canvas-embed-content.js'
+
+/** What a backend must supply for the seams to work against it. */
+export interface CanvasFileAdapter {
+  /** Distinguishes a stored image asset from a reference to another canvas. */
+  isImageRef(file: string): boolean
+  /** Resolves a canvas reference to its spatial content, or undefined. */
+  loadCanvas(ref: string): Promise<SpatialCanvas | undefined>
+  /** Resolves an image reference to a displayable URL, or undefined. */
+  loadImageUrl(ref: string): Promise<string | undefined>
+  /** Stores a picked/dropped/pasted image, returning its new reference. */
+  storeImage(file: File): Promise<string | undefined>
+}
+
+export interface UseCanvasFileSeamsOptions {
+  readonly canvas: SpatialCanvas
+  readonly adapter: CanvasFileAdapter
+  /**
+   * Reference -> an opaque revision marker (the referenced canvas's
+   * `updatedAt`). A moved marker is what makes an edit made elsewhere show up
+   * on the next refresh; an absent one simply never invalidates.
+   */
+  readonly stampOf: ReadonlyMap<string, string>
+}
+
+export interface CanvasFileSeams {
+  resolveFileCanvas: (file: string) => SpatialCanvas | undefined
+  resolveFileImage: (file: string) => { href: string } | undefined
+  onAddImage: (file: File) => Promise<string | undefined>
+  isImageFileRef: (file: string) => boolean
+}
+
+export function useCanvasFileSeams({
+  canvas,
+  adapter,
+  stampOf,
+}: UseCanvasFileSeamsOptions): CanvasFileSeams {
+  const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, SpatialCanvas>>(new Map())
+  const embedStampsRef = useRef<Map<string, string>>(new Map())
+  // Image assets are immutable once stored, so object URLs cache for the
+  // lifetime of the page and are revoked together on unmount.
+  const [imageUrls, setImageUrls] = useState<ReadonlyMap<string, string>>(new Map())
+  const imageUrlsRef = useRef<ReadonlyMap<string, string>>(imageUrls)
+  imageUrlsRef.current = imageUrls
+
+  // Kept in a ref so a caller that rebuilds its adapter object every render
+  // cannot restart the fetch effects; the adapter is a backend binding, not
+  // reactive state.
+  const adapterRef = useRef(adapter)
+  adapterRef.current = adapter
+
+  useEffect(
+    () => () => {
+      for (const url of imageUrlsRef.current.values()) URL.revokeObjectURL(url)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    const refs = collectFileRefs(canvas).filter((ref) => !adapterRef.current.isImageRef(ref))
+    if (refs.length === 0) return
+    const stale = refs.filter(
+      (ref) => !embedContent.has(ref) || embedStampsRef.current.get(ref) !== stampOf.get(ref),
+    )
+    if (stale.length === 0) return
+    let cancelled = false
+    void Promise.all(
+      stale.map(async (ref) => [ref, await adapterRef.current.loadCanvas(ref)] as const),
+    ).then((loaded) => {
+      if (cancelled) return
+      setEmbedContent((prev) => {
+        const next = new Map(prev)
+        for (const [ref, content] of loaded) {
+          if (content !== undefined) next.set(ref, content)
+          else next.delete(ref)
+          embedStampsRef.current.set(ref, stampOf.get(ref) ?? '')
+        }
+        return next
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [canvas, embedContent, stampOf])
+
+  useEffect(() => {
+    const refs = collectFileRefs(canvas).filter(
+      (ref) => adapterRef.current.isImageRef(ref) && !imageUrls.has(ref),
+    )
+    if (refs.length === 0) return
+    let cancelled = false
+    void Promise.all(
+      refs.map(async (ref) => [ref, await adapterRef.current.loadImageUrl(ref)] as const),
+    ).then((loaded) => {
+      if (cancelled) return
+      setImageUrls((prev) => {
+        // When every load failed, keep the SAME map instance: a fresh (equal)
+        // map would re-trigger this effect and spin the failed reads forever.
+        // Failed refs retry only on the next canvas change.
+        let added = false
+        const next = new Map(prev)
+        for (const [ref, url] of loaded) {
+          if (url !== undefined) {
+            next.set(ref, url)
+            added = true
+          }
+        }
+        return added ? next : prev
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [canvas, imageUrls])
+
+  const resolveFileCanvas = useCallback((file: string) => embedContent.get(file), [embedContent])
+  const resolveFileImage = useCallback(
+    (file: string) => {
+      const href = imageUrls.get(file)
+      return href === undefined ? undefined : { href }
+    },
+    [imageUrls],
+  )
+  const onAddImage = useCallback((file: File) => adapterRef.current.storeImage(file), [])
+  const isImageFileRef = useCallback((file: string) => adapterRef.current.isImageRef(file), [])
+
+  return { resolveFileCanvas, resolveFileImage, onAddImage, isImageFileRef }
+}

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -11,6 +11,7 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
+import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
 import { CanvasFileStore } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
@@ -18,9 +19,7 @@ import { LoroStore } from './loro-store.js'
 const log = getAppLogger('canvas-embed-content')
 
 /** Loads one referenced canvas's spatial content from IndexedDB. */
-export async function loadEmbeddedSpatialCanvas(
-  canvasId: string,
-): Promise<SpatialCanvas | undefined> {
+async function loadEmbeddedSpatialCanvas(canvasId: string): Promise<SpatialCanvas | undefined> {
   try {
     const result = await new LoroStore().load(canvasId)
     if (result.kind !== 'ok') return undefined
@@ -42,7 +41,7 @@ export function collectFileRefs(canvas: SpatialCanvas): readonly string[] {
 /** Reference prefix distinguishing stored image assets from canvas ids. */
 const IMAGE_REF_PREFIX = 'asset:'
 
-export function isImageRef(file: string): boolean {
+function isImageRef(file: string): boolean {
   return file.startsWith(IMAGE_REF_PREFIX)
 }
 
@@ -50,7 +49,7 @@ export function isImageRef(file: string): boolean {
  * Stores a picked/dropped/pasted image in the canvas file store and returns
  * the reference for the created file node, or undefined on failure.
  */
-export async function storeImageAsset(file: File): Promise<string | undefined> {
+async function storeImageAsset(file: File): Promise<string | undefined> {
   try {
     const ref = `${IMAGE_REF_PREFIX}${crypto.randomUUID()}`
     await new CanvasFileStore().put(ref, {
@@ -66,8 +65,21 @@ export async function storeImageAsset(file: File): Promise<string | undefined> {
 }
 
 /** Loads a stored image asset as an object URL, or undefined when missing. */
-export async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
+async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
   const blob = await new CanvasFileStore().get(ref)
   if (blob === null) return undefined
   return URL.createObjectURL(blob)
+}
+
+/**
+ * The browser-local binding of the editor's file seams. Declared here beside
+ * the four functions it wires so the page is left with no backend knowledge
+ * of its own — the daemon page supplies its own adapter over the daemon's
+ * `/api/canvas/:workspaceId/:slug/file/:fileId` endpoints.
+ */
+export const BROWSER_LOCAL_FILE_ADAPTER: CanvasFileAdapter = {
+  isImageRef,
+  loadCanvas: loadEmbeddedSpatialCanvas,
+  loadImageUrl: loadImageAssetUrl,
+  storeImage: storeImageAsset,
 }

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -13,6 +13,7 @@ import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
 import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
+import { isImageRef, newImageRef } from './canvas-file-ref.js'
 import { CanvasFileStore } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
 
@@ -38,20 +39,13 @@ export function collectFileRefs(canvas: SpatialCanvas): readonly string[] {
   return [...new Set(canvas.nodes.flatMap((node) => (node.type === 'file' ? [node.file] : [])))]
 }
 
-/** Reference prefix distinguishing stored image assets from canvas ids. */
-const IMAGE_REF_PREFIX = 'asset:'
-
-function isImageRef(file: string): boolean {
-  return file.startsWith(IMAGE_REF_PREFIX)
-}
-
 /**
  * Stores a picked/dropped/pasted image in the canvas file store and returns
  * the reference for the created file node, or undefined on failure.
  */
 async function storeImageAsset(file: File): Promise<string | undefined> {
   try {
-    const ref = `${IMAGE_REF_PREFIX}${crypto.randomUUID()}`
+    const ref = newImageRef(crypto.randomUUID())
     await new CanvasFileStore().put(ref, {
       mimeType: file.type,
       blob: file,

--- a/apps/web/src/lib/canvas-file-ref.ts
+++ b/apps/web/src/lib/canvas-file-ref.ts
@@ -1,0 +1,32 @@
+/**
+ * The one convention distinguishing a file node that points at a stored image
+ * from one that points at another canvas.
+ *
+ * Shared by both backends deliberately: a canvas authored in browser-local
+ * mode and one authored against the daemon must mean the same thing by the
+ * same `file` value, or moving content between them would silently
+ * reinterpret every image node as a canvas reference.
+ *
+ * The colon is what makes this unambiguous — a daemon slug and a browser-local
+ * canvas id both match /^[a-zA-Z0-9_-]+$/, so neither can ever collide with a
+ * prefixed reference.
+ */
+const IMAGE_REF_PREFIX = 'asset:'
+
+export function isImageRef(file: string): boolean {
+  return file.startsWith(IMAGE_REF_PREFIX)
+}
+
+/** Mints a reference for a newly stored image. */
+export function newImageRef(id: string): string {
+  return `${IMAGE_REF_PREFIX}${id}`
+}
+
+/**
+ * The backend-side id inside an image reference. The daemon's file route
+ * validates this against /^[a-zA-Z0-9_-]+$/, so the prefix must be stripped
+ * before it travels in a path.
+ */
+export function imageRefId(file: string): string {
+  return file.slice(IMAGE_REF_PREFIX.length)
+}

--- a/apps/web/src/lib/daemon-file-adapter.test.ts
+++ b/apps/web/src/lib/daemon-file-adapter.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The daemon binding of the editor's file seams. Until this existed, the
+ * daemon page passed no seams at all, so canvas embeds (J5a) and image nodes
+ * (J5b) silently did nothing there while working in browser-local mode.
+ */
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { Loro } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDaemonFileAdapter } from './daemon-file-adapter.js'
+
+const BASE = 'http://127.0.0.1:3099'
+const WS = 'ws-1'
+const SLUG = 'my-canvas'
+
+function snapshotOf(text: string): Uint8Array {
+  const doc = new Loro()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 10, height: 10, text }],
+    edges: [],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+const FAKE_UUID = '11111111-2222-3333-4444-555555555555'
+const FAKE_OBJECT_URL = 'blob:stubbed'
+
+beforeEach(() => {
+  // Patch the two members in place rather than replacing the globals: a
+  // spread of `URL`/`crypto` copies no prototype methods, which silently
+  // strips crypto.getRandomValues and breaks Loro's wasm several layers away
+  // from anything this file is about.
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue(FAKE_OBJECT_URL)
+  vi.spyOn(crypto, 'randomUUID').mockReturnValue(FAKE_UUID)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createDaemonFileAdapter', () => {
+  it('treats an asset: reference as an image and anything else as a canvas slug', () => {
+    const adapter = createDaemonFileAdapter({
+      daemonFetch: vi.fn(),
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    // The SAME convention browser-local uses, so a canvas keeps meaning the
+    // same thing in both modes. A daemon slug can never collide: slugs match
+    // /^[a-zA-Z0-9_-]+$/ and so cannot contain a colon.
+    expect(adapter.isImageRef('asset:abc')).toBe(true)
+    expect(adapter.isImageRef('sibling-canvas')).toBe(false)
+  })
+
+  it('fetches an image from the daemon file route, stripping the asset: prefix', async () => {
+    // The route validates fileId against /^[a-zA-Z0-9_-]+$/, so the prefix
+    // must not travel in the path.
+    const daemonFetch = vi.fn(async () => new Response(new Blob(['12345'])))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    const url = await adapter.loadImageUrl('asset:file-abc')
+
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/${SLUG}/file/file-abc`)
+    expect(url).toBe(FAKE_OBJECT_URL)
+  })
+
+  it('resolves a missing image to undefined instead of throwing', async () => {
+    const daemonFetch = vi.fn(async () => new Response(null, { status: 404 }))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    // Totality: a broken reference keeps the card, it never takes the page down.
+    await expect(adapter.loadImageUrl('asset:gone')).resolves.toBeUndefined()
+  })
+
+  it('uploads an image and returns the reference the node should carry', async () => {
+    const daemonFetch = vi.fn(async () => new Response(null, { status: 204 }))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    const file = new File(['xy'], 'x.png', { type: 'image/png' })
+    const ref = await adapter.storeImage(file)
+
+    expect(ref).toBe(`asset:${FAKE_UUID}`)
+    const [url, init] = daemonFetch.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe(`${BASE}/api/canvas/${WS}/${SLUG}/file/${FAKE_UUID}`)
+    expect(init.method).toBe('PUT')
+    // The route rejects an unrecognised Content-Type with 415, so the
+    // picked file's own type has to travel.
+    expect(new Headers(init.headers).get('Content-Type')).toBe('image/png')
+  })
+
+  it('reports a rejected upload as undefined rather than minting a dangling reference', async () => {
+    const daemonFetch = vi.fn(async () => new Response(null, { status: 413 }))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    // Returning the ref anyway would put a node on the canvas pointing at
+    // bytes the daemon never stored.
+    await expect(
+      adapter.storeImage(new File(['x'], 'x.png', { type: 'image/png' })),
+    ).resolves.toBeUndefined()
+  })
+
+  it('loads a referenced canvas from its snapshot', async () => {
+    const daemonFetch = vi.fn(async () => new Response(snapshotOf('hello') as BodyInit))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    const loaded = await adapter.loadCanvas('sibling')
+
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/sibling/snapshot`)
+    expect(loaded?.nodes[0]).toMatchObject({ id: 'n1', text: 'hello' })
+  })
+
+  it('resolves an unreachable referenced canvas to undefined', async () => {
+    const daemonFetch = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    await expect(adapter.loadCanvas('sibling')).resolves.toBeUndefined()
+  })
+
+  it('percent-encodes a slug on its way into the path', async () => {
+    const daemonFetch = vi.fn(async () => new Response(null, { status: 404 }))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+    })
+
+    await adapter.loadCanvas('a b')
+
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/a%20b/snapshot`)
+  })
+})

--- a/apps/web/src/lib/daemon-file-adapter.ts
+++ b/apps/web/src/lib/daemon-file-adapter.ts
@@ -1,0 +1,86 @@
+/**
+ * The daemon binding of the editor's file seams (see use-canvas-file-seams.ts
+ * for the backend-agnostic half).
+ *
+ * Every method is total: a missing file, a rejected upload, or an unreachable
+ * daemon resolves to `undefined` so the editor keeps the card. A broken
+ * reference must never take the page down, and it must never be reported as
+ * success either — an upload that failed returns undefined rather than a
+ * reference to bytes the daemon never stored.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { Loro } from 'loro-crdt'
+import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
+import { getAppLogger } from './app-logger.js'
+import { imageRefId, isImageRef, newImageRef } from './canvas-file-ref.js'
+
+const log = getAppLogger('daemon-file-adapter')
+
+export interface DaemonFileAdapterOptions {
+  readonly daemonFetch: typeof fetch
+  readonly daemonBaseUrl: string
+  readonly workspaceId: string
+  readonly slug: string
+}
+
+export function createDaemonFileAdapter({
+  daemonFetch,
+  daemonBaseUrl,
+  workspaceId,
+  slug,
+}: DaemonFileAdapterOptions): CanvasFileAdapter {
+  const canvasPath = (target: string) =>
+    `${daemonBaseUrl}/api/canvas/${workspaceId}/${encodeURIComponent(target)}`
+
+  return {
+    isImageRef,
+
+    async loadCanvas(ref) {
+      try {
+        const res = await daemonFetch(`${canvasPath(ref)}/snapshot`)
+        if (!res.ok) return undefined
+        const doc = new Loro()
+        doc.import(new Uint8Array(await res.arrayBuffer()))
+        return readSpatialCanvas(doc) as SpatialCanvas
+      } catch (err) {
+        log.warn('referenced canvas load failed', { ref, err })
+        return undefined
+      }
+    },
+
+    async loadImageUrl(ref) {
+      try {
+        // This canvas's own slug, not the reference: the file route scopes
+        // reads by the canvas that owns the workspace's file directory.
+        const res = await daemonFetch(`${canvasPath(slug)}/file/${imageRefId(ref)}`)
+        if (!res.ok) return undefined
+        return URL.createObjectURL(await res.blob())
+      } catch (err) {
+        log.warn('image load failed', { ref, err })
+        return undefined
+      }
+    },
+
+    async storeImage(file) {
+      const id = crypto.randomUUID()
+      try {
+        const res = await daemonFetch(`${canvasPath(slug)}/file/${id}`, {
+          method: 'PUT',
+          // The route answers 415 for a Content-Type it has no extension
+          // mapping for, so the picked file's own type has to travel.
+          headers: { 'Content-Type': file.type },
+          body: file,
+        })
+        if (!res.ok) {
+          log.warn('image upload rejected', { status: res.status })
+          return undefined
+        }
+        return newImageRef(id)
+      } catch (err) {
+        log.warn('image upload failed', { err })
+        return undefined
+      }
+    },
+  }
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,4 +1,3 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { Copy, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -21,19 +20,14 @@ import {
 } from '../components/ui/alert-dialog.js'
 import { Button } from '../components/ui/button.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
+import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import {
-  collectFileRefs,
-  isImageRef,
-  loadEmbeddedSpatialCanvas,
-  loadImageAssetUrl,
-  storeImageAsset,
-} from '../lib/canvas-embed-content.js'
+import { BROWSER_LOCAL_FILE_ADAPTER } from '../lib/canvas-embed-content.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -161,23 +155,6 @@ export function BrowserLocalCanvasPage({
   // The generation guard drops a stale resolution that would otherwise
   // clobber a newer refresh triggered by a fast switch.
   const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
-  // Referenced-canvas content cache for inline embeds: the editor's
-  // resolveFileCanvas seam is synchronous, so referenced canvases are
-  // pre-fetched here. Entries refresh when the referenced canvas's
-  // updatedAt moves in the list (edits elsewhere show up on next refresh).
-  const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, SpatialCanvas>>(new Map())
-  const embedStampsRef = useRef<Map<string, string>>(new Map())
-  // Image assets are immutable once stored, so object URLs cache forever
-  // per session and are revoked together on unmount.
-  const [imageUrls, setImageUrls] = useState<ReadonlyMap<string, string>>(new Map())
-  const imageUrlsRef = useRef<ReadonlyMap<string, string>>(imageUrls)
-  imageUrlsRef.current = imageUrls
-  useEffect(
-    () => () => {
-      for (const url of imageUrlsRef.current.values()) URL.revokeObjectURL(url)
-    },
-    [],
-  )
   const listGenerationRef = useRef(0)
   // Fullscreen target for WorkspaceTopBar's onEnterFullscreen; the whole page
   // (editor + chrome), not just the Excalidraw canvas.
@@ -290,70 +267,17 @@ export function BrowserLocalCanvasPage({
     setEdgeLock,
   } = useCanvasSync(backend)
 
-  // Pre-fetch referenced canvases for inline embeds; refresh when the
-  // referenced canvas's updatedAt moves in the list.
-  useEffect(() => {
-    const refs = collectFileRefs(canvas).filter((ref) => !isImageRef(ref))
-    if (refs.length === 0) return
-    let cancelled = false
-    const stampOf = new Map(canvases.map((entry) => [entry.id, entry.updatedAt]))
-    const stale = refs.filter(
-      (ref) => !embedContent.has(ref) || embedStampsRef.current.get(ref) !== stampOf.get(ref),
-    )
-    if (stale.length === 0) return
-    void Promise.all(
-      stale.map(async (ref) => [ref, await loadEmbeddedSpatialCanvas(ref)] as const),
-    ).then((loaded) => {
-      if (cancelled) return
-      setEmbedContent((prev) => {
-        const next = new Map(prev)
-        for (const [ref, content] of loaded) {
-          if (content !== undefined) next.set(ref, content)
-          else next.delete(ref)
-          embedStampsRef.current.set(ref, stampOf.get(ref) ?? '')
-        }
-        return next
-      })
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [canvas, canvases, embedContent])
-  const resolveFileCanvas = useCallback((file: string) => embedContent.get(file), [embedContent])
-  useEffect(() => {
-    const refs = collectFileRefs(canvas).filter((ref) => isImageRef(ref) && !imageUrls.has(ref))
-    if (refs.length === 0) return
-    let cancelled = false
-    void Promise.all(refs.map(async (ref) => [ref, await loadImageAssetUrl(ref)] as const)).then(
-      (loaded) => {
-        if (cancelled) return
-        setImageUrls((prev) => {
-          // When every load failed, keep the SAME map instance: a fresh
-          // (equal) map would re-trigger this effect and spin the failed
-          // reads forever. Failed refs retry only on the next canvas change.
-          let added = false
-          const next = new Map(prev)
-          for (const [ref, url] of loaded) {
-            if (url !== undefined) {
-              next.set(ref, url)
-              added = true
-            }
-          }
-          return added ? next : prev
-        })
-      },
-    )
-    return () => {
-      cancelled = true
-    }
-  }, [canvas, imageUrls])
-  const resolveFileImage = useCallback(
-    (file: string) => {
-      const href = imageUrls.get(file)
-      return href === undefined ? undefined : { href }
-    },
-    [imageUrls],
-  )
+  // The seams themselves are backend-agnostic (see use-canvas-file-seams.ts);
+  // this page only supplies the browser-local binding and the staleness
+  // stamps that make an edit made elsewhere show up on the next refresh.
+  const fileSeams = useCanvasFileSeams({
+    canvas,
+    adapter: BROWSER_LOCAL_FILE_ADAPTER,
+    stampOf: useMemo(
+      () => new Map(canvases.map((entry) => [entry.id, entry.updatedAt])),
+      [canvases],
+    ),
+  })
 
   const commands = useWhiteboardCommands({
     provider: { kind: 'browser-local', capabilities },
@@ -583,10 +507,7 @@ export function BrowserLocalCanvasPage({
               .filter((entry) => entry.id !== canvasId)
               .map((entry) => ({ file: entry.id, label: entry.name }))}
             onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
-            resolveFileCanvas={resolveFileCanvas}
-            resolveFileImage={resolveFileImage}
-            onAddImage={storeImageAsset}
-            isImageFileRef={isImageRef}
+            {...fileSeams}
             lockedNodeIds={lockedNodeIds}
             lockedEdgeIds={lockedEdgeIds}
             onToggleNodeLock={setNodeLock}

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -14,12 +14,14 @@ import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
+import { createDaemonFileAdapter } from '../lib/daemon-file-adapter.js'
 import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -182,6 +184,27 @@ export function DaemonCanvasPage({
     onVersionCreated: () => setVersionRefreshSignal((n) => n + 1),
     onViewportRequest: (payload) => applyViewportRequest(payload, spatialEditorRef.current),
     identity: canvas ?? undefined,
+  })
+
+  // Canvas embeds (J5a) and image nodes (J5b), over the daemon's own file and
+  // snapshot routes. The staleness stamp is the referenced canvas's
+  // updatedAt, exactly as in browser-local mode.
+  const fileSeams = useCanvasFileSeams({
+    canvas: canvasValue,
+    adapter: useMemo(
+      () =>
+        createDaemonFileAdapter({
+          daemonFetch,
+          daemonBaseUrl,
+          workspaceId: canvas?.workspaceId ?? '',
+          slug: canvas?.slug ?? '',
+        }),
+      [daemonFetch, daemonBaseUrl, canvas?.workspaceId, canvas?.slug],
+    ),
+    stampOf: useMemo(
+      () => new Map(controller.canvases.map((entry) => [entry.slug, entry.updatedAt ?? ''])),
+      [controller.canvases],
+    ),
   })
 
   const commands = useWhiteboardCommands({
@@ -499,6 +522,7 @@ export function DaemonCanvasPage({
                 .filter((entry) => entry.slug !== canvas?.slug)
                 .map((entry) => ({ file: entry.slug, label: entry.slug }))}
               onOpenFileRef={(file) => controller.switchCanvas(file)}
+              {...fileSeams}
               lockedNodeIds={lockedNodeIds}
               lockedEdgeIds={lockedEdgeIds}
               onToggleNodeLock={setNodeLock}

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Both canvas pages must hand the editor the same file seams.
+ *
+ * This exists because they did not: the seams were written inline in
+ * BrowserLocalCanvasPage, so DaemonCanvasPage shipped passing none of them and
+ * canvas embeds (J5a) and image nodes (J5b) silently did nothing in daemon
+ * mode. Nothing failed — each page's own tests only ever exercised its own
+ * mode, which is exactly why a per-page test cannot catch this class.
+ *
+ * A source scan rather than a render: the defect is a missing prop at a call
+ * site, and asserting on the call site is what makes "the two pages agree"
+ * checkable at all. Tier-2 conformance, same shape as canvas-viewer's
+ * geometry conformance test.
+ */
+import { describe, expect, it } from 'vitest'
+
+const PAGES = ['./BrowserLocalCanvasPage.tsx', './DaemonCanvasPage.tsx'] as const
+
+const sources = import.meta.glob('./{BrowserLocalCanvasPage,DaemonCanvasPage}.tsx', {
+  query: '?raw',
+  import: 'default',
+})
+
+async function read(page: string): Promise<string> {
+  const loader = sources[page]
+  expect(loader, `no source loader for ${page}`).toBeDefined()
+  return (await loader?.()) as string
+}
+
+describe('canvas page file seams', () => {
+  it.each(PAGES)('%s passes the shared seams to SpatialEditor', async (page) => {
+    const source = await read(page)
+
+    // The spread is the point: enumerating the four props per page is how
+    // they drifted apart in the first place, so a page that spells them out
+    // individually should fail here even if it happens to pass all four.
+    expect(source).toContain('{...fileSeams}')
+    expect(source).toContain('useCanvasFileSeams(')
+  })
+
+  it.each(PAGES)('%s builds its seams from an adapter, not inline loading', async (page) => {
+    const source = await read(page)
+
+    // Caching (staleness stamps, the same-instance guard, URL revocation)
+    // belongs to the shared hook. A page reaching for these again means the
+    // logic is being re-derived per backend — the original defect.
+    expect(source).not.toContain('createObjectURL')
+    expect(source).not.toContain('revokeObjectURL')
+  })
+})

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,10 @@
 #    and absolute home-dir path leaks before they enter git history).
 #  - the real gate lives on pre-push, run only by the integrator who pushes — it mirrors
 #    CI so a broken build / failing test / typecheck error is caught before it leaves the machine.
+#
+# Note that a correct config here is NOT sufficient: another tool appending its own block
+# to .git/hooks/<name> makes ITS exit status the script's, silently reducing every command
+# below to advisory (verify-git-hooks.mjs exists because that had actually happened).
 
 pre-commit:
   parallel: true
@@ -21,6 +25,12 @@ pre-commit:
 pre-push:
   parallel: true
   commands:
+    # Cheap, and it answers "were the gates below actually enforced on the way
+    # here?" — a hook whose exit status was hijacked lets every pre-commit run
+    # pass silently, so this is checked at the last point before code leaves
+    # the machine.
+    git-hooks:
+      run: pnpm verify:git-hooks
     typecheck:
       run: pnpm -r typecheck
     test-node:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:browser:trace": "vitest run --project web-browser --project canvas-viewer-browser --project canvas-render-browser --browser.trace=on",
     "test:watch": "vitest --project mcp-node",
     "check:pr-title": "pnpm --filter @kamiazya/whiteboard-mcp check:pr-title",
+    "verify:git-hooks": "node packages/mcp-server/scripts/verify-git-hooks.mjs",
     "typecheck": "pnpm -r typecheck",
     "dev": "concurrently -k -n web,mcp -c blue,green \"pnpm --filter @kamiazya/whiteboard-web dev\" \"pnpm --filter @kamiazya/whiteboard-mcp dev\"",
     "mcp": "pnpm --filter @kamiazya/whiteboard-mcp mcp",

--- a/packages/mcp-server/scripts/verify-git-hooks.mjs
+++ b/packages/mcp-server/scripts/verify-git-hooks.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Detects — and optionally repairs — installed git hooks whose exit status is
+ * no longer lefthook's.
+ *
+ * lefthook generates a hook script ending in `call_lefthook run "<hook>" "$@"`.
+ * That call's status IS the script's status, which is what makes a failing
+ * pre-commit command block the commit. A tool that APPENDS its own block to
+ * the same file (code-review-graph installs this way) makes its own last
+ * command the script's status instead — and such blocks typically end in
+ * `|| true`, so every lefthook gate silently becomes advisory while still
+ * printing its failure. The gate looks like it works right up until it
+ * matters.
+ *
+ * Usage:
+ *   node verify-git-hooks.mjs          # report; exit 1 when a hook is broken
+ *   node verify-git-hooks.mjs --fix    # move appended blocks ahead of lefthook
+ */
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+/** The line lefthook's generated script ends with. */
+const LEFTHOOK_CALL = /^call_lefthook run .*$/m
+
+/**
+ * The executable commands sitting after lefthook's invocation, in order.
+ * Empty when the hook is well-formed, or when lefthook does not manage it at
+ * all. Comments and blank lines are ignored — they cannot change an exit
+ * status, and a shebang line after the first is only a comment.
+ */
+export function findCommandsAfterLefthook(script) {
+  const match = LEFTHOOK_CALL.exec(script)
+  if (match === null) return []
+  const tail = script.slice(match.index + match[0].length)
+  return tail
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+}
+
+/**
+ * Moves an appended block ahead of lefthook's invocation, so lefthook runs
+ * last and git sees its status. Returns the repaired script, or null when
+ * there is nothing to repair.
+ */
+export function hoistAppendedBlock(script) {
+  const match = LEFTHOOK_CALL.exec(script)
+  if (match === null) return null
+  const callEnd = match.index + match[0].length
+  const head = script.slice(0, match.index)
+  const call = match[0]
+  const tail = script.slice(callEnd)
+  if (findCommandsAfterLefthook(script).length === 0) return null
+  return `${head}${tail.replace(/^\n+/, '')}\n${call}\n`
+}
+
+function main(argv) {
+  const repoRoot = resolve(import.meta.dirname, '../../../')
+  const hooksDir = join(repoRoot, '.git', 'hooks')
+  if (!existsSync(hooksDir)) {
+    process.stdout.write('no .git/hooks directory — nothing to verify\n')
+    return 0
+  }
+  const shouldFix = argv.includes('--fix')
+  let broken = 0
+  for (const name of readdirSync(hooksDir).filter((n) => !n.endsWith('.sample'))) {
+    const path = join(hooksDir, name)
+    const script = readFileSync(path, 'utf8')
+    const extra = findCommandsAfterLefthook(script)
+    if (extra.length === 0) continue
+    broken += 1
+    process.stdout.write(
+      `.git/hooks/${name} runs after lefthook, so git sees THIS exit status:\n` +
+        extra.map((line) => `    ${line}\n`).join(''),
+    )
+    if (shouldFix) {
+      const repaired = hoistAppendedBlock(script)
+      if (repaired !== null) {
+        writeFileSync(path, repaired)
+        process.stdout.write(`  fixed: moved ahead of lefthook\n`)
+        broken -= 1
+      }
+    }
+  }
+  if (broken > 0) {
+    process.stdout.write('\nRun with --fix to repair, then re-run to confirm.\n')
+    return 1
+  }
+  process.stdout.write('git hooks preserve lefthook exit status\n')
+  return 0
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/packages/mcp-server/scripts/verify-git-hooks.test.ts
+++ b/packages/mcp-server/scripts/verify-git-hooks.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Guards the shape of the INSTALLED git hooks, which is a different question
+ * from whether lefthook.yml is correct.
+ *
+ * A tool that appends its own block to an existing hook file (code-review-graph
+ * does this) silently disables every gate lefthook runs: the script's exit
+ * status becomes the appended block's, not lefthook's, so a failing secretlint
+ * still lets the commit through. That is a gate you believe you have and do
+ * not — the worst kind — and nothing else in the repo notices, because
+ * lefthook itself reports the failure correctly on its way past.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { findCommandsAfterLefthook } from './verify-git-hooks.mjs'
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../')
+const HOOKS_DIR = join(REPO_ROOT, '.git', 'hooks')
+
+const LEFTHOOK_TAIL = `call_lefthook run "pre-commit" "$@"\n`
+const LEFTHOOK_SCRIPT = `#!/bin/sh\ncall_lefthook()\n{\n  lefthook "$@"\n}\n\n${LEFTHOOK_TAIL}`
+
+describe('findCommandsAfterLefthook', () => {
+  it('accepts a hook that ends with the lefthook invocation', () => {
+    expect(findCommandsAfterLefthook(LEFTHOOK_SCRIPT)).toEqual([])
+  })
+
+  it('reports commands appended after the lefthook invocation', () => {
+    const appended = `${LEFTHOOK_SCRIPT}\n#!/bin/sh\n# Installed by some-tool.\nsome-tool update || true\n`
+    expect(findCommandsAfterLefthook(appended)).toEqual(['some-tool update || true'])
+  })
+
+  it('ignores comments and blank lines after the invocation, which cannot change the exit status', () => {
+    const commented = `${LEFTHOOK_SCRIPT}\n\n# a trailing note\n\n`
+    expect(findCommandsAfterLefthook(commented)).toEqual([])
+  })
+
+  it('says nothing about a hook lefthook does not manage', () => {
+    // Someone else's hook is not this guard's business — only the case where
+    // lefthook's exit status is being discarded.
+    expect(findCommandsAfterLefthook('#!/bin/sh\necho hi\n')).toEqual([])
+  })
+})
+
+describe('the hooks installed in this clone', () => {
+  const hookFiles = existsSync(HOOKS_DIR)
+    ? readdirSync(HOOKS_DIR).filter((name) => !name.endsWith('.sample'))
+    : []
+
+  // Skipped rather than failed on a fresh checkout (CI) where no hook has
+  // been installed: absence is not the defect this guards.
+  it.skipIf(hookFiles.length === 0)(
+    'never discard lefthook exit status by appending to its script',
+    () => {
+      const broken = hookFiles
+        .map((name) => ({
+          name,
+          extra: findCommandsAfterLefthook(readFileSync(join(HOOKS_DIR, name), 'utf8')),
+        }))
+        .filter((entry) => entry.extra.length > 0)
+
+      expect(
+        broken,
+        `These hooks run commands after lefthook, so git sees THEIR exit status and every ` +
+          `lefthook gate is advisory:\n${broken
+            .map((entry) => `  .git/hooks/${entry.name}: ${entry.extra.join(' ; ')}`)
+            .join('\n')}\n` +
+          `Run 'pnpm verify:git-hooks --fix' to move the appended block ahead of lefthook.`,
+      ).toEqual([])
+    },
+  )
+})


### PR DESCRIPTION
Canvas embeds (J5a) and image nodes (J5b) only ever worked in browser-local mode. `DaemonCanvasPage` passed none of the four file seams to `SpatialEditor`, so in daemon mode a canvas-reference node rendered as a bare card that never expanded, and pasting or dropping an image did nothing at all.

The daemon side was already complete. `PUT`/`GET /api/canvas/:workspaceId/:slug/file/:fileId` and the snapshot route have been there all along — MCP's `load_image` uses them. Nothing but the web wiring was missing.

## Why nothing failed

Each page's tests only ever exercised its own mode. That is the whole reason this survived, and it is why the anti-recurrence guard here is a **conformance test across both pages** rather than another per-page test. Mutation-checked: dropping the daemon page's seam spread fails it.

## Commits

1. **`refactor(web)`** — extract the seams behind `CanvasFileAdapter` (behaviour-preserving). The caching rules are why this is a shared hook and not a second copy: staleness stamps, the same-map-instance guard that stops failed image reads spinning forever, and object-URL revocation on unmount.
2. **`fix(repo)`** — the pre-commit gate was not a gate (see below).
3. **`feat(web)`** — the daemon adapter, which is now just four functions.

## The reference convention

`asset:<id>` is deliberately the **same** in both modes. A canvas has to mean the same thing by the same `file` value wherever it is opened, or moving content between modes would reinterpret every image node as a canvas reference. The colon keeps it unambiguous: a daemon slug and a browser-local canvas id both match `/^[a-zA-Z0-9_-]+$/`, so neither can collide. The daemon's file route validates `fileId` against that same pattern, so the adapter strips the prefix before it travels in a path.

A failed upload returns `undefined` rather than the reference — reporting success would leave a node pointing at bytes the daemon never stored.

## The pre-commit gate was not a gate

Found while committing the first change: `.git/hooks/pre-commit` held two concatenated scripts, lefthook's followed by a block appended by code-review-graph ending in `|| true`. lefthook's exit status was never checked, so the script always exited 0 and git committed anyway. secretlint reported its failure correctly on the way past, which is exactly what let this survive — the output looks identical to a gate that works.

Verified by breaking it: a staged file containing an absolute home-dir path committed cleanly. After the fix the same commit exits 1 and leaves HEAD alone.

`verify-git-hooks.mjs` detects the shape (executable commands after lefthook's invocation; comments cannot change an exit status, so they are ignored) and `--fix` hoists the block ahead of it. Wired into pre-push, because the question it answers is "were the gates actually enforced on the way here?". It targets the general shape, not this one tool — several editor and code-intelligence integrations install by appending.

`CONTRIBUTING.md`'s hook section was also describing a pre-commit that does not exist: secretlint was missing entirely and the hook was called non-blocking. Corrected to what runs.

## Verification

`pnpm test` 589/589 files green (6242 passed), `pnpm -r typecheck` clean, `pnpm knip` clean.

**Manual daemon-mode verification is still outstanding** — the adapter is unit-tested against a fake fetch, and the route contract was read from the daemon source, but I have not yet driven a real paired daemon session end-to-end. Holding as draft until that is done.
