### PR TITLE
fix(mcp-server): narrow published engines to the range its deps support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "packageManager": "pnpm@11.12.0",
   "engines": {
-    "node": ">=22"
+    "node": "^22 || ^24 || >=26"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -84,7 +84,7 @@
     "./dist/server/mcp/index.js"
   ],
   "engines": {
-    "node": ">=22"
+    "node": "^22 || ^24 || >=26"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -65,7 +65,11 @@ describe('publish contract', () => {
   })
 
   it('declares the public npm publish contract in package metadata', () => {
-    expect(mcpPackage.engines).toEqual({ node: '>=22' })
+    // Mirrors the narrowest engines range among the published runtime deps
+    // (nanoid 6 declares '^22 || ^24 || >=26'). A plain '>=22' would advertise
+    // support for odd non-LTS releases that a dependency then rejects, so the
+    // consumer's install warns instead of the contract being honest up front.
+    expect(mcpPackage.engines).toEqual({ node: '^22 || ^24 || >=26' })
     expect(mcpPackage.publishConfig).toMatchObject({
       registry: 'https://registry.npmjs.org',
       access: 'public',


### PR DESCRIPTION
## What

Narrows `engines.node` from `>=22` to `^22 || ^24 || >=26` in the published package and the workspace root, and updates the publish-contract test that pins it.

## Why

`nanoid` 6 (merged in #534) declares `engines: "^22 || ^24 || >=26"`, which excludes the odd non-LTS releases **23 and 25**. The published package declared `>=22`, so a consumer installing `@kamiazya/whiteboard-mcp` on Node 23 or 25 resolved a runtime dependency that immediately rejected their Node version:

```
npm WARN EBADENGINE Unsupported engine {
  package: 'nanoid@6.0.1',
  required: { node: '^22 || ^24 || >=26' },
  current: { node: 'v23.x' }
}
```

The contract advertised support the dependency tree does not actually provide. npm only warns rather than failing, which is exactly why this is worth fixing explicitly — it degrades quietly.

The workspace root is `private: true` and never reaches a consumer, but `pnpm install` there resolves the same nanoid, so leaving it at `>=22` would claim Node 23 is a supported *development* environment for the same reason. `engine-strict` is not set, so this stays a warning and does not block anyone mid-work.

## Coverage of supported Node lines

Per the official release schedule, as of 2026-08-11:

| Node | Status | EOL |
|---|---|---|
| 20 | EOL (2026-04-30) | — |
| 22 | **Maintenance LTS** | 2027-04-30 |
| 24 | **Active LTS** | 2028-04-30 |
| 26 | LTS from 2026-10-28 | 2029-04-30 |

The new range covers every currently-supported line and nothing that is EOL or non-LTS.

## Verification

`packages/mcp-server/src/server/publish-contract.test.ts` pins this contract, so the change was made test-first: updating the expectation reproduced the failure (`expected { node: '>=22' } to deeply equal { node: '^22 || ^24 || >=26' }`) before either `package.json` was touched.

- `pnpm test --project mcp-node` — 262 files / 3213 tests green
- `pnpm -r typecheck` clean
- `pnpm install --frozen-lockfile` produces no EBADENGINE warning on the repo's own Node 24

## Follow-up (not in this change)

When Node 22 reaches EOL on 2027-04-30 this range should narrow again to `^24 || >=26`. Doing that now would drop users still on a supported LTS line, so it is deliberately left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Node.js versions to 22, 24, and 26 or newer.
  * Node.js versions 23 and 25 are no longer supported.
  * Updated package validation to reflect the revised runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->