### PR TITLE
feat(web): animate the loading experience end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @kamiazya/whiteboard
 
+<p align="center">
+  <img src="apps/web/public/boot-splash.svg" alt="Whiteboard — a pen stroke drawing itself onto a whiteboard" width="176" height="168" />
+</p>
+
 > A collaborative OpenCanvas whiteboard for Claude Code, Codex, and Gemini CLI. Draw with your AI agent to align on specs, architecture, and workflows — directly on a shared real-time canvas.
 
 [![npm version](https://img.shields.io/npm/v/@kamiazya/whiteboard-mcp.svg)](https://www.npmjs.com/package/@kamiazya/whiteboard-mcp)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @kamiazya/whiteboard
 
 <p align="center">
-  <img src="apps/web/public/boot-splash.svg" alt="Whiteboard — a pen stroke drawing itself onto a whiteboard" width="176" height="168" />
+  <img src="apps/web/public/boot-splash.svg" alt="Whiteboard — a hand sketches nodes and edges, AI tidies them into a diagram, and the mark returns" width="264" height="222" />
 </p>
 
 > A collaborative OpenCanvas whiteboard for Claude Code, Codex, and Gemini CLI. Draw with your AI agent to align on specs, architecture, and workflows — directly on a shared real-time canvas.

--- a/apps/web/index-html.test.ts
+++ b/apps/web/index-html.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it } from 'vitest'
 // HTML with inline CSS. Nothing else can assert on it — index.css and the
 // theme class are not applied at that point — hence a file-level contract.
 const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8')
+// The animated mark itself is the shared external SVG (also embedded by the
+// README), self-contained because it renders inside <img> where it can
+// inherit nothing from the page.
+const svg = readFileSync(new URL('./public/boot-splash.svg', import.meta.url), 'utf8')
 
 describe('index.html boot splash', () => {
   it('paints the boot state INSIDE #root so React removes it on first commit', () => {
@@ -13,13 +17,27 @@ describe('index.html boot splash', () => {
     expect(root).toContain('wb-boot')
   })
 
+  it('references the shared boot-splash SVG asset', () => {
+    expect(html).toContain('/boot-splash.svg')
+  })
+
   it('follows the OS color scheme so a dark-mode cold load does not flash white', () => {
     expect(html).toContain('prefers-color-scheme: dark')
   })
+})
 
-  it('neutralizes the boot animation under prefers-reduced-motion', () => {
-    const idx = html.indexOf('prefers-reduced-motion: reduce')
+describe('public/boot-splash.svg', () => {
+  it('loops its draw animation', () => {
+    expect(svg).toMatch(/animation:[^;]*infinite/)
+  })
+
+  it('neutralizes the animation under prefers-reduced-motion', () => {
+    const idx = svg.indexOf('prefers-reduced-motion: reduce')
     expect(idx).toBeGreaterThan(-1)
-    expect(html.slice(idx)).toMatch(/animation:[^;]*0\.01ms/)
+    expect(svg.slice(idx)).toMatch(/animation:[^;]*0\.01ms/)
+  })
+
+  it('is self-contained (no external references, CSP-safe inside <img>)', () => {
+    expect(svg).not.toMatch(/url\(|href=|@import/)
   })
 })

--- a/apps/web/index-html.test.ts
+++ b/apps/web/index-html.test.ts
@@ -27,14 +27,19 @@ describe('index.html boot splash', () => {
 })
 
 describe('public/boot-splash.svg', () => {
-  it('loops its draw animation', () => {
-    expect(svg).toMatch(/animation:[^;]*infinite/)
+  it('draws the stroke ONCE (no redraw loop)', () => {
+    expect(svg).toMatch(/animation:[^;]*wb-draw/)
+    expect(svg).not.toMatch(/animation:[^;]*wb-draw[^;]*infinite/)
   })
 
-  it('neutralizes the animation under prefers-reduced-motion', () => {
+  it('settles into an infinite breathing loop after the draw', () => {
+    expect(svg).toMatch(/animation:[^;]*wb-breathe[^;]*infinite/)
+  })
+
+  it('neutralizes all animation under prefers-reduced-motion', () => {
     const idx = svg.indexOf('prefers-reduced-motion: reduce')
     expect(idx).toBeGreaterThan(-1)
-    expect(svg.slice(idx)).toMatch(/animation:[^;]*0\.01ms/)
+    expect(svg.slice(idx)).toContain('animation: none')
   })
 
   it('is self-contained (no external references, CSP-safe inside <img>)', () => {

--- a/apps/web/index-html.test.ts
+++ b/apps/web/index-html.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// The boot splash is the only UI that exists before the app bundle (and the
+// vendored viewer font main.tsx awaits) has loaded, so it lives in the raw
+// HTML with inline CSS. Nothing else can assert on it — index.css and the
+// theme class are not applied at that point — hence a file-level contract.
+const html = readFileSync(new URL('./index.html', import.meta.url), 'utf8')
+
+describe('index.html boot splash', () => {
+  it('paints the boot state INSIDE #root so React removes it on first commit', () => {
+    const root = html.slice(html.indexOf('<div id="root">'), html.indexOf('</body>'))
+    expect(root).toContain('wb-boot')
+  })
+
+  it('follows the OS color scheme so a dark-mode cold load does not flash white', () => {
+    expect(html).toContain('prefers-color-scheme: dark')
+  })
+
+  it('neutralizes the boot animation under prefers-reduced-motion', () => {
+    const idx = html.indexOf('prefers-reduced-motion: reduce')
+    expect(idx).toBeGreaterThan(-1)
+    expect(html.slice(idx)).toMatch(/animation:[^;]*0\.01ms/)
+  })
+})

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -39,7 +39,7 @@
          The animated mark (pen stroke drawing itself + wordmark) is the
          shared external SVG public/boot-splash.svg — same file the README
          embeds — with its animation and reduced-motion guard inside. -->
-    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><img src="/boot-splash.svg" alt="" width="176" height="168" /></div></div>
+    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><img src="/boot-splash.svg" alt="" width="264" height="222" /></div></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,51 +19,71 @@
       :root {
         --wb-boot-bg: oklch(1 0 0);
         --wb-boot-line: oklch(0.87 0 0);
+        --wb-boot-ink: oklch(0.556 0 0);
       }
       @media (prefers-color-scheme: dark) {
         :root {
           --wb-boot-bg: oklch(0.145 0 0);
           --wb-boot-line: oklch(1 0 0 / 22%);
+          --wb-boot-ink: oklch(0.708 0 0);
         }
       }
       .wb-boot {
         position: fixed;
         inset: 0;
         display: flex;
+        flex-direction: column;
+        gap: 14px;
         align-items: center;
         justify-content: center;
         background: var(--wb-boot-bg);
       }
-      /* A quiet whiteboard-shaped mark breathing, not a spinner: opacity +
-         scale only (compositor-friendly, no layout churn). */
-      .wb-boot__mark {
-        width: 56px;
-        height: 42px;
-        border: 2px solid var(--wb-boot-line);
-        border-radius: 10px;
-        animation: wb-boot-breathe 1.4s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+      .wb-boot__label {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        color: var(--wb-boot-ink);
       }
-      @keyframes wb-boot-breathe {
-        0%,
-        100% {
-          opacity: 0.35;
-          transform: scale(0.94);
-        }
-        50% {
+      /* A pen stroke drawing itself onto the board, looping: the classic
+         stroke-dashoffset reveal (compositor/paint only, no layout churn).
+         Base state is the fully drawn squiggle so the reduced-motion
+         one-shot below lands on something visible, not a blank board. */
+      .wb-boot__stroke {
+        stroke-dasharray: 80;
+        stroke-dashoffset: 0;
+        animation: wb-boot-draw 2s ease-in-out infinite;
+      }
+      @keyframes wb-boot-draw {
+        0% {
+          stroke-dashoffset: 80;
           opacity: 1;
-          transform: scale(1);
+        }
+        55% {
+          stroke-dashoffset: 0;
+          opacity: 1;
+        }
+        80% {
+          stroke-dashoffset: 0;
+          opacity: 0;
+        }
+        100% {
+          stroke-dashoffset: 80;
+          opacity: 0;
         }
       }
       @media (prefers-reduced-motion: reduce) {
-        .wb-boot__mark {
-          animation: wb-boot-breathe 0.01ms 1;
+        .wb-boot__stroke {
+          animation: wb-boot-draw 0.01ms 1;
         }
       }
     </style>
   </head>
   <body>
     <!-- Inside #root so React's first commit replaces it — no removal code. -->
-    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><div class="wb-boot__mark"></div></div></div>
+    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><svg width="88" height="66" viewBox="0 0 88 66" fill="none" aria-hidden="true"><rect x="2" y="2" width="84" height="62" rx="10" stroke="var(--wb-boot-line)" stroke-width="3"/><path class="wb-boot__stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" stroke="var(--wb-boot-ink)" stroke-width="3.5" stroke-linecap="round"/></svg><div class="wb-boot__label">Whiteboard</div></div></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -18,72 +18,28 @@
     <style>
       :root {
         --wb-boot-bg: oklch(1 0 0);
-        --wb-boot-line: oklch(0.87 0 0);
-        --wb-boot-ink: oklch(0.556 0 0);
       }
       @media (prefers-color-scheme: dark) {
         :root {
           --wb-boot-bg: oklch(0.145 0 0);
-          --wb-boot-line: oklch(1 0 0 / 22%);
-          --wb-boot-ink: oklch(0.708 0 0);
         }
       }
       .wb-boot {
         position: fixed;
         inset: 0;
         display: flex;
-        flex-direction: column;
-        gap: 14px;
         align-items: center;
         justify-content: center;
         background: var(--wb-boot-bg);
       }
-      .wb-boot__label {
-        font-family:
-          system-ui,
-          -apple-system,
-          sans-serif;
-        font-size: 13px;
-        letter-spacing: 0.04em;
-        color: var(--wb-boot-ink);
-      }
-      /* A pen stroke drawing itself onto the board, looping: the classic
-         stroke-dashoffset reveal (compositor/paint only, no layout churn).
-         Base state is the fully drawn squiggle so the reduced-motion
-         one-shot below lands on something visible, not a blank board. */
-      .wb-boot__stroke {
-        stroke-dasharray: 80;
-        stroke-dashoffset: 0;
-        animation: wb-boot-draw 2s ease-in-out infinite;
-      }
-      @keyframes wb-boot-draw {
-        0% {
-          stroke-dashoffset: 80;
-          opacity: 1;
-        }
-        55% {
-          stroke-dashoffset: 0;
-          opacity: 1;
-        }
-        80% {
-          stroke-dashoffset: 0;
-          opacity: 0;
-        }
-        100% {
-          stroke-dashoffset: 80;
-          opacity: 0;
-        }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .wb-boot__stroke {
-          animation: wb-boot-draw 0.01ms 1;
-        }
-      }
     </style>
   </head>
   <body>
-    <!-- Inside #root so React's first commit replaces it — no removal code. -->
-    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><svg width="88" height="66" viewBox="0 0 88 66" fill="none" aria-hidden="true"><rect x="2" y="2" width="84" height="62" rx="10" stroke="var(--wb-boot-line)" stroke-width="3"/><path class="wb-boot__stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" stroke="var(--wb-boot-ink)" stroke-width="3.5" stroke-linecap="round"/></svg><div class="wb-boot__label">Whiteboard</div></div></div>
+    <!-- Inside #root so React's first commit replaces it — no removal code.
+         The animated mark (pen stroke drawing itself + wordmark) is the
+         shared external SVG public/boot-splash.svg — same file the README
+         embeds — with its animation and reduced-motion guard inside. -->
+    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><img src="/boot-splash.svg" alt="" width="176" height="168" /></div></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,9 +4,66 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Whiteboard</title>
+    <!--
+      Boot splash: the only UI that exists before the app bundle (and the
+      vendored viewer font main.tsx awaits) has loaded, so it must be inline
+      CSS + markup — index.css and the theme class are not applied yet.
+      CSS-only on purpose: the production CSP allows inline styles but not
+      inline scripts, so the persisted-theme override cannot run this early;
+      prefers-color-scheme covers the default 'system' preference, and
+      main.tsx applies the stored class before React paints anything else.
+      Colors mirror index.css --background/--border for both schemes so the
+      splash-to-app handoff does not shift the ground color.
+    -->
+    <style>
+      :root {
+        --wb-boot-bg: oklch(1 0 0);
+        --wb-boot-line: oklch(0.87 0 0);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --wb-boot-bg: oklch(0.145 0 0);
+          --wb-boot-line: oklch(1 0 0 / 22%);
+        }
+      }
+      .wb-boot {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--wb-boot-bg);
+      }
+      /* A quiet whiteboard-shaped mark breathing, not a spinner: opacity +
+         scale only (compositor-friendly, no layout churn). */
+      .wb-boot__mark {
+        width: 56px;
+        height: 42px;
+        border: 2px solid var(--wb-boot-line);
+        border-radius: 10px;
+        animation: wb-boot-breathe 1.4s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+      }
+      @keyframes wb-boot-breathe {
+        0%,
+        100% {
+          opacity: 0.35;
+          transform: scale(0.94);
+        }
+        50% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .wb-boot__mark {
+          animation: wb-boot-breathe 0.01ms 1;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <!-- Inside #root so React's first commit replaces it — no removal code. -->
+    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><div class="wb-boot__mark"></div></div></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/public/boot-splash.svg
+++ b/apps/web/public/boot-splash.svg
@@ -1,45 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="176" height="168" viewBox="0 0 88 84" role="img" aria-label="Whiteboard">
   <title>Whiteboard</title>
   <!--
-    The boot-splash mark: a pen stroke drawing itself onto a whiteboard,
-    looping. Self-contained (CSS animation inside the SVG) so the same file
-    serves the index.html splash and the README, where it renders inside an
-    <img> and can inherit nothing from the page. Colors are mid-grays chosen
-    to read on both light and dark grounds for the same reason.
+    The boot-splash mark: a pen stroke draws itself onto the whiteboard
+    ONCE, then the mark settles into a slow breathing loop — a standing
+    redraw loop reads as noise in the README. Self-contained (CSS animation
+    inside the SVG) so the same file serves the index.html splash and the
+    README, where it renders inside an <img> and can inherit nothing from
+    the page. Colors are mid-grays chosen to read on both light and dark
+    grounds for the same reason.
   -->
   <style>
+    .mark {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: wb-breathe 3.2s ease-in-out 1.2s infinite;
+    }
     .stroke {
       stroke-dasharray: 80;
       stroke-dashoffset: 0;
-      animation: wb-draw 2s ease-in-out infinite;
+      animation: wb-draw 1.2s ease-out;
     }
     @keyframes wb-draw {
-      0% {
+      from {
         stroke-dashoffset: 80;
-        opacity: 1;
-      }
-      55% {
-        stroke-dashoffset: 0;
-        opacity: 1;
-      }
-      80% {
-        stroke-dashoffset: 0;
-        opacity: 0;
-      }
-      100% {
-        stroke-dashoffset: 80;
-        opacity: 0;
       }
     }
-    /* One-shot lands on the fully drawn stroke (the base state above),
-       never a blank board. */
+    @keyframes wb-breathe {
+      0%,
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      50% {
+        opacity: 0.72;
+        transform: scale(0.985);
+      }
+    }
+    /* Static, fully drawn mark — the base states above are the final frame. */
     @media (prefers-reduced-motion: reduce) {
+      .mark,
       .stroke {
-        animation: wb-draw 0.01ms 1;
+        animation: none;
       }
     }
   </style>
-  <rect x="2" y="2" width="84" height="62" rx="10" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
-  <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3.5" stroke-linecap="round"/>
+  <g class="mark">
+    <rect x="2" y="2" width="84" height="62" rx="10" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
+    <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3.5" stroke-linecap="round"/>
+  </g>
   <text x="44" y="80" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" letter-spacing="0.4" fill="#909090">Whiteboard</text>
 </svg>

--- a/apps/web/public/boot-splash.svg
+++ b/apps/web/public/boot-splash.svg
@@ -1,52 +1,176 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="176" height="168" viewBox="0 0 88 84" role="img" aria-label="Whiteboard">
+<svg xmlns="http://www.w3.org/2000/svg" width="264" height="222" viewBox="0 0 176 148" role="img" aria-label="Whiteboard">
   <title>Whiteboard</title>
   <!--
-    The boot-splash mark: a pen stroke draws itself onto the whiteboard
-    ONCE, then the mark settles into a slow breathing loop — a standing
-    redraw loop reads as noise in the README. Self-contained (CSS animation
-    inside the SVG) so the same file serves the index.html splash and the
-    README, where it renders inside an <img> and can inherit nothing from
-    the page. Colors are mid-grays chosen to read on both light and dark
-    grounds for the same reason.
+    The boot-splash mark, as a story: the signature squiggle draws itself
+    (this much is what the splash screen's 1.5s hold shows), holds a beat
+    and fades; a cursor sketches nodes and edges; a spark (the one accent
+    color - the AI's hand) tidies them into an aligned diagram; the diagram
+    bows out and the signature squiggle returns softly, breathing. Where
+    the animation ends, it always lands on the logo.
+    Self-contained (CSS animation inside the SVG) so the same file serves
+    the index.html splash and the README, where it renders inside an <img>
+    and can inherit nothing from the page. Colors are mid-grays chosen to
+    read on both light and dark grounds for the same reason.
   -->
   <style>
-    .mark {
-      transform-box: fill-box;
-      transform-origin: center;
-      animation: wb-breathe 3.2s ease-in-out 1.2s infinite;
-    }
+    /* Phase 0 (0-2.2s): signature squiggle - draw, hold a beat, fade.
+       Returns at 9.7s as a soft fade-in of the already-drawn stroke. */
     .stroke {
       stroke-dasharray: 80;
-      stroke-dashoffset: 0;
-      animation: wb-draw 1.2s ease-out;
+      stroke-dashoffset: 80;
+      animation:
+        wb-draw 1.2s ease-out forwards,
+        wb-fade 0.35s ease-in 1.7s forwards,
+        wb-unfade 0.9s ease-out 9.7s forwards;
     }
     @keyframes wb-draw {
-      from {
-        stroke-dashoffset: 80;
+      to {
+        stroke-dashoffset: 0;
       }
     }
+    @keyframes wb-fade {
+      to {
+        opacity: 0;
+      }
+    }
+    @keyframes wb-unfade {
+      to {
+        opacity: 1;
+      }
+    }
+    @keyframes wb-out {
+      to {
+        opacity: 0;
+      }
+    }
+    /* Phase 1 (2.2-6.2s): a cursor sketches three nodes and two edges. */
+    .node-g {
+      transform-box: fill-box;
+      transform-origin: center;
+    }
+    .g1 { transform: rotate(-4deg); animation: wb-tidy1 0.7s cubic-bezier(0.22, 1, 0.36, 1) 7.2s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    .g2 { transform: rotate(3deg);  animation: wb-tidy2 0.7s cubic-bezier(0.22, 1, 0.36, 1) 7.3s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    .g3 { transform: rotate(-2deg); animation: wb-tidy3 0.7s cubic-bezier(0.22, 1, 0.36, 1) 7.4s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    @keyframes wb-tidy1 {
+      to {
+        transform: translate(-2px, -2px) rotate(0deg);
+      }
+    }
+    @keyframes wb-tidy2 {
+      to {
+        transform: translate(2px, 4px) rotate(0deg);
+      }
+    }
+    @keyframes wb-tidy3 {
+      to {
+        transform: translate(5px, 4px) rotate(0deg);
+      }
+    }
+    .node {
+      stroke-dasharray: 100;
+      stroke-dashoffset: 100;
+    }
+    .n1 { animation: wb-drawn 0.55s ease-out 2.7s forwards; }
+    .n2 { animation: wb-drawn 0.55s ease-out 3.5s forwards; }
+    .n3 { animation: wb-drawn 0.55s ease-out 4.3s forwards; }
+    .edge {
+      stroke-dasharray: 100;
+      stroke-dashoffset: 100;
+    }
+    .e1 { animation: wb-drawn 0.45s ease-in-out 5.1s forwards, wb-fade 0.3s ease-out 7.2s forwards; }
+    .e2 { animation: wb-drawn 0.45s ease-in-out 5.7s forwards, wb-fade 0.3s ease-out 7.2s forwards; }
+    @keyframes wb-drawn {
+      to {
+        stroke-dashoffset: 0;
+      }
+    }
+    /* Phase 2 (6.7-8.6s): the spark tidies - nodes align, edges straighten. */
+    .tidy-edge {
+      stroke-dasharray: 100;
+      stroke-dashoffset: 100;
+    }
+    .t1 { animation: wb-drawn 0.35s ease-out 7.6s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    .t2 { animation: wb-drawn 0.35s ease-out 7.75s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    .t3 { animation: wb-drawn 0.35s ease-out 7.9s forwards, wb-out 0.5s ease-in 9.2s forwards; }
+    .cursor {
+      opacity: 0;
+      animation: wb-cursor-path 4.4s ease-in-out 2.2s forwards;
+    }
+    @keyframes wb-cursor-path {
+      0%   { transform: translate(180px, 140px); opacity: 0; }
+      8%   { transform: translate(26px, 32px); opacity: 1; }
+      20%  { transform: translate(56px, 48px); opacity: 1; }
+      27%  { transform: translate(102px, 26px); opacity: 1; }
+      39%  { transform: translate(132px, 42px); opacity: 1; }
+      45%  { transform: translate(60px, 84px); opacity: 1; }
+      57%  { transform: translate(92px, 100px); opacity: 1; }
+      63%  { transform: translate(56px, 40px); opacity: 1; }
+      75%  { transform: translate(100px, 34px); opacity: 1; }
+      80%  { transform: translate(42px, 50px); opacity: 1; }
+      92%  { transform: translate(72px, 82px); opacity: 1; }
+      100% { transform: translate(72px, 82px); opacity: 0; }
+    }
+    .spark {
+      transform-box: fill-box;
+      transform-origin: center;
+      opacity: 0;
+      animation: wb-spark-pop 1.9s ease-in-out 6.7s forwards;
+    }
+    @keyframes wb-spark-pop {
+      0%   { opacity: 0; transform: scale(0.4) rotate(0deg); }
+      18%  { opacity: 1; transform: scale(1.15) rotate(20deg); }
+      45%  { opacity: 1; transform: scale(0.95) rotate(45deg); }
+      80%  { opacity: 1; transform: scale(1) rotate(70deg); }
+      100% { opacity: 0; transform: scale(0.6) rotate(90deg); }
+    }
+    /* Finale (11s-): the logo - board plus squiggle - breathes. */
+    .scene {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: wb-breathe 3.2s ease-in-out 11s infinite;
+    }
     @keyframes wb-breathe {
-      0%,
-      100% {
+      0%, 100% {
         opacity: 1;
         transform: scale(1);
       }
       50% {
         opacity: 0.72;
-        transform: scale(0.985);
+        transform: scale(0.99);
       }
     }
-    /* Static, fully drawn mark — the base states above are the final frame. */
+    /* Static, fully drawn logo - the story collapses to its landing frame. */
     @media (prefers-reduced-motion: reduce) {
-      .mark,
-      .stroke {
+      .scene, .cursor, .node, .edge, .tidy-edge, .spark, .node-g, .stroke {
         animation: none;
+      }
+      .stroke {
+        stroke-dashoffset: 0;
+      }
+      .node-g, .edge, .tidy-edge, .cursor, .spark {
+        display: none;
       }
     }
   </style>
-  <g class="mark">
-    <rect x="2" y="2" width="84" height="62" rx="10" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
-    <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3.5" stroke-linecap="round"/>
+  <g class="scene">
+    <rect x="2" y="2" width="172" height="120" rx="12" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
+    <g transform="translate(30 22) scale(1.35)">
+      <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <path class="edge e1" pathLength="100" d="M54 37 C 70 33, 84 27, 100 31" fill="none" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
+    <path class="edge e2" pathLength="100" d="M42 46 C 46 60, 58 70, 70 80" fill="none" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
+    <path class="tidy-edge t1" pathLength="100" d="M52 35 L102 35" fill="none" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
+    <path class="tidy-edge t2" pathLength="100" d="M37 44 C 37 66, 79 64, 79 84" fill="none" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
+    <path class="tidy-edge t3" pathLength="100" d="M117 44 C 117 66, 79 64, 79 84" fill="none" stroke="#909090" stroke-width="2" stroke-linecap="round"/>
+    <g class="node-g g1"><rect class="node n1" pathLength="100" x="24" y="28" width="30" height="18" rx="4" fill="none" stroke="#909090" stroke-width="2.5"/></g>
+    <g class="node-g g2"><rect class="node n2" pathLength="100" x="100" y="22" width="30" height="18" rx="4" fill="none" stroke="#909090" stroke-width="2.5"/></g>
+    <g class="node-g g3"><rect class="node n3" pathLength="100" x="58" y="80" width="32" height="18" rx="4" fill="none" stroke="#909090" stroke-width="2.5"/></g>
+    <g class="spark">
+      <path d="M150 14 L152.2 20.8 L159 23 L152.2 25.2 L150 32 L147.8 25.2 L141 23 L147.8 20.8 Z" fill="#3b6ecc"/>
+    </g>
   </g>
-  <text x="44" y="80" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" letter-spacing="0.4" fill="#909090">Whiteboard</text>
+  <g class="cursor">
+    <path d="M0 0 L0 12 L3.2 9.2 L5.6 14 L7.8 12.9 L5.4 8.2 L9.5 7.6 Z" fill="#5b5b5b" stroke="#fdfdfd" stroke-width="1"/>
+  </g>
+  <text x="88" y="143" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" letter-spacing="0.4" fill="#909090">Whiteboard</text>
 </svg>

--- a/apps/web/public/boot-splash.svg
+++ b/apps/web/public/boot-splash.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="176" height="168" viewBox="0 0 88 84" role="img" aria-label="Whiteboard">
+  <title>Whiteboard</title>
+  <!--
+    The boot-splash mark: a pen stroke drawing itself onto a whiteboard,
+    looping. Self-contained (CSS animation inside the SVG) so the same file
+    serves the index.html splash and the README, where it renders inside an
+    <img> and can inherit nothing from the page. Colors are mid-grays chosen
+    to read on both light and dark grounds for the same reason.
+  -->
+  <style>
+    .stroke {
+      stroke-dasharray: 80;
+      stroke-dashoffset: 0;
+      animation: wb-draw 2s ease-in-out infinite;
+    }
+    @keyframes wb-draw {
+      0% {
+        stroke-dashoffset: 80;
+        opacity: 1;
+      }
+      55% {
+        stroke-dashoffset: 0;
+        opacity: 1;
+      }
+      80% {
+        stroke-dashoffset: 0;
+        opacity: 0;
+      }
+      100% {
+        stroke-dashoffset: 80;
+        opacity: 0;
+      }
+    }
+    /* One-shot lands on the fully drawn stroke (the base state above),
+       never a blank board. */
+    @media (prefers-reduced-motion: reduce) {
+      .stroke {
+        animation: wb-draw 0.01ms 1;
+      }
+    }
+  </style>
+  <rect x="2" y="2" width="84" height="62" rx="10" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
+  <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3.5" stroke-linecap="round"/>
+  <text x="44" y="80" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" letter-spacing="0.4" fill="#909090">Whiteboard</text>
+</svg>

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -2,7 +2,7 @@ import { resetTokenStoreForTests } from '@kamiazya/whiteboard-mcp/api-client'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { createMemoryRouter, MemoryRouter, RouterProvider, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { App } from './App.js'
+import { App, LazyPageFallback } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
 // App reaches every page through React.lazy(), so a page renders only once
@@ -983,5 +983,18 @@ describe('App error boundary', () => {
       mockDaemonConnectionResult = { status: 'none' }
       reportSpy.mockRestore()
     }
+  })
+})
+
+describe('lazy page fallback', () => {
+  // Suspense commits this before a lazy page chunk resolves, so this IS the
+  // loading state: the structural page skeleton (pulsing header + canvas
+  // placeholders), not a bare line of centered text. Tested directly —
+  // through <App> the lazy chunks resolve once per module, so only the
+  // file's first render could ever observe the fallback.
+  it('renders the structural page skeleton with the message as its label', () => {
+    const { container } = render(<LazyPageFallback heightClass="h-full" message="Loading…" />)
+    expect(screen.getByLabelText('Loading…')).toBeTruthy()
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
   })
 })

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { readDaemonTokenOnce } from '@kamiazya/whiteboard-mcp/api-client'
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { BetaBanner } from './components/BetaBanner.js'
+import { CanvasPageSkeleton } from './components/CanvasPageSkeleton.js'
 import { ErrorBoundary } from './components/ErrorBoundary.js'
 import { useDaemonConnection } from './hooks/useDaemonConnection.js'
 import {
@@ -71,19 +72,23 @@ interface AppProps {
 }
 
 // Suspense fallback shared by every lazy page chunk (DaemonCanvasPage and
-// BrowserLocalCanvasPage). The height class differs by mount site (root
-// fills the viewport; the in-banner branches fill the flex row under it), so
-// it's a prop; message is also a prop so the daemon-specific and
-// backend-agnostic mount sites show accurate copy without duplicating this
-// component.
-function LazyPageFallback({ heightClass, message }: { heightClass: string; message: string }) {
+// BrowserLocalCanvasPage). Reuses the structural CanvasPageSkeleton so the
+// chunk-load state and the page's own connecting state are one continuous
+// pulse instead of a text line snapping to a skeleton. The height class
+// differs by mount site (root fills the viewport; the in-banner branches
+// fill the flex row under it), so it's a prop; message becomes the
+// accessible label so daemon-specific and backend-agnostic mount sites
+// announce accurate copy.
+export function LazyPageFallback({
+  heightClass,
+  message,
+}: {
+  heightClass: string
+  message: string
+}) {
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className={`flex ${heightClass} items-center justify-center text-sm text-muted-foreground`}
-    >
-      {message}
+    <div className={heightClass}>
+      <CanvasPageSkeleton label={message} />
     </div>
   )
 }

--- a/apps/web/src/boot-splash.test.ts
+++ b/apps/web/src/boot-splash.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  dismissBootSplash,
+  SPLASH_FADE_MS,
+  SPLASH_MIN_VISIBLE_MS,
+  splashHoldMs,
+} from './boot-splash.js'
+
+describe('splashHoldMs', () => {
+  it('holds out to the minimum visible time', () => {
+    expect(splashHoldMs(400, false)).toBe(SPLASH_MIN_VISIBLE_MS - 400)
+  })
+
+  it('does not hold once the minimum has already elapsed (slow load)', () => {
+    expect(splashHoldMs(SPLASH_MIN_VISIBLE_MS + 1, false)).toBe(0)
+  })
+
+  it('never holds under reduced motion', () => {
+    expect(splashHoldMs(0, true)).toBe(0)
+  })
+})
+
+describe('dismissBootSplash', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = '<div id="root"><div class="wb-boot"></div></div>'
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('waits out the hold, fades the splash, then resolves', async () => {
+    let resolved = false
+    const p = dismissBootSplash({ elapsedMs: 100, reducedMotion: false }).then(() => {
+      resolved = true
+    })
+    const splash = document.querySelector('.wb-boot') as HTMLElement
+
+    // Mid-hold: splash untouched, promise pending.
+    await vi.advanceTimersByTimeAsync(SPLASH_MIN_VISIBLE_MS - 100 - 1)
+    expect(splash.style.opacity).toBe('')
+    expect(resolved).toBe(false)
+
+    // Hold over: fade begins but the promise waits for the fade.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(splash.style.opacity).toBe('0')
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(SPLASH_FADE_MS)
+    await p
+    expect(resolved).toBe(true)
+  })
+
+  it('resolves immediately under reduced motion, leaving the splash unfaded', async () => {
+    const p = dismissBootSplash({ elapsedMs: 0, reducedMotion: true })
+    await vi.advanceTimersByTimeAsync(0)
+    await p
+    expect((document.querySelector('.wb-boot') as HTMLElement).style.opacity).toBe('')
+  })
+
+  it('tolerates a missing splash element (already replaced)', async () => {
+    document.body.innerHTML = '<div id="root"></div>'
+    const p = dismissBootSplash({ elapsedMs: SPLASH_MIN_VISIBLE_MS, reducedMotion: false })
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(p).resolves.toBeUndefined()
+  })
+})

--- a/apps/web/src/boot-splash.test.ts
+++ b/apps/web/src/boot-splash.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   dismissBootSplash,
+  elapsedSinceFirstPaint,
   SPLASH_FADE_MS,
   SPLASH_MIN_VISIBLE_MS,
   splashHoldMs,
@@ -17,6 +18,26 @@ describe('splashHoldMs', () => {
 
   it('never holds under reduced motion', () => {
     expect(splashHoldMs(0, true)).toBe(0)
+  })
+})
+
+describe('elapsedSinceFirstPaint', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  // A slow HTML fetch delays first paint past the time origin; the clock
+  // must start when the splash became visible, not when navigation began.
+  it('measures from first-contentful-paint, not the time origin', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(2000)
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+      { name: 'first-contentful-paint', startTime: 1800 } as PerformanceEntry,
+    ])
+    expect(elapsedSinceFirstPaint()).toBe(200)
+  })
+
+  it('falls back to the time origin when no paint entry exists', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(700)
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([])
+    expect(elapsedSinceFirstPaint()).toBe(700)
   })
 })
 

--- a/apps/web/src/boot-splash.ts
+++ b/apps/web/src/boot-splash.ts
@@ -7,9 +7,9 @@
  * splash. Timings mirror the wb-boot-draw keyframes in index.html.
  */
 
-// One draw cycle reaches the fully drawn stroke at 55% of 2s (1100ms) and
-// starts fading it at 80% (1600ms); handing off inside that window means
-// the user sees the completed stroke plus a beat, never a blank board.
+// The stroke finishes drawing at 1.2s (wb-draw in public/boot-splash.svg);
+// holding to 1.5s means the user sees the completed stroke plus a beat —
+// the mark's slow breathing loop then carries any longer wait.
 export const SPLASH_MIN_VISIBLE_MS = 1500
 export const SPLASH_FADE_MS = 200
 

--- a/apps/web/src/boot-splash.ts
+++ b/apps/web/src/boot-splash.ts
@@ -25,6 +25,21 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Elapsed time since the splash first PAINTED, not since the navigation
+ * time origin: on a slow HTML fetch the first paint lags the origin, and
+ * an origin-based clock would count time the user never saw the splash,
+ * cutting the hold short. First paint precedes module execution, so the
+ * paint entry is normally recorded by the time this runs; when it is not
+ * (jsdom, very old browsers), fall back to the time origin.
+ */
+export function elapsedSinceFirstPaint(): number {
+  const paints =
+    typeof performance.getEntriesByType === 'function' ? performance.getEntriesByType('paint') : []
+  const fcp = paints.find((entry) => entry.name === 'first-contentful-paint')
+  return Math.max(0, performance.now() - (fcp?.startTime ?? 0))
+}
+
+/**
  * Hold the splash out to its minimum visible time, then fade it out.
  * Resolves once the splash is invisible and safe to replace. Reduced
  * motion skips both the artificial hold and the fade — those users get
@@ -32,7 +47,7 @@ function sleep(ms: number): Promise<void> {
  */
 export async function dismissBootSplash({
   doc = document,
-  elapsedMs = performance.now(),
+  elapsedMs = elapsedSinceFirstPaint(),
   reducedMotion = typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches,
 }: {

--- a/apps/web/src/boot-splash.ts
+++ b/apps/web/src/boot-splash.ts
@@ -7,9 +7,10 @@
  * splash. Timings mirror the wb-boot-draw keyframes in index.html.
  */
 
-// The stroke finishes drawing at 1.2s (wb-draw in public/boot-splash.svg);
-// holding to 1.5s means the user sees the completed stroke plus a beat —
-// the mark's slow breathing loop then carries any longer wait.
+// The signature stroke finishes drawing at 1.2s (wb-draw in
+// public/boot-splash.svg); holding to 1.5s shows the completed stroke plus
+// a beat. A longer wait rolls on into the SVG's sketch-then-tidy story,
+// which always lands back on the breathing logo.
 export const SPLASH_MIN_VISIBLE_MS = 1500
 export const SPLASH_FADE_MS = 200
 

--- a/apps/web/src/boot-splash.ts
+++ b/apps/web/src/boot-splash.ts
@@ -1,0 +1,49 @@
+/**
+ * Deliberate splash-screen pacing for the index.html boot splash: the app
+ * gets ready in the background (font load, module graph), but the splash
+ * stays up until its draw animation has completed plus a beat, then fades
+ * out before React's first commit replaces it. Without the hold, a fast
+ * load dismisses the splash mid-stroke — it reads as a flicker, not a
+ * splash. Timings mirror the wb-boot-draw keyframes in index.html.
+ */
+
+// One draw cycle reaches the fully drawn stroke at 55% of 2s (1100ms) and
+// starts fading it at 80% (1600ms); handing off inside that window means
+// the user sees the completed stroke plus a beat, never a blank board.
+export const SPLASH_MIN_VISIBLE_MS = 1500
+export const SPLASH_FADE_MS = 200
+
+/** How much longer the splash must stay up, measured from first paint. */
+export function splashHoldMs(elapsedMs: number, reducedMotion: boolean): number {
+  if (reducedMotion) return 0
+  return Math.max(0, SPLASH_MIN_VISIBLE_MS - elapsedMs)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Hold the splash out to its minimum visible time, then fade it out.
+ * Resolves once the splash is invisible and safe to replace. Reduced
+ * motion skips both the artificial hold and the fade — those users get
+ * the app as soon as it is ready.
+ */
+export async function dismissBootSplash({
+  doc = document,
+  elapsedMs = performance.now(),
+  reducedMotion = typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+}: {
+  doc?: Document
+  elapsedMs?: number
+  reducedMotion?: boolean
+} = {}): Promise<void> {
+  const hold = splashHoldMs(elapsedMs, reducedMotion)
+  if (hold > 0) await sleep(hold)
+  const splash = doc.querySelector('.wb-boot')
+  if (!(splash instanceof HTMLElement) || reducedMotion) return
+  splash.style.transition = `opacity ${SPLASH_FADE_MS}ms ease-out`
+  splash.style.opacity = '0'
+  await sleep(SPLASH_FADE_MS)
+}

--- a/apps/web/src/components/CanvasPageSkeleton.test.tsx
+++ b/apps/web/src/components/CanvasPageSkeleton.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CanvasPageSkeleton } from './CanvasPageSkeleton.js'
+
+afterEach(cleanup)
+
+describe('CanvasPageSkeleton', () => {
+  it('announces itself with the given label', () => {
+    const { getByRole } = render(<CanvasPageSkeleton label="Loading canvas" />)
+    expect(getByRole('status').getAttribute('aria-label')).toBe('Loading canvas')
+  })
+
+  // The skeleton must not flash: it stays invisible for a beat and only
+  // fades in when the wait turns out to be real (skeleton-appear in
+  // index.css). A skeleton that pops for one frame between a resolved
+  // chunk and first paint reads as a glitch, not as progress.
+  it('appears through the delayed skeleton-appear animation', () => {
+    const { getByRole } = render(<CanvasPageSkeleton label="Loading canvas" />)
+    expect(getByRole('status').className).toContain('skeleton-appear')
+  })
+})

--- a/apps/web/src/components/CanvasPageSkeleton.tsx
+++ b/apps/web/src/components/CanvasPageSkeleton.tsx
@@ -3,6 +3,9 @@
  * area placeholders instead of a lone sentence, so the page's shape is
  * stable from first paint. Announced politely to assistive tech via the
  * status role + label (the visible pulse carries no text).
+ *
+ * skeleton-appear keeps it invisible for a beat so a fast load never
+ * flashes placeholders (see index.css).
  */
 export function CanvasPageSkeleton({ label }: { label: string }) {
   return (
@@ -10,7 +13,7 @@ export function CanvasPageSkeleton({ label }: { label: string }) {
       role="status"
       aria-live="polite"
       aria-label={label}
-      className="flex h-full w-full flex-col"
+      className="skeleton-appear flex h-full w-full flex-col"
     >
       <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
         <div className="h-5 w-36 animate-pulse rounded bg-muted" />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -184,6 +184,25 @@
   }
 
   /*
+   * Skeletons appear only when the wait is real: invisible for a beat,
+   * then a gentle fade-in. A skeleton that pops for a single frame
+   * between a resolved chunk and first paint reads as a glitch, not as
+   * progress — fast loads should show quiet background, not a flash of
+   * pulsing placeholders. The reduced-motion floor below collapses the
+   * fade itself; the delay still suppresses the flash.
+   */
+  @keyframes skeleton-appear {
+    to {
+      opacity: 1;
+    }
+  }
+
+  .skeleton-appear {
+    opacity: 0;
+    animation: skeleton-appear var(--motion-duration-normal) var(--motion-ease-out) 300ms forwards;
+  }
+
+  /*
    * Reduced-motion floor: neutralize every animation and transition —
    * including tw-animate-css's data-state entrances — for users who asked
    * the OS for less motion. 0.01ms instead of 0 so `animationend` /

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { App } from './App.js'
+import { dismissBootSplash } from './boot-splash.js'
 import { applyThemeClass, readPersistedTheme, resolveTheme } from './hooks/useThemeMode.js'
 import './index.css'
 import { purgeLegacyReconnectCredentials } from './lib/purge-legacy-reconnect-credentials.js'
@@ -45,4 +46,10 @@ function renderApp(root: HTMLElement): void {
 // indefinitely — first paint then proceeds with fallback system-font
 // metrics and self-corrects once the font finishes loading in the
 // background (see CanvasViewer's useViewerFontReady for that path).
-void ensureViewerFontLoaded().then(() => renderApp(rootEl))
+//
+// dismissBootSplash then paces the index.html splash: the app is ready at
+// this point, but the splash stays up until its draw animation lands plus
+// a beat, and fades out before React's first commit replaces it.
+void ensureViewerFontLoaded()
+  .then(() => dismissBootSplash())
+  .then(() => renderApp(rootEl))

--- a/apps/web/src/motion-foundation.browser.test.tsx
+++ b/apps/web/src/motion-foundation.browser.test.tsx
@@ -47,6 +47,15 @@ describe('motion foundation', () => {
     expect(styles.getPropertyValue('--motion-ease-out').trim()).toContain('cubic-bezier')
   })
 
+  it('ships the delayed skeleton-appear rule (no placeholder flash on fast loads)', () => {
+    const css = collectCssText()
+    const ruleIdx = css.indexOf('.skeleton-appear')
+    expect(ruleIdx).toBeGreaterThan(-1)
+    const rule = css.slice(ruleIdx, css.indexOf('}', ruleIdx))
+    expect(rule).toContain('opacity: 0')
+    expect(rule).toMatch(/animation:.*0\.3s|animation:.*300ms/)
+  })
+
   it('ships a prefers-reduced-motion guard neutralizing animations and transitions', () => {
     const css = collectCssText()
     const mediaIdx = css.indexOf('prefers-reduced-motion: reduce')

--- a/apps/web/src/motion-foundation.browser.test.tsx
+++ b/apps/web/src/motion-foundation.browser.test.tsx
@@ -47,13 +47,20 @@ describe('motion foundation', () => {
     expect(styles.getPropertyValue('--motion-ease-out').trim()).toContain('cubic-bezier')
   })
 
-  it('ships the delayed skeleton-appear rule (no placeholder flash on fast loads)', () => {
-    const css = collectCssText()
-    const ruleIdx = css.indexOf('.skeleton-appear')
-    expect(ruleIdx).toBeGreaterThan(-1)
-    const rule = css.slice(ruleIdx, css.indexOf('}', ruleIdx))
-    expect(rule).toContain('opacity: 0')
-    expect(rule).toMatch(/animation:.*0\.3s|animation:.*300ms/)
+  it('keeps skeletons invisible for a 300ms DELAY (computed style, not just the shorthand)', () => {
+    // Computed values, so a refactor that turns 300ms into the duration
+    // instead of the delay (letting the fade start immediately) fails here.
+    const el = document.createElement('div')
+    el.className = 'skeleton-appear'
+    document.body.appendChild(el)
+    try {
+      const cs = getComputedStyle(el)
+      expect(cs.animationDelay).toBe('0.3s')
+      expect(cs.opacity).toBe('0')
+      expect(cs.animationFillMode).toBe('forwards')
+    } finally {
+      el.remove()
+    }
   })
 
   it('ships a prefers-reduced-motion guard neutralizing animations and transitions', () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -408,7 +408,7 @@ export function DaemonIndexPage({
           <div
             role="status"
             aria-label="Loading canvases"
-            className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+            className="skeleton-appear grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
           >
             {[0, 1, 2, 3].map((i) => (
               <div key={i} className="animate-pulse rounded-lg border p-2">

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       'public-headers.test.ts',
       'vite-dev-headers.test.ts',
       'vite-plugin-strip-wasm-sourcemap.test.ts',
+      'index-html.test.ts',
       'scripts/**/*.test.ts',
     ],
   },

--- a/packages/mcp-server/scripts/smoke/mcp-daemon-origin-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-daemon-origin-smoke.mjs
@@ -93,12 +93,22 @@ try {
   const pairUrl = `${daemonBaseUrl}/pair?origin=${encodeURIComponent(
     'https://app.example',
   )}&challenge=smoke-challenge&state=smoke-state`
-  await page.goto(pairUrl, { waitUntil: 'networkidle' })
+  // 'load', not 'networkidle': the service worker's precache traffic can
+  // keep the network busy past the goto timeout, and every assertion below
+  // waits explicitly anyway.
+  await page.goto(pairUrl, { waitUntil: 'load' })
 
+  // waitFor, not isVisible: isVisible ignores its timeout and reports the
+  // instantaneous state, which races the boot splash's deliberate hold
+  // (apps/web/src/boot-splash.ts) — the app renders ~1.7s after load.
   const consentHeading = page.getByRole('heading', {
     name: /allow this web app to use your local daemon/i,
   })
-  if (await consentHeading.isVisible({ timeout: 10_000 }).catch(() => false)) {
+  const consentVisible = await consentHeading
+    .waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true)
+    .catch(() => false)
+  if (consentVisible) {
     console.log('  pass  /pair renders the consent page from the built bundle')
   } else {
     console.error('  FAIL  /pair did not render the consent heading')


### PR DESCRIPTION
## Summary

Two loading gaps were visible on every cold load of the web app:

1. **Blank white page before the bundle arrives.** Until the app bundle (and the awaited viewer font) loads, the page was an empty white rectangle — jarring on dark-theme systems and indistinguishable from a hung server. `index.html` now ships an inline, CSS-only boot splash: a pen stroke drawing itself onto a whiteboard-shaped board, with a "Whiteboard" wordmark. It lives **inside `#root`**, so React's first commit replaces it with zero handoff code. It follows `prefers-color-scheme` (the production CSP forbids inline scripts, so the persisted-theme override cannot run this early) and is neutralized under `prefers-reduced-motion` (the one-shot lands on the fully drawn stroke, not a blank board).
2. **Bare "Loading…" text while lazy page chunks load.** The shared Suspense fallback was a centered text line that snapped into the page. It now reuses `CanvasPageSkeleton`, so chunk-load and the page's own connecting state are one continuous pulse; the message becomes the accessible `role=status` label.

3. **Splash-screen pacing.** The app still gets ready in the background, but the splash is dismissed only after the draw animation has landed plus a beat (1.5s from first paint), then fades out — a fast load no longer cuts the stroke off mid-draw. Reduced-motion users skip the hold and the fade entirely.

4. **The mark is a shared external SVG.** `apps/web/public/boot-splash.svg` plays the signature-squiggle → sketch → AI-tidy → logo-returns story, with the reduced-motion guard (static drawn logo) (and its reduced-motion guard) inside the file, so the identical asset serves the splash and the README hero — GitHub renders CSS-animated SVGs inside `<img>`.

5. **No skeleton flash on fast loads.** Skeletons stay invisible for a 300ms beat and fade in only when the wait turns out to be real — a placeholder that pops for one frame reads as a glitch, not progress. Verified: opacity 0 right after the splash on a fast load; faded in at +700ms with an artificially delayed chunk.

## Visual repro

The mark tells the product's story in one self-contained SVG (splash and README share the file): the signature squiggle draws (all the splash's 1.5s hold shows) → a cursor sketches nodes and edges → a spark (the AI's hand, the single accent color) tidies them into an aligned diagram → the diagram bows out and the squiggle returns softly, breathing:

![boot-splash-story.gif](https://github.com/user-attachments/assets/c2b3acab-7795-4741-a947-6ce259261da9)

Real cold load — splash draws, holds a beat, fades, skeleton, canvas:

![cold-load-handoff.gif](https://github.com/user-attachments/assets/d340d1e8-8fcf-4897-98f5-bebfa2bc7abc)

Structural skeleton while the page chunk loads (was a bare "Loading…" line), then the loaded canvas:

![app-loaded.png](https://github.com/user-attachments/assets/4190867a-405f-45be-85a8-7a0d4123b699)
![app-final.png](https://github.com/user-attachments/assets/9d010cda-eb7c-49bc-82e0-0cbf88db5438)

## Smoke fix

The daemon-origin smoke's consent-heading check used `isVisible()`, whose timeout option is ignored — it raced the deliberate ~1.7s paced render and failed on CI. It now genuinely waits (`waitFor`), and `goto` waits for `'load'` instead of `'networkidle'` (service-worker precache traffic can hold the network open past the goto timeout). Verified locally end to end against the built bundle: all daemon-origin smoke steps pass.

## Tests

- `apps/web/src/boot-splash.test.ts` pins the pacing contract: hold to minimum visible time, fade before resolve, reduced-motion passthrough, missing-splash tolerance.
- New `apps/web/index-html.test.ts` (web-node) pins the splash contract: markup inside `#root`, dark-scheme support, reduced-motion neutralization.
- `App.test.tsx` pins that the Suspense fallback renders the structural skeleton with the message as its accessible label.
- Full `apps/web` jsdom (1735) + web-node (54) suites pass; typecheck, knip, biome clean.
- Verified in a real browser (Playwright against the dev server): splash in both schemes → skeleton → loaded canvas.

Note: the local pre-push `mcp-node` run has 2 pre-existing unhandled-rejection errors reproduced identically on clean main (`http-server.test.ts` opens the machine's real data dir, which another worktree's daemon migrated ahead) — machine-local test-isolation issue, unrelated to this diff; filed as a whiteboard issue canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centered, accessible boot splash with light and dark theme support.
  * Added timed splash dismissal with reduced-motion support.
  * Improved loading states with structural skeleton placeholders.

* **Enhancements**
  * Skeletons now appear after a brief delay to reduce visual flashing.
  * Added a boot-splash preview image to the README.

* **Bug Fixes**
  * Improved browser smoke-test reliability during page loading and consent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

