### PR TITLE
feat(web): derive a display slug from a canvas name (foundation for the shared list)

### DIFF
--- a/apps/web/src/lib/derive-display-slug.property.test.ts
+++ b/apps/web/src/lib/derive-display-slug.property.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { deriveDisplaySlug } from './derive-display-slug.js'
+
+// The charset property matches the daemon's validateSlug rule, so a future promotion of display
+// slugs to real slugs never has to re-derive.
+const SLUG_SHAPE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+
+describe('deriveDisplaySlug properties', () => {
+  fcTest.prop(
+    [
+      fc.option(fc.string({ maxLength: 40 }), { nil: undefined }),
+      fc.array(fc.string(), { maxLength: 8 }),
+    ],
+    withDefaults(),
+  )('always yields a valid slug shape that is not already taken', (name, existing) => {
+    const out = deriveDisplaySlug(name, existing)
+    expect(out).toMatch(SLUG_SHAPE)
+    expect(existing).not.toContain(out)
+  })
+
+  fcTest.prop(
+    [
+      fc.option(fc.string({ maxLength: 40 }), { nil: undefined }),
+      fc.array(fc.string(), { maxLength: 8 }),
+    ],
+    withDefaults(),
+  )('is deterministic', (name, existing) => {
+    expect(deriveDisplaySlug(name, existing)).toBe(deriveDisplaySlug(name, existing))
+  })
+})

--- a/apps/web/src/lib/derive-display-slug.test.ts
+++ b/apps/web/src/lib/derive-display-slug.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { deriveDisplaySlug } from './derive-display-slug.js'
+
+describe('deriveDisplaySlug', () => {
+  it('slugifies a display name', () => {
+    expect(deriveDisplaySlug('My Design Notes', [])).toBe('my-design-notes')
+  })
+
+  it('falls back to untitled when the name is absent or yields nothing sluggable', () => {
+    expect(deriveDisplaySlug(undefined, [])).toBe('untitled')
+    expect(deriveDisplaySlug('🎨✨', [])).toBe('untitled')
+    expect(deriveDisplaySlug('   ', [])).toBe('untitled')
+  })
+
+  it('suffixes to avoid entries already taken', () => {
+    expect(deriveDisplaySlug('My Design Notes', ['my-design-notes'])).toBe('my-design-notes-2')
+    expect(deriveDisplaySlug('My Design Notes', ['my-design-notes', 'my-design-notes-2'])).toBe(
+      'my-design-notes-3',
+    )
+  })
+
+  it('degrades a non-latin name to untitled rather than mojibake', () => {
+    expect(deriveDisplaySlug('設計メモ', [])).toBe('untitled')
+  })
+
+  it('collapses runs of separators and trims edge hyphens', () => {
+    expect(deriveDisplaySlug('  --Weekly   sync!!  ', [])).toBe('weekly-sync')
+  })
+})

--- a/apps/web/src/lib/derive-display-slug.ts
+++ b/apps/web/src/lib/derive-display-slug.ts
@@ -1,0 +1,18 @@
+// Display-only sibling of deriveNewCanvasSlug: browser-local list rows have a
+// display name and an opaque UUID, and the UUID is what the UI currently shows
+// as the secondary line. This derives a slug-shaped label from the name
+// instead. NOT persisted and NOT an identity — but it deliberately matches the
+// daemon's validateSlug charset, so if display slugs are ever promoted to real
+// slugs nothing has to re-derive.
+export function deriveDisplaySlug(name: string | undefined, existing: readonly string[]): string {
+  const base =
+    (name ?? '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'untitled'
+  const taken = new Set(existing)
+  if (!taken.has(base)) return base
+  let n = 2
+  while (taken.has(`${base}-${n}`)) n++
+  return `${base}-${n}`
+}


### PR DESCRIPTION
Slice S2 of the UI-unification initiative — deliberately **foundation-only**, and parallel-safe (new leaf module, no existing callers; verified by grep since the impact graph indexes the main checkout).

Browser-local list rows have a display name and an opaque UUID, and the UUID is what the switcher currently renders as its secondary line — observed directly during S1's browser verification (`24affeac-cbf0-…` as row text). This derives a slug-shaped label from the name instead: `My Design Notes` → `my-design-notes`, suffixed `-2`/`-3` against a taken set, degrading to `untitled` for names with nothing sluggable (symbols-only, non-latin).

**Display-only, non-persisted, not an identity.** But the output deliberately satisfies the daemon's `validateSlug` charset, pinned by a fast-check property — so if display slugs are ever promoted to real slugs (the deferred slug-as-storage-key decision, Task #9), nothing has to re-derive.

## userReach: foundation, with a named follow-up

No call site yet, by design. Wired by **S5** (the `/local` list page + switcher secondary line, Task #6 on the board). The design passed `check-design.mjs` — which caught my own malformed `blastRadius` field on the first run, its first real save.

## Verification

- Unit suite + fast-check properties (shape-and-not-taken over arbitrary unicode names, determinism).
- Property mutation-checked per AGENTS.md: removing the edge-trim fails the shape property with shrunk counterexample `" "` — the generator is dense enough to reach the interesting inputs.
- typecheck, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX