### PR TITLE
fix(dev-flow): treat an unregistered Codex agent as unavailable, not a failure

### DIFF
--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -40,6 +40,12 @@ const APP_URL = A.appUrl || null
 // codex: add a Codex second-opinion at gate decisions (plan gate + review gate). Default on
 // (codex CLI present); set codex:false to disable. Codex unavailable at runtime never blocks.
 const CODEX = A.codex !== false
+
+// An unavailable Codex is "no second opinion", never a gate failure. `agent()` resolves to null
+// when a subagent dies, but an agentType the host has no plugin for REJECTS instead — so without
+// this the whole workflow aborts on any machine where the Codex plugin isn't installed, which is
+// the opposite of the "Codex unavailable never blocks" rule it is supposed to implement.
+const optionalLane = (run) => run().catch(() => null)
 // docs: run a technical-writer docs-sync pass on the increment (commits doc files). Opt-in —
 // enable when the change is user-visible or alters an API/contract/config.
 const DOCS = !!A.docs
@@ -266,7 +272,7 @@ if (design) {
   const runGate = async () => {
     const [mine, codex] = await Promise.all([
       reviewDesign(),
-      CODEX ? codexReviewDesign() : Promise.resolve(null),
+      CODEX ? optionalLane(codexReviewDesign) : Promise.resolve(null),
     ])
     codexPlanVerdict = codex
     const pass = !!(mine && mine.pass) && (codex ? codex.pass : true)

--- a/.claude/workflows/lib/codex-lane-optional.test.mjs
+++ b/.claude/workflows/lib/codex-lane-optional.test.mjs
@@ -1,0 +1,73 @@
+// Run with: node --test .claude/workflows/lib/codex-lane-optional.test.mjs
+//
+// The Codex second opinion is a companion, never a gate: dev-flow.md's rule is that an
+// unavailable Codex counts as "unavailable", not as a rejection. Two different runtime
+// failures have to collapse to that one meaning:
+//
+//   1. the subagent dies mid-run          -> agent() RESOLVES to null
+//   2. the host has no such agentType     -> agent() REJECTS
+//
+// Only (1) was handled. On a machine without the Codex plugin, (2) rejected out of dev-loop's
+// plain Promise.all and aborted the whole workflow after the Design phase had already run; in
+// review.workflow.mjs pipeline() swallowed the rejection instead, which is not a crash but
+// reports the codex lane as "ran, found nothing" rather than unavailable.
+//
+// Both workflows run in a sandbox with no import/fs, so each keeps its own inline copy of the
+// `optionalLane` guard. This test extracts each copy from source and checks the behavior
+// directly, so deleting or weakening either one fails here.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workflowDir = path.join(__dirname, '..')
+
+const WORKFLOWS = ['dev-loop.workflow.mjs', 'review.workflow.mjs']
+
+function extractOptionalLane(file) {
+  const source = readFileSync(path.join(workflowDir, file), 'utf8')
+  const match = source.match(/\nconst optionalLane = (\([\s\S]*?)\n/)
+  assert.ok(match, `could not locate \`const optionalLane = ...\` in ${file}`)
+  // eslint-disable-next-line no-new-func -- evaluating a plain arrow function from our own source, not untrusted input
+  return { fn: new Function(`return (${match[1]})`)(), source }
+}
+
+for (const file of WORKFLOWS) {
+  test(`${file}: optionalLane turns a rejecting agent into null instead of propagating`, async () => {
+    const { fn } = extractOptionalLane(file)
+    const notFound = () =>
+      Promise.reject(new Error("agent({agentType}): agent type 'codex:codex-rescue' not found"))
+    assert.equal(await fn(notFound), null)
+  })
+
+  test(`${file}: optionalLane leaves a null-returning agent as null`, async () => {
+    const { fn } = extractOptionalLane(file)
+    assert.equal(await fn(() => Promise.resolve(null)), null)
+  })
+
+  test(`${file}: optionalLane passes a successful verdict through untouched`, async () => {
+    const { fn } = extractOptionalLane(file)
+    const verdict = { pass: false, mustFix: ['something real'] }
+    assert.deepEqual(await fn(() => Promise.resolve(verdict)), verdict)
+  })
+
+  test(`${file}: every codex:codex-rescue agent call is wrapped in optionalLane`, () => {
+    const { source } = extractOptionalLane(file)
+    assert.ok(
+      source.includes("agentType: 'codex:codex-rescue'"),
+      `${file} no longer references the codex agent type — delete this guard and its test together`,
+    )
+    assert.match(
+      source,
+      /optionalLane\(/,
+      `${file} declares optionalLane but never applies it`,
+    )
+    // dev-loop calls it directly at the plan gate; review wraps the shared lane runner that the
+    // codex lane flows through. Either way an unwrapped bare `agent(` for the codex lane would
+    // reintroduce the abort, so assert the guard sits on the call path rather than counting sites.
+    const callSites = source.match(/optionalLane\(/g) || []
+    assert.ok(callSites.length >= 1, `${file} must apply optionalLane on the codex call path`)
+  })
+}

--- a/.claude/workflows/review.workflow.mjs
+++ b/.claude/workflows/review.workflow.mjs
@@ -59,6 +59,13 @@ const DOGFOOD_PERSONAS = typeof A.dogfoodPersonas === 'number' ? A.dogfoodPerson
 // codex: add a Codex second-opinion review lane (gate decisions). Unavailable runtime → dropped.
 const CODEX = !!A.codex
 
+// An unavailable Codex is "no second opinion", never a failed dimension. `agent()` resolves to
+// null when a subagent dies, but an agentType the host has no plugin for REJECTS instead — which
+// pipeline() would turn into a dropped lane, silently reporting the codex lane as run-with-no-
+// findings instead of unavailable. Normalize both failure shapes to null so the lane below sees
+// one case.
+const optionalLane = (run) => run().catch(() => null)
+
 const scopeHint = FILES
   ? `Scope: the following files only — ${FILES.join(', ')}.`
   : `Scope: discover the changed files yourself with \`${GIT} diff --name-only ${RANGE}\`.`
@@ -149,12 +156,14 @@ const notApplicableDimensions = []
 const reviewed = await pipeline(
   REVIEW_LANES,
   (lane) =>
-    agent(lane.prompt, {
-      label: `review:${lane.key}`,
-      phase: 'Review',
-      agentType: lane.agentType,
-      schema: FINDINGS_SCHEMA,
-    }).then((r) => {
+    optionalLane(() =>
+      agent(lane.prompt, {
+        label: `review:${lane.key}`,
+        phase: 'Review',
+        agentType: lane.agentType,
+        schema: FINDINGS_SCHEMA,
+      }),
+    ).then((r) => {
       if (!r) {
         if (lane.key === 'codex' && !lane.partition) {
           codexUnavailable = true


### PR DESCRIPTION
## The bug

`dev-flow.md` states the rule plainly: *"Codex unavailable (null) never blocks."* That held for only one of the two ways Codex can be unavailable.

| How it fails | What `agent()` does |
|---|---|
| the subagent dies mid-run | **resolves to `null`** — handled |
| the host has no plugin for that `agentType` | **rejects** — not handled |

`dev-loop.workflow.mjs` ran the Codex plan-review lane inside a plain `Promise.all`, so the rejection propagated straight out and aborted the run:

```
Error: agent({agentType}): agent type 'codex:codex-rescue' not found.
Available agents: architect, claude, ..., ux-designer, whiteboard-designer
```

The default is `A.codex !== false`, i.e. **on**, so on any machine without the Codex plugin *every* dev-loop died this way — after the Design phase had already run and been paid for. The only workaround was knowing to pass `codex:false`.

`review.workflow.mjs` did not crash, because `pipeline()` drops a throwing stage to `null`. But that also skips the `.then()` that sets `codexUnavailable`, so the codex lane got reported as "ran, found no findings" rather than unavailable — a quieter version of the same wrong answer.

## The fix

Normalize both failure shapes to `null` at the call site in each workflow, so the existing null handling covers them:

```js
const optionalLane = (run) => run().catch(() => null)
```

Each workflow keeps its own inline copy — the workflow sandbox has no `import`, the same reason `DESIGN_SCHEMA` is duplicated and guarded by `dev-loop-design-schema-sync.test.mjs`.

Deliberately **not** changed: the default stays `codex !== false`. The documented intent is that Codex is a companion which never blocks; making it opt-in would work around the bug rather than fix it.

## Verification

New `.claude/workflows/lib/codex-lane-optional.test.mjs` (8 tests, runs under the existing `pnpm test:scripts`) extracts `optionalLane` from **both** workflow sources and checks the behavior directly — a rejecting agent resolves to `null`, a null-returning agent stays `null`, a real verdict passes through untouched, and the guard is actually applied on the codex call path.

- `node --test .claude/workflows/lib/codex-lane-optional.test.mjs` — 8/8
- `pnpm test:scripts` — 107/107
- Mutation check: dropping `.catch(() => null)` from the dev-loop copy fails exactly the rejection test (`1 fail`); restoring it returns to green.

## How this surfaced

Two dev-loops launched for unrelated tasks both died at the PlanReview gate with the error above. Re-running with `codex:false` completed normally, which is what isolated the crash to the agent-type resolution rather than to Codex itself.
