### PR TITLE
fix(dev-flow): fail loudly on malformed workflow args, and guard every Codex lane

### DIFF
--- a/.claude/workflows/audit-triage.workflow.mjs
+++ b/.claude/workflows/audit-triage.workflow.mjs
@@ -13,7 +13,15 @@ export const meta = {
 
 // --- inputs (runtime delivers args as a JSON string) ---
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const SCOPE = A.scope || 'the whole repository'
 const CWD = A.cwd || null

--- a/.claude/workflows/ci-triage.workflow.mjs
+++ b/.claude/workflows/ci-triage.workflow.mjs
@@ -11,7 +11,15 @@ export const meta = {
 }
 
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const PR = A.pr
 const CWD = A.cwd || null

--- a/.claude/workflows/consult-adversarial.workflow.mjs
+++ b/.claude/workflows/consult-adversarial.workflow.mjs
@@ -17,7 +17,15 @@ export const meta = {
 
 // --- inputs (runtime delivers args as a JSON string) ---
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const QUESTION = A.question || ''
 const CWD = A.cwd || null

--- a/.claude/workflows/consult-adversarial.workflow.mjs
+++ b/.claude/workflows/consult-adversarial.workflow.mjs
@@ -34,6 +34,12 @@ const BUDGET = A.verifyBudget || 'bounded'
 const PANEL = ({ minimal: 2, bounded: 3, generous: 5 })[BUDGET] || 3
 const MAX_ROUNDS = Number(A.maxRounds || 3)
 const CODEX = A.codex !== false
+
+// An unavailable Codex is "no second opinion", never a gate failure. `agent()` resolves to null
+// when a subagent dies, but an agentType the host has no plugin for REJECTS instead — so without
+// this the whole workflow aborts on any machine where the Codex plugin isn't installed, which is
+// the opposite of the "Codex unavailable never blocks" rule it is supposed to implement.
+const optionalLane = (run) => run().catch(() => null)
 const GIT = CWD ? `git -C ${CWD}` : 'git'
 const cwdHint = CWD ? ` Read the repo under ${CWD} (run git as \`${GIT} ...\`).` : ' Read the repo to ground your reasoning.'
 
@@ -68,6 +74,10 @@ const VERDICT_SCHEMA = {
 // --- consultant (the "council"): produce an answer to a brief ---
 async function consult(brief, round) {
   if (CONSULTANT === 'codex') {
+    // Deliberately NOT wrapped in optionalLane. Here Codex is the answer, not a second opinion:
+    // the caller opted in explicitly (the default consultant is 'agent'), so an unavailable Codex
+    // has no meaningful null to degrade to — swallowing it would hand back an empty answer as if
+    // the consultation had happened. Let it reject and say so.
     return agent(`${brief}\n\n${cwdHint} Give a concrete, grounded answer with assumptions made.`,
       { label: `consult:codex:${round}`, phase: 'Consult', agentType: 'codex:codex-rescue', schema: ANSWER_SCHEMA })
   }
@@ -136,8 +146,9 @@ while (true) {
   if (CODEX && claims.length) {
     const c0 = claims[0]
     skeptics.push(() =>
-      agent(`Adversarially refute the most load-bearing claim in this answer if you can.\nQUESTION: ${QUESTION}\nCLAIM: ${c0.claim}\n${cwdHint} refuted:true only with concrete repo evidence.`,
-        { label: `skeptic:${round}:codex`, phase: 'Verify', agentType: 'codex:codex-rescue', schema: VERDICT_SCHEMA }))
+      optionalLane(() =>
+        agent(`Adversarially refute the most load-bearing claim in this answer if you can.\nQUESTION: ${QUESTION}\nCLAIM: ${c0.claim}\n${cwdHint} refuted:true only with concrete repo evidence.`,
+          { label: `skeptic:${round}:codex`, phase: 'Verify', agentType: 'codex:codex-rescue', schema: VERDICT_SCHEMA })))
   }
   const verdicts = (await parallel(skeptics)).filter(Boolean)
   const survived = verdicts.filter((v) => v.refuted)

--- a/.claude/workflows/dependabot-triage.workflow.mjs
+++ b/.claude/workflows/dependabot-triage.workflow.mjs
@@ -13,7 +13,15 @@ export const meta = {
 }
 
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const ONLY_PRS = Array.isArray(A.prs) && A.prs.length ? A.prs : null
 const INCLUDE_ALERTS = A.includeAlerts !== false

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -17,7 +17,15 @@ export const meta = {
 // --- inputs ---
 // The runtime delivers `args` as a JSON *string* (not an object), so normalize first.
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const TASK = A.taskTitle || 'untitled task'
 const SPEC = A.taskSpec || ''

--- a/.claude/workflows/dogfood-triage.workflow.mjs
+++ b/.claude/workflows/dogfood-triage.workflow.mjs
@@ -14,7 +14,15 @@ export const meta = {
 // --- inputs ---
 // The runtime delivers `args` as a JSON *string* (not an object), so normalize first.
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const PERSONA_COUNT = A.personaCount || 3
 const APP_URL = A.appUrl || 'http://localhost:5173'

--- a/.claude/workflows/investigate.workflow.mjs
+++ b/.claude/workflows/investigate.workflow.mjs
@@ -12,7 +12,15 @@ export const meta = {
 
 // --- inputs (runtime delivers args as a JSON string) ---
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const QUESTION = A.question || ''
 const CWD = A.cwd || null

--- a/.claude/workflows/lib/args-parse.test.mjs
+++ b/.claude/workflows/lib/args-parse.test.mjs
@@ -1,0 +1,67 @@
+// Run with: node --test .claude/workflows/lib/args-parse.test.mjs
+//
+// Every workflow receives `args` as a JSON string and parses it in one IIFE at the top of the
+// file. That parse used to swallow a SyntaxError and fall back to `{}`, which is the worst
+// possible failure: the workflow does not stop, it runs to completion against empty inputs.
+// A dev-loop launched with one unescaped quote in its spec became `taskTitle: 'untitled task'`
+// with an empty body and still spent four agents before concluding no spec had been supplied.
+//
+// Malformed args is a caller bug with no sane default, so it must throw. The other three
+// shapes still have to behave: a valid JSON string parses, an object passes through, and an
+// absent `args` is a legitimate "no arguments" call.
+//
+// The workflow sandbox has no `import`, so each workflow carries its own copy of the parser.
+// This test extracts every copy and runs the same four checks against all of them, so a new
+// workflow that reintroduces the silent fallback fails here.
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workflowDir = path.join(__dirname, '..')
+
+const WORKFLOWS = readdirSync(workflowDir)
+  .filter((f) => f.endsWith('.workflow.mjs'))
+  .sort()
+
+// Guards against this test silently covering nothing if the directory layout changes.
+test('there are workflow files to check', () => {
+  assert.ok(WORKFLOWS.length >= 10, `expected the workflow set, found ${WORKFLOWS.length}`)
+})
+
+function extractArgsParser(file) {
+  const source = readFileSync(path.join(workflowDir, file), 'utf8')
+  const match = source.match(/\nconst A = (\(\(\) => \{[\s\S]*?\n\}\)\(\))\n/)
+  assert.ok(match, `could not locate the \`const A = (() => {...})()\` args parser in ${file}`)
+  // eslint-disable-next-line no-new-func -- evaluating our own source with `args` injected, not untrusted input
+  return new Function('args', `return ${match[1]}`)
+}
+
+for (const file of WORKFLOWS) {
+  test(`${file}: parses a valid args JSON string`, () => {
+    const parse = extractArgsParser(file)
+    assert.deepEqual(parse('{"taskTitle":"x","n":1}'), { taskTitle: 'x', n: 1 })
+  })
+
+  test(`${file}: passes an object through unchanged`, () => {
+    const parse = extractArgsParser(file)
+    const obj = { taskTitle: 'x' }
+    assert.equal(parse(obj), obj)
+  })
+
+  test(`${file}: treats an absent args as no arguments`, () => {
+    const parse = extractArgsParser(file)
+    assert.deepEqual(parse(undefined), {})
+    assert.deepEqual(parse(null), {})
+  })
+
+  test(`${file}: THROWS on malformed args instead of falling back to {}`, () => {
+    const parse = extractArgsParser(file)
+    // An unescaped double quote inside a string value — exactly what silently emptied a
+    // dev-loop's spec — plus a plainly truncated object.
+    assert.throws(() => parse('{"taskSpec":"he said "hi" to me"}'), /args/i)
+    assert.throws(() => parse('{"taskTitle":'), /args/i)
+  })
+}

--- a/.claude/workflows/lib/codex-lane-optional.test.mjs
+++ b/.claude/workflows/lib/codex-lane-optional.test.mjs
@@ -16,7 +16,7 @@
 // `optionalLane` guard. This test extracts each copy from source and checks the behavior
 // directly, so deleting or weakening either one fails here.
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
@@ -24,7 +24,18 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const workflowDir = path.join(__dirname, '..')
 
-const WORKFLOWS = ['dev-loop.workflow.mjs', 'review.workflow.mjs']
+// Enumerated, never a fixed list: this guard first shipped naming dev-loop and review by hand,
+// which quietly exempted plan-initiative and consult-adversarial — both of which had the same
+// unguarded lane in the same plain Promise.all. Any workflow that reaches for the Codex agent
+// type is in scope automatically.
+const WORKFLOWS = readdirSync(workflowDir)
+  .filter((f) => f.endsWith('.workflow.mjs'))
+  .filter((f) => readFileSync(path.join(workflowDir, f), 'utf8').includes("agentType: 'codex:codex-rescue'"))
+  .sort()
+
+test('the codex-using workflows are discovered', () => {
+  assert.ok(WORKFLOWS.length >= 4, `expected every codex-using workflow, found ${WORKFLOWS.join(', ')}`)
+})
 
 function extractOptionalLane(file) {
   const source = readFileSync(path.join(workflowDir, file), 'utf8')

--- a/.claude/workflows/plan-initiative.workflow.mjs
+++ b/.claude/workflows/plan-initiative.workflow.mjs
@@ -32,6 +32,12 @@ const CONTEXT_PATHS = Array.isArray(A.contextPaths) ? A.contextPaths : []
 const DEPTH = A.depth === 'detailed' ? 'detailed' : 'concept'
 const VISUALIZE = A.visualize !== false
 const CODEX = A.codex !== false
+
+// An unavailable Codex is "no second opinion", never a gate failure. `agent()` resolves to null
+// when a subagent dies, but an agentType the host has no plugin for REJECTS instead — so without
+// this the whole workflow aborts on any machine where the Codex plugin isn't installed, which is
+// the opposite of the "Codex unavailable never blocks" rule it is supposed to implement.
+const optionalLane = (run) => run().catch(() => null)
 // consult: adversarially vet the plan's load-bearing cross-perspective conflicts via the
 // consult-adversarial workflow before returning (opt-in — expensive). consultant: agent|codex|panel.
 const CONSULT = !!A.consult
@@ -152,8 +158,8 @@ const runGate = async (pl) => {
     agent(`Review this initiative plan for completeness before slicing into dev-loops. Plan: ${JSON.stringify(pl)}. Fail with mustFix if slices aren't single-scope, dependencies/risks are missing, fixture/test paths or assertions would break, or high-risk angles are unaddressed.`,
       { label: 'gate:plan-reviewer', phase: 'Gate', agentType: 'plan-reviewer', schema: PLAN_VERDICT_SCHEMA }),
     CODEX
-      ? agent(`Independently review this initiative plan as a gate. Plan: ${JSON.stringify(pl)}. Read the repo to check assumptions; flag scope/sequencing/risk/assumption problems; fail with concrete mustFix if it should not proceed.`,
-          { label: 'gate:codex', phase: 'Gate', agentType: 'codex:codex-rescue', schema: PLAN_VERDICT_SCHEMA })
+      ? optionalLane(() => agent(`Independently review this initiative plan as a gate. Plan: ${JSON.stringify(pl)}. Read the repo to check assumptions; flag scope/sequencing/risk/assumption problems; fail with concrete mustFix if it should not proceed.`,
+          { label: 'gate:codex', phase: 'Gate', agentType: 'codex:codex-rescue', schema: PLAN_VERDICT_SCHEMA }))
       : Promise.resolve(null),
   ])
   return {

--- a/.claude/workflows/plan-initiative.workflow.mjs
+++ b/.claude/workflows/plan-initiative.workflow.mjs
@@ -17,7 +17,15 @@ export const meta = {
 
 // --- inputs (runtime delivers args as a JSON string) ---
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const INITIATIVE = A.initiative || ''
 const CONTEXT_PATHS = Array.isArray(A.contextPaths) ? A.contextPaths : []

--- a/.claude/workflows/pr-feedback.workflow.mjs
+++ b/.claude/workflows/pr-feedback.workflow.mjs
@@ -13,10 +13,14 @@ export const meta = {
 }
 
 const A = (() => {
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
   try {
-    return typeof args === 'string' ? JSON.parse(args) : args && typeof args === 'object' ? args : {}
-  } catch {
-    return {}
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
   }
 })()
 const PR = A.pr

--- a/.claude/workflows/reconcile.workflow.mjs
+++ b/.claude/workflows/reconcile.workflow.mjs
@@ -13,7 +13,15 @@ export const meta = {
 
 // --- inputs (runtime delivers args as a JSON string) ---
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 const TIP = A.integrationTip || 'HEAD'
 const BRANCHES = Array.isArray(A.branches) ? A.branches : []

--- a/.claude/workflows/review.workflow.mjs
+++ b/.claude/workflows/review.workflow.mjs
@@ -14,7 +14,15 @@ export const meta = {
 // --- inputs (override via Workflow args) ---
 // The runtime delivers `args` as a JSON *string* (not an object), so normalize first.
 const A = (() => {
-  try { return typeof args === 'string' ? JSON.parse(args) : (args && typeof args === 'object' ? args : {}) } catch { return {} }
+  if (typeof args !== 'string') return args && typeof args === 'object' ? args : {}
+  // Malformed args is a caller bug with no sane default. Falling back to {} does not stop the
+  // run — it completes against empty inputs and reports "nothing was specified" after spending
+  // the whole agent budget, which reads as a finding rather than the input error it is.
+  try {
+    return JSON.parse(args)
+  } catch (err) {
+    throw new Error(`args is not valid JSON (${err.message}): ${args.slice(0, 200)}`)
+  }
 })()
 // range: a git range understood by `git diff`/`git log` (default: changes since branch diverged from origin/main).
 const RANGE = A.range || 'origin/main...HEAD'


### PR DESCRIPTION
Two failures of the same shape: a workflow that keeps running after something it needed was missing.

## 1. Malformed `args` ran the workflow against empty inputs

Every workflow takes `args` as a JSON string and parsed it behind `catch { return {} }`. That does not stop the run — it completes against empty inputs and reports the emptiness as a finding.

A dev-loop launched with one unescaped quote in its spec became `taskTitle: 'untitled task'` with an empty body, and spent **four agents / ~157k tokens** before concluding that no spec had been supplied. The conclusion reads as a statement about the task; it was an input error.

Malformed args is a caller bug with no sane default, so it now throws with the parser message and a prefix of the offending string:

```
Error: args is not valid JSON (JSON Parse error: Expected '}'): {"question":"broken json test: he said "hi"}
```

Verified live against the real `Workflow` tool: **0 agents, 16ms**, versus four agents before. The three shapes that do have a meaning are unchanged — a valid JSON string parses, an object passes through, an absent `args` is a no-arguments call (also verified live: a normal run completes as before).

All eleven workflows carry their own copy; the sandbox has no `import`, the same reason `DESIGN_SCHEMA` is duplicated and guarded by `dev-loop-design-schema-sync.test.mjs`.

## 2. The earlier Codex fix covered two of four call sites

The previous change wrapped the Codex second-opinion lane so an unregistered `agentType` degrades to "unavailable" instead of aborting the run — and its test enumerated `['dev-loop.workflow.mjs', 'review.workflow.mjs']` **by hand**.

Four workflows use that agent type. `plan-initiative` and `consult-adversarial` kept the unguarded lane in the same plain `Promise.all`, both with Codex default-ON, so on a machine without the Codex plugin they still abort mid-run. The bug was reported fixed while two thirds of the call sites still had it.

Both guards now discover their targets by scanning the workflow directory — the args test by filename, the Codex test by whether the file references the agent type — so a new workflow is in scope automatically rather than needing someone to remember the list.

One Codex call is deliberately left unwrapped, with a comment saying why: `consult-adversarial`'s primary consultant, reached only by an explicit `consultant: 'codex'` (the default is `'agent'`). There Codex *is* the answer rather than a second opinion, so a `null` would hand back an empty consultation as if it had happened — the same silent-empty failure this PR exists to remove.

## Verification

- `pnpm test:scripts` — 167/167 (45 new args cases across 11 workflows, 17 Codex cases across 4)
- Red confirmed first for both: all 11 workflows failed the throw case; `plan-initiative` and `consult-adversarial` failed all four Codex cases before the guard
- Syntax-checked every workflow with an async-function wrapper matching the sandbox (plain `node --check` cannot parse these — they use top-level `await` and `return`)
