### PR TITLE
test: pin port behaviour with contracts run against every implementation

### DIFF
--- a/apps/web/src/lib/browser-local-backend.contract.test.ts
+++ b/apps/web/src/lib/browser-local-backend.contract.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The browser-local implementation against the shared CanvasBackend contract.
+ * Its transport siblings run the same cases from mcp-server, where they live.
+ *
+ * In-memory stores rather than real IndexedDB: the contract is about what a
+ * caller of the port may rely on, and the persistence layer has its own
+ * browser-mode suite (`browser-local-backend.browser.test.tsx`).
+ */
+import type { CanvasBackendHarness } from '@kamiazya/whiteboard-mcp/canvas-backend-contract-suite'
+import { canvasBackendContract } from '@kamiazya/whiteboard-mcp/canvas-backend-contract-suite'
+import { describe } from 'vitest'
+import { BrowserLocalBackend } from './browser-local-backend.js'
+import type { CanvasFileStore } from './canvas-file-store.js'
+import type { LoroStore } from './loro-store.js'
+
+function createStores(written: Uint8Array[]) {
+  let snapshot: Uint8Array | null = null
+  const deltas: Uint8Array[] = []
+
+  const store = {
+    load: async (_canvasId: string) =>
+      snapshot === null
+        ? ({ kind: 'not-found' } as const)
+        : ({ kind: 'ok', snapshot, deltas } as const),
+    save: async (_canvasId: string, bytes: Uint8Array) => {
+      snapshot = bytes
+      written.push(bytes)
+    },
+    appendDelta: async (_canvasId: string, bytes: Uint8Array) => {
+      deltas.push(bytes)
+      written.push(bytes)
+    },
+  } as unknown as LoroStore
+
+  const files = new Map<string, { mimeType: string; blob: Blob }>()
+  const fileStore = {
+    get: async (fileId: string) => files.get(fileId)?.blob ?? null,
+    put: async (fileId: string, record: { mimeType: string; blob: Blob }) => {
+      files.set(fileId, record)
+    },
+  } as unknown as CanvasFileStore
+
+  return { store, fileStore }
+}
+
+describe('CanvasBackend contract: BrowserLocalBackend', () => {
+  canvasBackendContract((): CanvasBackendHarness => {
+    const written: Uint8Array[] = []
+    const { store, fileStore } = createStores(written)
+    const backend = new BrowserLocalBackend('canvas-a', store, fileStore)
+    return { backend, sentUpdates: () => written, cleanup: () => backend.disconnect() }
+  })
+})

--- a/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The SharedWorker half of the SseStreamSource contract — the implementation
+ * the app actually ships, driven through its real construction path with MSW
+ * standing in for the daemon.
+ *
+ * The contract itself lives with the port in mcp-server. Running the same cases
+ * on both sides is the point: a defect reached a merged branch because every
+ * test drove the hub, and the gap was invisible from inside that suite.
+ */
+import '@vitest/web-worker'
+import type { SseStreamSourceHarness } from '@kamiazya/whiteboard-mcp/sse-stream-source-contract'
+import { sseStreamSourceContract } from '@kamiazya/whiteboard-mcp/sse-stream-source-contract'
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, describe, vi } from 'vitest'
+import { createSharedSseStreamSource } from './sse-shared-stream-source.js'
+
+const BASE = 'http://127.0.0.1:3099'
+
+// Deliberately never reset between cases. The whole point of this
+// implementation is that one stream per origin outlives any single consumer,
+// so clearing these would close nothing and simply hide the live stream from
+// every case after the first. The contract's per-case document keys are what
+// separate one case's traffic from another's.
+let streamOpens = 0
+const openedStreamIds: string[] = []
+const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
+const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
+let pushFrame: ((frame: string) => void) | null = null
+
+const server = setupServer(
+  http.get(`${BASE}/api/sync/stream`, () => {
+    streamOpens += 1
+    const id = `worker-stream-${streamOpens}`
+    openedStreamIds.push(id)
+    return new HttpResponse(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          const enc = new TextEncoder()
+          controller.enqueue(
+            enc.encode(`event: ready\ndata: ${JSON.stringify({ streamId: id })}\n\n`),
+          )
+          pushFrame = (f) => controller.enqueue(enc.encode(f))
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    )
+  }),
+  http.post(`${BASE}/api/sync/subscribe`, async ({ request }) => {
+    subscribeBodies.push((await request.json()) as (typeof subscribeBodies)[number])
+    return HttpResponse.json({ ok: true })
+  }),
+  http.post(`${BASE}/api/sync/message`, async ({ request }) => {
+    controlMessages.push((await request.json()) as (typeof controlMessages)[number])
+    return HttpResponse.json({ ok: true })
+  }),
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+afterAll(() => server.close())
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+function createHarness(): SseStreamSourceHarness {
+  const source = createSharedSseStreamSource(BASE, 'contract-token')
+  if (!source) throw new Error('SharedWorker unavailable')
+
+  return {
+    source,
+    pushUpdate: (doc, bytes) => {
+      pushFrame?.(`event: update\ndata: ${JSON.stringify({ doc, update: toBase64(bytes) })}\n\n`)
+    },
+    pushText: (doc, raw) => {
+      pushFrame?.(`event: message\ndata: ${JSON.stringify({ doc, raw })}\n\n`)
+    },
+    subscribedDocs: () => subscribeBodies.flatMap((b) => b.subscribe ?? []),
+    unsubscribedDocs: () => subscribeBodies.flatMap((b) => b.unsubscribe ?? []),
+    controlMessages: () => controlMessages,
+    openedStreamIds: () => openedStreamIds,
+    ready: async () => {
+      await vi.waitFor(() => {
+        if (pushFrame === null) throw new Error('stream not open')
+      })
+    },
+    // A SharedWorker cannot be terminated and this source is cached per origin,
+    // so teardown is a no-op; the contract's per-case document keys are what
+    // keep one case's traffic from being read as another's.
+    cleanup: () => {},
+  }
+}
+
+describe('SseStreamSource contract: SharedWorker-backed source', () => {
+  sseStreamSourceContract(createHarness)
+})

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,9 @@
       // type-checker only; vitest.config.ts carries the matching alias.
       "@kamiazya/whiteboard-mcp/sse-stream-source-contract": [
         "../../packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts"
+      ],
+      "@kamiazya/whiteboard-mcp/canvas-backend-contract-suite": [
+        "../../packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts"
       ]
     }
   },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,7 +14,14 @@
     "skipLibCheck": true,
     "types": ["vite/client", "vite-plugin-pwa/client"],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      // Test-only, and deliberately NOT in mcp-server's published `exports`:
+      // the SseStreamSource contract imports vitest, so it must not appear on
+      // the package's runtime surface. A `paths` entry resolves it for the
+      // type-checker only; vitest.config.ts carries the matching alias.
+      "@kamiazya/whiteboard-mcp/sse-stream-source-contract": [
+        "../../packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts"
+      ]
     }
   },
   "include": ["src", "vite.config.ts", "vitest.config.ts"]

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts',
       ),
+      '@kamiazya/whiteboard-mcp/canvas-backend-contract-suite': resolve(
+        __dirname,
+        '../../packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts',
+      ),
       // Subpath alias must precede the root alias: rollup-alias prefix-matches,
       // so the root entry alone would rewrite '/scene' to 'index.ts/scene'.
       '@kamiazya/whiteboard-canvas-viewer/scene': resolve(

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -22,6 +22,13 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/api-contracts/runtime.ts',
       ),
+      // Also test-only: the SseStreamSource behavioural contract, declared once
+      // in the package that owns the port and run here against the
+      // SharedWorker-backed implementation this app ships.
+      '@kamiazya/whiteboard-mcp/sse-stream-source-contract': resolve(
+        __dirname,
+        '../../packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts',
+      ),
       // Subpath alias must precede the root alias: rollup-alias prefix-matches,
       // so the root entry alone would rewrite '/scene' to 'index.ts/scene'.
       '@kamiazya/whiteboard-canvas-viewer/scene': resolve(

--- a/packages/mcp-server/src/server/routes/sync-sse.test.ts
+++ b/packages/mcp-server/src/server/routes/sync-sse.test.ts
@@ -206,6 +206,35 @@ describe('SSE sync transport', () => {
     expect(frames.some((f) => f.includes('viewport_request') && f.includes('req-2'))).toBe(true)
   })
 
+  it('stops treating a stream as ready for a document it unsubscribed', async () => {
+    // Readiness lives on the subscription, so releasing the document takes it
+    // with it. Held separately it would outlive the subscription and keep the
+    // daemon sending viewport requests for a canvas the client stopped
+    // receiving updates for.
+    const app = createApp(createRuntimeOptions())
+    const { res, streamId } = await openStream(app)
+    await app.request('/api/sync/subscribe', {
+      method: 'POST',
+      headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ streamId, subscribe: ['ws-1/vp-gone'] }),
+    })
+    await app.request('/api/sync/message', {
+      method: 'POST',
+      headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ streamId, doc: 'ws-1/vp-gone', message: { type: 'client_ready' } }),
+    })
+
+    await app.request('/api/sync/subscribe', {
+      method: 'POST',
+      headers: { ...auth, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ streamId, unsubscribe: ['ws-1/vp-gone'] }),
+    })
+    sendViewportRequest('ws-1', 'vp-gone', 'req-gone', { mode: 'fit' })
+
+    const frames = await readEvents(res, 1, 300)
+    expect(frames.filter((f) => f.includes('viewport_request'))).toEqual([])
+  })
+
   it('resolves a pending viewport request from a viewport_response', async () => {
     const app = createApp(createRuntimeOptions())
     const { streamId } = await openStream(app)

--- a/packages/mcp-server/src/server/routes/sync-sse.ts
+++ b/packages/mcp-server/src/server/routes/sync-sse.ts
@@ -62,13 +62,22 @@ export function setSyncSseHooks(hooks: {
   resolveViewportRequest = hooks.resolveViewportRequest
 }
 
+/**
+ * `ready` says the stream has signalled `client_ready` for that document. A
+ * viewport request is withheld until then and replayed from cache on ready,
+ * matching the WebSocket path — a pre-ready client cannot apply a viewport,
+ * and sending it both now and on replay would deliver it twice.
+ *
+ * It is a field on the subscription rather than a second set keyed by the same
+ * document, so readiness cannot outlive the subscription it describes:
+ * unsubscribing is one delete, with nothing left to forget to clear.
+ */
+interface SyncStreamDoc {
+  ready: boolean
+}
+
 interface SyncStream {
-  docs: Set<string>
-  // Docs this stream has signalled `client_ready` for. A viewport request is
-  // withheld until then and replayed from cache on ready, matching the
-  // WebSocket path — a pre-ready client cannot apply a viewport, and sending
-  // it both now and on replay would deliver it twice.
-  ready: Set<string>
+  docs: Map<string, SyncStreamDoc>
   send: (event: string, data: string) => void
 }
 
@@ -125,7 +134,7 @@ export function sseBroadcastTextToReady(workspaceId: string, slug: string, raw: 
   const payload: SyncMessageEvent = { doc: key, raw }
   const frame = JSON.stringify(payload)
   for (const stream of streams.values()) {
-    if (!stream.ready.has(key)) continue
+    if (!stream.docs.get(key)?.ready) continue
     stream.send('message', frame)
   }
 }
@@ -149,8 +158,7 @@ export function createSyncSseRouter() {
 
     return streamSSE(c, async (stream) => {
       const entry: SyncStream = {
-        docs: new Set(),
-        ready: new Set(),
+        docs: new Map(),
         send: (event, data) => {
           void stream.writeSSE({ event, data })
         },
@@ -183,12 +191,12 @@ export function createSyncSseRouter() {
     // believing it is subscribed and waiting forever for updates.
     if (!stream) return c.json({ error: 'unknown_stream' }, 404)
 
-    for (const key of parsed.data.subscribe ?? []) stream.docs.add(key)
-    for (const key of parsed.data.unsubscribe ?? []) {
-      stream.docs.delete(key)
-      stream.ready.delete(key)
+    for (const key of parsed.data.subscribe ?? []) {
+      if (!stream.docs.has(key)) stream.docs.set(key, { ready: false })
     }
-    return c.json({ ok: true, docs: [...stream.docs].sort() })
+    // One delete takes the readiness with it.
+    for (const key of parsed.data.unsubscribe ?? []) stream.docs.delete(key)
+    return c.json({ ok: true, docs: [...stream.docs.keys()].sort() })
   })
 
   // The client->server half of the sync protocol. A WebSocket carries these as
@@ -204,7 +212,14 @@ export function createSyncSseRouter() {
 
     const { doc, message } = parsed.data
     if (message.type === 'client_ready') {
-      stream.ready.add(doc)
+      // Upsert rather than require an existing subscription: subscribe and
+      // client_ready are separate POSTs with no ordering guarantee between
+      // them, and dropping readiness that arrived first would withhold the
+      // viewport request for good. Declaring readiness is a statement of
+      // interest in the document either way.
+      const entry = stream.docs.get(doc) ?? { ready: false }
+      entry.ready = true
+      stream.docs.set(doc, entry)
       // Replay the latest viewport request so a stream that connected after
       // the request was issued still inherits the same fit/scroll/zoom intent.
       const cached = getCachedViewportRequest(doc)

--- a/packages/mcp-server/src/shared/canvas-backend.contract.test.ts
+++ b/packages/mcp-server/src/shared/canvas-backend.contract.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+// The two transport backends against the shared CanvasBackend contract. The
+// browser-local implementation runs the same cases from apps/web, where its
+// store lives.
+import { describe, vi } from 'vitest'
+import { DaemonBackend } from './daemon-backend.js'
+import { SseBackend } from './sse-backend.js'
+import type { CanvasBackendHarness } from './test-utils/canvas-backend-contract.js'
+import { canvasBackendContract } from './test-utils/canvas-backend-contract.js'
+
+const BASE = 'http://127.0.0.1:3099'
+
+/** Records what a backend POSTs upstream and serves the routes it reads. */
+function createFetch(sent: Uint8Array[]) {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input)
+    if (url.includes('/snapshot')) return new Response(new Uint8Array([1, 1, 1]), { status: 200 })
+    if (url.includes('/update')) {
+      const body = init?.body
+      if (body instanceof ArrayBuffer) sent.push(new Uint8Array(body))
+      return new Response('{}', { status: 200 })
+    }
+    if (url.includes('/api/sync/stream')) {
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                `event: ready\ndata: ${JSON.stringify({ streamId: 'contract-stream' })}\n\n`,
+              ),
+            )
+          },
+        }),
+        { status: 200 },
+      )
+    }
+    // A file the canvas does not have. 404 is what the daemon answers.
+    if (url.includes('/file/')) return new Response('not found', { status: 404 })
+    return new Response('{}', { status: 200 })
+  }) as unknown as typeof globalThis.fetch
+}
+
+describe('CanvasBackend contract: SseBackend', () => {
+  canvasBackendContract((): CanvasBackendHarness => {
+    const sent: Uint8Array[] = []
+    const backend = new SseBackend('ws-1', 'canvas-a', BASE, { fetch: createFetch(sent) })
+    return { backend, sentUpdates: () => sent, cleanup: () => backend.disconnect() }
+  })
+})
+
+/**
+ * A WebSocket stand-in. DaemonBackend constructs `new WebSocket(...)` itself
+ * rather than taking a factory, and swapping the global is the seam its
+ * existing reconnect test already uses — so this follows that rather than
+ * opening a new injection point in production code for tests alone.
+ */
+class FakeWebSocket {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+  readyState = 1
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  binaryType = 'arraybuffer'
+  readonly sent: unknown[] = []
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+    // The real socket opens on a later tick, which is what gives a disconnect
+    // a window to land mid-connect.
+    setTimeout(() => {
+      // close() on a CONNECTING socket aborts the handshake: the browser fires
+      // onclose and never onopen. Modelling that matters — a fake that opened
+      // anyway would report a defect the real transport cannot have.
+      if (this.readyState !== 1) return
+      this.onopen?.()
+      this.onmessage?.({ data: new Uint8Array([1, 1, 1]).buffer })
+    }, 0)
+  }
+
+  send(data: unknown): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+
+describe('CanvasBackend contract: DaemonBackend', () => {
+  canvasBackendContract((): CanvasBackendHarness => {
+    const sent: Uint8Array[] = []
+    const realWs = globalThis.WebSocket
+    FakeWebSocket.instances = []
+    ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
+    const backend = new DaemonBackend('ws-1', 'canvas-a', BASE, { fetch: createFetch(sent) })
+    return {
+      backend,
+      // The socket is sent a Uint8Array view, not an ArrayBuffer.
+      sentUpdates: () =>
+        FakeWebSocket.instances.flatMap((ws) =>
+          ws.sent.filter((d): d is Uint8Array => d instanceof Uint8Array),
+        ),
+      cleanup: () => {
+        backend.disconnect()
+        ;(globalThis as { WebSocket: unknown }).WebSocket = realWs
+      },
+    }
+  })
+})

--- a/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+// The hub half of the SseStreamSource contract. Its sibling runs the same
+// cases against the SharedWorker-backed source in apps/web, which is the
+// implementation the app actually ships.
+import { describe, vi } from 'vitest'
+import { SseStreamHub } from './sse-stream-hub.js'
+import type { SseStreamSourceHarness } from './test-utils/sse-stream-source-contract.js'
+import { sseStreamSourceContract } from './test-utils/sse-stream-source-contract.js'
+
+const BASE = 'http://d'
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64')
+}
+
+/** A daemon stand-in: mints a stream id, records the POSTs, pushes frames. */
+function createHarness(): SseStreamSourceHarness {
+  let streamSeq = 0
+  const openedStreamIds: string[] = []
+  const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
+  const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
+  let push: ((frame: string) => void) | null = null
+
+  const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input)
+    if (url.includes('/api/sync/stream')) {
+      streamSeq += 1
+      const id = `hub-stream-${streamSeq}`
+      openedStreamIds.push(id)
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            const enc = new TextEncoder()
+            controller.enqueue(
+              enc.encode(`event: ready\ndata: ${JSON.stringify({ streamId: id })}\n\n`),
+            )
+            push = (f) => controller.enqueue(enc.encode(f))
+          },
+        }),
+        { status: 200 },
+      )
+    }
+    const body = init?.body ? JSON.parse(String(init.body)) : {}
+    if (url.includes('/api/sync/subscribe')) subscribeBodies.push(body)
+    if (url.includes('/api/sync/message')) controlMessages.push(body)
+    return new Response('{}', { status: 200 })
+  })
+
+  const hub = new SseStreamHub({
+    fetch: fetch as unknown as typeof globalThis.fetch,
+    baseUrl: BASE,
+  })
+
+  return {
+    source: hub,
+    pushUpdate: (doc, bytes) => {
+      push?.(`event: update\ndata: ${JSON.stringify({ doc, update: toBase64(bytes) })}\n\n`)
+    },
+    pushText: (doc, raw) => {
+      push?.(`event: message\ndata: ${JSON.stringify({ doc, raw })}\n\n`)
+    },
+    subscribedDocs: () => subscribeBodies.flatMap((b) => b.subscribe ?? []),
+    unsubscribedDocs: () => subscribeBodies.flatMap((b) => b.unsubscribe ?? []),
+    controlMessages: () => controlMessages,
+    openedStreamIds: () => openedStreamIds,
+    ready: async () => {
+      await vi.waitFor(() => {
+        if (push === null) throw new Error('stream not open')
+      })
+    },
+    cleanup: () => hub.close(),
+  }
+}
+
+describe('SseStreamSource contract: SseStreamHub', () => {
+  sseStreamSourceContract(createHarness)
+})

--- a/packages/mcp-server/src/shared/sse-stream-hub.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.ts
@@ -123,7 +123,12 @@ export function fromBase64(value: string): Uint8Array {
 
 export class SseStreamHub implements SseStreamSource {
   private readonly options: SseStreamHubOptions
-  private readonly listeners = new Map<string, Set<DocListener>>()
+  /**
+   * One record per document. `ready` lives beside the listeners rather than in
+   * a set of its own so it cannot outlive the subscription it describes:
+   * releasing a document is a single delete, with nothing left to forget.
+   */
+  private readonly docs = new Map<string, { listeners: Set<DocListener>; ready: boolean }>()
   private abort: AbortController | null = null
   /** Minted by the daemon and delivered on the stream itself, so it exists only
    *  between a stream opening and that stream ending. */
@@ -132,9 +137,6 @@ export class SseStreamHub implements SseStreamSource {
   private closed = false
   private retryTimer: ReturnType<typeof setTimeout> | null = null
   private retryResolve: (() => void) | null = null
-  /** Documents that have signalled readiness, so the signal can be repeated
-   *  against a stream the daemon opened after a reconnect. */
-  private readonly readyDocs = new Set<string>()
 
   constructor(options: SseStreamHubOptions) {
     this.options = { ...options, baseUrl: options.baseUrl.replace(/\/$/, '') }
@@ -146,24 +148,24 @@ export class SseStreamHub implements SseStreamSource {
    * back off, so an abandoned canvas stops costing traffic.
    */
   subscribe(doc: string, listener: DocListener): () => void {
-    let set = this.listeners.get(doc)
-    if (!set) {
-      set = new Set()
-      this.listeners.set(doc, set)
+    let entry = this.docs.get(doc)
+    if (!entry) {
+      entry = { listeners: new Set(), ready: false }
+      this.docs.set(doc, entry)
       void this.send({ subscribe: [doc] })
     }
-    set.add(listener)
+    entry.listeners.add(listener)
     void this.start()
 
     return () => {
-      const current = this.listeners.get(doc)
+      const current = this.docs.get(doc)
       if (!current) return
-      current.delete(listener)
-      if (current.size > 0) return
-      this.listeners.delete(doc)
-      // Readiness is replayed on every reconnect, so a document left here would
-      // keep declaring the new stream ready for a canvas nobody is watching.
-      this.readyDocs.delete(doc)
+      current.listeners.delete(listener)
+      if (current.listeners.size > 0) return
+      // One delete drops the readiness with it. Kept apart, it would survive
+      // here and keep declaring every reconnected stream ready for a canvas
+      // nobody is watching.
+      this.docs.delete(doc)
       void this.send({ unsubscribe: [doc] })
     }
   }
@@ -172,7 +174,8 @@ export class SseStreamHub implements SseStreamSource {
     // Readiness is stream state, not a one-off event: the daemon only routes
     // viewport requests to streams that declared it, and a reconnect gives us
     // a stream that never has.
-    if (isClientReady(message)) this.readyDocs.add(doc)
+    const entry = this.docs.get(doc)
+    if (isClientReady(message) && entry) entry.ready = true
     // Before a stream exists there is nothing to address, and the daemon would
     // have nowhere to apply it. Readiness is replayed once one opens; the other
     // control messages are inert server-side, so dropping them costs nothing.
@@ -214,9 +217,9 @@ export class SseStreamHub implements SseStreamSource {
     const delayFor = this.options.retryDelayMs ?? defaultRetryDelayMs
 
     let attempt = 0
-    while (!this.closed && this.listeners.size > 0) {
+    while (!this.closed && this.docs.size > 0) {
       const connected = await this.readStreamOnce()
-      if (this.closed || this.listeners.size === 0) break
+      if (this.closed || this.docs.size === 0) break
       attempt = connected ? 0 : attempt + 1
       await this.wait(delayFor(attempt))
     }
@@ -274,9 +277,10 @@ export class SseStreamHub implements SseStreamSource {
     if (!payload) return
     this.streamId = payload.streamId
 
-    const docs = [...this.listeners.keys()]
+    const docs = [...this.docs.keys()]
     if (docs.length > 0) void this.send({ subscribe: docs })
-    for (const doc of this.readyDocs) {
+    for (const [doc, entry] of this.docs) {
+      if (!entry.ready) continue
       void this.post('/api/sync/message', {
         streamId: payload.streamId,
         doc,
@@ -303,19 +307,19 @@ export class SseStreamHub implements SseStreamSource {
     if (evt.event === 'update') {
       const payload = parseFrame(syncUpdateEventSchema, evt.data)
       if (!payload) return
-      const set = this.listeners.get(payload.doc)
-      if (!set) return
+      const entry = this.docs.get(payload.doc)
+      if (!entry) return
       const bytes = fromBase64(payload.update)
-      for (const l of set) l.onUpdate(bytes)
+      for (const l of entry.listeners) l.onUpdate(bytes)
       return
     }
     // Text frames are addressed too, so a version_created for one canvas never
     // reaches another canvas sharing this stream.
     const envelope = parseFrame(syncMessageEventSchema, evt.data)
     if (!envelope) return
-    const set = this.listeners.get(envelope.doc)
-    if (!set) return
-    for (const l of set) l.onMessage(envelope.raw)
+    const entry = this.docs.get(envelope.doc)
+    if (!entry) return
+    for (const l of entry.listeners) l.onMessage(envelope.raw)
   }
 
   close(): void {
@@ -327,8 +331,7 @@ export class SseStreamHub implements SseStreamSource {
     // Settle a wait in flight: the loop awaiting it checks `closed` and exits.
     this.retryResolve?.()
     this.retryResolve = null
-    this.listeners.clear()
-    this.readyDocs.clear()
+    this.docs.clear()
     this.started = false
   }
 }

--- a/packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts
@@ -1,0 +1,135 @@
+/**
+ * The behavioural contract every `CanvasBackend` must satisfy, written once and
+ * run against each implementation.
+ *
+ * Three ship — the WebSocket daemon backend, the SSE backend, and the
+ * browser-local one — and each grew its own suite, so a behaviour one of them
+ * got wrong was only ever caught if someone thought to write that case in that
+ * file. The teardown case below is the clearest example: a delivery after
+ * `disconnect()` resurrects state the caller deliberately left, and it is a
+ * hazard every backend has for its own reasons.
+ *
+ * What this deliberately does NOT replace: the finer per-implementation races.
+ * A snapshot whose *body read* completes after disconnect — one await later
+ * than the response — cannot be provoked without controlling that
+ * implementation's timing, so it stays pinned where it can be
+ * (`sse-backend.test.ts`). A contract is a floor under every implementation,
+ * not a substitute for knowing one.
+ *
+ * Cases here are deliberately implementation-independent — no assertion about
+ * which endpoint is called or what the snapshot bytes are, only about what a
+ * caller of the port is entitled to rely on.
+ */
+import { expect, it } from 'vitest'
+import type { CanvasBackend, CanvasBackendHandlers } from '../canvas-backend-contract.js'
+
+export interface CanvasBackendHarness {
+  backend: CanvasBackend
+  /** Bytes the backend has pushed upstream, however it does that. */
+  sentUpdates(): Uint8Array[]
+  cleanup(): void
+}
+
+interface Recorded {
+  handlers: CanvasBackendHandlers
+  calls: string[]
+}
+
+function recorder(): Recorded {
+  const calls: string[] = []
+  return {
+    calls,
+    handlers: {
+      onSnapshot: () => calls.push('snapshot'),
+      onRemoteUpdate: () => calls.push('update'),
+      onConnected: () => calls.push('connected'),
+      onVersionCreated: () => calls.push('version'),
+      onRestoreStarted: () => calls.push('restoreStarted'),
+      onRestoreComplete: () => calls.push('restoreComplete'),
+      onHeadChanged: () => calls.push('head'),
+      onViewportRequest: () => calls.push('viewport'),
+      onExportRequest: () => calls.push('export'),
+    } satisfies CanvasBackendHandlers,
+  }
+}
+
+/** Long enough for any in-flight async connect work to land if it is going to. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 100))
+
+export function canvasBackendContract(
+  create: () => CanvasBackendHarness | Promise<CanvasBackendHarness>,
+): void {
+  it('seeds the document and reports the connection', async () => {
+    // Deliberately no ordering assertion between the two. The implementations
+    // genuinely disagree — a WebSocket is "connected" when the socket opens and
+    // the snapshot is the first frame after, while the SSE backend fetches the
+    // snapshot before it subscribes — and the port has never specified which.
+    // Pinning one here would silently make the other's behaviour a bug.
+    const h = await create()
+    const rec = recorder()
+
+    h.backend.connect(rec.handlers)
+    await settle()
+
+    expect(rec.calls).toContain('snapshot')
+    expect(rec.calls).toContain('connected')
+    h.backend.disconnect()
+    h.cleanup()
+  })
+
+  it('delivers nothing more once disconnect has returned', async () => {
+    // Connecting does asynchronous work in every implementation, so a teardown
+    // can always land mid-flight. Seeding a document the caller has abandoned
+    // resurrects state it deliberately left behind.
+    //
+    // Measured from the moment disconnect returns, not from connect: a
+    // callback the backend fires synchronously inside connect() has already
+    // been delivered to a caller that was still listening, and forbidding that
+    // would make a legitimate design (the browser-local backend reports its
+    // connection immediately) fail for no reason.
+    const h = await create()
+    const rec = recorder()
+
+    h.backend.connect(rec.handlers)
+    h.backend.disconnect()
+    const atDisconnect = [...rec.calls]
+    await settle()
+
+    expect(rec.calls).toEqual(atDisconnect)
+    h.cleanup()
+  })
+
+  it('resolves getFile to null for a file that does not exist', async () => {
+    // Not a throw: a missing attachment is an ordinary outcome on a canvas
+    // whose file was deleted, and the editor renders a placeholder for it.
+    const h = await create()
+
+    await expect(h.backend.getFile('no-such-file')).resolves.toBeNull()
+    h.cleanup()
+  })
+
+  it('sends a local update upstream', async () => {
+    const h = await create()
+    const rec = recorder()
+    h.backend.connect(rec.handlers)
+    await settle()
+
+    await h.backend.pushLocalUpdate(new Uint8Array([4, 5, 6]))
+    await settle()
+
+    expect(h.sentUpdates()).toContainEqual(new Uint8Array([4, 5, 6]))
+    h.backend.disconnect()
+    h.cleanup()
+  })
+
+  it('never throws on a control message sent before connecting', async () => {
+    // The editor can request an export or report readiness while the transport
+    // is still coming up, or after it dropped. Every implementation either
+    // queues or ignores; none may throw into the caller.
+    const h = await create()
+
+    expect(() => h.backend.sendClientReady()).not.toThrow()
+    expect(() => h.backend.sendExportResponse('req-1', 'data:image/png;base64,AAA')).not.toThrow()
+    h.cleanup()
+  })
+}

--- a/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
@@ -1,0 +1,190 @@
+/**
+ * The behavioural contract every `SseStreamSource` must satisfy, written once
+ * and run against each implementation.
+ *
+ * It exists because a defect got all the way to a merged branch that only a
+ * suite shaped like this would have caught: `SseStreamSource` has two
+ * implementations — the hub, and a SharedWorker-backed proxy — and every test
+ * drove the hub. The proxy is the one the app actually ships, and it addressed
+ * its control messages with a stream the daemon had never heard of, so
+ * `client_ready` was dropped and viewport requests were never delivered.
+ *
+ * Per-implementation suites cannot prevent that: the gap is the combination
+ * nobody wrote a test for, and the missing combination is invisible from
+ * inside either suite. Only a contract run against every implementation makes
+ * a new implementation's untested behaviour a failure rather than a silence.
+ */
+import { expect, it, vi } from 'vitest'
+import type { SseStreamSource } from '../sse-stream-hub.js'
+
+/**
+ * A running implementation plus the daemon-side observations the contract
+ * asserts against. Each implementation supplies its own plumbing (a fake fetch,
+ * or a real SharedWorker against a mock server); the contract only ever talks
+ * through this.
+ */
+export interface SseStreamSourceHarness {
+  source: SseStreamSource
+  /** Emit an `update` frame from the daemon for `doc`. */
+  pushUpdate(doc: string, bytes: Uint8Array): void
+  /** Emit a server text frame from the daemon for `doc`. */
+  pushText(doc: string, raw: string): void
+  /** Documents the daemon has been asked to route into the stream. */
+  subscribedDocs(): string[]
+  /** Documents the daemon has been asked to stop routing. */
+  unsubscribedDocs(): string[]
+  /** Control messages the daemon received, with the stream each was sent for. */
+  controlMessages(): { streamId: string; doc: string; message: unknown }[]
+  /** Stream ids the daemon minted for this source. */
+  openedStreamIds(): string[]
+  /** Wait until the daemon has an open stream ready to receive frames. */
+  ready(): Promise<void>
+  cleanup(): void
+}
+
+/**
+ * A document key per invocation. Some implementations cannot be torn down (a
+ * SharedWorker has no terminate), so one case's traffic must not be readable
+ * as another's.
+ */
+let seq = 0
+const nextDoc = (): string => `contract-ws/doc-${++seq}`
+
+const until = (predicate: () => boolean): Promise<void> =>
+  vi.waitFor(() => expect(predicate()).toBe(true)) as unknown as Promise<void>
+
+/** A real window in which a wrong delivery could arrive, for asserting none does. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 50))
+
+function collect(source: SseStreamSource, doc: string) {
+  const updates: Uint8Array[] = []
+  const messages: string[] = []
+  const off = source.subscribe(doc, {
+    onUpdate: (b) => updates.push(b),
+    onMessage: (m) => messages.push(m),
+  })
+  return { updates, messages, off }
+}
+
+/**
+ * Subscribe and wait until the daemon has actually been told to route the
+ * document. A frame pushed before that is legitimately dropped — the
+ * subscription may still be in flight (across a port, for the worker-backed
+ * source) — so pushing without this asserts a race rather than the behaviour.
+ */
+async function subscribed(h: SseStreamSourceHarness, doc: string) {
+  const collected = collect(h.source, doc)
+  await h.ready()
+  await until(() => h.subscribedDocs().includes(doc))
+  return collected
+}
+
+/**
+ * Registers the contract cases. Call inside a `describe` for one implementation.
+ *
+ * `create` is invoked per case, so each gets a fresh source where the
+ * implementation allows one.
+ */
+export function sseStreamSourceContract(
+  create: () => SseStreamSourceHarness | Promise<SseStreamSourceHarness>,
+): void {
+  it('announces a document to the daemon when it is first subscribed', async () => {
+    const h = await create()
+    const doc = nextDoc()
+    collect(h.source, doc)
+
+    await until(() => h.subscribedDocs().includes(doc))
+    h.cleanup()
+  })
+
+  it('delivers an update for a subscribed document', async () => {
+    const h = await create()
+    const doc = nextDoc()
+    const { updates } = await subscribed(h, doc)
+
+    h.pushUpdate(doc, new Uint8Array([1, 2, 255]))
+
+    await until(() => updates.length === 1)
+    expect(updates[0]).toEqual(new Uint8Array([1, 2, 255]))
+    h.cleanup()
+  })
+
+  it('does not deliver an update addressed to another document', async () => {
+    // One stream serves many canvases, so every frame carries its doc key.
+    // Without this an edit to one canvas would be applied to another.
+    const h = await create()
+    const doc = nextDoc()
+    const other = nextDoc()
+    const { updates } = await subscribed(h, doc)
+
+    h.pushUpdate(other, new Uint8Array([9]))
+    await settle()
+
+    expect(updates).toEqual([])
+    h.cleanup()
+  })
+
+  it('delivers a text message for a subscribed document but not for another', async () => {
+    const h = await create()
+    const doc = nextDoc()
+    const other = nextDoc()
+    const { messages } = await subscribed(h, doc)
+
+    h.pushText(other, '{"type":"head_changed","head":"nope"}')
+    await settle()
+    expect(messages).toEqual([])
+
+    h.pushText(doc, '{"type":"head_changed","head":"yes"}')
+    await until(() => messages.length === 1)
+    expect(messages[0]).toContain('yes')
+    h.cleanup()
+  })
+
+  it('sends a control message under the stream id its own stream was opened with', async () => {
+    // The defect this contract was written for. Whoever owns the stream must
+    // answer for the control message: the daemon addresses it by stream, and a
+    // caller naming a stream the daemon never opened has its message dropped —
+    // silently, since the send is fire-and-forget.
+    const h = await create()
+    const doc = nextDoc()
+    await subscribed(h, doc)
+
+    h.source.sendMessage(doc, { type: 'client_ready' })
+
+    await until(() => h.controlMessages().some((m) => m.doc === doc))
+    const sent = h.controlMessages().find((m) => m.doc === doc)
+    expect(sent?.message).toEqual({ type: 'client_ready' })
+    expect(h.openedStreamIds()).toContain(sent?.streamId)
+    h.cleanup()
+  })
+
+  it('stops delivering to a listener that unsubscribed', async () => {
+    const h = await create()
+    const doc = nextDoc()
+    const { updates, off } = await subscribed(h, doc)
+
+    off()
+    await until(() => h.unsubscribedDocs().includes(doc))
+    h.pushUpdate(doc, new Uint8Array([7]))
+    await settle()
+
+    expect(updates).toEqual([])
+    h.cleanup()
+  })
+
+  it('keeps delivering while another listener for the same document remains', async () => {
+    // Refcounting is per document, not per listener: releasing one canvas view
+    // must not silence a second one watching the same document.
+    const h = await create()
+    const doc = nextDoc()
+    const first = await subscribed(h, doc)
+    const second = collect(h.source, doc)
+
+    first.off()
+    h.pushUpdate(doc, new Uint8Array([3]))
+
+    await until(() => second.updates.length === 1)
+    expect(first.updates).toEqual([])
+    h.cleanup()
+  })
+}


### PR DESCRIPTION
Two of the defects in the SSE transport work were not one-off mistakes but instances of a class the codebase's structure invites. This addresses the structure rather than the instances.

## Ports with more than one implementation had no shared contract

`SseStreamSource` has two implementations and `CanvasBackend` has three. Each grew its own suite, so a behaviour one implementation got wrong was caught only if someone thought to write that case in that file.

That is how the Critical defect in #514 reached a merged branch: every test drove the hub, while the SharedWorker-backed source is the one the app ships — and it addressed control messages with a stream the daemon had never opened, so `client_ready` was dropped and viewport requests were never delivered. The gap was the combination nobody wrote a test for, and it is invisible from inside either suite.

Each port now has one behavioural contract, run against every implementation. A new implementation's untested behaviour becomes a failure rather than a silence.

The contracts live with the port in `mcp-server`; `apps/web` reaches them through a test-only alias. They are deliberately **not** in the package's published `exports` — they import `vitest` — so a `paths` entry resolves them for the type-checker and `vitest.config.ts` carries the matching runtime alias.

**Verified against the defects themselves.** Reintroducing the wrong stream id turns the same case red on both `SseStreamSource` implementations. Removing each backend's own teardown guard turns the teardown case red on all three.

### What the contracts deliberately do not do

- **No ordering claim between snapshot and connection.** The implementations genuinely disagree — a WebSocket is connected when the socket opens and the snapshot is the frame after; the SSE backend fetches the snapshot before it subscribes — and the port has never specified which. Pinning one would silently make the other's behaviour a bug, which is a design decision, not a test.
- **No replacement for the finer per-implementation races.** A snapshot whose *body read* completes after disconnect — one await later than the response — cannot be provoked without controlling that implementation's timing. It stays pinned where it can be, in `sse-backend.test.ts`. A contract is a floor under every implementation, not a substitute for knowing one.

Writing them surfaced two false positives in my own harnesses, both fixed before they could be read as findings: a fake WebSocket that fired `onopen` after `close()` (a real socket aborts the handshake instead), and a teardown case measured from `connect` rather than from `disconnect`, which would have failed the browser-local backend for reporting its connection synchronously — a legitimate design.

## State that must move together was split across collections

The hub held `listeners` and `readyDocs`; the daemon held `stream.docs` and `stream.ready`. Both are keyed by the same document, so releasing one meant remembering to delete from both — and forgetting is precisely the defect that shipped: readiness outlived the subscription, and every reconnect re-declared the stream ready for a canvas nobody was watching.

One record per document makes that unrepresentable. Unsubscribing is a single delete, with nothing left to forget.

Behaviour-preserving; no existing assertion changed. The daemon keeps accepting a `client_ready` that arrives before its `subscribe`, because those are separate POSTs with no ordering between them and dropping it would withhold the viewport request for good.

## Verification

606 test files / 6391 tests passing; typecheck, knip and build clean.
