### PR TITLE
feat(web): let the canvas choose its edge routing style

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -20,6 +20,24 @@ Never hand-edit the lockfile. If typecheck breaks after a lockfile change with "
 - Use the harness `Monitor` tool for anything that must be watched across turns (CI checks, PR states, deploys). A background subagent's polling loop dies with its turn — a subagent told to "keep polling" will silently stop.
 - If an executor agent is needed, pair it with a Monitor: the monitor detects the event, the main session wakes the agent for one action.
 
+## Verifying on a Preview deployment
+
+`apps/web` registers a Workbox service worker, so **what the server deploys and what the browser executes are two different questions**. A preview URL you have opened before is controlled by a service worker serving its precache, and it will keep running the bundle from an earlier visit however many times you reload.
+
+This is worth naming because it fakes the most misleading result there is: a fix that is deployed, correct, and covered by tests, behaving in the browser exactly as if it had never been written. Checking the deploy history does not rule it out — that answers what the server returns, not what the page runs.
+
+Before treating a preview observation as evidence about the code:
+
+```js
+// In the page console. `controlled: true` means you may be running an old bundle.
+await navigator.serviceWorker.getRegistrations()
+// Clear it, then reload:
+for (const r of await navigator.serviceWorker.getRegistrations()) await r.unregister()
+for (const k of await caches.keys()) await caches.delete(k)
+```
+
+When a preview contradicts a green test, suspect the cache before suspecting the layer under test. The cheapest discriminator is a **control action**: exercise some other feature that writes through the same path (adding a node, say). If the control persists and the feature under test does not, the transport and the server are fine and the difference is in the code the browser is actually running.
+
 ## CI flakes
 
 - A known-flake failure gets one `gh run rerun <id> --failed`. The second occurrence of the same flake in CI promotes it to a root-cause fix lane (own worktree + dev-loop); do not keep re-running.

--- a/.claude/rules/package-canvas-workspace.md
+++ b/.claude/rules/package-canvas-workspace.md
@@ -49,6 +49,15 @@
   `doc.getMap('edges')` keyed by edgeId. Each value is a plain object
   (not a nested LoroMap container) — this preserves node-level CRDT
   merge while avoiding Loro's nested-container overwrite issues.
+- A third map, `doc.getMap('canvas')`, holds the canvas ENVELOPE —
+  properties of the canvas rather than of anything on it (today
+  `x-whiteboard`, the rendering preferences). Separate because the merge
+  story differs in kind: nodes and edges are keyed per object so two peers
+  editing different objects both survive, whereas a canvas-wide preference
+  is one value with one meaning and last-writer-wins per key is all it
+  needs. Anything the canvas carries beside `nodes`/`edges` must be written
+  here — a schema round-trip through JSON is NOT evidence it persists,
+  since this bridge is the path the app actually saves through.
 
 ## Tests
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -60,6 +60,7 @@
 import type {
   CanvasColor,
   ClipboardFragment,
+  EdgeRoutingStyle,
   SpatialCanvas,
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
@@ -211,6 +212,21 @@ const MINIMAP_HEIGHT_PX = 110
  * screen collides in exactly the same way, and a media query cannot see it.
  */
 const MINIMAP_MIN_ROOT_WIDTH_PX = 768
+
+/**
+ * The routing styles offered in the UI.
+ *
+ * `curved` is a valid model value but routes as `straight` until the SVG
+ * backend can draw a curve, so offering it would be a control that changes
+ * nothing. It joins this list when it renders.
+ */
+const EDGE_ROUTING_CHOICES: readonly {
+  readonly style: EdgeRoutingStyle
+  readonly label: string
+}[] = [
+  { style: 'straight', label: 'Straight' },
+  { style: 'orthogonal', label: 'Orthogonal' },
+]
 
 export interface SpatialEditorProps {
   readonly canvas: SpatialCanvas
@@ -2890,6 +2906,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     },
                   })
                 }
+                // Empty space IS the canvas, so canvas-wide settings are acted
+                // on from here — the recorded OOUI rule puts actions on an
+                // existing object with that object, and keeps the dock's "+"
+                // menu for things that do not exist yet.
+                //
+                // Provisional placement: a canvas with several settings wants
+                // its own surface rather than a growing context menu.
+                const currentRouting = canvas['x-whiteboard']?.edgeRouting?.style ?? 'straight'
+                emptyItems.push({ kind: 'separator' })
+                emptyItems.push({
+                  kind: 'options',
+                  label: 'Edge routing',
+                  options: EDGE_ROUTING_CHOICES.map(({ style, label }) => ({
+                    key: style,
+                    label,
+                    selected: currentRouting === style,
+                    onSelect: () => {
+                      const command: EditorCommand = { kind: 'set-edge-routing', style }
+                      onChange(applyCommand(canvasRef.current, command), command)
+                    },
+                  })),
+                })
                 return emptyItems
               }
               const items: ContextMenuItem[] = []

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -604,3 +604,45 @@ describe('create-edge', () => {
     ).toBe(canvas)
   })
 })
+
+// The routing style belongs to the canvas, so the command that sets it names
+// no node. It is the first command that edits the canvas ENVELOPE rather than
+// its contents.
+describe('set-edge-routing', () => {
+  const empty: SpatialCanvas = { nodes: [], edges: [] }
+
+  it('records the style on the canvas', () => {
+    const next = applyCommand(empty, { kind: 'set-edge-routing', style: 'orthogonal' })
+    expect(next['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+  })
+
+  it('leaves nodes and edges untouched', () => {
+    const canvas = {
+      nodes: [{ id: 'a', type: 'text' as const, x: 0, y: 0, width: 10, height: 10, text: 'hi' }],
+      edges: [{ id: 'e1', fromNode: 'a', toNode: 'a' }],
+    }
+    const next = applyCommand(canvas, { kind: 'set-edge-routing', style: 'orthogonal' })
+
+    expect(next.nodes).toEqual(canvas.nodes)
+    expect(next.edges).toEqual(canvas.edges)
+  })
+
+  // Returning to the default should leave no trace, so a canvas that never
+  // chose a style and one that chose and reverted serialize identically.
+  it('removes the setting when the style goes back to straight', () => {
+    const set = applyCommand(empty, { kind: 'set-edge-routing', style: 'orthogonal' })
+    const reverted = applyCommand(set, { kind: 'set-edge-routing', style: 'straight' })
+
+    expect(reverted).not.toHaveProperty('x-whiteboard')
+  })
+
+  it('keeps any other canvas-level extension it does not own', () => {
+    const withOther: SpatialCanvas = {
+      ...empty,
+      'x-whiteboard': { edgeRouting: { style: 'curved' } },
+    }
+    const next = applyCommand(withOther, { kind: 'set-edge-routing', style: 'orthogonal' })
+
+    expect(next['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+  })
+})

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -21,6 +21,7 @@
 import type {
   CanvasColor,
   CanvasEdge,
+  EdgeRoutingStyle,
   SpatialCanvas,
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
@@ -78,6 +79,13 @@ export type EditorLeafCommand =
       readonly id: string
       // undefined returns the object to the theme default (field removed).
       readonly color: CanvasColor | undefined
+    }
+  | {
+      // The one command that edits the canvas ENVELOPE rather than its
+      // contents, so it names no node: routing style is a property of the
+      // canvas, and per-edge overrides are a later, separate command.
+      readonly kind: 'set-edge-routing'
+      readonly style: EdgeRoutingStyle
     }
   | {
       readonly kind: 'set-edge-color'
@@ -257,6 +265,21 @@ function setEdgeEnds(
 }
 
 /** `color: undefined` removes the field — the theme default, canonically. */
+/**
+ * `straight` is the default, so choosing it REMOVES the setting rather than
+ * recording it. A canvas that never chose a style and one that chose and
+ * changed its mind then serialize identically — otherwise every canvas anyone
+ * opened the menu on would carry a redundant extension forever.
+ */
+function setEdgeRouting(canvas: SpatialCanvas, style: EdgeRoutingStyle): SpatialCanvas {
+  const { 'x-whiteboard': extension, ...rest } = canvas
+  if (style === 'straight') {
+    const { edgeRouting: _removed, ...others } = extension ?? {}
+    return Object.keys(others).length === 0 ? rest : { ...rest, 'x-whiteboard': others }
+  }
+  return { ...rest, 'x-whiteboard': { ...extension, edgeRouting: { style } } }
+}
+
 function setNodeColor(
   canvas: SpatialCanvas,
   id: string,
@@ -387,6 +410,8 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return setEdgeSide(canvas, command.id, command.endpoint, command.side)
     case 'set-node-color':
       return setNodeColor(canvas, command.id, command.color)
+    case 'set-edge-routing':
+      return setEdgeRouting(canvas, command.style)
     case 'set-edge-color':
       return setEdgeColor(canvas, command.id, command.color)
     case 'set-node-url':

--- a/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
@@ -1,0 +1,121 @@
+// Provisional UI for the canvas-wide routing style.
+//
+// It lives on empty space because empty space IS the canvas, and the recorded
+// OOUI rule puts actions on an existing object with that object — the dock's
+// "+" menu stays for things that do not exist yet. Placement is provisional;
+// the rule it follows is not.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 400, y: 240, width: 120, height: 60, text: 'B' },
+  ],
+  edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+}
+
+function makeHost() {
+  const latest = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (c: HTMLElement) => c.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+function openCanvasMenu(root: HTMLElement) {
+  const r = root.getBoundingClientRect()
+  root.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + 700,
+      clientY: r.top + 560,
+      button: 2,
+    }),
+  )
+}
+
+const optionButton = (container: HTMLElement, label: string) =>
+  [...container.querySelectorAll('[data-testid="context-menu"] button')].find(
+    (button) => button.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined
+
+it('offers the routing style from the canvas itself, not the creation menu', async () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  openCanvasMenu(rootOf(container))
+
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+  })
+  expect(container.textContent).toContain('Edge routing')
+  expect(optionButton(container, 'Orthogonal')).toBeDefined()
+
+  // The dock's "+" menu is for what does not exist yet; a canvas-wide setting
+  // must not appear there.
+  const addButton = container.querySelector('[data-testid="add-button"]') as HTMLButtonElement
+  addButton.click()
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="add-menu"]')).not.toBeNull()
+  })
+  expect(container.querySelector('[data-testid="add-menu"]')?.textContent).not.toContain('routing')
+})
+
+it('records the choice on the canvas and bends the edge', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  openCanvasMenu(rootOf(container))
+
+  await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
+  optionButton(container, 'Orthogonal')?.click()
+
+  await vi.waitFor(() => {
+    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+  })
+  // The scene follows: a bent edge has more than the two endpoint points.
+  await vi.waitFor(() => {
+    const polyline = container.querySelector('polyline')
+    expect(polyline?.getAttribute('points')?.split(' ').length).toBeGreaterThan(2)
+  })
+})
+
+// Straight is the default, so choosing it must leave no trace — otherwise
+// every canvas anyone opened the menu on carries a redundant extension.
+it('drops the setting again when the style returns to straight', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  openCanvasMenu(rootOf(container))
+  await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
+  optionButton(container, 'Orthogonal')?.click()
+  await vi.waitFor(() =>
+    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal'),
+  )
+
+  openCanvasMenu(rootOf(container))
+  await vi.waitFor(() => expect(optionButton(container, 'Straight')).toBeDefined())
+  optionButton(container, 'Straight')?.click()
+
+  await vi.waitFor(() => {
+    expect(latest.canvas).not.toHaveProperty('x-whiteboard')
+  })
+})

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -747,6 +747,13 @@ describe('createCanvasSyncSession', () => {
   describe('model-based: random EditorCommand sequences', () => {
     const nodeIdArb = fc.constantFrom('n-a', 'n-b', 'n-c')
     const commandArb: fc.Arbitrary<EditorCommand> = fc.oneof(
+      // A canvas-wide setting: the first command that edits the ENVELOPE
+      // rather than a node, and the shape of command this file's properties
+      // were blind to.
+      fc.record({
+        kind: fc.constant('set-edge-routing' as const),
+        style: fc.constantFrom('straight' as const, 'orthogonal' as const),
+      }),
       fc.record({
         kind: fc.constant('move-node' as const),
         id: nodeIdArb,
@@ -821,6 +828,52 @@ describe('createCanvasSyncSession', () => {
         } finally {
           vi.useRealTimers()
         }
+      },
+    )
+
+    // What the property above never asks: does the DOCUMENT end up holding
+    // what the editor produced? Counting pending commits passes happily for a
+    // command that persists nothing — and a canvas-wide setting did exactly
+    // that, reaching the screen and vanishing on the next reload.
+    //
+    // Replaying the pushed payloads over the initial snapshot is what a
+    // reloading client does, so this asks the question the way the bug asked
+    // it. Deliberately no assertion that anything WAS pushed: a command that
+    // changes nothing legitimately pushes nothing, and the replay of an empty
+    // list still has to equal the unchanged canvas.
+    fcTest.prop(
+      [fc.array(commandArb, { minLength: 1, maxLength: 12 })],
+      withDefaults({ numRuns: 30 }),
+    )(
+      'a command sequence leaves the document equal to the canvas it produced',
+      async (commands) => {
+        const backend = makeFakeBackend()
+        const session = createCanvasSyncSession(backend, makeDeps())
+        session.connect()
+        const initial = baseCanvas()
+        const snapshotBytes = makeSnapshot(initial)
+        backend._ctrl.handlers?.onSnapshot(snapshotBytes)
+
+        let canvas: SpatialCanvas = initial
+        for (const command of commands) {
+          canvas = applyCommand(canvas, command)
+          session.onChange(canvas, command)
+          await vi.advanceTimersByTimeAsync(1000)
+          await flushMicrotasks()
+        }
+        await session.dispose()
+        await flushMicrotasks()
+
+        const replay = new LoroDoc()
+        replay.import(snapshotBytes)
+        for (const bytes of backend._ctrl.pushLocalUpdateCalls) replay.import(bytes)
+        const stored = readSpatialCanvas(replay)
+
+        expect(stored['x-whiteboard']).toEqual(canvas['x-whiteboard'])
+        const byId = <T extends { id: string }>(list: readonly T[]) =>
+          [...list].sort((a, b) => a.id.localeCompare(b.id))
+        expect(byId(stored.nodes)).toEqual(byId(canvas.nodes))
+        expect(byId(stored.edges)).toEqual(byId(canvas.edges))
       },
     )
   })

--- a/packages/canvas-workspace/src/loro-bridge.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.test.ts
@@ -844,3 +844,62 @@ test('a lock written after the snapshot survives snapshot + update replay', () =
       .sort(),
   ).toEqual([FILE_NODE.id, TEXT_NODE.id].sort())
 })
+
+// The canvas ENVELOPE, not its contents. Nodes and edges each get a keyed
+// map so two peers editing different objects converge; a canvas-wide
+// preference is one value with one meaning, so last-writer-wins per key is
+// the whole story.
+describe('canvas-level extension', () => {
+  test('round-trips the routing style', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+    })
+
+    expect(readSpatialCanvas(doc)['x-whiteboard']).toEqual({
+      edgeRouting: { style: 'orthogonal' },
+    })
+  })
+
+  test('leaves the key absent when the canvas never set one', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [], edges: [] })
+
+    expect(readSpatialCanvas(doc)).not.toHaveProperty('x-whiteboard')
+  })
+
+  // Reverting to the default must clear the stored value, or the canvas keeps
+  // rendering a preference the user turned off.
+  test('clears the stored setting when the canvas drops it', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+    })
+    writeSpatialCanvas(doc, { nodes: [], edges: [] })
+
+    expect(readSpatialCanvas(doc)).not.toHaveProperty('x-whiteboard')
+  })
+
+  test('survives a merge from a peer that only moved a node', () => {
+    const a = makeDoc()
+    writeSpatialCanvas(a, {
+      nodes: [TEXT_NODE],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+    })
+    const b = makeDoc()
+    b.import(a.export({ mode: 'snapshot' }))
+    writeSpatialCanvas(b, {
+      nodes: [{ ...TEXT_NODE, x: 999 }],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+    })
+    a.import(b.export({ mode: 'snapshot' }))
+
+    expect(readSpatialCanvas(a)['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+  })
+})

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -3,6 +3,7 @@ import {
   type CanvasEdge,
   canvasCoreMetaSchema,
   canvasEdgeSchema,
+  canvasExtensionSchema,
   type ExtensionFacets,
   extensionFacetsSchema,
   type SpatialCanvas,
@@ -14,6 +15,18 @@ import type { z } from 'zod'
 
 const NODES_KEY = 'nodes'
 const EDGES_KEY = 'edges'
+/**
+ * The canvas ENVELOPE — properties of the canvas rather than of anything on
+ * it (today: the `x-whiteboard` rendering preferences).
+ *
+ * A third top-level map rather than a field beside the node entries, because
+ * the merge story is different in kind. Nodes and edges are keyed per object
+ * so two peers editing different objects both survive; a canvas-wide
+ * preference is ONE value with one meaning, and last-writer-wins per key is
+ * the whole of what it needs.
+ */
+const CANVAS_KEY = 'canvas'
+const EXTENSION_FIELD = 'x-whiteboard'
 const FACETS_KEY = 'facets'
 // Editor state that is NOT canvas content: stored beside the canvas in the
 // same doc (so it survives reload and syncs to peers) but in its own map,
@@ -85,6 +98,13 @@ function edgeToFields(edge: CanvasEdge): Fields {
 export function writeSpatialCanvas(doc: LoroDoc, canvas: SpatialCanvas): void {
   const nodesMap = doc.getMap(NODES_KEY)
   const edgesMap = doc.getMap(EDGES_KEY)
+  // Deleted rather than left behind when the canvas drops it: a canvas that
+  // returned to the default must stop rendering a preference the author
+  // turned off.
+  const canvasMap = doc.getMap(CANVAS_KEY)
+  const extension = canvas[EXTENSION_FIELD]
+  if (extension === undefined) canvasMap.delete(EXTENSION_FIELD)
+  else canvasMap.set(EXTENSION_FIELD, extension)
 
   const existingNodeIds = new Set<string>(nodesMap.keys())
   const existingEdgeIds = new Set<string>(edgesMap.keys())
@@ -320,7 +340,11 @@ export function readSpatialCanvas(doc: LoroDoc): SpatialCanvas {
     if (parsed.success) edges.push(parsed.data)
   }
 
-  return { nodes, edges }
+  // Parsed, not trusted: the stored value came from another version or peer,
+  // and canvas-model's own rule for this key is that an unreadable payload
+  // costs the preference, never the canvas.
+  const extension = canvasExtensionSchema.safeParse(doc.getMap(CANVAS_KEY).get(EXTENSION_FIELD))
+  return extension.success ? { nodes, edges, [EXTENSION_FIELD]: extension.data } : { nodes, edges }
 }
 
 /**


### PR DESCRIPTION
The style shipped in #522/#523 with **no way to set it**: nothing in the repo wrote the canvas-level extension, so neither a person nor an agent could reach it. I confirmed that only after being asked whether a UI existed — the slice-C PR pinned that the setting is *read*, and I never checked that anything could write it.

## Where the control lives

On empty canvas space, because empty space **is** the canvas, and the recorded OOUI rule puts actions on an existing object with that object. The dock's `+` menu stays for what does not exist yet — a test asserts the setting never appears there.

Placement is provisional: a canvas with several settings wants its own surface rather than a growing context menu. The rule it follows is not provisional.

## Two behaviours worth naming

Choosing `straight` **removes** the setting rather than recording it, so a canvas that never chose and one that chose and reverted serialize identically. Otherwise every canvas anyone opened the menu on would carry a redundant extension forever.

`curved` is a valid model value but routes as `straight` until the SVG backend can draw one, so it is left out of the menu. A control that changes nothing is worse than an absent one.

## Verification

Browser suite green (424 tests) including three new tests: the setting is offered from the canvas and not the `+` menu, choosing it records on the canvas *and* bends the rendered edge, and returning to straight leaves no trace. `pnpm -r typecheck` clean.