### PR TITLE
feat(web): snap a resized edge the way a moved box already snaps

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -132,6 +132,7 @@ import type { Box, ResizeHandleKind } from './geometry.js'
 import {
   distanceToPolyline,
   findFreeSpot,
+  HANDLE_SIGN,
   hitTest,
   indexNodeBoxes,
   polylineMidpoint,
@@ -144,7 +145,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
-import { type SnapBox, snapBox } from './snap.js'
+import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
@@ -730,16 +731,54 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * only one of them would let the box render in one place and land in
      * another.
      *
-     * Move only. A resize would have to snap the dragged EDGE rather than the
-     * origin, which is a different candidate set — deferred rather than
-     * approximated, since an approximate resize snap fights the handle.
+     * Serves both gestures, but they snap DIFFERENT things: a move snaps the
+     * box (three lines per axis — edge, centre, edge), a resize snaps only the
+     * edge under the handle. Feeding a resize the move candidates would let
+     * the box's own centre or far edge pull the handle, which reads as the
+     * handle fighting the pointer.
      */
-    const snapMovePoint = (
+    const snapGesturePoint = (
       raw: Point,
       suspended: boolean,
     ): { point: Point; guides: { x: readonly number[]; y: readonly number[] } } => {
       const unchanged = { point: raw, guides: { x: [], y: [] } }
-      if (suspended || gestureState.kind !== 'moving') return unchanged
+      if (suspended) return unchanged
+      const options = {
+        thresholdCanvasPx: SNAP_THRESHOLD_SCREEN_PX / viewport.zoom,
+        gridSize: SNAP_GRID_CANVAS_PX,
+      }
+
+      if (gestureState.kind === 'resizing') {
+        // Only the node being resized is excluded — nothing else moves with a
+        // resize, so every other box stays a legitimate target.
+        const others = boxes
+          .filter((entry) => entry.id !== gestureState.nodeId)
+          .map((entry) => entry.box)
+        const sign = HANDLE_SIGN[gestureState.handle]
+        const start = gestureState.startBox
+        const guides: { x: number[]; y: number[] } = { x: [], y: [] }
+        let point = raw
+
+        // sign 0 means that axis is anchored (an edge handle moves one axis
+        // only), -1 the leading edge travels, +1 the trailing one.
+        if (sign.x !== 0) {
+          const dx = raw.x - gestureState.startPoint.x
+          const edge = sign.x === -1 ? start.x + dx : start.x + start.width + dx
+          const snapped = snapEdge(edge, others, options, 'x')
+          point = { ...point, x: raw.x + (snapped.position - edge) }
+          if (snapped.guide !== undefined) guides.x.push(snapped.guide)
+        }
+        if (sign.y !== 0) {
+          const dy = raw.y - gestureState.startPoint.y
+          const edge = sign.y === -1 ? start.y + dy : start.y + start.height + dy
+          const snapped = snapEdge(edge, others, options, 'y')
+          point = { ...point, y: raw.y + (snapped.position - edge) }
+          if (snapped.guide !== undefined) guides.y.push(snapped.guide)
+        }
+        return { point, guides }
+      }
+
+      if (gestureState.kind !== 'moving') return unchanged
       const moving = boxes.find((entry) => entry.id === gestureState.nodeId)
       if (moving === undefined) return unchanged
 
@@ -777,10 +816,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const result = snapBox(
         candidate,
         boxes.filter((entry) => !carried.has(entry.id)).map((entry) => entry.box),
-        {
-          thresholdCanvasPx: SNAP_THRESHOLD_SCREEN_PX / viewport.zoom,
-          gridSize: SNAP_GRID_CANVAS_PX,
-        },
+        options,
       )
       return {
         point: { x: raw.x + (result.x - candidate.x), y: raw.y + (result.y - candidate.y) },
@@ -1132,7 +1168,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         return
       }
       if (gestureState.kind === 'idle') return
-      const snapped = snapMovePoint(screenToCanvas(screenPoint, viewport), e.metaKey || e.ctrlKey)
+      const snapped = snapGesturePoint(
+        screenToCanvas(screenPoint, viewport),
+        e.metaKey || e.ctrlKey,
+      )
       setSnapGuides(snapped.guides)
       setLivePoint(snapped.point)
       applyResult(
@@ -1210,7 +1249,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const screenPoint = clientPointToRootLocal(e, root)
       // Snapped with the same helper the preview used, so the box commits
       // exactly where the last frame drew it.
-      const point = snapMovePoint(
+      const point = snapGesturePoint(
         screenToCanvas(screenPoint, viewport),
         e.metaKey || e.ctrlKey,
       ).point

--- a/apps/web/src/components/spatial-editor/snap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/snap.browser.test.tsx
@@ -186,3 +186,74 @@ it('DOES snap a group frame to a LOCKED member, which stays put', () => {
   // ...and the lock still holds: the member did not travel.
   expect(byId(latest.canvas, 'inner').x).toBe(412)
 })
+
+// Resizing snaps the DRAGGED EDGE. Handles are real DOM elements with their
+// own pointerdown — the root's handler never hit-tests them — so the press
+// must target the handle, not the editor root, or the gesture is a move.
+function startResize(container: HTMLElement, handleKind: string) {
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  // Select `b` first: handles only mount for the current selection.
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + 450,
+    clientY: r.top + 430,
+  })
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + 450, clientY: r.top + 430 })
+  const handle = container.querySelector(`[data-testid="resize-handle-${handleKind}"]`) as Element
+  expect(handle, `no ${handleKind} handle`).toBeTruthy()
+  return { root, r, handle }
+}
+
+it('snaps a resized edge to a neighbour edge, leaving the anchored edge alone', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const { root, r, handle } = startResize(container, 'w')
+
+  // West edge from 400 to 235: 2 from `a`\'s right edge at 237, 5 from the
+  // grid line at 240, so the neighbour wins.
+  fireEvent.pointerDown(handle, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 400,
+    clientY: r.top + 430,
+  })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 235, clientY: r.top + 430 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 235, clientY: r.top + 430 })
+
+  const b = byId(latest.canvas, 'b')
+  expect(b.x).toBe(237)
+  // The opposite edge is anchored by the gesture, so the width absorbs it all.
+  expect(b.x + b.width).toBe(500)
+  // The un-dragged axis must not move: a west handle resizes x only.
+  expect(b.y).toBe(400)
+  expect(b.height).toBe(60)
+})
+
+it('leaves a resized edge where the pointer stopped while Cmd is held', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const { root, r, handle } = startResize(container, 'w')
+
+  fireEvent.pointerDown(handle, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 400,
+    clientY: r.top + 430,
+  })
+  fireEvent.pointerMove(root, {
+    pointerId: 1,
+    clientX: r.left + 235,
+    clientY: r.top + 430,
+    metaKey: true,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 1,
+    clientX: r.left + 235,
+    clientY: r.top + 430,
+    metaKey: true,
+  })
+
+  expect(byId(latest.canvas, 'b').x).toBe(235)
+})

--- a/apps/web/src/components/spatial-editor/snap.test.ts
+++ b/apps/web/src/components/spatial-editor/snap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { type SnapBox, snapBox } from './snap.js'
+import { type SnapBox, snapBox, snapEdge } from './snap.js'
 
 const box = (x: number, y: number, width = 100, height = 60): SnapBox => ({ x, y, width, height })
 
@@ -119,5 +119,57 @@ describe('snapBox — totality', () => {
       guidesX: [],
       guidesY: [],
     })
+  })
+})
+
+describe('snapEdge — one dragged edge, not a whole box', () => {
+  // A resize moves an EDGE, so its only line is the edge itself. Reusing the
+  // move candidates would let the box's centre or far edge pull the handle,
+  // which reads as the handle fighting the pointer.
+  const other = box(100, 100, 100, 60) // x: 100 / 150 / 200, y: 100 / 130 / 160
+
+  it('pulls a near-miss edge onto a neighbour leading edge', () => {
+    expect(snapEdge(103, [other], NODE_ONLY, 'x')).toEqual({ position: 100, guide: 100 })
+  })
+
+  it('snaps to a neighbour trailing edge', () => {
+    expect(snapEdge(197, [other], NODE_ONLY, 'x')).toEqual({ position: 200, guide: 200 })
+  })
+
+  it('snaps to a neighbour centre', () => {
+    expect(snapEdge(148, [other], NODE_ONLY, 'x')).toEqual({ position: 150, guide: 150 })
+  })
+
+  it('projects the other axis when asked for y', () => {
+    expect(snapEdge(133, [other], NODE_ONLY, 'y')).toEqual({ position: 130, guide: 130 })
+    // The x lines must not leak into a y snap.
+    expect(snapEdge(203, [other], NODE_ONLY, 'y')).toEqual({ position: 203, guide: undefined })
+  })
+
+  it('falls back to the grid, which draws no guide', () => {
+    expect(snapEdge(503, [], WITH_GRID, 'x')).toEqual({ position: 500, guide: undefined })
+  })
+
+  it('prefers a neighbour over the grid at equal distance', () => {
+    expect(snapEdge(102, [box(104, 500)], WITH_GRID, 'x')).toEqual({ position: 104, guide: 104 })
+  })
+
+  it('leaves an edge alone when nothing is in range', () => {
+    expect(snapEdge(500, [other], NODE_ONLY, 'x')).toEqual({ position: 500, guide: undefined })
+  })
+
+  it('is total on degenerate input', () => {
+    expect(snapEdge(Number.NaN, [other], NODE_ONLY, 'x')).toEqual({
+      position: Number.NaN,
+      guide: undefined,
+    })
+    expect(snapEdge(103, [other], { thresholdCanvasPx: -1, gridSize: 10 }, 'x')).toEqual({
+      position: 103,
+      guide: undefined,
+    })
+    // A non-finite neighbour is skipped, not fatal.
+    expect(
+      snapEdge(103, [{ x: Number.NaN, y: 0, width: 1, height: 1 }, other], NODE_ONLY, 'x'),
+    ).toEqual({ position: 100, guide: 100 })
   })
 })

--- a/apps/web/src/components/spatial-editor/snap.ts
+++ b/apps/web/src/components/spatial-editor/snap.ts
@@ -67,17 +67,12 @@ function finiteBox(box: SnapBox): boolean {
  */
 function candidatesForAxis(
   start: number,
-  extent: number,
+  movingOffsets: readonly number[],
   others: readonly SnapBox[],
   options: SnapOptions,
   pick: (box: SnapBox) => { start: number; extent: number },
 ): Candidate[] {
   const candidates: Candidate[] = []
-
-  // The moving box offers three lines of its own: leading edge, centre and
-  // trailing edge. Matching centre-to-centre and edge-to-edge is what makes
-  // differently-sized boxes line up the way they look aligned.
-  const movingOffsets = [0, extent / 2, extent]
 
   for (const other of others) {
     if (!finiteBox(other)) continue
@@ -147,15 +142,18 @@ export function snapBox(
   if (!finiteBox(moving)) return noSnap
   if (!Number.isFinite(options.thresholdCanvasPx) || options.thresholdCanvasPx < 0) return noSnap
 
+  // A moving box offers three lines of its own — leading edge, centre and
+  // trailing edge. Matching centre-to-centre and edge-to-edge is what makes
+  // differently-sized boxes line up the way they look aligned.
   const xWinner = best(
-    candidatesForAxis(moving.x, moving.width, others, options, (box) => ({
+    candidatesForAxis(moving.x, [0, moving.width / 2, moving.width], others, options, (box) => ({
       start: box.x,
       extent: box.width,
     })),
     options.thresholdCanvasPx,
   )
   const yWinner = best(
-    candidatesForAxis(moving.y, moving.height, others, options, (box) => ({
+    candidatesForAxis(moving.y, [0, moving.height / 2, moving.height], others, options, (box) => ({
       start: box.y,
       extent: box.height,
     })),
@@ -168,4 +166,36 @@ export function snapBox(
     guidesX: xWinner?.guide === undefined ? [] : [xWinner.guide],
     guidesY: yWinner?.guide === undefined ? [] : [yWinner.guide],
   }
+}
+
+/**
+ * Snaps ONE dragged edge, for a resize.
+ *
+ * A resize moves an edge, not a whole box, so the edge is the only line the
+ * gesture offers — passing the move candidates here would let the box's own
+ * centre or far edge pull the handle, which reads as the handle fighting the
+ * pointer. That difference is why this is a separate entry point rather than
+ * `snapBox` with a zero-size box.
+ *
+ * The candidates it can land on are the same as for a move (a neighbour's
+ * leading edge, centre, or trailing edge, plus the grid), so a resized edge
+ * lines up with content the same way a moved one does.
+ */
+export function snapEdge(
+  position: number,
+  others: readonly SnapBox[],
+  options: SnapOptions,
+  axis: 'x' | 'y',
+): { position: number; guide: number | undefined } {
+  const unchanged = { position, guide: undefined }
+  if (!Number.isFinite(position)) return unchanged
+  if (!Number.isFinite(options.thresholdCanvasPx) || options.thresholdCanvasPx < 0) return unchanged
+
+  const winner = best(
+    candidatesForAxis(position, [0], others, options, (box) =>
+      axis === 'x' ? { start: box.x, extent: box.width } : { start: box.y, extent: box.height },
+    ),
+    options.thresholdCanvasPx,
+  )
+  return winner === undefined ? unchanged : { position: winner.origin, guide: winner.guide }
 }


### PR DESCRIPTION
Completes the deferral from #508: dragging a resize handle now snaps the edge under it, the same way dragging a box already snaps the box.

## Why a separate entry point

A resize moves an **edge**, not a box. Reusing the move candidates would let the box's own centre or far edge pull the handle, which reads as the handle fighting the pointer — that is why #508 deferred this rather than approximating it.

`snapEdge` is that entry point: one coordinate in, one snapped coordinate plus its guide out. What it can land on is unchanged (a neighbour's leading edge, centre or trailing edge, plus the grid), so a resized edge lines up with content exactly like a moved one.

`candidatesForAxis` now takes the moving lines as a parameter instead of deriving three from an extent — a move offers three, a resize offers one. That is what lets both share one candidate builder instead of forking it, and the move path's existing tests pass untouched.

## Wiring

`HANDLE_SIGN` says which edges the handle actually moves (`0` means that axis is anchored), each travelling edge goes through `snapEdge`, and the **pointer** is nudged by the difference — the same "adjust the pointer, not the command" rule the move path uses, so preview and commit cannot disagree.

Only the resized node is excluded from the candidates. Nothing else moves during a resize, so every other box stays a legitimate target — unlike a move, which must also exclude a multi-selection and a frame's carried members.

## A test correction worth recording

My first attempt fired `pointerdown` on the editor root at the handle's coordinates and got a **move**, which looked like the handle geometry was wrong. It was not.

Resize handles are real DOM elements with their own `onPointerDown` (`SelectionOverlay.tsx`), and the editor root's handler never hit-tests them — it only hit-tests node boxes. So a synthetic pointerdown on the root can only ever start a move, at any coordinates. The press has to target the handle element; the move and release still go to the root. (`SpatialEditor.browser.test.tsx` already used this pattern; I had not followed it.)

## Verification

`pnpm test` 590/590 files green (6260 passed), typecheck and knip clean. Mutation-checked: disabling the resize branch fails the snap assertion.

Manually verified in Chrome against the dev server — dragging a node's east edge to 1063 landed it on 1060. No guide line appeared in that particular case, correctly: the winning candidate was a grid line, and grid snaps deliberately draw no guide (there is no content to point at). I did not separately observe a resize snapping to a *neighbour* line in the manual pass; that path is covered by the automated browser test.
