### PR TITLE
fix(render): stop a bent edge painting a filled wedge

### DIFF
--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -422,7 +422,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" stroke="#888" stroke-width="1.5" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" fill="none" stroke="#888" stroke-width="1.5" role="presentation"/></svg>',
     )
   })
 
@@ -441,7 +441,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0" fill="none" role="presentation"/></svg>',
     )
   })
 
@@ -463,7 +463,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
     )
   })
 
@@ -485,7 +485,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" role="presentation"/><polygon points="0,0 10,-4 10,4" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" role="presentation"/><polygon points="0,0 10,-4 10,4" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
     )
   })
 
@@ -508,7 +508,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" stroke="#888" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="#888" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" stroke="#888" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="#888" role="presentation"/></svg>',
     )
   })
 
@@ -530,7 +530,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="5,5 5,5" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="5,5 5,5" fill="none" role="presentation"/></svg>',
     )
   })
 
@@ -720,4 +720,32 @@ describe('image nodes', () => {
     expect(svg).toContain('role="presentation"')
     expect(svg).not.toContain('<title>')
   })
+})
+
+// SVG's initial `fill` is black, and a <polyline> fills the region its points
+// enclose. A two-point edge encloses nothing, so this was invisible until
+// routing started bending paths — then every corner grew a filled wedge in
+// whatever fill the surrounding document happened to inherit. Reported as a
+// black blob on a canvas after a node was duplicated.
+it('draws a bent edge as a line, not a filled wedge', () => {
+  const svg = renderSceneToSvg({
+    nodes: [
+      {
+        kind: 'edge',
+        id: 'e1',
+        path: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+        ],
+        fromSide: 'right',
+        toSide: 'top',
+        fromEnd: 'none',
+        toEnd: 'none',
+      },
+    ],
+  })
+
+  const polyline = /<polyline[^>]*>/.exec(svg)?.[0] ?? ''
+  expect(polyline).toContain('fill="none"')
 })

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -161,7 +161,12 @@ function renderNode(node: SceneNode): string {
     case 'edge': {
       const points = node.path.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
       const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
-      const polyline = `<polyline points="${points}"${appearance} ${PRESENTATION_ATTR}/>`
+      // `fill="none"` is not decoration. SVG's initial fill is black and a
+      // <polyline> fills the region its points enclose, so a bent edge would
+      // paint a solid wedge across its own corner in whatever fill the
+      // surrounding document inherits — invisible while every path had two
+      // points, glaring the moment routing started bending them.
+      const polyline = `<polyline points="${points}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
       // Arrowheads are filled triangles in the edge's stroke color, drawn
       // after (over) the polyline. Geometry comes from the shared helper so
       // sceneBounds always agrees on how far the wings reach.

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -180,6 +180,6 @@ export const SHAPE_APPEARANCE_GOLDEN_SVG =
   '<rect x="120" y="0" width="100" height="60"/>' +
   '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
   '<g><text x="0" y="80" fill="#111" font-family="Inter" font-size="14">Styled</text></g>' +
-  '<polyline points="0,120 100,120" stroke="#888" stroke-width="1.5" role="presentation"/>' +
+  '<polyline points="0,120 100,120" fill="none" stroke="#888" stroke-width="1.5" role="presentation"/>' +
   '<polygon points="100,120 90,124 90,116" fill="#888" role="presentation"/>' +
   '</svg>'


### PR DESCRIPTION
The black blob reported after duplicating a node.

## Cause

SVG's initial `fill` is black, and a `<polyline>` fills the region its points enclose. Edges never set `fill`, so they inherited whatever the surrounding document had — `rgb(64,64,64)` in the editor.

A two-point path encloses nothing, which is why this stayed invisible for as long as every edge was a straight line. Obstacle routing (#521) started bending paths, and each corner became a solid wedge. Duplicating a node produced the arrangement that made an edge detour, which is why that action appeared to cause it.

Export never showed it, because nothing there inherits a dark fill. The editor does — so the same document rendered differently in the two places that are supposed to agree.

## How it was found

Three suspects were ruled out with evidence before this one was reached: the routed paths themselves (all three edges of the reported canvas route to sane geometry), the shared layout + SVG output (node rects and 8×11 arrowheads, nothing else), and the referenced images (the asset is a blue square).

What found it was rendering the reported canvas in the real editor and listing every element over 40px with a dark paint. `polyline … fill=rgb(64, 64, 64)` is not something you notice reading the markup; it only shows up when you ask the browser what it actually painted.

## Note on the goldens

The pinned polyline strings and the determinism golden move with this change. That is a deliberate serializer-format change, reviewed as such — not drift.

## Verification

`pnpm test` green (610 files, 6486 tests), `pnpm -r typecheck` clean.