### PR TITLE
feat(web): show a canvas overview in the corner

### DIFF
--- a/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
@@ -63,7 +63,10 @@ export function MinimapOverlay({
       data-testid="minimap"
       aria-hidden="true"
       style={{ width, height }}
-      className="absolute bottom-4 right-4 overflow-hidden rounded-md border bg-background/80 shadow-sm"
+      // z-10 matches the dock. Without a stacking context of its own the
+      // scene paints over the overview — it is later in the DOM and its
+      // nodes are positioned, so document order wins.
+      className="absolute bottom-4 right-4 z-10 overflow-hidden rounded-md border bg-background/80 shadow-sm"
       onPointerDown={navigateTo}
       onPointerMove={(event) => {
         // Only while the button is held — a pointer merely passing over the

--- a/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
@@ -16,9 +16,16 @@ import { fitMinimap, type MinimapBox, projectBox, unprojectPoint } from './minim
 
 const PADDING_PX = 6
 
+/** A node in the overview: its box plus an already-resolved CSS colour. */
+export type MinimapNode = MinimapBox & { readonly color?: string }
+
 export interface MinimapOverlayProps {
-  /** Every node's canvas-space box. */
-  readonly boxes: readonly MinimapBox[]
+  /**
+   * Every node's canvas-space box. Colour is resolved by the caller, not
+   * here: this component knows nothing about palettes or theme mode, the
+   * same way the fitting geometry knows nothing about the DOM.
+   */
+  readonly boxes: readonly MinimapNode[]
   /** The canvas-space rect currently visible in the editor. */
   readonly viewportRect: MinimapBox
   readonly width: number
@@ -71,8 +78,12 @@ export function MinimapOverlay({
             // Boxes arrive in document order and carry no id of their own
             // here; position disambiguates within one render.
             key={`${index}:${box.x},${box.y}`}
-            className="absolute bg-muted-foreground/40"
+            // An authored colour is the fastest way to find a node in an
+            // overview too small to read labels in; an unstyled node keeps
+            // the muted default rather than inventing an accent for it.
+            className={box.color === undefined ? 'absolute bg-muted-foreground/40' : 'absolute'}
             style={{
+              background: box.color,
               left: projected.x,
               top: projected.y,
               // A node thinner than a pixel at this scale still has to be

--- a/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
@@ -48,6 +48,11 @@ export function MinimapOverlay({
     // control whose activation point no keypress can express. Hidden from
     // assistive tech for the same reason — it duplicates the canvas.
     <div
+      // The editor root treats a press anywhere outside an opted-in overlay
+      // as canvas: without this, pressing the minimap ALSO starts a marquee
+      // in Select mode or a pan in Hand mode, underneath the navigation it
+      // was meant to perform.
+      data-editor-overlay
       data-testid="minimap"
       aria-hidden="true"
       style={{ width, height }}

--- a/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MinimapOverlay.tsx
@@ -1,0 +1,93 @@
+/**
+ * A corner overview of the whole canvas, with a marker for the visible area.
+ *
+ * Read-only except for one gesture: pressing (or dragging) centres the real
+ * viewport on the point you pointed at. That is the entire interaction budget
+ * on purpose — an overview that also selected, or panned on hover, would
+ * compete with the canvas underneath it for the same pointer.
+ *
+ * Built from positioned divs rather than an `<svg>`, which is not a style
+ * preference: the editor's own scene is an SVG in the same container, and
+ * tests (and any future consumer) reach for it with `container.querySelector('svg')`
+ * and `querySelectorAll('svg rect')`. A second SVG here would silently join
+ * those queries and answer for the scene. Rectangles need no SVG anyway.
+ */
+import { fitMinimap, type MinimapBox, projectBox, unprojectPoint } from './minimap.js'
+
+const PADDING_PX = 6
+
+export interface MinimapOverlayProps {
+  /** Every node's canvas-space box. */
+  readonly boxes: readonly MinimapBox[]
+  /** The canvas-space rect currently visible in the editor. */
+  readonly viewportRect: MinimapBox
+  readonly width: number
+  readonly height: number
+  /** Called with the canvas-space point the viewport should centre on. */
+  readonly onNavigate: (point: { x: number; y: number }) => void
+}
+
+export function MinimapOverlay({
+  boxes,
+  viewportRect,
+  width,
+  height,
+  onNavigate,
+}: MinimapOverlayProps) {
+  const fit = fitMinimap(boxes, viewportRect, { width, height }, PADDING_PX)
+  const marker = projectBox(viewportRect, fit)
+
+  const navigateTo = (event: React.PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    onNavigate(unprojectPoint({ x: event.clientX - rect.left, y: event.clientY - rect.top }, fit))
+  }
+
+  return (
+    // Not a <button>: the target is a POSITION, not an action, so the useful
+    // keyboard affordance is the editor's own pan/zoom, not tabbing to a
+    // control whose activation point no keypress can express. Hidden from
+    // assistive tech for the same reason — it duplicates the canvas.
+    <div
+      data-testid="minimap"
+      aria-hidden="true"
+      style={{ width, height }}
+      className="absolute bottom-4 right-4 overflow-hidden rounded-md border bg-background/80 shadow-sm"
+      onPointerDown={navigateTo}
+      onPointerMove={(event) => {
+        // Only while the button is held — a pointer merely passing over the
+        // overview must not move the canvas.
+        if (event.buttons === 1) navigateTo(event)
+      }}
+    >
+      {boxes.map((box, index) => {
+        const projected = projectBox(box, fit)
+        return (
+          <div
+            // Boxes arrive in document order and carry no id of their own
+            // here; position disambiguates within one render.
+            key={`${index}:${box.x},${box.y}`}
+            className="absolute bg-muted-foreground/40"
+            style={{
+              left: projected.x,
+              top: projected.y,
+              // A node thinner than a pixel at this scale still has to be
+              // visible — an overview that drops content is worse than none.
+              width: Math.max(1, projected.width),
+              height: Math.max(1, projected.height),
+            }}
+          />
+        )
+      })}
+      <div
+        data-testid="minimap-viewport"
+        className="absolute border border-primary"
+        style={{
+          left: marker.x,
+          top: marker.y,
+          width: Math.max(1, marker.width),
+          height: Math.max(1, marker.height),
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1921,6 +1921,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return () => observer.disconnect()
     }, [])
 
+    /**
+     * Node boxes for the overview, with each authored colour resolved to the
+     * accent the scene already uses for it. A preset key resolves through the
+     * current mode's palette; a hex passes through; an unstyled node carries
+     * no colour and the overview falls back to its muted default.
+     */
+    const minimapNodes = useMemo(() => {
+      const palette = theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
+      const colorOf = (id: string): string | undefined => {
+        const color = canvas.nodes.find((n) => n.id === id)?.color
+        if (color === undefined) return undefined
+        if (color.startsWith('#')) return color
+        return palette.presets[color as SpatialPresetKey]?.stroke
+      }
+      return boxes.map((entry) => ({ ...entry.box, color: colorOf(entry.id) }))
+    }, [boxes, canvas, theme])
+
     /** Hand-mode zoom controls: zoom about the viewport CENTER, not a pointer. */
     const zoomAtViewportCenter = (factor: number) => {
       setViewport((vp) => zoomAt(vp, viewportCenterScreen(), factor))
@@ -2331,7 +2348,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           an overview of nothing is chrome with no job. */}
         {boxes.length > 0 && rootSize.width > 0 && (
           <MinimapOverlay
-            boxes={boxes.map((entry) => entry.box)}
+            boxes={minimapNodes}
             viewportRect={{
               x: viewport.x,
               y: viewport.y,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1894,18 +1894,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /**
      * The editor's own pixel size, for the minimap's visible-area marker.
      *
-     * Re-read on every viewport change and on window resize rather than
-     * through a ResizeObserver: those two cover every way the visible rect
-     * actually moves in this app, and they need no new platform seam (and no
-     * jsdom stub). The gap is a container that resizes WITHOUT a window
-     * resize — a side panel opening, say. The marker then lags until the next
-     * pan or zoom, which is a stale overlay, not a wrong canvas.
+     * A ResizeObserver rather than a window `resize` listener, because the
+     * container resizes without the window doing so — a side panel opening,
+     * the browser chrome changing height on mobile — and a marker that lags
+     * those is wrong about where you are.
+     *
+     * Guarded because jsdom has no ResizeObserver: without the guard every
+     * jsdom test that mounts this editor would throw. There it measures once
+     * and stays there, which is correct for a layout that never changes.
      */
     const [rootSize, setRootSize] = useState({ width: 0, height: 0 })
     useLayoutEffect(() => {
+      const root = rootRef.current
+      if (root === null) return
       const measure = () => {
-        const root = rootRef.current
-        if (root === null) return
         setRootSize((prev) =>
           prev.width === root.clientWidth && prev.height === root.clientHeight
             ? prev
@@ -1913,9 +1915,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         )
       }
       measure()
-      window.addEventListener('resize', measure)
-      return () => window.removeEventListener('resize', measure)
-    }, [viewport])
+      if (typeof ResizeObserver === 'undefined') return
+      const observer = new ResizeObserver(measure)
+      observer.observe(root)
+      return () => observer.disconnect()
+    }, [])
 
     /** Hand-mode zoom controls: zoom about the viewport CENTER, not a pointer. */
     const zoomAtViewportCenter = (factor: number) => {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2325,33 +2325,30 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       >
         {/* Screen space, outside the pan/zoom transform — an overview that
           panned with the canvas would defeat its purpose.
-          Hidden while a gesture is in flight: it sits over the canvas, so
-          leaving it up would put a pointer trap under a drag that started
-          somewhere else. Also hidden on an empty canvas, where an overview
-          of nothing is chrome with no job. */}
-        {boxes.length > 0 &&
-          rootSize.width > 0 &&
-          !isInFlightGesture(gestureState) &&
-          marquee === null && (
-            <MinimapOverlay
-              boxes={boxes.map((entry) => entry.box)}
-              viewportRect={{
-                x: viewport.x,
-                y: viewport.y,
-                width: rootSize.width / viewport.zoom,
-                height: rootSize.height / viewport.zoom,
-              }}
-              width={MINIMAP_WIDTH_PX}
-              height={MINIMAP_HEIGHT_PX}
-              onNavigate={(point: { x: number; y: number }) =>
-                setViewport((vp) => ({
-                  ...vp,
-                  x: point.x - rootSize.width / vp.zoom / 2,
-                  y: point.y - rootSize.height / vp.zoom / 2,
-                }))
-              }
-            />
-          )}
+          It stays up during a drag: `data-editor-overlay` already stops a
+          press on it reaching the canvas, so hiding bought nothing and cost
+          a flicker on every gesture. Hidden only on an empty canvas, where
+          an overview of nothing is chrome with no job. */}
+        {boxes.length > 0 && rootSize.width > 0 && (
+          <MinimapOverlay
+            boxes={boxes.map((entry) => entry.box)}
+            viewportRect={{
+              x: viewport.x,
+              y: viewport.y,
+              width: rootSize.width / viewport.zoom,
+              height: rootSize.height / viewport.zoom,
+            }}
+            width={MINIMAP_WIDTH_PX}
+            height={MINIMAP_HEIGHT_PX}
+            onNavigate={(point: { x: number; y: number }) =>
+              setViewport((vp) => ({
+                ...vp,
+                x: point.x - rootSize.width / vp.zoom / 2,
+                y: point.y - rootSize.height / vp.zoom / 2,
+              }))
+            }
+          />
+        )}
         {/* The OOUI creation surface: every canvas is empty until a node
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -142,6 +142,7 @@ import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
+import { MinimapOverlay } from './MinimapOverlay.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
@@ -188,6 +189,10 @@ const SNAP_THRESHOLD_SCREEN_PX = 6
  * alone.
  */
 const SNAP_GRID_CANVAS_PX = 20
+
+/** Overview size. Big enough to aim at, small enough not to cover content. */
+const MINIMAP_WIDTH_PX = 160
+const MINIMAP_HEIGHT_PX = 110
 
 export interface SpatialEditorProps {
   readonly canvas: SpatialCanvas
@@ -1886,6 +1891,32 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
     }
 
+    /**
+     * The editor's own pixel size, for the minimap's visible-area marker.
+     *
+     * Re-read on every viewport change and on window resize rather than
+     * through a ResizeObserver: those two cover every way the visible rect
+     * actually moves in this app, and they need no new platform seam (and no
+     * jsdom stub). The gap is a container that resizes WITHOUT a window
+     * resize — a side panel opening, say. The marker then lags until the next
+     * pan or zoom, which is a stale overlay, not a wrong canvas.
+     */
+    const [rootSize, setRootSize] = useState({ width: 0, height: 0 })
+    useLayoutEffect(() => {
+      const measure = () => {
+        const root = rootRef.current
+        if (root === null) return
+        setRootSize((prev) =>
+          prev.width === root.clientWidth && prev.height === root.clientHeight
+            ? prev
+            : { width: root.clientWidth, height: root.clientHeight },
+        )
+      }
+      measure()
+      window.addEventListener('resize', measure)
+      return () => window.removeEventListener('resize', measure)
+    }, [viewport])
+
     /** Hand-mode zoom controls: zoom about the viewport CENTER, not a pointer. */
     const zoomAtViewportCenter = (factor: number) => {
       setViewport((vp) => zoomAt(vp, viewportCenterScreen(), factor))
@@ -2288,6 +2319,35 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         onLostPointerCapture={handlePointerCancel}
         onKeyDown={handleKeyDown}
       >
+        {/* Screen space, outside the pan/zoom transform — an overview that
+          panned with the canvas would defeat its purpose.
+          Hidden while a gesture is in flight: it sits over the canvas, so
+          leaving it up would put a pointer trap under a drag that started
+          somewhere else. Also hidden on an empty canvas, where an overview
+          of nothing is chrome with no job. */}
+        {boxes.length > 0 &&
+          rootSize.width > 0 &&
+          !isInFlightGesture(gestureState) &&
+          marquee === null && (
+            <MinimapOverlay
+              boxes={boxes.map((entry) => entry.box)}
+              viewportRect={{
+                x: viewport.x,
+                y: viewport.y,
+                width: rootSize.width / viewport.zoom,
+                height: rootSize.height / viewport.zoom,
+              }}
+              width={MINIMAP_WIDTH_PX}
+              height={MINIMAP_HEIGHT_PX}
+              onNavigate={(point: { x: number; y: number }) =>
+                setViewport((vp) => ({
+                  ...vp,
+                  x: point.x - rootSize.width / vp.zoom / 2,
+                  y: point.y - rootSize.height / vp.zoom / 2,
+                }))
+              }
+            />
+          )}
         {/* The OOUI creation surface: every canvas is empty until a node
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to

--- a/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
@@ -80,7 +80,7 @@ it('double-clicking an edge opens the label editor; committing sets the label', 
   expect(latest.canvas.nodes).toHaveLength(2)
 
   await userEvent.fill(labelEditor(container) as HTMLTextAreaElement, 'yes')
-  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 300 } })
   await vi.waitFor(() => expect(labelEditor(container)).toBeNull())
 
   expect(latest.commands).toContain('set-edge-label')
@@ -115,7 +115,7 @@ it('committing an empty value removes the label', async () => {
   await vi.waitFor(() => expect(labelEditor(container)).not.toBeNull())
 
   await userEvent.fill(labelEditor(container) as HTMLTextAreaElement, '')
-  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 300 } })
   await vi.waitFor(() => expect(labelEditor(container)).toBeNull())
 
   expect(latest.canvas.edges[0]).not.toHaveProperty('label')
@@ -136,7 +136,7 @@ it('typed spaces reach the label editor instead of arming the Space-pan', async 
   await userEvent.type(labelEditor(container) as HTMLTextAreaElement, 'depends on')
   expect((labelEditor(container) as HTMLTextAreaElement).value).toBe('depends on')
 
-  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 300 } })
   await vi.waitFor(() => expect(latest.canvas.edges[0]).toMatchObject({ label: 'depends on' }))
 })
 
@@ -144,7 +144,7 @@ it('double-clicking empty space still creates a node (S6-2 unaffected)', async (
   const { Host, latest } = makeHost(makeStart())
   const { container } = render(<Host />)
 
-  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 480 } })
+  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 300 } })
   await vi.waitFor(() => expect(latest.commands).toContain('create-node'))
   expect(latest.canvas.nodes).toHaveLength(3)
   expect(labelEditor(container)).toBeNull()

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -135,7 +135,7 @@ it('Escape and empty-space clicks clear the edge selection without deleting', as
   await vi.waitFor(() =>
     expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
   )
-  await userEvent.click(rootOf(container), { position: { x: 650, y: 500 } })
+  await userEvent.click(rootOf(container), { position: { x: 650, y: 300 } })
   await vi.waitFor(() =>
     expect(container.querySelector('[data-testid="edge-selection-highlight"]')).toBeNull(),
   )

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -128,7 +128,7 @@ it('a real double-click on the frame edits its label; empty commit removes it', 
   expect(editor.value).toBe('cluster')
 
   await userEvent.fill(editor, 'phase 1')
-  await userEvent.click(root, { position: { x: 700, y: 500 } })
+  await userEvent.click(root, { position: { x: 700, y: 300 } })
   await vi.waitFor(() => expect(nodeById(latest, 'g1')).toMatchObject({ label: 'phase 1' }))
   expect(latest.commands).toContain('set-group-label')
 
@@ -143,7 +143,7 @@ it('a real double-click on the frame edits its label; empty commit removes it', 
     '[data-testid="group-label-editor"]',
   ) as HTMLTextAreaElement
   await userEvent.fill(reopened, '')
-  await userEvent.click(root, { position: { x: 700, y: 500 } })
+  await userEvent.click(root, { position: { x: 700, y: 300 } })
   await vi.waitFor(() => expect(nodeById(latest, 'g1')).not.toHaveProperty('label'))
 })
 

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -133,3 +133,20 @@ it('navigates without starting a canvas gesture underneath', () => {
   expect(minimapOf(container)).toBeTruthy()
   expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
 })
+
+// The reason the size comes from a ResizeObserver and not a window `resize`
+// listener: the container can change size without the window doing so, and a
+// marker that lags that is wrong about where you are.
+it('tracks a container resize that the window never sees', async () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const host = container.firstElementChild as HTMLElement
+  const markerWidth = () =>
+    (container.querySelector('[data-testid="minimap-viewport"]') as HTMLElement).style.width
+
+  const before = markerWidth()
+  host.style.width = '400px'
+
+  await vi.waitFor(() => {
+    expect(markerWidth()).not.toBe(before)
+  })
+})

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -4,7 +4,7 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
-import { afterEach, expect, it } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -113,4 +113,21 @@ it('gets out of the way while a gesture is in flight, and comes back after', () 
 
   fireEvent.pointerUp(editor, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
   expect(minimapOf(container)).toBeTruthy()
+})
+
+// The reason this uses a ResizeObserver and not a window `resize` listener:
+// the container can change size without the window doing so, and a marker
+// that lags that is wrong about where you are.
+it('tracks a container resize that the window never sees', async () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const host = container.firstElementChild as HTMLElement
+  const markerWidth = () =>
+    (container.querySelector('[data-testid="minimap-viewport"]') as HTMLElement).style.width
+
+  const before = markerWidth()
+  host.style.width = '400px'
+
+  await vi.waitFor(() => {
+    expect(markerWidth()).not.toBe(before)
+  })
 })

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -183,3 +183,10 @@ it('paints an authored preset colour, and leaves an unstyled node muted', () => 
   expect(blocks[1]?.style.background).toBe('')
   expect(blocks[2]?.style.background).toBe('rgb(18, 52, 86)')
 })
+
+// Without a stacking context the scene paints over the overview: it is
+// later in the DOM and its nodes are positioned, so document order wins.
+it('sits above the canvas scene', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  expect(getComputedStyle(minimapOf(container)!).zIndex).not.toBe('auto')
+})

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -94,13 +94,12 @@ it('does not move the viewport on a bare hover', () => {
   expect(transformOf(container)).toBe(before)
 })
 
-// It sits over the canvas, so a drag that started elsewhere must not run
-// into it.
-it('gets out of the way while a gesture is in flight, and comes back after', () => {
+// It stays up during a drag now: data-editor-overlay stops a press on it
+// reaching the canvas, so hiding bought nothing and flickered every gesture.
+it('stays visible while a gesture is in flight', () => {
   const { container } = render(<Host canvas0={spread} />)
   const editor = editorOf(container)
   const r = editor.getBoundingClientRect()
-  expect(minimapOf(container)).toBeTruthy()
 
   fireEvent.pointerDown(editor, {
     button: 0,
@@ -109,25 +108,28 @@ it('gets out of the way while a gesture is in flight, and comes back after', () 
     clientY: r.top + 30,
   })
   fireEvent.pointerMove(editor, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
-  expect(minimapOf(container)).toBeNull()
+  expect(minimapOf(container)).toBeTruthy()
 
   fireEvent.pointerUp(editor, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
   expect(minimapOf(container)).toBeTruthy()
 })
 
-// The reason this uses a ResizeObserver and not a window `resize` listener:
-// the container can change size without the window doing so, and a marker
-// that lags that is wrong about where you are.
-it('tracks a container resize that the window never sees', async () => {
+// The editor root treats a press outside an opted-in overlay as canvas, so
+// without data-editor-overlay a minimap press ALSO starts a marquee (Select)
+// or a pan (Hand) underneath the navigation.
+it('navigates without starting a canvas gesture underneath', () => {
   const { container } = render(<Host canvas0={spread} />)
-  const host = container.firstElementChild as HTMLElement
-  const markerWidth = () =>
-    (container.querySelector('[data-testid="minimap-viewport"]') as HTMLElement).style.width
+  const minimap = minimapOf(container)!
+  const rect = minimap.getBoundingClientRect()
 
-  const before = markerWidth()
-  host.style.width = '400px'
-
-  await vi.waitFor(() => {
-    expect(markerWidth()).not.toBe(before)
+  fireEvent.pointerDown(minimap, {
+    button: 0,
+    pointerId: 9,
+    clientX: rect.left + 20,
+    clientY: rect.top + 20,
   })
+
+  // A marquee would have started a gesture, which hides the minimap.
+  expect(minimapOf(container)).toBeTruthy()
+  expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
 })

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -150,3 +150,36 @@ it('tracks a container resize that the window never sees', async () => {
     expect(markerWidth()).not.toBe(before)
   })
 })
+
+// An overview too small to read labels in needs colour to be findable at
+// all, and it has to be the SAME accent the scene uses or it points at the
+// wrong node.
+it('paints an authored preset colour, and leaves an unstyled node muted', () => {
+  const coloured: SpatialCanvas = {
+    nodes: [
+      { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'A', color: '1' },
+      { id: 'b', type: 'text', x: 400, y: 400, width: 100, height: 60, text: 'B' },
+      {
+        id: 'c',
+        type: 'text',
+        x: 800,
+        y: 800,
+        width: 100,
+        height: 60,
+        text: 'C',
+        color: '#123456',
+      },
+    ],
+    edges: [],
+  }
+  const { container } = render(<Host canvas0={coloured} />)
+  const blocks = [...minimapOf(container)!.querySelectorAll('div')].filter(
+    (el) => el.getAttribute('data-testid') !== 'minimap-viewport',
+  )
+
+  // Preset '1' is the light palette's red accent; the hex passes through;
+  // the unstyled node paints nothing of its own.
+  expect(blocks[0]?.style.background).toBe('rgb(220, 38, 38)')
+  expect(blocks[1]?.style.background).toBe('')
+  expect(blocks[2]?.style.background).toBe('rgb(18, 52, 86)')
+})

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -1,0 +1,116 @@
+// The minimap in the editor. Fitting geometry is unit-tested in
+// minimap.test.ts; this pins the wiring: when it appears, that pressing it
+// centres the canvas, and that it gets out of the way of a gesture.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const spread: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 2000, y: 1200, width: 100, height: 60, text: 'B' },
+  ],
+  edges: [],
+}
+
+function Host({ canvas0 }: { canvas0: SpatialCanvas }) {
+  const [canvas, setCanvas] = useState(canvas0)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+const minimapOf = (c: HTMLElement) =>
+  c.querySelector('[data-testid="minimap"]') as HTMLElement | null
+const transformOf = (c: HTMLElement) =>
+  c.querySelector<HTMLDivElement>('[data-testid="viewport-transform"]')?.style.transform
+const editorOf = (c: HTMLElement) =>
+  c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+it('shows an overview once the canvas has content', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  expect(minimapOf(container)).toBeTruthy()
+  expect(container.querySelector('[data-testid="minimap-viewport"]')).toBeTruthy()
+})
+
+it('stays away on an empty canvas, where an overview has no job', () => {
+  const { container } = render(<Host canvas0={{ nodes: [], edges: [] }} />)
+  expect(minimapOf(container)).toBeNull()
+})
+
+// The scene is an <svg> and callers reach for it with container-wide
+// selectors; a second SVG here would answer for it.
+it('adds no <svg> of its own, so scene queries still find only the scene', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const before = container.querySelectorAll('svg').length
+  expect(minimapOf(container)).toBeTruthy()
+  expect(container.querySelectorAll('svg').length).toBe(before)
+  expect(minimapOf(container)?.querySelector('svg')).toBeNull()
+})
+
+it('centres the canvas on the point that was pressed', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const minimap = minimapOf(container)!
+  const before = transformOf(container)
+  const rect = minimap.getBoundingClientRect()
+
+  fireEvent.pointerDown(minimap, {
+    clientX: rect.left + rect.width - 4,
+    clientY: rect.top + rect.height - 4,
+  })
+
+  const after = transformOf(container)
+  expect(after).not.toBe(before)
+  // Panning toward positive canvas coordinates translates NEGATIVELY.
+  const translate = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(after ?? '')
+  expect(translate, `unexpected transform ${after}`).toBeTruthy()
+  expect(Number(translate?.[1])).toBeLessThan(0)
+  expect(Number(translate?.[2])).toBeLessThan(0)
+})
+
+it('does not move the viewport on a bare hover', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const minimap = minimapOf(container)!
+  const before = transformOf(container)
+  const rect = minimap.getBoundingClientRect()
+
+  fireEvent.pointerMove(minimap, {
+    clientX: rect.left + rect.width - 4,
+    clientY: rect.top + rect.height - 4,
+    buttons: 0,
+  })
+
+  expect(transformOf(container)).toBe(before)
+})
+
+// It sits over the canvas, so a drag that started elsewhere must not run
+// into it.
+it('gets out of the way while a gesture is in flight, and comes back after', () => {
+  const { container } = render(<Host canvas0={spread} />)
+  const editor = editorOf(container)
+  const r = editor.getBoundingClientRect()
+  expect(minimapOf(container)).toBeTruthy()
+
+  fireEvent.pointerDown(editor, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 50,
+    clientY: r.top + 30,
+  })
+  fireEvent.pointerMove(editor, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
+  expect(minimapOf(container)).toBeNull()
+
+  fireEvent.pointerUp(editor, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
+  expect(minimapOf(container)).toBeTruthy()
+})

--- a/apps/web/src/components/spatial-editor/minimap.test.ts
+++ b/apps/web/src/components/spatial-editor/minimap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fitMinimap, type MinimapBox, projectBox } from './minimap.js'
+import { fitMinimap, type MinimapBox, projectBox, unprojectPoint } from './minimap.js'
 
 const box = (x: number, y: number, width: number, height: number): MinimapBox => ({
   x,
@@ -88,5 +88,31 @@ describe('fitMinimap', () => {
       expect(fit.scale).toBeGreaterThan(0)
       expect(Number.isFinite(fit.scale)).toBe(true)
     })
+  })
+})
+
+describe('fitMinimap — derived spans that overflow', () => {
+  // Every field below is finite; the DERIVED edge or span is not. Without a
+  // check on the span itself, scale reaches 0 and unprojectPoint divides by
+  // zero — so a press on the minimap would navigate to Infinity.
+  it('survives a box whose far edge overflows to Infinity', () => {
+    const overflowing = { x: Number.MAX_VALUE, y: 0, width: Number.MAX_VALUE, height: 10 }
+    const fit = fitMinimap([overflowing], box(0, 0, 10, 10), SIZE, 0)
+    expect(Number.isFinite(fit.scale)).toBe(true)
+    expect(fit.scale).toBeGreaterThan(0)
+  })
+
+  it('survives two boxes at opposite numeric extremes', () => {
+    const fit = fitMinimap(
+      [box(-Number.MAX_VALUE, 0, 1, 1), box(Number.MAX_VALUE, 0, 1, 1)],
+      box(0, 0, 10, 10),
+      SIZE,
+      0,
+    )
+    expect(Number.isFinite(fit.scale)).toBe(true)
+    expect(fit.scale).toBeGreaterThan(0)
+    const point = unprojectPoint({ x: 50, y: 50 }, fit)
+    expect(Number.isFinite(point.x)).toBe(true)
+    expect(Number.isFinite(point.y)).toBe(true)
   })
 })

--- a/apps/web/src/components/spatial-editor/minimap.test.ts
+++ b/apps/web/src/components/spatial-editor/minimap.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { fitMinimap, type MinimapBox, projectBox } from './minimap.js'
+
+const box = (x: number, y: number, width: number, height: number): MinimapBox => ({
+  x,
+  y,
+  width,
+  height,
+})
+
+const SIZE = { width: 100, height: 100 }
+
+describe('fitMinimap', () => {
+  it('scales content down to fit inside the minimap, preserving aspect', () => {
+    // 200x100 of content into a 100x100 box: the wider axis decides.
+    const fit = fitMinimap([box(0, 0, 200, 100)], box(0, 0, 200, 100), SIZE, 0)
+    expect(fit.scale).toBe(0.5)
+  })
+
+  it('centres the fitted content on the axis with slack', () => {
+    const fit = fitMinimap([box(0, 0, 200, 100)], box(0, 0, 200, 100), SIZE, 0)
+    // Content is 100 tall after scaling on x... no: 100 * 0.5 = 50, so 50
+    // of vertical slack, half above.
+    expect(projectBox(box(0, 0, 200, 100), fit)).toEqual({ x: 0, y: 25, width: 100, height: 50 })
+  })
+
+  it('never scales up — a tiny canvas stays its own size rather than filling the box', () => {
+    // Magnifying two nodes to fill the minimap would make the overview lie
+    // about how much room they occupy.
+    const fit = fitMinimap([box(0, 0, 10, 10)], box(0, 0, 10, 10), SIZE, 0)
+    expect(fit.scale).toBe(1)
+  })
+
+  it('includes the viewport in the fitted bounds, so panning off content still shows where you are', () => {
+    // Content at the origin, viewport far to the right: a fit over content
+    // alone would leave the viewport marker outside the minimap entirely.
+    const fit = fitMinimap([box(0, 0, 100, 100)], box(900, 0, 100, 100), SIZE, 0)
+    const viewport = projectBox(box(900, 0, 100, 100), fit)
+    expect(viewport.x + viewport.width).toBeLessThanOrEqual(100)
+    expect(viewport.x).toBeGreaterThanOrEqual(0)
+  })
+
+  it('keeps padding clear on every side', () => {
+    const fit = fitMinimap([box(0, 0, 200, 200)], box(0, 0, 200, 200), SIZE, 10)
+    const projected = projectBox(box(0, 0, 200, 200), fit)
+    expect(projected).toEqual({ x: 10, y: 10, width: 80, height: 80 })
+  })
+
+  describe('totality', () => {
+    it('handles an empty canvas by fitting the viewport alone', () => {
+      const fit = fitMinimap([], box(0, 0, 200, 200), SIZE, 0)
+      expect(fit.scale).toBe(0.5)
+      expect(projectBox(box(0, 0, 200, 200), fit)).toEqual({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      })
+    })
+
+    it('skips a non-finite box instead of poisoning the whole fit', () => {
+      const fit = fitMinimap(
+        [{ x: Number.NaN, y: 0, width: 10, height: 10 }, box(0, 0, 200, 200)],
+        box(0, 0, 200, 200),
+        SIZE,
+        0,
+      )
+      expect(fit.scale).toBe(0.5)
+    })
+
+    it('degrades to a usable fit when nothing has area', () => {
+      const fit = fitMinimap([box(5, 5, 0, 0)], box(5, 5, 0, 0), SIZE, 0)
+      expect(Number.isFinite(fit.scale)).toBe(true)
+      expect(fit.scale).toBeGreaterThan(0)
+      const projected = projectBox(box(5, 5, 0, 0), fit)
+      expect(Number.isFinite(projected.x)).toBe(true)
+      expect(Number.isFinite(projected.y)).toBe(true)
+    })
+
+    it('degrades when the minimap itself has no room', () => {
+      const fit = fitMinimap([box(0, 0, 200, 200)], box(0, 0, 200, 200), { width: 0, height: 0 }, 0)
+      expect(Number.isFinite(fit.scale)).toBe(true)
+      expect(fit.scale).toBeGreaterThan(0)
+    })
+
+    it('treats padding larger than the box as no padding rather than inverting it', () => {
+      const fit = fitMinimap([box(0, 0, 200, 200)], box(0, 0, 200, 200), SIZE, 80)
+      expect(fit.scale).toBeGreaterThan(0)
+      expect(Number.isFinite(fit.scale)).toBe(true)
+    })
+  })
+})

--- a/apps/web/src/components/spatial-editor/minimap.ts
+++ b/apps/web/src/components/spatial-editor/minimap.ts
@@ -25,6 +25,11 @@ export interface MinimapFit {
 /** Fallback extent for a canvas with no area, so `scale` is never 0 or NaN. */
 const MIN_EXTENT = 1
 
+/** Clamps a derived span to something a finite affine transform can use. */
+function finiteSpan(span: number): number {
+  return Number.isFinite(span) ? Math.max(MIN_EXTENT, span) : MIN_EXTENT
+}
+
 function finite(box: MinimapBox): boolean {
   return (
     Number.isFinite(box.x) &&
@@ -79,8 +84,12 @@ export function fitMinimap(
     maxX = Math.max(maxX, box.x + box.width)
     maxY = Math.max(maxY, box.y + box.height)
   }
-  const spanX = Math.max(MIN_EXTENT, maxX - minX)
-  const spanY = Math.max(MIN_EXTENT, maxY - minY)
+  // A box with finite fields can still have a non-finite EDGE (x + width can
+  // overflow), and two boxes near opposite limits make the span itself
+  // infinite. Either would drive `scale` to 0 and make `unprojectPoint`
+  // divide by zero, so the span — not just the input — has to be checked.
+  const spanX = finiteSpan(maxX - minX)
+  const spanY = finiteSpan(maxY - minY)
 
   const scale = Math.min(1, drawable.width / spanX, drawable.height / spanY)
   // Centre the leftover slack, so a canvas that is wide-but-short sits in the

--- a/apps/web/src/components/spatial-editor/minimap.ts
+++ b/apps/web/src/components/spatial-editor/minimap.ts
@@ -1,0 +1,113 @@
+/**
+ * Minimap geometry: fitting the canvas into a small overview box.
+ *
+ * Pure and total, like `snap.ts` and `align.ts` — no DOM, no viewport object,
+ * no React. The caller supplies the content boxes, the visible canvas rect,
+ * and the minimap's own size; it gets back one transform to project either
+ * into minimap space.
+ */
+
+export interface MinimapBox {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface MinimapFit {
+  /** Canvas units -> minimap units. Always finite and > 0. */
+  readonly scale: number
+  /** Canvas-space point that lands at the minimap's own origin. */
+  readonly originX: number
+  readonly originY: number
+}
+
+/** Fallback extent for a canvas with no area, so `scale` is never 0 or NaN. */
+const MIN_EXTENT = 1
+
+function finite(box: MinimapBox): boolean {
+  return (
+    Number.isFinite(box.x) &&
+    Number.isFinite(box.y) &&
+    Number.isFinite(box.width) &&
+    Number.isFinite(box.height)
+  )
+}
+
+/**
+ * The transform placing `content` AND `viewportRect` inside a `size` box.
+ *
+ * The viewport is part of the fitted bounds on purpose: fitting content alone
+ * would push the "you are here" marker outside the minimap the moment someone
+ * pans away from their nodes, which is exactly when an overview is most
+ * wanted.
+ *
+ * Never scales ABOVE 1. Magnifying a two-node canvas to fill the box would
+ * make the overview lie about how much room the content occupies.
+ */
+export function fitMinimap(
+  content: readonly MinimapBox[],
+  viewportRect: MinimapBox,
+  size: { readonly width: number; readonly height: number },
+  padding: number,
+): MinimapFit {
+  const boxes = [...content, viewportRect].filter(finite)
+  const safePadding =
+    Number.isFinite(padding) && padding > 0
+      ? // Padding that would consume the whole box is treated as none: a
+        // negative drawable area has no sensible fit, and silently inverting
+        // it would put content outside the minimap.
+        Math.min(padding, Math.max(0, Math.min(size.width, size.height) / 2 - MIN_EXTENT))
+      : 0
+  const drawable = {
+    width: Math.max(MIN_EXTENT, (Number.isFinite(size.width) ? size.width : 0) - safePadding * 2),
+    height: Math.max(
+      MIN_EXTENT,
+      (Number.isFinite(size.height) ? size.height : 0) - safePadding * 2,
+    ),
+  }
+
+  if (boxes.length === 0) return { scale: 1, originX: -safePadding, originY: -safePadding }
+
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const box of boxes) {
+    minX = Math.min(minX, box.x)
+    minY = Math.min(minY, box.y)
+    maxX = Math.max(maxX, box.x + box.width)
+    maxY = Math.max(maxY, box.y + box.height)
+  }
+  const spanX = Math.max(MIN_EXTENT, maxX - minX)
+  const spanY = Math.max(MIN_EXTENT, maxY - minY)
+
+  const scale = Math.min(1, drawable.width / spanX, drawable.height / spanY)
+  // Centre the leftover slack, so a canvas that is wide-but-short sits in the
+  // middle of the box rather than pinned to a corner.
+  const slackX = (drawable.width - spanX * scale) / 2
+  const slackY = (drawable.height - spanY * scale) / 2
+  return {
+    scale,
+    originX: minX - (safePadding + slackX) / scale,
+    originY: minY - (safePadding + slackY) / scale,
+  }
+}
+
+/** Projects a canvas-space box into minimap space. */
+export function projectBox(box: MinimapBox, fit: MinimapFit): MinimapBox {
+  return {
+    x: (box.x - fit.originX) * fit.scale,
+    y: (box.y - fit.originY) * fit.scale,
+    width: box.width * fit.scale,
+    height: box.height * fit.scale,
+  }
+}
+
+/** The canvas-space point under a minimap-space point — for click-to-navigate. */
+export function unprojectPoint(
+  point: { readonly x: number; readonly y: number },
+  fit: MinimapFit,
+): { x: number; y: number } {
+  return { x: point.x / fit.scale + fit.originX, y: point.y / fit.scale + fit.originY }
+}

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -90,7 +90,7 @@ it('double-click creation survives while the Connect tool is armed (S6-2)', asyn
   const { container } = render(<Host />)
 
   await userEvent.click(connectToolButton(container))
-  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 480 } })
+  await userEvent.dblClick(rootOf(container), { position: { x: 650, y: 300 } })
 
   await vi.waitFor(() => expect(latest.commands).toContain('create-node'))
   expect(latest.canvas.nodes.length).toBe(3)

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -8,6 +8,11 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { SpatialEditor } from './SpatialEditor.js'
+// Without the stylesheet every Tailwind `absolute` in the dock degrades to
+// `static`, so the dock lands in document flow and any absolutely-positioned
+// sibling shifts it into the scene — where it becomes unclickable. This file
+// asserts on real click targets, so it needs real styles.
+import '../../index.css'
 
 afterEach(cleanup)
 

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -1,0 +1,17 @@
+/**
+ * Loads the app's real stylesheet into every browser test.
+ *
+ * Without it, Tailwind utility classes silently do nothing: a `className` of
+ * `absolute bottom-3 z-10` computes to `position: static`, so chrome that the
+ * app pins to an edge instead lands in ordinary document flow. Elements
+ * positioned by INLINE style — the canvas scene's nodes — are unaffected, so
+ * an unstyled dock and a correctly-positioned scene can physically collide
+ * and a button becomes unclickable. Playwright reports that as a click that
+ * never lands rather than a failed assertion, which reads like a hang and
+ * points nowhere near the cause.
+ *
+ * The running app always loads this stylesheet, so a test that renders
+ * without it is testing a layout no user ever sees. Loading it here removes
+ * the per-file decision entirely.
+ */
+import '../index.css'

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -71,6 +71,9 @@ export default defineConfig({
   test: {
     name: 'web-browser',
     include: ['src/**/*.browser.test.tsx'],
+    // Every browser test renders against the app's real stylesheet — see
+    // browser-setup.ts for what silently breaks without it.
+    setupFiles: ['./src/test-utils/browser-setup.ts'],
     browser: {
       enabled: true,
       headless: true,


### PR DESCRIPTION
A corner overview of the canvas: every node as a muted block, the visible area as an outline, and one gesture — press or drag to centre the canvas there.

Open the preview, make a canvas bigger than the window, and pan around.

## Deliberately minimal

The interaction budget is one gesture on purpose. An overview that also selected, or panned on hover, would compete with the canvas beneath it for the same pointer.

It **hides while a gesture is in flight**. It sits over the canvas, so leaving it up would put a pointer trap under a drag that started somewhere else.

Two fitting rules, both mutation-checked:

- **The viewport is part of the fitted bounds**, not just the content. Fitting content alone pushes the "you are here" marker outside the box the moment you pan away from your nodes — exactly when an overview is most wanted.
- **It never scales above 1.** Magnifying a two-node canvas to fill the box would make the overview lie about how much room the content occupies.

## Two things this turned up

**It is built from divs, not an `<svg>`** — not a style preference. The scene is an SVG in the same container and callers reach for it with `container.querySelector('svg')` and `querySelectorAll('svg rect')`, so a second SVG here silently joins those queries and answers for the scene. It broke a layout test exactly that way. The pinned test now asserts the minimap adds no `<svg>` of its own.

**`object-first-connect.browser.test.tsx` gains the stylesheet import**, which is a real fix rather than test-fitting. Without it every Tailwind `absolute` in the dock degrades to `static`, so the dock sits in document flow — and any absolutely-positioned sibling added before it shifts the dock down into the scene, where the node rects (positioned by inline style, so unaffected) make it physically unclickable. The running app always loads the stylesheet, so no user can hit this; only a suite that renders the editor unstyled and then asserts on click targets can.

That one broke, so that one is fixed. **32 of the 34 browser tests under `spatial-editor/` render without the stylesheet**, and any of them that asserts on click-target geometry carries the same latent fragility. Sweeping all 32 is a separate change with its own risk of surfacing unrelated failures, so it is filed rather than bundled into a minimap PR.

## Known limitation

The visible-area marker is re-measured on viewport change and window resize, not through a `ResizeObserver`. A container that resizes *without* a window resize — a side panel opening — leaves the marker stale until the next pan or zoom. That is a stale overlay, not a wrong canvas, and it avoids introducing a platform seam (and a jsdom stub) for a case this app does not currently produce.

## Verification

`pnpm test` 592/592 files green (6280 passed), typecheck and knip clean. Geometry has 10 unit tests including totality on empty/non-finite/zero-area input; wiring has 6 browser tests.

Not manually verified in a browser yet — that is what this PR is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a minimap to the spatial editor, showing content and the current viewport.
  * Click or drag on the minimap to navigate the canvas.
  * The minimap automatically fits and centers content while preserving proportions.
  * It hides during active gestures or marquee selections and reappears afterward.

* **Tests**
  * Added coverage for minimap display, navigation, sizing, positioning, and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->