### PR TITLE
feat: let the user name a daemon port and disconnect from a daemon

### DIFF
--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -9,6 +9,28 @@ import { ConnectionStatus } from './ConnectionStatus.js'
 afterEach(cleanup)
 
 describe('ConnectionStatus chip', () => {
+  it('offers a way out while sync is on, and says what it does not do', () => {
+    // Connected was the one state with no exit: every other state offers a
+    // next step, so a user who picked the wrong daemon had to clear storage.
+    const onDisconnect = vi.fn()
+    render(
+      <ConnectionStatus
+        state="synced"
+        daemonBaseUrl="http://127.0.0.1:3099"
+        onDisconnect={onDisconnect}
+      />,
+      { container: document.body },
+    )
+    fireEvent.click(screen.getByTestId('connection-chip'))
+
+    const popover = screen.getByTestId('connection-popover')
+    // Disconnecting stops using this daemon here; it neither unpairs nor
+    // deletes anything on the daemon, and the copy has to say so.
+    expect(popover.textContent).toMatch(/stays on the daemon|not deleted/i)
+    fireEvent.click(screen.getByTestId('connection-disconnect'))
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+  })
+
   it('explains the reconnecting state instead of opening an empty popover', () => {
     // The chip can reach this state, so the popover must have something to
     // say; a state with no branch renders an empty box on click.

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -35,6 +35,12 @@ export interface ConnectionStatusProps {
   readonly onContinueBrowserLocal?: () => void
   /** local only: page-supplied popover extras (daemon detection, capability hint). */
   readonly children?: ReactNode
+  /**
+   * synced only: stop using this daemon in this browser. It does NOT unpair
+   * and does NOT touch anything stored on the daemon — the copy says so,
+   * because "disconnect" reads like a destructive word.
+   */
+  readonly onDisconnect?: () => void
 }
 
 const CHIP_LABEL: Record<ConnectionState, string> = {
@@ -56,6 +62,7 @@ export function ConnectionStatus({
   daemonBaseUrl,
   onRepair,
   onContinueBrowserLocal,
+  onDisconnect,
   children,
 }: ConnectionStatusProps) {
   return (
@@ -106,6 +113,22 @@ export function ConnectionStatus({
               ) : null}
               .
             </p>
+            {onDisconnect && (
+              <div className="mt-1 flex flex-col gap-1.5">
+                <button
+                  type="button"
+                  data-testid="connection-disconnect"
+                  onClick={onDisconnect}
+                  className="text-left font-medium underline"
+                >
+                  Disconnect from this daemon
+                </button>
+                <p className="text-xs text-muted-foreground">
+                  This browser stops using it and stops looking for it. Your data stays on the
+                  daemon and is not deleted; pairing is not revoked.
+                </p>
+              </div>
+            )}
           </div>
         )}
         {state === 'reconnecting' && (

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -35,6 +35,30 @@ describe('DaemonDetectedBanner', () => {
     cleanup()
   })
 
+  it('probes a port the user typed, including one outside the scanned range', async () => {
+    // Discovery scans ten ports from 3099 and re-checks remembered URLs, so a
+    // daemon anywhere else — a dev worktree's derived port, or a packaged
+    // daemon whose first ten candidates were taken — is otherwise unreachable.
+    const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+      />,
+    )
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+    probeFn.mockClear()
+
+    fireEvent.change(screen.getByTestId('daemon-port-input'), { target: { value: '3419' } })
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await waitFor(() =>
+      expect(probeFn.mock.calls.some((call) => call[0] === 'http://127.0.0.1:3419')).toBe(true),
+    )
+  })
+
   it('auto-probes on mount when locationProtocol is http:', async () => {
     const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
     render(

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -103,6 +103,8 @@ export function DaemonDetectedBanner({
   // silent auto-probe on loopback mounts must not spawn failure copy the
   // user never asked for.
   const [manualCheckFailed, setManualCheckFailed] = useState(false)
+  const [portInput, setPortInput] = useState('')
+  const [portError, setPortError] = useState<string | null>(null)
   const [dismissedAt, setDismissedAt] = useState(
     () => settingsStore.load().storage.dismissedDaemonCtaAt,
   )
@@ -185,7 +187,7 @@ export function DaemonDetectedBanner({
     }
   }
 
-  function runProbe(forceRecheck?: boolean) {
+  function runProbe(forceRecheck?: boolean, explicit?: string) {
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
@@ -198,7 +200,12 @@ export function DaemonDetectedBanner({
     if (pageOriginScheme === 'https') {
       hintTimerRef.current = setTimeout(() => setShowLnaHint(true), LNA_HINT_DELAY_MS)
     }
-    const known = settingsStore.load().storage.knownDaemonBaseUrls ?? []
+    const stored = settingsStore.load().storage
+    const known = stored.knownDaemonBaseUrls ?? []
+    // Daemons the user disconnected from stay out of both the remembered
+    // list and the scan; naming one by hand overrides that, which is the
+    // only way back after a disconnect.
+    const dismissed = stored.dismissedDaemonBaseUrls ?? []
     // The server side binds dynamically (findAvailablePort from 3099; dev
     // worktrees use derived ports), so a single fixed-port ping misses
     // moved daemons. Remembered baseUrls are always re-checked; the wider
@@ -206,6 +213,8 @@ export function DaemonDetectedBanner({
     // auto-probe stays narrow.
     const candidates = candidateBaseUrls({
       remembered: [...known, baseUrl],
+      dismissed,
+      ...(explicit === undefined ? {} : { explicit }),
       ...(forceRecheck ? {} : { portRangeCount: 0 }),
     })
     discoverDaemons({
@@ -240,7 +249,21 @@ export function DaemonDetectedBanner({
           for (const daemon of [...nextFound].reverse()) {
             list = rememberKnownDaemon(list, daemon.baseUrl)
           }
-          return { ...current, storage: { ...current.storage, knownDaemonBaseUrls: list } }
+          // Finding a daemon clears its dismissal: it is here because the
+          // user asked for it, so leaving the flag would drop it again on
+          // the next load.
+          const foundUrls = new Set(nextFound.map((daemon) => daemon.baseUrl))
+          const stillDismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
+            (entry) => !foundUrls.has(entry),
+          )
+          return {
+            ...current,
+            storage: {
+              ...current.storage,
+              knownDaemonBaseUrls: list,
+              dismissedDaemonBaseUrls: stillDismissed,
+            },
+          }
         })
       }
     })
@@ -315,6 +338,19 @@ export function DaemonDetectedBanner({
     )
   }, [result, settingsStore, dismissedAt])
 
+  function submitPort() {
+    const port = Number(portInput.trim())
+    // Loopback host is fixed rather than accepted from the field: a full URL
+    // would let this page be aimed at an arbitrary origin, and the daemon is
+    // always local.
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      setPortError('Enter a port between 1 and 65535.')
+      return
+    }
+    setPortError(null)
+    runProbe(true, `http://127.0.0.1:${port}`)
+  }
+
   return (
     <>
       {showUnsupportedNotice && (
@@ -385,6 +421,41 @@ export function DaemonDetectedBanner({
             </>
           ) : (
             <>No local daemon found at {baseUrl}.</>
+          )}
+        </span>
+      )}
+      {result !== null && !result.detected && (
+        // Offered whenever a check concluded with nothing found, not only
+        // after a manual re-check: an auto-probe that finds nothing leaves the
+        // user with no way to name the daemon they know is running.
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <label htmlFor="daemon-port-input">Running on another port?</label>
+          <input
+            id="daemon-port-input"
+            data-testid="daemon-port-input"
+            type="text"
+            inputMode="numeric"
+            value={portInput}
+            onChange={(event) => setPortInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') submitPort()
+            }}
+            placeholder="3099"
+            className="w-16 rounded border px-1 py-0.5"
+            aria-describedby={portError ? 'daemon-port-error' : undefined}
+          />
+          <button
+            type="button"
+            data-testid="daemon-port-connect"
+            onClick={submitPort}
+            className="font-medium underline"
+          >
+            Check
+          </button>
+          {portError && (
+            <span id="daemon-port-error" role="alert" className="text-amber-700">
+              {portError}
+            </span>
           )}
         </span>
       )}

--- a/apps/web/src/lib/daemon-discovery.test.ts
+++ b/apps/web/src/lib/daemon-discovery.test.ts
@@ -14,6 +14,36 @@ function probeMap(map: Record<string, DaemonProbeResult>) {
 }
 
 describe('candidateBaseUrls', () => {
+  it('leaves out a daemon the user disconnected from, even inside the scanned range', () => {
+    // Disconnecting has to survive a reload, and the default scan would
+    // otherwise rediscover a daemon on 3099 the moment the page reopened —
+    // making the button a no-op the second time you look at it.
+    const candidates = candidateBaseUrls({
+      remembered: ['http://127.0.0.1:3099'],
+      dismissed: ['http://127.0.0.1:3099'],
+      portRangeCount: 3,
+    })
+
+    expect(candidates).not.toContain('http://127.0.0.1:3099')
+    expect(candidates).toContain('http://127.0.0.1:3100')
+  })
+
+  it('re-admits a dismissed daemon once it is named explicitly', () => {
+    // Entering a port by hand is an unambiguous request for that daemon, so
+    // it has to outrank an earlier dismissal or the user cannot get back.
+    // Outside the scanned range and absent from `remembered`, so `explicit`
+    // is the only thing that can put it in the list at all — a port inside
+    // the scan would lead it whether or not this argument is honoured.
+    const candidates = candidateBaseUrls({
+      remembered: [],
+      dismissed: ['http://127.0.0.1:3419'],
+      explicit: 'http://127.0.0.1:3419',
+      portRangeCount: 3,
+    })
+
+    expect(candidates[0]).toBe('http://127.0.0.1:3419')
+  })
+
   it('puts remembered daemons first, then the port range, deduplicated', () => {
     const candidates = candidateBaseUrls({
       remembered: ['http://127.0.0.1:3105', 'http://127.0.0.1:3099'],

--- a/apps/web/src/lib/daemon-discovery.ts
+++ b/apps/web/src/lib/daemon-discovery.ts
@@ -41,20 +41,44 @@ function normalizeBaseUrl(baseUrl: string): string {
 
 export function candidateBaseUrls({
   remembered,
+  dismissed = [],
+  explicit,
   portRangeStart = DEFAULT_PORT_RANGE_START,
   portRangeCount = DEFAULT_PORT_RANGE_COUNT,
 }: {
   remembered: readonly string[]
+  /**
+   * Daemons the user disconnected from. Excluded even when they fall inside
+   * the scanned range — otherwise disconnecting from the daemon on the
+   * default port would last exactly until the next page load.
+   */
+  dismissed?: readonly string[]
+  /**
+   * A daemon the user named by hand. It leads the list and overrides a
+   * dismissal, because typing a port is an unambiguous request for that
+   * daemon and there would otherwise be no way back from a disconnect.
+   *
+   * It is also the only way to reach a daemon outside the scanned range —
+   * a dev worktree binds a hash-derived port, and a packaged daemon whose
+   * first ten candidates are taken lands past the scan as well.
+   */
+  explicit?: string
   portRangeStart?: number
   portRangeCount?: number
 }): string[] {
   const seen = new Set<string>()
   const candidates: string[] = []
+  const blocked = new Set(dismissed.map(normalizeBaseUrl))
   const push = (baseUrl: string) => {
     const normalized = normalizeBaseUrl(baseUrl)
-    if (seen.has(normalized)) return
+    if (seen.has(normalized) || blocked.has(normalized)) return
     seen.add(normalized)
     candidates.push(normalized)
+  }
+  if (explicit !== undefined) {
+    const normalized = normalizeBaseUrl(explicit)
+    blocked.delete(normalized)
+    push(normalized)
   }
   for (const baseUrl of remembered) push(baseUrl)
   for (let i = 0; i < portRangeCount; i++) push(`http://127.0.0.1:${portRangeStart + i}`)

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -87,6 +87,24 @@ const storageSettingsSchema = z
       // tampered array must not turn discovery into an unbounded fan-out.
       .max(5, 'must contain at most 5 daemon URLs')
       .optional(),
+    // Daemons the user explicitly disconnected from. Discovery skips these
+    // even inside its scanned port range, which is what makes a disconnect
+    // outlive the page — without it the default-port daemon reappears on the
+    // next load and the action reads as a no-op. Same http(s) constraint and
+    // same cap as the known list, for the same reasons.
+    dismissedDaemonBaseUrls: z
+      .array(
+        z.string().refine((value) => {
+          try {
+            const { protocol } = new URL(value)
+            return protocol === 'http:' || protocol === 'https:'
+          } catch {
+            return false
+          }
+        }, 'must be an http(s) URL'),
+      )
+      .max(5, 'must contain at most 5 daemon URLs')
+      .optional(),
     dismissedPersistenceWarningAt: z.string().optional(),
     dismissedBetaBannerAt: z.string().optional(),
     dismissedDaemonCtaAt: z.string().optional(),

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -372,6 +372,32 @@ describe('DaemonCanvasPage', () => {
     expect(createdBackends[1]?.disconnectCount).toBe(0)
   })
 
+  it('records the daemon as dismissed when disconnecting, so discovery stops finding it', async () => {
+    // Forgetting alone is not enough: the default port range is rescanned on
+    // every visit, so a daemon on 3099 would come straight back and the
+    // action would read as a no-op the second time.
+    const onContinueBrowserLocal = vi.fn()
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          createBackend={makeCreateBackend()}
+          onContinueBrowserLocal={onContinueBrowserLocal}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+
+    fireEvent.click(screen.getByTestId('connection-chip'))
+    fireEvent.click(screen.getByTestId('connection-disconnect'))
+
+    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    const stored = JSON.stringify(window.localStorage)
+    expect(stored).toContain(DAEMON_BASE_URL)
+    expect(stored).toContain('dismissedDaemonBaseUrls')
+  })
+
   it('flips the connection chip to "Reconnecting" while the transport is down', async () => {
     // A chip that reads Synced while the transport is down tells the user
     // remote edits are arriving when they are not.

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -355,6 +355,31 @@ export function DaemonCanvasPage({
         })
       }}
       onContinueBrowserLocal={onContinueBrowserLocal}
+      onDisconnect={
+        onContinueBrowserLocal &&
+        (() => {
+          // Recorded so discovery skips it next time: the default port range
+          // is rescanned on every visit, so forgetting alone would bring this
+          // daemon straight back and make the action look like a no-op.
+          settingsStore.update((current) => {
+            const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
+              (entry) => entry !== daemonBaseUrl,
+            )
+            const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
+              (entry) => entry !== daemonBaseUrl,
+            )
+            return {
+              ...current,
+              storage: {
+                ...current.storage,
+                knownDaemonBaseUrls: known,
+                dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
+              },
+            }
+          })
+          onContinueBrowserLocal()
+        })
+      }
     />
   )
 


### PR DESCRIPTION
Two halves of one thing: naming a daemon, and stopping using it.

## Naming a port

`daemon-discovery.ts` scans ten ports from 3099 and re-checks remembered URLs. Its own module doc admits the hole:

> dev worktree daemons run on hash-derived ports … The browser cannot read the daemon registry file

So a worktree daemon is unreachable from the app no matter what the user does, and a packaged daemon whose first ten candidates are taken lands past the scan with the same result. A user whose 3099–3108 range is occupied cannot connect at all.

The field takes a **port, not a URL**: the loopback host is fixed, so the page cannot be aimed at an arbitrary origin, and the daemon is always local anyway. It appears whenever a check concluded with nothing found — not only after a manual re-check, since an auto-probe that finds nothing otherwise leaves no affordance.

## Disconnecting

Connected was the one state with no way out. Every other state offers a next step — re-pair, continue browser-local — while the synced popover only named the daemon holding your data. Picking the wrong one meant clearing site storage.

Disconnecting forgets the daemon **and** records it as dismissed. Forgetting alone is not enough: the default range is rescanned every visit, so a daemon on 3099 would come straight back and the action would read as a no-op the second time. Naming a port by hand clears the dismissal, which is what keeps the door open — and is why these two ship together. Disconnect alone would be a trap: disconnect from your only in-range daemon and there is no way back.

The copy states what it does **not** do — data stays on the daemon, pairing is not revoked — because "disconnect" reads like a destructive word. A component test pins that sentence.

## Verification

Red-first throughout. Three mutation checks: ignoring the dismissal list in discovery, dropping the dismissal write in the page, and (from the port picker) an out-of-scan-range port that only the explicit argument can reach.

Two of the tests here are covered at the **page** layer rather than only in the component, because a handler that is never passed down is this codebase's recurring bug shape — the same class as the thumbnail prop and `syncStatus`, both found this week.

609 test files / 6471 tests passing; typecheck, knip and build clean.
