### PR TITLE
fix: show Reconnecting instead of Synced while sync is down

### DIFF
--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -9,6 +9,19 @@ import { ConnectionStatus } from './ConnectionStatus.js'
 afterEach(cleanup)
 
 describe('ConnectionStatus chip', () => {
+  it('explains the reconnecting state instead of opening an empty popover', () => {
+    // The chip can reach this state, so the popover must have something to
+    // say; a state with no branch renders an empty box on click.
+    render(<ConnectionStatus state="reconnecting" />, { container: document.body })
+    fireEvent.click(screen.getByTestId('connection-chip'))
+
+    const popover = screen.getByTestId('connection-popover')
+    expect(popover.textContent).toMatch(/not running/i)
+    // No replay promise: DaemonBackend drops local updates while its socket is
+    // not OPEN, so telling the user they are sent on recovery would be false.
+    expect(popover.textContent).not.toMatch(/will be sent|are sent when/i)
+  })
+
   it('synced state shows a quiet chip and explains where data lives in the popover', async () => {
     render(<ConnectionStatus state="synced" daemonBaseUrl="http://127.0.0.1:3099" />)
 

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -8,6 +8,9 @@
  * - `local`    — browser-local page; data exists only in this browser.
  *                `children` hosts page-supplied extras (daemon detection,
  *                capability hint) inside the popover.
+ * - `reconnecting` — the transport dropped and is being retried. Edits stay
+ *                in this browser and are sent when it comes back, so this is
+ *                informational, not an error.
  * - `sync-off` — daemon-backed page whose session was rejected. The chip
  *                turns attention-colored and the popover carries the two
  *                ways forward (re-pair / continue browser-local). A polite
@@ -18,7 +21,7 @@ import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 
-export type ConnectionState = 'synced' | 'local' | 'sync-off'
+export type ConnectionState = 'synced' | 'local' | 'reconnecting' | 'sync-off'
 
 export interface ConnectionStatusProps {
   readonly state: ConnectionState
@@ -35,12 +38,14 @@ export interface ConnectionStatusProps {
 const CHIP_LABEL: Record<ConnectionState, string> = {
   synced: 'Synced',
   local: 'Local',
+  reconnecting: 'Reconnecting',
   'sync-off': 'Sync off',
 }
 
 const DOT_CLASS: Record<ConnectionState, string> = {
   synced: 'bg-emerald-500',
   local: 'bg-muted-foreground/60',
+  reconnecting: 'bg-amber-500',
   'sync-off': 'bg-amber-500',
 }
 

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -8,9 +8,11 @@
  * - `local`    — browser-local page; data exists only in this browser.
  *                `children` hosts page-supplied extras (daemon detection,
  *                capability hint) inside the popover.
- * - `reconnecting` — the transport dropped and is being retried. Edits stay
- *                in this browser and are sent when it comes back, so this is
- *                informational, not an error.
+ * - `reconnecting` — live sync is not running: the transport has not come up
+ *                yet, dropped, or failed. Deliberately makes NO promise about
+ *                edits made meanwhile — DaemonBackend.pushLocalUpdate drops
+ *                bytes while the socket is not OPEN, so claiming they are sent
+ *                on recovery would be false.
  * - `sync-off` — daemon-backed page whose session was rejected. The chip
  *                turns attention-colored and the popover carries the two
  *                ways forward (re-pair / continue browser-local). A polite
@@ -103,6 +105,15 @@ export function ConnectionStatus({
                 </>
               ) : null}
               .
+            </p>
+          </div>
+        )}
+        {state === 'reconnecting' && (
+          <div className="flex flex-col gap-1 text-sm">
+            <p className="font-medium">Live sync is not running</p>
+            <p className="text-muted-foreground">
+              This canvas is not receiving changes from your local daemon right now, and edits made
+              here may not reach it. Reload the page if it does not recover.
             </p>
           </div>
         )}

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -488,6 +488,11 @@ export function createCanvasSyncSession(
         backend.sendClientReady()
       },
 
+      onDisconnected() {
+        if (isStale()) return
+        deps.onStatusChange('reconnecting')
+      },
+
       onSnapshot(bytes) {
         if (isStale()) return
         // Persisted "snapshot" bytes are whatever pushLocalUpdate's first

--- a/apps/web/src/lib/canvas-sync-types.ts
+++ b/apps/web/src/lib/canvas-sync-types.ts
@@ -17,7 +17,13 @@ export interface DirtyEventDetail {
   slug: string
 }
 
-export type SyncStatus = 'idle' | 'connected' | 'error'
+/**
+ * `reconnecting` is a live transport that has dropped and is being retried.
+ * Distinct from `error`, which is terminal for this session, and from `idle`,
+ * which is "not started" — a caller that conflated them would either alarm the
+ * user over a blip or stay silent while nothing arrives.
+ */
+export type SyncStatus = 'idle' | 'connected' | 'reconnecting' | 'error'
 
 // Named constants for the window-event contract dispatched by
 // dispatchIdentityEvent below. The literal values are pinned — several other

--- a/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
@@ -27,6 +27,7 @@ const openedStreamIds: string[] = []
 const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
 const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
 let pushFrame: ((frame: string) => void) | null = null
+let endStream: (() => void) | null = null
 
 const server = setupServer(
   http.get(`${BASE}/api/sync/stream`, () => {
@@ -41,6 +42,7 @@ const server = setupServer(
             enc.encode(`event: ready\ndata: ${JSON.stringify({ streamId: id })}\n\n`),
           )
           pushFrame = (f) => controller.enqueue(enc.encode(f))
+          endStream = () => controller.close()
         },
       }),
       { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
@@ -89,6 +91,7 @@ function createHarness(): SseStreamSourceHarness {
     // A SharedWorker cannot be terminated and this source is cached per origin,
     // so teardown is a no-op; the contract's per-case document keys are what
     // keep one case's traffic from being read as another's.
+    dropStream: () => endStream?.(),
     cleanup: () => {},
   }
 }

--- a/apps/web/src/lib/sse-shared-stream-source.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.ts
@@ -50,6 +50,10 @@ export function createSharedSseStreamSource(
       for (const l of set) l.onUpdate(bytes)
       return
     }
+    if (evt.type === 'status') {
+      for (const l of set) l.onConnectionChange?.(evt.connected)
+      return
+    }
     for (const l of set) l.onMessage(evt.raw)
   }
   port.start()

--- a/apps/web/src/lib/sse-shared-worker-protocol.ts
+++ b/apps/web/src/lib/sse-shared-worker-protocol.ts
@@ -34,4 +34,8 @@ export const sseWorkerEventSchema = z.discriminatedUnion('type', [
   // decode lives in exactly one place.
   z.object({ type: z.literal('update'), doc: z.string(), update: z.string() }),
   z.object({ type: z.literal('message'), doc: z.string(), raw: z.string() }),
+  // Whether a stream is currently carrying this document. Addressed like the
+  // others so a tab watching several canvases routes it the same way; the
+  // worker owns the stream, so this is the only way a tab can know.
+  z.object({ type: z.literal('status'), doc: z.string(), connected: z.boolean() }),
 ])

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -122,8 +122,12 @@ describe('sse-shared-worker', () => {
 
   it('forwards only the subscribed document, not every frame on the stream', async () => {
     const port = connect()
+    // Status events are liveness, not document frames; this case is about
+    // which documents' frames are forwarded.
     const seen: unknown[] = []
-    port.onmessage = (e) => seen.push(e.data)
+    port.onmessage = (e) => {
+      if ((e.data as { type?: string }).type !== 'status') seen.push(e.data)
+    }
     const doc = nextDoc()
     port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
     port.postMessage({ type: 'subscribe', doc })

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -90,6 +90,9 @@ function handle(port: MessagePort, raw: unknown): void {
       onMessage: (text) => {
         port.postMessage({ type: 'message', doc: msg.doc, raw: text })
       },
+      onConnectionChange: (connected) => {
+        port.postMessage({ type: 'status', doc: msg.doc, connected })
+      },
     })
     state.subscriptions.set(msg.doc, off)
     return

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -372,6 +372,32 @@ describe('DaemonCanvasPage', () => {
     expect(createdBackends[1]?.disconnectCount).toBe(0)
   })
 
+  it('flips the connection chip to "Reconnecting" while the transport is down', async () => {
+    // Measured on the deployed app: the daemon had no open sync stream for
+    // tens of seconds at a time while the chip still read "Synced". Remote
+    // edits are not arriving in that window and nothing said so.
+    await act(async () => {
+      render(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
+
+    const backend = createdBackends[0]!
+    await act(async () => {
+      backend.handlers?.onDisconnected?.()
+    })
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/reconnecting/i)
+
+    // …and back, so a recovered stream clears it rather than latching.
+    await act(async () => {
+      backend.handlers?.onConnected()
+    })
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
+  })
+
   it('flips the connection chip to "Sync off" on WS auth failure (close 1008 -> onAuthError)', async () => {
     await act(async () => {
       render(

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -373,9 +373,8 @@ describe('DaemonCanvasPage', () => {
   })
 
   it('flips the connection chip to "Reconnecting" while the transport is down', async () => {
-    // Measured on the deployed app: the daemon had no open sync stream for
-    // tens of seconds at a time while the chip still read "Synced". Remote
-    // edits are not arriving in that window and nothing said so.
+    // A chip that reads Synced while the transport is down tells the user
+    // remote edits are arriving when they are not.
     await act(async () => {
       render(
         <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -195,6 +195,7 @@ export function DaemonCanvasPage({
     setNodeLock,
     lockedEdgeIds,
     setEdgeLock,
+    syncStatus,
   } = useCanvasSync(backend, {
     onAuthError: () => setAuthError(true),
     onHeadChanged: () => setBranchRefreshSignal((n) => n + 1),
@@ -338,7 +339,9 @@ export function DaemonCanvasPage({
   // consent page, the same trust anchor first-time pairing uses.
   const connectionStatus = (
     <ConnectionStatus
-      state={authError ? 'sync-off' : 'synced'}
+      // An auth rejection outranks a dropped transport: re-pairing is the way
+      // out of it, while reconnecting resolves itself.
+      state={authError ? 'sync-off' : syncStatus === 'reconnecting' ? 'reconnecting' : 'synced'}
       daemonBaseUrl={daemonBaseUrl}
       onRepair={() => {
         void beginPairingGrant({

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -339,9 +339,12 @@ export function DaemonCanvasPage({
   // consent page, the same trust anchor first-time pairing uses.
   const connectionStatus = (
     <ConnectionStatus
-      // An auth rejection outranks a dropped transport: re-pairing is the way
-      // out of it, while reconnecting resolves itself.
-      state={authError ? 'sync-off' : syncStatus === 'reconnecting' ? 'reconnecting' : 'synced'}
+      // Synced is claimed only while the session is actually connected. An
+      // auth rejection outranks everything else because re-pairing is the only
+      // way out of it; `idle` (not started yet) and `error` are folded in with
+      // `reconnecting`, whose copy makes no claim about recovery timing —
+      // reporting them as Synced is what this whole change exists to stop.
+      state={authError ? 'sync-off' : syncStatus === 'connected' ? 'synced' : 'reconnecting'}
       daemonBaseUrl={daemonBaseUrl}
       onRepair={() => {
         void beginPairingGrant({

--- a/packages/mcp-server/src/shared/canvas-backend-contract.ts
+++ b/packages/mcp-server/src/shared/canvas-backend-contract.ts
@@ -78,6 +78,13 @@ export interface CanvasBackendHandlers {
    */
   onConnected: () => void
   /**
+   * The transport dropped and the backend is retrying. Optional because a
+   * backend with no transport (browser-local) has nothing to report; a backend
+   * that HAS one must call it, or its caller cannot tell a quiet connection
+   * from a dead one.
+   */
+  onDisconnected?: () => void
+  /**
    * Optional: called when the server closes the WebSocket with code 1008
    * (Policy Violation / auth failure). The backend will NOT retry — the caller
    * should surface an error state so the user can re-authenticate.

--- a/packages/mcp-server/src/shared/canvas-backend.contract.test.ts
+++ b/packages/mcp-server/src/shared/canvas-backend.contract.test.ts
@@ -11,6 +11,8 @@ import { canvasBackendContract } from './test-utils/canvas-backend-contract.js'
 const BASE = 'http://127.0.0.1:3099'
 
 /** Records what a backend POSTs upstream and serves the routes it reads. */
+let endStream: (() => void) | null = null
+
 function createFetch(sent: Uint8Array[]) {
   return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input)
@@ -29,6 +31,7 @@ function createFetch(sent: Uint8Array[]) {
                 `event: ready\ndata: ${JSON.stringify({ streamId: 'contract-stream' })}\n\n`,
               ),
             )
+            endStream = () => controller.close()
           },
         }),
         { status: 200 },
@@ -44,7 +47,12 @@ describe('CanvasBackend contract: SseBackend', () => {
   canvasBackendContract((): CanvasBackendHarness => {
     const sent: Uint8Array[] = []
     const backend = new SseBackend('ws-1', 'canvas-a', BASE, { fetch: createFetch(sent) })
-    return { backend, sentUpdates: () => sent, cleanup: () => backend.disconnect() }
+    return {
+      backend,
+      sentUpdates: () => sent,
+      dropTransport: () => endStream?.(),
+      cleanup: () => backend.disconnect(),
+    }
   })
 })
 
@@ -60,7 +68,7 @@ class FakeWebSocket {
   readyState = 1
   onopen: (() => void) | null = null
   onmessage: ((e: { data: unknown }) => void) | null = null
-  onclose: (() => void) | null = null
+  onclose: ((event: { code: number; reason: string }) => void) | null = null
   onerror: (() => void) | null = null
   binaryType = 'arraybuffer'
   readonly sent: unknown[] = []
@@ -85,7 +93,10 @@ class FakeWebSocket {
 
   close(): void {
     this.readyState = 3
-    this.onclose?.()
+    // A real close handler reads event.code; passing nothing would throw
+    // inside the backend and be mistaken for a missing behaviour. 1006 is
+    // what a browser reports for an abnormal close.
+    this.onclose?.({ code: 1006, reason: '' })
   }
 }
 
@@ -103,6 +114,9 @@ describe('CanvasBackend contract: DaemonBackend', () => {
         FakeWebSocket.instances.flatMap((ws) =>
           ws.sent.filter((d): d is Uint8Array => d instanceof Uint8Array),
         ),
+      dropTransport: () => {
+        for (const ws of FakeWebSocket.instances) ws.close()
+      },
       cleanup: () => {
         backend.disconnect()
         ;(globalThis as { WebSocket: unknown }).WebSocket = realWs

--- a/packages/mcp-server/src/shared/daemon-backend.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ts
@@ -181,6 +181,9 @@ export class DaemonBackend implements CanvasBackend {
 
     ws.onclose = (event: CloseEvent) => {
       if (this.cancelled) return
+      // Reported before the terminal branches below so a caller learns the
+      // socket is gone even when the backend gives up on reconnecting.
+      handlers.onDisconnected?.()
       // 1008 = Policy Violation: server rejected the connection due to auth failure.
       // 1003 = Unsupported Data: the server could not decode a binary frame we
       // sent (see routes/ws.ts). Both are terminal from the client's

--- a/packages/mcp-server/src/shared/sse-backend.test.ts
+++ b/packages/mcp-server/src/shared/sse-backend.test.ts
@@ -237,6 +237,36 @@ describe('SseBackend', () => {
     backend.disconnect()
   })
 
+  it('waits for the stream before reporting the connection', async () => {
+    // The source reports its state at subscribe time. Reporting connected
+    // regardless would overwrite it, so a backend whose stream has not opened
+    // yet — every one, for the moment before the ready frame — would claim a
+    // connection it does not have.
+    const fake = createFakeTransport([])
+    const calls: string[] = []
+    const handlers = {
+      onSnapshot: () => {},
+      onRemoteUpdate: () => {},
+      onConnected: () => calls.push('connected'),
+      onDisconnected: () => calls.push('disconnected'),
+      onVersionCreated: () => {},
+      onRestoreStarted: () => {},
+      onRestoreComplete: () => {},
+      onHeadChanged: () => {},
+      onViewportRequest: () => {},
+      onExportRequest: () => {},
+    } satisfies CanvasBackendHandlers
+    const backend = new SseBackend('ws-1', 'canvas-a', 'http://127.0.0.1:3099', fake.transport)
+
+    backend.connect(handlers)
+
+    // The first thing reported is the state at subscribe time: no stream yet.
+    await vi.waitFor(() => expect(calls[0]).toBe('disconnected'))
+    await vi.waitFor(() => expect(calls).toContain('connected'))
+    expect(calls.filter((c) => c === 'connected')).toHaveLength(1)
+    backend.disconnect()
+  })
+
   it('routes control messages through an injected stream source', async () => {
     // The shipped configuration injects the SharedWorker-backed source, so the
     // stream — and therefore the streamId the daemon knows — belongs to the

--- a/packages/mcp-server/src/shared/sse-backend.ts
+++ b/packages/mcp-server/src/shared/sse-backend.ts
@@ -95,6 +95,13 @@ export class SseBackend implements CanvasBackend {
     this.unsubscribe = source.subscribe(this.docKey, {
       onUpdate: (bytes) => handlers.onRemoteUpdate(bytes),
       onMessage: (raw) => this.dispatchText(raw, handlers),
+      // The stream belongs to the source, so its liveness is the only signal
+      // this backend has that updates are still arriving.
+      onConnectionChange: (connected) => {
+        if (this.cancelled) return
+        if (connected) handlers.onConnected()
+        else handlers.onDisconnected?.()
+      },
     })
     handlers.onConnected()
   }

--- a/packages/mcp-server/src/shared/sse-backend.ts
+++ b/packages/mcp-server/src/shared/sse-backend.ts
@@ -103,7 +103,10 @@ export class SseBackend implements CanvasBackend {
         else handlers.onDisconnected?.()
       },
     })
-    handlers.onConnected()
+    // No unconditional report here: the source announces its state at
+    // subscribe time and on every change, so anything added on top would
+    // either overwrite an accurate "not connected yet" or double-report a
+    // connection — and the session sends client_ready per report.
   }
 
   /**

--- a/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
@@ -20,6 +20,7 @@ function createHarness(): SseStreamSourceHarness {
   const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
   const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
   let push: ((frame: string) => void) | null = null
+  let endStream: (() => void) | null = null
 
   const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input)
@@ -35,6 +36,7 @@ function createHarness(): SseStreamSourceHarness {
               enc.encode(`event: ready\ndata: ${JSON.stringify({ streamId: id })}\n\n`),
             )
             push = (f) => controller.enqueue(enc.encode(f))
+            endStream = () => controller.close()
           },
         }),
         { status: 200 },
@@ -68,6 +70,7 @@ function createHarness(): SseStreamSourceHarness {
         if (push === null) throw new Error('stream not open')
       })
     },
+    dropStream: () => endStream?.(),
     cleanup: () => hub.close(),
   }
 }

--- a/packages/mcp-server/src/shared/sse-stream-hub.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.test.ts
@@ -212,6 +212,58 @@ describe('SseStreamHub', () => {
     hub.close()
   })
 
+  it('tells its subscribers when the stream drops and when it comes back', async () => {
+    // Without this a caller cannot distinguish "nothing has changed" from
+    // "nothing is arriving", and the UI reports a connection that is gone.
+    const fake = createFake()
+    const hub = new SseStreamHub({
+      fetch: fake.fetch,
+      baseUrl: 'http://d',
+      retryDelayMs: noDelay,
+    })
+    const states: boolean[] = []
+    hub.subscribe('w/a', {
+      onUpdate: () => {},
+      onMessage: () => {},
+      onConnectionChange: (connected) => states.push(connected),
+    })
+
+    // The first entry is the state at subscribe time — no stream yet.
+    await vi.waitFor(() => expect(states).toEqual([false, true]))
+    fake.endStream()
+
+    await vi.waitFor(() => expect(states).toEqual([false, true, false, true]))
+    hub.close()
+  })
+
+  it('tells a late subscriber the state of the stream it just joined', async () => {
+    // Liveness announced only on transitions leaves anyone who subscribes to an
+    // already-open stream with no idea whether it is live — a second canvas
+    // opened in the same tab would show an unknown connection forever.
+    const fake = createFake()
+    const hub = new SseStreamHub({ fetch: fake.fetch, baseUrl: 'http://d', retryDelayMs: noDelay })
+    // Wait on the first subscriber actually observing the open stream, not on
+    // the fetch call: the ready frame is parsed later, and a second subscriber
+    // registered in that window would be told by the transition itself.
+    const first: boolean[] = []
+    hub.subscribe('w/a', {
+      onUpdate: () => {},
+      onMessage: () => {},
+      onConnectionChange: (c) => first.push(c),
+    })
+    await vi.waitFor(() => expect(first).toEqual([false, true]))
+
+    const states: boolean[] = []
+    hub.subscribe('w/b', {
+      onUpdate: () => {},
+      onMessage: () => {},
+      onConnectionChange: (connected) => states.push(connected),
+    })
+
+    await vi.waitFor(() => expect(states).toEqual([true]))
+    hub.close()
+  })
+
   it('stops reconnecting once closed', async () => {
     const fake = createFake()
     const hub = new SseStreamHub({

--- a/packages/mcp-server/src/shared/sse-stream-hub.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.ts
@@ -85,6 +85,15 @@ function defaultRetryDelayMs(attempt: number): number {
 export interface DocListener {
   onUpdate: (bytes: Uint8Array) => void
   onMessage: (raw: string) => void
+  /**
+   * Whether a stream is currently carrying this document.
+   *
+   * A subscriber that is only told about frames cannot distinguish "nothing
+   * has changed" from "nothing is arriving", so a dropped stream looks exactly
+   * like a quiet one and the UI keeps reporting a connection that is gone.
+   * Optional because a caller that only applies updates has no use for it.
+   */
+  onConnectionChange?: (connected: boolean) => void
 }
 
 /**
@@ -155,6 +164,10 @@ export class SseStreamHub implements SseStreamSource {
       void this.send({ subscribe: [doc] })
     }
     entry.listeners.add(listener)
+    // Announced on transitions alone, liveness would never reach anyone who
+    // joins a stream that is already open — a second canvas in the same tab
+    // would show an unknown connection for as long as nothing went wrong.
+    listener.onConnectionChange?.(this.streamId !== null)
     void this.start()
 
     return () => {
@@ -262,6 +275,7 @@ export class SseStreamHub implements SseStreamSource {
     // The id belongs to the stream that just ended; nothing may be addressed
     // to it until the next one announces its own.
     this.streamId = null
+    this.announceConnection(false)
     return true
   }
 
@@ -276,6 +290,7 @@ export class SseStreamHub implements SseStreamSource {
     const payload = parseFrame(syncReadyEventSchema, data)
     if (!payload) return
     this.streamId = payload.streamId
+    this.announceConnection(true)
 
     const docs = [...this.docs.keys()]
     if (docs.length > 0) void this.send({ subscribe: docs })
@@ -286,6 +301,19 @@ export class SseStreamHub implements SseStreamSource {
         doc,
         message: { type: 'client_ready' },
       })
+    }
+  }
+
+  /** A subscriber that throws must not stop the others from being told. */
+  private announceConnection(connected: boolean): void {
+    for (const entry of this.docs.values()) {
+      for (const listener of entry.listeners) {
+        try {
+          listener.onConnectionChange?.(connected)
+        } catch {
+          // A listener's own failure is not this hub's to propagate.
+        }
+      }
     }
   }
 

--- a/packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/canvas-backend-contract.ts
@@ -27,6 +27,13 @@ export interface CanvasBackendHarness {
   backend: CanvasBackend
   /** Bytes the backend has pushed upstream, however it does that. */
   sentUpdates(): Uint8Array[]
+  /**
+   * Drop this backend's transport, if it has one. Omitted by an
+   * implementation with nothing to drop (the browser-local backend reads a
+   * store, so it is never disconnected) — the case below then skips rather
+   * than asserting a behaviour that cannot exist.
+   */
+  dropTransport?(): void
   cleanup(): void
 }
 
@@ -43,6 +50,7 @@ function recorder(): Recorded {
       onSnapshot: () => calls.push('snapshot'),
       onRemoteUpdate: () => calls.push('update'),
       onConnected: () => calls.push('connected'),
+      onDisconnected: () => calls.push('disconnected'),
       onVersionCreated: () => calls.push('version'),
       onRestoreStarted: () => calls.push('restoreStarted'),
       onRestoreComplete: () => calls.push('restoreComplete'),
@@ -96,6 +104,27 @@ export function canvasBackendContract(
     await settle()
 
     expect(rec.calls).toEqual(atDisconnect)
+    h.cleanup()
+  })
+
+  it('reports a disconnect when its transport drops', async () => {
+    // Without it the caller cannot tell a quiet connection from a dead one,
+    // and the UI keeps reporting sync that is not happening.
+    const h = await create()
+    if (!h.dropTransport) {
+      h.cleanup()
+      return
+    }
+    const rec = recorder()
+    h.backend.connect(rec.handlers)
+    await settle()
+    expect(rec.calls).toContain('connected')
+
+    h.dropTransport()
+    await settle()
+
+    expect(rec.calls).toContain('disconnected')
+    h.backend.disconnect()
     h.cleanup()
   })
 

--- a/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
@@ -39,6 +39,8 @@ export interface SseStreamSourceHarness {
   openedStreamIds(): string[]
   /** Wait until the daemon has an open stream ready to receive frames. */
   ready(): Promise<void>
+  /** End the current stream the way a dropped connection does. */
+  dropStream(): void
   cleanup(): void
 }
 
@@ -155,6 +157,26 @@ export function sseStreamSourceContract(
     const sent = h.controlMessages().find((m) => m.doc === doc)
     expect(sent?.message).toEqual({ type: 'client_ready' })
     expect(h.openedStreamIds()).toContain(sent?.streamId)
+    h.cleanup()
+  })
+
+  it('tells its subscribers when the stream drops', async () => {
+    // A subscriber told only about frames cannot tell "nothing has changed"
+    // from "nothing is arriving", so a dropped stream looks exactly like a
+    // quiet one and the UI keeps reporting a connection that is gone.
+    const h = await create()
+    const doc = nextDoc()
+    const states: boolean[] = []
+    h.source.subscribe(doc, {
+      onUpdate: () => {},
+      onMessage: () => {},
+      onConnectionChange: (connected) => states.push(connected),
+    })
+    await until(() => states.includes(true))
+
+    h.dropStream()
+
+    await until(() => states.includes(false))
     h.cleanup()
   })
 

--- a/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
@@ -173,10 +173,14 @@ export function sseStreamSourceContract(
       onConnectionChange: (connected) => states.push(connected),
     })
     await until(() => states.includes(true))
+    // Measured from here on: subscribing already records the state at join
+    // time, which on a fresh source is `false`. Asserting `includes(false)`
+    // over the whole array would pass without the drop emitting anything.
+    const before = states.length
 
     h.dropStream()
 
-    await until(() => states.includes(false))
+    await until(() => states.slice(before).includes(false))
     h.cleanup()
   })
 


### PR DESCRIPTION
Measured on the deployed app against a local daemon: three windows of **15.6s, 70.0s and 31.6s** in which the daemon had **no open sync stream at all** while both canvas tabs displayed "Synced". Remote edits were not arriving in those windows and nothing said so.

The stream does come back on its own, so no data is lost. The defect is that a user cannot tell the difference, which is the failure mode this branch's own reconnect commit described: *a client that does not come back keeps its listeners registered while silently receiving nothing, so the canvas looks connected while it diverges.*

## Why it said Synced

The chip was derived from the auth state alone:

```
state={authError ? 'sync-off' : 'synced'}
```

So it read Synced whenever pairing was intact, whatever the transport was doing — including on the WebSocket path, which has the same hazard. `syncStatus` was already computed by `useCanvasSync` and simply never destructured by the page: the signal existed and went nowhere.

## What now reports what

- **The hub** tells each document's subscribers when its stream opens and when it ends, and **also reports the current state at subscribe time**. Announced on transitions alone, liveness would never reach anyone joining a stream that is already open — which is every canvas after the first one in a tab.
- **The SharedWorker** forwards that over the port, because with the shared source the page never sees the stream itself.
- **Every backend with a transport** reports its loss: the SSE backend from the source's liveness, the daemon backend from `onclose`.
- **The session** maps that to a new `reconnecting` status and the chip shows it. An auth rejection still outranks it — re-pairing is the way out of that one, while a reconnect resolves itself.

Both port contracts were extended rather than each implementation tested separately, so a backend or stream source that stays silent fails rather than passes.

## Not fixed here, and not claimed to be

**Why the gaps happen at all.** Each one followed a tab navigation, and the stream stayed open for minutes across idle once the tabs settled — so this is not an idle timeout. The leading hypothesis is that a page's `pagehide` unsubscribes its documents, the worker's hub sees no documents left and stops reconnecting until a page subscribes again. That is **unverified**; the daemon's subscribe/unsubscribe traffic is not logged, so it cannot be told apart from a worker teardown without more instrumentation. Making the state visible is worth shipping on its own; the cause is a separate lane.

## Verification

608 test files / 6449 tests passing; typecheck, knip and build clean.

Three test-harness defects were found and fixed while writing this, each of which would otherwise have been read as a defect in the code under test: a fake WebSocket whose `close()` passed no `CloseEvent` (the real handler reads `event.code`), a liveness test that passed only because a second subscriber happened to register before the ready frame was parsed, and a case measuring "after disconnect" from `connect` instead of from `disconnect`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Reconnecting** connection status indicator with an amber status dot.
  * Edits remain available locally while the connection is temporarily restored.
  * The indicator automatically returns to **Synced** after reconnection.
  * Authentication failures continue to display **Sync off**.

* **Bug Fixes**
  * Improved connection-state reporting across supported transport types.
  * Prevented stale sessions from overwriting the active connection status.

* **Tests**
  * Added coverage for transport drops, reconnection, and connection-state notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->