### PR TITLE
docs(review-gate): record that a path-only pointer is not a substitute for inlined criteria

### DIFF
--- a/.claude/skills/review-gate/SKILL.md
+++ b/.claude/skills/review-gate/SKILL.md
@@ -107,6 +107,17 @@ glob/read `resources/*.md` itself. The launching session (this skill's
 caller) must do the glob+read and pass `content` through `args`; that is why
 the mechanism accepts `{name, content}` objects rather than a directory path.
 
+**Do not shortcut step 2 by passing a PATH as `content`.** The reviewing
+agent does have `Read`, so "read `resources/<name>.md` and apply it" looks
+equivalent and saves inlining hundreds of lines into `args`. Measured on a
+real run, it is not: of four lanes given a path-only pointer, **two never
+opened the file** and reviewed from the pointer sentence alone. The two that
+did read it were the ones whose pointer carried an emphatic, specific
+instruction — which is exactly the kind of difference you cannot rely on.
+Inlining the body is what makes the criteria unconditionally present in the
+prompt, and a lane that silently reviewed against nothing is indistinguishable
+in the report from one that found no issues.
+
 `.claude/agents/reviewer-dimension.md` still carries its own embedded `##
 Dimensions` summary (contract, boundary, dead-code, test-coverage, auth,
 correctness) as the legacy fallback — used when a caller passes plain


### PR DESCRIPTION
A shortcut that looked free and measurably is not.

The skill tells the launching session to glob+read `resources/*.md` and pass each file **body** as `content`. Passing a path instead — `content: "read resources/<name>.md and apply it"` — looks equivalent, since the reviewing agent has `Read`, and it saves inlining hundreds of lines into `args`.

Measured on a real review run with four dimensions given path-only pointers:

| lane | issued a `Read` for its criteria? |
|---|---|
| `accessibility` | ✅ |
| `test-coverage` | ✅ |
| `correctness` | ❌ never opened it |
| `reachability` | ❌ never opened it |

Counted by grepping every subagent transcript in the run's directory for a `Read` `tool_use` targeting `resources/`. The two that read it were the two whose pointer happened to carry an emphatic, specific instruction — not a property you can depend on.

**The failure is silent.** A lane that reviewed against no criteria at all reports exactly like a lane that read them and found nothing: `findings: []`. Nothing in the consolidated report distinguishes the two.

So the skill keeps its instruction, and now says why, with the measurement attached — the next person to notice the same apparent shortcut gets the answer instead of re-running the experiment.

Documentation only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX