### PR TITLE
fix(web): outline every selected node, not just the extras

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3271,9 +3271,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               ))}
             </svg>
           )}
-          {extraIds.size > 0 && (
+          {/* Which nodes are in the selection. The overlay above outlines the
+            region the handles act on, which says nothing about membership —
+            outlining only the extras left the primary looking untouched, so a
+            Select All over three nodes read as though it had skipped one. */}
+          {isMultiSelection && (
             <svg
-              data-testid="extra-selection-outlines"
+              data-testid="member-outlines"
               aria-hidden="true"
               style={{
                 position: 'absolute',
@@ -3283,24 +3287,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 pointerEvents: 'none',
               }}
             >
-              {[...extraIds].flatMap((id) => {
-                const b = boxes.find((entry) => entry.id === id)
-                return b === undefined ? (
-                  []
-                ) : (
-                  <rect
-                    key={id}
-                    x={b.box.x}
-                    y={b.box.y}
-                    width={b.box.width}
-                    height={b.box.height}
-                    fill="none"
-                    stroke="#2563eb"
-                    strokeWidth={1.5 / viewport.zoom}
-                    opacity={0.7}
-                  />
-                )
-              })}
+              {selectionMembers.map(({ id, box }) => (
+                <rect
+                  key={id}
+                  x={box.x}
+                  y={box.y}
+                  width={box.width}
+                  height={box.height}
+                  fill="none"
+                  stroke="#2563eb"
+                  strokeWidth={1.5 / viewport.zoom}
+                  opacity={0.7}
+                />
+              ))}
             </svg>
           )}
           {selection !== undefined && selectionBox !== undefined && (

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -163,12 +163,10 @@ it('Group selection from a multi-selected node frames the selection with padding
   fireEvent.pointerDown(root, { pointerId: 1, clientX: 60, clientY: 60, buttons: 1 })
   fireEvent.pointerMove(root, { pointerId: 1, clientX: 500, clientY: 400, buttons: 1 })
   fireEvent.pointerUp(root, { pointerId: 1, clientX: 500, clientY: 400 })
-  // Primary selection renders the overlay; the second node is an extra
-  // outline (same split marquee.browser.test.tsx asserts).
+  // The overlay outlines the region the handles act on; membership is marked
+  // per node, primary included (same split marquee.browser.test.tsx asserts).
   await vi.waitFor(() =>
-    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
-      1,
-    ),
+    expect(container.querySelectorAll('[data-testid="member-outlines"] rect').length).toBe(2),
   )
 
   rightClick(root, 180, 150)
@@ -254,8 +252,8 @@ it('Group selection can frame a selection that includes a group frame', async ()
   fireEvent.pointerUp(root, { pointerId: 1, clientX: 600, clientY: 400 })
   await vi.waitFor(() =>
     expect(
-      container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length,
-    ).toBeGreaterThanOrEqual(1),
+      container.querySelectorAll('[data-testid="member-outlines"] rect').length,
+    ).toBeGreaterThanOrEqual(2),
   )
 
   rightClick(root, 450, 150)

--- a/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
@@ -76,11 +76,9 @@ it('plain drag on empty space marquee-selects the intersecting nodes', async () 
 
   await vi.waitFor(() => {
     expect(container.querySelector('[data-testid="marquee-rect"]')).toBeNull()
-    // a is primary (selection overlay), b is an extra outline.
+    // One overlay for the region the handles act on, one outline per member.
     expect(container.querySelectorAll('[data-testid="selection-overlay"]').length).toBe(1)
-    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
-      1,
-    )
+    expect(container.querySelectorAll('[data-testid="member-outlines"] rect').length).toBe(2)
   })
 })
 

--- a/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-resize.browser.test.tsx
@@ -176,3 +176,21 @@ it('accumulates repeated keypresses even when the parent has not re-rendered', (
   expect(first).toBeGreaterThan(100)
   expect(second).toBeGreaterThan(first as number)
 })
+
+// The union outline says "this region is selected"; it says nothing about
+// WHICH nodes are in it. Before this, only the extras were outlined, so the
+// primary — one of the selected nodes — looked untouched, and Select All on
+// three nodes appeared to skip one.
+it('outlines every selected node, the primary included', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectBoth(root)
+
+  const outlined = [...container.querySelectorAll('[data-testid="member-outlines"] rect')].map(
+    (rect) => Math.round(rect.getBoundingClientRect().x - root.getBoundingClientRect().x),
+  )
+
+  expect(outlined).toHaveLength(2)
+  expect(outlined.sort((a, b) => a - b)).toEqual([0, 200])
+})

--- a/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
@@ -66,14 +66,12 @@ it('shift-click adds members; outlines mark them; shift-click again removes', as
   await frame()
 
   await vi.waitFor(() => {
-    expect(container.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length).toBe(
-      1,
-    )
+    expect(container.querySelectorAll('[data-testid="member-outlines"] rect').length).toBe(2)
   })
 
   press(root, 350, 130, { shift: true })
   await vi.waitFor(() => {
-    expect(container.querySelector('[data-testid="extra-selection-outlines"]')).toBeNull()
+    expect(container.querySelector('[data-testid="member-outlines"]')).toBeNull()
   })
 })
 

--- a/apps/web/src/components/spatial-editor/touch-multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-multi-select.browser.test.tsx
@@ -54,8 +54,8 @@ function makeHost() {
 }
 
 const rootOf = (c: HTMLElement) => c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
-const extraOutlines = (c: HTMLElement) =>
-  c.querySelectorAll('[data-testid="extra-selection-outlines"] rect').length
+const memberOutlines = (c: HTMLElement) =>
+  c.querySelectorAll('[data-testid="member-outlines"] rect').length
 const nodeAt = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((n) => n.id === id)
 
 type Pt = { x: number; y: number }
@@ -77,14 +77,14 @@ it('gathers a node tapped by a second finger while the first holds one', () => {
   const root = rootOf(container)
 
   down(root, A, 1)
-  expect(extraOutlines(container)).toBe(0)
+  expect(memberOutlines(container)).toBe(0)
 
   down(root, B, 2)
   up(root, B, 2)
-  expect(extraOutlines(container)).toBe(1)
+  expect(memberOutlines(container)).toBe(2)
 
   up(root, A, 1)
-  expect(extraOutlines(container)).toBe(1)
+  expect(memberOutlines(container)).toBe(2)
 })
 
 it('keeps gathering after the first tap, while the anchor finger stays down', () => {
@@ -98,7 +98,7 @@ it('keeps gathering after the first tap, while the anchor finger stays down', ()
   down(root, C, 3)
   up(root, C, 3)
 
-  expect(extraOutlines(container)).toBe(2)
+  expect(memberOutlines(container)).toBe(3)
   up(root, A, 1)
 })
 
@@ -110,11 +110,11 @@ it('drops a gathered node when it is tapped again', () => {
   down(root, A, 1)
   down(root, B, 2)
   up(root, B, 2)
-  expect(extraOutlines(container)).toBe(1)
+  expect(memberOutlines(container)).toBe(2)
 
   down(root, B, 3)
   up(root, B, 3)
-  expect(extraOutlines(container)).toBe(0)
+  expect(memberOutlines(container)).toBe(0)
 
   up(root, A, 1)
 })
@@ -152,7 +152,7 @@ it('still pinches when the second finger lands on empty space', () => {
   down(root, EMPTY, 2)
   move(root, { x: EMPTY.x + 200, y: EMPTY.y + 200 }, 2)
 
-  expect(extraOutlines(container)).toBe(0)
+  expect(memberOutlines(container)).toBe(0)
   expect(transform()).not.toBe(before)
 
   up(root, { x: EMPTY.x + 200, y: EMPTY.y + 200 }, 2)
@@ -169,6 +169,6 @@ it('does not gather for a mouse pointer', () => {
   down(root, B, 2, 'mouse')
   up(root, B, 2, 'mouse')
 
-  expect(extraOutlines(container)).toBe(0)
+  expect(memberOutlines(container)).toBe(0)
   up(root, A, 1, 'mouse')
 })


### PR DESCRIPTION
Select All over three nodes looked as though it had skipped one — reported on the `latest` preview.

Handles moved to the selection's union in #517. The union outline says which **region** the handles act on; it says nothing about which nodes are in it. Membership was still marked per node, but only for the extras, so the primary became the one node in the selection with no mark of its own. With three nodes selected, two were outlined and the middle one looked untouched.

This is a regression from #517, not a pre-existing bug: before that change the overlay's rect *was* the primary's own box, so the primary was outlined by it.

The layer now outlines every member and is named for what it shows (`member-outlines`). The counts in the tests that read it move by one for the same reason.

## Verification

Reproduced from the reported canvas: three nodes selected, two outlines. Browser suite green (419 tests), typecheck clean.