### PR TITLE
feat(dev-flow): let execution mode vary while the checkpoints stay the same

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -8,6 +8,20 @@ Always-on map of how work runs in this repo. Day-to-day development goes through
 
 Small change? Skip planning and go straight to `dev-loop`. Periodic product check? `dogfood-triage`. Periodic **codebase-health** check (standing problems a diff never shows — unwired/incomplete features, architecture/maintainability debt, contract drift, test gaps, onboarding friction)? `audit-triage` → integrator files survivors into Tasks / whiteboard canvases. Run it after each substantial fold, weekly, or pre-milestone.
 
+**Execution mode is chosen up front — the checkpoints are the invariant, who runs them is not.**
+
+| mode | for | verifying in a running app |
+|---|---|---|
+| `dev-loop` workflow | scope-disjoint parallel work, non-UI, a spec that will not move mid-flight | **impossible** — the `developer` agent has Read/Edit/Write/Bash/Glob/Grep and no browser |
+| main session, inline | UI/interaction work; exploratory work whose spec changes as you learn; anything needing judgement mid-course | native |
+| hybrid — **the default for UI** | implement inline, then run `review.workflow.mjs` over the diff | native, plus independent review |
+
+Choose as early as possible, and switch when investigation says otherwise: a dev-loop design that answers `manualVerification` with anything but `none:` stops **before** Implement and returns the approved design plus a recommendation, so the main session resumes from the plan instead of restarting. Passing `dogfood:true` + `appUrl` keeps the run instead.
+
+Inline work is held to the same design checkpoints by `node .claude/scripts/check-design.mjs <design.json>`, which lists the unmet ones individually rather than answering yes/no.
+
+Never drop the review lanes just because implementation moved inline. Adversarial verify and an independent QA agent catch what self-review structurally cannot — reviewing your own work is weakest at exactly the self-skepticism those lanes supply.
+
 **Parallelism — don't serialize development.** Independent items run as **concurrent dev-loops, each in its own worktree** so none contends on the main working tree. Create a ready worktree with `node .claude/scripts/new-worktree.mjs <name>` (`git worktree add` + `pnpm install`, ~6s), launch a `dev-loop` with `cwd=<worktree>`, run several at once, then `reconcile` and fold in dependency order. The main session orchestrates from repo root and never `cd`s away while workflows run (relative `scriptPath` would break).
 
 **The only constraint is write-scope disjointness — lane *count* is not.** Launch as many concurrent dev-loops as you have scope-disjoint work for; do not self-impose a lane cap. The gate per item is: its owned/edited files do not overlap another in-flight lane's (different files in the same dir are fine — git merges per file; a *shared* file means sequence them). Tests-only additions (new `*.test.ts`) are almost always disjoint and safe to fan out widely. Fold/`reconcile` cost is the only real ceiling, and it is cheap relative to idle capacity.

--- a/.claude/scripts/check-design.mjs
+++ b/.claude/scripts/check-design.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Run the design checkpoints against a design document, from ANY execution mode.
+//
+// The workflow's PlanReview gate enforces these on a design an agent produced. Work done inline in
+// the main session goes through no such gate, so the same checkpoints are runnable here — the bar
+// belongs to the change, not to whoever happens to be executing it.
+//
+//   node .claude/scripts/check-design.mjs design.json
+//   echo '{...}' | node .claude/scripts/check-design.mjs
+//
+// Exit 0 when every checkpoint is met, 1 with one line per unmet checkpoint.
+import { readFileSync } from 'node:fs'
+import { explainDesignShape } from '../workflows/lib/explain-design.mjs'
+
+const file = process.argv[2]
+let raw
+try {
+  raw = file && file !== '-' ? readFileSync(file, 'utf8') : readFileSync(0, 'utf8')
+} catch (err) {
+  process.stderr.write(`could not read ${file ?? 'stdin'}: ${err.message}\n`)
+  process.exit(2)
+}
+
+let design
+try {
+  design = JSON.parse(raw)
+} catch (err) {
+  process.stderr.write(`not valid JSON: ${err.message}\n`)
+  process.exit(2)
+}
+
+const problems = explainDesignShape(design)
+if (problems.length === 0) {
+  process.stdout.write('design checkpoints: all met\n')
+  process.exit(0)
+}
+process.stdout.write(`design checkpoints: ${problems.length} unmet\n`)
+for (const p of problems) process.stdout.write(`  - ${p}\n`)
+process.exit(1)

--- a/.claude/workflows/dev-loop.workflow.mjs
+++ b/.claude/workflows/dev-loop.workflow.mjs
@@ -127,6 +127,14 @@ const DESIGN_SCHEMA = {
       description:
         'The concrete path by which a user reaches this change, naming the entry point that makes it reachable and confirming this increment adds it (e.g. "registered via registerToolWithAnnotations + called by smoke:e2e"; "rendered by CanvasList, reachable from /w/:ws"; "mounted on the Hono app in createServer"). Never empty. When the increment deliberately lands unwired, supply exactly one entry "foundation: <reason> — wired by <named follow-up>"; an unwired slice with no named follow-up is not an acceptable answer.',
     },
+    // Optional by design: an absent answer preserves the previous behaviour. When present and not
+    // `none:`, dev-loop hands the design back to the main session BEFORE implementing, because the
+    // `developer` agent has no browser and can only report the unmet step afterwards.
+    manualVerification: {
+      type: 'string',
+      description:
+        'What must be looked at in a running app for this change to count as verified (AGENTS.md step 3) — e.g. "open a canvas, drag a node, watch the edge re-route". Answer "none: <reason>" when tests alone settle it (a pure helper, a server-side path, a docs change).',
+    },
   },
   required: ['completionCriteria', 'scope', 'testScenarios', 'properties', 'blastRadius', 'userReach'],
 }
@@ -200,6 +208,7 @@ const ALLOWED_TOP_LEVEL_KEYS = [
   'properties',
   'blastRadius',
   'userReach',
+  'manualVerification',
 ]
 const ALLOWED_TEST_SCENARIO_KEYS = ['unit', 'browser', 'e2e']
 
@@ -226,6 +235,7 @@ function isValidDesignShape(d) {
   if (!isNonBlankList(d.properties)) return false
   if (!isNonBlankList(d.blastRadius)) return false
   if (!isNonBlankList(d.userReach)) return false
+  if (d.manualVerification !== undefined && typeof d.manualVerification !== 'string') return false
   return true
 }
 
@@ -236,6 +246,27 @@ function isValidDesignShape(d) {
 function shouldGenerateDesign({ hasDesign, skipDesign, discardedInvalidProvidedDesign }) {
   if (hasDesign) return false
   return !skipDesign || !!discardedInvalidProvidedDesign
+}
+
+// Mirrors .claude/workflows/lib/explain-design.mjs (unit-tested via node:test — the workflow
+// sandbox has no module resolution, so it is duplicated rather than imported; keep both in sync).
+// The `developer` agent has no browser, so it cannot perform AGENTS.md step 3 and can only report
+// the debt afterwards. When the design says a running app must be looked at, the cheapest moment
+// to switch execution mode is here — the design is written and reviewed, so the main session
+// resumes from an approved plan instead of restarting.
+function shouldHandBackForLiveVerification({ manualVerification, dogfood }) {
+  const answer = typeof manualVerification === 'string' ? manualVerification.trim() : ''
+  if (answer === '' || answer.startsWith('none:') || dogfood) {
+    return { handBack: false, recommendation: '' }
+  }
+  return {
+    handBack: true,
+    recommendation:
+      `This change needs verifying in a running app (${answer}), which no pipeline agent can do. ` +
+      'Recommend implementing it from the main session, which has the browser tools, then running ' +
+      'review.workflow.mjs over the resulting diff for the independent dimensions and QA. ' +
+      'Re-run this dev-loop with dogfood:true + appUrl instead if a persona pass is enough.',
+  }
 }
 
 // Gates the Implement phase on the PlanReview gate's final verdict. A failed gate ALWAYS blocks:
@@ -258,7 +289,7 @@ if (design && !isValidDesignShape(design)) {
 if (shouldGenerateDesign({ hasDesign: !!design, skipDesign: SKIP_DESIGN, discardedInvalidProvidedDesign })) {
   phase('Design')
   design = await agent(
-    `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), risks, \`properties\`, and \`blastRadius\`.\n\n\`properties\` — the invariants, round-trips, or metamorphic relations this change must preserve (e.g. parser/serializer round-trip, state-machine invariant, CRDT idempotence/convergence, concurrent-store convergence). Never empty: for a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry \`"none: <reason>"\` instead.\n\n\`blastRadius\` — who ELSE this change reaches, which \`scope\` does not answer. Enumerate the existing call sites/consumers of every symbol you plan to change, and flag each one with whether a test would fail if the change broke it; a caller with NO covering test is the finding this field exists to surface. Prefer an impact-graph MCP tool when one is connected (e.g. code-review-graph's \`get_impact_radius_tool\`/\`query_graph_tool\`, after a \`build_or_update_graph_tool\` refresh); otherwise fall back to grep over the symbol names. Never empty: supply exactly one entry \`"none: <reason>"\` for a genuine leaf change with no existing callers, or \`"unavailable: <reason>"\` if no impact tool is connected AND grep is not workable here — do not stall the gate over it.\n\n\`userReach\` — how a USER reaches this, which \`blastRadius\` does not answer. Name the concrete entry point that makes the change reachable and confirm THIS increment adds it: the MCP tool registration (+ the \`smoke:e2e\` step that calls it), the Hono route mounted on the app, the parent that renders the component on a real screen, the flag that is not only parsed but read. A slice that builds, typechecks and passes its tests while nothing registers/mounts/renders it delivers nothing and comes back as rework — its tests pass precisely because they call the new code directly. Never empty: if this increment deliberately lands unwired, supply exactly one entry \`"foundation: <reason> — wired by <named follow-up>"\`. An unwired slice with no named follow-up is not an acceptable answer; either wire it here or name what wires it.\n\nIf and only if this change touches a UI surface (\`apps/web\`, \`canvas-viewer\`, or anything rendered to a user), read \`.claude/skills/review-gate/resources/accessibility.md\` and fold its constraints into the design and into \`testScenarios\` — accessible names, keyboard reachability, focus behavior around anything that opens, and whether an affordance you are adding is pointer-only. Those are the criteria the \`accessibility\` review dimension judges the built result by, so meeting them here costs a sentence instead of a rewrite. Skip this entirely for non-UI changes.\n\nDo NOT write code yet.`,
+    `Write a design doc for this dev task. Task: ${TASK}\nSpec: ${SPEC}\n${cwdNote}\nInspect the relevant code first, then produce: completion criteria, change scope, contract/Zod/type impact, test scenarios (unit/browser/e2e), risks, \`properties\`, and \`blastRadius\`.\n\n\`properties\` — the invariants, round-trips, or metamorphic relations this change must preserve (e.g. parser/serializer round-trip, state-machine invariant, CRDT idempotence/convergence, concurrent-store convergence). Never empty: for a stateless/pure-UI change with no parser/store/state-machine surface, supply exactly one entry \`"none: <reason>"\` instead.\n\n\`blastRadius\` — who ELSE this change reaches, which \`scope\` does not answer. Enumerate the existing call sites/consumers of every symbol you plan to change, and flag each one with whether a test would fail if the change broke it; a caller with NO covering test is the finding this field exists to surface. Prefer an impact-graph MCP tool when one is connected (e.g. code-review-graph's \`get_impact_radius_tool\`/\`query_graph_tool\`, after a \`build_or_update_graph_tool\` refresh); otherwise fall back to grep over the symbol names. Never empty: supply exactly one entry \`"none: <reason>"\` for a genuine leaf change with no existing callers, or \`"unavailable: <reason>"\` if no impact tool is connected AND grep is not workable here — do not stall the gate over it.\n\n\`userReach\` — how a USER reaches this, which \`blastRadius\` does not answer. Name the concrete entry point that makes the change reachable and confirm THIS increment adds it: the MCP tool registration (+ the \`smoke:e2e\` step that calls it), the Hono route mounted on the app, the parent that renders the component on a real screen, the flag that is not only parsed but read. A slice that builds, typechecks and passes its tests while nothing registers/mounts/renders it delivers nothing and comes back as rework — its tests pass precisely because they call the new code directly. Never empty: if this increment deliberately lands unwired, supply exactly one entry \`"foundation: <reason> — wired by <named follow-up>"\`. An unwired slice with no named follow-up is not an acceptable answer; either wire it here or name what wires it.\n\nIf and only if this change touches a UI surface (\`apps/web\`, \`canvas-viewer\`, or anything rendered to a user), read \`.claude/skills/review-gate/resources/accessibility.md\` and fold its constraints into the design and into \`testScenarios\` — accessible names, keyboard reachability, focus behavior around anything that opens, and whether an affordance you are adding is pointer-only. Those are the criteria the \`accessibility\` review dimension judges the built result by, so meeting them here costs a sentence instead of a rewrite. Skip this entirely for non-UI changes.\n\n`manualVerification` — what must be looked at in a RUNNING app for this to count as verified (AGENTS.md step 3). Be concrete: "open a canvas, drag a node, watch the edge re-route". Answer `"none: <reason>"` when tests alone settle it (a pure helper, a server-side path, a docs change). Answer honestly: no pipeline agent has a browser, so a non-`none:` answer stops this run and hands the design back to the main session to implement with real browser tools — that is the intended outcome, not a failure.\n\nDo NOT write code yet.`,
     { label: 'design', phase: 'Design', schema: DESIGN_SCHEMA },
   )
 }
@@ -322,6 +353,28 @@ if (shouldBlockOnFailedPlanReview({ pass: planVerdict.pass })) {
     openFollowups: [],
     needsHumanGate: true,
     note: `PlanReview did not pass after ${MAX_PLAN_REV} revision(s); returning to the integrator instead of implementing a rejected design. mustFix: ${(planVerdict.mustFix || []).join('; ')}`,
+  }
+}
+
+const liveVerification = shouldHandBackForLiveVerification({
+  manualVerification: design && design.manualVerification,
+  dogfood: DOGFOOD,
+})
+if (liveVerification.handBack) {
+  log(`handing back before Implement: ${liveVerification.recommendation}`)
+  return {
+    taskTitle: TASK,
+    baseRef: BASE,
+    cwd: CWD,
+    design,
+    planVerdict,
+    codexPlanVerdict,
+    implReport: null,
+    review: null,
+    openFollowups: [],
+    needsHumanGate: true,
+    recommendation: liveVerification.recommendation,
+    note: 'Design approved but NOT implemented: it needs verification in a running app, which no pipeline agent can perform. The design is returned intact so the main session can implement from it.',
   }
 }
 

--- a/.claude/workflows/lib/design-schema.mjs
+++ b/.claude/workflows/lib/design-schema.mjs
@@ -59,6 +59,14 @@ export const DESIGN_SCHEMA = {
       description:
         'The concrete path by which a user reaches this change, naming the entry point that makes it reachable and confirming this increment adds it (e.g. "registered via registerToolWithAnnotations + called by smoke:e2e"; "rendered by CanvasList, reachable from /w/:ws"; "mounted on the Hono app in createServer"). Never empty. When the increment deliberately lands unwired, supply exactly one entry "foundation: <reason> — wired by <named follow-up>"; an unwired slice with no named follow-up is not an acceptable answer.',
     },
+    // Optional by design: an absent answer preserves the previous behaviour. When present and not
+    // `none:`, dev-loop hands the design back to the main session BEFORE implementing, because the
+    // `developer` agent has no browser and can only report the unmet step afterwards.
+    manualVerification: {
+      type: 'string',
+      description:
+        'What must be looked at in a running app for this change to count as verified (AGENTS.md step 3) — e.g. "open a canvas, drag a node, watch the edge re-route". Answer "none: <reason>" when tests alone settle it (a pure helper, a server-side path, a docs change).',
+    },
   },
   required: ['completionCriteria', 'scope', 'testScenarios', 'properties', 'blastRadius', 'userReach'],
 }
@@ -84,6 +92,7 @@ const ALLOWED_TOP_LEVEL_KEYS = [
   'properties',
   'blastRadius',
   'userReach',
+  'manualVerification',
 ]
 const ALLOWED_TEST_SCENARIO_KEYS = ['unit', 'browser', 'e2e']
 
@@ -112,6 +121,7 @@ export function isValidDesignShape(d) {
   if (!isNonBlankList(d.properties)) return false
   if (!isNonBlankList(d.blastRadius)) return false
   if (!isNonBlankList(d.userReach)) return false
+  if (d.manualVerification !== undefined && typeof d.manualVerification !== 'string') return false
   return true
 }
 

--- a/.claude/workflows/lib/explain-design.mjs
+++ b/.claude/workflows/lib/explain-design.mjs
@@ -1,0 +1,99 @@
+// The per-checkpoint half of the design gate. `isValidDesignShape` answers yes/no, which is all
+// the workflow needs; someone working inline in the main session needs to know WHICH checkpoint is
+// missing so the design can be brought up to the same bar one field at a time.
+//
+// Each entry below is one checkpoint. Keeping them as data rather than a chain of `if`s is what
+// makes the gate divisible: a caller can report all of them, or one, or filter to the ones a
+// particular task actually touches.
+
+const nonBlankList = (v) =>
+  Array.isArray(v) && v.length > 0 && v.every((x) => typeof x === 'string' && /\S/.test(x))
+const stringList = (v) => Array.isArray(v) && v.every((x) => typeof x === 'string')
+
+const CHECKPOINTS = [
+  {
+    field: 'completionCriteria',
+    ok: (d) => stringList(d.completionCriteria) && d.completionCriteria !== undefined,
+    supply: 'a list of observable criteria, each one a test could check',
+  },
+  {
+    field: 'scope',
+    ok: (d) => typeof d.scope === 'string',
+    supply: 'the files you intend to edit',
+  },
+  {
+    field: 'testScenarios.unit',
+    ok: (d) => !!d.testScenarios && typeof d.testScenarios === 'object' && stringList(d.testScenarios.unit) && d.testScenarios.unit !== undefined,
+    supply: 'at least one nearest-layer test scenario (see the test-layer-selection skill)',
+  },
+  {
+    field: 'properties',
+    ok: (d) => nonBlankList(d.properties),
+    supply: 'the invariants/round-trips this change must preserve, or one "none: <reason>" entry',
+  },
+  {
+    field: 'blastRadius',
+    ok: (d) => nonBlankList(d.blastRadius),
+    supply:
+      'who else in the codebase this reaches and whether a test watches them, or one "none: <reason>" / "unavailable: <reason>" entry',
+  },
+  {
+    field: 'userReach',
+    ok: (d) => nonBlankList(d.userReach),
+    supply:
+      'the entry point that makes this reachable by a user, or one "foundation: <reason> — wired by <named follow-up>" entry',
+  },
+]
+
+/**
+ * List what a design is still missing, one checkpoint per entry. Empty means it clears the same
+ * bar the workflow's PlanReview gate enforces.
+ *
+ * @param {unknown} design
+ * @returns {string[]}
+ */
+export function explainDesignShape(design) {
+  if (!design || typeof design !== 'object' || Array.isArray(design)) {
+    return ['design: supply a design object with the checkpoint fields (see DESIGN_SCHEMA)']
+  }
+  const problems = []
+  for (const { field, ok, supply } of CHECKPOINTS) {
+    if (ok(design)) continue
+    const raw = field.split('.').reduce((acc, k) => (acc == null ? acc : acc[k]), design)
+    const state = raw === undefined ? 'missing' : 'present but empty or malformed'
+    problems.push(`${field}: ${state} — supply ${supply}`)
+  }
+  return problems
+}
+
+/**
+ * Decide whether a run should stop and hand the design back to the main session instead of
+ * implementing it.
+ *
+ * The pipeline's `developer` agent has Read/Edit/Write/Bash/Glob/Grep and no browser, so it cannot
+ * perform AGENTS.md step 3 — it can only report the debt afterwards, which is what an observed run
+ * did after spending its whole budget. When the design itself says the change needs looking at in
+ * a running app, the cheapest moment to switch execution mode is here: the design is already
+ * written and reviewed, so the main session resumes from an approved plan rather than restarting.
+ *
+ * Fail-safe by construction: an absent or blank answer preserves the previous behaviour rather
+ * than halting runs whose designs predate the field. `dogfood: true` means the caller already
+ * arranged a live browser lane, so the verification has somewhere to happen inside the run.
+ *
+ * @param {{manualVerification?: unknown, dogfood?: boolean}} input
+ * @returns {{handBack: boolean, recommendation: string}}
+ */
+export function shouldHandBackForLiveVerification({ manualVerification, dogfood }) {
+  const answer = typeof manualVerification === 'string' ? manualVerification.trim() : ''
+  if (answer === '' || answer.startsWith('none:') || dogfood) {
+    return { handBack: false, recommendation: '' }
+  }
+  return {
+    handBack: true,
+    recommendation:
+      `This change needs verifying in a running app (${answer}), which no pipeline agent can do. ` +
+      'Recommend implementing it from the main session, which has the browser tools, then running ' +
+      'review.workflow.mjs over the resulting diff for the independent dimensions and QA. ' +
+      'Re-run this dev-loop with dogfood:true + appUrl instead if a persona pass is enough.',
+  }
+}

--- a/.claude/workflows/lib/explain-design.test.mjs
+++ b/.claude/workflows/lib/explain-design.test.mjs
@@ -1,0 +1,115 @@
+// Run with: node --test .claude/workflows/lib/explain-design.test.mjs
+// `isValidDesignShape` answers yes/no, which is all the workflow gate needs. A human working
+// inline needs the other half: WHICH checkpoint is missing, one at a time, so a design can be
+// brought up to the same bar incrementally instead of being re-submitted blind.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { explainDesignShape } from './explain-design.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+import { isValidDesignShape } from './design-schema.mjs'
+
+const complete = {
+  completionCriteria: ['users can export a canvas'],
+  scope: 'apps/web/src/pages/Export.tsx',
+  testScenarios: { unit: ['export returns a PNG'] },
+  properties: ['none: pure UI wiring'],
+  blastRadius: ['none: new leaf module'],
+  userReach: ['rendered by CanvasPage, reachable from /w/:ws'],
+}
+
+test('a complete design explains nothing', () => {
+  assert.deepEqual(explainDesignShape(complete), [])
+})
+
+test('each missing checkpoint is reported separately, naming the field', () => {
+  const { blastRadius, userReach, ...partial } = complete
+  const problems = explainDesignShape(partial)
+  assert.equal(problems.length, 2)
+  assert.ok(problems.some((p) => p.includes('blastRadius')))
+  assert.ok(problems.some((p) => p.includes('userReach')))
+})
+
+test('a problem says what to supply, not just what is wrong', () => {
+  const { userReach, ...partial } = complete
+  assert.match(explainDesignShape(partial)[0], /foundation:/)
+})
+
+test('a blank entry is reported as its own problem, distinct from a missing field', () => {
+  const blank = explainDesignShape({ ...complete, blastRadius: ['   '] })
+  const missing = explainDesignShape({ ...complete, blastRadius: undefined })
+  assert.equal(blank.length, 1)
+  assert.equal(missing.length, 1)
+  assert.notEqual(blank[0], missing[0])
+})
+
+test('a non-object is one problem, not a crash', () => {
+  for (const bad of [null, undefined, 'nope', []]) {
+    assert.equal(explainDesignShape(bad).length, 1)
+  }
+})
+
+// One source of truth: the gate's boolean is derived from the explanation, so a checkpoint can
+// never be enforced by one and ignored by the other.
+test('isValidDesignShape agrees with explainDesignShape on every fixture', () => {
+  for (const d of [complete, {}, null, { ...complete, userReach: [] }, { ...complete, scope: 42 }]) {
+    assert.equal(isValidDesignShape(d), explainDesignShape(d).length === 0, JSON.stringify(d))
+  }
+})
+
+// --- execution-mode handback ---
+import { shouldHandBackForLiveVerification } from './explain-design.mjs'
+
+// The observed failure: dev-loop implemented a UI change, then reported "manual browser
+// verification was not performed — no browser-automation MCP tool was available in this
+// subagent's toolset". The developer agent's tools are Read/Edit/Write/Bash/Glob/Grep; it
+// structurally cannot do AGENTS.md step 3. Learning that AFTER implementing costs the whole run.
+test('a design needing live verification hands back before implementing', () => {
+  const r = shouldHandBackForLiveVerification({ manualVerification: 'drag a node and watch the edge re-route', dogfood: false })
+  assert.equal(r.handBack, true)
+  assert.match(r.recommendation, /main session/i)
+})
+
+test('the none: sentinel does not hand back', () => {
+  assert.equal(shouldHandBackForLiveVerification({ manualVerification: 'none: pure server-side helper', dogfood: false }).handBack, false)
+})
+
+// Absent means the design never answered, which must preserve the existing behaviour rather than
+// stopping every run that predates the field.
+test('an absent answer does not hand back', () => {
+  for (const v of [undefined, null, '', '   ']) {
+    assert.equal(shouldHandBackForLiveVerification({ manualVerification: v, dogfood: false }).handBack, false)
+  }
+})
+
+// dogfood:true means the caller already arranged a browser lane against a running app, so the
+// verification the design asks for has somewhere to happen inside the run.
+test('an explicit dogfood lane suppresses the handback', () => {
+  assert.equal(shouldHandBackForLiveVerification({ manualVerification: 'click the toolbar button', dogfood: true }).handBack, false)
+})
+
+// The workflow keeps a mirrored inline copy (no module resolution in the sandbox); this is what
+// keeps the two honest, and it also pins that the handback happens BEFORE Implement — a handback
+// after implementing would defeat its whole purpose.
+test('inline shouldHandBackForLiveVerification in dev-loop matches this module, and gates Implement', () => {
+  const source = readFileSync(path.join(__dirname, '..', 'dev-loop.workflow.mjs'), 'utf8')
+  const match = source.match(/\nfunction shouldHandBackForLiveVerification\(\{[\s\S]*?\n\}\n/)
+  assert.ok(match, 'could not locate the inline shouldHandBackForLiveVerification')
+  // eslint-disable-next-line no-new-func -- evaluating our own source
+  const inline = new Function(`${match[0]}\nreturn shouldHandBackForLiveVerification`)()
+  for (const input of [
+    { manualVerification: 'drag a node', dogfood: false },
+    { manualVerification: 'none: pure helper', dogfood: false },
+    { manualVerification: 'drag a node', dogfood: true },
+    { manualVerification: undefined, dogfood: false },
+  ]) {
+    assert.deepEqual(inline(input), shouldHandBackForLiveVerification(input), JSON.stringify(input))
+  }
+  assert.ok(
+    source.indexOf('if (liveVerification.handBack)') < source.indexOf('// --- Phase 3: implement'),
+    'the handback must be evaluated before the Implement phase',
+  )
+})


### PR DESCRIPTION
The pipeline cannot do everything, and until now the discipline lived only inside it.

`dev-loop`'s `developer` agent has `Read/Edit/Write/Bash/Glob/Grep` and **no browser**, so it structurally cannot perform AGENTS.md step 3 ("open the real screen and confirm the behavior directly"). An observed run implemented a UI change and then reported the debt:

> Manual browser verification was not performed — no browser-automation MCP tool was available in this subagent's toolset. … This manual-verification step is owed to the integrator before merge.

Meanwhile the main session — which *does* have the browser — went through no design gate at all. The checkpoints and the executor were welded together, so picking the right executor meant giving up the checkpoints.

## Three pieces

**1. The checkpoints, divisible and runnable from anywhere.** `explainDesignShape` lists the unmet ones individually instead of answering yes/no:

```
$ echo '{"completionCriteria":["…"],"scope":"…","testScenarios":{"unit":["…"]},"properties":["none: …"]}' \
    | node .claude/scripts/check-design.mjs
design checkpoints: 2 unmet
  - blastRadius: missing — supply who else in the codebase this reaches and whether a test
    watches them, or one "none: <reason>" / "unavailable: <reason>" entry
  - userReach: missing — supply the entry point that makes this reachable by a user, or one
    "foundation: <reason> — wired by <named follow-up>" entry
```

They are data, not a chain of `if`s, so a caller can report all of them or filter to the ones a task touches. `isValidDesignShape` is pinned to agree with the explanation on every fixture, so a checkpoint can never be enforced by the gate and ignored by the CLI.

**2. Handing back early, with a recommendation.** A new optional `manualVerification` design field asks what must be looked at in a running app. Answered with anything but `none:`, dev-loop stops **before** Implement and returns the approved design plus:

> This change needs verifying in a running app (…), which no pipeline agent can do. Recommend implementing it from the main session, which has the browser tools, then running `review.workflow.mjs` over the resulting diff for the independent dimensions and QA. Re-run this dev-loop with `dogfood:true` + `appUrl` instead if a persona pass is enough.

The design **survives the handback**, so the main session resumes from a reviewed plan instead of restarting — deciding early is only cheap if changing your mind is too. Fail-safe by construction: an absent answer preserves today's behaviour, and `dogfood:true` suppresses the handback because the caller already arranged a live lane.

**3. The rule, now short.** `dev-flow.md` gains a mode table (workflow / inline / hybrid, with hybrid the default for UI) and one paragraph. It stays short because pieces 1 and 2 answer mechanically what would otherwise be prose — the repo's own ladder puts executable above rule.

The one thing the doc insists on: **never drop the review lanes just because implementation moved inline.** Self-review is weakest at exactly the skepticism an adversarial verify supplies. Both of this session's real catches — a reproduced defect, and an overstated "mutation-checked" claim in a commit message — came from independent lanes, not from the author.

## Verification

```
$ pnpm test:scripts
ℹ tests 179
ℹ pass 179
ℹ fail 0
```

| mutation | result |
|---|---|
| move the handback after Implement | ✅ the ordering assertion fails |
| make the `none:` sentinel hand back too | ✅ the inline-mirror diff fails |

`explain-design.mjs` follows the established pattern for logic the workflow sandbox cannot import (`design-schema.mjs`, `normalize-dimensions.mjs`, `fix-loop.mjs`): a canonical tested module plus a drift test that evaluates the workflow's inline copy and diffs the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
