### PR TITLE
fix(dev-flow): stop a dead design agent from turning the PlanReview gate off

### DIFF
--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -238,11 +238,13 @@ function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedD
   return !skipDesign || !!discardedInvalidProvidedDesign
 }
 
-// Gates the Implement phase on the PlanReview gate's final verdict. Mirrors
-// .claude/workflows/lib/design-schema.mjs's shouldBlockOnFailedPlanReview (see the sync test for
-// why this is duplicated instead of imported).
-function shouldBlockOnFailedPlanReview({ hasDesign, pass }) {
-  return !!hasDesign && !pass
+// Gates the Implement phase on the PlanReview gate's final verdict. A failed gate ALWAYS blocks:
+// there is deliberately no `hasDesign` escape hatch, because the gate only runs `if (design)` and
+// `planVerdict` defaults to `{ pass: true }`, so a skipped design can never reach here with
+// `pass: false`. Mirrors .claude/workflows/lib/design-schema.mjs's shouldBlockOnFailedPlanReview
+// (see the sync test for why this is duplicated instead of imported).
+function shouldBlockOnFailedPlanReview({ pass }) {
+  return !pass
 }
 
 // --- Phase 1: design ---
@@ -292,15 +294,24 @@ if (design) {
   while (!planVerdict.pass && planRev < MAX_PLAN_REV) {
     planRev += 1
     log(`PlanReview failed (revise ${planRev}/${MAX_PLAN_REV}): ${(planVerdict.mustFix || []).join('; ')}`)
-    design = await agent(
+    // agent() resolves to null when a subagent dies (a stalled stream, a terminal API error).
+    // Assigning that straight to `design` would destroy the design the previous round produced and
+    // send `null` into the next gate call, which then fails for the wrong reason. Keep the last
+    // good design and stop revising — the failed verdict already blocks Implement.
+    const revised = await agent(
       `Revise this design to address the must-fix items, keeping the same schema. Task: ${TASK}\nDesign: ${JSON.stringify(design)}\nMust-fix: ${JSON.stringify(planVerdict.mustFix || [])}`,
       { label: `design-revise:${planRev}`, phase: 'Design', schema: DESIGN_SCHEMA },
     )
+    if (!revised) {
+      log(`design-revise:${planRev} returned nothing (agent died) — keeping the previous design; the failed gate stands`)
+      break
+    }
+    design = revised
     planVerdict = await runGate()
   }
 }
 
-if (shouldBlockOnFailedPlanReview({ hasDesign: !!design, pass: planVerdict.pass })) {
+if (shouldBlockOnFailedPlanReview({ pass: planVerdict.pass })) {
   return {
     taskTitle: TASK,
     design,

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -125,11 +125,12 @@ export function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidPr
   return !skipDesign || !!discardedInvalidProvidedDesign
 }
 
-// Gates dev-loop's Implement phase on the PlanReview gate's final verdict. Without this, a design
-// that keeps failing PlanReview past the revision cap (e.g. a state/store design carrying only the
-// `none:` properties sentinel) still proceeds into Implement labeled "Approved design," making the
-// gate advisory instead of blocking. `hasDesign` is false when design/PlanReview was skipped
-// entirely (skipDesign with a pre-approved designDoc) — that case must not block.
-export function shouldBlockOnFailedPlanReview({ hasDesign, pass }) {
-  return !!hasDesign && !pass
+// Gates dev-loop's Implement phase on the PlanReview gate's final verdict. A failed gate ALWAYS
+// blocks. There is deliberately no `hasDesign` escape hatch: the gate only runs `if (design)` and
+// `planVerdict` defaults to `{ pass: true }`, so a skipped design can never reach here with
+// `pass: false`. The only way to be here without a design is that the revise agent died and its
+// `null` replaced a design that had existed — precisely when the gate must hold. An observed run
+// with that escape hatch implemented and committed against `design: null` and a failed gate.
+export function shouldBlockOnFailedPlanReview({ pass }) {
+  return !pass
 }

--- a/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+++ b/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
@@ -233,11 +233,24 @@ test('shouldBlockOnFailedPlanReview does not block when the plan-review gate pas
   assert.equal(sharedShouldBlockOnFailedPlanReview(input), false)
 })
 
-test('shouldBlockOnFailedPlanReview does not block when design/PlanReview was skipped entirely', () => {
+// The gate only ever runs `if (design)`, and `planVerdict` defaults to `{ pass: true }` — so a
+// skipped design can never produce `pass: false`. The only way to arrive here without a design is
+// that the revise agent DIED and its `null` overwrote a design that had existed, which is exactly
+// when the gate must hold. A `hasDesign` escape hatch here turned a hard gate into no gate: an
+// observed run implemented and committed against `design: null` and `planVerdict.pass: false`.
+test('a failed gate blocks implementation even when the design was lost with it', () => {
   const shouldBlockOnFailedPlanReview = extractShouldBlockOnFailedPlanReview()
   const input = { hasDesign: false, pass: false }
-  assert.equal(shouldBlockOnFailedPlanReview(input), false)
-  assert.equal(sharedShouldBlockOnFailedPlanReview(input), false)
+  assert.equal(shouldBlockOnFailedPlanReview(input), true)
+  assert.equal(sharedShouldBlockOnFailedPlanReview(input), true)
+})
+
+// The other half of the same incident: a transient agent death must not destroy the design that
+// passed through the previous iteration, or the next gate call reviews `null` and fails for the
+// wrong reason.
+test('a failed design revision does not overwrite the last good design', () => {
+  assert.doesNotMatch(source, /design = await agent\(\s*\n\s*`Revise this design/)
+  assert.match(source, /const revised = await agent\(/)
 })
 
 test('shouldGenerateDesign regenerates when skipDesign is set but the provided designDoc was just discarded as invalid', () => {


### PR DESCRIPTION
A dev-loop run implemented and committed against `design: null` and `planVerdict.pass: false`. The gate did not fail open by accident of configuration — it was written to.

## What happened

The design-revise agent died mid-stream (`API Error: Response stalled mid-stream`). `agent()` resolves to `null` on a subagent death, and the loop assigned that straight to `design`, **destroying the design the previous round had produced**. The next gate call reviewed `null` and failed for that reason — the plan-reviewer's own rationale reads *"the Design field is literally null"*. Then:

```js
shouldBlockOnFailedPlanReview({ hasDesign: false, pass: false })  // → false
```

Implement ran anyway. A hard gate became no gate because of one transient API failure.

## Both halves

**The `hasDesign` escape hatch is deleted.** It was added for "design/PlanReview skipped entirely", but that input is **unreachable in the skip case**: the gate only runs `if (design)`, and `planVerdict` defaults to `{ pass: true }`, so a skipped design can never arrive with `pass: false`. The only reachable path to `hasDesign: false, pass: false` is the agent-death case — precisely when the gate must hold. `!pass` is both correct and shorter.

**A failed revision no longer overwrites the last good design.** `revised` is checked before assignment; on null the loop keeps the previous design, logs why, and stops revising. The already-failed verdict then blocks Implement on its own.

## About the test that had to change

`shouldBlockOnFailedPlanReview({ hasDesign: false, pass: false }) === false` was asserted and labelled *"does not block when design/PlanReview was skipped entirely"*. That description does not match any reachable state, for the reason above — the test was pinning the bug. It is inverted here, with the unreachability argument written into the test so the next reader does not re-derive it.

## Verification

```
$ pnpm test:scripts
ℹ tests 168
ℹ pass 168
ℹ fail 0
```

| mutation | result |
|---|---|
| restore the `hasDesign` escape hatch | ✅ the gate test fails |
| restore `design = await agent(...)` in the revise loop | ✅ the revision test fails |

## How it was found

By running dev-loop on a real task, not by inspection — the same way the previous two gate defects surfaced (#554). The run's own artifact is the evidence: `design: null`, `planVerdict.pass: false`, `implReport.committed: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
