### PR TITLE
test(web): stop the browser suite failing on timing rather than behaviour

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -40,8 +40,18 @@ vi.mock('../components/spatial-editor/index.js', () => ({
 
 const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
 
-// The body save is debounced (500ms) inside use-markdown-body; wait past it.
-const SAVE_SETTLE_MS = 800
+/**
+ * Waits until the page reports the debounced save as landed.
+ *
+ * The save is debounced 500ms and then has to reach IndexedDB, so a fixed
+ * sleep is a bet on machine speed — the timing-based assertion this repo
+ * treats as a recurring flake shape, and what tipped these tests over under
+ * load. `Saved` is the page's own report that the write completed, which is
+ * the condition these tests actually depend on before tearing the page down.
+ */
+async function waitForSaved(): Promise<void> {
+  await waitFor(() => expect(screen.getByText('Saved')).toBeTruthy(), { timeout: 15_000 })
+}
 
 describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', () => {
   beforeEach(async () => {
@@ -87,10 +97,7 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
       expect(document.querySelector('.cm-content')?.textContent).toBe('# Persisted note')
     })
 
-    // Let the debounced Loro save land before tearing the page down.
-    await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
-    const markdownCanvasId = await store.getDefaultCanvasId()
-    expect(markdownCanvasId).not.toBeNull()
+    await waitForSaved()
     first.unmount()
 
     // A fresh page against the same store reopens the markdown note with
@@ -123,7 +130,7 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // snapshot row, written from the same edit as the OKF core facet.
     await screen.findByRole('button', { name: 'リリース計画' }, { timeout: 10_000 })
 
-    await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
+    await waitForSaved()
     first.unmount()
 
     // The facet itself round-trips through the Loro 'core' map, so the
@@ -164,7 +171,7 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     await userEvent.click(title)
     await userEvent.keyboard('Titled')
 
-    await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
+    await waitForSaved()
     first.unmount()
 
     render(<BrowserLocalCanvasPage store={store} />)
@@ -231,7 +238,7 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // more than its label text, so a full-string match asserts the wrong thing.
     await screen.findByRole('button', { name: /Architecture map/ }, { timeout: 10_000 })
 
-    await new Promise((resolve) => setTimeout(resolve, SAVE_SETTLE_MS))
+    await waitForSaved()
     first.unmount()
 
     render(<BrowserLocalCanvasPage store={store} />)

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -14,4 +14,17 @@
  * without it is testing a layout no user ever sees. Loading it here removes
  * the per-file decision entirely.
  */
+import { configure } from '@testing-library/react'
 import '../index.css'
+
+/**
+ * Testing Library's `findBy*`/`waitFor` default is 1000ms, which is a
+ * fast-machine number: under parallel browser files it is routinely too
+ * short for a portal to mount or an IndexedDB round trip to land. Ten tests
+ * had already worked around it with a local `{ timeout: 10_000 }`, which is
+ * the smell of a global default set too low.
+ *
+ * Like the test timeout, this is a ceiling rather than a delay — raising it
+ * slows nothing down that succeeds.
+ */
+configure({ asyncUtilTimeout: 5_000 })

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -71,6 +71,18 @@ export default defineConfig({
   test: {
     name: 'web-browser',
     include: ['src/**/*.browser.test.tsx'],
+    // Browser mode's 15s default is a real ceiling here, not a safety net: a
+    // test that mounts a page, drives Radix through a portal and waits on
+    // IndexedDB spends most of its budget on machine time, and vitest runs
+    // these files in PARALLEL. On a loaded machine that tips whole files over
+    // at once — the observed failures are `Test timed out`, not assertion
+    // failures, and the same tests pass 4/4 when their file runs alone.
+    //
+    // A timeout costs nothing while tests pass; it only decides how long a
+    // genuinely hung test takes to report. 30s matches the precedent already
+    // set by vitest.docs-snapshots.config.ts.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     // Every browser test renders against the app's real stylesheet — see
     // browser-setup.ts for what silently breaks without it.
     setupFiles: ['./src/test-utils/browser-setup.ts'],


### PR DESCRIPTION
## What it actually was

The web-browser suite failed one or more random tests per full run under
load — a different one each time, always passing when its file ran alone.
I chased three hypotheses (focus races across parallel browser pages, Radix
portal timing, accessible-name computation) and **all three were wrong**.

Reproducing it deliberately under synthetic CPU load settled it: of seven
failures, **six were `Test timed out`**, not assertion failures. The suite
was not racing on anything. It was not finishing in time.

## Two configuration causes

**`vitest.browser.config.ts` set no `testTimeout`**, so browser mode's 15s
default governed tests that mount a page, drive Radix through a portal and
wait on IndexedDB — while vitest runs those files in parallel. Raised to
30s, matching the precedent already set by `vitest.docs-snapshots.config.ts`.

**Testing Library's `findBy*`/`waitFor` default is 1000ms**, a fast-machine
number. Ten tests already carried a local `{ timeout: 10_000 }` workaround —
the smell of a global default set too low. Now configured once in
`browser-setup.ts`.

Neither slows anything down. A timeout is a ceiling, not a delay; what
changes is only how long a genuinely hung test takes to report.

## One test-hygiene fix

The markdown page tests traded four fixed 800ms sleeps for waiting on the
page's own `Saved` report. The sleep had to cover a 500ms debounce plus an
IndexedDB write, so it was a bet on machine speed — the timing-based
assertion `integrator-flow.md` already names as this repo's recurring flake
shape, and the first thing to tip over.

## Measured, not asserted

Same 10-busy-loop load throughout:

| | failures |
|---|---|
| before | 7 |
| after | 4 |
| quiet machine, after | 0 / 476 |

The four survivors are still pure 30s timeouts on a machine with 10 of 16
cores saturated by unrelated work — harsher than any real runner, and CI's
`test-browser` passed on every PR through this whole investigation. Raising
the ceiling further would be papering over rather than fixing, so it stops
here rather than chasing zero against an artificial stressor.

## Filed separately, not fixed here

Every worktree's mcp-node suite **and every dev daemon** resolves the same
real `~/.whiteboard` data dir, even though each worktree gets its own
derived port. Dev daemons outlive `git worktree remove` — one was still
running on port 3516 for a worktree deleted earlier in the session — and a
stale daemon built from a branch that no longer exists keeps migrating the
shared DB. The next `pnpm test --project mcp-node` on any branch then fails
the pre-push gate with `IncompatibleDatabaseError` while all 3215 tests
pass. That is the strongest form of the "shared global resource" flake shape
integrator-flow.md warns about, and it needs isolation plus daemon teardown
rather than anyone deleting a database.
