### PR TITLE
test(mcp-server): stop the mcp-node suite migrating the real ~/.whiteboard

### DIFF
--- a/packages/mcp-server/vitest-data-dir.test.ts
+++ b/packages/mcp-server/vitest-data-dir.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The mcp-node suite must never touch the developer's real data dir.
+ *
+ * `getDataDir()` falls back to `~/.whiteboard` when `WHITEBOARD_DATA_DIR` is
+ * unset, and several tests boot the server far enough to run migrations. On a
+ * machine whose `~/.whiteboard/whiteboard.db` was last migrated by a DIFFERENT
+ * build — a dev daemon from a worktree that has since been deleted keeps
+ * running and keeps writing there — the run dies with two unhandled
+ * `IncompatibleDatabaseError` rejections while every test still passes. That
+ * fails the lefthook pre-push gate for reasons that have nothing to do with
+ * the branch being pushed.
+ *
+ * Asserting on the resolved env var rather than on a log line keeps this
+ * independent of which test happens to boot the server today.
+ */
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('mcp-node data dir isolation', () => {
+  it('points WHITEBOARD_DATA_DIR somewhere other than the real home data dir', () => {
+    const configured = process.env.WHITEBOARD_DATA_DIR
+    expect(configured, 'WHITEBOARD_DATA_DIR must be set for the mcp-node project').toBeTruthy()
+    expect(resolve(configured as string)).not.toBe(resolve(homedir(), '.whiteboard'))
+  })
+
+  it('keeps that dir inside the checkout, so two worktrees never share one', () => {
+    // A per-worktree path is what stops worktree A's suite colliding with
+    // worktree B's daemon; an OS-global temp path would reintroduce it.
+    expect(resolve(process.env.WHITEBOARD_DATA_DIR as string)).toContain(
+      resolve(import.meta.dirname),
+    )
+  })
+})

--- a/packages/mcp-server/vitest.data-dir-setup.ts
+++ b/packages/mcp-server/vitest.data-dir-setup.ts
@@ -1,0 +1,17 @@
+/**
+ * Empties this project's test data dir before the run.
+ *
+ * A database migrated by an older branch must not outlive a branch switch in
+ * the same worktree: it would record migrations the current build no longer
+ * ships and fail the whole run with an `IncompatibleDatabaseError` that has
+ * nothing to do with the tests. Starting empty makes each run self-contained.
+ *
+ * Left in place afterwards on purpose — a failed run's database is often the
+ * only evidence of what went wrong, and the next run clears it.
+ */
+import { rmSync } from 'node:fs'
+import { MCP_NODE_DATA_DIR } from './vitest.node.config.js'
+
+export default function setup(): void {
+  rmSync(MCP_NODE_DATA_DIR, { recursive: true, force: true })
+}

--- a/packages/mcp-server/vitest.node.config.ts
+++ b/packages/mcp-server/vitest.node.config.ts
@@ -1,5 +1,28 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineProject, mergeConfig } from 'vitest/config'
 import sharedConfig from './vitest.shared.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Where this project's tests are allowed to keep state.
+ *
+ * `getDataDir()` falls back to `~/.whiteboard` when `WHITEBOARD_DATA_DIR` is
+ * unset, and enough of this suite boots the server to run migrations against
+ * whatever lives there. That is the developer's REAL database, shared with
+ * every dev daemon on the machine — and daemons outlive `git worktree
+ * remove`, so one built from a deleted branch keeps migrating it. The next
+ * run on any branch then dies with unhandled `IncompatibleDatabaseError`
+ * rejections while every test passes, failing the pre-push gate for reasons
+ * unrelated to the change being pushed.
+ *
+ * Deliberately inside the checkout rather than an OS temp dir: each worktree
+ * has its own, so two worktrees can run their suites at the same time without
+ * sharing a database. `globalSetup` empties it before every run so a database
+ * migrated by an older branch never outlives a branch switch.
+ */
+export const MCP_NODE_DATA_DIR = resolve(__dirname, 'tmp/test-data-dir')
 
 export default mergeConfig(
   sharedConfig,
@@ -15,6 +38,8 @@ export default mergeConfig(
         // Local dev-tooling tests colocated with the scripts they cover
         // (e.g. the ensure-http-dev-daemon SessionStart hook helper).
         'scripts/**/*.test.ts',
+        // Guards this project's own data-dir isolation.
+        'vitest-data-dir.test.ts',
       ],
       exclude: ['src/**/*.smoke.test.ts', 'src/**/*.distribution.test.ts'],
       environment: 'node',
@@ -24,6 +49,8 @@ export default mergeConfig(
       // without masking real hangs.
       testTimeout: 10_000,
       hookTimeout: 10_000,
+      env: { WHITEBOARD_DATA_DIR: MCP_NODE_DATA_DIR },
+      globalSetup: ['./vitest.data-dir-setup.ts'],
     },
   }),
 )


### PR DESCRIPTION
## Why this blocked work rather than merely being untidy

`getDataDir()` falls back to `~/.whiteboard` when `WHITEBOARD_DATA_DIR` is
unset, and enough of the mcp-node suite boots the server to run migrations
against whatever lives there — the developer's **real** database, shared with
anything on the machine that uses the default.

`.mcp.json` registers the **published** `@kamiazya/whiteboard-mcp@latest`
(deliberately — it is the plugin/team surface). A published daemon uses that
same default dir with the migration set of its own release. That release ran
`0005-canvases-kind`; current source ships only `0001`–`0004`. So the
published daemon leaves behind a migration history this checkout does not
recognise, and the next `pnpm test --project mcp-node` on **any** branch dies
with two unhandled `IncompatibleDatabaseError` rejections **while all 3215
tests pass** — failing the lefthook pre-push gate for reasons unrelated to
the change being pushed. It cost two blocked pushes before the cause was
found, and the error's own advice (delete the database) only helps until the
next published-daemon run.

**The repo's own dev daemons are not the culprit.** `with-dev-data-dir`
already points them at a per-worktree `<repoRoot>/.dev-data`, precisely so
parallel lanes cannot corrupt each other. The gap was that the test suite
never got the same treatment.

## The fix

`WHITEBOARD_DATA_DIR` now points the mcp-node project at
`packages/mcp-server/tmp/test-data-dir` (already gitignored) — mirroring
`.dev-data` rather than inventing a new convention.

Inside the checkout rather than an OS temp path, on purpose: each worktree
gets its own, so two worktrees can run their suites concurrently without
sharing a database. `globalSetup` empties it before each run, so a database
migrated by an older branch never survives a branch switch in the same
worktree.

## The guard

`vitest-data-dir.test.ts` asserts on the resolved env var rather than on a
log line, which keeps it independent of whichever test happens to boot the
server today. Mutation-checked: dropping the `env` entry turns both cases
red.

Verified by mtime that a full run no longer touches `~/.whiteboard` — the
real database sat untouched at 23:04 while the suite ran at 23:12 and wrote
into the checkout instead.

## Correction

An earlier revision of this branch's commit message blamed stale dev daemons
outliving `git worktree remove`. That was wrong: those daemons use
per-worktree `.dev-data` and never touch `~/.whiteboard`. The message and the
in-source rationale have been corrected to the published-package mechanism
above, which the migration-set comparison confirms.
