### PR TITLE
feat(web): take a waiting update while the tab is hidden, and keep the notice

### DIFF
--- a/apps/web/src/pwa/UpdateToast.test.tsx
+++ b/apps/web/src/pwa/UpdateToast.test.tsx
@@ -38,13 +38,26 @@ describe('UpdateToast', () => {
     expect(overlay?.className).toMatch(/\bz-\d+\b/)
   })
 
-  it('hides the toast and calls onDismiss when Dismiss is clicked', () => {
+  // Putting it off must not make it unfindable. A user with no reason to care
+  // about versions would otherwise dismiss once and run old code forever,
+  // which is the failure this notice exists to prevent.
+  it('collapses to a persistent chip instead of disappearing', () => {
     const onDismiss = vi.fn()
     render(<UpdateToast onReload={vi.fn()} onDismiss={onDismiss} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }))
 
     expect(onDismiss).toHaveBeenCalledTimes(1)
-    expect(screen.queryByText(/Update available/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reload' })).toBeNull()
+    expect(screen.getByRole('button', { name: /Update available/i })).toBeTruthy()
+  })
+
+  it('reopens from the chip', () => {
+    render(<UpdateToast onReload={vi.fn()} onDismiss={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }))
+    fireEvent.click(screen.getByRole('button', { name: /Update available/i }))
+
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeTruthy()
   })
 })

--- a/apps/web/src/pwa/UpdateToast.tsx
+++ b/apps/web/src/pwa/UpdateToast.tsx
@@ -9,8 +9,25 @@ export interface UpdateToastProps {
 // SW-controlled assets under a user mid-draw risks losing in-flight edit
 // state, so the user must opt into the reload explicitly.
 export function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
-  const [dismissed, setDismissed] = useState(false)
-  if (dismissed) return null
+  const [collapsed, setCollapsed] = useState(false)
+
+  // Putting it off collapses the notice rather than removing it. Someone with
+  // no reason to care about versions would otherwise dismiss once and keep
+  // running old code indefinitely — which looks exactly like a fix that was
+  // never shipped.
+  if (collapsed) {
+    return (
+      <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+        <button
+          type="button"
+          onClick={() => setCollapsed(false)}
+          className="rounded-full border bg-background px-3 py-1 text-muted-foreground text-xs shadow-md transition-colors hover:bg-accent hover:text-foreground"
+        >
+          Update available
+        </button>
+      </div>
+    )
+  }
 
   // Fixed + z-index, not document flow: the app shell fills 100dvh, so a
   // static element appended to <body> sits below the viewport and the
@@ -37,12 +54,12 @@ export function UpdateToast({ onReload, onDismiss }: UpdateToastProps) {
         <button
           type="button"
           onClick={() => {
-            setDismissed(true)
+            setCollapsed(true)
             onDismiss()
           }}
           className="rounded-md px-2 py-0.5 text-muted-foreground transition-colors hover:bg-accent"
         >
-          Dismiss
+          Later
         </button>
       </div>
     </div>

--- a/apps/web/src/pwa/mount-update-toast.test.tsx
+++ b/apps/web/src/pwa/mount-update-toast.test.tsx
@@ -23,16 +23,20 @@ describe('mountUpdateToast', () => {
     expect(updateServiceWorker).toHaveBeenCalledWith(true)
   })
 
-  it('does not re-show the toast after Dismiss for the rest of the page lifetime', async () => {
+  // Putting it off leaves a chip rather than nothing: an update nobody can
+  // find again is how a page keeps running old code for the rest of its life.
+  // What must not happen is the expanded form reopening on its own.
+  it('leaves a persistent chip after Later, and does not reopen on a later refresh', async () => {
     const { mountUpdateToast } = await import('./mount-update-toast.js')
 
     mountUpdateToast(vi.fn())
-    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }))
-    expect(screen.queryByText(/Update available/i)).toBeNull()
+    fireEvent.click(await screen.findByRole('button', { name: 'Later' }))
+    expect(screen.queryByRole('button', { name: 'Reload' })).toBeNull()
+    expect(screen.getByRole('button', { name: /Update available/i })).toBeTruthy()
 
-    // A second onNeedRefresh within the same page lifetime must stay hidden.
     mountUpdateToast(vi.fn())
-    expect(screen.queryByText(/Update available/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reload' })).toBeNull()
+    expect(screen.getByRole('button', { name: /Update available/i })).toBeTruthy()
   })
 
   it('reuses the existing root when onNeedRefresh fires again before dismiss', async () => {

--- a/apps/web/src/pwa/mount-update-toast.tsx
+++ b/apps/web/src/pwa/mount-update-toast.tsx
@@ -34,18 +34,13 @@ export function mountUpdateToast(updateServiceWorker: (reloadPage?: boolean) => 
   root.render(
     <UpdateToast
       onReload={() => updateServiceWorker(true)}
+      // The toast collapses itself to a persistent chip rather than going
+      // away, so the root stays mounted — unmounting here would remove the
+      // very reminder the collapse exists to keep. This only records that the
+      // user has already been told, so a later onNeedRefresh does not reopen
+      // the expanded form under them.
       onDismiss={() => {
         dismissedThisPageLoad = true
-        // Guard + defer: unmounting synchronously from an event handler
-        // rendered by this same root makes React 18 warn about unmounting a
-        // root while it is rendering, and a double-click would unmount twice.
-        if (activeRoot === null) return
-        const rootToUnmount = activeRoot
-        activeRoot = null
-        setTimeout(() => {
-          rootToUnmount.unmount()
-          container?.remove()
-        }, 0)
       }}
     />,
   )

--- a/apps/web/src/pwa/register-sw.ts
+++ b/apps/web/src/pwa/register-sw.ts
@@ -53,6 +53,19 @@ export function setupSwRegistration({
               .catch((err: unknown) => {
                 log.error('failed to load the update toast module', err)
               })
+            // The notice alone leaves the swap waiting on a click that a user
+            // with no reason to care about versions may never give. Taking it
+            // while the tab is hidden costs nothing and needs no decision from
+            // them — and the prompt strategy's reason for existing (never swap
+            // under someone mid-draw) does not apply to a tab nobody is
+            // looking at.
+            void import('./sw-idle-apply.js')
+              .then(({ startSwIdleAutoApply }) => {
+                startSwIdleAutoApply({ apply: () => updateServiceWorker(true) })
+              })
+              .catch((err: unknown) => {
+                log.error('failed to load the idle auto-apply module', err)
+              })
           },
           onRegisteredSW: (_swScriptUrl, registration) => {
             // A long-open or quickly-reloaded tab may never re-check sw.js on

--- a/apps/web/src/pwa/sw-idle-apply.test.ts
+++ b/apps/web/src/pwa/sw-idle-apply.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SW_IDLE_SETTLE_MS, startSwIdleAutoApply } from './sw-idle-apply.js'
+
+function fakeDoc(initial: DocumentVisibilityState = 'visible') {
+  let visibilityState = initial
+  const listeners = new Set<() => void>()
+  return {
+    get visibilityState() {
+      return visibilityState
+    },
+    addEventListener: (_type: string, listener: () => void) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: () => void) => listeners.delete(listener),
+    setVisibility(next: DocumentVisibilityState) {
+      visibilityState = next
+      for (const listener of listeners) listener()
+    },
+    listenerCount: () => listeners.size,
+  }
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('startSwIdleAutoApply', () => {
+  it('applies once the tab has stayed hidden long enough', async () => {
+    const apply = vi.fn()
+    const doc = fakeDoc()
+    startSwIdleAutoApply({ apply, doc: doc as unknown as Document })
+
+    doc.setVisibility('hidden')
+    expect(apply).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS)
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  // Applying reloads the page. Doing that under someone who is looking at it —
+  // let alone mid-drag — is exactly what the prompt strategy exists to avoid.
+  it('never applies while the tab is visible', async () => {
+    const apply = vi.fn()
+    const doc = fakeDoc()
+    startSwIdleAutoApply({ apply, doc: doc as unknown as Document })
+
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS * 5)
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  // Coming back before the settle period means the user was switching tabs,
+  // not leaving — the reload would land just as they return to their canvas.
+  it('abandons the apply if the tab comes back first', async () => {
+    const apply = vi.fn()
+    const doc = fakeDoc()
+    startSwIdleAutoApply({ apply, doc: doc as unknown as Document })
+
+    doc.setVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS / 2)
+    doc.setVisibility('visible')
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS * 3)
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  // The settle period is what covers a debounced write that has not flushed
+  // yet, so a caller that still has work in flight can hold the swap off.
+  it('holds off while the caller reports work in flight', async () => {
+    const apply = vi.fn()
+    const doc = fakeDoc()
+    let busy = true
+    startSwIdleAutoApply({ apply, doc: doc as unknown as Document, isIdle: () => !busy })
+
+    doc.setVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS * 3)
+    expect(apply).not.toHaveBeenCalled()
+
+    busy = false
+    doc.setVisibility('visible')
+    doc.setVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS)
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops listening when the returned stop is called', async () => {
+    const apply = vi.fn()
+    const doc = fakeDoc()
+    const stop = startSwIdleAutoApply({ apply, doc: doc as unknown as Document })
+
+    stop()
+    expect(doc.listenerCount()).toBe(0)
+
+    doc.setVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(SW_IDLE_SETTLE_MS * 3)
+    expect(apply).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/pwa/sw-idle-apply.ts
+++ b/apps/web/src/pwa/sw-idle-apply.ts
@@ -1,0 +1,72 @@
+import { getAppLogger } from '../lib/app-logger.js'
+
+const log = getAppLogger('sw-idle-apply')
+
+/**
+ * How long the tab must stay hidden before the swap is taken.
+ *
+ * Long enough that a quick tab switch does not trigger a reload the user
+ * returns into, and long enough to cover the editor's debounced write window
+ * so nothing in flight is lost.
+ */
+export const SW_IDLE_SETTLE_MS = 5_000
+
+export interface StartSwIdleAutoApplyOptions {
+  /** Applies the waiting worker. This reloads the page. */
+  readonly apply: () => void
+  /** Caller's "nothing in flight" signal; defaults to always idle. */
+  readonly isIdle?: () => boolean
+  readonly doc?: Document
+}
+
+export type StopSwIdleAutoApply = () => void
+
+/**
+ * Takes a waiting service worker update at the one moment it costs nothing:
+ * while the tab is hidden.
+ *
+ * The prompt strategy exists so an update never swaps under someone mid-draw,
+ * and that reasoning does not apply to a tab nobody is looking at. Without
+ * this, an update waits for a click that a user with no reason to care about
+ * versions may never give — and the page keeps running old code indefinitely,
+ * which is how a fix that shipped can look like a fix that was never written.
+ *
+ * Returning before the settle period cancels the swap: that is someone
+ * switching tabs, not leaving, and the reload would land as they come back.
+ */
+export function startSwIdleAutoApply({
+  apply,
+  isIdle = () => true,
+  doc = document,
+}: StartSwIdleAutoApplyOptions): StopSwIdleAutoApply {
+  let pending: ReturnType<typeof setTimeout> | undefined
+
+  const cancel = (): void => {
+    if (pending === undefined) return
+    clearTimeout(pending)
+    pending = undefined
+  }
+
+  const onVisibilityChange = (): void => {
+    if (doc.visibilityState !== 'hidden') {
+      cancel()
+      return
+    }
+    cancel()
+    pending = setTimeout(() => {
+      pending = undefined
+      // Re-checked rather than trusted from when the timer was set: both can
+      // change during the settle period, and applying then would reload a
+      // visible tab or drop work that arrived meanwhile.
+      if (doc.visibilityState !== 'hidden' || !isIdle()) return
+      log.debug('applying the waiting service worker while the tab is hidden')
+      apply()
+    }, SW_IDLE_SETTLE_MS)
+  }
+
+  doc.addEventListener('visibilitychange', onVisibilityChange)
+  return () => {
+    cancel()
+    doc.removeEventListener('visibilitychange', onVisibilityChange)
+  }
+}


### PR DESCRIPTION
An update waited on a click, and "Dismiss" removed the notice for the rest of the page's life. Someone with no reason to care about versions could dismiss once and keep running old code indefinitely — which looks exactly like a fix that was never shipped.

## Idle auto-apply

The swap is now taken while the tab is **hidden**. The prompt strategy exists so an update never lands under someone mid-draw, and that reasoning does not apply to a tab nobody is looking at.

- Returning before the settle period cancels it — that is a tab switch, not leaving, and the reload would land just as they come back.
- The settle period also covers the editor's debounced write window, and a caller with work in flight can hold it off through `isIdle`.
- Visibility and idleness are re-checked when the timer fires, not trusted from when it was set.

## Persistent notice

"Later" collapses the notice to a small chip instead of removing it, and the chip reopens it. Putting it off no longer makes it unfindable.

## What this deliberately does not do

It does not block interaction while an update is available. This editor's storage is per-map, so a stale client degrades rather than corrupts — an old client's full resync leaves maps it does not know about intact, which is exactly what happened to the canvas-level extension. Taking the canvas away mid-drag would destroy the work the update is meant to protect.

If a genuinely incompatible version ever ships, blocking should be gated on a declared incompatibility rather than on "an update exists".

## Verification

`pnpm test` green (611 files, 6499 tests) including five new tests for the idle rules and two for the collapse; `pnpm -r typecheck` clean.

One existing test changed intent with the behaviour: it pinned that the toast stays gone after Dismiss, which is the failure mode this PR removes.