### PR TITLE
fix(web): keep the canvas switcher label on the open canvas's own snapshot

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -659,10 +659,13 @@ describe('BrowserLocalCanvasPage', () => {
     // Resolve generation 3 (fresh, matches the final c1 state) BEFORE
     // generation 2 (stale, superseded) — the out-of-order case the
     // generation guard exists to handle.
+    // The fresh marker rides a row OTHER than the open canvas: the open
+    // canvas's own label comes from the loaded snapshot, not from the list.
     const freshList: CanvasSnapshot[] = [
+      snap,
       {
-        id: 'c1',
-        name: 'untitled (fresh)',
+        id: 'c3',
+        name: 'Other canvas (fresh)',
         updatedAt: '2026-05-26T00:00:00.000Z',
         kind: 'spatial' as const,
       },
@@ -684,10 +687,54 @@ describe('BrowserLocalCanvasPage', () => {
 
     // The stale (generation 2) resolution must not clobber the fresh one:
     // opening the switcher again must show only the fresh name.
-    const switcherButton = await screen.findByRole('button', { name: 'untitled (fresh)' })
+    const switcherButton = await screen.findByRole('button', { name: 'untitled' })
     fireEvent.pointerDown(switcherButton, { button: 0, ctrlKey: false })
-    await screen.findByTestId('new-canvas-menu-item')
+    await screen.findByText('Other canvas (fresh)')
     expect(screen.queryByText('Other canvas (stale)')).toBeNull()
+  })
+
+  it('shows the renamed canvas in the switcher even when the list read wins the race against the save', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+
+    const resolvers: Array<(list: CanvasSnapshot[]) => void> = []
+    const controllableStore: BrowserLocalStore = {
+      getDefaultCanvasId: store.getDefaultCanvasId.bind(store),
+      setDefaultCanvasId: store.setDefaultCanvasId.bind(store),
+      load: store.load.bind(store),
+      save: store.save.bind(store),
+      del: store.del.bind(store),
+      generateId: store.generateId.bind(store),
+      listCanvases: () => new Promise((resolve) => resolvers.push(resolve)),
+    }
+
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={controllableStore} loro={new FakeLoroStore()} />)
+    })
+    await act(async () => {
+      resolvers[0]!([snap])
+    })
+
+    const canvasActions = await screen.findByLabelText('Canvas actions')
+    fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+    fireEvent.pointerUp(await screen.findByText('Rename canvas'))
+    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
+    fireEvent.keyDown(titleInput, { key: 'Enter' })
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Renamed canvas')
+    })
+
+    // The rename's list refresh resolves with the PRE-rename row: the store
+    // read raced the still-in-flight save and lost. Nothing schedules another
+    // refresh afterwards, so a list-only switcher label would stay stale
+    // forever — the current canvas's row must come from the loaded snapshot.
+    await act(async () => {
+      resolvers[resolvers.length - 1]!([snap])
+    })
+    expect(screen.getByRole('button', { name: 'Renamed canvas' })).toBeTruthy()
   })
 
   it('never triggers a React setState-in-render warning across mount, canvas switch, and create-canvas', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -721,16 +721,22 @@ describe('BrowserLocalCanvasPage', () => {
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     fireEvent.pointerUp(await screen.findByText('Rename canvas'))
     const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    const refreshesBeforeRename = resolvers.length
     fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
     fireEvent.keyDown(titleInput, { key: 'Enter' })
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Renamed canvas')
     })
 
-    // The rename's list refresh resolves with the PRE-rename row: the store
-    // read raced the still-in-flight save and lost. Nothing schedules another
-    // refresh afterwards, so a list-only switcher label would stay stale
-    // forever — the current canvas's row must come from the loaded snapshot.
+    // The rename must have queued a list refresh of its own — otherwise
+    // resolving "the latest" one below would just re-resolve an already-settled
+    // promise from mount and pass without exercising the race at all.
+    expect(resolvers.length).toBeGreaterThan(refreshesBeforeRename)
+
+    // It resolves with the PRE-rename row: the store read raced the
+    // still-in-flight save and lost. Nothing schedules another refresh
+    // afterwards, so a list-only switcher label would stay stale forever —
+    // the current canvas's row must come from the loaded snapshot.
     await act(async () => {
       resolvers[resolvers.length - 1]!([snap])
     })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -300,9 +300,17 @@ export function BrowserLocalCanvasPage({
   // selected id changes synchronously on switch/create. Synthesize a
   // fallback option for the gap between those two so the controlled
   // <select>'s value always matches one of its own options.
+  //
+  // The open canvas's own row is always taken from the loaded snapshot rather
+  // than from the list: the list read races the save that a rename queues, and
+  // a read that resolves first pins the pre-rename name with nothing left to
+  // schedule another refresh. The snapshot is this canvas's live truth; the
+  // list is only the copy the switcher reads for the OTHER canvases.
   const switcherOptions =
-    pageState.kind === 'editing' && !canvases.some((c) => c.id === pageState.snapshot.id)
-      ? [...canvases, pageState.snapshot]
+    pageState.kind === 'editing'
+      ? canvases.some((c) => c.id === pageState.snapshot.id)
+        ? canvases.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
+        : [...canvases, pageState.snapshot]
       : canvases
 
   if (pageState.kind === 'load-degraded') {


### PR DESCRIPTION
## Symptom

CI on `main` failed in `web-browser`:
[`BrowserLocalCanvasPage.markdown.browser.test.tsx > the title survives a remount and renames the canvas in the switcher`](https://github.com/kamiazya/whiteboard/actions/runs/31489056858/job/93771145946#step:5:1)

The DOM at failure time tells the whole story:

| element | source | value |
|---|---|---|
| `<h1>` | loaded snapshot | `リリース計画` ✅ |
| switcher button | canvas list | `リリース計` ❌ — one keystroke behind, never converged in 10s |

## Root cause

In local mode the switcher label comes from `canvases`, the asynchronously
refreshed `listCanvases()` result. That refresh only runs from the effect keyed
on `[canvasId, currentUpdatedAt, listCanvases]`.

A rename does `renameCanvas` → `setSnapshot` → effect fires → `listCanvases()`
reads the store — concurrently with the `store.save()` that same rename queued.
When the read resolves first it pins the **pre-rename** name, and since only a
change to `updatedAt` can trigger another refresh, **nothing schedules one**.
The stale label sticks forever.

Fast typing makes it deterministic rather than merely likely: `updatedAt` is
millisecond-resolution, so two renames landing in the same millisecond share it
and the second never re-fires the effect at all — leaving the switcher exactly
one keystroke behind, which is precisely what CI captured.

## Fix

The open canvas's row now always comes from the loaded snapshot; the list stays
the copy the switcher reads for the **other** canvases (`BrowserLocalCanvasPage.tsx:303`).

## Verification

Red test first, at the nearest layer that can make the race deterministic
(`apps/web` jsdom): a controllable `listCanvases` resolves the post-rename
refresh with the pre-rename row. Red before the fix, green after.

The existing "drops a stale listCanvases resolution" test keeps its invariant —
its fresh-marker just moved onto a row that is not the open canvas, since the
open canvas's label is snapshot-derived by design. Not weakened.

The race only surfaces under CI's slower IndexedDB: the browser test passed 3/3
locally without the fix, which is why the jsdom test is the regression guard.

```
apps/web jsdom     145 files | 1729 tests  passed
web-browser         82 files |  470 tests  passed
pnpm -r typecheck                          Done
```

## Manual verification

Real app (`pnpm --filter @kamiazya/whiteboard-web dev`): created a markdown note,
typed `リリース計画` into the title. The switcher label tracked it live, and both
`<h1>` and the switcher still read `リリース計画` after a reload.

No screenshot: `Page.captureScreenshot` times out against this app in the local
Chrome automation setup, so the test output above stands in as the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the canvas switcher to immediately reflect renamed or otherwise updated details for the currently open canvas.
  * Prevented stale asynchronous list results from overwriting the current canvas’s latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->