### PR TITLE
fix(mcp-server): neutralize desktop-env detection in the real-opener test

### DIFF
--- a/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
@@ -21,11 +21,18 @@
 // bare name on darwin (PATH-resolved), so a fake `open` script placed first
 // on PATH is invoked directly. On Linux it prefers its own bundled
 // `xdg-open` script (an absolute path, NOT PATH-resolved) UNLESS that
-// bundled copy is missing or non-executable — but that bundled script
-// itself honors the `$BROWSER` environment variable ahead of any
-// desktop-specific detection, so setting `BROWSER=<fake command name>` (in
-// addition to the PATH shim) reaches the same fake executable on both
-// platforms without touching node_modules.
+// bundled copy is missing or non-executable. That bundled script only
+// reads `$BROWSER` from its `open_generic()` branch, which `detectDE()`
+// reaches ONLY when it fails to recognize a desktop environment — on a
+// real desktop session (`XDG_CURRENT_DESKTOP` set, or a live `$DISPLAY`/
+// `$WAYLAND_DISPLAY`) it instead dispatches to a real DE-specific opener
+// (e.g. `kde-open5`), bypassing `$BROWSER` entirely and never touching the
+// fake opener. `detectDE()`'s `X-Generic` case short-circuits straight to
+// `open_generic`, so the child env below pins
+// `XDG_CURRENT_DESKTOP=X-Generic` and drops `DISPLAY`/`WAYLAND_DISPLAY`
+// (whose presence alone routes `open_generic` to a real browser launch
+// ahead of `$BROWSER` — see `has_display()`), making `$BROWSER` reach the
+// fake executable regardless of the host desktop session.
 import { spawn, spawnSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -58,6 +65,18 @@ function makeTempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix))
   tempDirs.push(dir)
   return dir
+}
+
+/** Overrides that stop the vendored `xdg-open`'s `detectDE()`/`has_display()`
+ * from routing to a real desktop opener ahead of `$BROWSER` — see the file
+ * header comment. Shared by every test in this suite so the child env is
+ * neutralized identically regardless of the guard under test. */
+function neutralizedDesktopEnv(): Readonly<Record<string, string | undefined>> {
+  return {
+    XDG_CURRENT_DESKTOP: 'X-Generic',
+    DISPLAY: undefined,
+    WAYLAND_DISPLAY: undefined,
+  }
 }
 
 /** A fake `open`/`xdg-open`/$BROWSER opener that records its single argv URL. */
@@ -151,6 +170,27 @@ async function launchDaemonInPty(args: {
   return { readyLine: winner, pid, closed }
 }
 
+/** Polls `recordFile` until it has at least one line or `deadlineMs` elapses.
+ * Deterministic stand-in for a fixed sleep: the positive assertion's outcome
+ * must not depend on how long the harness happens to wait past the first
+ * write. */
+async function pollForRecordedLines(recordFile: string, deadlineMs: number): Promise<string[]> {
+  const start = Date.now()
+  for (;;) {
+    let recorded: string
+    try {
+      recorded = readFileSync(recordFile, 'utf8')
+    } catch {
+      recorded = ''
+    }
+    const lines = recorded.split('\n').filter((l) => l.length > 0)
+    if (lines.length > 0 || Date.now() - start >= deadlineMs) {
+      return lines
+    }
+    await delay(50)
+  }
+}
+
 async function killAndWait(pid: number, closed: Promise<unknown>): Promise<void> {
   try {
     process.kill(pid, 'SIGTERM')
@@ -179,116 +219,120 @@ afterEach(async () => {
   }
 })
 
-describe.skipIf(!hasWorkingPty)('daemon run auto-open: real process launch', () => {
-  it(
-    'invokes the fake opener with the hosted app URL exactly once when every guard passes',
-    async () => {
-      const port = await findAvailablePort(4310)
-      const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-      const { recordFile } = makeFakeOpenBin()
-      const binDir = dirname(recordFile)
+// A CI runner is expected to always have python3/forkpty (see the file
+// header). Skipping there too would let the suite vanish silently instead
+// of failing loudly if a runner image ever lost it; a dev machine without a
+// working pty still skips.
+describe.skipIf(!hasWorkingPty && !process.env.CI)(
+  'daemon run auto-open: real process launch',
+  () => {
+    it(
+      'invokes the fake opener with the hosted app URL exactly once when every guard passes',
+      async () => {
+        const port = await findAvailablePort(4310)
+        const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
+        const { recordFile } = makeFakeOpenBin()
+        const binDir = dirname(recordFile)
 
-      const { pid, closed } = await launchDaemonInPty({
-        port,
-        dataDir,
-        extraEnv: {
-          PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
-          BROWSER: FAKE_BROWSER_COMMAND,
-          CI: undefined,
-          container: undefined,
-        },
-      })
+        const { pid, closed } = await launchDaemonInPty({
+          port,
+          dataDir,
+          extraEnv: {
+            PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
+            BROWSER: FAKE_BROWSER_COMMAND,
+            CI: undefined,
+            container: undefined,
+            ...neutralizedDesktopEnv(),
+          },
+        })
 
-      // The open() call is awaited before the dispatcher's never-resolving
-      // keep-alive promise, but the fake opener's own exit still round-trips
-      // through a real subprocess spawn — give it a moment to land on disk.
-      await delay(OPEN_SETTLE_MS)
+        // The open() call is awaited before the dispatcher's never-resolving
+        // keep-alive promise, but the fake opener's own exit still round-trips
+        // through a real subprocess spawn — poll for the write instead of a
+        // fixed sleep so the assertion doesn't depend on how long we happen to
+        // wait past the first observation.
+        const lines = await pollForRecordedLines(recordFile, OPEN_SETTLE_MS)
 
-      let recorded: string
-      try {
-        recorded = readFileSync(recordFile, 'utf8')
-      } catch {
-        recorded = ''
-      }
-      const lines = recorded.split('\n').filter((l) => l.length > 0)
+        await killAndWait(pid, closed)
+        liveChildren.splice(0, liveChildren.length)
 
-      await killAndWait(pid, closed)
-      liveChildren.splice(0, liveChildren.length)
+        expect(lines).toEqual(['https://kamiazya-whiteboard.pages.dev/'])
+      },
+      READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
+    )
 
-      expect(lines).toEqual(['https://kamiazya-whiteboard.pages.dev/'])
-    },
-    READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
-  )
+    it(
+      'never invokes the opener when CI=true, even with a real TTY',
+      async () => {
+        const port = await findAvailablePort(4311)
+        const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
+        const { recordFile } = makeFakeOpenBin()
+        const binDir = dirname(recordFile)
 
-  it(
-    'never invokes the opener when CI=true, even with a real TTY',
-    async () => {
-      const port = await findAvailablePort(4311)
-      const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-      const { recordFile } = makeFakeOpenBin()
-      const binDir = dirname(recordFile)
+        const { pid, closed } = await launchDaemonInPty({
+          port,
+          dataDir,
+          extraEnv: {
+            PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
+            BROWSER: FAKE_BROWSER_COMMAND,
+            CI: 'true',
+            ...neutralizedDesktopEnv(),
+          },
+        })
 
-      const { pid, closed } = await launchDaemonInPty({
-        port,
-        dataDir,
-        extraEnv: {
-          PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
-          BROWSER: FAKE_BROWSER_COMMAND,
-          CI: 'true',
-        },
-      })
+        await delay(OPEN_SETTLE_MS)
 
-      await delay(OPEN_SETTLE_MS)
+        let recorded: string
+        try {
+          recorded = readFileSync(recordFile, 'utf8')
+        } catch {
+          recorded = ''
+        }
 
-      let recorded: string
-      try {
-        recorded = readFileSync(recordFile, 'utf8')
-      } catch {
-        recorded = ''
-      }
+        await killAndWait(pid, closed)
+        liveChildren.splice(0, liveChildren.length)
 
-      await killAndWait(pid, closed)
-      liveChildren.splice(0, liveChildren.length)
+        expect(recorded).toBe('')
+      },
+      READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
+    )
 
-      expect(recorded).toBe('')
-    },
-    READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
-  )
+    it(
+      'never invokes the opener when --no-open is passed, even with a real TTY',
+      async () => {
+        const port = await findAvailablePort(4312)
+        const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
+        const { recordFile } = makeFakeOpenBin()
+        const binDir = dirname(recordFile)
 
-  it(
-    'never invokes the opener when --no-open is passed, even with a real TTY',
-    async () => {
-      const port = await findAvailablePort(4312)
-      const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-      const { recordFile } = makeFakeOpenBin()
-      const binDir = dirname(recordFile)
+        const { pid, closed } = await launchDaemonInPty({
+          port,
+          dataDir,
+          extraArgs: ['--no-open'],
+          extraEnv: {
+            PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
+            BROWSER: FAKE_BROWSER_COMMAND,
+            CI: undefined,
+            container: undefined,
+            ...neutralizedDesktopEnv(),
+          },
+        })
 
-      const { pid, closed } = await launchDaemonInPty({
-        port,
-        dataDir,
-        extraArgs: ['--no-open'],
-        extraEnv: {
-          PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
-          BROWSER: FAKE_BROWSER_COMMAND,
-          CI: undefined,
-          container: undefined,
-        },
-      })
+        await delay(OPEN_SETTLE_MS)
 
-      await delay(OPEN_SETTLE_MS)
+        let recorded: string
+        try {
+          recorded = readFileSync(recordFile, 'utf8')
+        } catch {
+          recorded = ''
+        }
 
-      let recorded: string
-      try {
-        recorded = readFileSync(recordFile, 'utf8')
-      } catch {
-        recorded = ''
-      }
+        await killAndWait(pid, closed)
+        liveChildren.splice(0, liveChildren.length)
 
-      await killAndWait(pid, closed)
-      liveChildren.splice(0, liveChildren.length)
-
-      expect(recorded).toBe('')
-    },
-    READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
-  )
-})
+        expect(recorded).toBe('')
+      },
+      READINESS_TIMEOUT_MS + OPEN_SETTLE_MS + SHUTDOWN_TIMEOUT_MS + 5_000,
+    )
+  },
+)

--- a/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run-auto-open-launch.test.ts
@@ -69,15 +69,13 @@ function makeTempDir(prefix: string): string {
 
 /** Overrides that stop the vendored `xdg-open`'s `detectDE()`/`has_display()`
  * from routing to a real desktop opener ahead of `$BROWSER` — see the file
- * header comment. Shared by every test in this suite so the child env is
- * neutralized identically regardless of the guard under test. */
-function neutralizedDesktopEnv(): Readonly<Record<string, string | undefined>> {
-  return {
-    XDG_CURRENT_DESKTOP: 'X-Generic',
-    DISPLAY: undefined,
-    WAYLAND_DISPLAY: undefined,
-  }
-}
+ * header comment. Spread into every test's child env so the host desktop
+ * session can't change the outcome of the guard under test. */
+const NEUTRALIZED_DESKTOP_ENV = {
+  XDG_CURRENT_DESKTOP: 'X-Generic',
+  DISPLAY: undefined,
+  WAYLAND_DISPLAY: undefined,
+} as const
 
 /** A fake `open`/`xdg-open`/$BROWSER opener that records its single argv URL. */
 function makeFakeOpenBin(): { binDir: string; recordFile: string } {
@@ -170,6 +168,15 @@ async function launchDaemonInPty(args: {
   return { readyLine: winner, pid, closed }
 }
 
+/** The opener's record file, or `''` while it has never been invoked. */
+function readRecord(recordFile: string): string {
+  try {
+    return readFileSync(recordFile, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
 /** Polls `recordFile` until it has at least one line or `deadlineMs` elapses.
  * Deterministic stand-in for a fixed sleep: the positive assertion's outcome
  * must not depend on how long the harness happens to wait past the first
@@ -177,13 +184,9 @@ async function launchDaemonInPty(args: {
 async function pollForRecordedLines(recordFile: string, deadlineMs: number): Promise<string[]> {
   const start = Date.now()
   for (;;) {
-    let recorded: string
-    try {
-      recorded = readFileSync(recordFile, 'utf8')
-    } catch {
-      recorded = ''
-    }
-    const lines = recorded.split('\n').filter((l) => l.length > 0)
+    const lines = readRecord(recordFile)
+      .split('\n')
+      .filter((l) => l.length > 0)
     if (lines.length > 0 || Date.now() - start >= deadlineMs) {
       return lines
     }
@@ -231,8 +234,7 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
       async () => {
         const port = await findAvailablePort(4310)
         const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-        const { recordFile } = makeFakeOpenBin()
-        const binDir = dirname(recordFile)
+        const { binDir, recordFile } = makeFakeOpenBin()
 
         const { pid, closed } = await launchDaemonInPty({
           port,
@@ -242,15 +244,13 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
             BROWSER: FAKE_BROWSER_COMMAND,
             CI: undefined,
             container: undefined,
-            ...neutralizedDesktopEnv(),
+            ...NEUTRALIZED_DESKTOP_ENV,
           },
         })
 
         // The open() call is awaited before the dispatcher's never-resolving
         // keep-alive promise, but the fake opener's own exit still round-trips
-        // through a real subprocess spawn — poll for the write instead of a
-        // fixed sleep so the assertion doesn't depend on how long we happen to
-        // wait past the first observation.
+        // through a real subprocess spawn.
         const lines = await pollForRecordedLines(recordFile, OPEN_SETTLE_MS)
 
         await killAndWait(pid, closed)
@@ -266,8 +266,7 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
       async () => {
         const port = await findAvailablePort(4311)
         const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-        const { recordFile } = makeFakeOpenBin()
-        const binDir = dirname(recordFile)
+        const { binDir, recordFile } = makeFakeOpenBin()
 
         const { pid, closed } = await launchDaemonInPty({
           port,
@@ -276,18 +275,12 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
             PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
             BROWSER: FAKE_BROWSER_COMMAND,
             CI: 'true',
-            ...neutralizedDesktopEnv(),
+            ...NEUTRALIZED_DESKTOP_ENV,
           },
         })
 
         await delay(OPEN_SETTLE_MS)
-
-        let recorded: string
-        try {
-          recorded = readFileSync(recordFile, 'utf8')
-        } catch {
-          recorded = ''
-        }
+        const recorded = readRecord(recordFile)
 
         await killAndWait(pid, closed)
         liveChildren.splice(0, liveChildren.length)
@@ -302,8 +295,7 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
       async () => {
         const port = await findAvailablePort(4312)
         const dataDir = makeTempDir('whiteboard-auto-open-launch-data-')
-        const { recordFile } = makeFakeOpenBin()
-        const binDir = dirname(recordFile)
+        const { binDir, recordFile } = makeFakeOpenBin()
 
         const { pid, closed } = await launchDaemonInPty({
           port,
@@ -314,18 +306,12 @@ describe.skipIf(!hasWorkingPty && !process.env.CI)(
             BROWSER: FAKE_BROWSER_COMMAND,
             CI: undefined,
             container: undefined,
-            ...neutralizedDesktopEnv(),
+            ...NEUTRALIZED_DESKTOP_ENV,
           },
         })
 
         await delay(OPEN_SETTLE_MS)
-
-        let recorded: string
-        try {
-          recorded = readFileSync(recordFile, 'utf8')
-        } catch {
-          recorded = ''
-        }
+        const recorded = readRecord(recordFile)
 
         await killAndWait(pid, closed)
         liveChildren.splice(0, liveChildren.length)


### PR DESCRIPTION
## The bug

`daemon-run-auto-open-launch.test.ts`'s positive assertion fails on any real desktop session:

```
expected [] to deeply equal [ 'https://kamiazya-whiteboard.pages.dev/' ]
```

It is not a timing problem and not a product bug — auto-open really does work. The test's interception is what breaks.

`open`'s vendored `xdg-open` runs `detectDE()` first. `$BROWSER` is read by exactly one branch, `open_generic()`, and `detectDE()` only reaches it when it returns `generic`. On a session with `XDG_CURRENT_DESKTOP` set it dispatches to a DE-specific opener instead; and even in the generic branch, `open_generic()` prefers a real `xdg_x_scheme_handler` launch over `$BROWSER` whenever `has_display()` is true.

So on this machine (`XDG_CURRENT_DESKTOP=KDE`, `DISPLAY=:1`, `WAYLAND_DISPLAY=wayland-0`) the daemon's `open()` reached `/usr/bin/kde-open5` — never the fake recording opener. The recorded file stayed empty, and **a real browser tab was opened against the live hosted URL on every run**.

## Why nobody noticed

`describe.skipIf(!hasWorkingPty)` — CI has no pty, so the block silently vanishes there. CI stayed green while every developer with a desktop session got a red test plus a browser tab.

## The fix (test-only, no production code)

1. Neutralize desktop-environment detection in the child env: `XDG_CURRENT_DESKTOP='X-Generic'`, `DISPLAY`/`WAYLAND_DISPLAY` unset. `X-Generic` is `detectDE()`'s first case and short-circuits every fallback probe, so `$BROWSER` always reaches the fake opener regardless of host session.
2. Replace the positive test's fixed `OPEN_SETTLE_MS` sleep with a deadline-bounded poll of the record file, so the verdict does not depend on how long the harness waits past the first write. The two negative tests keep a fixed grace window — an absence assertion has no event to poll for, and they are only meaningful because the positive control in the same file and env proves interception works.
3. `describe.skipIf(!hasWorkingPty && !process.env.CI)` — a dev machine without a pty still skips, but a CI runner that ever loses one now fails loudly instead of silently dropping the suite. That silent-skip is the structural reason this stayed invisible.

The file header comment previously claimed `BROWSER` reaches the fake opener unconditionally on both platforms. That claim is the bug; it now states the actual `detectDE`/`open_generic` constraint.

## Verification

- 3/3 pass on this KDE/Wayland machine; full `mcp-node` project green (262 files, 3213 tests).
- Mutation check: restoring `XDG_CURRENT_DESKTOP` to the host value reproduces the original failure exactly (`1 failed | 2 passed`); reverting restores green. This is what proves the fix is the DE neutralization rather than a timing change.
- No real browser opens during the run any more.

Not attempted: moving this to a pty-free layer. The TTY guard and dispatcher wiring are already covered pty-free by `daemon-run-auto-open.test.ts` and `dispatcher-daemon-run-auto-open.test.ts`; what this file uniquely covers is the real `open()` → OS exec plumbing, which needs a real process by definition.
