### PR TITLE
feat(web): collapse the canvas header into one canvas-level row

### DIFF
--- a/apps/web/src/components/SaveStatusChip.test.tsx
+++ b/apps/web/src/components/SaveStatusChip.test.tsx
@@ -1,0 +1,53 @@
+// The browser-local autosave state as a colored chip, modeled on the
+// connection chip: a colored dot PLUS a visible text label (color alone
+// must never carry the state — WCAG 1.4.1), with a popover carrying the
+// sentence-shaped explanation.
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { SaveStatusChip } from './SaveStatusChip.js'
+
+afterEach(cleanup)
+
+const chip = (container: HTMLElement) =>
+  container.querySelector('[data-testid="save-status-chip"]') as HTMLElement
+
+it('shows Saved with the calm dot', () => {
+  const { container } = render(<SaveStatusChip state={{ kind: 'saved', lastSavedAt: null }} />)
+  expect(chip(container).textContent).toContain('Saved')
+  expect(chip(container).querySelector('.bg-emerald-500')).toBeTruthy()
+})
+
+it('shows Saving… while a write is in flight', () => {
+  const { container } = render(<SaveStatusChip state={{ kind: 'saving', lastSavedAt: null }} />)
+  expect(chip(container).textContent).toContain('Saving…')
+  expect(chip(container).querySelector('.bg-amber-500')).toBeTruthy()
+})
+
+it('shows Unsaved changes for a pending write', () => {
+  const { container } = render(<SaveStatusChip state={{ kind: 'pending', lastSavedAt: null }} />)
+  expect(chip(container).textContent).toContain('Unsaved changes')
+})
+
+it('degraded carries its own message as the visible label, with the attention pulse', () => {
+  const { container } = render(
+    <SaveStatusChip
+      state={{
+        kind: 'degraded',
+        reason: 'quota',
+        message: 'Storage is full',
+        lastSavedAt: null,
+      }}
+    />,
+  )
+  expect(chip(container).textContent).toContain('Storage is full')
+  expect(container.querySelector('[data-testid="save-status-chip-pulse"]')).toBeTruthy()
+})
+
+it('the popover explains the state as text on demand', () => {
+  const { container, baseElement } = render(
+    <SaveStatusChip state={{ kind: 'saved', lastSavedAt: null }} />,
+  )
+  fireEvent.click(chip(container))
+  const popover = baseElement.querySelector('[data-testid="save-status-popover"]')
+  expect(popover?.textContent).toContain('saved')
+})

--- a/apps/web/src/components/SaveStatusChip.test.tsx
+++ b/apps/web/src/components/SaveStatusChip.test.tsx
@@ -1,7 +1,7 @@
-// The browser-local autosave state as a colored chip, modeled on the
-// connection chip: a colored dot PLUS a visible text label (color alone
-// must never carry the state — WCAG 1.4.1), with a popover carrying the
-// sentence-shaped explanation.
+// The browser-local autosave state as a color-only dot beside the title
+// (owner decision): the label lives in the accessible name and tooltip,
+// the sentence-shaped explanation in a popover — assistive tech always
+// gets the state as text even though sighted glances read color alone.
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, expect, it } from 'vitest'
 import { SaveStatusChip } from './SaveStatusChip.js'
@@ -11,24 +11,26 @@ afterEach(cleanup)
 const chip = (container: HTMLElement) =>
   container.querySelector('[data-testid="save-status-chip"]') as HTMLElement
 
-it('shows Saved with the calm dot', () => {
+it('names Saved accessibly while showing only the calm dot', () => {
   const { container } = render(<SaveStatusChip state={{ kind: 'saved', lastSavedAt: null }} />)
-  expect(chip(container).textContent).toContain('Saved')
+  expect(chip(container).getAttribute('aria-label')).toBe('Saved')
+  // Color-only on the surface: no visible words on the dot itself.
+  expect(chip(container).textContent).toBe('')
   expect(chip(container).querySelector('.bg-emerald-500')).toBeTruthy()
 })
 
-it('shows Saving… while a write is in flight', () => {
+it('names Saving… while a write is in flight', () => {
   const { container } = render(<SaveStatusChip state={{ kind: 'saving', lastSavedAt: null }} />)
-  expect(chip(container).textContent).toContain('Saving…')
+  expect(chip(container).getAttribute('aria-label')).toBe('Saving…')
   expect(chip(container).querySelector('.bg-amber-500')).toBeTruthy()
 })
 
-it('shows Unsaved changes for a pending write', () => {
+it('names Unsaved changes for a pending write', () => {
   const { container } = render(<SaveStatusChip state={{ kind: 'pending', lastSavedAt: null }} />)
-  expect(chip(container).textContent).toContain('Unsaved changes')
+  expect(chip(container).getAttribute('aria-label')).toBe('Unsaved changes')
 })
 
-it('degraded carries its own message as the visible label, with the attention pulse', () => {
+it('degraded carries its own message as the accessible name, with the attention pulse', () => {
   const { container } = render(
     <SaveStatusChip
       state={{
@@ -39,7 +41,7 @@ it('degraded carries its own message as the visible label, with the attention pu
       }}
     />,
   )
-  expect(chip(container).textContent).toContain('Storage is full')
+  expect(chip(container).getAttribute('aria-label')).toBe('Storage is full')
   expect(container.querySelector('[data-testid="save-status-chip-pulse"]')).toBeTruthy()
 })
 

--- a/apps/web/src/components/SaveStatusChip.tsx
+++ b/apps/web/src/components/SaveStatusChip.tsx
@@ -1,0 +1,74 @@
+/**
+ * Browser-local autosave state as a header chip, the visual sibling of the
+ * connection chip: colored dot PLUS visible text (color never carries the
+ * state alone), explanation on demand in a popover. Distinct from
+ * HeaderSaveDot on purpose — that dot tracks "no named VERSION taken yet"
+ * on daemon-backed pages; this chip tracks whether the last write to this
+ * browser's storage actually landed, including the degraded failure state
+ * the version dot has no equivalent of.
+ */
+import { cn } from '@/lib/utils'
+import type { BrowserLocalPersistenceState } from '../pages/use-browser-local-canvas-controller.js'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js'
+
+export interface SaveStatusChipProps {
+  readonly state: BrowserLocalPersistenceState
+}
+
+const LABEL: Record<Exclude<BrowserLocalPersistenceState['kind'], 'degraded'>, string> = {
+  saved: 'Saved',
+  saving: 'Saving…',
+  pending: 'Unsaved changes',
+}
+
+const DOT_CLASS: Record<BrowserLocalPersistenceState['kind'], string> = {
+  saved: 'bg-emerald-500',
+  saving: 'bg-amber-500',
+  pending: 'bg-amber-500',
+  degraded: 'bg-amber-500',
+}
+
+const EXPLANATION: Record<BrowserLocalPersistenceState['kind'], string> = {
+  saved: 'All changes are saved in this browser.',
+  saving: 'Writing your latest changes to this browser now.',
+  pending: 'Changes are waiting to be written to this browser.',
+  degraded: 'The last write to this browser failed. Your edits stay in memory for this session.',
+}
+
+export function SaveStatusChip({ state }: SaveStatusChipProps) {
+  const label = state.kind === 'degraded' ? state.message : LABEL[state.kind]
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="save-status-chip"
+          className={cn(
+            'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
+            'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
+            state.kind === 'degraded' && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
+          )}
+        >
+          <span aria-hidden="true" className="relative inline-flex size-2">
+            {state.kind === 'degraded' && (
+              // One-shot attention echo, same treatment as the connection
+              // chip's sync-off: pulses twice on entry, then rests.
+              <span
+                data-testid="save-status-chip-pulse"
+                className="absolute inset-0 rounded-full bg-amber-500 animate-[attention-pulse_900ms_var(--motion-ease-out)_2]"
+              />
+            )}
+            <span className={cn('absolute inset-0 rounded-full', DOT_CLASS[state.kind])} />
+          </span>
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent data-testid="save-status-popover">
+        <div className="flex flex-col gap-1 text-sm">
+          <p className="font-medium">{label}</p>
+          <p className="text-muted-foreground">{EXPLANATION[state.kind]}</p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/SaveStatusChip.tsx
+++ b/apps/web/src/components/SaveStatusChip.tsx
@@ -1,15 +1,18 @@
 /**
- * Browser-local autosave state as a header chip, the visual sibling of the
- * connection chip: colored dot PLUS visible text (color never carries the
- * state alone), explanation on demand in a popover. Distinct from
- * HeaderSaveDot on purpose — that dot tracks "no named VERSION taken yet"
- * on daemon-backed pages; this chip tracks whether the last write to this
+ * Browser-local autosave state as a colored DOT beside the canvas title
+ * (owner decision: routine save state should not spend words — color at a
+ * glance, the label on hover, the sentence in a popover on click). The
+ * accessible name always carries the label, so the dot is color-only for
+ * sighted glances, never for assistive tech. Deliberately distinct from
+ * HeaderSaveDot — that dot tracks "no named VERSION taken yet" on
+ * daemon-backed pages; this one tracks whether the last write to this
  * browser's storage actually landed, including the degraded failure state
  * the version dot has no equivalent of.
  */
 import { cn } from '@/lib/utils'
 import type { BrowserLocalPersistenceState } from '../pages/use-browser-local-canvas-controller.js'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover.js'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js'
 
 export interface SaveStatusChipProps {
   readonly state: BrowserLocalPersistenceState
@@ -39,30 +42,31 @@ export function SaveStatusChip({ state }: SaveStatusChipProps) {
   const label = state.kind === 'degraded' ? state.message : LABEL[state.kind]
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          data-testid="save-status-chip"
-          className={cn(
-            'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
-            'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
-            state.kind === 'degraded' && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
-          )}
-        >
-          <span aria-hidden="true" className="relative inline-flex size-2">
-            {state.kind === 'degraded' && (
-              // One-shot attention echo, same treatment as the connection
-              // chip's sync-off: pulses twice on entry, then rests.
-              <span
-                data-testid="save-status-chip-pulse"
-                className="absolute inset-0 rounded-full bg-amber-500 animate-[attention-pulse_900ms_var(--motion-ease-out)_2]"
-              />
-            )}
-            <span className={cn('absolute inset-0 rounded-full', DOT_CLASS[state.kind])} />
-          </span>
-          {label}
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              data-testid="save-status-chip"
+              aria-label={label}
+              className="flex shrink-0 items-center justify-center rounded-full p-1.5 transition-colors duration-(--motion-duration-normal) ease-(--motion-ease-out) hover:bg-accent"
+            >
+              <span aria-hidden="true" className="relative inline-flex size-2">
+                {state.kind === 'degraded' && (
+                  // One-shot attention echo, same treatment as the connection
+                  // chip's sync-off: pulses twice on entry, then rests.
+                  <span
+                    data-testid="save-status-chip-pulse"
+                    className="absolute inset-0 rounded-full bg-amber-500 animate-[attention-pulse_900ms_var(--motion-ease-out)_2]"
+                  />
+                )}
+                <span className={cn('absolute inset-0 rounded-full', DOT_CLASS[state.kind])} />
+              </span>
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
       <PopoverContent data-testid="save-status-popover">
         <div className="flex flex-col gap-1 text-sm">
           <p className="font-medium">{label}</p>

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -406,7 +406,7 @@ describe('WorkspaceTopBar browser mode', () => {
   // variants only take effect against the real viewport width, so this
   // guard can only run in the browser layer (jsdom class-list checks alone
   // would pass even if the CSS never generated).
-  it('collapses the right-side actions into a "More actions" kebab under 400px, without hiding the left-side group', async () => {
+  it('collapses the right-side actions into a "View options" kebab under 400px, without hiding the left-side group', async () => {
     // `display:none` on an ancestor (the collapse group, not the button
     // itself) drops the button out of the accessibility tree, so
     // page.getByRole()/toBeVisible() can't distinguish "present but hidden"
@@ -455,7 +455,7 @@ describe('WorkspaceTopBar browser mode', () => {
     const onEnterFullscreen = vi.fn()
     cleanup()
     renderTopBar({ onEnterFullscreen })
-    await page.getByRole('button', { name: 'More actions' }).click()
+    await page.getByRole('button', { name: 'View options' }).click()
     await page.getByRole('menuitem', { name: 'Fullscreen' }).click()
     expect(onEnterFullscreen).toHaveBeenCalledTimes(1)
 

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -776,7 +776,7 @@ describe('WorkspaceTopBar — ~400px collapse (RED-first)', () => {
     const exposedGroup = screen.getByTestId('topbar-right-actions-exposed')
     expect(exposedGroup.className).toContain('max-[400px]:hidden')
 
-    const kebabTrigger = screen.getByRole('button', { name: 'More actions' })
+    const kebabTrigger = screen.getByRole('button', { name: 'View options' })
     expect(kebabTrigger.className).toContain('min-[400px]:hidden')
   })
 })

--- a/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
@@ -147,7 +147,7 @@ describe('CanvasProperties title typing (controlled-input round trip)', () => {
 describe('CanvasProperties as the canvas row', () => {
   it('the Properties toggle is an icon button with a real accessible name and controls link', () => {
     render(<CanvasProperties meta={{ type: 'markdown' }} onChange={vi.fn()} />)
-    const toggle = screen.getByRole('button', { name: 'Canvas properties' })
+    const toggle = screen.getByRole('button', { name: 'Properties' })
     // Icon-only: the word moved into aria-label + tooltip, off the surface.
     expect(toggle.textContent).not.toContain('Properties')
     expect(toggle.getAttribute('aria-expanded')).toBe('false')
@@ -163,11 +163,11 @@ describe('CanvasProperties as the canvas row', () => {
       <CanvasProperties
         meta={{ type: 'markdown' }}
         onChange={vi.fn()}
-        settings={<button type="button" aria-label="Canvas display settings" />}
+        settings={<button type="button" aria-label="Display settings" />}
         actions={<span data-testid="row-actions">ops</span>}
       />,
     )
-    expect(screen.getByRole('button', { name: 'Canvas display settings' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Display settings' })).toBeTruthy()
     expect(screen.getByTestId('row-actions')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
@@ -143,3 +143,31 @@ describe('CanvasProperties title typing (controlled-input round trip)', () => {
     expect(onChange).toHaveBeenCalledWith({ type: 'markdown' })
   })
 })
+
+describe('CanvasProperties as the canvas row', () => {
+  it('the Properties toggle is an icon button with a real accessible name and controls link', () => {
+    render(<CanvasProperties meta={{ type: 'markdown' }} onChange={vi.fn()} />)
+    const toggle = screen.getByRole('button', { name: 'Canvas properties' })
+    // Icon-only: the word moved into aria-label + tooltip, off the surface.
+    expect(toggle.textContent).not.toContain('Properties')
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    const disclosureId = toggle.getAttribute('aria-controls')
+    expect(disclosureId).toBeTruthy()
+    expect(document.getElementById(disclosureId as string)).toBeTruthy()
+  })
+
+  it('renders the settings slot beside the toggle and the actions cluster at the right edge', () => {
+    render(
+      <CanvasProperties
+        meta={{ type: 'markdown' }}
+        onChange={vi.fn()}
+        settings={<button type="button" aria-label="Canvas display settings" />}
+        actions={<span data-testid="row-actions">ops</span>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Canvas display settings' })).toBeTruthy()
+    expect(screen.getByTestId('row-actions')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -116,7 +116,7 @@ export function CanvasProperties({
             <button
               type="button"
               onClick={() => setOpen((current) => !current)}
-              aria-label="Canvas properties"
+              aria-label="Properties"
               aria-expanded={open}
               aria-controls={`${suggestionsId}-disclosure`}
               className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
@@ -124,7 +124,7 @@ export function CanvasProperties({
               <Info aria-hidden="true" className="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Canvas properties</TooltipContent>
+          <TooltipContent>Properties</TooltipContent>
         </Tooltip>
         {settings}
         {actions !== undefined && (

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -10,6 +10,11 @@ export interface CanvasPropertiesProps {
   /** Offered as datalist completions for `type`; the field stays free text. */
   readonly typeSuggestions?: readonly string[]
   /**
+   * Save-state indicator, rendered LEFT of the title — the canvas's "am I
+   * safe" signal reads before its name, like a title-bar dirty dot.
+   */
+  readonly status?: ReactNode
+  /**
    * Canvas display settings control, rendered beside the properties toggle.
    * Spatial canvases pass the settings popover; markdown canvases omit it —
    * edge routing has no meaning for a document with no spatial scene.
@@ -49,6 +54,7 @@ export function CanvasProperties({
   meta,
   onChange,
   typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
+  status,
   settings,
   actions,
 }: CanvasPropertiesProps) {
@@ -90,6 +96,7 @@ export function CanvasProperties({
   return (
     <div className="border-border bg-background flex flex-col gap-2 border-b px-3 py-2">
       <div className="flex items-center gap-2">
+        {status}
         <label className="sr-only" htmlFor={`${suggestionsId}-title`}>
           Title
         </label>

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -1,12 +1,26 @@
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
-import { X } from 'lucide-react'
+import { Info, X } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useId, useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 
 export interface CanvasPropertiesProps {
   readonly meta: CanvasCoreMeta
   readonly onChange: (next: CanvasCoreMeta) => void
   /** Offered as datalist completions for `type`; the field stays free text. */
   readonly typeSuggestions?: readonly string[]
+  /**
+   * Canvas display settings control, rendered beside the properties toggle.
+   * Spatial canvases pass the settings popover; markdown canvases omit it —
+   * edge routing has no meaning for a document with no spatial scene.
+   */
+  readonly settings?: ReactNode
+  /**
+   * Right-edge cluster: canvas STATE and whole-document operations (save
+   * chip, duplicate, delete). Supplied by the page — this component owns
+   * the canvas row's layout, not the operations themselves.
+   */
+  readonly actions?: ReactNode
 }
 
 /**
@@ -35,6 +49,8 @@ export function CanvasProperties({
   meta,
   onChange,
   typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
+  settings,
+  actions,
 }: CanvasPropertiesProps) {
   const [open, setOpen] = useState(false)
   const [draftTag, setDraftTag] = useState('')
@@ -88,18 +104,29 @@ export function CanvasProperties({
           placeholder="Untitled"
           className="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-base font-medium outline-none"
         />
-        <button
-          type="button"
-          onClick={() => setOpen((current) => !current)}
-          aria-expanded={open}
-          className="text-muted-foreground hover:text-foreground shrink-0 rounded px-2 py-1 text-xs"
-        >
-          Properties
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setOpen((current) => !current)}
+              aria-label="Canvas properties"
+              aria-expanded={open}
+              aria-controls={`${suggestionsId}-disclosure`}
+              className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
+            >
+              <Info aria-hidden="true" className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Canvas properties</TooltipContent>
+        </Tooltip>
+        {settings}
+        {actions !== undefined && (
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">{actions}</div>
+        )}
       </div>
 
       {open && (
-        <div className="flex flex-col gap-2 pb-1">
+        <div id={`${suggestionsId}-disclosure`} className="flex flex-col gap-2 pb-1">
           <div className="flex items-center gap-2">
             <label
               className="text-muted-foreground w-12 shrink-0 text-xs"

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -1,0 +1,123 @@
+/**
+ * Canvas-wide display settings (edge routing style, line jumps) as a gear
+ * popover for the canvas header row. Standalone from SpatialEditor so the
+ * PAGE places it with the other canvas-level chrome; it speaks the same
+ * (canvas, onChange) command contract the editor does.
+ *
+ * Picks apply immediately and keep the popover open — these are property
+ * pickers, and closing per pick would force a reopen for every adjustment.
+ * Radix owns dismissal (outside click, Escape) and returns focus to the
+ * gear, so a keyboard user never falls to <body>.
+ */
+import type { EdgeRoutingStyle, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { SlidersHorizontal } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
+import type { EditorCommand } from './commands.js'
+import { applyCommand } from './commands.js'
+
+export interface CanvasDisplaySettingsProps {
+  readonly canvas: SpatialCanvas
+  readonly onChange: (next: SpatialCanvas, command: EditorCommand) => void
+}
+
+const EDGE_ROUTING_CHOICES: readonly { style: EdgeRoutingStyle; label: string }[] = [
+  { style: 'straight', label: 'Straight' },
+  { style: 'orthogonal', label: 'Orthogonal' },
+  { style: 'curved', label: 'Curved' },
+]
+
+const OPTION_CLASS =
+  'flex h-7 min-w-7 items-center justify-center rounded px-2 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none'
+
+export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySettingsProps) {
+  // Eager command chaining: two picks from the same open popover can land
+  // before a slow parent commits the first, and the second must build on
+  // the first's result, not the stale prop. The ref follows the prop only
+  // after the parent actually re-renders with it.
+  const canvasRef = useRef(canvas)
+  useEffect(() => {
+    canvasRef.current = canvas
+  }, [canvas])
+  const run = (command: EditorCommand) => {
+    const running = applyCommand(canvasRef.current, command)
+    canvasRef.current = running
+    onChange(running, command)
+  }
+
+  const currentRouting = canvas['x-whiteboard']?.edgeRouting?.style ?? 'straight'
+  const currentJumps = canvas['x-whiteboard']?.edgeRouting?.lineJumps ?? 'none'
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              data-testid="canvas-settings-button"
+              aria-label="Canvas display settings"
+              className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
+            >
+              <SlidersHorizontal aria-hidden="true" className="size-4" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Canvas display settings</TooltipContent>
+      </Tooltip>
+      <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-muted-foreground">Edge routing</span>
+            <span className="flex items-center gap-0.5">
+              {EDGE_ROUTING_CHOICES.map(({ style, label }) => (
+                <button
+                  key={style}
+                  type="button"
+                  aria-pressed={currentRouting === style}
+                  onClick={() => run({ kind: 'set-edge-routing', style })}
+                  className={cn(
+                    OPTION_CLASS,
+                    currentRouting === style
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'text-muted-foreground',
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-muted-foreground">Line jumps</span>
+            <span className="flex items-center gap-0.5">
+              {(
+                [
+                  { lineJumps: 'none', label: 'Off' },
+                  { lineJumps: 'arc', label: 'On' },
+                ] as const
+              ).map(({ lineJumps, label }) => (
+                <button
+                  key={lineJumps}
+                  type="button"
+                  aria-pressed={currentJumps === lineJumps}
+                  onClick={() => run({ kind: 'set-line-jumps', lineJumps })}
+                  className={cn(
+                    OPTION_CLASS,
+                    currentJumps === lineJumps
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'text-muted-foreground',
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -58,14 +58,14 @@ export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySetting
             <button
               type="button"
               data-testid="canvas-settings-button"
-              aria-label="Canvas display settings"
+              aria-label="Display settings"
               className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
             >
               <SlidersHorizontal aria-hidden="true" className="size-4" />
             </button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent>Canvas display settings</TooltipContent>
+        <TooltipContent>Display settings</TooltipContent>
       </Tooltip>
       <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
         <div className="flex flex-col gap-1">

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -78,16 +78,6 @@ export interface ContextMenuProps {
   readonly y: number
   readonly items: readonly ContextMenuItem[]
   readonly onClose: () => void
-  /** Overrides for a second, non-context use of this surface (e.g. the canvas settings popover). */
-  readonly testId?: string
-  readonly ariaLabel?: string
-  /**
-   * Called on Escape dismissal only — NOT on outside clicks, which move
-   * focus themselves. A trigger-opened menu passes its trigger's focus()
-   * here so a keyboard user does not fall to <body> when the focused menu
-   * unmounts (same hand-back the dock's add menu performs).
-   */
-  readonly onEscape?: () => void
 }
 
 /**
@@ -128,15 +118,7 @@ function CustomColorPanel({
   )
 }
 
-export function ContextMenu({
-  x,
-  y,
-  items,
-  onClose,
-  testId,
-  ariaLabel,
-  onEscape,
-}: ContextMenuProps) {
+export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null)
   // A menu opened near the editor's right/bottom edge would clip outside it,
   // so the requested position is nudged back inside once the real menu size
@@ -181,9 +163,9 @@ export function ContextMenu({
       ref={menuRef}
       data-editor-overlay
       data-context-menu
-      data-testid={testId ?? 'context-menu'}
+      data-testid="context-menu"
       role="menu"
-      aria-label={ariaLabel ?? 'Canvas actions'}
+      aria-label="Canvas actions"
       tabIndex={-1}
       className="min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none"
       // Positioning (incl. stacking) is inline, not utility classes: the
@@ -199,7 +181,6 @@ export function ContextMenu({
         if (e.key === 'Escape') {
           e.stopPropagation()
           onClose()
-          onEscape?.()
         }
       }}
     >

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -62,7 +62,6 @@ import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type {
   CanvasColor,
   ClipboardFragment,
-  EdgeRoutingStyle,
   SpatialCanvas,
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
@@ -110,7 +109,6 @@ import {
   Pencil,
   Scissors,
   SendToBack,
-  SlidersHorizontal,
   Sparkles,
   SquareDashed,
   StickyNote,
@@ -237,14 +235,6 @@ const MINIMAP_HEIGHT_PX = 110
 const MINIMAP_MIN_ROOT_WIDTH_PX = 768
 
 /** The routing styles offered in the UI. */
-const EDGE_ROUTING_CHOICES: readonly {
-  readonly style: EdgeRoutingStyle
-  readonly label: string
-}[] = [
-  { style: 'straight', label: 'Straight' },
-  { style: 'orthogonal', label: 'Orthogonal' },
-  { style: 'curved', label: 'Curved' },
-]
 
 export interface SpatialEditorProps {
   readonly canvas: SpatialCanvas
@@ -480,9 +470,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // deliberately NOT a mode — the palette's Add note works in every mode.
     const [tool, setTool] = useState<EditorTool>(defaultTool)
     /** Open right-click menu: screen position (root-relative) + hit target. */
-    // Canvas-wide display settings popover, anchored at the dock's gear.
-    const [settingsMenu, setSettingsMenu] = useState<{ x: number; y: number } | null>(null)
-    const settingsButtonRef = useRef<HTMLButtonElement | null>(null)
     const [contextMenu, setContextMenu] = useState<{
       x: number
       y: number
@@ -1756,48 +1743,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
-     * Canvas-wide display settings, shown in the dock's settings popover.
-     * Option rows apply immediately and keep the popover open (the shared
-     * ContextMenu option-row contract), eager on canvasRef like every other
-     * command path so a second pick chains off the first.
-     */
-    const canvasSettingsItems = (): ContextMenuItem[] => {
-      const currentRouting = canvas['x-whiteboard']?.edgeRouting?.style ?? 'straight'
-      const currentJumps = canvas['x-whiteboard']?.edgeRouting?.lineJumps ?? 'none'
-      const run = (command: EditorCommand) => {
-        const running = applyCommand(canvasRef.current, command)
-        canvasRef.current = running
-        onChange(running, command)
-      }
-      return [
-        {
-          kind: 'options',
-          label: 'Edge routing',
-          options: EDGE_ROUTING_CHOICES.map(({ style, label }) => ({
-            key: style,
-            label,
-            selected: currentRouting === style,
-            onSelect: () => run({ kind: 'set-edge-routing', style }),
-          })),
-        },
-        {
-          kind: 'options',
-          label: 'Line jumps',
-          options: (
-            [
-              { lineJumps: 'none', label: 'Off' },
-              { lineJumps: 'arc', label: 'On' },
-            ] as const
-          ).map(({ lineJumps, label }) => ({
-            label,
-            selected: currentJumps === lineJumps,
-            onSelect: () => run({ kind: 'set-line-jumps', lineJumps }),
-          })),
-        },
-      ]
-    }
-
-    /**
      * Clones the selection as ONE batch command (one undo step): reminted
      * ids via the clipboard-fragment helpers, +16px offset (the standard
      * duplicate-again cascade), edges kept only when both endpoints are
@@ -2874,45 +2819,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 }
           }
           tool={tool}
-          trailing={
-            tool === 'hand' ? undefined : (
-              <button
-                ref={settingsButtonRef}
-                type="button"
-                data-testid="canvas-settings-button"
-                aria-label="Canvas settings"
-                aria-haspopup="menu"
-                aria-expanded={settingsMenu !== null}
-                onClick={(e) => {
-                  if (settingsMenu !== null) {
-                    setSettingsMenu(null)
-                    return
-                  }
-                  const root = rootRef.current
-                  if (root === null) return
-                  const rect = e.currentTarget.getBoundingClientRect()
-                  const rootRect = root.getBoundingClientRect()
-                  // Anchored at the gear; ContextMenu clamps itself back
-                  // inside the editor, so a dock-adjacent anchor just means
-                  // "as close to the gear as fits".
-                  setSettingsMenu({
-                    x: rect.left - rootRect.left,
-                    y: rect.top - rootRect.top,
-                  })
-                }}
-                className={TOOL_BUTTON_CLASS}
-              >
-                <SlidersHorizontal aria-hidden="true" className="size-4" />
-              </button>
-            )
-          }
           onToolChange={(next) => {
             setTool(next)
             // A context menu is an edit affordance of the mode it was
             // opened in — switching tools (especially into view-only hand
             // mode) must not leave it floating.
             setContextMenu(null)
-            setSettingsMenu(null)
             // Entering hand mode drops EVERY edit affordance, not just the
             // menu: a surviving selection would keep Delete/resize/connect
             // handles live, an open editor would keep accepting text, and
@@ -2963,17 +2875,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               addImageFile(file, pendingImagePointRef.current ?? undefined)
               pendingImagePointRef.current = null
             }}
-          />
-        )}
-        {settingsMenu !== null && (
-          <ContextMenu
-            testId="canvas-settings-menu"
-            ariaLabel="Canvas settings"
-            x={settingsMenu.x}
-            y={settingsMenu.y}
-            onClose={() => setSettingsMenu(null)}
-            onEscape={() => settingsButtonRef.current?.focus()}
-            items={canvasSettingsItems()}
           />
         )}
         {contextMenu !== null && (

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -52,8 +52,6 @@ interface ToolPaletteProps {
   readonly onCreateImage?: () => void
   readonly tool: EditorTool
   readonly onToolChange: (tool: EditorTool) => void
-  /** Docked after the Add button (canvas-wide settings and the like). */
-  readonly trailing?: ReactNode
 }
 
 export const TOOL_BUTTON_CLASS = `${DOCK_BUTTON_CLASS} aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground`
@@ -73,7 +71,6 @@ export function ToolPalette({
   onCreateImage,
   tool,
   onToolChange,
-  trailing,
 }: ToolPaletteProps) {
   const [addOpen, setAddOpen] = useState(false)
   const dockRef = useRef<HTMLDivElement | null>(null)
@@ -257,12 +254,6 @@ export function ToolPalette({
             </button>
           ))}
         </div>
-      )}
-      {trailing !== undefined && (
-        <>
-          <div aria-hidden="true" className="mx-0.5 h-5 w-px bg-border" />
-          {trailing}
-        </>
       )}
     </div>
   )

--- a/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
@@ -1,14 +1,12 @@
-// Canvas-wide display settings (edge routing style, line jumps) live in a
-// dedicated settings popover on the dock, not in the empty-space context
-// menu — the menu is for actions on the canvas; a growing settings list
-// wants its own surface. This pins the wiring: the gear opens the popover,
-// a pick emits the canvas-wide command, and the context menu no longer
-// carries the rows.
+// The canvas display-settings popover, standalone: the gear opens it, a
+// pick applies the canvas-wide command immediately and keeps it open for
+// the next tweak, consecutive picks chain under a deferred parent, and
+// dismissal returns focus to the gear.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
-import { afterEach, expect, it } from 'vitest'
-import { SpatialEditor } from './SpatialEditor.js'
+import { afterEach, expect, it, vi } from 'vitest'
+import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
 
 afterEach(cleanup)
 
@@ -25,124 +23,92 @@ function makeHost() {
   function Host() {
     const [canvas, setCanvas] = useState(initial)
     latest.canvas = canvas
-    return (
-      <div style={{ width: 900, height: 700 }}>
-        <SpatialEditor
-          defaultTool="select"
-          canvas={canvas}
-          onChange={(next) => setCanvas(next)}
-          theme="light"
-        />
-      </div>
-    )
+    return <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
   }
   return { Host, latest }
 }
 
-const gearOf = (container: HTMLElement) =>
-  container.querySelector('[data-testid="canvas-settings-button"]') as HTMLElement
+const gear = (c: HTMLElement) =>
+  c.querySelector('[data-testid="canvas-settings-button"]') as HTMLElement
+const menu = () => document.querySelector('[data-testid="canvas-settings-menu"]')
+const option = (label: string) =>
+  [...(menu()?.querySelectorAll('button') ?? [])].find((b) => b.textContent?.trim() === label) as
+    | HTMLButtonElement
+    | undefined
 
-const settingsMenu = (container: HTMLElement) =>
-  container.querySelector('[data-testid="canvas-settings-menu"]')
-
-it('the gear opens the settings popover with both option rows', () => {
+it('the gear opens the popover with both option rows', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
 
-  expect(settingsMenu(container)).toBeNull()
-  fireEvent.click(gearOf(container))
-
-  const menu = settingsMenu(container)
-  expect(menu).toBeTruthy()
-  expect(menu?.textContent).toContain('Edge routing')
-  expect(menu?.textContent).toContain('Line jumps')
+  expect(menu()).toBeNull()
+  fireEvent.click(gear(container))
+  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  expect(menu()?.textContent).toContain('Edge routing')
+  expect(menu()?.textContent).toContain('Line jumps')
 })
 
-it('picking a routing style applies it canvas-wide; the popover stays open for the next tweak', () => {
+it('a pick applies canvas-wide and keeps the popover open; current values are marked', async () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  fireEvent.click(gearOf(container))
-  const curved = settingsMenu(container)?.querySelector('[aria-label="Curved"]') as HTMLElement
-  expect(curved).toBeTruthy()
-  fireEvent.click(curved)
+  fireEvent.click(gear(container))
+  await vi.waitFor(() => expect(option('Curved')).toBeDefined())
+  fireEvent.click(option('Curved') as HTMLElement)
 
-  expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('curved')
-  // Option rows are property pickers: they apply immediately and keep the
-  // surface open, same contract as the context menu's rows.
-  const menu = settingsMenu(container)
-  expect(menu).toBeTruthy()
+  await vi.waitFor(() => {
+    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('curved')
+  })
+  expect(menu()).toBeTruthy()
+  expect(option('Curved')?.getAttribute('aria-pressed')).toBe('true')
 
-  fireEvent.keyDown(menu as HTMLElement, { key: 'Escape' })
-  expect(settingsMenu(container)).toBeNull()
+  fireEvent.click(option('On') as HTMLElement)
+  await vi.waitFor(() => {
+    expect(latest.canvas['x-whiteboard']?.edgeRouting?.lineJumps).toBe('arc')
+  })
 })
 
-it('toggling line jumps applies canvas-wide', () => {
-  const { Host, latest } = makeHost()
-  const { container } = render(<Host />)
-
-  fireEvent.click(gearOf(container))
-  const on = settingsMenu(container)?.querySelector('[aria-label="On"]') as HTMLElement
-  fireEvent.click(on)
-
-  expect(latest.canvas['x-whiteboard']?.edgeRouting?.lineJumps).toBe('arc')
-})
-
-it('the popover marks the current values as selected', () => {
-  const withCurved: SpatialCanvas = {
-    ...initial,
-    'x-whiteboard': { edgeRouting: { style: 'curved', lineJumps: 'arc' } },
-  }
-  function Host() {
-    const [canvas, setCanvas] = useState(withCurved)
+it('consecutive picks both survive a deferred parent', async () => {
+  const latest = { canvas: initial }
+  function DeferredHost() {
+    const [canvas, setCanvas] = useState(initial)
+    latest.canvas = canvas
     return (
-      <div style={{ width: 900, height: 700 }}>
-        <SpatialEditor
-          defaultTool="select"
-          canvas={canvas}
-          onChange={(next) => setCanvas(next)}
-          theme="light"
-        />
-      </div>
+      <CanvasDisplaySettings
+        canvas={canvas}
+        onChange={(next) => {
+          setTimeout(() => {
+            latest.canvas = next
+            setCanvas(next)
+          }, 30)
+        }}
+      />
     )
   }
-  const { container } = render(<Host />)
+  const { container } = render(<DeferredHost />)
+  fireEvent.click(gear(container))
+  await vi.waitFor(() => expect(option('Orthogonal')).toBeDefined())
+  fireEvent.click(option('Orthogonal') as HTMLElement)
+  fireEvent.click(option('On') as HTMLElement)
 
-  fireEvent.click(gearOf(container))
-  const curved = settingsMenu(container)?.querySelector('[aria-label="Curved"]')
-  const on = settingsMenu(container)?.querySelector('[aria-label="On"]')
-  expect(curved?.getAttribute('aria-checked')).toBe('true')
-  expect(on?.getAttribute('aria-checked')).toBe('true')
+  await vi.waitFor(() => {
+    expect(latest.canvas['x-whiteboard']?.edgeRouting).toEqual({
+      style: 'orthogonal',
+      lineJumps: 'arc',
+    })
+  })
 })
 
-it('Escape hands focus back to the gear, like the add menu does', () => {
+it('Escape closes and hands focus back to the gear', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
 
-  const gear = gearOf(container)
-  fireEvent.click(gear)
-  const menu = settingsMenu(container) as HTMLElement
-  expect(menu).toBeTruthy()
+  const trigger = gear(container)
+  fireEvent.click(trigger)
+  await vi.waitFor(() => expect(menu()).toBeTruthy())
 
-  fireEvent.keyDown(menu, { key: 'Escape' })
-  expect(settingsMenu(container)).toBeNull()
-  // Closing unmounts the focused popover; without an explicit hand-back a
-  // keyboard user's focus falls to <body> and they lose their place.
-  expect(document.activeElement).toBe(gear)
-})
-
-it('the empty-space context menu no longer carries the settings rows', () => {
-  const { Host } = makeHost()
-  const { container } = render(<Host />)
-  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
-
-  const r = root.getBoundingClientRect()
-  fireEvent.contextMenu(root, { clientX: r.left + 700, clientY: r.top + 500 })
-
-  const menu = container.querySelector('[data-testid="context-menu"]')
-  expect(menu).toBeTruthy()
-  expect(menu?.textContent).not.toContain('Edge routing')
-  expect(menu?.textContent).not.toContain('Line jumps')
-  // Actions stay: the menu is still where you act on the canvas.
-  expect(menu?.textContent).toContain('Tidy canvas')
+  fireEvent.keyDown(menu() as HTMLElement, { key: 'Escape' })
+  await vi.waitFor(() => expect(menu()).toBeNull())
+  // Radix hands focus back to the trigger, so a keyboard user keeps their
+  // place instead of falling to <body>.
+  await vi.waitFor(() => expect(document.activeElement).toBe(trigger))
 })

--- a/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
@@ -1,12 +1,15 @@
-// Canvas-wide routing style, set from the dock's settings popover.
+// Canvas-wide routing style, set from the canvas row's settings popover.
 //
 // The rendering assertions are the point here: a pick must not just record
-// the extension on the canvas, it must change what the scene draws. The
-// popover wiring itself is pinned in canvas-settings.browser.test.tsx.
+// the extension on the canvas, it must change what the scene DRAWS. The
+// host composes the popover and the editor over one canvas state, exactly
+// as the page does; the popover's own wiring is pinned in
+// canvas-settings.browser.test.tsx.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -26,6 +29,7 @@ function makeHost() {
     latest.canvas = canvas
     return (
       <div style={{ width: 900, height: 700 }}>
+        <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
@@ -40,11 +44,12 @@ function makeHost() {
 
 function openSettings(container: HTMLElement) {
   const gear = container.querySelector('[data-testid="canvas-settings-button"]') as HTMLElement
-  gear.click()
+  fireEvent.click(gear)
 }
 
-const optionButton = (container: HTMLElement, label: string) =>
-  [...container.querySelectorAll('[data-testid="canvas-settings-menu"] button')].find(
+// The popover renders in a portal, so options are queried from the document.
+const optionButton = (_container: HTMLElement, label: string) =>
+  [...document.querySelectorAll('[data-testid="canvas-settings-menu"] button')].find(
     (button) => button.textContent?.trim() === label,
   ) as HTMLButtonElement | undefined
 
@@ -54,9 +59,9 @@ it('offers the routing style from the settings popover, not the creation menu', 
   openSettings(container)
 
   await vi.waitFor(() => {
-    expect(container.querySelector('[data-testid="canvas-settings-menu"]')).not.toBeNull()
+    expect(document.querySelector('[data-testid="canvas-settings-menu"]')).not.toBeNull()
   })
-  expect(container.textContent).toContain('Edge routing')
+  expect(document.body.textContent).toContain('Edge routing')
   expect(optionButton(container, 'Orthogonal')).toBeDefined()
 
   // The dock's "+" menu is for what does not exist yet; a canvas-wide setting
@@ -151,6 +156,7 @@ it('toggles line jumps from the canvas menu and draws the hop arc', async () => 
     latest.canvas = canvas
     return (
       <div style={{ width: 900, height: 700 }}>
+        <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
@@ -193,19 +199,16 @@ it('consecutive style + jumps picks both survive a deferred parent', async () =>
   function DeferredHost() {
     const [canvas, setCanvas] = useState(initial)
     latest.canvas = canvas
+    const deferSet = (next: SpatialCanvas) => {
+      setTimeout(() => {
+        latest.canvas = next
+        setCanvas(next)
+      }, 30)
+    }
     return (
       <div style={{ width: 900, height: 700 }}>
-        <SpatialEditor
-          defaultTool="select"
-          canvas={canvas}
-          onChange={(next) => {
-            setTimeout(() => {
-              latest.canvas = next
-              setCanvas(next)
-            }, 30)
-          }}
-          theme="light"
-        />
+        <CanvasDisplaySettings canvas={canvas} onChange={deferSet} />
+        <SpatialEditor defaultTool="select" canvas={canvas} onChange={deferSet} theme="light" />
       </div>
     )
   }

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -27,7 +27,7 @@ interface TopBarSecondaryActionsProps {
   onOpenSettings?: () => void
 }
 
-// Right side: theme and fullscreen — plus the "More actions" kebab that
+// Right side: theme and fullscreen — plus the "View options" kebab that
 // reuses the exact same handlers below 400px so the header never wraps.
 // Version history moved to the canvas's HistoryCluster (bottom-left).
 export function TopBarSecondaryActions({
@@ -82,7 +82,7 @@ export function TopBarSecondaryActions({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label="More actions"
+            aria-label="View options"
             data-testid="topbar-more-actions-trigger"
             className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground min-[400px]:hidden"
           >

--- a/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.browser.test.tsx
@@ -1,4 +1,11 @@
-import { cleanup, render as rtlRender, screen, waitFor, within } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -132,7 +139,8 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
         timeout: 5000,
       },
     )
-    screen.getByRole('button', { name: /delete canvas/i }).click()
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }), { button: 0 })
+    fireEvent.pointerUp(await screen.findByRole('menuitem', { name: /^delete$/i }))
     const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
     within(dialog)
       .getByRole('button', { name: /^delete$/i })
@@ -150,7 +158,8 @@ describe('BrowserLocalCanvasPage (browser — real IndexedDB)', () => {
         timeout: 5000,
       },
     )
-    screen.getByRole('button', { name: /delete canvas/i }).click()
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }), { button: 0 })
+    fireEvent.pointerUp(await screen.findByRole('menuitem', { name: /^delete$/i }))
     const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
     within(dialog)
       .getByRole('button', { name: /^delete$/i })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -42,10 +42,13 @@ async function renderLoaded(store = new IndexedDBStore()) {
   return store
 }
 
-// Click the header "Delete canvas" trigger and wait for the confirmation
-// dialog to appear.
+// Open the canvas row's operations kebab, pick "Delete canvas", and wait
+// for the confirmation dialog to appear.
 async function openDeleteDialog(): Promise<HTMLElement> {
-  screen.getByRole('button', { name: /delete canvas/i }).click()
+  const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+  fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
+  const item = await screen.findByRole('menuitem', { name: /delete canvas/i })
+  fireEvent.pointerUp(item)
   return screen.findByRole('alertdialog', undefined, { timeout: 5000 })
 }
 
@@ -98,7 +101,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
     expect(screen.queryByTestId('cleanup-completed')).toBeNull()
     expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument()
-    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument()
   })
 
   it('cancelling via Escape keeps the canvas intact', async () => {
@@ -119,11 +122,9 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     expect(dialog).toHaveAccessibleDescription(/permanently removes the canvas.*cannot be undone/i)
   })
 
-  it('focus moves into the dialog on open and returns to the trigger on close', async () => {
+  it('focus moves into the dialog on open and returns to the kebab on close', async () => {
     await renderLoaded()
-    const trigger = screen.getByRole('button', { name: /delete canvas/i })
-    trigger.click()
-    const dialog = await screen.findByRole('alertdialog', undefined, { timeout: 5000 })
+    const dialog = await openDeleteDialog()
     await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true), {
       timeout: 5000,
     })
@@ -132,7 +133,10 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
       .getByRole('button', { name: /cancel/i })
       .click()
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
-    await waitFor(() => expect(document.activeElement).toBe(trigger), { timeout: 5000 })
+    // The menu item that opened the dialog is long unmounted — focus must
+    // land back on the kebab, not fall to <body>.
+    const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+    await waitFor(() => expect(document.activeElement).toBe(kebab), { timeout: 5000 })
   })
 
   it('confirming delete while a save is pending flushes and deletes exactly once', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -42,12 +42,12 @@ async function renderLoaded(store = new IndexedDBStore()) {
   return store
 }
 
-// Open the canvas row's operations kebab, pick "Delete canvas", and wait
+// Open the canvas row's operations kebab, pick "Delete", and wait
 // for the confirmation dialog to appear.
 async function openDeleteDialog(): Promise<HTMLElement> {
-  const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+  const kebab = screen.getByRole('button', { name: 'More actions' })
   fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
-  const item = await screen.findByRole('menuitem', { name: /delete canvas/i })
+  const item = await screen.findByRole('menuitem', { name: /^delete$/i })
   fireEvent.pointerUp(item)
   return screen.findByRole('alertdialog', undefined, { timeout: 5000 })
 }
@@ -135,7 +135,7 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
     // The menu item that opened the dialog is long unmounted — focus must
     // land back on the kebab, not fall to <body>.
-    const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+    const kebab = screen.getByRole('button', { name: 'More actions' })
     await waitFor(() => expect(document.activeElement).toBe(kebab), { timeout: 5000 })
   })
 

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -50,7 +50,9 @@ const { BrowserLocalCanvasPage } = await import('./BrowserLocalCanvasPage.js')
  * the condition these tests actually depend on before tearing the page down.
  */
 async function waitForSaved(): Promise<void> {
-  await waitFor(() => expect(screen.getByText('Saved')).toBeTruthy(), { timeout: 15_000 })
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy(), {
+    timeout: 15_000,
+  })
 }
 
 describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -110,6 +110,29 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
   })
 
+  it('a markdown canvas has no display-settings gear — edge routing is spatial-only', async () => {
+    const store = new IndexedDBStore()
+    render(<BrowserLocalCanvasPage store={store} />)
+
+    // Fresh DB boots into a spatial canvas: the gear is offered there.
+    await screen.findByTestId('mock-spatial-editor')
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="canvas-settings-button"]')).not.toBeNull()
+    })
+
+    const switcher = await screen.findByRole('button', { name: 'untitled' }, { timeout: 10_000 })
+    await userEvent.click(switcher)
+    await userEvent.click(await screen.findByTestId('new-markdown-menu-item'))
+    await waitFor(() => {
+      expect(document.querySelector('[contenteditable="true"]')).not.toBeNull()
+    })
+
+    // Edge routing has no meaning for a document with no spatial scene —
+    // the gear must not carry over; the rest of the canvas row does.
+    expect(document.querySelector('[data-testid="canvas-settings-button"]')).toBeNull()
+    expect(document.querySelector('[data-testid="save-status-chip"]')).toBeTruthy()
+  })
+
   it('the title survives a remount and renames the canvas in the switcher', async () => {
     const store = new IndexedDBStore()
     const first = render(<BrowserLocalCanvasPage store={store} />)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.rename.browser.test.tsx
@@ -96,7 +96,9 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
     fireEvent.change(titleInput, { target: { value: 'Reloaded title' } })
     titleInput.blur()
     await waitForTitle('Reloaded title')
-    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument(), {
+      timeout: 5000,
+    })
 
     cleanup()
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
@@ -165,14 +167,18 @@ describe('BrowserLocalCanvasPage rename (browser — real IndexedDB)', () => {
     fireEvent.change(titleInput, { target: { value: 'Named canvas' } })
     titleInput.blur()
     await waitForTitle('Named canvas')
-    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument(), {
+      timeout: 5000,
+    })
 
     const titleInput2 = await openRenameInput()
     titleInput2.focus()
     fireEvent.change(titleInput2, { target: { value: '   ' } })
     titleInput2.blur()
     await waitForTitle('untitled')
-    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument(), { timeout: 5000 })
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument(), {
+      timeout: 5000,
+    })
 
     cleanup()
     render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -270,7 +270,13 @@ describe('BrowserLocalCanvasPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled (copy)')
     })
-    expect(duplicateBtn.disabled).toBe(false)
+    // The actions cluster remounts with the canvas row when the page
+    // navigates to the copy (the row is keyed on canvas identity), so the
+    // re-enabled state is asserted on the CURRENT button, not the stale node.
+    const freshDuplicateBtn = screen.getByRole('button', {
+      name: /duplicate/i,
+    }) as HTMLButtonElement
+    expect(freshDuplicateBtn.disabled).toBe(false)
     const list = await store.listCanvases()
     expect(list.filter((c) => c.name === 'untitled (copy)')).toHaveLength(1)
   })
@@ -306,6 +312,26 @@ describe('BrowserLocalCanvasPage', () => {
     expect(screen.getByText('Saved')).toBeTruthy()
     // the raw "saved" enum token must not leak to the UI
     expect(screen.queryByText('saved')).toBeNull()
+  })
+
+  it('the canvas row carries state, settings and operations in ONE row (no separate strip)', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    // Save state is the colored chip, not a bare text span.
+    expect(screen.getByTestId('save-status-chip').textContent).toContain('Saved')
+    // A spatial canvas offers its display settings from the same row.
+    expect(screen.getByRole('button', { name: 'Canvas display settings' })).toBeTruthy()
+    // The whole cluster lives inside the canvas row (CanvasProperties),
+    // beside the title — not in a second header strip of its own.
+    const title = screen.getByRole('textbox', { name: /title/i })
+    const row = title.closest('div.border-b')
+    expect(row?.contains(screen.getByTestId('save-status-chip'))).toBe(true)
+    expect(row?.contains(screen.getByRole('button', { name: 'Duplicate canvas' }))).toBe(true)
+    expect(row?.contains(screen.getByRole('button', { name: 'Delete canvas' }))).toBe(true)
   })
 
   it('surfaces the degraded save message in the header when a save fails', async () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -79,6 +79,23 @@ const snap: CanvasSnapshot = {
   kind: 'spatial' as const,
 }
 
+// Radix DropdownMenuTrigger opens on pointerDown (not click); the menu
+// mounts asynchronously, and items select on pointerUp.
+async function openCanvasOpsMenu() {
+  const trigger = screen.getByRole('button', { name: 'More canvas actions' })
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+  return screen.findByRole('menu')
+}
+
+function canvasOpsItem(name: RegExp) {
+  return screen.findByRole('menuitem', { name })
+}
+
+async function openDeleteConfirm() {
+  await openCanvasOpsMenu()
+  fireEvent.pointerUp(await canvasOpsItem(/delete canvas/i))
+}
+
 describe('BrowserLocalCanvasPage', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => {
@@ -174,45 +191,44 @@ describe('BrowserLocalCanvasPage', () => {
   })
 
   it('renders cleanup-completed view after delete button click and confirm', async () => {
+    vi.useRealTimers()
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    // After act, load is complete and editing state is rendered — button must exist
-    const cleanupBtn = screen.getByRole('button', { name: /delete/i })
+    // After act, load is complete and the canvas row is rendered — the
+    // rare operations live behind the kebab.
     await act(async () => {
-      cleanupBtn.click()
+      await openDeleteConfirm()
     })
     expect(screen.getByRole('alertdialog')).toBeTruthy()
     const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
     await act(async () => {
       confirmBtn.click()
-      await vi.runAllTimersAsync()
     })
-    expect(screen.getByTestId('cleanup-completed')).toBeTruthy()
+    expect(await screen.findByTestId('cleanup-completed')).toBeTruthy()
   })
 
   it('does not delete the canvas when the confirmation dialog is cancelled', async () => {
+    vi.useRealTimers()
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    const cleanupBtn = screen.getByRole('button', { name: /delete canvas/i })
     await act(async () => {
-      cleanupBtn.click()
+      await openDeleteConfirm()
     })
     expect(screen.getByRole('alertdialog')).toBeTruthy()
     const cancelBtn = screen.getByRole('button', { name: /cancel/i })
     await act(async () => {
       cancelBtn.click()
-      await vi.runAllTimersAsync()
     })
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
     expect(screen.queryByTestId('cleanup-completed')).toBeNull()
-    expect(screen.queryByRole('alertdialog')).toBeNull()
     expect(screen.getByRole('main')).toBeTruthy()
   })
 
@@ -228,10 +244,8 @@ describe('BrowserLocalCanvasPage', () => {
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} loro={loro} />)
     })
-    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i })
-    await act(async () => {
-      duplicateBtn.click()
-    })
+    await openCanvasOpsMenu()
+    fireEvent.pointerUp(await canvasOpsItem(/duplicate/i))
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled (copy)')
     })
@@ -259,24 +273,24 @@ describe('BrowserLocalCanvasPage', () => {
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} loro={loro} />)
     })
-    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i }) as HTMLButtonElement
-    fireEvent.click(duplicateBtn)
-    await waitFor(() => expect(duplicateBtn.disabled).toBe(true))
-    // A second click while disabled must not start a second duplicate.
-    fireEvent.click(duplicateBtn)
+    await openCanvasOpsMenu()
+    fireEvent.pointerUp(await canvasOpsItem(/duplicate/i))
+    // The menu closes on select; while the duplicate is in flight the item
+    // is disabled, so a second attempt from the reopened menu is inert.
+    await openCanvasOpsMenu()
+    const inFlightItem = await canvasOpsItem(/duplicate/i)
+    await waitFor(() => expect(inFlightItem.getAttribute('aria-disabled')).toBe('true'))
+    fireEvent.pointerUp(inFlightItem)
     await act(async () => {
       releaseLoad?.()
     })
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled (copy)')
     })
-    // The actions cluster remounts with the canvas row when the page
-    // navigates to the copy (the row is keyed on canvas identity), so the
-    // re-enabled state is asserted on the CURRENT button, not the stale node.
-    const freshDuplicateBtn = screen.getByRole('button', {
-      name: /duplicate/i,
-    }) as HTMLButtonElement
-    expect(freshDuplicateBtn.disabled).toBe(false)
+    // The row remounts with the copy (keyed on canvas identity): the fresh
+    // menu offers Duplicate enabled again.
+    await openCanvasOpsMenu()
+    expect((await canvasOpsItem(/duplicate/i)).getAttribute('aria-disabled')).toBeNull()
     const list = await store.listCanvases()
     expect(list.filter((c) => c.name === 'untitled (copy)')).toHaveLength(1)
   })
@@ -288,18 +302,21 @@ describe('BrowserLocalCanvasPage', () => {
     await store.save(snap)
     const loro = new FakeLoroStore()
     await loro.save('c1', new Loro().export({ mode: 'snapshot' }))
-    loro.load = async () => ({ kind: 'corrupt-snapshot' })
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} loro={loro} />)
     })
-    const duplicateBtn = screen.getByRole('button', { name: /duplicate/i }) as HTMLButtonElement
-    await act(async () => {
-      duplicateBtn.click()
-    })
+    // Break the Loro read only for the DUPLICATE — the canvas itself loaded
+    // fine, so the operations kebab is offered and the failure surfaces as
+    // an alert on an otherwise healthy page.
+    loro.load = async () => ({ kind: 'corrupt-snapshot' })
+    await openCanvasOpsMenu()
+    fireEvent.pointerUp(await canvasOpsItem(/duplicate/i))
     expect((await screen.findByRole('alert')).textContent).toMatch(/duplicat/i)
-    expect(duplicateBtn.disabled).toBe(false)
-    // No switch happened — still on the source canvas.
+    // No switch happened — still on the source canvas. (Asserted before
+    // reopening the menu: Radix's modal dropdown aria-hides the page.)
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+    await openCanvasOpsMenu()
+    expect((await canvasOpsItem(/duplicate/i)).getAttribute('aria-disabled')).toBeNull()
   })
 
   it('renders a human-readable save status instead of the raw state enum', async () => {
@@ -309,29 +326,39 @@ describe('BrowserLocalCanvasPage', () => {
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    expect(screen.getByText('Saved')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy()
     // the raw "saved" enum token must not leak to the UI
     expect(screen.queryByText('saved')).toBeNull()
   })
 
   it('the canvas row carries state, settings and operations in ONE row (no separate strip)', async () => {
+    vi.useRealTimers()
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    // Save state is the colored chip, not a bare text span.
-    expect(screen.getByTestId('save-status-chip').textContent).toContain('Saved')
+    // Save state is the color-only dot, named for assistive tech.
+    expect(screen.getByTestId('save-status-chip').getAttribute('aria-label')).toBe('Saved')
     // A spatial canvas offers its display settings from the same row.
     expect(screen.getByRole('button', { name: 'Canvas display settings' })).toBeTruthy()
-    // The whole cluster lives inside the canvas row (CanvasProperties),
-    // beside the title — not in a second header strip of its own.
+    // The whole cluster lives inside the canvas row (CanvasProperties) —
+    // the dot LEFT of the title, the rare operations behind one kebab at
+    // the right edge — not in a second header strip of its own.
     const title = screen.getByRole('textbox', { name: /title/i })
-    const row = title.closest('div.border-b')
-    expect(row?.contains(screen.getByTestId('save-status-chip'))).toBe(true)
-    expect(row?.contains(screen.getByRole('button', { name: 'Duplicate canvas' }))).toBe(true)
-    expect(row?.contains(screen.getByRole('button', { name: 'Delete canvas' }))).toBe(true)
+    const row = title.closest('div.border-b') as HTMLElement
+    const chip = screen.getByTestId('save-status-chip')
+    expect(row.contains(chip)).toBe(true)
+    expect(chip.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+    expect(row.contains(kebab)).toBe(true)
+    // Duplicate/Delete are menu items, not always-visible buttons.
+    expect(screen.queryByRole('button', { name: 'Duplicate canvas' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Delete canvas' })).toBeNull()
+    await openCanvasOpsMenu()
+    expect(await canvasOpsItem(/duplicate canvas/i)).toBeTruthy()
+    expect(await canvasOpsItem(/delete canvas/i)).toBeTruthy()
   })
 
   it('surfaces the degraded save message in the header when a save fails', async () => {
@@ -355,35 +382,34 @@ describe('BrowserLocalCanvasPage', () => {
     // A real save-failure round trip through SpatialEditor's onChange needs a
     // pointer gesture this suite does not drive; verify the persistence
     // state at least starts as Saved rather than immediately degraded.
-    expect(screen.getByText('Saved')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy()
   })
 
   it('offers a Start fresh action in the cleanup-completed view', async () => {
+    vi.useRealTimers()
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    const deleteBtn = screen.getByRole('button', { name: /delete/i })
     await act(async () => {
-      deleteBtn.click()
+      await openDeleteConfirm()
     })
-    const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
+    const confirmBtn = await screen.findByRole('button', { name: /^delete$/i })
     await act(async () => {
       confirmBtn.click()
-      await vi.runAllTimersAsync()
     })
     // cleanup-completed must not be a dead end: Start fresh mints a new canvas.
-    const startFresh = screen.getByRole('button', { name: /start fresh/i })
+    const startFresh = await screen.findByRole('button', { name: /start fresh/i })
     await act(async () => {
       startFresh.click()
-      await vi.runAllTimersAsync()
     })
-    expect(screen.getByRole('main')).toBeTruthy()
+    expect(await screen.findByRole('main')).toBeTruthy()
   })
 
   it('makes no network requests during load or cleanup', async () => {
+    vi.useRealTimers()
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('', { status: 200 }))
@@ -393,15 +419,14 @@ describe('BrowserLocalCanvasPage', () => {
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    const deleteBtn = screen.getByRole('button', { name: /delete/i })
     await act(async () => {
-      deleteBtn.click()
+      await openDeleteConfirm()
     })
-    const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
+    const confirmBtn = await screen.findByRole('button', { name: /^delete$/i })
     await act(async () => {
       confirmBtn.click()
-      await vi.runAllTimersAsync()
     })
+    await screen.findByTestId('cleanup-completed')
     expect(fetchSpy).not.toHaveBeenCalled()
     fetchSpy.mockRestore()
   })
@@ -418,8 +443,8 @@ describe('BrowserLocalCanvasPage', () => {
     expect(heading.textContent).toBe('untitled')
     // WorkspaceTopBar mounts through a lazy chunk; wait for it to resolve.
     expect(await screen.findByLabelText('Canvas actions')).toBeTruthy()
-    // Distinct from the Delete button's accessible name.
-    expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+    // Distinct from the canvas row's operations kebab.
+    expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
   })
 
   it("renaming through the top bar's canvas actions updates the heading and flushes a save", async () => {
@@ -472,8 +497,9 @@ describe('BrowserLocalCanvasPage', () => {
       render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
     })
     const switcher = await screen.findByRole('button', { name: 'untitled' })
-    // Accessible names must not collide with Delete or the canvas actions control.
-    expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+    // Accessible names must not collide with the operations kebab or the
+    // top bar's canvas actions control.
+    expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
     expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
     fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
     await screen.findByText('Other canvas')
@@ -860,7 +886,7 @@ describe('BrowserLocalCanvasPage', () => {
       await act(async () => {
         render(<BrowserLocalCanvasPage store={store} />)
       })
-      expect(screen.getByRole('button', { name: /delete/i })).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
       expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
     })
   })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -82,7 +82,7 @@ const snap: CanvasSnapshot = {
 // Radix DropdownMenuTrigger opens on pointerDown (not click); the menu
 // mounts asynchronously, and items select on pointerUp.
 async function openCanvasOpsMenu() {
-  const trigger = screen.getByRole('button', { name: 'More canvas actions' })
+  const trigger = screen.getByRole('button', { name: 'More actions' })
   fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
   return screen.findByRole('menu')
 }
@@ -93,7 +93,7 @@ function canvasOpsItem(name: RegExp) {
 
 async function openDeleteConfirm() {
   await openCanvasOpsMenu()
-  fireEvent.pointerUp(await canvasOpsItem(/delete canvas/i))
+  fireEvent.pointerUp(await canvasOpsItem(/^delete$/i))
 }
 
 describe('BrowserLocalCanvasPage', () => {
@@ -342,7 +342,7 @@ describe('BrowserLocalCanvasPage', () => {
     // Save state is the color-only dot, named for assistive tech.
     expect(screen.getByTestId('save-status-chip').getAttribute('aria-label')).toBe('Saved')
     // A spatial canvas offers its display settings from the same row.
-    expect(screen.getByRole('button', { name: 'Canvas display settings' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Display settings' })).toBeTruthy()
     // The whole cluster lives inside the canvas row (CanvasProperties) —
     // the dot LEFT of the title, the rare operations behind one kebab at
     // the right edge — not in a second header strip of its own.
@@ -351,14 +351,14 @@ describe('BrowserLocalCanvasPage', () => {
     const chip = screen.getByTestId('save-status-chip')
     expect(row.contains(chip)).toBe(true)
     expect(chip.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    const kebab = screen.getByRole('button', { name: 'More canvas actions' })
+    const kebab = screen.getByRole('button', { name: 'More actions' })
     expect(row.contains(kebab)).toBe(true)
     // Duplicate/Delete are menu items, not always-visible buttons.
-    expect(screen.queryByRole('button', { name: 'Duplicate canvas' })).toBeNull()
-    expect(screen.queryByRole('button', { name: 'Delete canvas' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^duplicate$/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull()
     await openCanvasOpsMenu()
-    expect(await canvasOpsItem(/duplicate canvas/i)).toBeTruthy()
-    expect(await canvasOpsItem(/delete canvas/i)).toBeTruthy()
+    expect(await canvasOpsItem(/^duplicate$/i)).toBeTruthy()
+    expect(await canvasOpsItem(/^delete$/i)).toBeTruthy()
   })
 
   it('surfaces the degraded save message in the header when a save fails', async () => {
@@ -444,7 +444,7 @@ describe('BrowserLocalCanvasPage', () => {
     // WorkspaceTopBar mounts through a lazy chunk; wait for it to resolve.
     expect(await screen.findByLabelText('Canvas actions')).toBeTruthy()
     // Distinct from the canvas row's operations kebab.
-    expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
   })
 
   it("renaming through the top bar's canvas actions updates the heading and flushes a save", async () => {
@@ -499,7 +499,7 @@ describe('BrowserLocalCanvasPage', () => {
     const switcher = await screen.findByRole('button', { name: 'untitled' })
     // Accessible names must not collide with the operations kebab or the
     // top bar's canvas actions control.
-    expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
     expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
     fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
     await screen.findByText('Other canvas')
@@ -886,7 +886,7 @@ describe('BrowserLocalCanvasPage', () => {
       await act(async () => {
         render(<BrowserLocalCanvasPage store={store} />)
       })
-      expect(screen.getByRole('button', { name: 'More canvas actions' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
       expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
     })
   })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,5 @@
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
-import { Copy, Trash2 } from 'lucide-react'
+import { Copy, EllipsisVertical, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
@@ -8,8 +8,14 @@ import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SaveStatusChip } from '../components/SaveStatusChip.js'
-import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
+import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
 import {
   AlertDialog,
@@ -20,7 +26,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '../components/ui/alert-dialog.js'
 import { Button } from '../components/ui/button.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
@@ -134,6 +139,8 @@ export function BrowserLocalCanvasPage({
   // disable-while-in-flight guard (a second click during the async
   // read-then-write must not start a second copy) and the error surface.
   const [isDuplicating, setIsDuplicating] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const canvasOpsButtonRef = useRef<HTMLButtonElement | null>(null)
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
   const handleDuplicate = async () => {
     if (isDuplicating) return
@@ -361,9 +368,10 @@ export function BrowserLocalCanvasPage({
     return <CanvasPageSkeleton label="Loading canvas" />
   }
 
-  // Right cluster of the canvas row: canvas STATE, then whole-document
-  // operations. One JSX value shared by both canvas-kind branches so the
-  // two rows cannot drift apart.
+  // Whole-document operations live behind a kebab: duplicate and delete
+  // are rare actions, and rare + destructive earns a menu (with words)
+  // over two always-visible icon buttons. One JSX value shared by both
+  // canvas-kind branches so the two rows cannot drift apart.
   const canvasRowActions = (
     <>
       {cleanupError && (
@@ -376,36 +384,47 @@ export function BrowserLocalCanvasPage({
           {duplicateError}
         </div>
       )}
-      <SaveStatusChip state={pageState.persistence} />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            aria-label="Duplicate canvas"
-            disabled={isDuplicating}
-            onClick={() => void handleDuplicate()}
-            variant="ghost"
-            size="sm"
-            className="size-7 p-0"
-          >
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                ref={canvasOpsButtonRef}
+                type="button"
+                aria-label="More canvas actions"
+                variant="ghost"
+                size="sm"
+                className="size-7 p-0"
+              >
+                <EllipsisVertical aria-hidden="true" className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>More canvas actions</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem disabled={isDuplicating} onSelect={() => void handleDuplicate()}>
             <Copy aria-hidden="true" className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Duplicate canvas</TooltipContent>
-      </Tooltip>
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
-          <Button
-            type="button"
-            aria-label="Delete canvas"
-            variant="ghost"
-            size="sm"
-            className="size-7 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+            Duplicate canvas
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+            onSelect={() => setConfirmDelete(true)}
           >
             <Trash2 aria-hidden="true" className="size-3.5" />
-          </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
+            Delete canvas
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent
+          // The menu item that opened this dialog unmounted with the menu;
+          // default close-focus would fall to <body>, so hand it to the kebab.
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            canvasOpsButtonRef.current?.focus()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
             <AlertDialogDescription>
@@ -502,6 +521,7 @@ export function BrowserLocalCanvasPage({
             <div className="flex h-full min-h-0 flex-col">
               <CanvasProperties
                 key={canvasId ?? 'no-canvas'}
+                status={<SaveStatusChip state={pageState.persistence} />}
                 actions={canvasRowActions}
                 meta={markdownDoc.coreMeta ?? fallbackCoreMeta(canvasKind, canvasName)}
                 onChange={(next) => {
@@ -539,6 +559,7 @@ export function BrowserLocalCanvasPage({
                 facets belong to the CANVAS, not to either editor. */}
             <CanvasProperties
               key={canvasId ?? 'no-canvas'}
+              status={<SaveStatusChip state={pageState.persistence} />}
               settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}
               actions={canvasRowActions}
               meta={coreFacets ?? fallbackCoreMeta(canvasKind, canvasName)}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -8,12 +8,6 @@ import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SaveStatusChip } from '../components/SaveStatusChip.js'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../components/ui/dropdown-menu.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
@@ -28,6 +22,12 @@ import {
   AlertDialogTitle,
 } from '../components/ui/alert-dialog.js'
 import { Button } from '../components/ui/button.js'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
 import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -7,6 +7,8 @@ import { CanvasProperties } from '../components/canvas-properties/CanvasProperti
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
+import { SaveStatusChip } from '../components/SaveStatusChip.js'
+import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
 import {
@@ -38,7 +40,6 @@ import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
 import { derivePageState } from './browser-local-page-state.js'
 import {
-  type BrowserLocalPersistenceState,
   type LoroStoreLike,
   useBrowserLocalCanvasController,
 } from './use-browser-local-canvas-controller.js'
@@ -85,18 +86,6 @@ interface BrowserLocalCanvasPageProps {
 
 // Map the persistence state machine to user-facing copy. `degraded` carries its
 // own message; the other states are not shown as raw enum tokens.
-function persistenceLabel(status: BrowserLocalPersistenceState): string {
-  switch (status.kind) {
-    case 'saved':
-      return 'Saved'
-    case 'saving':
-      return 'Saving…'
-    case 'pending':
-      return 'Unsaved changes'
-    case 'degraded':
-      return status.message
-  }
-}
 
 /**
  * The core meta to show when a canvas has none stored yet — every canvas
@@ -372,6 +361,72 @@ export function BrowserLocalCanvasPage({
     return <CanvasPageSkeleton label="Loading canvas" />
   }
 
+  // Right cluster of the canvas row: canvas STATE, then whole-document
+  // operations. One JSX value shared by both canvas-kind branches so the
+  // two rows cannot drift apart.
+  const canvasRowActions = (
+    <>
+      {cleanupError && (
+        <div role="alert" aria-live="assertive" className="text-destructive text-xs">
+          {cleanupError}
+        </div>
+      )}
+      {duplicateError && (
+        <div role="alert" aria-live="assertive" className="text-destructive text-xs">
+          {duplicateError}
+        </div>
+      )}
+      <SaveStatusChip state={pageState.persistence} />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            aria-label="Duplicate canvas"
+            disabled={isDuplicating}
+            onClick={() => void handleDuplicate()}
+            variant="ghost"
+            size="sm"
+            className="size-7 p-0"
+          >
+            <Copy aria-hidden="true" className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Duplicate canvas</TooltipContent>
+      </Tooltip>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            type="button"
+            aria-label="Delete canvas"
+            variant="ghost"
+            size="sm"
+            className="size-7 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Trash2 aria-hidden="true" className="size-3.5" />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes the canvas and its drawing data from this browser. This
+              action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => void triggerCleanup()}
+              className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+
   return (
     // Two-row grid shell (h-dvh makes the page own its viewport height):
     // every header-shaped row stacks inside the auto row, and the editor
@@ -435,70 +490,6 @@ export function BrowserLocalCanvasPage({
             onOpenSettings={handleOpenSettings}
           />
         </Suspense>
-        {/* Page-specific bits that WorkspaceTopBar has no slot for. A plain
-          div, not a second <header>: two sibling <header> landmarks under
-          <main> would both register as "banner" in accessibility trees
-          since <main> does not scope them the way sectioning content does. */}
-        <div className="flex shrink-0 flex-wrap items-center gap-3 border-b bg-background px-4 py-1 text-xs">
-          <span className="text-muted-foreground">{persistenceLabel(pageState.persistence)}</span>
-          {cleanupError && (
-            <div role="alert" aria-live="assertive" className="text-destructive">
-              {cleanupError}
-            </div>
-          )}
-          {duplicateError && (
-            <div role="alert" aria-live="assertive" className="text-destructive">
-              {duplicateError}
-            </div>
-          )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                aria-label="Duplicate canvas"
-                disabled={isDuplicating}
-                onClick={() => void handleDuplicate()}
-                variant="ghost"
-                size="sm"
-                className="size-7 p-0"
-              >
-                <Copy aria-hidden="true" className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Duplicate canvas</TooltipContent>
-          </Tooltip>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                type="button"
-                aria-label="Delete canvas"
-                variant="ghost"
-                size="sm"
-                className="size-7 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              >
-                <Trash2 aria-hidden="true" className="size-3.5" />
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This permanently removes the canvas and its drawing data from this browser. This
-                  action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => void triggerCleanup()}
-                  className="bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
-                >
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
       </div>
       {/* The snapshot's kind picks the editor: markdown canvases open the
           markdown editor (body and OKF core facets persisted as containers
@@ -511,6 +502,7 @@ export function BrowserLocalCanvasPage({
             <div className="flex h-full min-h-0 flex-col">
               <CanvasProperties
                 key={canvasId ?? 'no-canvas'}
+                actions={canvasRowActions}
                 meta={markdownDoc.coreMeta ?? fallbackCoreMeta(canvasKind, canvasName)}
                 onChange={(next) => {
                   markdownDoc.setCoreMeta(next)
@@ -547,6 +539,8 @@ export function BrowserLocalCanvasPage({
                 facets belong to the CANVAS, not to either editor. */}
             <CanvasProperties
               key={canvasId ?? 'no-canvas'}
+              settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}
+              actions={canvasRowActions}
               meta={coreFacets ?? fallbackCoreMeta(canvasKind, canvasName)}
               onChange={(next) => {
                 setCoreFacets(next)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -391,7 +391,7 @@ export function BrowserLocalCanvasPage({
               <Button
                 ref={canvasOpsButtonRef}
                 type="button"
-                aria-label="More canvas actions"
+                aria-label="More actions"
                 variant="ghost"
                 size="sm"
                 className="size-7 p-0"
@@ -400,19 +400,19 @@ export function BrowserLocalCanvasPage({
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent>More canvas actions</TooltipContent>
+          <TooltipContent>More actions</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end">
           <DropdownMenuItem disabled={isDuplicating} onSelect={() => void handleDuplicate()}>
             <Copy aria-hidden="true" className="size-3.5" />
-            Duplicate canvas
+            Duplicate
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive focus:bg-destructive/10 focus:text-destructive"
             onSelect={() => setConfirmDelete(true)}
           >
             <Trash2 aria-hidden="true" className="size-3.5" />
-            Delete canvas
+            Delete
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,6 +1,19 @@
 import { afterEach, expect, vi } from 'vitest'
 import { drainSchedulerMacrotasks } from './src/test-utils/scheduler-drain.js'
 
+// jsdom ships no ResizeObserver; Radix popper-positioned surfaces
+// (DropdownMenu/Popover content) observe their anchor on mount and throw
+// without one. A no-op is enough — layout geometry is a browser-mode
+// concern, jsdom tests only assert structure and wiring.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver
+}
+
 // Shared jsdom-project teardown hook. See src/test-utils/scheduler-drain.ts
 // for why this exists: React's scheduler can outlive a test's own cleanup,
 // so every test gets a bounded drain window before the next test (or the


### PR DESCRIPTION
## What

Reorganizes the browser-local canvas page header around its conceptual model — **workspace/app level** (top bar: which canvas, connection, viewing chrome) vs **canvas level** (identity, metadata, display settings, save state, whole-document operations) — collapsing the previous three rows into two:

```
Row 1 (unchanged):  [canvas ▾][✎]             [● Local] [theme][⛶][⚙app][⋮]
Row 2 (canvas row): [●][title]                          [ⓘ][⚙display][⋮ ops]
```

Owner-directed refinements: the save state is a **color-only dot LEFT of the title** — label in the accessible name + tooltip, sentence in the popover on click — and duplicate/delete are rare operations, so they live behind one **"More actions" kebab** whose menu items keep their words. Labels drop the redundant object (the row IS the canvas): "Duplicate", "Delete", "Properties", "Display settings". The top bar's narrow-viewport kebab renames to "View options" so the page never carries two "More actions" buttons. The controlled delete dialog hands focus back to the kebab on close.

- **CanvasProperties** grows `settings`/`actions` slots; the "Properties" text-button becomes an **Info icon** with `aria-label` + tooltip and the previously missing `aria-controls` link to its disclosure.
- **SaveStatusChip** (new) replaces the bare persistence text — a color-only dot whose label always lives in the accessible name and tooltip (assistive tech never gets color alone), popover explanation, and the connection chip's one-shot attention pulse for `degraded`, named with the state's own message. Deliberately distinct from `HeaderSaveDot` (named-version dirtiness on daemon pages — a different concept that never coexists on screen).
- **CanvasDisplaySettings** (new) extracts the dock gear popover (#592) into a standalone `(canvas, onChange)` component rendered in the canvas row, hidden for markdown canvases (no spatial scene to route). Radix Popover owns dismissal/focus-return, so `ContextMenu`'s popover props and `ToolPalette`'s `trailing` slot are reverted — the dock is tools-only again.
- **Duplicate/Delete** move into the row's right cluster unchanged (confirm dialog intact).

Daemon page is untouched — it has no canvas-level row today; building this row as a shared component for daemon mode is the named follow-up.

## Tests

- New: `SaveStatusChip.test.tsx` (4 states + popover), CanvasProperties icon/a11y + slot tests, standalone `canvas-settings.browser.test.tsx` (pick applies + stays open, deferred-parent chaining, Escape returns focus to the gear), page-level 2-row structure pinned for spatial (gear present, cluster inside the row) and markdown (gear absent, chip present).
- Preserved through the new surface: all edge-routing **rendering** assertions (orthogonal bend, curve `Q`, hop arc, no-trace-on-default, deferred-parent chaining).
- apps/web jsdom 1745 / page browser suites green; full `web-browser` had one HeaderBranchChip failure that passes in isolation (known load-flake family). knip/typecheck clean.

## Visual repro

Two-row header (emerald status dot left of the title; ⓘ properties, ⚙ display settings, ⋮ operations at the right edge):

![header-two-rows.png](https://github.com/user-attachments/assets/c703ad37-ea0d-4f9d-aa56-0e1cdf74c2e9)

The operations kebab (worded items; Delete styled destructive, confirm dialog unchanged):

![header-kebab-menu.png](https://github.com/user-attachments/assets/99853c88-d9fd-4d52-b939-878aa2c9ac81)

Display settings popover, opening from the canvas row:

![header-settings-popover.png](https://github.com/user-attachments/assets/7c989135-7687-40a4-b11c-050392132f8c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
