### PR TITLE
fix: re-send the document when the transport returns

### DIFF
--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -17,9 +17,10 @@ describe('ConnectionStatus chip', () => {
 
     const popover = screen.getByTestId('connection-popover')
     expect(popover.textContent).toMatch(/not running/i)
-    // No replay promise: DaemonBackend drops local updates while its socket is
-    // not OPEN, so telling the user they are sent on recovery would be false.
-    expect(popover.textContent).not.toMatch(/will be sent|are sent when/i)
+    // The recovery promise is only sound because the session re-sends the whole
+    // document on reconnect; a backend hands a closed socket one delta and it
+    // is gone. If that resend is ever removed, this sentence becomes a lie.
+    expect(popover.textContent).toMatch(/sent when the connection returns/i)
   })
 
   it('synced state shows a quiet chip and explains where data lives in the popover', async () => {

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -9,10 +9,10 @@
  *                `children` hosts page-supplied extras (daemon detection,
  *                capability hint) inside the popover.
  * - `reconnecting` — live sync is not running: the transport has not come up
- *                yet, dropped, or failed. Deliberately makes NO promise about
- *                edits made meanwhile — DaemonBackend.pushLocalUpdate drops
- *                bytes while the socket is not OPEN, so claiming they are sent
- *                on recovery would be false.
+ *                yet, dropped, or failed. Edits made meanwhile are not lost:
+ *                the session re-sends the whole document when the transport
+ *                returns, which is what makes that claim true — a backend
+ *                whose socket is closed drops the delta it was handed.
  * - `sync-off` — daemon-backed page whose session was rejected. The chip
  *                turns attention-colored and the popover carries the two
  *                ways forward (re-pair / continue browser-local). A polite
@@ -112,8 +112,8 @@ export function ConnectionStatus({
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is not running</p>
             <p className="text-muted-foreground">
-              This canvas is not receiving changes from your local daemon right now, and edits made
-              here may not reach it. Reload the page if it does not recover.
+              This canvas is not receiving changes from your local daemon right now. Your edits are
+              kept and sent when the connection returns. Reload the page if it does not recover.
             </p>
           </div>
         )}

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -68,6 +68,9 @@ type FakeBackendControl = {
   handlers: CanvasBackendHandlers | null
   disconnectCalled: boolean
   pushLocalUpdateCalls: Uint8Array[]
+  /** Models a transport that is down: pushes are accepted and discarded,
+   *  which is what DaemonBackend does when its socket is not OPEN. */
+  transportDown: boolean
 }
 
 function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
@@ -75,6 +78,7 @@ function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
     handlers: null,
     disconnectCalled: false,
     pushLocalUpdateCalls: [],
+    transportDown: false,
   }
   return {
     _ctrl: ctrl,
@@ -87,6 +91,7 @@ function makeFakeBackend(): CanvasBackend & { _ctrl: FakeBackendControl } {
       ctrl.handlers = null
     },
     pushLocalUpdate(bytes) {
+      if (ctrl.transportDown) return Promise.resolve()
       ctrl.pushLocalUpdateCalls.push(bytes)
       return Promise.resolve()
     },
@@ -157,33 +162,39 @@ describe('createCanvasSyncSession', () => {
     expect(sendReadySpy).toHaveBeenCalledTimes(1)
   })
 
-  it('re-sends the whole document when the transport comes back', async () => {
-    // A backend that drops a local update while its transport is down (the
-    // WebSocket one returns early unless the socket is OPEN) loses it for
-    // good: every push carries only that commit's delta, so no later push
-    // replays it. Re-sending full state on reconnect is what makes an edit
-    // made during an outage survive, and CRDT import makes the resend
-    // idempotent for the server.
+  it('re-sends every edit made while the transport was down', async () => {
+    // A backend whose transport is down discards the delta it is handed — the
+    // WebSocket one returns early unless the socket is OPEN — and every push
+    // carries only one commit's ops, so no later push replays it. The transport
+    // here discards rather than records, or an implementation that resent just
+    // the latest delta would pass.
     const backend = makeFakeBackend()
     const session = createCanvasSyncSession(backend, makeDeps())
     session.connect()
     backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
 
-    const command: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
-    session.onChange(applyCommand(twoNodeCanvas(), command), command)
+    backend._ctrl.transportDown = true
+    const moveA: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
+    const afterA = applyCommand(twoNodeCanvas(), moveA)
+    session.onChange(afterA, moveA)
     await vi.advanceTimersByTimeAsync(300)
-    backend._ctrl.pushLocalUpdateCalls.length = 0
+    const moveB: EditorCommand = { kind: 'move-node', id: 'n-b', x: 30, y: 40 }
+    session.onChange(applyCommand(afterA, moveB), moveB)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(backend._ctrl.pushLocalUpdateCalls).toEqual([])
 
+    backend._ctrl.transportDown = false
     backend._ctrl.handlers!.onConnected()
+    await flushMicrotasks()
 
-    expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(0)
-    // The resend must carry the edit, not merely be non-empty.
+    // Rebuilt from what the server would actually have received.
     const rebuilt = new LoroDoc()
     for (const bytes of backend._ctrl.pushLocalUpdateCalls) rebuilt.import(bytes)
-    expect(readSpatialCanvas(rebuilt).nodes.find((n) => n.id === 'n-a')).toMatchObject({
-      x: 10,
-      y: 20,
-    })
+    const nodes = readSpatialCanvas(rebuilt).nodes
+    expect(nodes.find((n) => n.id === 'n-a')).toMatchObject({ x: 10, y: 20 })
+    expect(nodes.find((n) => n.id === 'n-b')).toMatchObject({ x: 30, y: 40 })
+    // The state that predates the outage has to survive the resend too.
+    expect(nodes).toHaveLength(twoNodeCanvas().nodes.length)
   })
 
   it('hydrates via readSpatialCanvas on snapshot and publishes it to subscribers', () => {

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -157,6 +157,35 @@ describe('createCanvasSyncSession', () => {
     expect(sendReadySpy).toHaveBeenCalledTimes(1)
   })
 
+  it('re-sends the whole document when the transport comes back', async () => {
+    // A backend that drops a local update while its transport is down (the
+    // WebSocket one returns early unless the socket is OPEN) loses it for
+    // good: every push carries only that commit's delta, so no later push
+    // replays it. Re-sending full state on reconnect is what makes an edit
+    // made during an outage survive, and CRDT import makes the resend
+    // idempotent for the server.
+    const backend = makeFakeBackend()
+    const session = createCanvasSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+    const command: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
+    session.onChange(applyCommand(twoNodeCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+    backend._ctrl.pushLocalUpdateCalls.length = 0
+
+    backend._ctrl.handlers!.onConnected()
+
+    expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(0)
+    // The resend must carry the edit, not merely be non-empty.
+    const rebuilt = new LoroDoc()
+    for (const bytes of backend._ctrl.pushLocalUpdateCalls) rebuilt.import(bytes)
+    expect(readSpatialCanvas(rebuilt).nodes.find((n) => n.id === 'n-a')).toMatchObject({
+      x: 10,
+      y: 20,
+    })
+  })
+
   it('hydrates via readSpatialCanvas on snapshot and publishes it to subscribers', () => {
     const backend = makeFakeBackend()
     const session = createCanvasSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -496,7 +496,20 @@ export function createCanvasSyncSession(
         // nothing acknowledges a push today, so there is no such version to
         // send from, and inventing one that is wrong would lose edits
         // silently again.
-        if (doc !== null) void backend.pushLocalUpdate(doc.export({ mode: 'update' }))
+        const connectedDoc = doc
+        if (connectedDoc !== null) {
+          // Same handling as the local-update path: the export and the push
+          // both run inside the chain so a synchronous throw cannot escape
+          // into the backend's own connect handler, and a rejection is
+          // reported rather than left unhandled — this send IS the recovery,
+          // so its failure is exactly what the caller needs to hear about.
+          void Promise.resolve()
+            .then(() => backend.pushLocalUpdate(connectedDoc.export({ mode: 'update' })))
+            .catch(() => {
+              if (isStale()) return
+              deps.onStatusChange('error')
+            })
+        }
       },
 
       onDisconnected() {

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -486,6 +486,17 @@ export function createCanvasSyncSession(
         if (isStale()) return
         deps.onStatusChange('connected')
         backend.sendClientReady()
+        // Re-send everything this document holds. A backend whose transport
+        // was down dropped the deltas made meanwhile — each push carries only
+        // one commit's ops, so no later push replays them — and the server
+        // would never learn about those edits. Loro's import is idempotent,
+        // so a server that already has them merges a no-op.
+        //
+        // Full state rather than a delta since the last acknowledged version:
+        // nothing acknowledges a push today, so there is no such version to
+        // send from, and inventing one that is wrong would lose edits
+        // silently again.
+        if (doc !== null) void backend.pushLocalUpdate(doc.export({ mode: 'update' }))
       },
 
       onDisconnected() {


### PR DESCRIPTION
An edit made while the transport is down was **lost for good**.

Each push carries one commit's delta — `subscribeLocalUpdates` hands the backend exactly the ops from that commit — and `DaemonBackend.pushLocalUpdate` returns early unless the socket is `OPEN`. The delta is dropped, and no later push replays it because every later push is a different delta. The user sees their edit on screen; the daemon never learns about it.

This is the concrete harm behind the window the previous change made visible: the chip now says Reconnecting, but until now the honest thing to say about edits made in that window was nothing.

## The fix

The session holds the LoroDoc, so it re-sends the whole document on connect. Loro's import is idempotent: a resend is a no-op for a server that already has the ops, and a recovery for one that does not.

**Full state rather than a delta since the last acknowledged version.** Nothing acknowledges a push today, so there is no such version to send from — and inventing one that is wrong would lose edits silently again, which is the bug. The cost is one full document per reconnect. That is the cheap side of the trade, and a version-vector optimisation can come later on top of a correct baseline.

It sits in the session rather than in each backend because that is where the document is; a per-backend queue would need a byte cap, and every cap is a silent-loss policy.

## The copy is now true

The reconnecting popover was deliberately softened last change to promise nothing, because the drop was real. It now says edits are sent when the connection returns, and the component test pins that sentence — so removing the resend breaks a test that names the reason.

## Verification

Red-first; mutation-checked (removing the resend turns the new session test red). The test rebuilds a document from the resent bytes and asserts the edit is in it, rather than asserting the push was merely non-empty.

609 test files / 6466 tests passing; typecheck, knip and build clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconnecting now resends the latest document state, including edits made while disconnected.
  * Preserved changes are restored when the connection returns, preventing missed updates.
  * Repeated synchronization remains safe for changes already received.
* **User Experience**
  * Updated connection-status messaging to clarify that edits are retained and resent automatically after reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->