### PR TITLE
fix: make disconnecting from a daemon outlive the page

### DIFF
--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -6,6 +6,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
+import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { DaemonCanvasPage } from './DaemonCanvasPage.js'
 
 vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
@@ -377,6 +378,20 @@ describe('DaemonCanvasPage', () => {
     // every visit, so a daemon on 3099 would come straight back and the
     // action would read as a no-op the second time.
     const onContinueBrowserLocal = vi.fn()
+    // The state a connected browser is actually in: App.tsx stores the daemon
+    // it connected to, and that is what puts the page in daemon mode on the
+    // next load. Without seeding it the assertion below passes vacuously.
+    // Seeded through the store, not by writing JSON: a hand-built payload that
+    // fails the store's own validation is silently replaced by defaults, and
+    // every assertion below then passes without touching the real state.
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: {
+        ...current.storage,
+        localDaemonBaseUrl: DAEMON_BASE_URL,
+        knownDaemonBaseUrls: [DAEMON_BASE_URL],
+      },
+    }))
     await act(async () => {
       render(
         <DaemonCanvasPage
@@ -389,6 +404,10 @@ describe('DaemonCanvasPage', () => {
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
 
+    // Precondition, asserted rather than assumed: if the seed did not survive
+    // the store's own validation, everything below would pass vacuously.
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(DAEMON_BASE_URL)
+
     fireEvent.click(screen.getByTestId('connection-chip'))
     fireEvent.click(screen.getByTestId('connection-disconnect'))
 
@@ -396,6 +415,10 @@ describe('DaemonCanvasPage', () => {
     const stored = JSON.stringify(window.localStorage)
     expect(stored).toContain(DAEMON_BASE_URL)
     expect(stored).toContain('dismissedDaemonBaseUrls')
+    // App.tsx reads localDaemonBaseUrl to decide a page is daemon-backed, so
+    // leaving it set reconnects on the next load — which makes the popover's
+    // "this browser stops using it" false the moment the user reloads.
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
   })
 
   it('flips the connection chip to "Reconnecting" while the transport is down', async () => {
@@ -555,6 +578,20 @@ describe('DaemonCanvasPage', () => {
 
   it('offers the browser-local escape inside the chip popover and invokes the callback', async () => {
     const onContinueBrowserLocal = vi.fn()
+    // The state a connected browser is actually in: App.tsx stores the daemon
+    // it connected to, and that is what puts the page in daemon mode on the
+    // next load. Without seeding it the assertion below passes vacuously.
+    // Seeded through the store, not by writing JSON: a hand-built payload that
+    // fails the store's own validation is silently replaced by defaults, and
+    // every assertion below then passes without touching the real state.
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: {
+        ...current.storage,
+        localDaemonBaseUrl: DAEMON_BASE_URL,
+        knownDaemonBaseUrls: [DAEMON_BASE_URL],
+      },
+    }))
     await act(async () => {
       render(
         <DaemonCanvasPage

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -92,6 +92,9 @@ const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
 
 describe('DaemonCanvasPage', () => {
   beforeEach(() => {
+    // Settings live in localStorage and this suite seeds them, so without a
+    // reset a later test inherits whichever earlier test happened to run.
+    window.localStorage.clear()
     createdBackends.length = 0
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
@@ -412,9 +415,12 @@ describe('DaemonCanvasPage', () => {
     fireEvent.click(screen.getByTestId('connection-disconnect'))
 
     expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
-    const stored = JSON.stringify(window.localStorage)
-    expect(stored).toContain(DAEMON_BASE_URL)
-    expect(stored).toContain('dismissedDaemonBaseUrls')
+    // Asserted as arrays, not as substrings of the whole store: the daemon's
+    // URL also appears under localDaemonBaseUrl, so a `toContain` on the
+    // serialized storage holds whether or not the dismissal was recorded.
+    const storage = createUserSettingsStore().load().storage
+    expect(storage.dismissedDaemonBaseUrls).toContain(DAEMON_BASE_URL)
+    expect(storage.knownDaemonBaseUrls ?? []).not.toContain(DAEMON_BASE_URL)
     // App.tsx reads localDaemonBaseUrl to decide a page is daemon-backed, so
     // leaving it set reconnects on the next load — which makes the popover's
     // "this browser stops using it" false the moment the user reloads.

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -368,10 +368,16 @@ export function DaemonCanvasPage({
             const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
               (entry) => entry !== daemonBaseUrl,
             )
+            // Clearing the stored target is what makes this outlive the page:
+            // App.tsx reads localDaemonBaseUrl to decide a load is
+            // daemon-backed, so leaving it set reconnects on the next visit
+            // and the popover's "this browser stops using it" becomes false.
+            const { localDaemonBaseUrl, ...storage } = current.storage
             return {
               ...current,
               storage: {
-                ...current.storage,
+                ...storage,
+                ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
                 knownDaemonBaseUrls: known,
                 dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
               },


### PR DESCRIPTION
Found by dogfooding the shipped build, one hour after shipping it: disconnect from a daemon, reload, and you are straight back on it.

The popover promises **"This browser stops using it and stops looking for it."** The second half was true — discovery skips the dismissed daemon. The first was false the moment the user reloaded: `App.tsx` decides a load is daemon-backed from `localDaemonBaseUrl`, and disconnecting left that set. Disconnecting now clears it when it names the daemon being left.

Observed state after a disconnect in the real app, before this fix:

```
dismissedDaemonBaseUrls: ["http://127.0.0.1:3099"]   ← written
knownDaemonBaseUrls:     []                          ← cleared
localDaemonBaseUrl:      "http://127.0.0.1:3099"     ← left behind
```

## The test that was supposed to cover this

It passed vacuously three times over before it caught anything:

1. The settings key was simply absent in the harness, so `toBeUndefined()` held before the page did anything.
2. Seeded as hand-written JSON — which the store rejected as invalid and silently replaced with defaults, so the seed never reached the code under test.
3. The precondition read `localStorage` directly rather than through the store, so it confirmed the raw write and not what the store had loaded.

It now seeds and reads through the store, and asserts the precondition rather than assuming it: a seed that stops working fails loudly instead of turning the case green. That is the actual lesson here — the defect was in shipped code for an hour because its test could not fail.

## Verification

Red-first, with the red confirming the exact symptom seen in the browser (`expected 'http://127.0.0.1:3099' to be undefined`). 135 test files / 1618 tests in apps/web passing; typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnecting from the active daemon now clears its saved local connection address.
  * Saved connection settings for a different daemon remain unchanged.
  * Dismissal preferences continue to be preserved when disconnecting.

* **Tests**
  * Added coverage for connection cleanup and browser-local escape behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->