### PR TITLE
feat(web): edit the OKF core facets on spatial canvases too

### DIFF
--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -1,4 +1,4 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { CanvasCoreMeta, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -44,6 +44,9 @@ export interface UseCanvasSyncResult {
   /** Node ids locked in the doc's sidecar map (never part of the canvas value). */
   lockedNodeIds: ReadonlySet<string>
   setNodeLock: (nodeId: string, locked: boolean) => void
+  /** OKF core facets from the doc's sidecar map; undefined until hydrated or when never written. */
+  coreFacets: CanvasCoreMeta | undefined
+  setCoreFacets: (meta: CanvasCoreMeta) => void
   lockedEdgeIds: ReadonlySet<string>
   setEdgeLock: (edgeId: string, locked: boolean) => void
   canRedo: () => boolean
@@ -159,6 +162,7 @@ export function useCanvasSync(
   // Render signal only — the value itself is never read.
   const [, setHistoryVersion] = useState(0)
   const [lockedNodeIds, setLockedNodeIds] = useState<ReadonlySet<string>>(EMPTY_LOCKED_IDS)
+  const [coreFacets, setCoreFacetsState] = useState<CanvasCoreMeta | undefined>(undefined)
   const [lockedEdgeIds, setLockedEdgeIds] = useState<ReadonlySet<string>>(EMPTY_LOCKED_IDS)
   const [restoreInProgress, setRestoreInProgress] = useState(false)
   const [restoreLabel, setRestoreLabel] = useState<string | null>(null)
@@ -219,12 +223,18 @@ export function useCanvasSync(
       setLockedNodeIds(session.getNodeLocks())
       setLockedEdgeIds(session.getEdgeLocks())
     })
+    // Facets change no canvas value either, so they need their own
+    // notification for the same reason locks do.
+    const unsubscribeCoreFacets = session.subscribeCoreFacets(() => {
+      setCoreFacetsState(session.getCoreFacets())
+    })
     // Seed from the session as well as subscribing: hydration can complete
     // BEFORE this effect runs (the backend may deliver a snapshot
     // synchronously), and a missed notification would otherwise leave a
     // persisted lock invisible until the next toggle.
     setLockedNodeIds(session.getNodeLocks())
     setLockedEdgeIds(session.getEdgeLocks())
+    setCoreFacetsState(session.getCoreFacets())
     session.connect()
     session.onEditorReady()
 
@@ -232,6 +242,7 @@ export function useCanvasSync(
       unsubscribe()
       unsubscribeHistory()
       unsubscribeLocks()
+      unsubscribeCoreFacets()
       session.dispose()
     }
   }, [backend])
@@ -253,6 +264,10 @@ export function useCanvasSync(
   // the session on each render is always current and never stale.
   const setEdgeLock = useCallback((edgeId: string, locked: boolean) => {
     sessionRef.current?.setEdgeLock(edgeId, locked)
+  }, [])
+
+  const setCoreFacets = useCallback((meta: CanvasCoreMeta) => {
+    sessionRef.current?.setCoreFacets(meta)
   }, [])
 
   const setNodeLock = useCallback((nodeId: string, locked: boolean) => {
@@ -334,6 +349,8 @@ export function useCanvasSync(
     canUndo,
     lockedNodeIds,
     setNodeLock,
+    coreFacets,
+    setCoreFacets,
     lockedEdgeIds,
     setEdgeLock,
     canRedo,

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -8,8 +8,10 @@
 
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import {
+  readCoreFacets,
   readSpatialCanvas,
   setNodeLock,
+  writeCoreFacets,
   writeSpatialCanvas,
 } from '@kamiazya/whiteboard-canvas-workspace'
 import type {
@@ -1027,6 +1029,88 @@ describe('createCanvasSyncSession', () => {
       const result = readSpatialCanvas(merged)
       expect(result.edges).toEqual([])
       expect(result.nodes.find((n) => n.id === 'n-b')).toMatchObject({ text: 'renamed-by-peer' })
+    })
+  })
+
+  // Core facets live in the doc's own sidecar map exactly like a lock: never
+  // part of the canvas VALUE, so they must not publish a canvas, and the
+  // consumer only learns about them through a subscription — which is why
+  // hydration has to notify.
+  describe('core facets', () => {
+    it('hydration reports the persisted facets, not the default (reload regression)', () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+
+      const doc = new LoroDoc()
+      writeSpatialCanvas(doc, twoNodeCanvas())
+      writeCoreFacets(doc, { type: 'diagram', title: 'Stored title' })
+      const listener = vi.fn()
+      session.subscribeCoreFacets(listener)
+
+      backend._ctrl.handlers!.onSnapshot(doc.export({ mode: 'snapshot' }))
+
+      expect(session.getCoreFacets()).toEqual({ type: 'diagram', title: 'Stored title' })
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('reports undefined when the doc carries no core facets at all', () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+      expect(session.getCoreFacets()).toBeUndefined()
+    })
+
+    it('setCoreFacets pushes to peers and notifies, without publishing a canvas', async () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+      const canvasListener = vi.fn()
+      session.subscribe(canvasListener)
+      const facetListener = vi.fn()
+      session.subscribeCoreFacets(facetListener)
+      const pushesBefore = backend._ctrl.pushLocalUpdateCalls.length
+
+      session.setCoreFacets({ type: 'diagram', title: 'Renamed' })
+      await Promise.resolve()
+
+      expect(session.getCoreFacets()).toEqual({ type: 'diagram', title: 'Renamed' })
+      expect(facetListener).toHaveBeenCalled()
+      // A facet is not a canvas value — republishing would make the editor
+      // re-render its whole scene for a title edit.
+      expect(canvasListener).not.toHaveBeenCalled()
+      expect(backend._ctrl.pushLocalUpdateCalls.length).toBeGreaterThan(pushesBefore)
+    })
+
+    it('leaves the canvas value untouched when facets are written', () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+      // The canvas arrives as a snapshot; only the facet write travels as a
+      // pushed update, so a peer's view is snapshot THEN updates.
+      const snapshot = makeSnapshot(twoNodeCanvas())
+      backend._ctrl.handlers!.onSnapshot(snapshot)
+
+      session.setCoreFacets({ type: 'diagram', title: 'Renamed' })
+
+      const peer = new LoroDoc()
+      peer.import(snapshot)
+      for (const update of backend._ctrl.pushLocalUpdateCalls) peer.import(update)
+      expect(readSpatialCanvas(peer).nodes).toHaveLength(twoNodeCanvas().nodes.length)
+      expect(readCoreFacets(peer)).toEqual({ type: 'diagram', title: 'Renamed' })
+    })
+
+    it('is a no-op before a doc exists rather than throwing', () => {
+      const backend = makeFakeBackend()
+      const session = createCanvasSyncSession(backend, makeDeps())
+      session.connect()
+
+      expect(() => session.setCoreFacets({ type: 'diagram' })).not.toThrow()
+      expect(session.getCoreFacets()).toBeUndefined()
     })
   })
 

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -1,6 +1,7 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { CanvasCoreMeta, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import {
   deleteSpatialNode,
+  readCoreFacets,
   readEdgeLocks,
   readNodeLocks,
   readSpatialCanvas,
@@ -8,6 +9,7 @@ import {
   withSpatialBatch,
   setEdgeLock as workspaceSetEdgeLock,
   setNodeLock as workspaceSetNodeLock,
+  writeCoreFacets,
   writeSpatialCanvas,
   writeSpatialEdge,
   writeSpatialNode,
@@ -149,6 +151,14 @@ export interface CanvasSyncSession {
   getEdgeLocks(): ReadonlySet<string>
   setEdgeLock(edgeId: string, locked: boolean): void
   subscribeLocks(listener: () => void): () => void
+  // OKF core facets (type/title/tags/facetsRaw) live in the doc's own
+  // sidecar map, exactly like a lock: durable and peer-synced, yet never
+  // part of the canvas value, so a title edit neither reaches an export as
+  // a node nor makes the editor re-render its scene. `undefined` means the
+  // document has never had core meta written.
+  getCoreFacets(): CanvasCoreMeta | undefined
+  setCoreFacets(meta: CanvasCoreMeta): void
+  subscribeCoreFacets(listener: () => void): () => void
   // Current published canvas value (empty canvas before the first snapshot).
   getCanvas(): SpatialCanvas
   // Registers a listener for every published canvas value. `origin` tags
@@ -321,6 +331,7 @@ export function createCanvasSyncSession(
   let undoManager: UndoManager | null = null
   const historyListeners = new Set<() => void>()
   const lockListeners = new Set<() => void>()
+  const coreFacetListeners = new Set<() => void>()
   // Microtask defer: onPush fires inside Loro's commit, and a listener that
   // synchronously setStates mid-commit would re-enter React from a doc
   // mutation path.
@@ -571,6 +582,8 @@ export function createCanvasSyncSession(
             publishCanvasFromDoc(newDoc)
             // A remote peer may have locked or unlocked something.
             notifyLocksChanged()
+            // ...or retitled the document.
+            notifyCoreFacetsChanged()
           }
         })
 
@@ -578,6 +591,8 @@ export function createCanvasSyncSession(
         // Hydration decides the lock set for this session — without this,
         // a persisted lock reads as absent until the next toggle.
         notifyLocksChanged()
+        // Same for the stored title: absent until the next edit otherwise.
+        notifyCoreFacetsChanged()
       },
 
       onRemoteUpdate(bytes) {
@@ -804,6 +819,31 @@ export function createCanvasSyncSession(
     }
   }
 
+  function getCoreFacets(): CanvasCoreMeta | undefined {
+    return doc === null ? undefined : readCoreFacets(doc)
+  }
+
+  function notifyCoreFacetsChanged(): void {
+    for (const listener of coreFacetListeners) listener()
+  }
+
+  function setCoreFacets(meta: CanvasCoreMeta): void {
+    if (doc === null) return
+    // `writeCoreFacets` REPLACES the stored bucket, so `meta` must already be
+    // complete — including `facetsRaw`. Reaches peers through the doc's own
+    // subscribeLocalUpdates push, like a lock; the canvas VALUE is unchanged,
+    // so subscribers get a facet notification rather than a canvas publish.
+    writeCoreFacets(doc, meta)
+    notifyCoreFacetsChanged()
+  }
+
+  function subscribeCoreFacets(listener: () => void): () => void {
+    coreFacetListeners.add(listener)
+    return () => {
+      coreFacetListeners.delete(listener)
+    }
+  }
+
   return {
     connect,
     dispose,
@@ -822,5 +862,8 @@ export function createCanvasSyncSession(
     getEdgeLocks,
     setEdgeLock,
     subscribeLocks,
+    getCoreFacets,
+    setCoreFacets,
+    subscribeCoreFacets,
   }
 }

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -204,6 +204,44 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     })
   })
 
+  it('a spatial canvas gets the same properties bar, and its title round-trips', async () => {
+    const store = new IndexedDBStore()
+    await store.setDefaultCanvasId('spatial-1')
+    await store.save({
+      id: 'spatial-1',
+      name: 'Diagram A',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+      kind: 'spatial' as const,
+    })
+    const first = render(<BrowserLocalCanvasPage store={store} />)
+    await screen.findByTestId('mock-spatial-editor')
+
+    // Facets belong to the CANVAS, so a spatial canvas has the bar too —
+    // its document just lives behind the sync session's delta protocol
+    // rather than the markdown hook's snapshot save.
+    const title = await screen.findByRole('textbox', { name: /title/i }, { timeout: 10_000 })
+    // A canvas that predates the facet bar shows its NAME as the title, not
+    // an empty box the user would have to retype.
+    expect((title as HTMLInputElement).value).toBe('Diagram A')
+
+    await userEvent.click(title)
+    await userEvent.keyboard('{Control>}a{/Control}')
+    await userEvent.keyboard('Architecture map')
+    await screen.findByRole('button', { name: 'Architecture map' }, { timeout: 10_000 })
+
+    await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
+    first.unmount()
+
+    render(<BrowserLocalCanvasPage store={store} />)
+    await waitFor(
+      () => {
+        const restored = screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
+        expect(restored.value).toBe('Architecture map')
+      },
+      { timeout: 10_000 },
+    )
+  })
+
   it('spatial canvases still open the spatial editor after a markdown note exists', async () => {
     const store = new IndexedDBStore()
     // Distinctly-named spatial canvas so the round trip back to it is

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -227,7 +227,9 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     await userEvent.click(title)
     await userEvent.keyboard('{Control>}a{/Control}')
     await userEvent.keyboard('Architecture map')
-    await screen.findByRole('button', { name: 'Architecture map' }, { timeout: 10_000 })
+    // Regex rather than an exact name: the switcher's accessible name carries
+    // more than its label text, so a full-string match asserts the wrong thing.
+    await screen.findByRole('button', { name: /Architecture map/ }, { timeout: 10_000 })
 
     await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
     first.unmount()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,3 +1,4 @@
+import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import { Copy, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -95,6 +96,21 @@ function persistenceLabel(status: BrowserLocalPersistenceState): string {
     case 'degraded':
       return status.message
   }
+}
+
+/**
+ * The core meta to show when a canvas has none stored yet — every canvas
+ * that predates the facet bar, which is all of them.
+ *
+ * `title` is seeded from the canvas NAME rather than left blank: the two are
+ * one concept, so a canvas already called "Diagram A" must show that as its
+ * title, not an empty box the user has to retype. `untitled` is the list's
+ * placeholder for an unnamed canvas, so it stays a placeholder here instead
+ * of becoming a real stored title on the first unrelated edit.
+ */
+function fallbackCoreMeta(kind: CanvasSnapshot['kind'], name: string | null): CanvasCoreMeta {
+  const title = name && name !== 'untitled' ? name : undefined
+  return { type: kind, ...(title ? { title } : {}) }
 }
 
 export function BrowserLocalCanvasPage({
@@ -266,6 +282,8 @@ export function BrowserLocalCanvasPage({
     setNodeLock,
     lockedEdgeIds,
     setEdgeLock,
+    coreFacets,
+    setCoreFacets,
   } = useCanvasSync(backend)
 
   // The seams themselves are backend-agnostic (see use-canvas-file-seams.ts);
@@ -485,7 +503,7 @@ export function BrowserLocalCanvasPage({
             <div className="flex h-full min-h-0 flex-col">
               <CanvasProperties
                 key={canvasId ?? 'no-canvas'}
-                meta={markdownDoc.coreMeta}
+                meta={markdownDoc.coreMeta ?? fallbackCoreMeta(canvasKind, canvasName)}
                 onChange={(next) => {
                   markdownDoc.setCoreMeta(next)
                   // title and the canvas name are ONE concept: the facet is
@@ -515,38 +533,58 @@ export function BrowserLocalCanvasPage({
             </div>
           )
         ) : (
-          // Keyed on canvas identity: the editor's pan/zoom, in-flight
-          // gesture and open text editor all describe ONE canvas, and
-          // `SpatialCanvas` carries no id for the editor to notice a switch
-          // by. Without the key, switching canvases silently inherits the
-          // previous canvas's viewport. (The markdown branch keys for the
-          // same reason.)
-          <SpatialEditor
-            key={canvasId ?? 'no-canvas'}
-            canvas={canvas}
-            onChange={onChange}
-            externalVersion={externalVersion}
-            theme={resolvedTheme}
-            // File-node reference = browser-local canvas id; the current
-            // canvas is excluded (a self-reference card is pure noise).
-            fileRefOptions={canvases
-              .filter((entry) => entry.id !== canvasId)
-              .map((entry) => ({ file: entry.id, label: entry.name }))}
-            onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
-            {...fileSeams}
-            lockedNodeIds={lockedNodeIds}
-            lockedEdgeIds={lockedEdgeIds}
-            onToggleNodeLock={setNodeLock}
-            onToggleEdgeLock={setEdgeLock}
-            paletteLeading={
-              <HistoryCluster
-                onUndo={() => void undo()}
-                onRedo={() => void redo()}
-                canUndo={canUndo()}
-                canRedo={canRedo()}
+          <div className="flex h-full min-h-0 flex-col">
+            {/* Same bar as the markdown branch. A spatial canvas has no body
+                to sit above, so it sits above the viewport instead — the
+                facets belong to the CANVAS, not to either editor. */}
+            <CanvasProperties
+              key={canvasId ?? 'no-canvas'}
+              meta={coreFacets ?? fallbackCoreMeta(canvasKind, canvasName)}
+              onChange={(next) => {
+                setCoreFacets(next)
+                if (next.title !== coreFacets?.title) {
+                  void renameCanvas(next.title ?? '').catch(() => {
+                    // Surfaced through persistence state; the facet write is
+                    // independent and has already landed in the document.
+                  })
+                }
+              }}
+            />
+            <div className="relative min-h-0 flex-1">
+              {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
+                  gesture and open text editor all describe ONE canvas, and
+                  `SpatialCanvas` carries no id for the editor to notice a
+                  switch by. Without the key, switching canvases silently
+                  inherits the previous canvas's viewport. (The markdown
+                  branch keys for the same reason.) */}
+              <SpatialEditor
+                key={canvasId ?? 'no-canvas'}
+                canvas={canvas}
+                onChange={onChange}
+                externalVersion={externalVersion}
+                theme={resolvedTheme}
+                // File-node reference = browser-local canvas id; the current
+                // canvas is excluded (a self-reference card is pure noise).
+                fileRefOptions={canvases
+                  .filter((entry) => entry.id !== canvasId)
+                  .map((entry) => ({ file: entry.id, label: entry.name }))}
+                onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
+                {...fileSeams}
+                lockedNodeIds={lockedNodeIds}
+                lockedEdgeIds={lockedEdgeIds}
+                onToggleNodeLock={setNodeLock}
+                onToggleEdgeLock={setEdgeLock}
+                paletteLeading={
+                  <HistoryCluster
+                    onUndo={() => void undo()}
+                    onRedo={() => void redo()}
+                    canUndo={canUndo()}
+                    canRedo={canRedo()}
+                  />
+                }
               />
-            }
-          />
+            </div>
+          </div>
         )}
         {/* Markdown canvases keep CodeMirror's own history (its keymap
             already handles undo); the history group rides the spatial


### PR DESCRIPTION
#582 shipped the properties bar for markdown canvases only and named this as
the follow-up: a spatial canvas keeps its document inside the sync session,
behind the backend's delta protocol, so the bar could not reach it.

**That estimate was too pessimistic, and the commit says so.** The doc had
already been extracted out of `useCanvasSync` into `CanvasSyncSession`, a
plain non-React module — and node/edge **locks are an exact structural
precedent**: sidecar state in the doc, never part of the canvas value,
exposed as a get/set/subscribe trio, reaching peers through the doc's own
`subscribeLocalUpdates` push. Core facets are the same shape, so this mirrors
the lock trio rather than exposing the doc or adding a second doc owner.

## Two deliberate properties, both mirroring locks

**Facets never publish a canvas.** A title edit must not make the editor
re-render its whole scene, and a facet must never reach an export as a node.
The test asserts the canvas listener is *not* called.

**Hydration notifies.** Otherwise a stored title reads as absent until the
next edit — the same reload regression the lock tests already pin.
Mutation-checked: deleting the hydration notification turns that test red.

## A migration gap this surfaced

Writing the round-trip test showed a canvas named "Diagram A" rendering an
**empty title box**. That is every canvas that predates the bar — and #582
shipped it for markdown too.

Since title and name are one concept, the fallback now seeds the title from
the canvas name. The list's `untitled` placeholder stays a placeholder rather
than becoming a real stored title on the first unrelated edit.

## Verification

Real app, spatial canvas — the bar renders above the viewport, `type` derives
from the canvas kind, and a Japanese title survives a reload with the
switcher label following:

```
before edit:  { titleBefore: "",             spatialEditorPresent: true }
after edit:   { titleAfter:  "構成図 2026",   switcher: "構成図 2026" }
after reload: { persistedTitle: "構成図 2026", type: "spatial",
                switcher: "構成図 2026" }
```

**One honest gap:** canvas-and-facet coexistence is covered by the session
test — which reconstructs a peer from snapshot + pushed updates and asserts
the nodes survive alongside the facets — but NOT in the running app. Placing
a node through the toolbar did not work from the automation harness after
three attempts, so that half of the manual check is a gap, not a pass.

## A flake lead, as a side effect

The second commit fixes an assertion that matched the switcher by EXACT
accessible name. That name carries the persistence status, which lands
asynchronously, so the match was racing a suffix rather than asserting the
rename. It passed until merging main shifted the timing, then failed 3/3
while a probe showed both the title box and the switcher reading the right
text. The pre-existing markdown tests in the same file assert exact names the
same way — a candidate source for the suite's load-dependent flakiness, which
is tracked separately.

Suites: apps/web jsdom 1733, web-browser 471, arch-lint 53, plus typecheck,
knip and biome.
