### PR TITLE
feat(model): declare the canvas-level edge routing style

### DIFF
--- a/.claude/rules/package-canvas-model.md
+++ b/.claude/rules/package-canvas-model.md
@@ -26,7 +26,11 @@ paths:
 - mdast schemas follow the mdast spec content-model hierarchy (flow / phrasing / list / table / row content). Do not widen a parent's `children` back to the flat node union.
 - IDs: canvas ID = canonical ULID (first char `[0-7]`); node ID = nanoid (charset deliberately unenforced — documented looseness).
 - JSON Canvas geometry is integer, with no extension carve-out: `x-whiteboard` carries no geometry of its own.
-- `x-whiteboard` is the canvas-embed extension only, and is the one documented exception to the reject-not-drop rule above — an unrecognised payload is silently dropped (`.catch(undefined)`) so a node written by another version still parses. The reject-not-drop contract governs what others must honour; this key is our own escape hatch, and the node survives either way. Do NOT grow it into a general home for visual primitives JSON Canvas lacks (the `freehand`/`shape` variants were removed for exactly that reason) — express those through an existing node type instead.
+- There are two `x-whiteboard` keys, and the line between them is what keeps the node-level one from growing back:
+  - **On a NODE** it is the canvas-embed extension only — CONTENT that JSON Canvas cannot express. Do NOT grow it into a general home for visual primitives JSON Canvas lacks (the `freehand`/`shape` variants were removed for exactly that reason); express those through an existing node type instead.
+  - **On the CANVAS** it holds rendering PREFERENCES for things JSON Canvas already models (today: `edgeRouting.style`). A consumer that drops it still renders every edge, just with its own routing. Nothing that changes what the document MEANS belongs here.
+- Both are the documented exception to the reject-not-drop rule above — an unrecognised payload is silently dropped (`.catch(undefined)`) so a document written by another version still parses. The reject-not-drop contract governs what others must honour; these keys are our own escape hatch, and the document survives either way.
+- A preference meant to be overridable at a finer scope later (an edge overriding the canvas's routing style) declares its schema ONCE — `edgeRoutingSchema` — and the override reuses it rather than restating the shape.
 
 ## Tests
 

--- a/packages/canvas-codec/src/spatial/degrade.test.ts
+++ b/packages/canvas-codec/src/spatial/degrade.test.ts
@@ -92,3 +92,17 @@ describe('strictDegrade', () => {
     expect(strictDegrade(strictDegrade(canvas))).toEqual(strictDegrade(canvas))
   })
 })
+
+// The canvas-level key is a rendering preference, so strict JSON Canvas has
+// no room for it either. `strictDegrade` rebuilding the canvas from nodes and
+// edges alone already drops it — this pins that as the contract rather than
+// leaving it to how the object happens to be constructed.
+it('drops the canvas-level x-whiteboard as well', () => {
+  const degraded = strictDegrade({
+    nodes: [],
+    edges: [],
+    'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+  })
+
+  expect(degraded).not.toHaveProperty('x-whiteboard')
+})

--- a/packages/canvas-codec/src/spatial/degrade.ts
+++ b/packages/canvas-codec/src/spatial/degrade.ts
@@ -14,6 +14,13 @@ function degradeNode(node: SpatialNode): SpatialNode {
   return rest as SpatialNode
 }
 
+/**
+ * The canvas-level `x-whiteboard` (rendering preferences, e.g. edge routing
+ * style) goes the same way, and for the same reason: strict JSON Canvas has
+ * no room for it. Rebuilding from nodes and edges alone is what drops it —
+ * spelled out here because "the object literal happens not to mention it" is
+ * not a contract anyone can rely on.
+ */
 export function strictDegrade(canvas: SpatialCanvas): SpatialCanvas {
   return {
     nodes: canvas.nodes.map(degradeNode),

--- a/packages/canvas-codec/src/spatial/serialize.test.ts
+++ b/packages/canvas-codec/src/spatial/serialize.test.ts
@@ -1,5 +1,6 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it, vi } from 'vitest'
+import { parseSpatial } from './parse.js'
 import { serializeSpatial } from './serialize.js'
 
 const baseNode = { id: 'n1', x: 0, y: 0, width: 10, height: 10 } as const
@@ -51,4 +52,16 @@ describe('serializeSpatial', () => {
     vi.doUnmock('./degrade.js')
     vi.resetModules()
   })
+})
+
+it('extended mode keeps the canvas-level x-whiteboard through a round trip', () => {
+  const canvas: SpatialCanvas = {
+    nodes: [],
+    edges: [],
+    'x-whiteboard': { edgeRouting: { style: 'curved' } },
+  }
+  const result = parseSpatial(serializeSpatial(canvas, 'extended'))
+
+  expect(result.ok).toBe(true)
+  expect(result.ok && result.value['x-whiteboard']).toEqual({ edgeRouting: { style: 'curved' } })
 })

--- a/packages/canvas-model/src/spatial.test.ts
+++ b/packages/canvas-model/src/spatial.test.ts
@@ -278,3 +278,39 @@ describe('spatialCanvasSchema', () => {
     expect(missingTo.success).toBe(false)
   })
 })
+
+// Route SHAPE is a canvas-wide preference, not per-node decoration: an edge
+// routed one way and its neighbour another reads as a bug, not a choice.
+describe('canvas-level x-whiteboard', () => {
+  const canvasWith = (extension: unknown) => ({
+    nodes: [],
+    edges: [],
+    'x-whiteboard': extension,
+  })
+
+  it('accepts a routing style', () => {
+    const parsed = spatialCanvasSchema.parse(canvasWith({ edgeRouting: { style: 'orthogonal' } }))
+    expect(parsed['x-whiteboard']).toEqual({ edgeRouting: { style: 'orthogonal' } })
+  })
+
+  it('is absent-by-default, so a strict JSON Canvas document parses unchanged', () => {
+    expect(spatialCanvasSchema.parse({ nodes: [], edges: [] })['x-whiteboard']).toBeUndefined()
+  })
+
+  // Same escape-hatch rule the node-level key follows: a payload this version
+  // cannot read costs the setting, never the document.
+  it('silently drops an unreadable payload rather than failing the canvas', () => {
+    const parsed = spatialCanvasSchema.parse(canvasWith({ edgeRouting: { style: 'spiral' } }))
+    expect(parsed['x-whiteboard']).toBeUndefined()
+    expect(parsed.nodes).toEqual([])
+  })
+
+  it('rejects nothing about the canvas itself when the extension is unreadable', () => {
+    const parsed = spatialCanvasSchema.parse({
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'hi' }],
+      edges: [],
+      'x-whiteboard': 'not an object',
+    })
+    expect(parsed.nodes).toHaveLength(1)
+  })
+})

--- a/packages/canvas-model/src/spatial.ts
+++ b/packages/canvas-model/src/spatial.ts
@@ -106,12 +106,47 @@ function findDuplicateId(ids: string[]): string | undefined {
   return undefined
 }
 
+/**
+ * How an edge gets from one endpoint to the other once the router has decided
+ * it must step around something.
+ *
+ * Declared on its own rather than inline, because the same choice is meant to
+ * be overridable per edge later — that override has to reuse this type, not
+ * restate it.
+ *
+ * `straight` is the default and the only shape JSON Canvas itself implies:
+ * direct segments, bending only to clear an obstacle.
+ */
+export const edgeRoutingStyleSchema = z.enum(['straight', 'orthogonal', 'curved'])
+
+export type EdgeRoutingStyle = z.infer<typeof edgeRoutingStyleSchema>
+
+export const edgeRoutingSchema = z.object({ style: edgeRoutingStyleSchema })
+
+/**
+ * `x-whiteboard` at the CANVAS level — separate from the node-level key of the
+ * same name, and holding preferences rather than content.
+ *
+ * This is not the general escape hatch the node-level key was narrowed away
+ * from being. What lives here describes how to DRAW things JSON Canvas already
+ * models; a consumer that drops it still renders every edge, just with its own
+ * routing. Nothing that changes what the document MEANS belongs here.
+ */
+export const canvasExtensionSchema = z.object({
+  edgeRouting: edgeRoutingSchema.optional(),
+})
+
+export type CanvasExtension = z.infer<typeof canvasExtensionSchema>
+
 export const spatialCanvasSchema = z
   .object({
     // JSON Canvas 1.0 declares both top-level arrays optional; a bare `{}`
     // is a valid (empty) canvas.
     nodes: z.array(spatialNodeSchema).default([]),
     edges: z.array(canvasEdgeSchema).default([]),
+    // `.catch` for the same reason the node-level key uses it: a preference
+    // written by another version must cost the preference, never the canvas.
+    'x-whiteboard': canvasExtensionSchema.optional().catch(undefined),
   })
   .superRefine((value, ctx) => {
     const duplicateNodeId = findDuplicateId(value.nodes.map((node) => node.id))


### PR DESCRIPTION
Route shape — direct segments, orthogonal, or curved — is a canvas-wide preference. One edge routed one way and its neighbour another reads as a bug rather than a choice, so the setting belongs to the canvas. Slice B of the routing work agreed with the user (A was #521).

## Two `x-whiteboard` keys, and why that is not a contradiction

#515 narrowed the node-level `x-whiteboard` to canvas embeds and wrote *do not grow it into a general home*. This adds a **second** key, on the canvas rather than a node, and the line between them is what stops the node one growing back:

- **On a node** it carries CONTENT that JSON Canvas cannot express.
- **On the canvas** it carries PREFERENCES about drawing things JSON Canvas already models.

A consumer that drops the canvas key still renders every edge, just with its own routing — which is also why strict degradation drops it. That drop already happened by construction (`strictDegrade` rebuilds from nodes and edges); it is now pinned as a contract, because "the object literal happens not to mention it" is not something anyone can rely on.

Both keys share the silent-drop parse (`.catch(undefined)`): a payload written by another version costs the preference, never the document.

`edgeRoutingSchema` is declared on its own rather than inline because the same choice is meant to be overridable **per edge** later, and that override has to reuse the type rather than restate it — the exact drift this repo's Zod discipline exists to prevent.

## Scope

Nothing reads the setting yet. Rendering is unchanged; wiring the editor, export and viewer is slice C.

## Verification

`pnpm test` green (607 files, 6441 tests), `pnpm -r typecheck` clean.