### PR TITLE
feat(web): one-tap tidy for the spatial canvas

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -109,6 +109,7 @@ import {
   Pencil,
   Scissors,
   SendToBack,
+  Sparkles,
   SquareDashed,
   StickyNote,
   Tag,
@@ -178,6 +179,7 @@ import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
+import { tidyNodes } from './tidy.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   canvasToScreen,
@@ -3124,6 +3126,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     },
                   })
                 }
+                // Tidy needs a second node to tidy AGAINST — the item appears
+                // only once it can do something, like Align/Distribute above.
+                if (canvas.nodes.length >= 2) {
+                  emptyItems.push({ kind: 'separator' })
+                  emptyItems.push({
+                    label: 'Tidy canvas',
+                    icon: <Sparkles />,
+                    onSelect: () =>
+                      applyBoxMoves(tidyNodes(canvasRef.current.nodes, { locked: isLocked })),
+                  })
+                }
                 // Empty space IS the canvas, so canvas-wide settings are acted
                 // on from here — the recorded OOUI rule puts actions on an
                 // existing object with that object, and keeps the dock's "+"
@@ -3448,6 +3461,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     selected: false,
                     onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
                   })),
+                })
+              }
+              if (alignableCount >= 2) {
+                items.push({
+                  label: 'Tidy',
+                  icon: <Sparkles />,
+                  onSelect: () =>
+                    applyBoxMoves(
+                      tidyNodes(canvasRef.current.nodes, {
+                        scope: new Set([node.id, ...extraIds]),
+                        locked: isLocked,
+                      }),
+                    ),
                 })
               }
               if (lockEnabled) {

--- a/apps/web/src/components/spatial-editor/tidy.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/tidy.browser.test.tsx
@@ -1,0 +1,160 @@
+// Tidy in the editor. The geometry itself is unit-tested in tidy.test.ts;
+// this pins the wiring: a multi-node selection gets a Tidy action scoped to
+// the selection, empty space gets a whole-canvas one, one action is one undo
+// step, and a locked node is never moved.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import type { EditorCommand } from './commands.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// 'b' sits 8px off a's column — inside the tidy band — with plenty of
+// vertical clearance, so the only tidy move is b.x 48 → 40.
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 120, height: 60, text: 'A' },
+    { id: 'b', type: 'text', x: 48, y: 200, width: 80, height: 100, text: 'B' },
+  ],
+  edges: [],
+}
+
+function makeHost(start: SpatialCanvas, lockedNodes: readonly string[] = []) {
+  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+    canvas: start,
+    commands: [],
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next, command) => {
+            latest.commands.push(command)
+            setCanvas(next)
+          }}
+          theme="light"
+          lockedNodeIds={new Set(lockedNodes)}
+          onToggleNodeLock={() => {}}
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+function selectAll(root: HTMLElement) {
+  fireEvent.keyDown(root, { code: 'KeyA', key: 'a', metaKey: true })
+}
+
+function openMenuOn(root: HTMLElement, x: number, y: number) {
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + x, clientY: r.top + y })
+}
+
+const menuItem = (container: HTMLElement, label: string) =>
+  [
+    ...container.querySelectorAll<HTMLElement>('[data-testid="context-menu"] [role="menuitem"]'),
+  ].find((el) => el.textContent?.trim() === label)
+
+function clickItem(container: HTMLElement, label: string) {
+  const button = menuItem(container, label)
+  expect(button, `no menu item labelled ${label}`).toBeTruthy()
+  fireEvent.click(button as HTMLElement)
+}
+
+const byId = (canvas: SpatialCanvas, id: string) => canvas.nodes.find((node) => node.id === id)!
+
+it('tidies the selection in one undo step', () => {
+  const { Host, latest } = makeHost(initial)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70) // over node 'a', which is in the selection
+  latest.commands.length = 0
+  clickItem(container, 'Tidy')
+
+  expect(byId(latest.canvas, 'a')).toMatchObject({ x: 40, y: 40 })
+  expect(byId(latest.canvas, 'b')).toMatchObject({ x: 40, y: 200 })
+  // One batch, not one move per node: a tidy is one user action.
+  expect(latest.commands).toHaveLength(1)
+  expect(latest.commands[0]).toMatchObject({ kind: 'batch' })
+})
+
+it('offers no Tidy for a single-node selection', () => {
+  const { Host } = makeHost(initial)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 100,
+    clientY: r.top + 70,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 100, clientY: r.top + 70 })
+  openMenuOn(root, 100, 70)
+
+  expect(menuItem(container, 'Tidy')).toBeUndefined()
+})
+
+it('never moves a locked node — it stands as a fixed obstacle', () => {
+  // 'c' is locked and 12px off the column; select-all skips it, and tidy
+  // must leave it exactly where it was while still fixing 'b'.
+  const withLocked: SpatialCanvas = {
+    nodes: [
+      ...initial.nodes,
+      { id: 'c', type: 'text', x: 52, y: 400, width: 60, height: 40, text: 'C' },
+    ],
+    edges: [],
+  }
+  const { Host, latest } = makeHost(withLocked, ['c'])
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  selectAll(root)
+  openMenuOn(root, 100, 70)
+  clickItem(container, 'Tidy')
+
+  expect(byId(latest.canvas, 'b').x).toBe(40)
+  expect(byId(latest.canvas, 'c')).toMatchObject({ x: 52, y: 400 })
+})
+
+it('tidies the whole canvas from the empty-space menu', () => {
+  const { Host, latest } = makeHost(initial)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  openMenuOn(root, 600, 500) // empty space, nothing selected
+  latest.commands.length = 0
+  clickItem(container, 'Tidy canvas')
+
+  expect(byId(latest.canvas, 'b').x).toBe(40)
+  expect(latest.commands).toHaveLength(1)
+  expect(latest.commands[0]).toMatchObject({ kind: 'batch' })
+})
+
+it('emits nothing when the canvas is already tidy', () => {
+  const { Host, latest } = makeHost(initial)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+
+  openMenuOn(root, 600, 500)
+  clickItem(container, 'Tidy canvas')
+  latest.commands.length = 0
+
+  openMenuOn(root, 600, 500)
+  clickItem(container, 'Tidy canvas')
+  // Already a fixpoint: no second undo step to step back through.
+  expect(latest.commands).toHaveLength(0)
+})

--- a/apps/web/src/components/spatial-editor/tidy.test.ts
+++ b/apps/web/src/components/spatial-editor/tidy.test.ts
@@ -1,0 +1,118 @@
+// Tidy = deterministic normalization that respects the author's rough
+// topology: outermost-group units, fixed-first-anchor band alignment (no
+// running-mean chaining), bounded overlap resolution, locked nodes as
+// fixed obstacles. Only boxes that actually move are reported.
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../../test-utils/fast-check.js'
+import type { TidyNode } from './tidy.js'
+import { tidyNodes } from './tidy.js'
+
+const box = (
+  id: string,
+  x: number,
+  y: number,
+  width = 100,
+  height = 60,
+  type: TidyNode['type'] = 'text',
+): TidyNode => ({ id, type, x, y, width, height })
+
+const applyMoves = (
+  nodes: readonly TidyNode[],
+  moves: readonly { id: string; x: number; y: number }[],
+) =>
+  nodes.map((n) => {
+    const m = moves.find((mv) => mv.id === n.id)
+    return m === undefined ? n : { ...n, x: m.x, y: m.y }
+  })
+
+describe('band alignment', () => {
+  it('snaps a rough row to the grid-snapped anchor of its FIRST member', () => {
+    const nodes = [box('a', 0, 101), box('b', 200, 118), box('c', 400, 95)]
+    const moves = tidyNodes(nodes)
+    const after = applyMoves(nodes, [...moves])
+    // Sorted by top: c(95) starts the band; a(101) and b(118) join (within
+    // 24 of 95). Everyone lands on round8(95) = 96.
+    expect(after.map((n) => n.y)).toEqual([96, 96, 96])
+  })
+
+  it('never chains: a member joins only within range of the band FIRST anchor', () => {
+    // b is within 24 of a, c is within 24 of b but NOT of a — a running
+    // mean would drag c in; the fixed-first rule starts a new band at c.
+    const nodes = [box('a', 0, 0), box('b', 200, 20), box('c', 400, 40)]
+    const moves = tidyNodes(nodes)
+    const after = applyMoves(nodes, [...moves])
+    expect(after.find((n) => n.id === 'a')?.y).toBe(0)
+    expect(after.find((n) => n.id === 'b')?.y).toBe(0)
+    expect(after.find((n) => n.id === 'c')?.y).toBe(40)
+  })
+})
+
+describe('units', () => {
+  it('an outermost group scoops nested groups and members as ONE unit', () => {
+    // outer contains inner and m; aligning outer with the peer moves all
+    // of them by the same delta exactly once.
+    const nodes = [
+      box('outer', 0, 110, 300, 200, 'group'),
+      box('inner', 20, 130, 120, 80, 'group'),
+      box('m', 160, 150, 60, 40),
+      box('peer', 500, 96, 100, 60),
+    ]
+    const moves = tidyNodes(nodes)
+    const after = applyMoves(nodes, [...moves])
+    const dy = (after.find((n) => n.id === 'outer')?.y ?? 0) - 110
+    expect(dy).not.toBe(0)
+    expect(after.find((n) => n.id === 'inner')?.y).toBe(130 + dy)
+    expect(after.find((n) => n.id === 'm')?.y).toBe(150 + dy)
+  })
+})
+
+describe('overlap resolution', () => {
+  it('separates two overlapping singletons deterministically with a margin', () => {
+    const nodes = [box('a', 0, 0), box('b', 40, 0)]
+    const moves = tidyNodes(nodes)
+    const after = applyMoves(nodes, [...moves])
+    const a = after.find((n) => n.id === 'a')!
+    const b = after.find((n) => n.id === 'b')!
+    expect(Math.abs(b.x - a.x)).toBeGreaterThanOrEqual(100 + 24)
+    expect(a.y).toBe(b.y)
+  })
+
+  it('a locked node never moves; its overlapper moves away instead', () => {
+    const nodes = [box('a', 0, 0), box('b', 40, 0)]
+    const moves = tidyNodes(nodes, { locked: (id) => id === 'b' })
+    const after = applyMoves(nodes, [...moves])
+    expect(after.find((n) => n.id === 'b')).toMatchObject({ x: 40, y: 0 })
+    const a = after.find((n) => n.id === 'a')!
+    expect(a.x + 100 + 24 <= 40 || a.x >= 40 + 100 + 24 || a.y !== 0).toBe(true)
+  })
+})
+
+describe('scope and totality', () => {
+  it('nodes outside the scope stay put', () => {
+    const nodes = [box('a', 0, 101), box('b', 200, 118)]
+    const moves = tidyNodes(nodes, { scope: new Set(['a']) })
+    expect(moves.every((m) => m.id === 'a')).toBe(true)
+  })
+
+  it('an already tidy canvas produces no moves', () => {
+    const nodes = [box('a', 0, 0), box('b', 200, 0)]
+    expect(tidyNodes(nodes)).toEqual([])
+  })
+})
+
+describe('tidy properties', () => {
+  const nodeArb = fc.record({
+    x: fc.integer({ min: 0, max: 640 }),
+    y: fc.integer({ min: 0, max: 480 }),
+    w: fc.constantFrom(60, 100, 140),
+    h: fc.constantFrom(40, 60),
+  })
+  fcTest.prop([fc.array(nodeArb, { minLength: 2, maxLength: 12 })], withDefaults({ numRuns: 80 }))(
+    'tidy is idempotent: a second pass moves nothing',
+    (rects) => {
+      const nodes = rects.map((r, i) => box(`n${i}`, r.x, r.y, r.w, r.h))
+      const once = applyMoves(nodes, [...tidyNodes(nodes)])
+      expect(tidyNodes(once)).toEqual([])
+    },
+  )
+})

--- a/apps/web/src/components/spatial-editor/tidy.ts
+++ b/apps/web/src/components/spatial-editor/tidy.ts
@@ -1,0 +1,280 @@
+/**
+ * One-tap tidy: deterministic normalization that respects the author's
+ * rough topology instead of re-laying the canvas out wholesale.
+ *
+ * Three passes over UNITS (an outermost group and everything its box
+ * contains move as one; every other node is its own unit):
+ *
+ * 1. Band alignment, per axis: units whose edge anchors sit within
+ *    `TIDY_BAND_PX` of the band's FIRST member snap to that first
+ *    anchor's grid-rounded value. Banding by the fixed first anchor —
+ *    never a running mean — is what stops transitive chaining (A near B,
+ *    C near B's new spot) from dragging a whole diagonal into one line.
+ * 2. Overlap resolution as a deterministic sequential PLACEMENT: units in
+ *    document order claim their spot; a unit overlapping anything already
+ *    placed (or any immobile unit) hops along one axis — chosen once from
+ *    its first collision — until clear by `TIDY_MARGIN_PX`. Because every
+ *    processed unit ends fully clear of everything before it, a second
+ *    tidy has nothing to do: idempotence holds by construction (and is
+ *    pinned by a property test).
+ * 3. Edge legibility is deliberately NOT tidy's job — once nodes settle,
+ *    canvas-render's edge optimizer re-routes and re-sides edges on the
+ *    committed render.
+ *
+ * Pure and total like align.ts: returns ONLY the boxes that actually
+ * move; degenerate input never throws. Locked nodes never move and stand
+ * as fixed obstacles; out-of-scope units likewise.
+ */
+import type { BoxMove } from './align.js'
+
+export interface TidyNode {
+  readonly id: string
+  readonly type: 'text' | 'file' | 'link' | 'group'
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface TidyOptions {
+  /** Unit roots outside this set stay put (undefined = whole canvas). */
+  readonly scope?: ReadonlySet<string>
+  readonly locked?: (id: string) => boolean
+}
+
+const TIDY_BAND_PX = 24
+const TIDY_GRID_PX = 8
+const TIDY_MARGIN_PX = 24
+/**
+ * Best-effort ceiling: movable units beyond this stay put (the rest of
+ * the tidy still applies). Same class of bound as the edge optimizer's
+ * CROSSING_OPT_MAX_EDGES — this runs on a phone.
+ */
+const TIDY_MAX_UNITS = 300
+
+interface Rect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+interface Unit {
+  readonly rootId: string
+  /** Member node ids that move with the unit (locked members excluded). */
+  readonly movableIds: readonly string[]
+  bbox: Rect
+  readonly movable: boolean
+  dx: number
+  dy: number
+}
+
+const roundToGrid = (v: number) => Math.round(v / TIDY_GRID_PX) * TIDY_GRID_PX
+
+function fullyContains(outer: Rect, inner: Rect): boolean {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.w <= outer.x + outer.w &&
+    inner.y + inner.h <= outer.y + outer.h
+  )
+}
+
+function overlapsWithMargin(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.w + TIDY_MARGIN_PX &&
+    b.x < a.x + a.w + TIDY_MARGIN_PX &&
+    a.y < b.y + b.h + TIDY_MARGIN_PX &&
+    b.y < a.y + a.h + TIDY_MARGIN_PX
+  )
+}
+
+const rectOf = (n: TidyNode): Rect => ({ x: n.x, y: n.y, w: n.width, h: n.height })
+
+function usable(nodes: readonly TidyNode[]): TidyNode[] {
+  return nodes.filter(
+    (n) =>
+      Number.isFinite(n.x) &&
+      Number.isFinite(n.y) &&
+      Number.isFinite(n.width) &&
+      Number.isFinite(n.height),
+  )
+}
+
+/**
+ * Outermost-rooted single-scoop units: a group is a unit root iff no other
+ * group's box fully contains it (identical boxes tie-break to the earlier
+ * document index); each root claims every yet-unclaimed node its box
+ * contains in ONE flat scoop, so nested groups and their members can never
+ * be double-assigned. Everything else is a singleton unit.
+ */
+function buildUnits(nodes: readonly TidyNode[], options: TidyOptions): Unit[] {
+  const locked = options.locked ?? (() => false)
+  const inScope = (id: string) => options.scope === undefined || options.scope.has(id)
+  const groups = nodes.filter((n) => n.type === 'group')
+  const isRoot = (g: TidyNode, index: number) =>
+    !groups.some(
+      (h, hIndex) =>
+        h.id !== g.id &&
+        fullyContains(rectOf(h), rectOf(g)) &&
+        (!fullyContains(rectOf(g), rectOf(h)) || hIndex < index),
+    )
+  const claimed = new Set<string>()
+  const units: Unit[] = []
+  let movableCount = 0
+  const pushUnit = (rootId: string, memberNodes: readonly TidyNode[], bbox: Rect) => {
+    const movable = inScope(rootId) && !locked(rootId) && movableCount < TIDY_MAX_UNITS
+    if (movable) movableCount++
+    units.push({
+      rootId,
+      movableIds: memberNodes.filter((m) => !locked(m.id)).map((m) => m.id),
+      bbox: { ...bbox },
+      movable,
+      dx: 0,
+      dy: 0,
+    })
+  }
+  for (const [index, node] of nodes.entries()) {
+    if (claimed.has(node.id)) continue
+    if (node.type === 'group' && isRoot(node, groups.indexOf(node))) {
+      void index
+      const members = nodes.filter(
+        (m) => !claimed.has(m.id) && (m.id === node.id || fullyContains(rectOf(node), rectOf(m))),
+      )
+      for (const m of members) claimed.add(m.id)
+      pushUnit(node.id, members, rectOf(node))
+    }
+  }
+  for (const node of nodes) {
+    if (claimed.has(node.id)) continue
+    claimed.add(node.id)
+    pushUnit(node.id, [node], rectOf(node))
+  }
+  // Units participate in document order of their root — rebuild that order
+  // (group roots were emitted before later singletons above).
+  const orderOf = new Map(nodes.map((n, i) => [n.id, i]))
+  units.sort((a, b) => (orderOf.get(a.rootId) ?? 0) - (orderOf.get(b.rootId) ?? 0))
+  return units
+}
+
+/** One banded alignment pass along one axis (fixed-first-anchor rule). */
+function alignBands(units: Unit[], axis: 'x' | 'y'): void {
+  const anchor = (u: Unit) => (axis === 'x' ? u.bbox.x : u.bbox.y)
+  const sorted = [...units].sort((a, b) => anchor(a) - anchor(b))
+  let bandFirst: number | undefined
+  for (const unit of sorted) {
+    // STRICT inequality: consecutive band targets are >= one band apart
+    // (multiples of the grid), so a snapped unit sitting exactly one band
+    // from a neighbour must not re-join it on a later pass.
+    if (bandFirst === undefined || anchor(unit) - bandFirst >= TIDY_BAND_PX) {
+      bandFirst = anchor(unit)
+    }
+    if (!unit.movable) continue
+    const target = roundToGrid(bandFirst)
+    const delta = target - anchor(unit)
+    if (delta === 0) continue
+    if (axis === 'x') {
+      unit.bbox.x += delta
+      unit.dx += delta
+    } else {
+      unit.bbox.y += delta
+      unit.dy += delta
+    }
+  }
+}
+
+/**
+ * Deterministic sequential placement: immobile units occupy first; each
+ * movable unit then hops along ONE axis (chosen from its first collision:
+ * smaller penetration wins, ties go horizontal; direction away from the
+ * collider's centre, ties right/down) until clear of everything placed so
+ * far. Monotone in one direction, so it terminates after at most one hop
+ * per obstacle.
+ */
+function resolveOverlaps(units: Unit[]): void {
+  const occupied: Rect[] = units.filter((u) => !u.movable).map((u) => u.bbox)
+  for (const unit of units) {
+    if (!unit.movable) continue
+    const firstHit = occupied.find((r) => overlapsWithMargin(unit.bbox, r))
+    if (firstHit !== undefined) {
+      const penX =
+        Math.min(unit.bbox.x + unit.bbox.w, firstHit.x + firstHit.w) -
+        Math.max(unit.bbox.x, firstHit.x)
+      const penY =
+        Math.min(unit.bbox.y + unit.bbox.h, firstHit.y + firstHit.h) -
+        Math.max(unit.bbox.y, firstHit.y)
+      const axis: 'x' | 'y' = penX <= penY ? 'x' : 'y'
+      const unitCenter =
+        axis === 'x' ? unit.bbox.x + unit.bbox.w / 2 : unit.bbox.y + unit.bbox.h / 2
+      const hitCenter = axis === 'x' ? firstHit.x + firstHit.w / 2 : firstHit.y + firstHit.h / 2
+      const dir = unitCenter < hitCenter ? -1 : 1
+      let guard = occupied.length + 1
+      let hit: Rect | undefined = firstHit
+      while (hit !== undefined && guard-- > 0) {
+        // Hops land ON the grid, rounding AWAY from the collider so the
+        // clearance never shrinks — off-grid spots would feed the next
+        // pass's banding and unsettle the fixpoint.
+        const snapAway = (v: number) =>
+          dir === 1
+            ? Math.ceil(v / TIDY_GRID_PX) * TIDY_GRID_PX
+            : Math.floor(v / TIDY_GRID_PX) * TIDY_GRID_PX
+        const next =
+          axis === 'x'
+            ? dir === 1
+              ? snapAway(hit.x + hit.w + TIDY_MARGIN_PX)
+              : snapAway(hit.x - TIDY_MARGIN_PX - unit.bbox.w)
+            : dir === 1
+              ? snapAway(hit.y + hit.h + TIDY_MARGIN_PX)
+              : snapAway(hit.y - TIDY_MARGIN_PX - unit.bbox.h)
+        if (axis === 'x') {
+          unit.dx += next - unit.bbox.x
+          unit.bbox.x = next
+        } else {
+          unit.dy += next - unit.bbox.y
+          unit.bbox.y = next
+        }
+        hit = occupied.find((r) => overlapsWithMargin(unit.bbox, r))
+      }
+    }
+    occupied.push(unit.bbox)
+  }
+}
+
+export function tidyNodes(
+  nodes: readonly TidyNode[],
+  options: TidyOptions = {},
+): readonly BoxMove[] {
+  const clean = usable(nodes)
+  if (clean.length < 2) return []
+  const byId = new Map(clean.map((n) => [n.id, n]))
+  const units = buildUnits(clean, options)
+  // Run the passes to an internal FIXPOINT (bounded): an overlap hop can
+  // land a unit near a band boundary and vice versa, so a single sweep is
+  // not always stable. Iterating until nothing moves makes tidy's output
+  // its own fixpoint — which is exactly what the idempotence property
+  // requires: a second tidy starts at a fixpoint and moves nothing.
+  const TIDY_MAX_ITERATIONS = 8
+  for (let i = 0; i < TIDY_MAX_ITERATIONS; i++) {
+    const before = units.map((u) => `${u.bbox.x} ${u.bbox.y}`).join('|')
+    alignBands(units, 'x')
+    alignBands(units, 'y')
+    resolveOverlaps(units)
+    if (units.map((u) => `${u.bbox.x} ${u.bbox.y}`).join('|') === before) break
+  }
+  const moves: BoxMove[] = []
+  for (const unit of units) {
+    if (!unit.movable || (unit.dx === 0 && unit.dy === 0)) continue
+    for (const id of unit.movableIds) {
+      const node = byId.get(id)
+      if (node === undefined) continue
+      const x = Math.round(node.x + unit.dx)
+      const y = Math.round(node.y + unit.dy)
+      // Defensive twin of the canvas-workspace write guard: tidy must
+      // never emit a position the doc layer would refuse.
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+      if (x === node.x && y === node.y) continue
+      moves.push({ id, x, y })
+    }
+  }
+  return moves
+}


### PR DESCRIPTION
## What

One-tap **Tidy** for the spatial canvas — a deterministic normalization pass that respects the author's rough topology instead of re-laying the canvas out wholesale:

- **Band alignment**: nodes whose edges sit within 24px of a band's *first* member snap to that anchor's 8px-grid-rounded value. Banding by the fixed first anchor (never a running mean) stops transitive chaining from dragging a whole diagonal into one line.
- **Overlap resolution**: deterministic sequential placement — units in document order claim their spot; an overlapper hops along one axis (chosen from its first collision) to grid-aligned positions until clear by a 24px margin.
- **Units**: an outermost group and everything its box contains move as one; locked and out-of-scope nodes never move and stand as fixed obstacles.
- **Fixpoint**: the passes iterate (bounded at 8) until stable, so tidy's own output is a fixpoint — a second tidy moves nothing, pinned by a fast-check idempotence property.
- Edge legibility stays the edge optimizer's job: once nodes settle, routing re-sides and re-routes on the committed render.

## Wiring (per the agreed product decisions)

- Multi-node selection → context menu **Tidy**, scoped to the selection (rest of the canvas is a fixed obstacle).
- Empty space → **Tidy canvas** (whole canvas), shown once two nodes exist.
- Locked nodes are fixed obstacles; movable units are capped at 300 (best-effort partial apply — the rest of the tidy still runs).
- Both emit one batch command — one undo step — through the same `applyBoxMoves` path as Align/Distribute.

## Tests

- `tidy.test.ts` (jsdom): band snap, no-chaining, group single-scoop units, deterministic overlap separation, locked-as-obstacle, scope filtering, no-op on tidy input, and the idempotence property (80 runs). Both band-rule mutations were mutation-checked (running-mean band → 2 tests red; loosening the strict band boundary → property red).
- `tidy.browser.test.tsx` (real Chromium): selection Tidy is one batch/one undo step, no Tidy for a single-node selection, locked node untouched, whole-canvas tidy from the empty-space menu, second tidy emits nothing.

## Visual repro

Before (ragged column, overlapping pair):

![tidy-before.png](https://github.com/user-attachments/assets/b65bc204-d270-456a-a8c1-fd334b43eb06)

The affordance (empty-space menu):

![tidy-menu.png](https://github.com/user-attachments/assets/8d7c485f-8bc8-4d51-b441-0d84f1385bb3)

After one Tidy canvas (column flush, overlap separated with margin, edges re-routed):

![tidy-after.png](https://github.com/user-attachments/assets/eb092cbf-5d34-45e2-b299-787accfe29e2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
