### PR TITLE
fix(render): meet a node perpendicular to the side an edge attaches to

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -22,11 +22,13 @@ Never hand-edit the lockfile. If typecheck breaks after a lockfile change with "
 
 ## Verifying on a Preview deployment
 
-`apps/web` registers a Workbox service worker, so **what the server deploys and what the browser executes are two different questions**. A preview URL you have opened before is controlled by a service worker serving its precache, and it will keep running the bundle from an earlier visit however many times you reload.
+`apps/web` registers a Workbox service worker with `registerType: 'prompt'`, so **what the server deploys and what the browser executes are two different questions**. A URL you have opened before keeps running the bundle from that visit, and **reloading does not change that** — under `prompt` the new worker waits until something calls `skipWaiting`.
 
-This is worth naming because it fakes the most misleading result there is: a fix that is deployed, correct, and covered by tests, behaving in the browser exactly as if it had never been written. Checking the deploy history does not rule it out — that answers what the server returns, not what the page runs.
+For a real user that is handled and deliberate: a scheduler checks for updates periodically and on tab focus, and `UpdateToast` offers the swap rather than performing it under someone mid-draw. The pitfall is for anyone verifying a fix by *driving the page from a script*, which reloads without ever taking the offer.
 
-Before treating a preview observation as evidence about the code:
+It fakes the most misleading result there is: a fix that is deployed, correct, and covered by tests, behaving in the browser exactly as if it had never been written. Checking the deploy history does not rule it out — that answers what the server returns, not what the page runs.
+
+Accept the update through the toast if it is showing. Otherwise clear the worker outright:
 
 ```js
 // In the page console. `controlled: true` means you may be running an old bundle.

--- a/packages/canvas-render/src/layout/edge-obstacles.test.ts
+++ b/packages/canvas-render/src/layout/edge-obstacles.test.ts
@@ -214,3 +214,23 @@ describe('orthogonal edges meet a node perpendicular to its side', () => {
     expect(firstAxis(routed.path)).toBe(horizontalSide ? 'horizontal' : 'vertical')
   })
 })
+
+// The orthogonal path never travels the direct diagonal, so asking whether
+// THAT segment is blocked answers the wrong question: two obstacles can sit on
+// the two elbows while leaving the diagonal clear, and the router would then
+// build no detours and return a blocked elbow.
+it('detours when both elbows are blocked but the direct line is not', () => {
+  const onFirstElbow = node('m1', 200, 10, 40, 40)
+  const onSecondElbow = node('m2', 100, 200, 40, 40)
+  const nodes = [
+    node('a', 0, 0, 100, 60),
+    onFirstElbow,
+    onSecondElbow,
+    node('b', 400, 300, 100, 60),
+  ]
+
+  const routed = routeEdge(nodes, edge('a', 'b'), 'orthogonal')
+
+  expect(pathCrosses(routed.path, onFirstElbow), 'crosses m1').toBe(false)
+  expect(pathCrosses(routed.path, onSecondElbow), 'crosses m2').toBe(false)
+})

--- a/packages/canvas-render/src/layout/edge-obstacles.test.ts
+++ b/packages/canvas-render/src/layout/edge-obstacles.test.ts
@@ -164,3 +164,53 @@ describe('orthogonal routing style', () => {
     expect(routeEdge(nodes, edge('a', 'b')).path).toHaveLength(2)
   })
 })
+
+// An edge that leaves a node sideways but starts by running vertically traces
+// the node's own border for its first segment, so the two read as one line.
+// Leaving and arriving along the side's outward normal is what separates them.
+describe('orthogonal edges meet a node perpendicular to its side', () => {
+  const axisOf = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+    a.x === b.x ? 'vertical' : a.y === b.y ? 'horizontal' : 'diagonal'
+
+  const firstAxis = (path: readonly { x: number; y: number }[]) =>
+    axisOf(path[0] as { x: number; y: number }, path[1] as { x: number; y: number })
+  const lastAxis = (path: readonly { x: number; y: number }[]) =>
+    axisOf(path.at(-2) as { x: number; y: number }, path.at(-1) as { x: number; y: number })
+
+  it('leaves a right-side attachment horizontally', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+    const routed = routeEdge(nodes, { ...edge('a', 'b'), fromSide: 'right' }, 'orthogonal')
+
+    expect(routed.fromSide).toBe('right')
+    expect(firstAxis(routed.path)).toBe('horizontal')
+  })
+
+  it('leaves a bottom-side attachment vertically', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+    const routed = routeEdge(nodes, { ...edge('a', 'b'), fromSide: 'bottom' }, 'orthogonal')
+
+    expect(firstAxis(routed.path)).toBe('vertical')
+  })
+
+  it('arrives at a top-side attachment vertically', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+    const routed = routeEdge(nodes, { ...edge('a', 'b'), toSide: 'top' }, 'orthogonal')
+
+    expect(lastAxis(routed.path)).toBe('vertical')
+  })
+
+  it('arrives at a left-side attachment horizontally', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+    const routed = routeEdge(nodes, { ...edge('a', 'b'), toSide: 'left' }, 'orthogonal')
+
+    expect(lastAxis(routed.path)).toBe('horizontal')
+  })
+
+  it('holds for the derived sides too, with no explicit fromSide/toSide', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+    const routed = routeEdge(nodes, edge('a', 'b'), 'orthogonal')
+    const horizontalSide = routed.fromSide === 'left' || routed.fromSide === 'right'
+
+    expect(firstAxis(routed.path)).toBe(horizontalSide ? 'horizontal' : 'vertical')
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -251,14 +251,29 @@ function routeOrthogonal(
   const between = (middles: readonly Point[]) =>
     withoutRepeats([start, exit, ...middles, entry, end])
 
-  const region = blockingRegion(start, end, obstacles)
-  const candidates = [
-    between([{ x: entry.x, y: exit.y }]),
-    between([{ x: exit.x, y: entry.y }]),
-    ...(region === undefined
-      ? []
-      : detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1)))),
-  ]
+  const elbows = [between([{ x: entry.x, y: exit.y }]), between([{ x: exit.x, y: entry.y }])]
+  if (elbows.some((path) => pathIsClear(path, obstacles))) {
+    return bestCandidate(elbows, obstacles)
+  }
+
+  // Detours are needed when the paths this style actually travels are
+  // blocked — which the direct diagonal cannot answer, since an orthogonal
+  // edge never travels it. Two obstacles can sit on the two elbows while
+  // leaving that diagonal clear.
+  const region = unionRect(
+    obstacles.filter((rect) =>
+      elbows.some((path) =>
+        path.some((point, i) => i > 0 && segmentCrossesRect(path[i - 1] as Point, point, rect)),
+      ),
+    ),
+  )
+  const candidates =
+    region === undefined
+      ? elbows
+      : [
+          ...elbows,
+          ...detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1))),
+        ]
   return bestCandidate(candidates, obstacles)
 }
 

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -168,18 +168,6 @@ function bestCandidate(candidates: readonly Point[][], obstacles: readonly Rect[
   return byLength.find((path) => pathIsClear(path, obstacles)) ?? (byLength[0] as Point[])
 }
 
-/**
- * The two right-angle elbows between `start` and `end`: across then down, and
- * down then across. Every detour candidate is already axis-aligned, so the
- * orthogonal style is these two plus those, judged by the same rule.
- */
-function elbows(start: Point, end: Point): Point[][] {
-  return [
-    [start, { x: end.x, y: start.y }, end],
-    [start, { x: start.x, y: end.y }, end],
-  ]
-}
-
 /** Ways past a blocking region: over it, under it, left of it, right of it. */
 function detourCandidates(start: Point, end: Point, region: Rect): Point[][] {
   const above = region.y - OBSTACLE_CLEARANCE_PX
@@ -205,20 +193,72 @@ function routeStraight(start: Point, end: Point, obstacles: readonly Rect[]): Po
   return bestCandidate(detourCandidates(start, end, region), obstacles)
 }
 
+/** How far an orthogonal edge travels straight out of a node before turning. */
+const ORTHOGONAL_STUB_PX = 20
+
+/** The direction a side faces, away from the node's interior. */
+function outwardNormal(side: Side): Point {
+  switch (side) {
+    case 'top':
+      return { x: 0, y: -1 }
+    case 'bottom':
+      return { x: 0, y: 1 }
+    case 'left':
+      return { x: -1, y: 0 }
+    case 'right':
+      return { x: 1, y: 0 }
+  }
+}
+
+function stubFrom(point: Point, side: Side): Point {
+  const normal = outwardNormal(side)
+  return {
+    x: point.x + normal.x * ORTHOGONAL_STUB_PX,
+    y: point.y + normal.y * ORTHOGONAL_STUB_PX,
+  }
+}
+
+/** Drops repeated points, so a collapsed corner never becomes a zero-length segment. */
+function withoutRepeats(path: readonly Point[]): Point[] {
+  return path.filter((point, i) => {
+    const prev = path[i - 1]
+    return i === 0 || prev === undefined || point.x !== prev.x || point.y !== prev.y
+  })
+}
+
 /**
  * Right angles only, whether or not anything is in the way — that is what the
  * style asks for, so a clear path bends too.
+ *
+ * Both ends leave along their side's outward normal before turning. Without
+ * that stub an edge attached to a node's right side can start by running
+ * vertically, tracing the node's own border for its first segment so the two
+ * read as one line rather than as an edge meeting a box.
  *
  * The elbows come first and the detours join them only when something blocks,
  * which keeps the common case to a single corner instead of routing every
  * edge around a region that is not there.
  */
-function routeOrthogonal(start: Point, end: Point, obstacles: readonly Rect[]): Point[] {
+function routeOrthogonal(
+  start: Point,
+  end: Point,
+  fromSide: Side,
+  toSide: Side,
+  obstacles: readonly Rect[],
+): Point[] {
+  const exit = stubFrom(start, fromSide)
+  const entry = stubFrom(end, toSide)
+  const between = (middles: readonly Point[]) =>
+    withoutRepeats([start, exit, ...middles, entry, end])
+
   const region = blockingRegion(start, end, obstacles)
-  const candidates =
-    region === undefined
-      ? elbows(start, end)
-      : [...elbows(start, end), ...detourCandidates(start, end, region)]
+  const candidates = [
+    between([{ x: entry.x, y: exit.y }]),
+    between([{ x: exit.x, y: entry.y }]),
+    ...(region === undefined
+      ? []
+      : detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1)))),
+  ]
   return bestCandidate(candidates, obstacles)
 }
 
@@ -299,7 +339,7 @@ export function routeEdge(
     // pretending — see the routing-style slice notes.
     path:
       style === 'orthogonal'
-        ? routeOrthogonal(start, end, obstacles)
+        ? routeOrthogonal(start, end, fromSide, toSide, obstacles)
         : routeStraight(start, end, obstacles),
     fromSide,
     toSide,


### PR DESCRIPTION
Reported from a phone: an orthogonal edge ran along the node's own border, so the edge and the box read as one line.

## Cause

The elbow was chosen purely by length, with no regard for which side the edge attaches to. An edge leaving a node's right side could start by running vertically — straight along that node's border.

Both ends now leave along their side's outward normal before turning, so the elbow choice can no longer contradict the attachment side: the stub is placed before any choice is made.

## Rule note corrected while here

I wrote the Preview/service-worker note as if the product had a gap. It does not — this was raised and it is worth being accurate about.

`apps/web` uses `registerType: 'prompt'` with a scheduler that checks for updates periodically and on tab focus, and offers the swap through `UpdateToast` rather than performing it under someone mid-draw. Real users are handled, and the choice not to swap silently is deliberate for a canvas editor.

What bites is verification driven from a script: it reloads without ever taking the offer, and **a reload alone never adopts a waiting worker**. The note now says that instead.

## Verification

canvas-render 282 tests green including five new ones pinning perpendicular exit and arrival for explicit and derived sides; `pnpm test` 610 files green; `pnpm -r typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orthogonal edge routing so connectors leave and enter nodes perpendicularly at the selected sides.
  * Added outward spacing at connector endpoints and improved obstacle-detour routing for cleaner paths.
  * Removed duplicate routing points to prevent visual artifacts.

* **Documentation**
  * Clarified preview deployment updates, including accepting update notifications or clearing the service worker when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->