### PR TITLE
feat(render): route edges around the nodes between their endpoints

### DIFF
--- a/packages/canvas-render/src/layout/edge-obstacles.test.ts
+++ b/packages/canvas-render/src/layout/edge-obstacles.test.ts
@@ -1,0 +1,128 @@
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { routeEdge } from './spatial-edges.js'
+
+/**
+ * An edge drawn straight through whatever happens to lie between its
+ * endpoints reads as though it connects the node it crosses. Routing now
+ * steps around anything in the way — every node except the two the edge
+ * belongs to, which it must touch.
+ */
+
+const node = (id: string, x: number, y: number, w = 100, h = 60): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+const edge = (from: string, to: string): CanvasEdge => ({
+  id: 'e1',
+  fromNode: from,
+  toNode: to,
+})
+
+/** Whether a segment passes through a node's box (touching an edge does not count). */
+function segmentCrosses(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  box: SpatialNode,
+): boolean {
+  const steps = 200
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps
+    const x = a.x + (b.x - a.x) * t
+    const y = a.y + (b.y - a.y) * t
+    if (x > box.x && x < box.x + box.width && y > box.y && y < box.y + box.height) return true
+  }
+  return false
+}
+
+const pathCrosses = (path: readonly { x: number; y: number }[], box: SpatialNode) =>
+  path.some((point, i) => i > 0 && segmentCrosses(path[i - 1] as typeof point, point, box))
+
+describe('obstacle-aware edge routing', () => {
+  it('leaves a clear path exactly as it was: two points, endpoint to endpoint', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'))
+
+    expect(routed.path).toEqual([
+      { x: 100, y: 30 },
+      { x: 400, y: 30 },
+    ])
+  })
+
+  it('steps around a node standing between the endpoints', () => {
+    const blocker = node('mid', 200, 0)
+    const nodes = [node('a', 0, 0), blocker, node('b', 400, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'))
+
+    expect(routed.path.length).toBeGreaterThan(2)
+    expect(pathCrosses(routed.path, blocker)).toBe(false)
+  })
+
+  it('still touches both endpoints after detouring', () => {
+    const nodes = [node('a', 0, 0), node('mid', 200, 0), node('b', 400, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'))
+
+    expect(routed.path[0]).toEqual({ x: 100, y: 30 })
+    expect(routed.path.at(-1)).toEqual({ x: 400, y: 30 })
+  })
+
+  // The two endpoints are what the edge is FOR. Treating them as obstacles
+  // would make every edge detour around its own ends.
+  it('never treats its own endpoints as obstacles', () => {
+    const from = node('a', 0, 0, 300, 300)
+    const to = node('b', 400, 0, 300, 300)
+    const routed = routeEdge([from, to], edge('a', 'b'))
+
+    expect(routed.path).toHaveLength(2)
+  })
+
+  it('routes around several nodes in the way', () => {
+    const blockers = [node('m1', 150, -20), node('m2', 260, 10)]
+    const nodes = [node('a', 0, 0), ...blockers, node('b', 450, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'))
+
+    for (const blocker of blockers) {
+      expect(pathCrosses(routed.path, blocker), `crosses ${blocker.id}`).toBe(false)
+    }
+  })
+
+  // Layout must never abort over an arrangement no detour can clear.
+  it('returns a finite path even when the obstacle cannot be cleared', () => {
+    const swallowing = node('wall', -1000, -1000, 3000, 3000)
+    const nodes = [node('a', 0, 0), swallowing, node('b', 400, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'))
+
+    expect(routed.path.length).toBeGreaterThanOrEqual(2)
+    for (const point of routed.path) {
+      expect(Number.isFinite(point.x) && Number.isFinite(point.y)).toBe(true)
+    }
+  })
+})
+
+describe('routing properties', () => {
+  const coord = fc.integer({ min: -400, max: 400 })
+  const extent = fc.integer({ min: 1, max: 200 })
+  const nodeArb = (id: string) =>
+    fc.record({ x: coord, y: coord, w: extent, h: extent }).map((r) => node(id, r.x, r.y, r.w, r.h))
+
+  fcTest.prop(
+    [nodeArb('a'), nodeArb('b'), fc.array(nodeArb('m'), { maxLength: 4 })],
+    withDefaults(),
+  )('always yields a finite path anchored to both endpoints', (from, to, middles) => {
+    const others = middles.map((m, i) => ({ ...m, id: `m${i}` }))
+    const routed = routeEdge([from, to, ...others], edge('a', 'b'))
+
+    expect(routed.path.length).toBeGreaterThanOrEqual(2)
+    for (const point of routed.path) {
+      expect(Number.isFinite(point.x)).toBe(true)
+      expect(Number.isFinite(point.y)).toBe(true)
+    }
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -81,12 +81,117 @@ function selfEdgeLoopControlPoints(start: Point, side: Side): [Point, Point] {
   }
 }
 
+/** How far a detour keeps clear of the boxes it steps around, in px. */
+const OBSTACLE_CLEARANCE_PX = 16
+
+/**
+ * Whether a segment passes through a rect's INTERIOR. Touching a border does
+ * not count: every edge starts and ends on a border by construction, and a
+ * route that grazes a corner is not the failure this is looking for.
+ *
+ * Slab method, with the parallel-to-an-axis case handled by the same
+ * comparison rather than a special branch.
+ */
+function segmentCrossesRect(a: Point, b: Point, rect: Rect): boolean {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  let enter = 0
+  let exit = 1
+  const slabs: readonly [number, number, number][] = [
+    [dx, rect.x - a.x, rect.x + rect.w - a.x],
+    [dy, rect.y - a.y, rect.y + rect.h - a.y],
+  ]
+  for (const [delta, near, far] of slabs) {
+    if (delta === 0) {
+      // Parallel to this axis: no crossing unless it already lies within.
+      if (near > 0 || far < 0) return false
+      continue
+    }
+    const t0 = Math.min(near / delta, far / delta)
+    const t1 = Math.max(near / delta, far / delta)
+    enter = Math.max(enter, t0)
+    exit = Math.min(exit, t1)
+    if (enter >= exit) return false
+  }
+  return exit > enter
+}
+
+const pathIsClear = (path: readonly Point[], obstacles: readonly Rect[]) =>
+  path.every(
+    (point, i) =>
+      i === 0 || obstacles.every((rect) => !segmentCrossesRect(path[i - 1] as Point, point, rect)),
+  )
+
+function unionRect(rects: readonly Rect[]): Rect | undefined {
+  const [first, ...rest] = rects
+  if (first === undefined) return undefined
+  let minX = first.x
+  let minY = first.y
+  let maxX = first.x + first.w
+  let maxY = first.y + first.h
+  for (const rect of rest) {
+    minX = Math.min(minX, rect.x)
+    minY = Math.min(minY, rect.y)
+    maxX = Math.max(maxX, rect.x + rect.w)
+    maxY = Math.max(maxY, rect.y + rect.h)
+  }
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+}
+
+const pathLength = (path: readonly Point[]) =>
+  path.reduce(
+    (total, point, i) =>
+      i === 0
+        ? 0
+        : total +
+          Math.hypot(point.x - (path[i - 1] as Point).x, point.y - (path[i - 1] as Point).y),
+    0,
+  )
+
+/**
+ * A path from `start` to `end` that steps around everything in `obstacles`.
+ *
+ * Four candidates — over, under, left of, right of the blocking region — each
+ * a pair of waypoints on one side of it. The shortest candidate that is
+ * itself clear wins; if none is clear the shortest is used anyway, because
+ * layout has to return SOMETHING and a route that still crosses is better
+ * than a thrown error or a straight line through everything.
+ *
+ * Deliberately not a visibility graph or A*: this runs per edge on every
+ * layout, and four candidates against a union box handles the arrangements
+ * that actually occur (a node or two sitting between two others). A denser
+ * search belongs behind the routing-style setting, not in the default path.
+ */
+function detourAround(start: Point, end: Point, obstacles: readonly Rect[]): Point[] {
+  const blocking = obstacles.filter((rect) => segmentCrossesRect(start, end, rect))
+  const region = unionRect(blocking)
+  if (region === undefined) return [start, end]
+
+  const above = region.y - OBSTACLE_CLEARANCE_PX
+  const below = region.y + region.h + OBSTACLE_CLEARANCE_PX
+  const leftOf = region.x - OBSTACLE_CLEARANCE_PX
+  const rightOf = region.x + region.w + OBSTACLE_CLEARANCE_PX
+
+  const candidates: Point[][] = [
+    [start, { x: start.x, y: above }, { x: end.x, y: above }, end],
+    [start, { x: start.x, y: below }, { x: end.x, y: below }, end],
+    [start, { x: leftOf, y: start.y }, { x: leftOf, y: end.y }, end],
+    [start, { x: rightOf, y: start.y }, { x: rightOf, y: end.y }, end],
+  ]
+  const byLength = [...candidates].sort((a, b) => pathLength(a) - pathLength(b))
+  return byLength.find((path) => pathIsClear(path, obstacles)) ?? (byLength[0] as Point[])
+}
+
 /**
  * Resolves one canvas-model edge into a scene-graph edge with a concrete
  * point path. Pure function of (nodes, edge): never throws — a missing
  * endpoint id degenerates to a zero-length path at the origin rather than
  * raising, so a single bad reference never aborts layout for the rest of
  * the canvas.
+ *
+ * The path steps around any OTHER node between the endpoints; an edge drawn
+ * straight through a node reads as though it connects that node instead. The
+ * two endpoint nodes are never obstacles — the edge has to reach them.
  */
 export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): ResolvedEdgeNode {
   const fromNode = nodes.find((n) => n.id === edge.fromNode)
@@ -138,6 +243,15 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
 
   const start = sidePoint(fromRect, fromSide)
   const end = sidePoint(toRect, toSide)
+  const obstacles = nodes.filter((n) => n.id !== edge.fromNode && n.id !== edge.toNode).map(rectOf)
 
-  return { kind: 'edge', id: edge.id, path: [start, end], fromSide, toSide, fromEnd, toEnd }
+  return {
+    kind: 'edge',
+    id: edge.id,
+    path: detourAround(start, end, obstacles),
+    fromSide,
+    toSide,
+    fromEnd,
+    toEnd,
+  }
 }


### PR DESCRIPTION
An edge drawn straight through whatever lies between its endpoints reads as though it connects the node it crosses. Reported from a canvas where a link between two nodes ran across a third.

## What changed

A blocked path now steps around the blocking region: four candidates — over, under, left of, right of it — and the shortest one that is itself clear wins.

A clear path is returned exactly as before: two points, side to side. Every existing rendering is byte-identical, which the SVG determinism goldens already assert.

The two endpoint nodes are never obstacles — the edge has to reach them.

## What this deliberately is not

Not a visibility graph or A*. This runs per edge on every layout, and four candidates against the union of what blocks handles the arrangements that actually occur (a node or two sitting between two others). A denser search belongs behind the routing-style setting rather than in the default path.

Totality holds as everywhere else in canvas-render: an arrangement no detour can clear returns the shortest crossing route rather than throwing, because one awkward pair of nodes must not abort layout for the rest of the canvas.

## Scope

First of three slices agreed with the user:

- **A (this PR)** — obstacle avoidance in the shared router, so editor, export and viewer all get it at once.
- **B** — a canvas-level `x-whiteboard` setting for the route SHAPE (orthogonal polyline / curved detour), declared once so a per-edge override can reuse the same type later.
- **C** — wiring the setting through the three consumers.

## Verification

`pnpm test` green apart from the known `route-scope-registry` load flake (604 files, 6411 tests); `pnpm -r typecheck` clean. canvas-render's own suite is 270 green including the cross-platform determinism goldens.