### PR TITLE
feat(mcp): log when a stream's subscription set changes

### DIFF
--- a/packages/mcp-server/src/server/routes/sync-sse.ts
+++ b/packages/mcp-server/src/server/routes/sync-sse.ts
@@ -196,7 +196,21 @@ export function createSyncSseRouter() {
     }
     // One delete takes the readiness with it.
     for (const key of parsed.data.unsubscribe ?? []) stream.docs.delete(key)
-    return c.json({ ok: true, docs: [...stream.docs.keys()].sort() })
+    const docs = [...stream.docs.keys()].sort()
+    // A stream that reaches zero documents is the state worth seeing: the
+    // client stops reconnecting there, so a gap between "the last tab
+    // unsubscribed" and "a tab subscribed again" is a window with no stream
+    // at all. Without this the two are indistinguishable from the outside.
+    log.info(
+      {
+        streamId: parsed.data.streamId,
+        subscribed: parsed.data.subscribe ?? [],
+        unsubscribed: parsed.data.unsubscribe ?? [],
+        docCount: docs.length,
+      },
+      'sync subscriptions changed',
+    )
+    return c.json({ ok: true, docs })
   })
 
   // The client->server half of the sync protocol. A WebSocket carries these as


### PR DESCRIPTION
Groundwork for finding the cause of a defect that is currently only observable as a symptom.

Real-browser measurement found three windows — 15.6s, 70.0s and 31.6s — in which the daemon had **no open sync stream** while canvas tabs were open. The previous change made that state visible to the user; this one makes it diagnosable.

A stream that reaches zero documents is exactly where the client stops reconnecting, so such a window is bounded by "the last tab unsubscribed" and "a tab subscribed again". Neither event was recorded, which is why the gaps could not be attributed to a cause — a worker teardown and a subscription drop look identical from outside the process.

`POST /api/sync/subscribe` now logs the ids added and removed and the resulting document count, at `info`, next to the stream open/close records that already sit at that level. It costs nothing unless `WHITEBOARD_LOG_LEVEL` or `MCP_HTTP_DEBUG` asks for it.

## Why this ships before the fix

The daemon on the dev port runs from the main checkout in watch mode, so the reproduction needs this record to be on `main` first. Running an instrumented build from a worktree instead would mean pointing it at the main checkout's dev data directory to keep an existing pairing valid — invasive for no benefit.

The hypothesis to be tested once this lands, stated so it is not mistaken for a conclusion: a page's `pagehide` unsubscribes its documents, the worker's hub sees none left and stops reconnecting until a page subscribes again. **Unverified.**

## Verification

3213 mcp-node tests passing; typecheck clean. No behaviour change.
