### PR TITLE
fix(dev-flow): let a failed QA scenario reach the fix loop, and pin its review range

### DIFF
--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -335,7 +335,7 @@ const simplify = await agent(
 
 // --- Phase 5: review (compose the review workflow over this task's commits) ---
 phase('Review')
-const reviewRange = `${BASE}..HEAD`
+const reviewRange = `${BASE}...HEAD`
 let review = await workflow(
   { scriptPath: '.claude/workflows/review.workflow.mjs' },
   { range: reviewRange, cwd: CWD, files: FILES, dogfood: DOGFOOD, appUrl: APP_URL, codex: CODEX, ...REVIEW_ARGS },
@@ -344,14 +344,37 @@ let review = await workflow(
 // --- Phase 6: triage / fix loop — resolve everything at/above threshold ON THE SPOT, loop until
 // review is clean. Break out to the integrator only when a finding needs a human decision, or the
 // round cap is hit. Tickets are the exception, not the default — leave nothing half-done. ---
-const RANK = { LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4 }
-const threshold = RANK[FIX_THRESHOLD] || RANK.MEDIUM
+// Mirrors .claude/workflows/lib/fix-loop.mjs (unit-tested via node:test — the workflow sandbox has
+// no module resolution, so the logic is duplicated rather than imported; keep both in sync).
+const SEVERITY_RANK = { LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4 }
+// A FAILED qa-scenario joins the confirmed findings here. Filtering confirmedFindings alone let a
+// reproduced defect be counted in the summary and then dropped, handing the bug to the integrator
+// with zero fix attempts. QA carries no severity, so it enters at HIGH — observed breakage
+// outranks a static finding of the same name. Total: a malformed report yields empty lists rather
+// than aborting the loop.
+function triageReview(review, threshold) {
+  const findings = Array.isArray(review?.confirmedFindings) ? review.confirmedFindings : []
+  const qa = Array.isArray(review?.qa) ? review.qa : []
+  const qaFindings = qa
+    .filter((q) => q && q.status === 'fail')
+    .map((q) => ({
+      severity: 'HIGH',
+      title: `QA scenario "${q.scenario}" failed`,
+      file: '(qa)',
+      detail: q.notes || '',
+    }))
+  const all = [...findings, ...qaFindings]
+  return {
+    actionable: all.filter((f) => (SEVERITY_RANK[f.severity] || 0) >= threshold),
+    below: all.filter((f) => (SEVERITY_RANK[f.severity] || 0) < threshold),
+  }
+}
+const threshold = SEVERITY_RANK[FIX_THRESHOLD] || SEVERITY_RANK.MEDIUM
 const openFollowups = []
 let decisions = []
 let round = 0
-while (review && Array.isArray(review.confirmedFindings)) {
-  const actionable = review.confirmedFindings.filter((f) => (RANK[f.severity] || 0) >= threshold)
-  const below = review.confirmedFindings.filter((f) => (RANK[f.severity] || 0) < threshold)
+while (review) {
+  const { actionable, below } = triageReview(review, threshold)
   below.forEach((f) => openFollowups.push({ title: f.title, severity: f.severity, file: f.file, detail: f.detail }))
 
   if (actionable.length === 0 || round >= MAX_FIX) {

--- a/.claude/workflows/lib/fix-loop.mjs
+++ b/.claude/workflows/lib/fix-loop.mjs
@@ -1,0 +1,40 @@
+// Canonical, unit-tested reference for dev-loop's fix-loop triage (see fix-loop.test.mjs). The
+// Workflow runtime executes dev-loop.workflow.mjs as a standalone function body with no module
+// resolution (see the workflow-authoring skill's sandbox gotcha), so it keeps a mirrored inline
+// copy; the drift test in fix-loop.test.mjs is what keeps the two in sync.
+
+export const SEVERITY_RANK = { LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4 }
+
+/**
+ * Split a review report into what the fix loop must resolve now and what becomes a followup.
+ *
+ * A FAILED qa-scenario is included alongside the confirmed findings. It used to be counted in the
+ * summary and then dropped, because the loop filtered `confirmedFindings` only — so a QA agent
+ * that reproduced a defect with a scripted repro still handed the bug straight to the integrator
+ * with zero fix attempts. QA carries no severity of its own, so it enters at HIGH: it is evidence
+ * that something observably broke, which outranks a static finding of the same name.
+ *
+ * Total by construction: a null/malformed report yields empty lists rather than throwing, because
+ * this runs inside a loop whose failure mode would otherwise be an aborted dev-loop.
+ *
+ * @param {{confirmedFindings?: unknown, qa?: unknown} | null | undefined} review
+ * @param {number} threshold
+ * @returns {{actionable: Array<object>, below: Array<object>}}
+ */
+export function triageReview(review, threshold) {
+  const findings = Array.isArray(review?.confirmedFindings) ? review.confirmedFindings : []
+  const qa = Array.isArray(review?.qa) ? review.qa : []
+  const qaFindings = qa
+    .filter((q) => q && q.status === 'fail')
+    .map((q) => ({
+      severity: 'HIGH',
+      title: `QA scenario "${q.scenario}" failed`,
+      file: '(qa)',
+      detail: q.notes || '',
+    }))
+  const all = [...findings, ...qaFindings]
+  return {
+    actionable: all.filter((f) => (SEVERITY_RANK[f.severity] || 0) >= threshold),
+    below: all.filter((f) => (SEVERITY_RANK[f.severity] || 0) < threshold),
+  }
+}

--- a/.claude/workflows/lib/fix-loop.test.mjs
+++ b/.claude/workflows/lib/fix-loop.test.mjs
@@ -1,0 +1,82 @@
+// Run with: node --test .claude/workflows/lib/fix-loop.test.mjs
+// dev-loop's fix loop decides whether a defect gets fixed or merely reported, so its selection
+// logic is pinned here. The workflow sandbox has no module resolution, so dev-loop keeps a
+// mirrored inline copy — the drift test at the bottom is what keeps the two honest.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { SEVERITY_RANK, triageReview } from './fix-loop.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workflowPath = path.join(__dirname, '..', 'dev-loop.workflow.mjs')
+
+const finding = (severity, title) => ({ severity, title, file: 'a.ts', detail: 'd' })
+
+test('confirmed findings at or above the threshold are actionable, below it are followups', () => {
+  const review = { confirmedFindings: [finding('HIGH', 'h'), finding('LOW', 'l')], qa: [] }
+  const { actionable, below } = triageReview(review, SEVERITY_RANK.MEDIUM)
+  assert.deepEqual(actionable.map((f) => f.title), ['h'])
+  assert.deepEqual(below.map((f) => f.title), ['l'])
+})
+
+// The defect this function exists to fix: a qa-scenario that FAILED with a reproduced bug used to
+// be counted in the summary and then dropped on the floor, because the loop filtered
+// confirmedFindings only. A reproduced defect is the strongest signal the gate produces.
+test('a failed QA scenario becomes actionable rather than being dropped', () => {
+  const review = {
+    confirmedFindings: [],
+    qa: [
+      { scenario: 'smoke', status: 'pass', notes: 'fine' },
+      { scenario: 'error-recovery', status: 'fail', notes: 'repeated create sends the same slug' },
+    ],
+  }
+  const { actionable } = triageReview(review, SEVERITY_RANK.LOW)
+  assert.equal(actionable.length, 1)
+  assert.match(actionable[0].title, /error-recovery/)
+  assert.equal(actionable[0].severity, 'HIGH')
+  assert.match(actionable[0].detail, /same slug/)
+})
+
+test('passing and skipped QA scenarios are not actionable', () => {
+  const review = {
+    confirmedFindings: [],
+    qa: [
+      { scenario: 'smoke', status: 'pass' },
+      { scenario: 'startup', status: 'skip' },
+    ],
+  }
+  assert.deepEqual(triageReview(review, SEVERITY_RANK.LOW).actionable, [])
+})
+
+test('a missing or malformed review yields nothing actionable instead of throwing', () => {
+  for (const bad of [null, undefined, {}, { confirmedFindings: 'nope', qa: 'nope' }]) {
+    const { actionable, below } = triageReview(bad, SEVERITY_RANK.LOW)
+    assert.deepEqual(actionable, [])
+    assert.deepEqual(below, [])
+  }
+})
+
+test('inline triageReview in dev-loop.workflow.mjs matches this module', () => {
+  const source = readFileSync(workflowPath, 'utf8')
+  const match = source.match(/\nconst SEVERITY_RANK = [\s\S]*?\nfunction triageReview\(review, threshold\) \{[\s\S]*?\n\}\n/)
+  assert.ok(match, 'could not locate the inline SEVERITY_RANK + triageReview in dev-loop.workflow.mjs')
+  // eslint-disable-next-line no-new-func -- evaluating our own source, not untrusted input
+  const inline = new Function(`${match[0]}\nreturn { SEVERITY_RANK, triageReview }`)()
+  assert.deepEqual(inline.SEVERITY_RANK, SEVERITY_RANK)
+  const review = {
+    confirmedFindings: [finding('HIGH', 'h'), finding('LOW', 'l')],
+    qa: [{ scenario: 'error-recovery', status: 'fail', notes: 'boom' }],
+  }
+  assert.deepEqual(inline.triageReview(review, SEVERITY_RANK.MEDIUM), triageReview(review, SEVERITY_RANK.MEDIUM))
+})
+
+// `${BASE}..HEAD` re-anchors on every fetch, so a long run whose origin/main advanced reviewed a
+// diff containing spurious reversions of unrelated commits. Three dots pins the range to the
+// merge-base — the branch's own work — which is what review.workflow.mjs's own default already used.
+test('dev-loop reviews a merge-base range, not a moving two-dot range', () => {
+  const source = readFileSync(workflowPath, 'utf8')
+  assert.match(source, /const reviewRange = `\$\{BASE\}\.\.\.HEAD`/)
+  assert.doesNotMatch(source, /const reviewRange = `\$\{BASE\}\.\.HEAD`/)
+})


### PR DESCRIPTION
Two defects in the dev-loop machinery, both found by **running it on a real task** rather than by inspection. The first run (#543's follow-up: fix ADR-0006's recorded OOUI violation) surfaced them; this fixes the machinery, the product fix follows separately.

## 1. A reproduced defect was dropped on the floor

The fix loop filtered `review.confirmedFindings` only. A `qa-scenario` that **failed** — with a scripted repro the QA agent wrote, ran, and quoted in its notes — was counted in the summary as `qaFail: 1` and then ignored.

That run reported `fixRounds: 0` while holding a real, reproduced bug:

> after a failed create the canvas list never re-reads its rows, so every subsequent click re-derives the identical colliding slug and fails again — deterministically, until the whole page is reloaded

Nothing attempted to fix it. It went straight to the integrator as if the gate had found nothing actionable.

Failed QA scenarios now join the confirmed findings **at HIGH** — observed breakage outranks a static finding of the same name — and the selection moved out of the workflow body into `lib/fix-loop.mjs`, so it has tests instead of living inline. The loop's own termination is unchanged: it still breaks on an empty actionable set or the round cap, and `triageReview` is total, so a malformed report yields empty lists rather than aborting the loop.

## 2. The review range moved under the run

dev-loop diffed `${BASE}..HEAD` with **two** dots, while `review.workflow.mjs`'s own default already used **three** — dev-loop was the one that had diverged.

Two dots re-anchor on every fetch. Over that 33-minute run `origin/main` advanced four commits, so the review's diff contained spurious reversions of unrelated work (an opentelemetry downgrade, a revert of a desktop-env-detection fix, unrelated SpatialEditor changes). The QA agent noticed and re-derived the real scope by hand before it could test anything — work it should never have had to do, and a step a less careful lane would have skipped while reviewing four commits of someone else's code.

Three dots anchor on the merge-base: the branch's own commits, wherever main has moved.

## Verification

```
$ pnpm test:scripts
ℹ tests 113
ℹ pass 113
ℹ fail 0
```

Both mutation-checked by reverting the fix and confirming the failure, then restoring:

| mutation | result |
|---|---|
| restore the two-dot range | ✅ range test fails |
| drop the QA branch from the workflow's inline copy only | ✅ drift test fails |

`lib/fix-loop.mjs` follows the established pattern for logic the workflow sandbox cannot import (`design-schema.mjs`, `normalize-dimensions.mjs`): a canonical tested module plus a drift test that evaluates the workflow's inline copy and diffs the two.

## Not included

The product bug QA found is fixed on a separate branch, deliberately: merging this first means the next dev-loop run over that branch exercises the repaired gate, which is the only real proof that finding #1 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
