### PR TITLE
feat(mcp): expose one-tap tidy as the tidy_canvas MCP tool

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -77,6 +77,7 @@ import {
   SPATIAL_THEME_FONT_FAMILY,
   SPATIAL_THEME_GEOMETRY,
   sceneBounds,
+  tidyNodes,
 } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
@@ -179,7 +180,6 @@ import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
-import { tidyNodes } from './tidy.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   canvasToScreen,

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -62,6 +62,7 @@ The MCP server exposes a small, opinionated set of tools that match the canvas l
 |---|---|
 | `wb_canvas_create` / `wb_canvas_list` / `wb_canvas_get` / `wb_canvas_delete` | Canvas lifecycle (CRUD). |
 | `node_patch` / `edge_patch` / `body_patch` | Patch a canvas's spatial nodes, edges, or a node's Markdown body. |
+| `tidy_canvas` | Normalize a canvas's spatial layout: snap near-aligned nodes into rows/columns on the grid and separate overlaps, optionally restricted to a `scope` of node ids. Locked nodes never move. Idempotent — a second call reports no moves. |
 | `facet_set` | Set structured facet metadata on a canvas (used for the private ticketing backlog, among other uses). |
 | `canvas_render_svg` | Render the current canvas to an SVG string from its persisted document — no browser connection required. |
 | `canvas_digest` | Return the AI-facing spatial digest (overlap/containment/cluster/free-region summary) of a canvas. |

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -58,3 +58,5 @@ export type {
 export { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from './theme/spatial-palette.js'
 export type { SpatialThemeMode, SpatialThemeOptions } from './theme/spatial-theme.js'
 export { createSpatialTheme } from './theme/spatial-theme.js'
+export type { TidyMove, TidyNode, TidyOptions } from './tidy.js'
+export { tidyNodes } from './tidy.js'

--- a/packages/canvas-render/src/tidy.test.ts
+++ b/packages/canvas-render/src/tidy.test.ts
@@ -3,7 +3,7 @@
 // running-mean chaining), bounded overlap resolution, locked nodes as
 // fixed obstacles. Only boxes that actually move are reported.
 import { describe, expect, it } from 'vitest'
-import { fc, fcTest, withDefaults } from '../../test-utils/fast-check.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
 import type { TidyNode } from './tidy.js'
 import { tidyNodes } from './tidy.js'
 

--- a/packages/canvas-render/src/tidy.ts
+++ b/packages/canvas-render/src/tidy.ts
@@ -18,14 +18,18 @@
  *    tidy has nothing to do: idempotence holds by construction (and is
  *    pinned by a property test).
  * 3. Edge legibility is deliberately NOT tidy's job — once nodes settle,
- *    canvas-render's edge optimizer re-routes and re-sides edges on the
+ *    the edge optimizer re-routes and re-sides edges on the
  *    committed render.
  *
- * Pure and total like align.ts: returns ONLY the boxes that actually
- * move; degenerate input never throws. Locked nodes never move and stand
- * as fixed obstacles; out-of-scope units likewise.
+ * Pure and total: returns ONLY the boxes that actually move; degenerate
+ * input never throws. Locked nodes never move and stand as fixed
+ * obstacles; out-of-scope units likewise.
  */
-import type { BoxMove } from './align.js'
+export interface TidyMove {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+}
 
 export interface TidyNode {
   readonly id: string
@@ -243,7 +247,7 @@ function resolveOverlaps(units: Unit[]): void {
 export function tidyNodes(
   nodes: readonly TidyNode[],
   options: TidyOptions = {},
-): readonly BoxMove[] {
+): readonly TidyMove[] {
   const clean = usable(nodes)
   if (clean.length < 2) return []
   const byId = new Map(clean.map((n) => [n.id, n]))
@@ -261,7 +265,7 @@ export function tidyNodes(
     resolveOverlaps(units)
     if (units.map((u) => `${u.bbox.x} ${u.bbox.y}`).join('|') === before) break
   }
-  const moves: BoxMove[] = []
+  const moves: TidyMove[] = []
   for (const unit of units) {
     if (!unit.movable || (unit.dx === 0 && unit.dy === 0)) continue
     for (const id of unit.movableIds) {

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -131,6 +131,7 @@ const EXPECTED_TOOLS = [
   'facet_set',
   'node_lock',
   'node_patch',
+  'tidy_canvas',
   'version_list',
   'version_restore',
   'version_save',
@@ -250,6 +251,20 @@ async function main() {
     nodeId: 'okf-body',
     locked: false,
   })
+
+  // tidy_canvas: the canvas holds a single node here, so the contract answer
+  // is "nothing to tidy" — the call still runs the full pipeline (input
+  // parse → doc load → tidy → structuredContent vs outputSchema), which is
+  // the drift guard this smoke exists for. The geometry itself is covered by
+  // canvas-render's unit/property tests.
+  const tidied = await callTool('tidy_canvas', {
+    workspaceId: WORKSPACE_ID,
+    canvasId,
+  })
+  if (tidied.canvasId !== canvasId || !Array.isArray(tidied.moved) || tidied.moved.length !== 0) {
+    throw new Error(`tidy_canvas returned unexpected shape: ${JSON.stringify(tidied)}`)
+  }
+  console.log('[e2e] tidy_canvas → single-node canvas reports no moves')
 
   // edge_lock reaches its ghost-id guard only: no MCP tool creates an edge
   // (edges come from the editor), so this is the whole of its reachable

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -37,6 +37,7 @@ export const ALL_REGISTERED_TOOLS = [
   'facet_set',
   'node_lock',
   'node_patch',
+  'tidy_canvas',
   'version_list',
   'version_restore',
   'version_save',
@@ -49,6 +50,7 @@ export const ALL_REGISTERED_TOOLS = [
 export const COVERED_TOOLS = [
   'canvas_import_okf',
   'node_lock',
+  'tidy_canvas',
   'facet_set',
   'version_save',
   'version_restore',

--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
@@ -130,6 +130,22 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
 
   registerToolWithAnnotations(
     server,
+    tools.tidyCanvas.name,
+    {
+      inputSchema: tools.tidyCanvas.inputSchema.shape,
+      outputSchema: tools.tidyCanvas.outputSchema,
+    },
+    async (args) => {
+      const parsed = tools.tidyCanvas.inputSchema.parse(args)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.tidyCanvas.execute(parsed),
+      )
+      return structuredJsonResult(result)
+    },
+  )
+
+  registerToolWithAnnotations(
+    server,
     tools.canvasRenderSvg.name,
     {
       inputSchema: tools.canvasRenderSvg.inputSchema.shape,

--- a/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
@@ -11,6 +11,7 @@ const ACTIVE_TOOL_NAMES = [
   'node_patch',
   'edge_lock',
   'edge_patch',
+  'tidy_canvas',
   'body_patch',
   'canvas_render_svg',
   'canvas_digest',

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -23,6 +23,7 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   edge_patch: { profile: MUTATING_IDEMPOTENT, title: 'Patch spatial canvas edge' },
   node_lock: { profile: MUTATING_IDEMPOTENT, title: 'Lock or unlock a spatial canvas node' },
   edge_lock: { profile: MUTATING_IDEMPOTENT, title: 'Lock or unlock a spatial canvas edge' },
+  tidy_canvas: { profile: MUTATING_IDEMPOTENT, title: 'Tidy spatial canvas layout' },
   body_patch: { profile: MUTATING, title: 'Patch canvas markdown body' },
   canvas_render_svg: { profile: READ_ONLY, title: 'Render canvas as SVG' },
   canvas_digest: { profile: READ_ONLY, title: 'Generate AI-facing canvas digest' },

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -28,6 +28,7 @@ import { createFacetSetTool } from './tools/facet-set.js'
 import { createNodeLockTool } from './tools/node-lock.js'
 import { createNodePatchTool } from './tools/node-patch.js'
 import { createReindexTool } from './tools/reindex-tool.js'
+import { createTidyCanvasTool } from './tools/tidy-canvas.js'
 import { createVersionListTool } from './tools/version-list.js'
 import { createVersionRestoreTool } from './tools/version-restore.js'
 import { createVersionSaveTool } from './tools/version-save.js'
@@ -126,6 +127,7 @@ export function createServer(deps: ServerDeps) {
     edgeLock: createEdgeLockTool(deps),
     nodePatch: createNodePatchTool(deps),
     edgePatch: createEdgePatchTool(deps),
+    tidyCanvas: createTidyCanvasTool(deps),
     bodyPatch: createBodyPatchTool(deps),
     canvasRenderSvg: createCanvasRenderSvgTool(deps),
     canvasDigest: createCanvasDigestTool(deps),

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -101,6 +101,12 @@ export {
   reindexInputSchema,
   reindexOutputSchema,
 } from './tools/reindex-tool.js'
+export type { TidyCanvasInput, TidyCanvasOutput } from './tools/tidy-canvas.js'
+export {
+  createTidyCanvasTool,
+  tidyCanvasInputSchema,
+  tidyCanvasOutputSchema,
+} from './tools/tidy-canvas.js'
 export type { VersionListInput, VersionListOutput } from './tools/version-list.js'
 export {
   createVersionListTool,

--- a/packages/server-core/src/tools/tidy-canvas.test.ts
+++ b/packages/server-core/src/tools/tidy-canvas.test.ts
@@ -1,0 +1,143 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
+import { setNodeLock, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import {
+  FakeCanvasDocStore,
+  registerCanvasInWorkspace,
+} from '../test-utils/fake-canvas-doc-store.js'
+import { createInMemoryWorkspaceIndex } from '../test-utils/in-memory-workspace-index.js'
+import { loadCanvasDoc } from './canvas-doc-io.js'
+import { createTidyCanvasTool } from './tidy-canvas.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+
+async function seedCanvas(
+  canvasDocStore: FakeCanvasDocStore,
+  canvas: SpatialCanvas,
+  lockedIds: readonly string[] = [],
+): Promise<void> {
+  await registerCanvasInWorkspace(canvasDocStore, WORKSPACE_ID, CANVAS_ID)
+  const seedDoc = new LoroDoc()
+  writeSpatialCanvas(seedDoc, canvas)
+  for (const id of lockedIds) setNodeLock(seedDoc, id, true)
+  const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+  await canvasDocStore.saveSnapshot({
+    docRef: { kind: 'canvas', canvasId: CANVAS_ID },
+    manifest,
+    chunks,
+    frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, workspaceIndex: createInMemoryWorkspaceIndex(), blobStore: {} as never }
+}
+
+const box = (id: string, x: number, y: number) => ({
+  id,
+  type: 'text' as const,
+  x,
+  y,
+  width: 100,
+  height: 50,
+  text: id,
+})
+
+describe('tidy_canvas tool', () => {
+  test('tidies the whole canvas and persists the moved nodes', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    // A rough row: y 101/118/95 all sit within one band of the topmost
+    // (95), so everyone snaps to round8(95) = 96.
+    await seedCanvas(canvasDocStore, {
+      nodes: [box('a', 0, 101), box('b', 200, 118), box('c', 400, 95)],
+      edges: [],
+    })
+    const deps = makeDeps(canvasDocStore)
+    const tool = createTidyCanvasTool(deps)
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.canvasId).toBe(CANVAS_ID)
+    expect([...result.moved].sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+      { id: 'a', x: 0, y: 96 },
+      { id: 'b', x: 200, y: 96 },
+      { id: 'c', x: 400, y: 96 },
+    ])
+
+    const { canvas } = await loadCanvasDoc(deps, CANVAS_ID)
+    expect(canvas.nodes.map((n) => n.y)).toEqual([96, 96, 96])
+  })
+
+  test('a locked node never moves but still anchors its band', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, { nodes: [box('a', 0, 101), box('b', 200, 118)], edges: [] }, [
+      'a',
+    ])
+    const deps = makeDeps(canvasDocStore)
+    const tool = createTidyCanvasTool(deps)
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    // b joins a's band (118 - 101 < 24) and lands on round8(101) = 104;
+    // locked a stays exactly where it was.
+    expect(result.moved).toEqual([{ id: 'b', x: 200, y: 104 }])
+    const { canvas } = await loadCanvasDoc(deps, CANVAS_ID)
+    expect(canvas.nodes.find((n) => n.id === 'a')?.y).toBe(101)
+    expect(canvas.nodes.find((n) => n.id === 'b')?.y).toBe(104)
+  })
+
+  test('scope restricts moves to the listed nodes', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [box('a', 0, 101), box('b', 200, 118)],
+      edges: [],
+    })
+    const tool = createTidyCanvasTool(makeDeps(canvasDocStore))
+
+    const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      scope: ['a'],
+    })
+
+    expect(result.moved.every((m) => m.id === 'a')).toBe(true)
+  })
+
+  test('an already tidy canvas reports no moves and leaves the doc unchanged', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [box('a', 0, 0), box('b', 200, 0)],
+      edges: [],
+    })
+    const deps = makeDeps(canvasDocStore)
+    const tool = createTidyCanvasTool(deps)
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(result.moved).toEqual([])
+  })
+
+  test('tidy output is a fixpoint: running the tool twice moves nothing more', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    await seedCanvas(canvasDocStore, {
+      nodes: [box('a', 25, 0), box('b', 0, 0), box('c', 3, 210)],
+      edges: [],
+    })
+    const tool = createTidyCanvasTool(makeDeps(canvasDocStore))
+
+    await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+    const second = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(second.moved).toEqual([])
+  })
+
+  test('rejects an unknown canvas', async () => {
+    const canvasDocStore = new FakeCanvasDocStore()
+    const tool = createTidyCanvasTool(makeDeps(canvasDocStore))
+
+    await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow()
+  })
+})

--- a/packages/server-core/src/tools/tidy-canvas.ts
+++ b/packages/server-core/src/tools/tidy-canvas.ts
@@ -1,0 +1,71 @@
+import {
+  canvasIdSchema,
+  nodeIdSchema,
+  spatialCanvasSchema,
+  workspaceIdSchema,
+} from '@kamiazya/whiteboard-canvas-model'
+import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
+import { readNodeLocks } from '@kamiazya/whiteboard-canvas-workspace'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { PatchValidationError } from './errors.js'
+import { withReindex } from './with-reindex.js'
+import { assertCanvasInWorkspace } from './workspace-tree-io.js'
+
+export const tidyCanvasInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    canvasId: canvasIdSchema,
+    /** Restrict tidy to these unit roots; everything else stands as a fixed obstacle. */
+    scope: z.array(nodeIdSchema).min(1).optional(),
+  })
+  .strict()
+export type TidyCanvasInput = z.infer<typeof tidyCanvasInputSchema>
+
+export const tidyCanvasOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    /** Only the nodes that actually moved, with their new positions. */
+    moved: z.array(
+      z.object({ id: nodeIdSchema, x: z.number().int(), y: z.number().int() }).strict(),
+    ),
+  })
+  .strict()
+export type TidyCanvasOutput = z.infer<typeof tidyCanvasOutputSchema>
+
+export function createTidyCanvasTool(deps: ServerDeps) {
+  return {
+    name: 'tidy_canvas' as const,
+    inputSchema: tidyCanvasInputSchema,
+    outputSchema: tidyCanvasOutputSchema,
+    execute: withReindex(deps, async (input: TidyCanvasInput): Promise<TidyCanvasOutput> => {
+      await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
+      const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      // Locks bind agents exactly as they bind the editor: a locked node is
+      // a fixed obstacle tidy routes around, never a participant it moves.
+      const locks = readNodeLocks(doc)
+      const moved = tidyNodes(canvas.nodes, {
+        scope: input.scope === undefined ? undefined : new Set(input.scope),
+        locked: (id) => locks.has(id),
+      })
+      if (moved.length === 0) return { canvasId: input.canvasId, moved: [] }
+
+      const target = new Map(moved.map((move) => [move.id, move]))
+      const candidateCanvas = {
+        nodes: canvas.nodes.map((node) => {
+          const move = target.get(node.id)
+          return move === undefined ? node : { ...node, x: move.x, y: move.y }
+        }),
+        edges: canvas.edges,
+      }
+      const parsed = spatialCanvasSchema.safeParse(candidateCanvas)
+      if (!parsed.success) throw new PatchValidationError(parsed.error.issues)
+
+      await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+
+      return { canvasId: input.canvasId, moved: [...moved] }
+    }),
+  }
+}


### PR DESCRIPTION
## What

Exposes the editor's one-tap Tidy (#589) to agents as a **`tidy_canvas` MCP tool**, per the panel's deferred follow-up.

- **`canvas-render`** now owns the tidy core (`tidyNodes` + the unit/property tests, moved verbatim from `apps/web`): it is pure layout over node geometry — model-only deps, no DOM — so it sits beside the other layout code and both composition roots can reach it. `apps/web` imports it from the package; editor behavior is unchanged (its browser wiring tests still pass).
- **`server-core`** adds the `tidy_canvas` tool: load persisted doc → treat sidecar-locked nodes as fixed obstacles (locks bind agents exactly as they bind the pointer) → optional `scope` of unit roots → validate the tidied canvas through `spatialCanvasSchema` → save → report only the nodes that actually moved.
- **`mcp-server`** wires the full tool checklist: registration behind the canvas write lock, `MUTATING_IDEMPOTENT` profile (tidy's output is its own fixpoint), smoke-coverage classification (COVERED), a `tidy_canvas` step in `mcp-e2e-smoke`, and the docs tool table row.

## Tests

- `canvas-render`: the 8 tidy unit/property tests (idempotence PBT included) moved with the module — 615 tests green across `server-core-node` + `canvas-render-node`.
- `server-core`: new `tidy-canvas.test.ts` (6 tests) against the real Loro persistence path — whole-canvas tidy persists, locked node anchors its band but never moves, scope restriction, no-op on tidy input, cross-call fixpoint, unknown-canvas rejection.
- `mcp-node` (3214), apps/web jsdom (1734), `web-browser` tidy wiring (5), `pnpm build`, `pnpm knip` — all green.

## Verification against the live daemon

`pnpm smoke:e2e` passes with the new step, and the branch daemon was exercised over real HTTP:

```
tools/list        → includes tidy_canvas
tidy_canvas       → {"canvasId":"01KZREP…","moved":[]}          (single-node canvas: contract no-op)
scope:["ghost"]   → {"canvasId":"01KZREP…","moved":[]}          (total, no crash)
unknown canvasId  → isError: "Canvas not found: … in workspace tidy-dogfood"
```

Multi-node movement over the wire has no MCP-only reproduction path (no MCP tool creates a second spatial node — same reachability boundary the smoke documents for `edge_lock`); it is covered by the server-core tests above on the real doc path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
