### PR TITLE
fix(web): replace DaemonCanvasPage's empty-state creation form with immediate create (ADR-0006)

### DIFF
--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -714,6 +714,44 @@ describe('DaemonCanvasPage', () => {
     fireEvent.click(await screen.findByTestId('select-tool-button'))
   })
 
+  it('disables Create a canvas while a create is in flight, and a same-tick second click is a no-op', async () => {
+    mockListCanvases.mockResolvedValue({ canvases: [] })
+    let resolveCreate: (value: { slug: string }) => void = () => {}
+    mockCreateCanvas.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      }),
+    )
+
+    await act(async () => {
+      render(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Create a canvas' }).hasAttribute('disabled')).toBe(
+        true,
+      ),
+    )
+    // A second, same-tick click while the first create is still pending must
+    // not fire a second create call — `disabled` is the guard (see the
+    // `creating` state's comment), so this is exercising that guard, not an
+    // in-handler early-return.
+    fireEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
+    expect(mockCreateCanvas).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveCreate({ slug: 'untitled' })
+    })
+  })
+
   it('shows the createError alert in the empty-canvases state when creation fails', async () => {
     mockListCanvases.mockResolvedValue({ canvases: [] })
     mockCreateCanvas.mockRejectedValue(new Error('slug already exists'))

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -657,7 +657,7 @@ describe('DaemonCanvasPage', () => {
     expect(screen.queryByTestId('spatial-editor-container')).toBeNull()
   })
 
-  it('renders a create-canvas form when the workspace has zero canvases', async () => {
+  it('renders a create-canvas button, not a form, when the workspace has zero canvases (ADR-0006)', async () => {
     mockListCanvases.mockResolvedValue({ canvases: [] })
 
     await act(async () => {
@@ -672,14 +672,17 @@ describe('DaemonCanvasPage', () => {
     )
     expect(screen.queryByLabelText('Canvases')).toBeNull()
     expect(screen.queryByTestId('spatial-editor-container')).toBeNull()
-    expect(screen.getByLabelText('New canvas name')).toBeTruthy()
+    // No form, no name-first input: creation is immediate, naming follows (ADR-0006 point 3).
+    expect(screen.queryByLabelText(/new canvas name/i)).toBeNull()
+    expect(screen.queryByRole('form')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Create a canvas' })).toBeTruthy()
   })
 
-  it('submits the create-canvas form and mounts the editor once the canvas exists', async () => {
+  it('clicking Create a canvas derives a slug and mounts the editor once the canvas exists', async () => {
     mockListCanvases.mockResolvedValueOnce({ canvases: [] })
-    mockCreateCanvas.mockResolvedValue({ slug: 'brand-new' })
+    mockCreateCanvas.mockResolvedValue({ slug: 'untitled' })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'brand-new', updatedAt: '2026-01-03' }],
+      canvases: [{ slug: 'untitled', updatedAt: '2026-01-03' }],
     })
 
     await act(async () => {
@@ -693,21 +696,17 @@ describe('DaemonCanvasPage', () => {
       expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
     )
 
-    const input = screen.getByLabelText('New canvas name') as HTMLInputElement
-    const form = input.closest('form')!
-
     await act(async () => {
-      fireEvent.change(input, { target: { value: 'brand-new' } })
-    })
-    await act(async () => {
-      fireEvent.submit(form)
+      fireEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
     })
 
+    // No name typed by the user — the slug is derived, same as the daemon
+    // index page's own empty-state control.
     expect(mockCreateCanvas).toHaveBeenCalledWith(
       expect.anything(),
       DAEMON_BASE_URL,
       'w1',
-      'brand-new',
+      'untitled',
     )
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
     // Hand (view-only) is the default tool; the host history cluster only
@@ -730,18 +729,18 @@ describe('DaemonCanvasPage', () => {
       expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
     )
 
-    const input = screen.getByLabelText('New canvas name') as HTMLInputElement
-    const form = input.closest('form')!
-
     await act(async () => {
-      fireEvent.change(input, { target: { value: 'brand-new' } })
-    })
-    await act(async () => {
-      fireEvent.submit(form)
+      fireEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
     })
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
     expect(screen.getByRole('alert').textContent).toMatch(/slug already exists/i)
+    // The control recovers (not left permanently disabled) so the user can retry.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Create a canvas' }).hasAttribute('disabled')).toBe(
+        false,
+      ),
+    )
   })
 
   describe('manual save version', () => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -14,6 +14,7 @@ import { MergeToast } from '../components/MergeToast.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
+import { Button } from '../components/ui/button.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
@@ -24,6 +25,7 @@ import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { createDaemonFetch } from '../lib/daemon-api-client.js'
 import { createDaemonFileAdapter } from '../lib/daemon-file-adapter.js'
+import { deriveNewCanvasSlug } from '../lib/derive-new-canvas-slug.js'
 import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
@@ -139,7 +141,13 @@ export function DaemonCanvasPage({
       : null
 
   const [authError, setAuthError] = useState(false)
-  const [newCanvasSlug, setNewCanvasSlug] = useState('')
+  // Disables the empty-state "Create a canvas" control while a create is in
+  // flight. `disabled` is the whole mechanism, deliberately with no
+  // `if (creating) return` guard inside the handler — see
+  // DaemonIndexPage.tsx's own `creating` state for why that guard was tried
+  // and removed there (stale closure read in the same-tick double-press
+  // case it exists to catch).
+  const [creating, setCreating] = useState(false)
   // Bumped on an externally observed HEAD change (another client, an MCP
   // tool call) so HeaderBranchChip refetches; the chip's own switch/create/
   // rename/delete actions already refetch internally and don't need this.
@@ -254,6 +262,19 @@ export function DaemonCanvasPage({
   // PNG, because the daemon's thumbnail endpoint validates a PNG signature
   // on upload and rejects anything else.
   const getThumbnailBlob = useCallback(() => exportScene('png'), [exportScene])
+
+  // Creation is immediate — no name is collected up front (ADR-0006 point
+  // 3). A slug is derived from the loaded canvases so it never collides with
+  // one already in this workspace; naming happens afterwards, in the opened
+  // canvas's own top bar. Mirrors DaemonIndexPage.tsx's empty-state handler.
+  const handleCreateCanvas = async (): Promise<void> => {
+    setCreating(true)
+    try {
+      await controller.createCanvas(deriveNewCanvasSlug(controller.canvases.map((c) => c.slug)))
+    } finally {
+      setCreating(false)
+    }
+  }
 
   const saveVersion = async (): Promise<void> => {
     if (!capabilities.versions || canvas === null || savingVersion) return
@@ -539,27 +560,19 @@ export function DaemonCanvasPage({
                 {controller.createError}
               </div>
             )}
-            <form
-              className="flex items-center gap-2"
-              onSubmit={(event) => {
-                event.preventDefault()
-                if (!newCanvasSlug.trim()) return
-                void controller.createCanvas(newCanvasSlug.trim())
-              }}
+            {/* An empty state is a reading surface, not a dense toolbar strip
+                (ADR-0006 point 4) — the control keeps its text label rather
+                than becoming an icon-only "+", matching DaemonIndexPage's
+                own empty-state "Create a canvas" button. */}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={creating}
+              onClick={() => void handleCreateCanvas()}
             >
-              <input
-                aria-label="New canvas name"
-                value={newCanvasSlug}
-                onChange={(event) => setNewCanvasSlug(event.target.value)}
-                className="rounded-md border bg-background px-2 py-1 text-xs"
-              />
-              <button
-                type="submit"
-                className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent"
-              >
-                Create canvas
-              </button>
-            </form>
+              Create a canvas
+            </Button>
           </div>
         ) : (
           // Spatial is the only view this slice supports; markdown-view

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -142,11 +142,9 @@ export function DaemonCanvasPage({
 
   const [authError, setAuthError] = useState(false)
   // Disables the empty-state "Create a canvas" control while a create is in
-  // flight. `disabled` is the whole mechanism, deliberately with no
-  // `if (creating) return` guard inside the handler — see
-  // DaemonIndexPage.tsx's own `creating` state for why that guard was tried
-  // and removed there (stale closure read in the same-tick double-press
-  // case it exists to catch).
+  // flight. `disabled` is the whole mechanism: an in-handler
+  // `if (creating) return` reads the render closure, so it is stale in exactly
+  // the same-tick double-press case it would have to catch.
   const [creating, setCreating] = useState(false)
   // Bumped on an externally observed HEAD change (another client, an MCP
   // tool call) so HeaderBranchChip refetches; the chip's own switch/create/
@@ -263,10 +261,9 @@ export function DaemonCanvasPage({
   // on upload and rejects anything else.
   const getThumbnailBlob = useCallback(() => exportScene('png'), [exportScene])
 
-  // Creation is immediate — no name is collected up front (ADR-0006 point
-  // 3). A slug is derived from the loaded canvases so it never collides with
-  // one already in this workspace; naming happens afterwards, in the opened
-  // canvas's own top bar. Mirrors DaemonIndexPage.tsx's empty-state handler.
+  // Creation is immediate — no name is collected up front (ADR-0006 point 3).
+  // The slug is derived from the loaded canvases so it never collides with one
+  // already in this workspace; naming happens afterwards in the canvas's top bar.
   const handleCreateCanvas = async (): Promise<void> => {
     setCreating(true)
     try {
@@ -561,9 +558,8 @@ export function DaemonCanvasPage({
               </div>
             )}
             {/* An empty state is a reading surface, not a dense toolbar strip
-                (ADR-0006 point 4) — the control keeps its text label rather
-                than becoming an icon-only "+", matching DaemonIndexPage's
-                own empty-state "Create a canvas" button. */}
+                (ADR-0006 point 4), so the control keeps its text label rather
+                than becoming an icon-only "+". */}
             <Button
               type="button"
               variant="outline"

--- a/apps/web/src/pages/use-daemon-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-daemon-canvas-controller.test.ts
@@ -266,6 +266,32 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.slug).toBeNull()
   })
 
+  // The empty-state caller derives its next slug from `canvases`. If a create fails because
+  // another client already took that slug, `canvases` is stale by definition — without a
+  // refresh here, a retry re-derives the SAME losing slug from the same stale list forever.
+  it('createCanvas re-reads the canvas list after a failure so a retry does not repeat the same slug', async () => {
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValueOnce({ canvases: [] })
+    mockCreateCanvas.mockRejectedValue(new Error('slug already exists'))
+
+    const { result } = renderHook(() =>
+      useDaemonCanvasController({ daemonBaseUrl: DAEMON_BASE_URL, daemonFetch: fetchFn }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    mockListCanvases.mockResolvedValueOnce({
+      canvases: [{ slug: 'untitled', updatedAt: '2026-01-01' }],
+    })
+
+    await act(async () => {
+      await result.current.createCanvas('untitled')
+    })
+
+    expect(result.current.createError).toBe('slug already exists')
+    // The refreshed list now shows the slug another client already took.
+    expect(result.current.canvases).toEqual([{ slug: 'untitled', updatedAt: '2026-01-01' }])
+  })
+
   it('createCanvas is a no-op before workspaceId has resolved', async () => {
     // Never resolves during this test, so workspaceId stays null past mount.
     mockListWorkspaces.mockReturnValue(new Promise(() => {}))

--- a/apps/web/src/pages/use-daemon-canvas-controller.ts
+++ b/apps/web/src/pages/use-daemon-canvas-controller.ts
@@ -154,6 +154,19 @@ export function useDaemonCanvasController(
         setSlug(created.slug)
       } catch (err) {
         setCreateError(errorMessage(err))
+        // The caller derives its next slug from `canvases`. A failure often means that list is
+        // already stale (another client took the slug) — without a refresh, a retry re-derives
+        // the SAME losing slug from the same stale list and collides forever.
+        try {
+          const { canvases: refreshed } = await listCanvasesApi(
+            daemonFetch,
+            daemonBaseUrl,
+            workspaceId,
+          )
+          setCanvases(refreshed)
+        } catch {
+          // Best-effort: leaving the previous (possibly stale) list is no worse than not trying.
+        }
       }
     },
     [daemonFetch, daemonBaseUrl, workspaceId],

--- a/apps/web/src/pages/use-daemon-canvas-controller.ts
+++ b/apps/web/src/pages/use-daemon-canvas-controller.ts
@@ -156,17 +156,11 @@ export function useDaemonCanvasController(
         setCreateError(errorMessage(err))
         // The caller derives its next slug from `canvases`. A failure often means that list is
         // already stale (another client took the slug) — without a refresh, a retry re-derives
-        // the SAME losing slug from the same stale list and collides forever.
-        try {
-          const { canvases: refreshed } = await listCanvasesApi(
-            daemonFetch,
-            daemonBaseUrl,
-            workspaceId,
-          )
-          setCanvases(refreshed)
-        } catch {
-          // Best-effort: leaving the previous (possibly stale) list is no worse than not trying.
-        }
+        // the SAME losing slug from the same stale list and collides forever. Best-effort:
+        // leaving the previous (possibly stale) list is no worse than not trying.
+        await listCanvasesApi(daemonFetch, daemonBaseUrl, workspaceId)
+          .then(({ canvases: refreshed }) => setCanvases(refreshed))
+          .catch(() => {})
       }
     },
     [daemonFetch, daemonBaseUrl, workspaceId],

--- a/docs/contributing/adr/0006-object-oriented-ui.md
+++ b/docs/contributing/adr/0006-object-oriented-ui.md
@@ -1,6 +1,6 @@
 # ADR-0006: Object-oriented UI — create from the palette, act from the object
 
-**Status:** Accepted — one known violation, recorded below
+**Status:** Accepted
 
 ## Context
 
@@ -19,8 +19,8 @@ already selected instead of competing for room in a global menu.
 `ToolPalette.tsx` has carried this decision in a header comment since it was
 written, citing an "ooui-palette-vs-object-actions decision" that exists
 nowhere in the repository. That comment is the only place the rule is
-written down, so surfaces built elsewhere have not consistently followed it —
-see the violation below. This ADR is that missing document.
+written down, so surfaces built elsewhere have not consistently followed it.
+This ADR is that missing document.
 
 ## Decision
 
@@ -43,21 +43,9 @@ Concretely:
    surface, not a memorized strip, and shows icon **and** text. This is
    restated as criterion 2 of
    `.claude/skills/review-gate/resources/accessibility.md`, which the design
-   phases and the `accessibility` review dimension load.
-
-## Known violation
-
-`DaemonCanvasPage.tsx` mounts a permanent creation **form** in its
-empty-workspace view: a `New canvas name…` text input plus a `Create canvas`
-text button. It violates points 1, 3, and 4 at once — a verb-first form,
-always present whether or not the user intends to create anything, demanding
-a name before the object exists.
-
-`CanvasDropdown.tsx` shows the conforming shape for the same capability in a
-reading surface: a `New canvas…` entry with an icon **and** a label.
-
-This is recorded rather than quietly fixed so the ADR describes the shipped
-state. Correcting the page is follow-up work, not part of writing this down.
+   phases and the `accessibility` review dimension load. `CanvasDropdown.tsx`
+   shows the conforming shape: a `New canvas…` entry with an icon **and** a
+   label.
 
 ## Consequences
 
@@ -92,5 +80,4 @@ accessible-name criterion. The surface, not the icon, decides.
 
 **Leave the rule in the ToolPalette comment.** Zero effort, and it is what the
 repo did until now. Rejected because a rule reachable only by opening one
-component is not a rule the next surface will follow — which the violation
-above demonstrates.
+component is not a rule the next surface will consistently follow.


### PR DESCRIPTION
Removes the last violation ADR-0006 recorded, and deletes the `## Known violation` section because none remains.

`DaemonCanvasPage`'s empty-workspace view mounted a `New canvas name…` input plus a `Create canvas` submit button — the same verb-first, name-before-object shape corrected on the canvas list in #559. It is now a single **text-labelled** `Create a canvas` button that derives a collision-free slug and creates immediately; naming happens afterwards in the canvas's own top bar.

The label stays text on purpose. ADR-0006 point 4 keys style to the **surface**, not the action: an empty state is a reading surface, so it keeps its words. Only the dense toolbar strip on the list page took the icon-only `+`. Copying the icon here would have been the icon-for-its-own-sake failure the criteria warn about.

Reuse over reinvention: the existing `deriveNewCanvasSlug` helper (unit- and property-tested, added in #559) is imported rather than duplicated, and the `if (creating) return` guard that #559 deleted as unprovable is deliberately **not** reintroduced — `disabled={creating}` remains the whole mechanism.

## A second bug found while checking the analogous failure path

The task asked whether this page had the same losing-slug failure mode as the list page. It did, one layer down: `useDaemonCanvasController.createCanvas` refreshed its `canvases` list only on success. After a failed create the caller re-derived its next slug from the same stale list and re-sent the identical losing slug. Fixed with a best-effort refresh on the failure path too.

## Verification

```
apps/web    Test Files 142 passed   Tests 1697 passed
web-browser Test Files   9 passed   Tests   51 passed
typecheck   clean
knip        clean
```

Mutation-checked independently by the integrator, not taken on report:

| mutation | result |
|---|---|
| drop the controller's failure refresh | ✅ the new controller test fails — **and** the `switchWorkspace` error test, so the refresh is load-bearing on two paths |
| drop `disabled={creating}` | ✅ the same-tick double-click test fails |

## Process note: this ran without a gate

The dev-loop run that produced these commits implemented against `design: null` and `planVerdict.pass: false`. Its design-revise agent died mid-stream, `null` overwrote the design, and the `hasDesign` escape hatch in `shouldBlockOnFailedPlanReview` let Implement proceed anyway. That hole is fixed separately in #566.

So this branch has **no reviewable design artifact**, and its PlanReview verdict is meaningless. I verified the result by hand instead: every instruction in the task spec checked against the actual diff (surface judgement, helper reuse, the non-reintroduced guard, the ADR reduction), plus the independent mutation checks above. What is genuinely missing and cannot be reconstructed is the design phase's record of alternatives considered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
