### PR TITLE
test: build a valid SpatialCanvas once instead of three times

### DIFF
--- a/packages/canvas-codec/src/spatial/round-trip.property.test.ts
+++ b/packages/canvas-codec/src/spatial/round-trip.property.test.ts
@@ -1,37 +1,8 @@
-import {
-  canvasEdgeArbitrary,
-  spatialNodeArbitrary,
-} from '@kamiazya/whiteboard-canvas-model/test-utils'
+import { spatialCanvasArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe, expect } from 'vitest'
-import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { fcTest, withDefaults } from '../test-utils/fast-check.js'
 import { parseSpatial } from './parse.js'
 import { serializeSpatial } from './serialize.js'
-
-const spatialCanvasArbitrary = fc.array(spatialNodeArbitrary, { maxLength: 4 }).chain((nodes) => {
-  const ids = nodes.map((node) => node.id)
-  const edgeArbitrary =
-    ids.length >= 2
-      ? fc
-          .tuple(fc.constantFrom(...ids), fc.constantFrom(...ids))
-          .chain(([fromNode, toNode]) =>
-            canvasEdgeArbitrary.map((edge) => ({ ...edge, fromNode, toNode })),
-          )
-      : fc.constant(undefined)
-
-  return fc
-    .array(edgeArbitrary, { maxLength: ids.length >= 2 ? 3 : 0 })
-    .map((edges) => ({
-      nodes,
-      edges: edges.filter((edge): edge is NonNullable<typeof edge> => edge !== undefined),
-    }))
-    .map((canvas) => ({
-      ...canvas,
-      // dedupe edge ids: the model schema rejects duplicates
-      edges: canvas.edges.filter(
-        (edge, index) => canvas.edges.findIndex((e) => e.id === edge.id) === index,
-      ),
-    }))
-})
 
 describe('extended JSON Canvas round-trip property (lossless)', () => {
   fcTest.prop([spatialCanvasArbitrary], withDefaults())(

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -8,6 +8,7 @@ import type {
   MdastTableCell,
   MdastTableRow,
 } from '../mdast/index.js'
+import type { SpatialCanvas } from '../spatial.js'
 import { fc } from './fast-check.js'
 
 const CROCKFORD_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
@@ -437,3 +438,34 @@ export function mdastRootArbitrary(maxDepth = 3): fc.Arbitrary<MdastRoot> {
     .array(mdastFlowContentArbitrary(maxDepth), { maxLength: 3 })
     .map((children) => ({ type: 'root', children }))
 }
+
+/**
+ * A SpatialCanvas that is valid by construction.
+ *
+ * The two invariants `spatialCanvasSchema` enforces — unique node ids, and
+ * edges whose endpoints exist — cannot be met by generating nodes and edges
+ * independently, so they are built in rather than filtered afterwards. Node ids
+ * in particular need the explicit uniqueness: `nodeIdArbitrary` has low entropy
+ * at small sizes (it shrinks to `" "`), so collisions are rare enough to pass
+ * hundreds of runs and then fail on someone else's seed.
+ *
+ * It lives here because three packages were each building this shape by hand
+ * and one of them had lost the node-id dedupe — a canvas the schema rejects,
+ * asserted to round-trip.
+ */
+export const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
+  .uniqueArray(spatialNodeArbitrary, { maxLength: 4, selector: (node) => node.id })
+  .chain((nodes): fc.Arbitrary<SpatialCanvas> => {
+    const ids = nodes.map((node) => node.id)
+    if (ids.length < 2) return fc.constant({ nodes, edges: [] })
+    return fc
+      .uniqueArray(
+        fc
+          .tuple(fc.constantFrom(...ids), fc.constantFrom(...ids))
+          .chain(([fromNode, toNode]) =>
+            canvasEdgeArbitrary.map((edge) => ({ ...edge, fromNode, toNode })),
+          ),
+        { maxLength: 3, selector: (edge) => edge.id },
+      )
+      .map((edges) => ({ nodes, edges }))
+  })

--- a/packages/canvas-viewer/src/scene.property.test.ts
+++ b/packages/canvas-viewer/src/scene.property.test.ts
@@ -7,46 +7,10 @@
  */
 
 import { strictDegrade } from '@kamiazya/whiteboard-canvas-codec'
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import {
-  canvasEdgeArbitrary,
-  spatialNodeArbitrary,
-} from '@kamiazya/whiteboard-canvas-model/test-utils'
+import { spatialCanvasArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { describe, expect, it } from 'vitest'
 import { parseViewerScene, serializeViewerScene } from './scene.js'
 import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
-
-// Unique-by-id nodes, then edges restricted to reference only those ids —
-// this is what keeps every generated canvas schema-valid (the duplicate-id
-// and dangling-reference invariants live in spatialCanvasSchema itself).
-const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
-  .uniqueArray(spatialNodeArbitrary, { minLength: 0, maxLength: 5, selector: (n) => n.id })
-  .chain((nodes) => {
-    if (nodes.length === 0) return fc.constant({ nodes, edges: [] })
-    const nodeIdArb = fc.constantFrom(...nodes.map((n) => n.id))
-    return fc
-      .array(
-        canvasEdgeArbitrary.chain((edge) =>
-          fc.tuple(nodeIdArb, nodeIdArb).map(([fromNode, toNode]) => ({
-            ...edge,
-            fromNode,
-            toNode,
-          })),
-        ),
-        { maxLength: 3 },
-      )
-      .chain((edges) => {
-        // Dedup edge ids the same way node ids are deduped, so the
-        // superRefine duplicate-id check never rejects a generated sample.
-        const seen = new Set<string>()
-        const uniqueEdges = edges.filter((e) => {
-          if (seen.has(e.id)) return false
-          seen.add(e.id)
-          return true
-        })
-        return fc.constant({ nodes, edges: uniqueEdges })
-      })
-  })
 
 describe('scene parse/serialize properties', () => {
   fcTest.prop([spatialCanvasArbitrary], withDefaults())(

--- a/packages/canvas-workspace/src/loro-bridge.property.test.ts
+++ b/packages/canvas-workspace/src/loro-bridge.property.test.ts
@@ -1,8 +1,6 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import {
-  canvasEdgeArbitrary,
   extensionFacetsArbitrary,
-  spatialNodeArbitrary,
+  spatialCanvasArbitrary,
 } from '@kamiazya/whiteboard-canvas-model/test-utils'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect } from 'vitest'
@@ -17,42 +15,6 @@ import {
   writeSpatialNode,
 } from './loro-bridge.js'
 import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
-
-/**
- * Same construction as canvas-codec's spatial round-trip property
- * (arbitrary edges wired to arbitrary node ids, deduped by edge id) so both
- * packages exercise the identical valid-by-construction SpatialCanvas shape.
- */
-const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
-  .array(spatialNodeArbitrary, { maxLength: 4 })
-  // nodeIdArbitrary has low entropy at small sizes (e.g. shrinks to " "),
-  // so distinct-by-construction node ids need an explicit dedupe — the
-  // model schema rejects duplicate node ids.
-  .map((nodes) => nodes.filter((node, index) => nodes.findIndex((n) => n.id === node.id) === index))
-  .chain((nodes) => {
-    const ids = nodes.map((node) => node.id)
-    const edgeArbitrary =
-      ids.length >= 2
-        ? fc
-            .tuple(fc.constantFrom(...ids), fc.constantFrom(...ids))
-            .chain(([fromNode, toNode]) =>
-              canvasEdgeArbitrary.map((edge) => ({ ...edge, fromNode, toNode })),
-            )
-        : fc.constant(undefined)
-
-    return fc
-      .array(edgeArbitrary, { maxLength: ids.length >= 2 ? 3 : 0 })
-      .map((edges) => ({
-        nodes,
-        edges: edges.filter((edge): edge is NonNullable<typeof edge> => edge !== undefined),
-      }))
-      .map((canvas) => ({
-        ...canvas,
-        edges: canvas.edges.filter(
-          (edge, index) => canvas.edges.findIndex((e) => e.id === edge.id) === index,
-        ),
-      }))
-  })
 
 function byId<T extends { id: string }>(items: readonly T[]): T[] {
   return [...items].sort((a, b) => a.id.localeCompare(b.id))


### PR DESCRIPTION
The extended JSON Canvas round-trip property has been failing intermittently — twice in one session, on two different seeds. **The codec was never at fault.** The generator was.

## What the counterexample showed

```
{"nodes":[{"id":"4",…,"type":"group"},{"id":"4",…,"type":"file"}],"edges":[]}
```

Two nodes with the same id. `parseSpatial` rejects that with `duplicate node id "4"` — exactly as it should, and `canvas-model` already pins that rejection in its own tests. The property was generating a canvas the model schema forbids and then asserting it round-trips losslessly.

`nodeIdArbitrary` has low entropy at small sizes (it shrinks to a single space), so a collision needs a specific seed and passes hundreds of runs in between. That is what made it look like load-related flake.

## Why it was only in one package

Three packages each hand-built the same valid-by-construction canvas for their property tests. Two carry the node-id dedupe — canvas-viewer via `uniqueArray`, canvas-workspace via an explicit filter with a comment explaining exactly this hazard. canvas-codec's copy had lost it, while its own comment in canvas-workspace claims the two are the "identical" construction.

Three copies of one shape, one of them silently divergent. This replaces them with a single `spatialCanvasArbitrary` in canvas-model's test-utils — the owning package, per the repo's rule for arbitraries shared across test files — so a fourth consumer cannot repeat the omission.

## Verification

Both recorded failing seeds (`1313522501`, `1514037069`) now pass at 5000 runs each. 609 test files / 6465 tests passing; typecheck, knip and build clean.

No production code changed.
