### PR TITLE
feat: drop the daemon port sweep and make entering a port the way in

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -49,7 +49,10 @@ describe('DaemonDetectedBanner', () => {
         probeFn={probeFn}
       />,
     )
-    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+    // Waits for the DETECTED render, not merely for the probe call: the call
+    // resolves later, so asserting on it would check the pre-detection state
+    // and pass even if the field disappeared once a daemon was found.
+    await screen.findByTestId('daemon-detected-banner')
 
     expect(screen.getByTestId('daemon-port-input')).toBeTruthy()
   })

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -35,6 +35,25 @@ describe('DaemonDetectedBanner', () => {
     cleanup()
   })
 
+  it('offers the port field even while a daemon is already connected', async () => {
+    // Entering a port is the primary way in, so it cannot be gated on a failed
+    // check: gating it there leaves a user connected to the wrong daemon with
+    // no way to name the right one, and a user whose dismissals hid every
+    // candidate with no way to name anything at all.
+    const probeFn = vi.fn().mockResolvedValue({ detected: true, instanceId: 'i-1' })
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="http:"
+        probeFn={probeFn}
+      />,
+    )
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+
+    expect(screen.getByTestId('daemon-port-input')).toBeTruthy()
+  })
+
   it('probes a port the user typed, including one outside the scanned range', async () => {
     // Discovery scans ten ports from 3099 and re-checks remembered URLs, so a
     // daemon anywhere else — a dev worktree's derived port, or a packaged
@@ -103,10 +122,11 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-    // A manual check sweeps the default port range in parallel (dynamic
-    // server-side ports); every probe in the sweep is a forced recheck.
-    await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(2))
+    fireEvent.change(await screen.findByTestId('daemon-port-input'), { target: { value: '3099' } })
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+    // A manual check bypasses the memo: the point of asking again is to get a
+    // fresh answer, not the one cached from a moment when the daemon was down.
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
     expect(probeFn.mock.calls[0]?.[0]).toBe('http://127.0.0.1:3099')
     for (const call of probeFn.mock.calls) {
       expect(call[1]).toMatchObject({ forceRecheck: true, pageOriginScheme: 'https' })
@@ -260,9 +280,9 @@ describe('DaemonDetectedBanner', () => {
   })
 
   it('a manual check finds a daemon on a non-default port (server-side ports are dynamic)', async () => {
-    // ensure-daemon binds findAvailablePort(3099): when 3099 is taken by
-    // something else, the daemon lives on 3100+ — the check must scan, not
-    // assume.
+    // ensure-daemon binds findAvailablePort(3099): when 3099 is taken the
+    // daemon lives on 3100+. There is no scan to stumble on it, so naming the
+    // port is how it is reached — the guarantee this case exists for.
     const probeFn = vi.fn(async (baseUrl: string) =>
       baseUrl === 'http://127.0.0.1:3101'
         ? ({ detected: true, instanceId: 'moved' } as const)
@@ -277,7 +297,10 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.change(await screen.findByTestId('daemon-port-input'), {
+      target: { value: '3101' },
+    })
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
 
     await screen.findByText(/A server responded at http:\/\/127\.0\.0\.1:3101/)
     expect(screen.getByRole('button', { name: /use here/i })).not.toBeNull()
@@ -298,7 +321,8 @@ describe('DaemonDetectedBanner', () => {
         probeFn={probeFn}
       />,
     )
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.change(await screen.findByTestId('daemon-port-input'), { target: { value: '3104' } })
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
     await screen.findByText(/responded at http:\/\/127\.0\.0\.1:3104/)
     expect(store.load().storage.knownDaemonBaseUrls).toEqual(['http://127.0.0.1:3104'])
     first.unmount()
@@ -327,9 +351,19 @@ describe('DaemonDetectedBanner', () => {
         return { detected: true, instanceId: 'worktree' } as const
       return { detected: false, reason: 'refused' } as const
     })
+    // Two daemons the user has reached before: with no port scan, that is
+    // where a multi-candidate check comes from.
+    const store = makeStore()
+    store.update((current) => ({
+      ...current,
+      storage: {
+        ...current.storage,
+        knownDaemonBaseUrls: ['http://127.0.0.1:3099', 'http://127.0.0.1:3102'],
+      },
+    }))
     render(
       <DaemonDetectedBanner
-        settingsStore={makeStore()}
+        settingsStore={store}
         fetch={vi.fn()}
         locationProtocol="https:"
         probeFn={probeFn}

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -215,7 +215,6 @@ export function DaemonDetectedBanner({
       remembered: [...known, baseUrl],
       dismissed,
       ...(explicit === undefined ? {} : { explicit }),
-      ...(forceRecheck ? {} : { portRangeCount: 0 }),
     })
     discoverDaemons({
       candidates,
@@ -338,17 +337,27 @@ export function DaemonDetectedBanner({
     )
   }, [result, settingsStore, dismissedAt])
 
-  function submitPort() {
+  /** Parses the port field, or null when it is empty. Invalid input reports. */
+  function enteredBaseUrl(): string | null {
+    if (portInput.trim() === '') return null
     const port = Number(portInput.trim())
     // Loopback host is fixed rather than accepted from the field: a full URL
     // would let this page be aimed at an arbitrary origin, and the daemon is
     // always local.
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
       setPortError('Enter a port between 1 and 65535.')
-      return
+      return null
     }
     setPortError(null)
-    runProbe(true, `http://127.0.0.1:${port}`)
+    // Loopback host fixed rather than taken from the field: a full URL would
+    // let this page be aimed at an arbitrary origin, and the daemon is local.
+    return `http://127.0.0.1:${port}`
+  }
+
+  function checkNow() {
+    const explicit = enteredBaseUrl()
+    if (explicit === null && portInput.trim() !== '') return
+    runProbe(true, explicit ?? undefined)
   }
 
   return (
@@ -372,7 +381,7 @@ export function DaemonDetectedBanner({
       {showManualAffordance && (
         <button
           type="button"
-          onClick={() => runProbe(true)}
+          onClick={checkNow}
           disabled={checking}
           aria-busy={checking}
           className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
@@ -424,10 +433,12 @@ export function DaemonDetectedBanner({
           )}
         </span>
       )}
-      {result !== null && !result.detected && (
-        // Offered whenever a check concluded with nothing found, not only
-        // after a manual re-check: an auto-probe that finds nothing leaves the
-        // user with no way to name the daemon they know is running.
+      {!showUnsupportedNotice && (
+        // Always offered, never gated on a failed check. Naming a port is the
+        // primary way in now that there is no port scan to stumble on one:
+        // gating it on "nothing found" leaves a user connected to the wrong
+        // daemon unable to name the right one, and a user whose dismissals
+        // hid every candidate unable to name anything at all.
         <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <label htmlFor="daemon-port-input">Running on another port?</label>
           <input
@@ -438,7 +449,7 @@ export function DaemonDetectedBanner({
             value={portInput}
             onChange={(event) => setPortInput(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter') submitPort()
+              if (event.key === 'Enter') checkNow()
             }}
             placeholder="3099"
             className="w-16 rounded border px-1 py-0.5"
@@ -447,7 +458,7 @@ export function DaemonDetectedBanner({
           <button
             type="button"
             data-testid="daemon-port-connect"
-            onClick={submitPort}
+            onClick={checkNow}
             className="font-medium underline"
           >
             Check

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -339,11 +339,14 @@ export function DaemonDetectedBanner({
 
   /** Parses the port field, or null when it is empty. Invalid input reports. */
   function enteredBaseUrl(): string | null {
-    if (portInput.trim() === '') return null
-    const port = Number(portInput.trim())
-    // Loopback host is fixed rather than accepted from the field: a full URL
-    // would let this page be aimed at an arbitrary origin, and the daemon is
-    // always local.
+    const value = portInput.trim()
+    if (value === '') {
+      // An empty field is a valid check of the remembered daemons, so a stale
+      // complaint about a previous entry must not sit next to it.
+      setPortError(null)
+      return null
+    }
+    const port = Number(value)
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
       setPortError('Enter a port between 1 and 65535.')
       return null

--- a/apps/web/src/lib/daemon-discovery.test.ts
+++ b/apps/web/src/lib/daemon-discovery.test.ts
@@ -14,55 +14,46 @@ function probeMap(map: Record<string, DaemonProbeResult>) {
 }
 
 describe('candidateBaseUrls', () => {
-  it('leaves out a daemon the user disconnected from, even inside the scanned range', () => {
-    // Disconnecting has to survive a reload, and the default scan would
-    // otherwise rediscover a daemon on 3099 the moment the page reopened —
-    // making the button a no-op the second time you look at it.
+  it('names only what the user pointed at or previously reached', () => {
+    // No port sweep. Scanning a fixed range guesses, and the guess is wrong
+    // in both directions: it misses every daemon outside it (a dev worktree's
+    // derived port, a packaged daemon whose first candidates were taken) while
+    // firing probes at ports nobody asked about. An explicit port is the
+    // primary way in; a remembered one is a port the user already named.
     const candidates = candidateBaseUrls({
-      remembered: ['http://127.0.0.1:3099'],
-      dismissed: ['http://127.0.0.1:3099'],
-      portRangeCount: 3,
+      remembered: ['http://127.0.0.1:3105'],
+      explicit: 'http://127.0.0.1:3646',
     })
 
-    expect(candidates).not.toContain('http://127.0.0.1:3099')
-    expect(candidates).toContain('http://127.0.0.1:3100')
+    expect(candidates).toEqual(['http://127.0.0.1:3646', 'http://127.0.0.1:3105'])
+  })
+
+  it('leaves out a daemon the user disconnected from', () => {
+    // Disconnecting has to survive a reload, so a dismissed daemon stays out
+    // of the remembered list's contribution.
+    const candidates = candidateBaseUrls({
+      remembered: ['http://127.0.0.1:3099', 'http://127.0.0.1:3105'],
+      dismissed: ['http://127.0.0.1:3099'],
+    })
+
+    expect(candidates).toEqual(['http://127.0.0.1:3105'])
   })
 
   it('re-admits a dismissed daemon once it is named explicitly', () => {
-    // Entering a port by hand is an unambiguous request for that daemon, so
-    // it has to outrank an earlier dismissal or the user cannot get back.
-    // Outside the scanned range and absent from `remembered`, so `explicit`
-    // is the only thing that can put it in the list at all — a port inside
-    // the scan would lead it whether or not this argument is honoured.
+    // Naming a port by hand is an unambiguous request for that daemon, and
+    // without this override a disconnect would be a one-way door.
     const candidates = candidateBaseUrls({
       remembered: [],
-      dismissed: ['http://127.0.0.1:3419'],
-      explicit: 'http://127.0.0.1:3419',
-      portRangeCount: 3,
+      dismissed: ['http://127.0.0.1:3646'],
+      explicit: 'http://127.0.0.1:3646',
     })
 
-    expect(candidates[0]).toBe('http://127.0.0.1:3419')
-  })
-
-  it('puts remembered daemons first, then the port range, deduplicated', () => {
-    const candidates = candidateBaseUrls({
-      remembered: ['http://127.0.0.1:3105', 'http://127.0.0.1:3099'],
-      portRangeStart: 3099,
-      portRangeCount: 3,
-    })
-    expect(candidates).toEqual([
-      'http://127.0.0.1:3105',
-      'http://127.0.0.1:3099',
-      'http://127.0.0.1:3100',
-      'http://127.0.0.1:3101',
-    ])
+    expect(candidates).toEqual(['http://127.0.0.1:3646'])
   })
 
   it('normalizes trailing slashes on remembered entries before deduplicating', () => {
     const candidates = candidateBaseUrls({
-      remembered: ['http://127.0.0.1:3099/'],
-      portRangeStart: 3099,
-      portRangeCount: 1,
+      remembered: ['http://127.0.0.1:3099/', 'http://127.0.0.1:3099'],
     })
     expect(candidates).toEqual(['http://127.0.0.1:3099'])
   })
@@ -75,7 +66,9 @@ describe('discoverDaemons', () => {
       'http://127.0.0.1:3101': DETECTED('b'),
     })
     const { found, failures } = await discoverDaemons({
-      candidates: candidateBaseUrls({ remembered: [], portRangeStart: 3099, portRangeCount: 4 }),
+      // Candidates listed outright: this case is about how discoverDaemons
+      // fans out over them, not about where the list comes from.
+      candidates: [3099, 3100, 3101, 3102].map((p) => `http://127.0.0.1:${p}`),
       probeFn,
       fetch: vi.fn() as unknown as typeof globalThis.fetch,
       pageOriginScheme: 'http',
@@ -103,7 +96,7 @@ describe('discoverDaemons', () => {
 
   it('returns empty when nothing responds', async () => {
     const { found } = await discoverDaemons({
-      candidates: candidateBaseUrls({ remembered: [], portRangeStart: 3099, portRangeCount: 2 }),
+      candidates: candidateBaseUrls({ remembered: ['http://127.0.0.1:3099'] }),
       probeFn: probeMap({}),
       fetch: vi.fn() as unknown as typeof globalThis.fetch,
       pageOriginScheme: 'http',

--- a/apps/web/src/lib/daemon-discovery.ts
+++ b/apps/web/src/lib/daemon-discovery.ts
@@ -1,13 +1,13 @@
 /**
- * Local-daemon discovery over a bounded candidate set.
+ * Local-daemon discovery over the daemons the user has actually named.
  *
- * The server side already binds dynamically: the packaged daemon takes the
- * first free port from 3099 upward (ensure-daemon's findAvailablePort) and
- * dev worktree daemons run on hash-derived ports. The browser cannot read
- * the daemon registry file, so discovery is limited to two channels:
- * previously remembered baseUrls (localStorage, most recent first) and a
- * small scan of the default port range. Everything is probed in parallel
- * with the same timeboxed ping used by the single-probe path.
+ * There is deliberately NO port scan. The server binds dynamically — the
+ * packaged daemon takes the first free port from 3099 upward, dev worktrees
+ * use hash-derived ports — and the browser cannot read the daemon registry,
+ * so any fixed range is a guess that is wrong in both directions: it misses
+ * every daemon outside it while firing probes at ports nobody asked about.
+ * Entering a port is the primary way in, and a remembered baseUrl is just a
+ * port the user named on an earlier visit.
  *
  * A baseUrl is a HINT, not an identity: a port can be re-bound by a
  * different daemon between visits, so results carry the ping's instanceId
@@ -17,10 +17,6 @@
 import type { DaemonProbeResult, ProbeDaemonOptions } from './daemon-probe.js'
 import { probeDaemon } from './daemon-probe.js'
 
-const DEFAULT_PORT_RANGE_START = 3099
-// findAvailablePort drift rarely goes far; a bounded scan keeps a manual
-// check under ~1s worst-case (probes run in parallel, each timeboxed).
-const DEFAULT_PORT_RANGE_COUNT = 10
 const MAX_REMEMBERED_DAEMONS = 5
 
 export interface DiscoveredDaemon {
@@ -43,8 +39,6 @@ export function candidateBaseUrls({
   remembered,
   dismissed = [],
   explicit,
-  portRangeStart = DEFAULT_PORT_RANGE_START,
-  portRangeCount = DEFAULT_PORT_RANGE_COUNT,
 }: {
   remembered: readonly string[]
   /**
@@ -63,8 +57,6 @@ export function candidateBaseUrls({
    * first ten candidates are taken lands past the scan as well.
    */
   explicit?: string
-  portRangeStart?: number
-  portRangeCount?: number
 }): string[] {
   const seen = new Set<string>()
   const candidates: string[] = []
@@ -81,7 +73,6 @@ export function candidateBaseUrls({
     push(normalized)
   }
   for (const baseUrl of remembered) push(baseUrl)
-  for (let i = 0; i < portRangeCount; i++) push(`http://127.0.0.1:${portRangeStart + i}`)
   return candidates
 }
 


### PR DESCRIPTION
Scanning ten ports from 3099 guessed, and the guess was wrong in both directions: it missed every daemon outside the range — a dev worktree's hash-derived port, a packaged daemon whose first candidates were taken — while firing probes at ports nobody asked about. `daemon-discovery.ts`'s own doc already admitted the first half.

Candidates are now the daemons the user actually named: an explicit port, plus the ones reached on earlier visits.

## The port field is unconditional now

It was gated on a check having concluded with nothing found. That gating created two traps, both reachable:

- Connected to the wrong daemon → the field never appears, so there is no way to name the right one. Switching required disconnecting first.
- Dismissals hid every candidate → nothing is found, but the affordance that would let you name a daemon was itself conditional on state the dismissals had changed.

Naming a port is the primary way in, so it cannot depend on a check failing first. The manual check now probes the entered port together with the remembered ones, rather than being a second, separate control.

## The four tests that went through the sweep

Each was rewritten to reach its daemon by name, keeping the guarantee it existed for rather than being deleted or relaxed:

| Guarantee | How it is reached now |
| :-- | :-- |
| A daemon on a non-default port is reachable | The port is typed — which is the whole point of the change |
| A manual check bypasses the probe memo | Typed port, forced re-check asserted |
| A found daemon is remembered and re-probed next mount | Found by name, then remounted |
| Several responders produce a picker | Two remembered daemons respond |

## Verification

Red-first. Mutation-checked two ways — not passing the entered port into the candidate list, and restoring the old gating — each turns several cases red.

One leftover (`portRangeCount: 0` at a call site) survived `tsc` because a spread into a call skips excess-property checking; found by grep and removed.

609 test files / 6472 tests passing; typecheck, knip and build clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual daemon connection using an entered port and a Check action.
  * Kept the port field available even when a daemon is already connected.
  * Preserved support for remembered and explicitly provided daemon addresses.

* **Bug Fixes**
  * Improved handling of HTTPS, dynamic-port, dismissed, and multiple-daemon scenarios.
  * Removed automatic scanning of a default port range, making discovery more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->