### PR TITLE
fix(web): redesign the canvas editor's chrome and multi-selection

### DIFF
--- a/apps/web/src/components/history-cluster/HistoryCluster.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.tsx
@@ -21,6 +21,7 @@
  */
 import { History, Redo2, Undo2 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { DOCK_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { VersionPanel } from '../workspace-top-bar/VersionPanel.js'
@@ -46,8 +47,7 @@ const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(n
 const MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+'
 const MOD_KEY = IS_MAC ? 'Meta' : 'Control'
 
-const CLUSTER_BUTTON_CLASS =
-  'flex size-9 pointer-coarse:size-11 items-center justify-center rounded-md text-muted-foreground transition-[transform,color,background-color] duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent hover:text-foreground active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
+export const CLUSTER_BUTTON_CLASS = DOCK_BUTTON_CLASS
 
 function StepButton({
   label,

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -10,7 +10,12 @@ export interface SelectionOverlayProps {
    * root's own empty-space hit-test never also sees them.
    */
   readonly onHandlePointerDown: (handle: ResizeHandleKind, box: Box, e: React.PointerEvent) => void
-  readonly onConnectPointerDown: (e: React.PointerEvent) => void
+  /**
+   * Absent while several nodes are selected. Connecting acts on ONE node, and
+   * offering it from handles that surround a group would claim the action
+   * applies to all of them.
+   */
+  readonly onConnectPointerDown?: (e: React.PointerEvent) => void
   /** Arrow-key nudge on a focused resize handle — the keyboard equivalent of a pointer drag. */
   readonly onHandleKeyDown?: (handle: ResizeHandleKind, box: Box, e: React.KeyboardEvent) => void
   /** Enter/Space on the focused connect handle — the keyboard equivalent of a pointer connect-drag. */
@@ -124,30 +129,31 @@ export function SelectionOverlay({
           }}
         />
       ))}
-      {CONNECT_SIDES.map((side) => (
-        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
-        <circle
-          key={side.kind}
-          data-testid={side.kind === 'e' ? 'connect-handle' : `connect-handle-${side.kind}`}
-          role="button"
-          tabIndex={0}
-          aria-label={`Connect to another node (from the ${side.label} side)`}
-          cx={side.cx(box, connectHandleSize)}
-          cy={side.cy(box, connectHandleSize)}
-          r={connectHandleSize / 2}
-          fill={SELECTION_STROKE}
-          style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
-          onPointerDown={(e) => {
-            if (e.button !== 0) return
-            e.stopPropagation()
-            onConnectPointerDown(e)
-          }}
-          onKeyDown={(e) => {
-            if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
-            onConnectKeyDown(e)
-          }}
-        />
-      ))}
+      {onConnectPointerDown !== undefined &&
+        CONNECT_SIDES.map((side) => (
+          // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+          <circle
+            key={side.kind}
+            data-testid={side.kind === 'e' ? 'connect-handle' : `connect-handle-${side.kind}`}
+            role="button"
+            tabIndex={0}
+            aria-label={`Connect to another node (from the ${side.label} side)`}
+            cx={side.cx(box, connectHandleSize)}
+            cy={side.cy(box, connectHandleSize)}
+            r={connectHandleSize / 2}
+            fill={SELECTION_STROKE}
+            style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
+            onPointerDown={(e) => {
+              if (e.button !== 0) return
+              e.stopPropagation()
+              onConnectPointerDown(e)
+            }}
+            onKeyDown={(e) => {
+              if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
+              onConnectKeyDown(e)
+            }}
+          />
+        ))}
       {onEditRequest !== undefined && (
         // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
         <g

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -195,6 +195,21 @@ const SNAP_GRID_CANVAS_PX = 20
 const MINIMAP_WIDTH_PX = 160
 const MINIMAP_HEIGHT_PX = 110
 
+/**
+ * Below this container width the overview and the dock fight for the bottom
+ * edge, so the overview yields.
+ *
+ * Both are bottom-anchored in the same container. The dock is centred and, on
+ * a coarse pointer, runs about 380px; the overview claims 160px plus a 16px
+ * inset on the right. They start touching once
+ * `(W + 380) / 2 > W - 176`, i.e. below ~732px. 768 rounds that up so the two
+ * never sit shoulder to shoulder with no gap.
+ *
+ * Keyed off the CONTAINER, not the viewport: a narrow editor column on a wide
+ * screen collides in exactly the same way, and a media query cannot see it.
+ */
+const MINIMAP_MIN_ROOT_WIDTH_PX = 768
+
 export interface SpatialEditorProps {
   readonly canvas: SpatialCanvas
   readonly onChange: (next: SpatialCanvas, command: EditorCommand) => void
@@ -2347,7 +2362,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           press on it reaching the canvas, so hiding bought nothing and cost
           a flicker on every gesture. Hidden only on an empty canvas, where
           an overview of nothing is chrome with no job. */}
-        {boxes.length > 0 && rootSize.width > 0 && (
+        {boxes.length > 0 && rootSize.width >= MINIMAP_MIN_ROOT_WIDTH_PX && (
           <MinimapOverlay
             boxes={minimapNodes}
             viewportRect={{

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -112,6 +112,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { DOCK_WIDE_BUTTON_CLASS } from '@/components/ui/dock-button'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import {
   extractClipboardFragment,
@@ -149,7 +150,6 @@ import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
-import { DOCK_WIDE_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1907,11 +1907,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       _handleBox: Box,
       e: React.KeyboardEvent,
     ) => {
-      if (selection === undefined || selectionBox === undefined) return
+      if (selection === undefined) return
+      // Geometry comes from `canvasRef`, not from the render snapshot the
+      // pointer path can afford to use. Key repeat delivers the next press
+      // before React has re-rendered, and a parent that applies `onChange`
+      // asynchronously lags further still — reading the stale snapshot would
+      // make every press compute the same coordinates, so holding the key
+      // would resize once and then appear to stick.
+      const members = [selection.id, ...extraIds].flatMap((id) => {
+        const node = canvasRef.current.nodes.find((candidate) => candidate.id === id)
+        return node === undefined
+          ? []
+          : [{ id, box: { x: node.x, y: node.y, width: node.width, height: node.height } }]
+      })
       // The resize anchor is the box the HANDLES surround, not the handle's
       // own tiny hit-box `_handleBox` describes — same reasoning as
       // onHandlePointerDown's `box: selectionBox` below.
-      const box = selectionBox
+      const box = unionBox(members.map((member) => member.box))
+      if (box === undefined) return
       const step = e.shiftKey ? RESIZE_KEYBOARD_STEP_LARGE : RESIZE_KEYBOARD_STEP
       const delta = ARROW_KEY_DELTA[e.key]
       if (delta === undefined) return
@@ -1927,28 +1940,29 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       }
       // Same handles, same meaning as the pointer drag: a lone node takes the
       // dragged box verbatim, a selection has each member re-placed inside it.
-      const commands: readonly EditorCommand[] = isMultiSelection
-        ? selectionMembers.map((member) => {
-            const scaled = scaleBoxWithin(box, nextBox, member.box)
-            return {
-              kind: 'resize-node',
-              id: member.id,
-              x: scaled.x,
-              y: scaled.y,
-              width: scaled.width,
-              height: scaled.height,
-            }
-          })
-        : [
-            {
-              kind: 'resize-node',
-              id: selection.id,
-              x: nextBox.x,
-              y: nextBox.y,
-              width: nextBox.width,
-              height: nextBox.height,
-            },
-          ]
+      const commands: readonly EditorCommand[] =
+        members.length > 1
+          ? members.map((member) => {
+              const scaled = scaleBoxWithin(box, nextBox, member.box)
+              return {
+                kind: 'resize-node',
+                id: member.id,
+                x: scaled.x,
+                y: scaled.y,
+                width: scaled.width,
+                height: scaled.height,
+              }
+            })
+          : [
+              {
+                kind: 'resize-node',
+                id: selection.id,
+                x: nextBox.x,
+                y: nextBox.y,
+                width: nextBox.width,
+                height: nextBox.height,
+              },
+            ]
       // Threaded through a running canvas, not re-applied to `canvasRef`
       // each time: the ref does not advance within this tick, so a second
       // command built on it would discard the first.
@@ -1957,6 +1971,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         running = applyCommand(running, command)
         onChange(running, command)
       }
+      // Same write-back the gesture path does (see applyResult): without it
+      // the ref keeps describing the pre-keypress canvas until the parent's
+      // re-render lands.
+      canvasRef.current = running
     }
 
     const handleConnectKeyDown = () => {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -142,6 +142,8 @@ import {
   indexNodeBoxes,
   polylineMidpoint,
   resizeBoxByDelta,
+  scaleBoxWithin,
+  unionBox,
 } from './geometry.js'
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
@@ -731,6 +733,27 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       selectedId !== null && selectedBox !== undefined
         ? { id: selectedId, box: selectedBox }
         : undefined
+
+    /**
+     * Every selected node with the box it currently occupies, primary first.
+     *
+     * The resize handles surround the UNION of these rather than the primary
+     * alone: handles drawn around a group have to act on the group, or a
+     * three-node selection offers one node's handles and resizes that node
+     * while the other two watch.
+     */
+    const selectionMembers = useMemo(() => {
+      if (selectedId === null) return []
+      return [selectedId, ...extraIds].flatMap((id) => {
+        const entry = boxes.find((candidate) => candidate.id === id)
+        return entry === undefined ? [] : [{ id, box: entry.box }]
+      })
+    }, [selectedId, extraIds, boxes])
+    const selectionBox = useMemo(
+      () => unionBox(selectionMembers.map((member) => member.box)),
+      [selectionMembers],
+    )
+    const isMultiSelection = selectionMembers.length > 1
 
     /**
      * The in-flight preview geometry, derived per frame from the gesture's own
@@ -1884,11 +1907,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       _handleBox: Box,
       e: React.KeyboardEvent,
     ) => {
-      if (selection === undefined) return
-      // The resize anchor is the NODE's box, not the handle's own tiny
-      // hit-box `_handleBox` describes — same reasoning as
-      // onHandlePointerDown's `box: selection.box` below.
-      const box = selection.box
+      if (selection === undefined || selectionBox === undefined) return
+      // The resize anchor is the box the HANDLES surround, not the handle's
+      // own tiny hit-box `_handleBox` describes — same reasoning as
+      // onHandlePointerDown's `box: selectionBox` below.
+      const box = selectionBox
       const step = e.shiftKey ? RESIZE_KEYBOARD_STEP_LARGE : RESIZE_KEYBOARD_STEP
       const delta = ARROW_KEY_DELTA[e.key]
       if (delta === undefined) return
@@ -1902,15 +1925,38 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       ) {
         return
       }
-      const command: EditorCommand = {
-        kind: 'resize-node',
-        id: selection.id,
-        x: nextBox.x,
-        y: nextBox.y,
-        width: nextBox.width,
-        height: nextBox.height,
+      // Same handles, same meaning as the pointer drag: a lone node takes the
+      // dragged box verbatim, a selection has each member re-placed inside it.
+      const commands: readonly EditorCommand[] = isMultiSelection
+        ? selectionMembers.map((member) => {
+            const scaled = scaleBoxWithin(box, nextBox, member.box)
+            return {
+              kind: 'resize-node',
+              id: member.id,
+              x: scaled.x,
+              y: scaled.y,
+              width: scaled.width,
+              height: scaled.height,
+            }
+          })
+        : [
+            {
+              kind: 'resize-node',
+              id: selection.id,
+              x: nextBox.x,
+              y: nextBox.y,
+              width: nextBox.width,
+              height: nextBox.height,
+            },
+          ]
+      // Threaded through a running canvas, not re-applied to `canvasRef`
+      // each time: the ref does not advance within this tick, so a second
+      // command built on it would discard the first.
+      let running = canvasRef.current
+      for (const command of commands) {
+        running = applyCommand(running, command)
+        onChange(running, command)
       }
-      onChange(applyCommand(canvasRef.current, command), command)
     }
 
     const handleConnectKeyDown = () => {
@@ -3239,9 +3285,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               })}
             </svg>
           )}
-          {selection !== undefined && (
+          {selection !== undefined && selectionBox !== undefined && (
             <SelectionOverlay
-              box={selection.box}
+              box={selectionBox}
               zoom={viewport.zoom}
               onHandlePointerDown={(handle, _handleBox, e) => {
                 const root = beginOverlayGesture(e)
@@ -3253,28 +3299,39 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     nodeId: selection.id,
                     handle,
                     point,
-                    // The resize anchor is the NODE's box, not the handle's own
-                    // tiny hit-box `_handleBox` describes — using the handle
-                    // box here would seed `reducePointerUpResizing`'s
-                    // anchor-preserving math from an 8px square instead of the
-                    // node, growing/shrinking from the wrong origin.
-                    box: selection.box,
+                    // The resize anchor is the box the HANDLES surround, not
+                    // the handle's own tiny hit-box `_handleBox` describes —
+                    // using the handle box here would seed
+                    // `reducePointerUpResizing`'s anchor-preserving math from
+                    // an 8px square instead, growing/shrinking from the wrong
+                    // origin.
+                    box: selectionBox,
+                    // Omitted for a lone node, which keeps the original
+                    // single-command path — including its collapse-to-zero
+                    // behavior, which group members deliberately do not share.
+                    ...(isMultiSelection ? { members: selectionMembers } : {}),
                   }),
                 )
               }}
-              onConnectPointerDown={(e) => {
-                if (beginOverlayGesture(e) === null) return
-                applyResult(
-                  reduceGesture(gestureState, canvas, {
-                    type: 'pointerdown-connect',
-                    nodeId: selection.id,
-                  }),
-                )
-              }}
+              // Connecting and editing act on ONE node; from handles that
+              // surround a group they would claim to apply to all of them.
+              onConnectPointerDown={
+                isMultiSelection
+                  ? undefined
+                  : (e) => {
+                      if (beginOverlayGesture(e) === null) return
+                      applyResult(
+                        reduceGesture(gestureState, canvas, {
+                          type: 'pointerdown-connect',
+                          nodeId: selection.id,
+                        }),
+                      )
+                    }
+              }
               onHandleKeyDown={handleResizeHandleKeyDown}
               onConnectKeyDown={handleConnectKeyDown}
               onEditRequest={
-                selectedNode?.type === 'text'
+                !isMultiSelection && selectedNode?.type === 'text'
                   ? () => {
                       applyResult(
                         reduceGesture(gestureState, canvas, {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -147,6 +147,7 @@ import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
+import { DOCK_WIDE_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
@@ -2392,7 +2393,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   data-testid="zoom-reset-button"
                   aria-label="Reset zoom to 100%"
                   onClick={() => zoomAtViewportCenter(1 / viewport.zoom)}
-                  className={`${TOOL_BUTTON_CLASS} w-12 text-xs tabular-nums`}
+                  className={`${DOCK_WIDE_BUTTON_CLASS} text-xs tabular-nums`}
                 >
                   {Math.round(viewport.zoom * 100)}%
                 </button>

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -455,6 +455,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // the marquee/move path mid-air.
     const touchPointsRef = useRef<Map<number, Point>>(new Map())
     const pinchActiveRef = useRef(false)
+    /**
+     * Touch multi-selection, the iOS "hold one, tap the rest" gesture.
+     *
+     * `gatherAnchorRef` is the finger holding the selection open; while it is
+     * down, a second finger's tap on a node collects that node instead of
+     * starting a pinch. Long press is NOT the trigger: the browser already
+     * synthesises `contextmenu` from it, and taking it would leave touch with
+     * no route to an object's menu.
+     *
+     * A second finger otherwise means pinch, so the two are separated by
+     * STATE rather than by timing — gathering needs a finger already holding
+     * a node, which a pinch never has. Fingers listed in `gatherPointersRef`
+     * have already done their job on the press and stay inert until they lift.
+     */
+    const gatherAnchorRef = useRef<number | null>(null)
+    const gatherPointersRef = useRef<Set<number>>(new Set())
     /** Last primary press for double-press detection: logical target + time. */
     const lastPressRef = useRef<{ key: string; at: number } | null>(null)
     const lastPanPointRef = useRef({ x: 0, y: 0 })
@@ -938,6 +954,40 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const isOverlayEvent = (e: React.SyntheticEvent) =>
       e.target instanceof Element && e.target.closest('[data-editor-overlay]') !== null
 
+    /**
+     * Add or remove one node from the multi-selection, shared by shift-click
+     * and the touch gather gesture so the two can never disagree about what
+     * "already selected" means.
+     *
+     * `primaryId` is passed in rather than read from state because the gather
+     * path learns the anchor from the in-flight gesture, whose `setSelectedId`
+     * has not been applied yet when this runs.
+     */
+    const toggleSelectionMember = (primaryId: string | null, hitId: string) => {
+      // Node and edge selection are mutually exclusive: Delete processes a
+      // selected edge FIRST, so an edge left selected here would be what a
+      // Delete on the node multi-selection actually removes.
+      setSelectedEdgeId(null)
+      if (primaryId === null) {
+        setSelectedId(hitId)
+        return
+      }
+      if (hitId === primaryId) {
+        // Deselecting the primary promotes an extra, if any.
+        const [next, ...rest] = [...extraIds]
+        setSelectedId(next ?? null)
+        setExtraIds(new Set(rest))
+        return
+      }
+      setSelectedId(primaryId)
+      setExtraIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(hitId)) next.delete(hitId)
+        else next.add(hitId)
+        return next
+      })
+    }
+
     const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
       if (isOverlayEvent(e)) return
       const root = rootRef.current
@@ -945,6 +995,47 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (e.pointerType === 'touch') {
         touchPointsRef.current.set(e.pointerId, clientPointToRootLocal(e, root))
         if (pinchActiveRef.current) return
+        if (gatherPointersRef.current.size > 0 || gatherAnchorRef.current !== null) {
+          // Already gathering: any further finger is another tap, never a
+          // pinch participant, so it must not sit in touchPointsRef.
+          touchPointsRef.current.delete(e.pointerId)
+        }
+        if (touchPointsRef.current.size === 2 || gatherAnchorRef.current !== null) {
+          const anchorId =
+            gatherAnchorRef.current ??
+            [...touchPointsRef.current.keys()].find((id) => id !== e.pointerId) ??
+            null
+          const anchorPrimary =
+            gatherAnchorRef.current !== null
+              ? selectedId
+              : gestureState.kind === 'moving'
+                ? gestureState.nodeId
+                : null
+          const gathered =
+            anchorPrimary === null
+              ? undefined
+              : hitTest(selectableBoxes, screenToCanvas(clientPointToRootLocal(e, root), viewport))
+          if (gathered !== undefined && anchorId !== null) {
+            touchPointsRef.current.delete(e.pointerId)
+            gatherPointersRef.current.add(e.pointerId)
+            if (gatherAnchorRef.current === null) {
+              gatherAnchorRef.current = anchorId
+              // Gathering is a selection act, not a drag. Whatever the anchor
+              // had begun to move is abandoned here — carrying a half-applied
+              // delta into the new multi-selection would jump every node
+              // gathered afterwards by an offset the user never gave it.
+              if (gestureState.kind !== 'idle') {
+                applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+              }
+            }
+            setMarquee(null)
+            isPanningRef.current = false
+            lastPressRef.current = null
+            doublePressRef.current = null
+            toggleSelectionMember(anchorPrimary, gathered)
+            return
+          }
+        }
         if (touchPointsRef.current.size === 2) {
           // The second finger converts whatever the first finger started
           // (marquee, node move, double-press arming) into navigation:
@@ -1002,23 +1093,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // re-renders because it compares node ids, not DOM identity.
       // Shift-click builds a multi-selection instead of starting a gesture.
       if (e.shiftKey && hitId !== undefined) {
-        // Node and edge selection are mutually exclusive: Delete processes a
-        // selected edge FIRST, so an edge left selected here would be what a
-        // Delete on the node multi-selection actually removes.
-        setSelectedEdgeId(null)
-        if (selectedId === null) {
-          setSelectedId(hitId)
-        } else if (hitId === selectedId) {
-          // Deselecting the primary promotes an extra, if any.
-          const [next, ...rest] = [...extraIds]
-          setSelectedId(next ?? null)
-          setExtraIds(new Set(rest))
-        } else {
-          const next = new Set(extraIds)
-          if (next.has(hitId)) next.delete(hitId)
-          else next.add(hitId)
-          setExtraIds(next)
-        }
+        toggleSelectionMember(selectedId, hitId)
         return
       }
       // Edge hit-test runs at the press so the double-press pairing can
@@ -1142,6 +1217,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
+      // A gathering finger has already acted on its press, and the anchor's
+      // own gesture was cancelled when gathering began — neither may resume
+      // dragging the canvas while the other is still down.
+      if (gatherPointersRef.current.has(e.pointerId) || gatherAnchorRef.current === e.pointerId) {
+        return
+      }
       if (e.pointerType === 'touch' && touchPointsRef.current.has(e.pointerId)) {
         const points = touchPointsRef.current
         const nextPoint = clientPointToRootLocal(e, root)
@@ -1202,6 +1283,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
+      // Gathering fingers act on the press, so their release carries no
+      // meaning — running the click/marquee logic here would re-collapse the
+      // very selection the gesture just built. The anchor lifting ends it.
+      if (gatherPointersRef.current.delete(e.pointerId)) return
+      if (gatherAnchorRef.current === e.pointerId) {
+        gatherAnchorRef.current = null
+        touchPointsRef.current.delete(e.pointerId)
+        return
+      }
       if (e.pointerType === 'touch') {
         touchPointsRef.current.delete(e.pointerId)
         if (pinchActiveRef.current) {
@@ -1372,6 +1462,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+      // Pointer ids are reused, so a gathering finger left in these refs by a
+      // cancel would silently deaden whichever later touch inherits its id.
+      gatherPointersRef.current.delete(e.pointerId)
+      if (gatherAnchorRef.current === e.pointerId) gatherAnchorRef.current = null
       if (e.pointerType === 'touch') {
         touchPointsRef.current.delete(e.pointerId)
         if (touchPointsRef.current.size === 0) pinchActiveRef.current = false

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -35,6 +35,7 @@ import {
   StickyNote,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { DOCK_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export type EditorTool = 'select' | 'hand' | 'connect'
@@ -53,8 +54,7 @@ interface ToolPaletteProps {
   readonly onToolChange: (tool: EditorTool) => void
 }
 
-export const TOOL_BUTTON_CLASS =
-  'flex size-9 items-center justify-center rounded-md hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground text-muted-foreground transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out)'
+export const TOOL_BUTTON_CLASS = `${DOCK_BUTTON_CLASS} aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground`
 
 interface AddMenuEntry {
   readonly label: string

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -168,6 +168,62 @@ export function resizeBoxByDelta(
   }
 }
 
+/** The smallest box covering all of `boxes`; `undefined` for an empty selection. */
+export function unionBox(boxes: readonly Box[]): Box | undefined {
+  if (boxes.length === 0) return undefined
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const box of boxes) {
+    minX = Math.min(minX, box.x)
+    minY = Math.min(minY, box.y)
+    maxX = Math.max(maxX, box.x + box.width)
+    maxY = Math.max(maxY, box.y + box.height)
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
+
+/** A node scaled to nothing can never be grabbed to grow again. */
+const MIN_SCALED_EXTENT_PX = 1
+
+/**
+ * Floors a scaled extent at one pixel — but only if there was an extent to
+ * begin with. A zero-width node is legal in JSON Canvas, and resizing the
+ * selection AROUND it is no reason to silently give it a width it never had.
+ */
+function scaleExtent(extent: number, scale: number): number {
+  if (extent <= 0) return extent
+  return Math.max(MIN_SCALED_EXTENT_PX, Math.round(extent * scale))
+}
+
+/**
+ * Re-places one member of a multi-selection after its enclosing box has been
+ * resized, preserving where the member sat inside that box and how much of it
+ * it filled.
+ *
+ * This is what makes resize handles around a whole selection mean the same
+ * thing as handles around one node: the group is treated as a single object,
+ * so the arrangement inside it survives the drag.
+ *
+ * Totality matters here — it runs on whatever the pointer produced, and a
+ * NaN coordinate would reach the canvas schema. A collapsed axis on the
+ * enclosing box has no ratio to preserve, so that axis passes through
+ * unscaled rather than dividing by zero; results are rounded because JSON
+ * Canvas geometry is integer, and floored at one pixel because rounding a
+ * heavy shrink otherwise lands on zero.
+ */
+export function scaleBoxWithin(startEnclosing: Box, nextEnclosing: Box, box: Box): Box {
+  const scaleX = startEnclosing.width > 0 ? nextEnclosing.width / startEnclosing.width : 1
+  const scaleY = startEnclosing.height > 0 ? nextEnclosing.height / startEnclosing.height : 1
+  return {
+    x: Math.round(nextEnclosing.x + (box.x - startEnclosing.x) * scaleX),
+    y: Math.round(nextEnclosing.y + (box.y - startEnclosing.y) * scaleY),
+    width: scaleExtent(box.width, scaleX),
+    height: scaleExtent(box.height, scaleY),
+  }
+}
+
 /**
  * Minimum distance from a point to a polyline (canvas coordinates). Used to
  * hit-test edges, which have no area of their own — the caller compares the

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -542,3 +542,72 @@ describe('delete-selection', () => {
     expect(result.selectedId).toBeUndefined()
   })
 })
+
+// Handles drawn around a whole selection have to mean what handles around one
+// node mean: the group resizes as a single object and the arrangement inside
+// it survives.
+describe('multi-selection resize', () => {
+  function pair(): SpatialCanvas {
+    return {
+      nodes: [
+        { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 100, text: 'a' },
+        { id: 'b', type: 'text', x: 200, y: 0, width: 100, height: 100, text: 'b' },
+      ],
+      edges: [],
+    }
+  }
+  const ENCLOSING = { x: 0, y: 0, width: 300, height: 100 }
+  const MEMBERS = [
+    { id: 'a', box: { x: 0, y: 0, width: 100, height: 100 } },
+    { id: 'b', box: { x: 200, y: 0, width: 100, height: 100 } },
+  ]
+
+  function dragSouthEastBy(dx: number, dy: number) {
+    const c = pair()
+    const down = reduceGesture(createIdleState(), c, {
+      type: 'pointerdown-handle',
+      nodeId: 'a',
+      handle: 'se',
+      point: { x: 300, y: 100 },
+      box: ENCLOSING,
+      members: MEMBERS,
+    })
+    return reduceGesture(down.state, c, {
+      type: 'pointerup',
+      point: { x: 300 + dx, y: 100 + dy },
+    })
+  }
+
+  it('commits one resize per member, scaled by the same factors', () => {
+    // 300 -> 600 wide, height unchanged.
+    expect(dragSouthEastBy(300, 0).commands).toEqual([
+      { kind: 'resize-node', id: 'a', x: 0, y: 0, width: 200, height: 100 },
+      { kind: 'resize-node', id: 'b', x: 400, y: 0, width: 200, height: 100 },
+    ])
+  })
+
+  it('keeps the gap between members proportional, not constant', () => {
+    // The 100px gap doubles with everything else; a constant gap would leave
+    // b at 300 and the group would no longer fill its own handles.
+    expect(dragSouthEastBy(300, 0).commands[1]).toMatchObject({ id: 'b', x: 400 })
+  })
+
+  it('still commits a single resize when the selection is one node', () => {
+    const c = pair()
+    const down = reduceGesture(createIdleState(), c, {
+      type: 'pointerdown-handle',
+      nodeId: 'a',
+      handle: 'se',
+      point: { x: 100, y: 100 },
+      box: { x: 0, y: 0, width: 100, height: 100 },
+    })
+    const up = reduceGesture(down.state, c, { type: 'pointerup', point: { x: 150, y: 100 } })
+    expect(up.commands).toEqual([
+      { kind: 'resize-node', id: 'a', x: 0, y: 0, width: 150, height: 100 },
+    ])
+  })
+
+  it('emits nothing when the drag ended where it began', () => {
+    expect(dragSouthEastBy(0, 0).commands).toEqual([])
+  })
+})

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -29,7 +29,7 @@
  */
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { EditorCommand } from './commands.js'
-import { type ResizeHandleKind, resizeBoxByDelta } from './geometry.js'
+import { type Box, type ResizeHandleKind, resizeBoxByDelta, scaleBoxWithin } from './geometry.js'
 import type { Point } from './viewport.js'
 
 interface MoveSnapshot {
@@ -41,13 +41,26 @@ interface MoveSnapshot {
   readonly startY: number
 }
 
+interface ResizeMember {
+  readonly id: string
+  readonly box: Box
+}
+
 interface ResizeSnapshot {
   readonly kind: 'resizing'
+  /** The primary node — what the validity check follows across a canvas swap. */
   readonly nodeId: string
   readonly startType: string
   readonly handle: ResizeHandleKind
   readonly startPoint: Point
-  readonly startBox: { x: number; y: number; width: number; height: number }
+  /** The box the handles surround: one node's, or the selection's union. */
+  readonly startBox: Box
+  /**
+   * Every node the handles act on, with the box it started at. Absent for a
+   * single-node resize, which keeps the original one-command path exactly —
+   * a multi-selection is the addition, not a rewrite of the common case.
+   */
+  readonly members?: readonly ResizeMember[]
 }
 
 interface ConnectSnapshot {
@@ -83,7 +96,9 @@ export type GestureEvent =
       readonly nodeId: string
       readonly handle: ResizeHandleKind
       readonly point: Point
-      readonly box: { x: number; y: number; width: number; height: number }
+      readonly box: Box
+      /** Present when the handles surround a multi-selection; see ResizeSnapshot. */
+      readonly members?: readonly ResizeMember[]
     }
   | { readonly type: 'pointerdown-connect'; readonly nodeId: string }
   | { readonly type: 'pointerdown-empty' }
@@ -216,6 +231,7 @@ function reducePointerDownHandle(
     handle: event.handle,
     startPoint: event.point,
     startBox: event.box,
+    ...(event.members === undefined ? {} : { members: event.members }),
   })
 }
 
@@ -246,18 +262,42 @@ function reducePointerUpResizing(
     nextBox.width === startBox.width &&
     nextBox.height === startBox.height
   if (isUnchanged) return idle
+  // A single node takes the dragged box verbatim, including the collapse to
+  // zero that overshooting a min-side handle produces. Its handles come back
+  // with it, so a collapsed node is still reachable.
+  if (state.members === undefined) {
+    return {
+      state: { kind: 'idle' },
+      commands: [
+        {
+          kind: 'resize-node',
+          id: state.nodeId,
+          x: nextBox.x,
+          y: nextBox.y,
+          width: nextBox.width,
+          height: nextBox.height,
+        },
+      ],
+    }
+  }
+  // Handles around a selection surround the union, so each member is
+  // re-placed inside the box they moved — the group behaves as one object
+  // rather than resizing the primary and leaving the rest behind. Members
+  // keep a one-pixel floor that a lone node does not: a member collapsed
+  // inside a group has no handles of its own to grab it back by.
   return {
     state: { kind: 'idle' },
-    commands: [
-      {
+    commands: state.members.map((member) => {
+      const box = scaleBoxWithin(startBox, nextBox, member.box)
+      return {
         kind: 'resize-node',
-        id: state.nodeId,
-        x: nextBox.x,
-        y: nextBox.y,
-        width: nextBox.width,
-        height: nextBox.height,
-      },
-    ],
+        id: member.id,
+        x: box.x,
+        y: box.y,
+        width: box.width,
+        height: box.height,
+      }
+    }),
   }
 }
 

--- a/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/minimap.browser.test.tsx
@@ -17,10 +17,10 @@ const spread: SpatialCanvas = {
   edges: [],
 }
 
-function Host({ canvas0 }: { canvas0: SpatialCanvas }) {
+function Host({ canvas0, width = 800 }: { canvas0: SpatialCanvas; width?: number }) {
   const [canvas, setCanvas] = useState(canvas0)
   return (
-    <div style={{ width: 800, height: 600 }}>
+    <div style={{ width, height: 600 }}>
       <SpatialEditor
         defaultTool="select"
         canvas={canvas}
@@ -42,6 +42,28 @@ it('shows an overview once the canvas has content', () => {
   const { container } = render(<Host canvas0={spread} />)
   expect(minimapOf(container)).toBeTruthy()
   expect(container.querySelector('[data-testid="minimap-viewport"]')).toBeTruthy()
+})
+
+// Both the overview and the dock are bottom-anchored inside the SAME
+// container, and the dock is centred and grows to ~380px on touch. Below
+// roughly 730px of container they overlap. The predicate is the container's
+// width, not the viewport's: a narrow editor column on a wide screen collides
+// exactly the same way, and a media query would miss it.
+it('stays away when the editor is too narrow to hold it beside the dock', () => {
+  const { container } = render(<Host canvas0={spread} width={390} />)
+  expect(minimapOf(container)).toBeNull()
+})
+
+it('comes back when the editor is widened past that point', async () => {
+  const { container } = render(<Host canvas0={spread} width={390} />)
+  const host = container.firstElementChild as HTMLElement
+  expect(minimapOf(container)).toBeNull()
+
+  host.style.width = '1000px'
+
+  await vi.waitFor(() => {
+    expect(minimapOf(container)).toBeTruthy()
+  })
 })
 
 it('stays away on an empty canvas, where an overview has no job', () => {
@@ -144,7 +166,9 @@ it('tracks a container resize that the window never sees', async () => {
     (container.querySelector('[data-testid="minimap-viewport"]') as HTMLElement).style.width
 
   const before = markerWidth()
-  host.style.width = '400px'
+  // Stays above the width at which the overview yields to the dock — this
+  // test is about tracking a resize, not about the yield threshold.
+  host.style.width = '1200px'
 
   await vi.waitFor(() => {
     expect(markerWidth()).not.toBe(before)

--- a/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
@@ -1,0 +1,140 @@
+// Resize handles around a MULTI-selection. Before this they surrounded only
+// the primary node, so a selection of three offered one node's handles and
+// resizing acted on that node alone — the other two just watched.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 100, text: 'a' },
+    { id: 'b', type: 'text', x: 200, y: 0, width: 100, height: 100, text: 'b' },
+  ],
+  edges: [],
+}
+
+const A = { x: 50, y: 50 }
+const B = { x: 250, y: 50 }
+
+function makeHost() {
+  const latest = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => {
+            latest.canvas = next
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (c: HTMLElement) => c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+const outlineOf = (c: HTMLElement) =>
+  c.querySelector('[data-testid="selection-overlay"] rect') as SVGRectElement
+const nodeAt = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((n) => n.id === id)
+
+function pressAt(
+  root: HTMLElement,
+  p: { x: number; y: number },
+  init: Record<string, unknown> = {},
+) {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + p.x,
+    clientY: r.top + p.y,
+    ...init,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + p.x, clientY: r.top + p.y })
+}
+
+function selectBoth(root: HTMLElement) {
+  pressAt(root, A)
+  pressAt(root, B, { shiftKey: true })
+}
+
+it('surrounds the whole selection, not just the primary node', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  pressAt(root, A)
+  expect(outlineOf(container).getAttribute('width')).toBe('100')
+
+  pressAt(root, B, { shiftKey: true })
+  const outline = outlineOf(container)
+  expect(outline.getAttribute('x')).toBe('0')
+  expect(outline.getAttribute('width')).toBe('300')
+  expect(outline.getAttribute('height')).toBe('100')
+})
+
+it('resizes every selected node when a handle is dragged', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectBoth(root)
+
+  const handle = container.querySelector('[data-testid="resize-handle-se"]') as SVGRectElement
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(handle, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + 300,
+    clientY: r.top + 100,
+  })
+  fireEvent.pointerMove(root, { pointerId: 2, clientX: r.left + 600, clientY: r.top + 100 })
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + 600, clientY: r.top + 100 })
+
+  // The union doubles in width; both members double and the gap doubles with
+  // them, so the selection still fills its own handles.
+  expect(nodeAt(latest.canvas, 'a')).toMatchObject({ x: 0, width: 200 })
+  expect(nodeAt(latest.canvas, 'b')).toMatchObject({ x: 400, width: 200 })
+})
+
+// Connect and Edit act on ONE node. Offering them from handles that surround
+// several says the action applies to all of them, which it does not.
+it('offers no per-node connect or edit affordance while several are selected', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  pressAt(root, A)
+  expect(container.querySelector('[data-testid="connect-handle"]')).toBeTruthy()
+
+  pressAt(root, B, { shiftKey: true })
+  expect(container.querySelector('[data-testid="connect-handle"]')).toBeNull()
+  expect(container.querySelector('[data-testid="edit-handle"]')).toBeNull()
+})
+
+// The keyboard path draws from the same handles, so it has to mean the same
+// thing. Resizing only the primary from handles that surround the group is
+// the bug the pointer path just stopped having.
+it('scales every selected node from an arrow key on a focused handle', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectBoth(root)
+
+  const handle = container.querySelector('[data-testid="resize-handle-e"]') as SVGRectElement
+  fireEvent.keyDown(handle, { key: 'ArrowRight', shiftKey: true })
+
+  const a = nodeAt(latest.canvas, 'a')
+  const b = nodeAt(latest.canvas, 'b')
+  expect(a?.width).toBeGreaterThan(100)
+  expect(b?.width).toBeGreaterThan(100)
+  expect(b?.x).toBeGreaterThan(200)
+})

--- a/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
@@ -138,3 +138,41 @@ it('scales every selected node from an arrow key on a focused handle', () => {
   expect(b?.width).toBeGreaterThan(100)
   expect(b?.x).toBeGreaterThan(200)
 })
+
+// Key repeat, and any parent that applies onChange asynchronously, both send a
+// second keypress before the render snapshot has caught up. Reading the
+// selection from that stale snapshot makes every press compute the same
+// coordinates, so holding the key resizes once and then stops.
+it('accumulates repeated keypresses even when the parent has not re-rendered', () => {
+  const commands: { id: string; width: number }[] = []
+  function LaggingHost() {
+    // Deliberately does NOT apply the change: stands in for a parent whose
+    // update lands a tick later.
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={initial}
+          onChange={(_next, command) => {
+            if (command?.kind === 'resize-node') {
+              commands.push({ id: command.id, width: command.width })
+            }
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<LaggingHost />)
+  const root = rootOf(container)
+  selectBoth(root)
+
+  const handle = container.querySelector('[data-testid="resize-handle-e"]') as SVGRectElement
+  fireEvent.keyDown(handle, { key: 'ArrowRight', shiftKey: true })
+  const first = commands.filter((c) => c.id === 'a').at(-1)?.width
+  fireEvent.keyDown(handle, { key: 'ArrowRight', shiftKey: true })
+  const second = commands.filter((c) => c.id === 'a').at(-1)?.width
+
+  expect(first).toBeGreaterThan(100)
+  expect(second).toBeGreaterThan(first as number)
+})

--- a/apps/web/src/components/spatial-editor/scale-within.test.ts
+++ b/apps/web/src/components/spatial-editor/scale-within.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '@/test-utils/fast-check'
+import { type Box, scaleBoxWithin, unionBox } from './geometry'
+
+const box = (x: number, y: number, width: number, height: number): Box => ({ x, y, width, height })
+
+describe('unionBox', () => {
+  it('covers every box it is given', () => {
+    expect(unionBox([box(10, 20, 30, 40), box(100, 0, 10, 10)])).toEqual(box(10, 0, 100, 60))
+  })
+
+  it('is the box itself for a single member', () => {
+    expect(unionBox([box(5, 6, 7, 8)])).toEqual(box(5, 6, 7, 8))
+  })
+
+  it('has no answer for an empty selection', () => {
+    expect(unionBox([])).toBeUndefined()
+  })
+})
+
+describe('scaleBoxWithin', () => {
+  it('leaves a member alone when the enclosing box did not change', () => {
+    const start = box(0, 0, 200, 100)
+    expect(scaleBoxWithin(start, start, box(20, 10, 50, 30))).toEqual(box(20, 10, 50, 30))
+  })
+
+  it('maps a member that fills the box onto the new box exactly', () => {
+    const start = box(0, 0, 200, 100)
+    const next = box(-10, 5, 400, 50)
+    expect(scaleBoxWithin(start, next, start)).toEqual(next)
+  })
+
+  it('scales offset and size together, so relative position survives', () => {
+    // Member sits at the horizontal midpoint and half the width; doubling the
+    // enclosing box must keep both facts true.
+    const start = box(0, 0, 200, 100)
+    const next = box(0, 0, 400, 200)
+    expect(scaleBoxWithin(start, next, box(100, 0, 100, 50))).toEqual(box(200, 0, 200, 100))
+  })
+
+  it('carries the origin shift of a handle that moves the min side', () => {
+    const start = box(100, 100, 200, 100)
+    // Dragging the NW handle 50/20 inward: same size, new origin.
+    const next = box(150, 120, 150, 80)
+    expect(scaleBoxWithin(start, next, box(100, 100, 100, 50))).toEqual(box(150, 120, 75, 40))
+  })
+
+  // A degenerate axis has no ratio to preserve. Dividing by it yields
+  // Infinity/NaN and would put the node at a coordinate no schema accepts.
+  it('passes a member through unscaled on an axis the enclosing box has collapsed', () => {
+    const start = box(0, 0, 0, 100)
+    const next = box(0, 0, 50, 200)
+    expect(scaleBoxWithin(start, next, box(0, 0, 0, 50))).toEqual(box(0, 0, 0, 100))
+  })
+
+  // JSON Canvas geometry is integer, and a node scaled to nothing is
+  // unrecoverable — it can never be grabbed to grow again.
+  it('returns integers and never collapses a member to zero', () => {
+    const result = scaleBoxWithin(box(0, 0, 1000, 1000), box(0, 0, 3, 3), box(0, 0, 100, 100))
+    expect(Number.isInteger(result.width)).toBe(true)
+    expect(Number.isInteger(result.height)).toBe(true)
+    expect(result.width).toBeGreaterThanOrEqual(1)
+    expect(result.height).toBeGreaterThanOrEqual(1)
+  })
+})
+
+const coord = fc.integer({ min: -500, max: 500 })
+const extent = fc.integer({ min: 1, max: 500 })
+const anyBox = fc.record({ x: coord, y: coord, width: extent, height: extent })
+
+describe('scaleBoxWithin properties', () => {
+  fcTest.prop([anyBox, anyBox], withDefaults())(
+    'is the identity when the enclosing box is unchanged',
+    (enclosing, member) => {
+      expect(scaleBoxWithin(enclosing, enclosing, member)).toEqual(member)
+    },
+  )
+
+  fcTest.prop([anyBox, anyBox, fc.double({ min: 0, max: 1, noNaN: true })], withDefaults())(
+    'anchors a member to the box it was scaled into, and never emits a non-finite coordinate',
+    (start, next, t) => {
+      // A member built to sit inside `start` by construction.
+      const member = {
+        x: start.x + Math.round(start.width * t * 0.5),
+        y: start.y + Math.round(start.height * t * 0.5),
+        width: Math.max(1, Math.round(start.width * 0.4)),
+        height: Math.max(1, Math.round(start.height * 0.4)),
+      }
+      const scaled = scaleBoxWithin(start, next, member)
+      // Rounding and the one-pixel floor can push a member a pixel past the
+      // edge; the guarantee is that it stays anchored to the box, not that it
+      // is clipped by it.
+      expect(scaled.x).toBeGreaterThanOrEqual(next.x - 1)
+      expect(scaled.y).toBeGreaterThanOrEqual(next.y - 1)
+      for (const value of Object.values(scaled)) {
+        expect(Number.isFinite(value)).toBe(true)
+      }
+    },
+  )
+})

--- a/apps/web/src/components/spatial-editor/touch-multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-multi-select.browser.test.tsx
@@ -1,0 +1,174 @@
+// Building a multi-selection by touch. Shift-click is the pointer path and has
+// no touch equivalent.
+//
+// The gesture is the iOS one: hold an item with one finger, tap others with a
+// second to gather them. Long-press is deliberately NOT used — the browser
+// already synthesises `contextmenu` from it, and taking it would leave touch
+// with no way to reach an object's menu.
+//
+// A second finger otherwise means pinch, so the two are told apart by STATE,
+// not by timing: only while the first finger holds a node does a second-finger
+// tap gather instead of zoom.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 300, y: 40, width: 120, height: 60, text: 'B' },
+    { id: 'c', type: 'text', x: 560, y: 40, width: 120, height: 60, text: 'C' },
+  ],
+  edges: [],
+}
+
+/** Node centres in root-local coordinates (viewport starts at origin, zoom 1). */
+const A = { x: 100, y: 70 }
+const B = { x: 360, y: 70 }
+const C = { x: 620, y: 70 }
+const EMPTY = { x: 400, y: 400 }
+
+function makeHost() {
+  const latest = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => {
+            latest.canvas = next
+            setCanvas(next)
+          }}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (c: HTMLElement) => c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+const extraOutlines = (c: HTMLElement) =>
+  c.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length
+const nodeAt = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((n) => n.id === id)
+
+type Pt = { x: number; y: number }
+
+function at(root: HTMLElement, p: Pt) {
+  const r = root.getBoundingClientRect()
+  return { clientX: r.left + p.x, clientY: r.top + p.y }
+}
+const down = (root: HTMLElement, p: Pt, pointerId: number, pointerType = 'touch') =>
+  fireEvent.pointerDown(root, { button: 0, pointerId, pointerType, ...at(root, p) })
+const move = (root: HTMLElement, p: Pt, pointerId: number, pointerType = 'touch') =>
+  fireEvent.pointerMove(root, { pointerId, pointerType, ...at(root, p) })
+const up = (root: HTMLElement, p: Pt, pointerId: number, pointerType = 'touch') =>
+  fireEvent.pointerUp(root, { pointerId, pointerType, ...at(root, p) })
+
+it('gathers a node tapped by a second finger while the first holds one', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  down(root, A, 1)
+  expect(extraOutlines(container)).toBe(0)
+
+  down(root, B, 2)
+  up(root, B, 2)
+  expect(extraOutlines(container)).toBe(1)
+
+  up(root, A, 1)
+  expect(extraOutlines(container)).toBe(1)
+})
+
+it('keeps gathering after the first tap, while the anchor finger stays down', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  down(root, A, 1)
+  down(root, B, 2)
+  up(root, B, 2)
+  down(root, C, 3)
+  up(root, C, 3)
+
+  expect(extraOutlines(container)).toBe(2)
+  up(root, A, 1)
+})
+
+it('drops a gathered node when it is tapped again', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  down(root, A, 1)
+  down(root, B, 2)
+  up(root, B, 2)
+  expect(extraOutlines(container)).toBe(1)
+
+  down(root, B, 3)
+  up(root, B, 3)
+  expect(extraOutlines(container)).toBe(0)
+
+  up(root, A, 1)
+})
+
+// Gathering is a selection act, not a drag: the anchor must not carry a
+// half-finished move into the new multi-selection, where every gathered node
+// would jump by a delta the user never applied to it.
+it('leaves the anchor where it started, even if it had begun to move', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  down(root, A, 1)
+  move(root, { x: A.x + 60, y: A.y + 30 }, 1)
+  down(root, B, 2)
+  up(root, B, 2)
+  move(root, { x: A.x + 120, y: A.y + 60 }, 1)
+  up(root, { x: A.x + 120, y: A.y + 60 }, 1)
+
+  expect(nodeAt(latest.canvas, 'a')?.x).toBe(40)
+  expect(nodeAt(latest.canvas, 'a')?.y).toBe(40)
+  expect(nodeAt(latest.canvas, 'b')?.x).toBe(300)
+})
+
+// A second finger on EMPTY space is the pinch the editor has always had.
+it('still pinches when the second finger lands on empty space', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const transform = () =>
+    container.querySelector<HTMLDivElement>('[data-testid="viewport-transform"]')?.style.transform
+
+  down(root, A, 1)
+  const before = transform()
+  down(root, EMPTY, 2)
+  move(root, { x: EMPTY.x + 200, y: EMPTY.y + 200 }, 2)
+
+  expect(extraOutlines(container)).toBe(0)
+  expect(transform()).not.toBe(before)
+
+  up(root, { x: EMPTY.x + 200, y: EMPTY.y + 200 }, 2)
+  up(root, A, 1)
+})
+
+// The mouse has shift-click; a second mouse pointer is not a thing.
+it('does not gather for a mouse pointer', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  down(root, A, 1, 'mouse')
+  down(root, B, 2, 'mouse')
+  up(root, B, 2, 'mouse')
+
+  expect(extraOutlines(container)).toBe(0)
+  up(root, A, 1, 'mouse')
+})

--- a/apps/web/src/components/ui/dock-button.test.ts
+++ b/apps/web/src/components/ui/dock-button.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { CLUSTER_BUTTON_CLASS } from '@/components/history-cluster/HistoryCluster'
+import { TOOL_BUTTON_CLASS } from '@/components/spatial-editor/ToolPalette'
+import { DOCK_BUTTON_HEIGHT_CLASS } from './dock-button'
+
+/**
+ * The dock is one row assembled from two files that cannot see each other:
+ * ToolPalette owns the tool buttons, HistoryCluster owns the leading slot the
+ * palette renders. They drifted once already — the cluster grew a
+ * `pointer-coarse` step and the palette did not, so a touch device showed a
+ * 44px control beside a 36px one in the same row. Nothing failed; the row just
+ * looked broken.
+ *
+ * Sharing the height token is what keeps them equal; these tests are what stop
+ * a future edit from re-declaring it locally.
+ */
+describe('dock button sizing', () => {
+  it('gives the palette and the leading cluster the same height token', () => {
+    expect(TOOL_BUTTON_CLASS).toContain(DOCK_BUTTON_HEIGHT_CLASS)
+    expect(CLUSTER_BUTTON_CLASS).toContain(DOCK_BUTTON_HEIGHT_CLASS)
+  })
+
+  it('scales up on coarse pointers, where a 36px target is below the touch floor', () => {
+    expect(DOCK_BUTTON_HEIGHT_CLASS).toMatch(/pointer-coarse:h-\d+/)
+  })
+
+  it('declares no local size token in either dock source (the drift that caused the mismatch)', async () => {
+    const sources = import.meta.glob(
+      ['../spatial-editor/ToolPalette.tsx', '../history-cluster/HistoryCluster.tsx'],
+      { query: '?raw', import: 'default', eager: true },
+    ) as Record<string, string>
+
+    expect(Object.keys(sources)).toHaveLength(2)
+    for (const [path, source] of Object.entries(sources)) {
+      // `size-*` sets width AND height at once, so a local one silently
+      // overrides the shared height. Icon sizing (`size-4` on the lucide
+      // glyphs) is a different concern and stays allowed.
+      const offenders = [...source.matchAll(/\bsize-(\d+)\b/g)]
+        .map((match) => match[1])
+        .filter((value) => value !== '4')
+      expect(offenders, `${path} re-declares a button size token`).toEqual([])
+    }
+  })
+})

--- a/apps/web/src/components/ui/dock-button.ts
+++ b/apps/web/src/components/ui/dock-button.ts
@@ -1,0 +1,40 @@
+/**
+ * Sizing tokens for the bottom dock's controls.
+ *
+ * The dock renders as one row but is assembled from two files that cannot
+ * import each other's intent: ToolPalette owns the tool buttons, and the
+ * `leading` slot is filled by whatever the host passes (today HistoryCluster,
+ * or the editor's own zoom controls in hand mode). Each having its own size
+ * literal is what let a `pointer-coarse` step land on one side only, putting a
+ * 44px control next to a 36px one in the same row.
+ *
+ * Height is separated from width because one control is legitimately not
+ * square: the zoom readout shows "100%" and must be wider than it is tall.
+ * Composing `DOCK_BUTTON_CLASS` for the square case and
+ * `DOCK_BUTTON_HEIGHT_CLASS` + an explicit width for the wide one keeps every
+ * control the same height without a width conflict — the previous code stacked
+ * `w-12` on top of `size-9`, leaving two competing width declarations whose
+ * winner depended on stylesheet order rather than on anything a reader could
+ * see.
+ *
+ * 44px on coarse pointers is the touch-target floor; 36px is comfortable for a
+ * mouse and keeps the dock narrow enough to stay one row on a phone.
+ */
+export const DOCK_BUTTON_HEIGHT_CLASS = 'h-9 pointer-coarse:h-11'
+
+const DOCK_BUTTON_WIDTH_CLASS = 'w-9 pointer-coarse:w-11'
+
+// Press feedback and the transition property list live here rather than on one
+// side: the cluster had `active:scale` and the palette did not, so half the row
+// answered a press and half looked inert. Shared also avoids a second
+// order-dependent conflict — `transition-colors` and
+// `transition-[transform,...]` both set transition-property, so composing them
+// would reintroduce exactly the width bug this module exists to remove.
+const DOCK_BUTTON_BASE_CLASS =
+  'flex items-center justify-center rounded-md text-muted-foreground transition-[transform,color,background-color] duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent hover:text-foreground active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
+
+/** A square dock control (icon only). */
+export const DOCK_BUTTON_CLASS = `${DOCK_BUTTON_BASE_CLASS} ${DOCK_BUTTON_HEIGHT_CLASS} ${DOCK_BUTTON_WIDTH_CLASS}`
+
+/** A dock control whose content sets its width (the zoom readout). */
+export const DOCK_WIDE_BUTTON_CLASS = `${DOCK_BUTTON_BASE_CLASS} ${DOCK_BUTTON_HEIGHT_CLASS} min-w-12 px-1.5`


### PR DESCRIPTION
Four canvas-editor chrome problems, each with a structural cause rather than a cosmetic one.

## The dock had no single owner of its sizing

It renders as one row but is assembled from two files that cannot see each other's intent: `ToolPalette` owns the tool buttons, and the `leading` slot is filled by whatever the host passes. Each carried its own size literal, so when the history cluster grew a `pointer-coarse` step to clear the 44px touch floor, the palette did not follow — a phone showed a 44px control beside a 36px one in the same row.

The zoom readout had a quieter version of the same problem: `w-12` stacked on top of `size-9` left two competing width declarations whose winner depended on stylesheet order rather than on anything a reader could see.

Both now compose shared tokens, with height separated from width so the one non-square control can state its width without a fight. Sharing a token fixes today's divergence; a test that rejects a locally re-declared `size-*` is what stops the next one.

## The overview re-created a collision the dock had already solved

`ToolPalette`'s own header records that independently positioned bottom islands collide as tools grow, and that folding them into one container was the fix. The overview then landed at bottom-right and collided from the other side — below roughly 730px of width the centred dock (about 380px on a coarse pointer) and the overview's 176px overlap.

The overview yields, because the dock is the only route to several actions while the overview duplicates navigation panning already provides.

The predicate is the **container's** width, not the viewport's: both elements are bottom-anchored inside the editor root, so a narrow editor column on a wide screen collides identically. A media query cannot see that; the `ResizeObserver` behind `rootSize` already can.

## Touch could not build a multi-selection at all

Shift-click was the only way, and touch has no shift. Marquee needs the Select tool, which is not the default.

The gesture is the iOS one: hold a node with one finger, tap others with a second to gather them. Long press is deliberately not the trigger — the browser already synthesises `contextmenu` from it, and taking it would leave touch with no route to an object's menu, trading one unreachable affordance for another.

A second finger otherwise means pinch, so the two are separated by **state**, not timing: gathering requires a finger already holding a node, which a pinch never has. A second finger on empty space still zooms exactly as before.

Gathering cancels whatever the anchor had begun to move — carrying a half-applied delta into the new selection would jump every node gathered afterwards by an offset the user never gave it.

## Handles surrounded one node while the outlines said three were selected

Dragging them resized the primary and left the rest behind. Handles now surround the union, and each member is re-placed inside the box they moved, so position within the group and the share each node fills both survive the drag.

A lone node keeps the original path verbatim, including the collapse to zero that overshooting a min-side handle produces. Group members get a one-pixel floor instead: a node collapsed inside a group has no handles of its own to grab it back by.

Connect and Edit are withdrawn while several are selected — both act on one node. The keyboard path draws from the same handles and scales the same way; leaving it alone would just relocate the bug.

## Visual repro

Selection of two, then one drag of the south-east handle. Both scale, the gap scales with them, and the selection still fills its own handles.

![multi-select-before.jpg](https://github.com/user-attachments/assets/26c98c62-0a4d-405b-b3f5-af4427b9d1e9)
![multi-select-after.jpg](https://github.com/user-attachments/assets/9796e0c8-8157-4670-821c-c2c45da899cb)

## Verification

Manually confirmed in a real browser: dock heights in both dock modes, the overview yielding at 390px and returning at 900px on the same populated canvas (with an explicit no-overlap check against the dock), and the multi-selection resize above.

**Not manually verified:** the touch gather, which needs two simultaneous touch pointers the local harness cannot produce. It rests on browser-mode coverage — real Chromium, exact geometry, including that a second finger on empty space still pinches.

`pnpm test` green (596 files), `pnpm -r typecheck` and `pnpm knip` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-selection now supports touch-based gathering and coordinated resizing.
  * Resizing multiple selected items preserves their relative positioning and proportions.
  * Connect controls are hidden when multiple items are selected.
  * The minimap adapts to the editor container width.
* **Style**
  * Dock, palette, and history controls now share consistent sizing, spacing, focus, and interaction styling.
* **Bug Fixes**
  * Improved selection outlines and resize behavior across pointer, keyboard, and touch interactions.
* **Tests**
  * Added coverage for multi-selection, touch gestures, minimap responsiveness, and control styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->