### PR TITLE
feat(render): draw the curved routing style

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -213,19 +213,14 @@ const MINIMAP_HEIGHT_PX = 110
  */
 const MINIMAP_MIN_ROOT_WIDTH_PX = 768
 
-/**
- * The routing styles offered in the UI.
- *
- * `curved` is a valid model value but routes as `straight` until the SVG
- * backend can draw a curve, so offering it would be a control that changes
- * nothing. It joins this list when it renders.
- */
+/** The routing styles offered in the UI. */
 const EDGE_ROUTING_CHOICES: readonly {
   readonly style: EdgeRoutingStyle
   readonly label: string
 }[] = [
   { style: 'straight', label: 'Straight' },
   { style: 'orthogonal', label: 'Orthogonal' },
+  { style: 'curved', label: 'Curved' },
 ]
 
 export interface SpatialEditorProps {

--- a/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
@@ -119,3 +119,24 @@ it('drops the setting again when the style returns to straight', async () => {
     expect(latest.canvas).not.toHaveProperty('x-whiteboard')
   })
 })
+
+// Curved was withheld from the menu while it rendered as a straight line. It
+// belongs there now, and what makes it real is a <path> in the scene rather
+// than the entry existing.
+it('draws a curve when the canvas asks for one', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  openCanvasMenu(rootOf(container))
+
+  await vi.waitFor(() => expect(optionButton(container, 'Curved')).toBeDefined())
+  optionButton(container, 'Curved')?.click()
+
+  await vi.waitFor(() => {
+    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('curved')
+  })
+  await vi.waitFor(() => {
+    const path = container.querySelector('[data-testid="viewport-transform"] path')
+    expect(path?.getAttribute('d')).toContain('Q')
+    expect(path?.getAttribute('fill')).toBe('none')
+  })
+})

--- a/packages/canvas-render/src/layout/edge-obstacles.test.ts
+++ b/packages/canvas-render/src/layout/edge-obstacles.test.ts
@@ -234,3 +234,26 @@ it('detours when both elbows are blocked but the direct line is not', () => {
   expect(pathCrosses(routed.path, onFirstElbow), 'crosses m1').toBe(false)
   expect(pathCrosses(routed.path, onSecondElbow), 'crosses m2').toBe(false)
 })
+
+// `curved` was accepted by the model but routed as `straight`, because the
+// backend could only draw a polyline. It travels the orthogonal waypoints —
+// perpendicular exit and entry, obstacles avoided — and asks for them to be
+// drawn rounded rather than square.
+describe('curved routing style', () => {
+  it('asks for rounded corners', () => {
+    const nodes = [node('a', 0, 0), node('b', 400, 300)]
+
+    expect(routeEdge(nodes, edge('a', 'b'), 'curved').rounded).toBe(true)
+    expect(routeEdge(nodes, edge('a', 'b'), 'orthogonal').rounded).toBeUndefined()
+    expect(routeEdge(nodes, edge('a', 'b'), 'straight').rounded).toBeUndefined()
+  })
+
+  it('travels the same waypoints as orthogonal, so it avoids obstacles too', () => {
+    const blocker = node('mid', 200, 0)
+    const nodes = [node('a', 0, 0), blocker, node('b', 400, 0)]
+    const curved = routeEdge(nodes, edge('a', 'b'), 'curved')
+
+    expect(curved.path).toEqual(routeEdge(nodes, edge('a', 'b'), 'orthogonal').path)
+    expect(pathCrosses(curved.path, blocker)).toBe(false)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -347,15 +347,16 @@ export function routeEdge(
   return {
     kind: 'edge',
     id: edge.id,
-    // 'curved' is accepted by the model but has no rendering yet: the scene
-    // graph carries edges as a point path and the SVG backend draws them as a
-    // <polyline>, so control points would render as corners. Until the
-    // backend can express a curve it routes as 'straight' rather than
-    // pretending — see the routing-style slice notes.
+    // 'curved' travels the same waypoints as 'orthogonal' — perpendicular
+    // exit and entry, obstacles stepped around — and differs only in asking
+    // for those corners to be drawn rounded. Keeping one set of waypoints is
+    // what makes the two styles agree about which nodes an edge avoids; only
+    // the drawing differs.
     path:
-      style === 'orthogonal'
-        ? routeOrthogonal(start, end, fromSide, toSide, obstacles)
-        : routeStraight(start, end, obstacles),
+      style === 'straight'
+        ? routeStraight(start, end, obstacles)
+        : routeOrthogonal(start, end, fromSide, toSide, obstacles),
+    ...(style === 'curved' ? { rounded: true as const } : {}),
     fromSide,
     toSide,
     fromEnd,

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -233,6 +233,14 @@ export interface ResolvedEdgeNode {
   // constructor can forget which ends carry an arrowhead.
   readonly fromEnd: 'none' | 'arrow'
   readonly toEnd: 'none' | 'arrow'
+  /**
+   * Draw the corners of `path` rounded rather than square. A rendering hint,
+   * not geometry: `path` stays the single source of the edge's shape, so
+   * sceneBounds, translateScene and scaleScene keep working on the points
+   * alone. The backend's rounding is chosen to stay inside the polyline
+   * (see its `<path>` construction), which is what makes that safe.
+   */
+  readonly rounded?: true
   readonly appearance?: Appearance
 }
 

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -749,3 +749,52 @@ it('draws a bent edge as a line, not a filled wedge', () => {
   const polyline = /<polyline[^>]*>/.exec(svg)?.[0] ?? ''
   expect(polyline).toContain('fill="none"')
 })
+
+describe('rounded edges', () => {
+  const bent = {
+    kind: 'edge' as const,
+    id: 'e1',
+    path: [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ],
+    fromSide: 'right' as const,
+    toSide: 'top' as const,
+    fromEnd: 'none' as const,
+    toEnd: 'none' as const,
+  }
+
+  it('draws a rounded edge as a path, never a polyline', () => {
+    const svg = renderSceneToSvg({ nodes: [{ ...bent, rounded: true }] })
+
+    expect(svg).toContain('<path')
+    expect(svg).not.toContain('<polyline')
+    expect(/<path[^>]*>/.exec(svg)?.[0]).toContain('fill="none"')
+  })
+
+  // The corner is the control point and the segment midpoints are on the
+  // curve, so the drawn shape stays inside the polyline it rounds. That is
+  // what lets sceneBounds, translateScene and scaleScene keep working on the
+  // points alone — a smoothing that overshot would put ink outside the bounds
+  // they compute.
+  it('keeps every coordinate inside the polyline it rounds', () => {
+    const svg = renderSceneToSvg({ nodes: [{ ...bent, rounded: true }] })
+    const d = /<path[^>]*\sd="([^"]*)"/.exec(svg)?.[1] ?? ''
+    const numbers = d.match(/-?[\d.]+/g)?.map(Number) ?? []
+    const xs = numbers.filter((_, i) => i % 2 === 0)
+    const ys = numbers.filter((_, i) => i % 2 === 1)
+
+    expect(numbers.length).toBeGreaterThan(0)
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(0)
+    expect(Math.max(...xs)).toBeLessThanOrEqual(100)
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(0)
+    expect(Math.max(...ys)).toBeLessThanOrEqual(100)
+  })
+
+  it('leaves an ordinary edge as a polyline, byte-for-byte', () => {
+    expect(renderSceneToSvg({ nodes: [bent] })).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 100,0 100,100" fill="none" role="presentation"/></svg>',
+    )
+  })
+})

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -123,6 +123,53 @@ function renderTableRow(row: TableRowSceneNode): string {
   return `<g>${row.cells.map(renderTableCell).join('')}</g>`
 }
 
+type EdgePoint = { readonly x: number; readonly y: number }
+
+const midpoint = (a: EdgePoint, b: EdgePoint): EdgePoint => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2,
+})
+
+/**
+ * The same polyline with its corners rounded off.
+ *
+ * Each interior vertex becomes the CONTROL point of a quadratic curve whose
+ * endpoints are the midpoints of the two segments meeting there. A quadratic
+ * Bézier never leaves the triangle of its three points, so the drawn shape
+ * stays inside the polyline — which is what lets `path` remain the single
+ * source of the edge's geometry, with sceneBounds/translateScene/scaleScene
+ * still correct working on the points alone. A smoothing that overshot (a
+ * Catmull-Rom spline through the vertices, say) would put ink outside the
+ * bounds those functions compute.
+ *
+ * Degenerate inputs fall back to the straight reading rather than emitting a
+ * malformed `d`, matching this package's never-throw rule.
+ */
+function roundedPathData(path: readonly EdgePoint[]): string {
+  const [first, ...rest] = path
+  const last = path.at(-1)
+  if (first === undefined || last === undefined) return ''
+  if (path.length < 3) {
+    return `M ${formatCoord(first.x)} ${formatCoord(first.y)} L ${formatCoord(last.x)} ${formatCoord(last.y)}`
+  }
+
+  const corners = rest.slice(0, -1)
+  const parts = [`M ${formatCoord(first.x)} ${formatCoord(first.y)}`]
+  let from = first
+  for (const [index, corner] of corners.entries()) {
+    const next = path[index + 2] as EdgePoint
+    const enter = midpoint(from, corner)
+    const leave = midpoint(corner, next)
+    parts.push(`L ${formatCoord(enter.x)} ${formatCoord(enter.y)}`)
+    parts.push(
+      `Q ${formatCoord(corner.x)} ${formatCoord(corner.y)} ${formatCoord(leave.x)} ${formatCoord(leave.y)}`,
+    )
+    from = corner
+  }
+  parts.push(`L ${formatCoord(last.x)} ${formatCoord(last.y)}`)
+  return parts.join(' ')
+}
+
 function renderNode(node: SceneNode): string {
   switch (node.kind) {
     case 'textRun':
@@ -165,8 +212,12 @@ function renderNode(node: SceneNode): string {
       // <polyline> fills the region its points enclose, so a bent edge would
       // paint a solid wedge across its own corner in whatever fill the
       // surrounding document inherits — invisible while every path had two
-      // points, glaring the moment routing started bending them.
-      const polyline = `<polyline points="${points}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+      // points, glaring the moment routing started bending them. A <path>
+      // needs it for exactly the same reason.
+      const polyline =
+        node.rounded === true
+          ? `<path d="${roundedPathData(node.path)}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+          : `<polyline points="${points}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
       // Arrowheads are filled triangles in the edge's stroke color, drawn
       // after (over) the polyline. Geometry comes from the shared helper so
       // sceneBounds always agrees on how far the wings reach.


### PR DESCRIPTION
`curved` was a valid model value that rendered as a straight line, so the menu withheld it — a control that changes nothing is worse than an absent one.

The gap was the scene graph having no way to say "curve": edges are a point path and the backend drew a `<polyline>`.

## A hint, not a second geometry

Edges gain a `rounded` flag. `path` stays the single source of the edge's shape, so `sceneBounds`, `translateScene` and `scaleScene` keep working on the points alone — no parallel curve representation to keep in sync with them.

That is only safe because of how the rounding is built: each corner becomes the **control** point of a quadratic whose endpoints are the midpoints of the two segments meeting there, and a quadratic never leaves the triangle of its three points. The drawn shape therefore stays inside the polyline it rounds, which a test pins directly.

A spline through the vertices (Catmull-Rom) would look similar and overshoot — putting ink outside the bounds those three functions compute. That is the reason for the choice, not aesthetics.

## Same waypoints as orthogonal

`curved` travels the orthogonal route — perpendicular exit and entry, obstacles stepped around — and differs only in the drawing. One set of waypoints is what makes the two styles agree about which nodes an edge avoids; a second router would let them disagree.

## Follow-up, deliberately not here

A self-edge still renders as a box: it is a four-point path drawn square. It is now one `rounded` flag away from being a loop, but that changes existing output for every self-edge and deserves its own review.

## Verification

`pnpm test` green (611 files, 6505 tests) — new tests cover the path element and its fill, the stays-inside-the-polyline property, the unchanged polyline output for ordinary edges, style selection, and the editor menu actually producing a `<path>` with a `Q` command. `pnpm -r typecheck` clean.