### PR TITLE
fix(test): stop the exposure property failing on a host that collides with its own error code

### DIFF
--- a/packages/mcp-server/src/server/security/server-mode-exposure.test.ts
+++ b/packages/mcp-server/src/server/security/server-mode-exposure.test.ts
@@ -412,6 +412,46 @@ describe('resolveServerModeExposure — deterministic contract anchors', () => {
 
 // Property 1: any https URL with a non-empty search/hash/credentials is
 // rejected, and the failure decision does not echo the raw URL.
+// Shared by the property and by the pinned counterexample below, so a regression in the assertion
+// itself is caught deterministically rather than only on the seeds that happen to generate a
+// colliding host.
+function assertRejectedWithoutEcho({
+  host,
+  suffix,
+  kind,
+}: {
+  host: string
+  suffix: string
+  kind: 'query' | 'fragment' | 'credentials'
+}) {
+  // Canary strings are long enough that they cannot be substrings of any
+  // failure code token.
+  const canary = `CANARY_${suffix}`
+  let url: string
+  switch (kind) {
+    case 'query':
+      url = `https://${host}?token=${canary}`
+      break
+    case 'fragment':
+      url = `https://${host}#${canary}`
+      break
+    case 'credentials':
+      url = `https://${canary}:${canary}@${host}`
+      break
+  }
+
+  const d: ServerModeExposureDecision = resolveServerModeExposure({
+    mode: 'server-mode',
+    bindHost: '0.0.0.0',
+    externalUrl: url,
+  })
+  expect(d.ok).toBe(false)
+  const serialized = JSON.stringify(d)
+  // The canary and the full URL must not appear in the failure decision.
+  expect(serialized).not.toContain(canary)
+  expect(serialized).not.toContain(url)
+}
+
 // We use a `CANARY_` prefix on generated values so short substrings cannot
 // accidentally appear inside error code tokens (e.g. "a" in "external").
 fcTest.prop(
@@ -429,35 +469,16 @@ fcTest.prop(
   withDefaults(),
 )(
   'any https URL with credentials/query/fragment is rejected and failure does not echo those pieces',
-  ({ host, suffix, kind }) => {
-    // Canary strings are long enough that they cannot be substrings of any
-    // failure code token.
-    const canary = `CANARY_${suffix}`
-    let url: string
-    switch (kind) {
-      case 'query':
-        url = `https://${host}?token=${canary}`
-        break
-      case 'fragment':
-        url = `https://${host}#${canary}`
-        break
-      case 'credentials':
-        url = `https://${canary}:${canary}@${host}`
-        break
-    }
-
-    const d: ServerModeExposureDecision = resolveServerModeExposure({
-      mode: 'server-mode',
-      bindHost: '0.0.0.0',
-      externalUrl: url,
-    })
-    expect(d.ok).toBe(false)
-    const serialized = JSON.stringify(d)
-    // The canary and the full URL must not appear in the failure decision.
-    expect(serialized).not.toContain(canary)
-    expect(serialized).not.toContain(host)
-  },
+  (input) => assertRejectedWithoutEcho(input),
 )
+
+// The shrunk counterexample from the property above, pinned as an example: `e.ex` is a substring
+// of the failure's own constant code (`server_mod<e.ex>ternal_url_must_be_origin`), so asserting
+// the bare host collides with a token the decision is entitled to contain. Nothing leaked — the
+// assertion was wrong, and only some seeds reach a host short enough to expose it.
+it('does not treat a host that is a substring of the failure code as a leak', () => {
+  assertRejectedWithoutEcho({ host: 'e.ex', suffix: '10000000', kind: 'query' })
+})
 
 // Property 2: any accepted server-mode decision has an origin-only publicBaseUrl.
 fcTest.prop(


### PR DESCRIPTION
CI hit this on an unrelated, markdown-only PR (#579), seed `811708841`, shrunk counterexample `host: "e.ex"`:

```
expected '{"ok":false,"code":"server_mode.external_url_must_be_origin"}'
  not to contain 'e.ex'
```

**Nothing leaked.** `e.ex` is a substring of the failure's own constant code:

```
server_mod e.ex ternal_url_must_be_origin
           ^^^^
```

So `expect(serialized).not.toContain(host)` flagged a token the decision is entitled to contain. Only seeds that generate a host short enough to collide reach it, which is why it lay dormant.

## The test already knew

Two lines above the assertion:

> `fc.domain()` produces hostnames that are valid but arbitrary — wrapping in a canary prefix is not needed for host **since we only check the full URL, not the host alone**.

And above that:

> We use a `CANARY_` prefix on generated values **so short substrings cannot accidentally appear inside error code tokens** (e.g. "a" in "external").

The reasoning was right and written down; the assertion just did not match it. It now asserts the full URL, as documented.

`AGENTS.md`'s usual prescriptions do not apply: this is not load-related, so reducing `numRuns` would not help, and pinning the seed would hide it rather than fix it.

## The pinned example had to be rewritten, because the first one was vacuous

Per the repo's discipline, the shrunk counterexample is pinned as an example test. My first attempt wrote it as a standalone `it()` with its own expectations — and the mutation check refused it:

| attempt | revert the assertion to `not.toContain(host)` |
|---|---|
| standalone `it()` with duplicated expectations | ❌ **still passed** — it never ran the property's assertion |
| property body extracted, both call one assertion | ✅ fails deterministically |

So the property's body is extracted into `assertRejectedWithoutEcho`, called by both the property and the pinned example. That extraction is the whole point: a guard that does not fail when you reintroduce the bug is not a guard, and a seed-dependent failure is not a regression test.

## Verification

```
$ pnpm vitest run --project mcp-node
Test Files  262 passed (262)
Tests  3215 passed | 5 skipped (3220)
```

Mutation-checked as above: restoring `not.toContain(host)` fails the pinned example every run, not on unlucky seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
