### PR TITLE
fix(web): stop the canvas surface being text-selectable

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2415,7 +2415,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       <div
         ref={rootRef}
         data-testid={testId}
-        className={className}
+        // The canvas is a drawing surface, not prose: a drag means marquee or
+        // pan, and Select All means every NODE. Leaving it text-selectable let
+        // the browser paint its own selection across the chrome — reported
+        // after a Select All. Text stays selectable where text is edited (see
+        // TextNodeEditor).
+        className={`select-none ${className ?? ''}`.trimEnd()}
         // A canvas editor's interaction surface has no static-content semantics
         // HTML/ARIA can describe more precisely than "application" — this is
         // the same documented tradeoff drawing/whiteboard editors commonly

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -76,6 +76,10 @@ export function TextNodeEditor({
         height: box.height,
         resize: 'none',
         boxSizing: 'border-box',
+        // Explicit, because the canvas root turns selection OFF and this
+        // inherits from it — without this the caret cannot select the text it
+        // is editing.
+        userSelect: 'text',
       }}
       onChange={(e) => {
         setValue(e.target.value)

--- a/apps/web/src/components/spatial-editor/select-none.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/select-none.browser.test.tsx
@@ -1,0 +1,52 @@
+// The canvas is a drawing surface, not prose. A drag across it means marquee
+// or pan, and Select All means "every node" — neither should leave the
+// browser's own text selection painted over the chrome. Text stays selectable
+// exactly where text is being edited.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 40, y: 40, width: 200, height: 100, text: 'hello' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState(initial)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+const rootOf = (c: HTMLElement) => c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+it('makes the canvas surface unselectable', () => {
+  const { container } = render(<Host />)
+  expect(getComputedStyle(rootOf(container)).userSelect).toBe('none')
+})
+
+it('keeps the text a node is being edited with selectable', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  const at = { clientX: r.left + 140, clientY: r.top + 90 }
+
+  // Double-press opens the editor (the editor's own detection, not dblclick).
+  for (let i = 0; i < 2; i++) {
+    fireEvent.pointerDown(root, { button: 0, pointerId: 1, ...at })
+    fireEvent.pointerUp(root, { pointerId: 1, ...at })
+  }
+
+  await vi.waitFor(() => {
+    const editor = container.querySelector('textarea')
+    expect(editor).not.toBeNull()
+    // Inherited `none` would leave the caret unable to select its own text.
+    expect(getComputedStyle(editor as HTMLTextAreaElement).userSelect).toBe('text')
+  })
+})


### PR DESCRIPTION
Select All left the browser's own text selection painted across the editor's chrome — reported after trying Cmd+A on the preview.

The canvas is a drawing surface, not prose: a drag across it means marquee or pan, and Select All means every **node** — the editor's handler already claims that key and calls `preventDefault`, so a native text selection is never the intended outcome there. It appeared because nothing said the surface was unselectable in the first place.

Selection is turned off at the root and back on inside the text editor, which inherits from it and would otherwise be unable to select the text it is editing — the one place on the canvas where text selection IS the point.

## Verification

Browser suite green (421 tests), including a new pair pinning `user-select: none` on the root and `text` on the open editor.