### PR TITLE
fix(dev-flow): remove both warnings a fresh worktree printed on every run

### DIFF
--- a/.claude/scripts/new-worktree.mjs
+++ b/.claude/scripts/new-worktree.mjs
@@ -10,7 +10,7 @@
 //
 // Remove when done: git worktree remove --force .claude/worktrees/<name>
 import { execFileSync, spawnSync } from 'node:child_process'
-import { existsSync, realpathSync } from 'node:fs'
+import { cpSync as nodeCpSync, existsSync, realpathSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { deriveDevPort } from '../../packages/mcp-server/scripts/dev/dev-port-lib.mjs'
@@ -40,6 +40,33 @@ export function runWireStep({ scriptPath, wtPath, spawn = spawnSync, log = (msg)
   } catch (err) {
     log(`[new-worktree] failed to wire Claude Code MCP for ${wtPath} (${err.message}). ${fallback}`)
     return { success: false }
+  }
+}
+
+/**
+ * Copy the main checkout's built `packages/mcp-server/dist` into a fresh worktree BEFORE its first
+ * `pnpm install`.
+ *
+ * That install links every workspace dep's declared `bin`, and @kamiazya/whiteboard-mcp declares
+ * `whiteboard -> dist/cli/index.js`. `dist` is gitignored, so a new worktree has none and pnpm
+ * prints two ENOENT warnings it can do nothing about. Seeding the directory first removes them,
+ * and leaves the worktree able to run the server without a build.
+ *
+ * Never load-bearing: an absent build or a failed copy is logged and skipped, because a worktree
+ * that exists without this is still a working worktree. The copy is a starting point, not a
+ * substitute for building — anything editing mcp-server rebuilds anyway.
+ *
+ * @returns {boolean} whether a dist was seeded
+ */
+export function seedBuiltDist({ mainRoot, worktreeRoot, existsSync: exists = existsSync, cpSync = nodeCpSync, log = (msg) => console.warn(msg) }) {
+  const from = `${mainRoot}/packages/mcp-server/dist`
+  if (!exists(from)) return false
+  try {
+    cpSync(from, `${worktreeRoot}/packages/mcp-server/dist`, { recursive: true })
+    return true
+  } catch (err) {
+    log(`[new-worktree] could not seed the built dist (${err.message}) — pnpm will warn about the unlinkable \`whiteboard\` bin; harmless.`)
+    return false
   }
 }
 
@@ -78,6 +105,9 @@ function main() {
   const run = (cmd, args) => execFileSync(cmd, args, { stdio: 'inherit' })
   if (!baseArg) run('git', ['-C', repoRoot, 'fetch', 'origin'])
   run('git', ['-C', repoRoot, 'worktree', 'add', wtPath, '-b', name, base])
+  // Before the first install: see seedBuiltDist for why pnpm cannot link the `whiteboard` bin
+  // otherwise.
+  seedBuiltDist({ mainRoot: repoRoot, worktreeRoot: wtPath })
   run('pnpm', ['--dir', wtPath, 'install', '--prefer-offline'])
 
   // A linked worktree always has a `.git` FILE (not a directory) at its root,

--- a/.claude/scripts/new-worktree.test.mjs
+++ b/.claude/scripts/new-worktree.test.mjs
@@ -67,3 +67,54 @@ test('runWireStep: reports success when the wire script exits zero', () => {
 
   assert.equal(result.success, true)
 })
+
+// --- pre-seeding the built dist ---
+import { seedBuiltDist } from './new-worktree.mjs'
+
+// `pnpm install` links every workspace dep's declared `bin`. @kamiazya/whiteboard-mcp declares
+// `whiteboard -> dist/cli/index.js`, and `dist` is gitignored, so a fresh worktree's FIRST install
+// cannot create the symlink and pnpm prints two ENOENT warnings. Verified: seeding dist before
+// that first install removes them. Moving the bin path was rejected — `dist/cli/index.js` is
+// pinned by prepend-cli-shebang, check-release-artifacts and three distribution smokes, and none
+// of that release surface should move for an install-time warning.
+test('seeds the built dist when the main checkout has one', () => {
+  const copies = []
+  const ok = seedBuiltDist({
+    mainRoot: '/repo',
+    worktreeRoot: '/wt',
+    existsSync: (p) => p === '/repo/packages/mcp-server/dist',
+    cpSync: (from, to) => copies.push([from, to]),
+    log: () => {},
+  })
+  assert.equal(ok, true)
+  assert.deepEqual(copies, [['/repo/packages/mcp-server/dist', '/wt/packages/mcp-server/dist']])
+})
+
+test('skips silently when the main checkout has no build yet', () => {
+  const copies = []
+  const ok = seedBuiltDist({
+    mainRoot: '/repo',
+    worktreeRoot: '/wt',
+    existsSync: () => false,
+    cpSync: (from, to) => copies.push([from, to]),
+    log: () => {},
+  })
+  assert.equal(ok, false)
+  assert.deepEqual(copies, [])
+})
+
+// Seeding is an optimisation, never a reason a worktree fails to be created.
+test('a copy failure is reported and swallowed', () => {
+  const logs = []
+  const ok = seedBuiltDist({
+    mainRoot: '/repo',
+    worktreeRoot: '/wt',
+    existsSync: () => true,
+    cpSync: () => {
+      throw new Error('disk full')
+    },
+    log: (m) => logs.push(m),
+  })
+  assert.equal(ok, false)
+  assert.ok(logs.some((m) => m.includes('disk full')))
+})

--- a/.claude/scripts/wire-worktree-mcp-lib.mjs
+++ b/.claude/scripts/wire-worktree-mcp-lib.mjs
@@ -245,3 +245,22 @@ export function removeStaleEntriesFromConfig(config, actions) {
   }
   return { ...config, projects }
 }
+
+/**
+ * True when this checkout is a LINKED worktree whose CLI-resolved project entry is the main
+ * checkout's, and that entry already holds `name`.
+ *
+ * `claude mcp add --scope local` keys its write by the project the CLI resolves, which for a
+ * linked worktree is the main checkout — there is only ever one project key per repository in
+ * ~/.claude.json. So an add attempted from a worktree lands on the main entry and fails with
+ * "already exists". The add cannot succeed, and retrying it each time a worktree is created just
+ * prints a failed command line. Detect it first and explain instead.
+ *
+ * @param {{ config: unknown, repoRoot: string, mainRoot: string, name: string }} input
+ */
+export function resolvesToAnotherProjectEntry({ config, repoRoot, mainRoot, name }) {
+  if (repoRoot === mainRoot) return false
+  const projects = config && typeof config === 'object' ? config.projects : null
+  if (!projects || typeof projects !== 'object') return false
+  return Boolean(projects[mainRoot]?.mcpServers?.[name])
+}

--- a/.claude/scripts/wire-worktree-mcp-lib.test.mjs
+++ b/.claude/scripts/wire-worktree-mcp-lib.test.mjs
@@ -313,3 +313,45 @@ test('docs-lock: the manual fallback `claude mcp add` command in development.md 
 
   assert.equal(docsFragment, expectedFragment, 'docs fallback command argv order must match buildClaudeMcpAddArgs')
 })
+
+// --- linked-worktree project-key collision ---
+import { resolvesToAnotherProjectEntry } from './wire-worktree-mcp-lib.mjs'
+
+// Observed on every `new-worktree.mjs` run: the script reads ~/.claude.json under the WORKTREE
+// path, finds nothing, and calls `claude mcp add --scope local` — which fails with "MCP server
+// whiteboard already exists in local config". ~/.claude.json holds exactly one project key for
+// this repo (the main checkout), so the CLI resolves a linked worktree to the main project and
+// collides with the entry already there. The add can never succeed; attempting it just prints a
+// failed command (with a redacted bearer token) on every worktree creation.
+test('a linked worktree whose main checkout already holds the entry is reported, not retried', () => {
+  const config = { projects: { '/repo': { mcpServers: { whiteboard: { type: 'http' } } } } }
+  assert.equal(
+    resolvesToAnotherProjectEntry({ config, repoRoot: '/repo/.claude/worktrees/x', mainRoot: '/repo', name: 'whiteboard' }),
+    true,
+  )
+})
+
+test('the main checkout itself is never treated as a collision', () => {
+  const config = { projects: { '/repo': { mcpServers: { whiteboard: {} } } } }
+  assert.equal(
+    resolvesToAnotherProjectEntry({ config, repoRoot: '/repo', mainRoot: '/repo', name: 'whiteboard' }),
+    false,
+  )
+})
+
+test('a worktree is not a collision when the main checkout has no such entry', () => {
+  const config = { projects: { '/repo': { mcpServers: {} } } }
+  assert.equal(
+    resolvesToAnotherProjectEntry({ config, repoRoot: '/repo/.claude/worktrees/x', mainRoot: '/repo', name: 'whiteboard' }),
+    false,
+  )
+})
+
+test('a missing or malformed config is not a collision', () => {
+  for (const config of [null, undefined, {}, { projects: null }]) {
+    assert.equal(
+      resolvesToAnotherProjectEntry({ config, repoRoot: '/repo/wt', mainRoot: '/repo', name: 'whiteboard' }),
+      false,
+    )
+  }
+})

--- a/.claude/scripts/wire-worktree-mcp.mjs
+++ b/.claude/scripts/wire-worktree-mcp.mjs
@@ -38,6 +38,7 @@ import {
   redactBearerTokens,
   removeStaleEntriesFromConfig,
   resolveMainCheckoutRoot,
+  resolvesToAnotherProjectEntry,
   verifyPostWrite,
 } from './wire-worktree-mcp-lib.mjs'
 
@@ -169,6 +170,20 @@ function defaultLiveWorktreePaths(mainCheckoutRoot) {
   return Array.from(raw.matchAll(/^worktree (.+)$/gm), (m) => resolve(m[1].trim()))
 }
 
+// The main checkout of a linked worktree: `git rev-parse --git-common-dir` points at the main
+// repository's .git, whose parent is that checkout.
+function mainCheckoutRoot(repoRoot) {
+  try {
+    const commonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim()
+    return resolve(commonDir, '..')
+  } catch {
+    return repoRoot
+  }
+}
+
 function wireWorktree({ worktreeRoot, env, spawn, readConfig, log, isMainCheckoutOverride, claudeCliAvailableOverride }) {
   const repoRoot = resolve(worktreeRoot)
   const mainCheckout = isMainCheckoutOverride ?? isMainCheckout(repoRoot)
@@ -216,7 +231,26 @@ function wireWorktree({ worktreeRoot, env, spawn, readConfig, log, isMainCheckou
     return
   }
 
-  // outcome === 'absent'
+  // outcome === 'absent' under THIS path — but `claude mcp add --scope local` keys its write by
+  // the project the CLI resolves, and a linked worktree resolves to the main checkout. If that
+  // entry already exists, the add fails with "already exists" no matter how often it is retried.
+  if (
+    resolvesToAnotherProjectEntry({
+      config: existingConfig,
+      repoRoot,
+      mainRoot: mainCheckoutRoot(repoRoot),
+      name: desired.name,
+    })
+  ) {
+    log(
+      `[wire-worktree-mcp] skipping: \`claude mcp add --scope local\` resolves a linked worktree to the ` +
+        `main checkout, which already registers "${desired.name}". ~/.claude.json holds one project key ` +
+        `per repository, so a per-worktree registration is not something the CLI can express. This ` +
+        `worktree's daemon still binds ${desired.url} — point a client at it directly if you need it.`,
+    )
+    return
+  }
+
   assertNotTrackedSettingsPath(CLAUDE_CONFIG_PATH)
   const addArgs = buildClaudeMcpAddArgs(desired)
   const result = spawn('claude', addArgs, { cwd: repoRoot })


### PR DESCRIPTION
`node .claude/scripts/new-worktree.mjs <name>` printed three warnings on every single run. Neither cause was harmful, and neither was something the developer could act on — which is exactly how a warning becomes noise people scroll past, taking the next real one with it.

## `claude mcp add` could never have succeeded

```
[wire-worktree-mcp] `claude mcp add --transport http whiteboard http://127.0.0.1:3593/mcp
  --scope local --header Authorization: Bearer [redacted]` failed (exit 1):
  MCP server whiteboard already exists in local config
```

`~/.claude.json` holds **one project key per repository** — verified: after many worktrees, it contains exactly one key for this repo, the main checkout. The CLI resolves a linked worktree to that same project, so an add attempted from a worktree lands on the entry already there and collides.

The script read the config under the *worktree* path, found nothing, concluded `absent`, and retried the impossible add every time. It now detects the collision before spawning and explains the constraint instead — including the port this worktree's daemon actually binds, so a client can be pointed at it directly:

```
[wire-worktree-mcp] skipping: `claude mcp add --scope local` resolves a linked worktree to the
main checkout, which already registers "whiteboard". ~/.claude.json holds one project key per
repository, so a per-worktree registration is not something the CLI can express. This worktree's
daemon still binds http://127.0.0.1:3958/mcp — point a client at it directly if you need it.
```

## pnpm could not link the `whiteboard` bin

```
[WARN] Failed to create bin at .../apps/web/node_modules/.bin/whiteboard.
  ENOENT: ... packages/mcp-server/dist/cli/index.js
```

`pnpm install` links every workspace dep's declared `bin`. `@kamiazya/whiteboard-mcp` declares `whiteboard -> dist/cli/index.js`, and `dist` is gitignored — so a fresh worktree's **first** install has no target. Seeding the main checkout's `dist` before that install removes both warnings.

**Rejected: moving the bin path.** `dist/cli/index.js` is pinned by `prepend-cli-shebang.mjs`, `check-release-artifacts.mjs`, and three distribution smokes. That release surface should not move for an install-time warning.

**A measurement that had to be redone.** The first attempt compared installs with and without `dist` and saw zero warnings both times — because a *re-install* never warns regardless of `dist`. Only a genuinely fresh worktree exhibits it. The rerun did it properly: `git worktree add` → seed `dist` → first `pnpm install` → warning gone.

## Result

```
$ node .claude/scripts/new-worktree.mjs warnfix-final
ready worktree: …/warnfix-final
  dev daemon port: 3958
[wire-worktree-mcp] skipping: … (the explanation above)

real 0m2.227s
```

No warnings. The bin symlink is now actually created, and worktree creation got **faster** (~2.2s vs ~4–10s) because install has less to do. The seeded `dist` also leaves a worktree able to run the server before its first build — a starting point, not a substitute: anything editing `mcp-server` rebuilds anyway.

Both paths are fail-safe. No build in the main checkout, a failed copy, or a missing config each skip silently rather than stopping worktree creation — a worktree that exists without either nicety is still a working worktree.

```
$ pnpm test:scripts
ℹ tests 186
ℹ pass 186
ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
