### PR TITLE
feat(web): tell the user what blocked a daemon check

### DIFF
--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -881,22 +881,78 @@ describe('DaemonDetectedBanner — local network permission', () => {
     expect(screen.queryByTestId('lna-explainer')).toBeNull()
   })
 
-  it('does not blame the browser for a failure it has been shown to allow', async () => {
-    // A granted permission rules the browser out, so pointing the user at
-    // site settings here would send them to change something already correct.
-    renderWithPermission('granted')
+  it('still checks when reading the permission throws', async () => {
+    // The read is awaited after 'checking' is claimed, so an unhandled
+    // rejection would leave the button disabled for good -- and the button is
+    // the only affordance that could recover from it.
+    const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+        queryPermissionFn={vi.fn().mockRejectedValue(new Error('permissions unavailable'))}
+      />,
+    )
 
     fireEvent.click(screen.getByTestId('daemon-port-connect'))
 
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
     await screen.findByTestId('daemon-check-failed-notice')
-    expect(screen.queryByTestId('daemon-check-blocked-notice')).toBeNull()
   })
 
-  it('names the browser as the obstacle when a failure follows a denial', async () => {
-    // Reached by a permission revoked between the gate check and the probe:
-    // the gate saw 'prompt', so the check ran, and the probe then failed.
+  it('stops at the gate when a later check finds the permission denied', async () => {
+    // The path this replaced a mis-named test for. A denied read returns at
+    // the gate, so no probe runs and no failure copy renders -- which is why
+    // asserting the failure notice here could never have worked.
     const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
-    const queryPermissionFn = vi.fn().mockResolvedValueOnce('prompt').mockResolvedValue('denied')
+    const queryPermissionFn = vi.fn().mockResolvedValueOnce('granted').mockResolvedValue('denied')
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+        queryPermissionFn={queryPermissionFn}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+    const callsBefore = probeFn.mock.calls.length
+
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await screen.findByTestId('lna-blocked')
+    expect(probeFn.mock.calls.length).toBe(callsBefore)
+  })
+
+  it('tells the user the prompt went unanswered when it did', async () => {
+    // Dismissing the prompt leaves the permission at 'prompt' after the sweep,
+    // which is neither an absent daemon nor a standing denial.
+    const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+        queryPermissionFn={vi.fn().mockResolvedValue('prompt')}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+    await screen.findByTestId('lna-explainer')
+    fireEvent.click(screen.getByTestId('lna-explainer-continue'))
+
+    await screen.findByTestId('daemon-check-unanswered-notice')
+  })
+
+  it('drops the unanswered copy once the prompt has been allowed', async () => {
+    // The bug this pins: the permission is read BEFORE the probe, but the
+    // prompt is answered DURING it, so reusing the pre-probe snapshot told a
+    // user who had just clicked Allow to go and allow it.
+    const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
+    const queryPermissionFn = vi.fn().mockResolvedValueOnce('prompt').mockResolvedValue('granted')
     render(
       <DaemonDetectedBanner
         settingsStore={makeStore()}
@@ -909,11 +965,8 @@ describe('DaemonDetectedBanner — local network permission', () => {
     fireEvent.click(screen.getByTestId('daemon-port-connect'))
     await screen.findByTestId('lna-explainer')
     fireEvent.click(screen.getByTestId('lna-explainer-continue'))
-    await waitFor(() => expect(probeFn).toHaveBeenCalled())
 
-    // The second read is what the failure copy is keyed on.
-    fireEvent.click(screen.getByTestId('daemon-port-connect'))
-
-    await screen.findByTestId('lna-blocked')
+    await screen.findByTestId('daemon-check-failed-notice')
+    expect(screen.queryByTestId('daemon-check-unanswered-notice')).toBeNull()
   })
 })

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -815,3 +815,105 @@ describe('DaemonDetectedBanner', () => {
     })
   })
 })
+
+describe('DaemonDetectedBanner — local network permission', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+  afterEach(() => {
+    cleanup()
+  })
+
+  function renderWithPermission(
+    permission: 'granted' | 'prompt' | 'denied' | 'unknown',
+    probeFn = vi.fn().mockResolvedValue(NOT_DETECTED),
+  ) {
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+        queryPermissionFn={vi.fn().mockResolvedValue(permission)}
+      />,
+    )
+    return probeFn
+  }
+
+  it('explains the permission before the check that would trigger the prompt', async () => {
+    // The prompt fires on the request, so probing first and explaining after
+    // would put the explanation behind the dialog it is meant to introduce.
+    const probeFn = renderWithPermission('prompt')
+
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await screen.findByTestId('lna-explainer')
+    expect(probeFn).not.toHaveBeenCalled()
+  })
+
+  it('runs the held-back check once the explanation is acknowledged', async () => {
+    const probeFn = renderWithPermission('prompt')
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+    await screen.findByTestId('lna-explainer')
+
+    fireEvent.click(screen.getByTestId('lna-explainer-continue'))
+
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+  })
+
+  it('does not probe at all once the permission is denied', async () => {
+    // Probing would fail in a way indistinguishable from an absent daemon,
+    // and cannot re-prompt, so it can only mislead.
+    const probeFn = renderWithPermission('denied')
+
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await screen.findByTestId('lna-blocked')
+    expect(probeFn).not.toHaveBeenCalled()
+  })
+
+  it('checks without an explanation once the permission is granted', async () => {
+    const probeFn = renderWithPermission('granted')
+
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+    expect(screen.queryByTestId('lna-explainer')).toBeNull()
+  })
+
+  it('does not blame the browser for a failure it has been shown to allow', async () => {
+    // A granted permission rules the browser out, so pointing the user at
+    // site settings here would send them to change something already correct.
+    renderWithPermission('granted')
+
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await screen.findByTestId('daemon-check-failed-notice')
+    expect(screen.queryByTestId('daemon-check-blocked-notice')).toBeNull()
+  })
+
+  it('names the browser as the obstacle when a failure follows a denial', async () => {
+    // Reached by a permission revoked between the gate check and the probe:
+    // the gate saw 'prompt', so the check ran, and the probe then failed.
+    const probeFn = vi.fn().mockResolvedValue(NOT_DETECTED)
+    const queryPermissionFn = vi.fn().mockResolvedValueOnce('prompt').mockResolvedValue('denied')
+    render(
+      <DaemonDetectedBanner
+        settingsStore={makeStore()}
+        fetch={vi.fn()}
+        locationProtocol="https:"
+        probeFn={probeFn}
+        queryPermissionFn={queryPermissionFn}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+    await screen.findByTestId('lna-explainer')
+    fireEvent.click(screen.getByTestId('lna-explainer-continue'))
+    await waitFor(() => expect(probeFn).toHaveBeenCalled())
+
+    // The second read is what the failure copy is keyed on.
+    fireEvent.click(screen.getByTestId('daemon-port-connect'))
+
+    await screen.findByTestId('lna-blocked')
+  })
+})

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -16,6 +16,15 @@ import {
   type ProbeDaemonOptions,
   probeDaemon,
 } from '../../lib/daemon-probe.js'
+import {
+  decideConnectGate,
+  explainProbeFailure,
+  type ProbeFailureExplanation,
+} from '../../lib/local-network-gate.js'
+import {
+  type LocalNetworkPermissionState,
+  queryLocalNetworkPermission,
+} from '../../lib/local-network-permission.js'
 import { beginPairingGrant } from '../../lib/pairing-grant.js'
 import type { UserSettingsStore } from '../../lib/user-settings-store.js'
 import { shouldShowDaemonCta } from './daemon-cta-visibility.js'
@@ -45,9 +54,11 @@ export const HOW_TO_CONNECT_URL =
 // before the user gives up and clicks again.
 const LNA_HINT_DELAY_MS = 1000
 
-// Phrased as a possibility, not a claim: the same stall also happens from
-// a plain network timeout with no permission prompt involved, and this
-// component has no way to distinguish the two from script.
+// Phrased as a possibility, not a claim: the same stall also happens from a
+// plain network timeout with no permission prompt involved. The permission
+// read settles that afterwards, but this hint is shown WHILE the sweep is
+// still outstanding, when the prompt (if any) is unanswered and there is
+// still nothing to distinguish the two cases by.
 export const LNA_HINT_TEXT =
   'This is taking a while — your browser may be asking for permission to reach local devices. Check for a permission prompt.'
 
@@ -64,6 +75,9 @@ interface DaemonDetectedBannerProps {
   // Injectable for tests; production default challenges the responder's
   // identity against the pinned key (see lib/daemon-identity-pin.ts).
   challengeFn?: (baseUrl: string) => Promise<IdentityChallengeResult>
+  // Injectable for tests; production default reads the browser's
+  // local-network permission (see lib/local-network-permission.ts).
+  queryPermissionFn?: () => Promise<LocalNetworkPermissionState>
 }
 
 /**
@@ -87,6 +101,7 @@ export function DaemonDetectedBanner({
     }),
   challengeFn = (baseUrl) =>
     challengeDaemonIdentity({ daemonBaseUrl: baseUrl, fetch: globalThis.fetch.bind(globalThis) }),
+  queryPermissionFn = () => queryLocalNetworkPermission(navigator.permissions),
 }: DaemonDetectedBannerProps) {
   const [result, setResult] = useState<DaemonProbeResult | null>(null)
   // Every daemon the last sweep confirmed (dynamic ports mean there can be
@@ -115,6 +130,17 @@ export function DaemonDetectedBanner({
   // silently deduped by the in-flight map one layer down.
   const [checking, setChecking] = useState(false)
   const [showLnaHint, setShowLnaHint] = useState(false)
+  // Last read of the browser's local-network permission. Read on demand
+  // rather than on mount: reading it is only useful next to a check, and a
+  // mount-time read would go stale the moment the user answers the prompt.
+  const [permission, setPermission] = useState<LocalNetworkPermissionState>('unknown')
+  // 'explain' holds the check back until the user has read why the browser
+  // is about to ask; 'blocked' replaces it entirely, because a denied
+  // permission cannot be re-prompted from script.
+  const [connectGate, setConnectGate] = useState<'idle' | 'explain' | 'blocked'>('idle')
+  // The port the held-back check was aimed at, so acknowledging the
+  // explanation resumes that check rather than a broader one.
+  const [gatedTarget, setGatedTarget] = useState<string | undefined>(undefined)
   const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // The store object identity never changes, so anything derived from it has
@@ -357,11 +383,49 @@ export function DaemonDetectedBanner({
     return `http://127.0.0.1:${port}`
   }
 
-  function checkNow() {
+  async function checkNow() {
     const explicit = enteredBaseUrl()
     if (explicit === null && portInput.trim() !== '') return
-    runProbe(true, explicit ?? undefined)
+    const target = explicit ?? undefined
+    // Claimed before the await, not inside runProbe: reading the permission
+    // is asynchronous, and across that gap the UI would otherwise still show
+    // the previous attempt — a live button a second click can double-start,
+    // next to a failure notice describing a check that is already being
+    // replaced.
+    setChecking(true)
+    setManualCheckFailed(false)
+
+    // Read the permission BEFORE probing, because probing is what triggers
+    // the prompt. Afterwards is too late to explain it, and a denial that is
+    // already on file makes the probe a guaranteed, unexplained failure.
+    const state = await queryPermissionFn()
+    setPermission(state)
+
+    const gate = decideConnectGate({ pageOriginScheme, permission: state })
+    if (gate === 'blocked') {
+      setChecking(false)
+      setConnectGate('blocked')
+      return
+    }
+    if (gate === 'explain') {
+      setChecking(false)
+      setGatedTarget(target)
+      setConnectGate('explain')
+      return
+    }
+    setConnectGate('idle')
+    runProbe(true, target)
   }
+
+  function confirmExplainedCheck() {
+    setConnectGate('idle')
+    runProbe(true, gatedTarget)
+  }
+
+  const failureExplanation: ProbeFailureExplanation | null =
+    result === null || result.detected
+      ? null
+      : explainProbeFailure({ pageOriginScheme, permission, reason: result.reason })
 
   return (
     <>
@@ -384,7 +448,7 @@ export function DaemonDetectedBanner({
       {showManualAffordance && (
         <button
           type="button"
-          onClick={checkNow}
+          onClick={() => void checkNow()}
           disabled={checking}
           aria-busy={checking}
           className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
@@ -400,42 +464,128 @@ export function DaemonDetectedBanner({
           {showLnaHint && <span className="text-xs text-muted-foreground">{LNA_HINT_TEXT}</span>}
         </>
       )}
-      {showManualAffordance && manualCheckFailed && (
-        // A CORS rejection (daemon running but this origin not in its
-        // WHITEBOARD_ALLOWED_WEB_ORIGINS) is indistinguishable from
-        // daemon-absent at the fetch layer, so the hosted-origin copy stays
-        // conditional ("if yours is running…") per the honesty discipline
-        // above. Loopback origins need no allowlist entry, so they get the
-        // plain not-found message.
-        <span data-testid="daemon-check-failed-notice" className="text-xs text-muted-foreground">
-          {pageOriginScheme === 'https' ? (
-            <>
-              No daemon reachable from this origin. If yours is running, approving it on the
-              daemon's consent page grants this origin access (a top-level navigation is not subject
-              to the CORS block that hides the daemon from the check) —{' '}
-              <button
-                type="button"
-                onClick={() => void beginGrantFn({ daemonBaseUrl: baseUrl })}
-                className="font-medium underline"
-              >
-                connect anyway
-              </button>
-              . Only approve a daemon you started yourself, or see{' '}
-              <a
-                href={HOW_TO_CONNECT_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="font-medium underline"
-              >
-                how to connect
-              </a>
-              .
-            </>
-          ) : (
-            <>No local daemon found at {baseUrl}.</>
-          )}
+      {connectGate === 'explain' && (
+        // Said before the check, not after: the browser's prompt is triggered
+        // BY the request, and a denial is remembered, so an unexplained
+        // prompt is a question the user usually gets exactly one chance to
+        // answer well.
+        <span
+          data-testid="lna-explainer"
+          role="dialog"
+          aria-label="About the local network permission"
+          className="flex flex-wrap items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-muted-foreground"
+        >
+          Your browser is about to ask whether this site may reach devices on your local network.
+          That is how it connects to the daemon running on your own machine — nothing leaves your
+          computer.
+          <button
+            type="button"
+            data-testid="lna-explainer-continue"
+            onClick={confirmExplainedCheck}
+            className="font-medium underline"
+          >
+            Continue
+          </button>
+          <button
+            type="button"
+            data-testid="lna-explainer-cancel"
+            onClick={() => setConnectGate('idle')}
+            className="font-medium underline"
+          >
+            Not now
+          </button>
         </span>
       )}
+      {connectGate === 'blocked' && (
+        // No check is offered here on purpose: the permission cannot be
+        // re-requested from script once it is denied, so a retry button would
+        // do nothing but fail again. Only browser settings can undo it.
+        <span
+          data-testid="lna-blocked"
+          role="alert"
+          className="flex flex-wrap items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-amber-700"
+        >
+          Your browser is blocking this site from reaching your local network, so the daemon cannot
+          be found however the port is set. Allow local network access for this site in your
+          browser's site settings, then check again.{' '}
+          <a
+            href={HOW_TO_CONNECT_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium underline"
+          >
+            How to connect
+          </a>
+        </span>
+      )}
+      {showManualAffordance && manualCheckFailed && failureExplanation === 'browser-blocked' && (
+        <span
+          data-testid="daemon-check-blocked-notice"
+          role="alert"
+          className="text-xs text-amber-700"
+        >
+          Your browser blocked the request to your local network. Allow local network access for
+          this site in your browser's site settings, then check again.
+        </span>
+      )}
+      {showManualAffordance &&
+        manualCheckFailed &&
+        failureExplanation === 'permission-unanswered' && (
+          <span
+            data-testid="daemon-check-unanswered-notice"
+            className="text-xs text-muted-foreground"
+          >
+            The browser asked for permission to reach your local network and the request was left
+            unanswered. Check again and choose Allow.
+          </span>
+        )}
+      {showManualAffordance && manualCheckFailed && failureExplanation === 'not-a-daemon' && (
+        <span
+          data-testid="daemon-check-wrong-server-notice"
+          className="text-xs text-muted-foreground"
+        >
+          Something is running on that port, but it is not a whiteboard daemon. Check the port
+          number.
+        </span>
+      )}
+      {showManualAffordance &&
+        manualCheckFailed &&
+        (failureExplanation === 'unreachable' || failureExplanation === 'unclear') && (
+          // A CORS rejection (daemon running but this origin not in its
+          // WHITEBOARD_ALLOWED_WEB_ORIGINS) is indistinguishable from
+          // daemon-absent at the fetch layer, so the hosted-origin copy stays
+          // conditional ("if yours is running…") per the honesty discipline
+          // above. Loopback origins need no allowlist entry, so they get the
+          // plain not-found message.
+          <span data-testid="daemon-check-failed-notice" className="text-xs text-muted-foreground">
+            {pageOriginScheme === 'https' ? (
+              <>
+                No daemon reachable from this origin. If yours is running, approving it on the
+                daemon's consent page grants this origin access (a top-level navigation is not
+                subject to the CORS block that hides the daemon from the check) —{' '}
+                <button
+                  type="button"
+                  onClick={() => void beginGrantFn({ daemonBaseUrl: baseUrl })}
+                  className="font-medium underline"
+                >
+                  connect anyway
+                </button>
+                . Only approve a daemon you started yourself, or see{' '}
+                <a
+                  href={HOW_TO_CONNECT_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium underline"
+                >
+                  how to connect
+                </a>
+                .
+              </>
+            ) : (
+              <>No local daemon found at {baseUrl}.</>
+            )}
+          </span>
+        )}
       {!showUnsupportedNotice && (
         // Always offered, never gated on a failed check. Naming a port is the
         // primary way in now that there is no port scan to stumble on one:
@@ -452,7 +602,7 @@ export function DaemonDetectedBanner({
             value={portInput}
             onChange={(event) => setPortInput(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter') checkNow()
+              if (event.key === 'Enter') void checkNow()
             }}
             placeholder="3099"
             className="w-16 rounded border px-1 py-0.5"
@@ -461,7 +611,7 @@ export function DaemonDetectedBanner({
           <button
             type="button"
             data-testid="daemon-port-connect"
-            onClick={checkNow}
+            onClick={() => void checkNow()}
             className="font-medium underline"
           >
             Check

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -206,6 +206,19 @@ export function DaemonDetectedBanner({
 
   // Always paired with aborting/settling the sweep the timer belongs to, so
   // a pending hint can never outlive its own probe.
+  // The only way this component reads the permission. A rejection has to
+  // become 'unknown' here rather than at each call site: both callers are
+  // downstream of a `setChecking(true)` or gate a piece of failure copy, so a
+  // propagating rejection strands the button or silently drops the copy
+  // instead of surfacing anything the user can act on.
+  async function readPermission(): Promise<LocalNetworkPermissionState> {
+    try {
+      return await queryPermissionFn()
+    } catch {
+      return 'unknown'
+    }
+  }
+
   function clearHintTimer() {
     if (hintTimerRef.current !== null) {
       clearTimeout(hintTimerRef.current)
@@ -265,7 +278,19 @@ export function DaemonDetectedBanner({
               failures[0] ??
               ({ detected: false, reason: 'network' } as const)),
       )
-      setManualCheckFailed(Boolean(forceRecheck) && nextFound.length === 0)
+      if (forceRecheck && nextFound.length === 0) {
+        // Re-read before the failure copy renders, never reuse the pre-probe
+        // snapshot: the prompt is answered DURING the sweep, so a check that
+        // began at 'prompt' and was then allowed would otherwise be explained
+        // as "left unanswered" — telling the user to allow what they just did.
+        void readPermission().then((settled) => {
+          if (controller.signal.aborted) return
+          setPermission(settled)
+          setManualCheckFailed(true)
+        })
+      } else {
+        setManualCheckFailed(false)
+      }
       if (nextFound.length > 0) {
         // Persist every confirmed daemon, first-found ending most recent,
         // so the next visit's narrow auto-probe reaches them directly.
@@ -398,7 +423,7 @@ export function DaemonDetectedBanner({
     // Read the permission BEFORE probing, because probing is what triggers
     // the prompt. Afterwards is too late to explain it, and a denial that is
     // already on file makes the probe a guaranteed, unexplained failure.
-    const state = await queryPermissionFn()
+    const state = await readPermission()
     setPermission(state)
 
     const gate = decideConnectGate({ pageOriginScheme, permission: state })
@@ -471,8 +496,11 @@ export function DaemonDetectedBanner({
         // answer well.
         <span
           data-testid="lna-explainer"
-          role="dialog"
-          aria-label="About the local network permission"
+          // A live region rather than role="dialog": this is inline and
+          // non-blocking, and an unfocused dialog is announced by nothing at
+          // all — a screen reader user would meet the browser's permission
+          // prompt without ever hearing the explanation meant to precede it.
+          role="status"
           className="flex flex-wrap items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-muted-foreground"
         >
           Your browser is about to ask whether this site may reach devices on your local network.
@@ -518,16 +546,12 @@ export function DaemonDetectedBanner({
           </a>
         </span>
       )}
-      {showManualAffordance && manualCheckFailed && failureExplanation === 'browser-blocked' && (
-        <span
-          data-testid="daemon-check-blocked-notice"
-          role="alert"
-          className="text-xs text-amber-700"
-        >
-          Your browser blocked the request to your local network. Allow local network access for
-          this site in your browser's site settings, then check again.
-        </span>
-      )}
+      {/* 'browser-blocked' deliberately has no branch here. Both routes to it
+          are handled elsewhere already: a proven block (reason 'blocked') puts
+          the capability tier at 'tier2-blocked' and renders
+          UNSUPPORTED_BROWSER_NOTICE instead of this row, and a denied
+          permission returns at the gate above without ever probing. A branch
+          for it would be unreachable UI. */}
       {showManualAffordance &&
         manualCheckFailed &&
         failureExplanation === 'permission-unanswered' && (

--- a/apps/web/src/lib/local-network-gate.test.ts
+++ b/apps/web/src/lib/local-network-gate.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { decideConnectGate, explainProbeFailure } from './local-network-gate.js'
+
+describe('decideConnectGate', () => {
+  it('probes straight away from a loopback page, whatever the permission says', () => {
+    // A loopback page reaches the daemon same-origin, so Local Network Access
+    // never applies. Explaining a permission that cannot gate this request
+    // would be a modal in front of nothing.
+    for (const permission of ['granted', 'prompt', 'denied', 'unknown'] as const) {
+      expect(decideConnectGate({ pageOriginScheme: 'http', permission })).toBe('probe')
+    }
+  })
+
+  it('explains itself before a prompt the user has not answered yet', () => {
+    // The prompt fires on the request itself, so without this the browser asks
+    // about "local network access" with no stated reason. A denial is sticky,
+    // making that unexplained prompt a one-shot the user usually loses.
+    expect(decideConnectGate({ pageOriginScheme: 'https', permission: 'prompt' })).toBe('explain')
+  })
+
+  it('does not probe once the permission is denied', () => {
+    // The request cannot succeed and re-asking does not re-prompt, so probing
+    // only produces a failure that looks like an absent daemon.
+    expect(decideConnectGate({ pageOriginScheme: 'https', permission: 'denied' })).toBe('blocked')
+  })
+
+  it('stays out of the way once the permission is granted', () => {
+    expect(decideConnectGate({ pageOriginScheme: 'https', permission: 'granted' })).toBe('probe')
+  })
+
+  it('probes when the permission could not be read', () => {
+    // 'unknown' means the engine does not know the feature, which in practice
+    // means it never prompts (Safari, Firefox). Showing a Chrome-shaped
+    // explanation there would describe a dialog that never appears.
+    expect(decideConnectGate({ pageOriginScheme: 'https', permission: 'unknown' })).toBe('probe')
+  })
+})
+
+describe('explainProbeFailure', () => {
+  it('rules the browser out when the permission is granted', () => {
+    // The case the probe could never call before. Note what it stops short
+    // of: a daemon that has not allowlisted this origin fails exactly like an
+    // empty port, so 'unreachable' claims only that the browser let the
+    // request through.
+    expect(
+      explainProbeFailure({
+        pageOriginScheme: 'https',
+        permission: 'granted',
+        reason: 'network',
+      }),
+    ).toBe('unreachable')
+  })
+
+  it('blames the browser when the permission is denied', () => {
+    expect(
+      explainProbeFailure({ pageOriginScheme: 'https', permission: 'denied', reason: 'network' }),
+    ).toBe('browser-blocked')
+  })
+
+  it('reports an unanswered prompt as its own outcome', () => {
+    // Dismissing the prompt is neither a missing daemon nor a standing
+    // denial: asking again still works, which no other outcome implies.
+    expect(
+      explainProbeFailure({ pageOriginScheme: 'https', permission: 'prompt', reason: 'network' }),
+    ).toBe('permission-unanswered')
+  })
+
+  it('rules the browser out on a loopback page even when the permission is unread', () => {
+    // Same-scheme loopback cannot be blocked by the browser, so the answer
+    // does not depend on a permission this page never needed.
+    expect(
+      explainProbeFailure({ pageOriginScheme: 'http', permission: 'unknown', reason: 'refused' }),
+    ).toBe('unreachable')
+  })
+
+  it('keeps a proven browser block over whatever the permission says', () => {
+    // WebKit's mixed-content rejection is measured, not inferred, and WebKit
+    // reports no local-network permission at all — trusting 'unknown' here
+    // would discard the one engine-confirmed block we can detect.
+    expect(
+      explainProbeFailure({ pageOriginScheme: 'https', permission: 'unknown', reason: 'blocked' }),
+    ).toBe('browser-blocked')
+  })
+
+  it('separates something answering badly from nothing answering', () => {
+    // An HTTP error or unparseable body means a server IS on that port and it
+    // is not the daemon — telling the user to start a daemon there would send
+    // them to fix the wrong thing.
+    for (const reason of ['http-error', 'malformed'] as const) {
+      expect(
+        explainProbeFailure({ pageOriginScheme: 'https', permission: 'granted', reason }),
+      ).toBe('not-a-daemon')
+    }
+  })
+
+  it('admits it cannot tell when the permission is unreadable', () => {
+    expect(
+      explainProbeFailure({ pageOriginScheme: 'https', permission: 'unknown', reason: 'network' }),
+    ).toBe('unclear')
+  })
+})

--- a/apps/web/src/lib/local-network-gate.ts
+++ b/apps/web/src/lib/local-network-gate.ts
@@ -1,0 +1,91 @@
+// Turning the browser's local-network permission into two decisions the
+// connect flow needs: whether to explain itself before the prompt appears,
+// and what a failed probe actually means.
+//
+// The second one is why this exists. A loopback fetch that fails tells you
+// nothing on its own — Chromium rejects a permission-blocked request with the
+// same "Failed to fetch" as a port with nothing behind it. Reading the
+// permission rules one of them out, so the UI can name a cause instead of
+// listing possibilities.
+
+import type { ProbeFailureReason } from './daemon-probe.js'
+import type { LocalNetworkPermissionState } from './local-network-permission.js'
+
+export type ConnectGate =
+  /** Nothing to explain — probe now. */
+  | 'probe'
+  /** The prompt is still ahead: say why before it appears. */
+  | 'explain'
+  /** Permission denied; probing cannot succeed and will not re-prompt. */
+  | 'blocked'
+
+export interface ConnectGateInput {
+  pageOriginScheme: 'http' | 'https'
+  permission: LocalNetworkPermissionState
+}
+
+export function decideConnectGate({ pageOriginScheme, permission }: ConnectGateInput): ConnectGate {
+  // A loopback page reaches the daemon same-origin, so no permission gates it.
+  if (pageOriginScheme === 'http') return 'probe'
+  if (permission === 'denied') return 'blocked'
+  if (permission === 'prompt') return 'explain'
+  // 'granted', and 'unknown' — an engine that does not know the feature does
+  // not prompt for it, so there is no dialog to prepare the user for.
+  return 'probe'
+}
+
+export type ProbeFailureExplanation =
+  /**
+   * The browser is not the obstacle. Deliberately not "nothing is there":
+   * a running daemon that has not allowlisted this origin rejects with the
+   * same "Failed to fetch" as an empty port, and no client-side signal
+   * separates them. Naming only what is known keeps the UI from sending
+   * someone to start a daemon that is already running.
+   */
+  | 'unreachable'
+  /** Something answered, but it is not a whiteboard daemon. */
+  | 'not-a-daemon'
+  /** The browser refused to make the request. */
+  | 'browser-blocked'
+  /** The permission prompt was shown and left unanswered. */
+  | 'permission-unanswered'
+  /** Not enough information to name a cause. */
+  | 'unclear'
+
+export interface ProbeFailureInput extends ConnectGateInput {
+  reason: ProbeFailureReason
+}
+
+export function explainProbeFailure({
+  pageOriginScheme,
+  permission,
+  reason,
+}: ProbeFailureInput): ProbeFailureExplanation {
+  // Something answered on that port; which port it was is no longer the
+  // question, so the permission has nothing to add.
+  if (reason === 'http-error' || reason === 'malformed') return 'not-a-daemon'
+
+  // Measured rather than inferred: WebKit's mixed-content rejection carries a
+  // distinct message, and WebKit exposes no local-network permission to
+  // corroborate it with.
+  if (reason === 'blocked') return 'browser-blocked'
+
+  if (pageOriginScheme === 'http') return 'unreachable'
+
+  switch (permission) {
+    case 'denied':
+      return 'browser-blocked'
+    case 'prompt':
+      // The prompt fires on the request, so reaching a rejection with the
+      // permission still unanswered means it was dismissed rather than denied
+      // — asking again will prompt again, which no other outcome implies.
+      return 'permission-unanswered'
+    case 'granted':
+      // The one case that used to be unanswerable. It rules the browser out;
+      // it does NOT single out an empty port, because a running daemon that
+      // has not allowlisted this origin fails identically here.
+      return 'unreachable'
+    default:
+      return 'unclear'
+  }
+}

--- a/apps/web/src/lib/local-network-permission.test.ts
+++ b/apps/web/src/lib/local-network-permission.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { queryLocalNetworkPermission } from './local-network-permission.js'
+
+// A Permissions stand-in that recognizes only the names it was built with,
+// mirroring how a real engine rejects an unknown descriptor with a TypeError
+// rather than resolving to some neutral state.
+function permissionsKnowing(known: Record<string, PermissionState>): Permissions {
+  return {
+    query: vi.fn(async (descriptor: { name: string }) => {
+      const state = known[descriptor.name]
+      if (state === undefined) {
+        throw new TypeError(`Unrecognized permission name: ${descriptor.name}`)
+      }
+      return { state } as PermissionStatus
+    }),
+  } as unknown as Permissions
+}
+
+describe('queryLocalNetworkPermission', () => {
+  it('reports unknown when the engine has no Permissions API', async () => {
+    // Safari and Firefox never prompt for local network access, so there is
+    // nothing to read. 'unknown' keeps callers on the pre-existing path
+    // instead of inventing a state the browser never had.
+    await expect(queryLocalNetworkPermission(undefined)).resolves.toBe('unknown')
+  })
+
+  it.each([
+    'granted',
+    'prompt',
+    'denied',
+  ] as const)('passes through the %s state of the loopback-network permission', async (state) => {
+    const permissions = permissionsKnowing({ 'loopback-network': state })
+    await expect(queryLocalNetworkPermission(permissions)).resolves.toBe(state)
+  })
+
+  it('asks for loopback-network, not the broader local-network', async () => {
+    // The daemon lives on 127.0.0.1, which the spec scopes to the narrower
+    // 'loopback-network' feature. Querying 'local-network' would read a
+    // permission the connection does not actually need.
+    const permissions = permissionsKnowing({
+      'loopback-network': 'granted',
+      'local-network': 'denied',
+    })
+    await expect(queryLocalNetworkPermission(permissions)).resolves.toBe('granted')
+  })
+
+  it('falls back to the Chromium alias when the spec name is unrecognized', async () => {
+    // Chromium shipped the coarse 'local-network-access' name before the
+    // spec split it in two, so a browser that prompts but predates the split
+    // must still be readable.
+    const permissions = permissionsKnowing({ 'local-network-access': 'denied' })
+    await expect(queryLocalNetworkPermission(permissions)).resolves.toBe('denied')
+  })
+
+  it('reports unknown when no name is recognized', async () => {
+    await expect(queryLocalNetworkPermission(permissionsKnowing({}))).resolves.toBe('unknown')
+  })
+
+  it('stops asking when the rejection is not about an unrecognized name', async () => {
+    // Only an unrecognized descriptor (TypeError) says anything about which
+    // name this engine understands. A permissions-policy denial rejects with
+    // a NotAllowedError and would reject the alias identically, so retrying
+    // it is a second pointless call — and the answer stays 'unknown' either
+    // way, which is why the call count is what pins the behavior.
+    const query = vi.fn(async () => {
+      throw new DOMException('denied by permissions policy', 'NotAllowedError')
+    })
+    const permissions = { query } as unknown as Permissions
+
+    await expect(queryLocalNetworkPermission(permissions)).resolves.toBe('unknown')
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/local-network-permission.ts
+++ b/apps/web/src/lib/local-network-permission.ts
@@ -1,0 +1,44 @@
+// Reading the browser's local-network permission WITHOUT triggering its
+// prompt, so the connect flow can explain itself before the prompt appears
+// and can offer a recovery path once the answer is already 'denied'.
+//
+// This matters because a denied answer is sticky: Local Network Access gates
+// the request on a permission rather than on a preflight the server could
+// satisfy, and a browser that has been told no stops asking. A fetch to the
+// daemon then fails indistinguishably from no daemon being there at all.
+// https://wicg.github.io/local-network-access/
+
+// 'unknown' is not a browser state — it means the question could not be asked
+// (no Permissions API, or an engine that does not recognize the feature), so
+// callers must fall back to behavior that does not depend on the answer.
+export type LocalNetworkPermissionState = 'granted' | 'prompt' | 'denied' | 'unknown'
+
+// The daemon listens on 127.0.0.1, which the spec scopes to the narrower
+// 'loopback-network' feature. 'local-network-access' is the coarse name
+// Chromium shipped before the spec split it, kept as a fallback for browsers
+// that prompt but predate the split.
+const PERMISSION_NAMES = ['loopback-network', 'local-network-access'] as const
+
+export async function queryLocalNetworkPermission(
+  permissions: Permissions | undefined,
+): Promise<LocalNetworkPermissionState> {
+  if (!permissions?.query) return 'unknown'
+
+  for (const name of PERMISSION_NAMES) {
+    try {
+      // The name is not in the lib.dom PermissionName union yet, so the cast
+      // is what lets us ask a question the type definitions predate.
+      const status = await permissions.query({ name } as unknown as PermissionDescriptor)
+      return status.state
+    } catch (error) {
+      // An unrecognized descriptor is the only rejection worth retrying under
+      // the other name. Anything else (notably a permissions-policy
+      // NotAllowedError) is the site's own configuration talking, not the
+      // user's answer, and must not be reported as a denial the user could
+      // undo in browser settings.
+      if (!(error instanceof TypeError)) return 'unknown'
+    }
+  }
+
+  return 'unknown'
+}

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1029,14 +1029,20 @@ describe('createApp daemon mutation auth', () => {
       expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
     })
 
-    it('OPTIONS preflight for a loopback Origin also carries Access-Control-Allow-Local-Network', async () => {
+    it('does not invent an Access-Control-Allow-Local-Network response header', async () => {
+      // Local Network Access gates on a user permission and defines no
+      // response header, so emitting one states a capability the server does
+      // not have: it cannot unblock an LNA denial no matter what it answers.
+      // Re-adding it would send the client looking for a server-side fix to a
+      // problem only the browser's permission can resolve.
+      // https://wicg.github.io/local-network-access/
       const app = createApp(createRuntimeOptions('secret'))
       const res = await app.request('/api/runtime/ping', {
         method: 'OPTIONS',
         headers: { Origin: 'http://localhost:5173' },
       })
       expect(res.status).toBe(204)
-      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
+      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBeNull()
     })
   })
 
@@ -1055,7 +1061,7 @@ describe('createApp daemon mutation auth', () => {
       expect(res.headers.get('Vary')).toContain('Origin')
     })
 
-    it('OPTIONS preflight for an allowlisted hosted origin returns PNA + ALN headers', async () => {
+    it('OPTIONS preflight for an allowlisted hosted origin returns the PNA header', async () => {
       const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
       const res = await app.request('/api/runtime/ping', {
         method: 'OPTIONS',
@@ -1066,7 +1072,6 @@ describe('createApp daemon mutation auth', () => {
         'https://kamiazya-whiteboard.pages.dev',
       )
       expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
-      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
     })
 
     it('does NOT reflect ACAO for an evil-prefix lookalike origin', async () => {
@@ -1150,7 +1155,6 @@ describe('createApp daemon mutation auth', () => {
         'https://pr-42.kamiazya-whiteboard.pages.dev',
       )
       expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
-      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
     })
 
     it('does NOT reflect ACAO for an origin outside the wildcard suffix', async () => {
@@ -1169,7 +1173,7 @@ describe('createApp daemon mutation auth', () => {
   describe('/mcp hosted-origin allowlist (WHITEBOARD_ALLOWED_WEB_ORIGINS)', () => {
     const allowedWebOrigins = ['https://kamiazya-whiteboard.pages.dev']
 
-    it('OPTIONS /mcp with an allowlisted hosted Origin returns PNA + ALN headers', async () => {
+    it('OPTIONS /mcp with an allowlisted hosted Origin returns the PNA header', async () => {
       const app = createApp({ ...createRuntimeOptions('secret'), allowedWebOrigins })
       const res = await app.request('http://127.0.0.1/mcp', {
         method: 'OPTIONS',
@@ -1180,7 +1184,6 @@ describe('createApp daemon mutation auth', () => {
         'https://kamiazya-whiteboard.pages.dev',
       )
       expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
-      expect(res.headers.get('Access-Control-Allow-Local-Network')).toBe('true')
     })
 
     it('OPTIONS /mcp with a non-allowlisted hosted Origin is still forbidden (default preserved)', async () => {

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1043,6 +1043,9 @@ describe('createApp daemon mutation auth', () => {
       })
       expect(res.status).toBe(204)
       expect(res.headers.get('Access-Control-Allow-Local-Network')).toBeNull()
+      // Asserted together so the pair is pinned as a contract: dropping BOTH
+      // headers would satisfy the absence check alone and look like a pass.
+      expect(res.headers.get('Access-Control-Allow-Private-Network')).toBe('true')
     })
   })
 

--- a/packages/mcp-server/src/server/security/cors-loopback.ts
+++ b/packages/mcp-server/src/server/security/cors-loopback.ts
@@ -117,12 +117,14 @@ export function createApiLoopbackCorsMiddleware(
 
     if (c.req.method.toUpperCase() === 'OPTIONS') {
       if (isAdmitted && origin) {
-        // Access-Control-Allow-Local-Network is Chrome's in-flight successor
-        // to Access-Control-Allow-Private-Network; both are emitted so the
-        // preflight satisfies whichever LNA generation the browser enforces.
+        // Private Network Access is on hold rather than withdrawn, so this
+        // header is kept for a browser still enforcing that generation. Its
+        // successor, Local Network Access, defines NO response header at all
+        // — it gates the request on a user permission instead, which no
+        // server response can satisfy. A server-side answer to an LNA block
+        // therefore does not exist; the client has to read the permission.
         // https://wicg.github.io/local-network-access/
         c.res.headers.set('Access-Control-Allow-Private-Network', 'true')
-        c.res.headers.set('Access-Control-Allow-Local-Network', 'true')
       }
       return new Response(null, { status: 204, headers: c.res.headers })
     }

--- a/packages/mcp-server/src/server/security/mcp-http.ts
+++ b/packages/mcp-server/src/server/security/mcp-http.ts
@@ -77,13 +77,12 @@ export function createMcpHttpOriginMiddleware(
 
     if (normalizeMethod(c.req.method) === 'OPTIONS') {
       if (origin) {
-        // Local Network Access preflight headers — required by Chrome for
-        // private-network → loopback requests. Both the legacy PNA header and
-        // its in-flight successor (ALN) are emitted so the preflight
-        // satisfies whichever LNA generation the browser enforces.
+        // Private Network Access preflight header, for a browser still
+        // enforcing that (on-hold) generation. Its successor, Local Network
+        // Access, defines no response header — it gates on a user permission
+        // instead, so no preflight answer here can unblock it.
         // https://wicg.github.io/local-network-access/
         c.res.headers.set('Access-Control-Allow-Private-Network', 'true')
-        c.res.headers.set('Access-Control-Allow-Local-Network', 'true')
       }
       return new Response(null, { status: 204, headers: c.res.headers })
     }


### PR DESCRIPTION
A failed daemon check has never been able to say why it failed. Chromium rejects a
permission-blocked loopback request with the same `TypeError: Failed to fetch` as a port with
nothing behind it, so the UI could only list possibilities. Reading the browser's local-network
permission rules one of them out.

## What changed

**The prompt is explained before it appears.** Chrome's Local Network Access prompt fires on the
request itself, so the first check produced a permission dialog with no stated reason. A denial is
remembered and script cannot re-prompt, which makes that unexplained dialog a question the user
gets one chance to answer well. The check now reads the permission first (reading does not prompt)
and says what is about to be asked.

**A standing denial stops the check instead of probing.** The request cannot succeed and cannot
re-prompt, so probing would only produce a failure that reads as an absent daemon. The recovery
panel points at site settings, which is the only thing that can undo it.

**Failure copy is keyed on the cause rather than the page scheme.** The case worth having is a
granted permission: it rules the browser out, so the UI no longer sends someone to change a site
setting that is already correct.

**A response header that does not exist is no longer sent.** `Access-Control-Allow-Local-Network`
was emitted on every preflight, commented as "Chrome's in-flight successor" to the Private Network
Access header. The spec it cited defines no response header at all — LNA replaced PNA's preflight
with a permission prompt. Emitting it stated a capability the daemon does not have and pointed
anyone debugging a blocked fetch at the server. The PNA header stays; that generation is on hold
rather than withdrawn.

## What it deliberately does not claim

`unreachable` stops short of "nothing is listening on that port". A running daemon that has not
allowlisted this origin fails identically at the fetch layer, so claiming an empty port would send
someone to start a daemon that is already running.

## Verified in Chrome 150

Measured against the running daemons before building on any of it:

| | production origin | `latest` preview |
|---|---|---|
| `loopback-network` | granted | granted |
| `local-network` | prompt | — |
| `GET /api/runtime/ping` (3099) | 200 / 13ms | 200 / 5ms |

Two things this settled. The permission names are queryable in the target browser, so `unknown`
is the rare path rather than the normal one. And `loopback-network` is the right name to read:
`local-network` sits at `prompt`, so querying it would have shown an explanation for a permission
this connection does not need.

A port with no daemon (`3105`) rejected in 3ms with `Failed to fetch` — indistinguishable from a
block without the permission read, which is the gap this PR closes.

## Tests

`apps/web` 137 files / 1652 tests, `mcp-node` 3219. Every new test was mutation-checked; two
mutations survived on the first pass and the tests were rewritten until they failed:

- a `NotAllowedError` case that asserted a return value both branches produce (now pins the call
  count, which is what actually differs)
- the `checking` flag and the stale failure notice, which the async permission read had quietly
  moved to after the await — a live button was double-startable across that gap

## Not verified

The new panels have not been exercised in a real browser: reaching them needs a permission state
this machine is not in (`granted` everywhere). The permission read itself was verified in Chrome
as above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer local-network permission handling when connecting to a detected daemon.
  * Checks now explain upcoming browser prompts, prevent attempts when access is denied, and resume after confirmation.
  * Added more specific connection failure messages, including browser blocking, unavailable services, and non-daemon responses.

* **Bug Fixes**
  * Updated network preflight responses to use the supported private-network permission header and omit the obsolete local-network header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->