### PR TITLE
feat(render): honour the canvas's edge routing style

### DIFF
--- a/packages/canvas-render/src/layout/edge-obstacles.test.ts
+++ b/packages/canvas-render/src/layout/edge-obstacles.test.ts
@@ -126,3 +126,41 @@ describe('routing properties', () => {
     }
   })
 })
+
+describe('orthogonal routing style', () => {
+  const isAxisAligned = (path: readonly { x: number; y: number }[]) =>
+    path.every((point, i) => {
+      if (i === 0) return true
+      const prev = path[i - 1] as typeof point
+      return point.x === prev.x || point.y === prev.y
+    })
+
+  it('bends into right angles even when the direct path is clear', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 200)]
+    const routed = routeEdge(nodes, edge('a', 'b'), 'orthogonal')
+
+    expect(routed.path.length).toBeGreaterThan(2)
+    expect(isAxisAligned(routed.path)).toBe(true)
+  })
+
+  it('leaves a straight-style edge diagonal, so the setting is what decides', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 200)]
+    const routed = routeEdge(nodes, edge('a', 'b'), 'straight')
+
+    expect(routed.path).toHaveLength(2)
+  })
+
+  it('stays axis-aligned while stepping around an obstacle', () => {
+    const blocker = node('mid', 200, 0)
+    const nodes = [node('a', 0, 0), blocker, node('b', 400, 0)]
+    const routed = routeEdge(nodes, edge('a', 'b'), 'orthogonal')
+
+    expect(isAxisAligned(routed.path)).toBe(true)
+    expect(pathCrosses(routed.path, blocker)).toBe(false)
+  })
+
+  it('defaults to straight when no style is given', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 200)]
+    expect(routeEdge(nodes, edge('a', 'b')).path).toHaveLength(2)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -444,3 +444,31 @@ describe('layoutSpatialCanvas', () => {
     expect(degenerate).toEqual(baseline)
   })
 })
+
+// The routing style rides on the canvas this function already receives, so
+// honouring it needs no plumbing through the editor, export or viewer. These
+// pin that it is READ — a router supporting a style nothing passes to it is
+// not a feature.
+describe('edge routing style from the canvas', () => {
+  const twoNodes = [textNode({ id: 'a', x: 0, y: 0 }), textNode({ id: 'b', x: 400, y: 200 })]
+  const link: SpatialCanvas['edges'] = [{ id: 'e1', fromNode: 'a', toNode: 'b' }]
+
+  const edgePathOf = (canvasValue: SpatialCanvas) => {
+    const scene = layoutSpatialCanvas(canvasValue, baseOptions())
+    const found = scene.nodes.find((n) => n.kind === 'edge')
+    if (found === undefined || found.kind !== 'edge') throw new Error('no edge in scene')
+    return found.path
+  }
+
+  it('bends the edge when the canvas asks for orthogonal', () => {
+    const path = edgePathOf({
+      ...canvas(twoNodes, link),
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+    })
+    expect(path.length).toBeGreaterThan(2)
+  })
+
+  it('leaves it direct when the canvas says nothing', () => {
+    expect(edgePathOf(canvas(twoNodes, link))).toHaveLength(2)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -407,7 +407,11 @@ function composeEdge(
 ): ResolvedEdgeNode {
   // `routeEdge` already degrades a missing endpoint per canvas-render's own
   // documented contract — nothing further to catch here.
-  const routed = routeEdge(canvas.nodes, edge)
+  //
+  // The routing style rides on the canvas, which this function already has,
+  // so honouring it costs no new plumbing through the consumers: editor,
+  // export and viewer all pass the canvas and get the same routes from it.
+  const routed = routeEdge(canvas.nodes, edge, canvas['x-whiteboard']?.edgeRouting?.style)
   const appearance = options.appearance.resolveEdge(edge)
   return appearance === undefined ? routed : { ...routed, appearance }
 }

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1,4 +1,4 @@
-import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type { CanvasEdge, EdgeRoutingStyle, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { ResolvedEdgeNode } from '../scene-graph.js'
 
 type Side = 'top' | 'right' | 'bottom' | 'left'
@@ -162,24 +162,64 @@ const pathLength = (path: readonly Point[]) =>
  * that actually occur (a node or two sitting between two others). A denser
  * search belongs behind the routing-style setting, not in the default path.
  */
-function detourAround(start: Point, end: Point, obstacles: readonly Rect[]): Point[] {
-  const blocking = obstacles.filter((rect) => segmentCrossesRect(start, end, rect))
-  const region = unionRect(blocking)
-  if (region === undefined) return [start, end]
+/** The candidate that clears every obstacle, shortest first; the shortest overall if none does. */
+function bestCandidate(candidates: readonly Point[][], obstacles: readonly Rect[]): Point[] {
+  const byLength = [...candidates].sort((a, b) => pathLength(a) - pathLength(b))
+  return byLength.find((path) => pathIsClear(path, obstacles)) ?? (byLength[0] as Point[])
+}
 
+/**
+ * The two right-angle elbows between `start` and `end`: across then down, and
+ * down then across. Every detour candidate is already axis-aligned, so the
+ * orthogonal style is these two plus those, judged by the same rule.
+ */
+function elbows(start: Point, end: Point): Point[][] {
+  return [
+    [start, { x: end.x, y: start.y }, end],
+    [start, { x: start.x, y: end.y }, end],
+  ]
+}
+
+/** Ways past a blocking region: over it, under it, left of it, right of it. */
+function detourCandidates(start: Point, end: Point, region: Rect): Point[][] {
   const above = region.y - OBSTACLE_CLEARANCE_PX
   const below = region.y + region.h + OBSTACLE_CLEARANCE_PX
   const leftOf = region.x - OBSTACLE_CLEARANCE_PX
   const rightOf = region.x + region.w + OBSTACLE_CLEARANCE_PX
-
-  const candidates: Point[][] = [
+  return [
     [start, { x: start.x, y: above }, { x: end.x, y: above }, end],
     [start, { x: start.x, y: below }, { x: end.x, y: below }, end],
     [start, { x: leftOf, y: start.y }, { x: leftOf, y: end.y }, end],
     [start, { x: rightOf, y: start.y }, { x: rightOf, y: end.y }, end],
   ]
-  const byLength = [...candidates].sort((a, b) => pathLength(a) - pathLength(b))
-  return byLength.find((path) => pathIsClear(path, obstacles)) ?? (byLength[0] as Point[])
+}
+
+/** The union of whatever `start`→`end` runs through, if anything does. */
+function blockingRegion(start: Point, end: Point, obstacles: readonly Rect[]): Rect | undefined {
+  return unionRect(obstacles.filter((rect) => segmentCrossesRect(start, end, rect)))
+}
+
+function routeStraight(start: Point, end: Point, obstacles: readonly Rect[]): Point[] {
+  const region = blockingRegion(start, end, obstacles)
+  if (region === undefined) return [start, end]
+  return bestCandidate(detourCandidates(start, end, region), obstacles)
+}
+
+/**
+ * Right angles only, whether or not anything is in the way — that is what the
+ * style asks for, so a clear path bends too.
+ *
+ * The elbows come first and the detours join them only when something blocks,
+ * which keeps the common case to a single corner instead of routing every
+ * edge around a region that is not there.
+ */
+function routeOrthogonal(start: Point, end: Point, obstacles: readonly Rect[]): Point[] {
+  const region = blockingRegion(start, end, obstacles)
+  const candidates =
+    region === undefined
+      ? elbows(start, end)
+      : [...elbows(start, end), ...detourCandidates(start, end, region)]
+  return bestCandidate(candidates, obstacles)
 }
 
 /**
@@ -193,7 +233,11 @@ function detourAround(start: Point, end: Point, obstacles: readonly Rect[]): Poi
  * straight through a node reads as though it connects that node instead. The
  * two endpoint nodes are never obstacles — the edge has to reach them.
  */
-export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): ResolvedEdgeNode {
+export function routeEdge(
+  nodes: readonly SpatialNode[],
+  edge: CanvasEdge,
+  style: EdgeRoutingStyle = 'straight',
+): ResolvedEdgeNode {
   const fromNode = nodes.find((n) => n.id === edge.fromNode)
   const toNode = nodes.find((n) => n.id === edge.toNode)
 
@@ -248,7 +292,15 @@ export function routeEdge(nodes: readonly SpatialNode[], edge: CanvasEdge): Reso
   return {
     kind: 'edge',
     id: edge.id,
-    path: detourAround(start, end, obstacles),
+    // 'curved' is accepted by the model but has no rendering yet: the scene
+    // graph carries edges as a point path and the SVG backend draws them as a
+    // <polyline>, so control points would render as corners. Until the
+    // backend can express a curve it routes as 'straight' rather than
+    // pretending — see the routing-style slice notes.
+    path:
+      style === 'orthogonal'
+        ? routeOrthogonal(start, end, obstacles)
+        : routeStraight(start, end, obstacles),
     fromSide,
     toSide,
     fromEnd,

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -125,7 +125,9 @@ export function composeCanvasScene(canvas: SpatialCanvas, measure: MeasureText):
   const blockNodes = canvas.nodes.flatMap((node) =>
     node.type === 'text' ? layoutTextNode(node, measure) : [placeholderFor(node)],
   )
-  const edgeNodes = canvas.edges.map((edge) => routeEdge(canvas.nodes, edge))
+  const edgeNodes = canvas.edges.map((edge) =>
+    routeEdge(canvas.nodes, edge, canvas['x-whiteboard']?.edgeRouting?.style),
+  )
   return { nodes: [...blockNodes, ...edgeNodes] }
 }
 


### PR DESCRIPTION
Slice C of the routing work (A was #521, B was #522).

## Wiring turned out to be nearly free

The style rides on the canvas that `layoutSpatialCanvas` already receives, so the editor, export and viewer needed **no changes at all** — they already pass the canvas and now get the same routes from it. Only the two direct `routeEdge` callers needed the argument. That is a consequence of putting the setting on the canvas rather than threading it as an option.

## Styles

`orthogonal` bends into right angles whether or not anything is in the way, since that is what the style asks for. The elbows are tried first and the detour candidates join them only when something blocks, so the common case stays a single corner rather than routing every edge around a region that is not there.

`straight` is unchanged and remains the default, so a canvas with no setting renders byte-identically — the determinism goldens cover it.

## What is deliberately not here

`curved` is accepted by the model but routes as `straight` for now, and **says so at the call site** rather than quietly looking like a straight edge.

The scene graph carries an edge as a point path and the SVG backend draws it as a `<polyline>`, so control points would render as corners — the same reason a self-edge loop is a box today rather than a loop. Curves need the backend to be able to express one, which is its own change and its own review.

## Verification

`pnpm test` green apart from the known `route-scope-registry` load flake (608 files, 6453 tests); `pnpm -r typecheck` clean.