### PR TITLE
fix(web): stop racing a timer against Radix's own return-focus in HeaderBranchChip

### DIFF
--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -224,9 +224,21 @@ export function HeaderBranchChip({
   // focus-driven open request after a close so it doesn't fight Radix's own
   // return-focus behavior; real hover-driven opens are unaffected.
   const suppressNextTooltipOpenRef = useRef(false)
-  // Only needed to detect, after a close, whether focus actually landed
-  // back on this trigger (see the safety-net check below).
+  // Radix's own return-focus (react-focus-scope) runs from a `setTimeout(…, 0)`
+  // scheduled when the menu's FocusScope unmounts, not synchronously with our
+  // onOpenChange. Racing that with a timer of our own to decide "did focus
+  // come back yet?" is inherently non-deterministic — under load, two
+  // setTimeout callbacks queued around the same moment have no guaranteed
+  // relative order, so our safety-net could fire and clear the suppression
+  // flag before Radix's delayed focus() call actually lands, letting the
+  // tooltip reopen. Listening for the real `focusin` event sidesteps the
+  // race entirely: whenever focus settles — however long that takes — we
+  // clear the flag only if it landed somewhere other than this trigger.
+  const pendingFocusInCleanupRef = useRef<(() => void) | null>(null)
+  // Only needed to detect, once focus settles, whether it landed back on
+  // this trigger (see the listener registered below).
   const chipButtonRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => () => pendingFocusInCleanupRef.current?.(), [])
 
   // Radix marks background content inert/aria-hidden while a dropdown or
   // dialog is open, so an error raised inside one of those flows must render
@@ -276,15 +288,20 @@ export function HeaderBranchChip({
             // itself caused by interacting with a DIFFERENT focusable
             // element (e.g. the kebab trigger), focus never returns here at
             // all, and nothing would ever consume the flag — permanently
-            // suppressing the next unrelated, genuine hover. Radix's own
-            // focus-return (if any) lands before this macrotask runs, so
-            // checking activeElement here reliably distinguishes the two
-            // cases instead of racing a blind timer against it.
-            setTimeout(() => {
-              if (document.activeElement !== chipButtonRef.current) {
+            // suppressing the next unrelated, genuine hover. Watch for focus
+            // actually settling somewhere else (rather than guessing with a
+            // timer) to clear the flag in that case.
+            pendingFocusInCleanupRef.current?.()
+            const handleFocusIn = (event: FocusEvent) => {
+              if (event.target !== chipButtonRef.current) {
                 suppressNextTooltipOpenRef.current = false
               }
-            }, 50)
+              pendingFocusInCleanupRef.current = null
+            }
+            document.addEventListener('focusin', handleFocusIn, { once: true })
+            pendingFocusInCleanupRef.current = () => {
+              document.removeEventListener('focusin', handleFocusIn)
+            }
           }
         }}
       >


### PR DESCRIPTION
`HeaderBranchChip.browser.test.tsx`'s "does not reopen the tooltip when the dropdown returns focus to the chip on close" failed three times today, always in a full `web-browser` run and never in isolation.

## It was a race between two timers, not a slow test

Closing the dropdown scheduled a 50ms safety net to clear the flag that suppresses the hover tooltip when Radix returns focus to the chip:

```js
setTimeout(() => {
  if (document.activeElement !== chipButtonRef.current) {
    suppressNextTooltipOpenRef.current = false
  }
}, 50)
```

That guesses "if focus has not come back within 50ms, it never will". But Radix's own return-focus is *also* deferred — `@radix-ui/react-focus-scope` calls `focus(previouslyFocusedElement)` inside its own `setTimeout(…, 0)`. So two independently queued macrotasks were racing. Normally 0 beats 50 and it works; under a congested event loop the ordering is not guaranteed, so the safety net could clear the flag *before* Radix's focus call landed, and the tooltip reopened. That is exactly why it only ever failed under full-suite load.

## The fix is deterministic, not longer

The timer is replaced with a `focusin` listener registered at the same synchronous moment the timeout used to be scheduled — so it is always attached before Radix's deferred `focus()` call, whatever the load:

```js
document.addEventListener('focusin', handleFocusIn, { once: true })
```

Correctness no longer depends on how fast our code runs relative to Radix's; we react to the DOM event whenever it actually happens. The flag is cleared only when focus is observed landing somewhere other than the chip. An unmount cleanup drops the listener if the component goes away before it fires.

Bumping the timeout would have hidden this until the next slow machine.

## Verification

Mutation-checked: removing the tooltip's suppression guard makes the target test fail again, so it still bites a reintroduced defect.

The file passes alone (18/18). The full `web-browser` project was run three consecutive times during investigation, all green, and once more after rebasing onto current `main` — 363/363.

Root-caused by a subagent; I verified the branch state, rebased it onto current `main`, and re-ran the suite before opening this.
