### PR TITLE
feat(mcp-server): accept and persist a spatial|markdown kind on canvas create

### DIFF
--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
@@ -7,8 +7,12 @@ import { createUserSettingsStore } from '../../lib/user-settings-store.js'
 import type { CanvasSnapshot } from '../../lib/whiteboard-client.js'
 import { ImportBrowserLocalPanel } from './ImportBrowserLocalPanel.js'
 
-function makeCanvas(id: string, name: string): CanvasSnapshot {
-  return { id, name, updatedAt: new Date().toISOString(), kind: 'spatial' as const }
+function makeCanvas(
+  id: string,
+  name: string,
+  kind: CanvasSnapshot['kind'] = 'spatial',
+): CanvasSnapshot {
+  return { id, name, updatedAt: new Date().toISOString(), kind }
 }
 
 function snapshotFor(tag: string): Uint8Array {
@@ -50,6 +54,41 @@ describe('ImportBrowserLocalPanel', () => {
 
     await screen.findByText('Alpha')
     await screen.findByText('Beta')
+  })
+
+  it("threads each canvas's kind into the create request (markdown stays markdown)", async () => {
+    const store = new MemoryStore()
+    await store.save(makeCanvas('c1', 'Notes', 'markdown'))
+    const daemonFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ slug: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+
+    render(
+      <ImportBrowserLocalPanel
+        workspaceId="ws1"
+        daemonFetch={daemonFetch}
+        browserLocalStore={store}
+        loroStore={makeLoroStore({ c1: { kind: 'ok', snapshot: snapshotFor('c1') } })}
+        settingsStore={createUserSettingsStore()}
+      />,
+    )
+
+    await screen.findByText('Notes')
+    fireEvent.click(screen.getByRole('button', { name: /import/i }))
+    await waitFor(() => expect(daemonFetch).toHaveBeenCalled())
+    const post = daemonFetch.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes('/canvases') && (init as RequestInit | undefined)?.method === 'POST',
+    )
+    expect(post).toBeTruthy()
+    // biome is right that post?.[1] could be undefined in general; the toBeTruthy above plus the
+    // non-null assertion (allowed by config) makes the intent explicit instead of casting past it.
+    const init = post![1] as RequestInit
+    expect(JSON.parse(String(init.body))).toEqual({
+      slug: expect.any(String),
+      kind: 'markdown',
+    })
   })
 
   it('renders an empty state, disables import, and makes zero calls when there are no canvases', async () => {

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
@@ -83,6 +83,7 @@ export function ImportBrowserLocalPanel({
             daemonBaseUrl,
             workspaceId,
             canvasName: canvas.name,
+            canvasKind: canvas.kind,
             loroLoad,
           })
           if (result.kind === 'ok') {

--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -100,7 +100,12 @@ describe('importOneCanvas', () => {
     const encodedWs = encodeURIComponent('ws 1#x')
     const [createUrl, createInit] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(createUrl).toBe(`http://127.0.0.1:3099/api/workspaces/${encodedWs}/canvases`)
-    expect(JSON.parse(createInit.body as string)).toEqual({ slug: 'my-canvas' })
+    // createCanvasRequestSchema.parse fills in the default kind: 'spatial' —
+    // browser-local canvases migrating in are always spatial.
+    expect(JSON.parse(createInit.body as string)).toEqual({
+      slug: 'my-canvas',
+      kind: 'spatial',
+    })
 
     const [updateUrl, updateInit] = fetchMock.mock.calls[1] as [string, RequestInit]
     expect(updateUrl).toBe(`http://127.0.0.1:3099/api/canvas/${encodedWs}/my-canvas/update`)

--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -91,6 +91,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws 1#x',
       canvasName: 'My Canvas',
+      canvasKind: 'markdown',
       loroLoad: loroOkResult(),
     })
 
@@ -100,11 +101,12 @@ describe('importOneCanvas', () => {
     const encodedWs = encodeURIComponent('ws 1#x')
     const [createUrl, createInit] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(createUrl).toBe(`http://127.0.0.1:3099/api/workspaces/${encodedWs}/canvases`)
-    // createCanvasRequestSchema.parse fills in the default kind: 'spatial' —
-    // browser-local canvases migrating in are always spatial.
+    // The created canvas's kind must match the source browser-local
+    // snapshot's kind — a markdown canvas migrated with a defaulted
+    // 'spatial' kind opens in the wrong editor with no way to correct it.
     expect(JSON.parse(createInit.body as string)).toEqual({
       slug: 'my-canvas',
-      kind: 'spatial',
+      kind: 'markdown',
     })
 
     const [updateUrl, updateInit] = fetchMock.mock.calls[1] as [string, RequestInit]
@@ -122,6 +124,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroOkResult(),
     })
 
@@ -144,6 +147,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroOkResult(),
     })
 
@@ -164,6 +168,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroOkResult(),
     })
 
@@ -182,6 +187,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroOkResult(),
     })
 
@@ -199,6 +205,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroOkResult(),
     })
 
@@ -218,6 +225,7 @@ describe('importOneCanvas', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
       canvasName: 'My Canvas',
+      canvasKind: 'spatial',
       loroLoad: loroLoad as LoroLoadResult,
     })
 

--- a/apps/web/src/components/migration/import-browser-local.ts
+++ b/apps/web/src/components/migration/import-browser-local.ts
@@ -1,3 +1,4 @@
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import {
   createCanvasRequestSchema,
   createCanvasResponseSchema,
@@ -43,6 +44,7 @@ interface ImportOneCanvasOptions {
   daemonBaseUrl: string
   workspaceId: string
   canvasName: string
+  canvasKind: CanvasKind
   loroLoad: LoroLoadResult
 }
 
@@ -92,7 +94,7 @@ export async function importOneCanvas(
 async function importOneCanvasUnsafe(
   options: ImportOneCanvasOptions,
 ): Promise<ImportOneCanvasResult> {
-  const { fetch, daemonBaseUrl, workspaceId, canvasName, loroLoad } = options
+  const { fetch, daemonBaseUrl, workspaceId, canvasName, canvasKind, loroLoad } = options
 
   if (loroLoad.kind !== 'ok') {
     return { kind: 'failed', reason: loroLoadFailureReason(loroLoad.kind) }
@@ -103,7 +105,7 @@ async function importOneCanvasUnsafe(
 
   for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
     const candidateSlug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`
-    const body = createCanvasRequestSchema.parse({ slug: candidateSlug })
+    const body = createCanvasRequestSchema.parse({ slug: candidateSlug, kind: canvasKind })
     const res = await fetch(
       `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases`,
       {

--- a/apps/web/src/lib/daemon-api-client.test.ts
+++ b/apps/web/src/lib/daemon-api-client.test.ts
@@ -142,7 +142,12 @@ describe('listCanvases', () => {
       .fn()
       .mockResolvedValue(jsonResponse({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] }))
     const result = await listCanvases(fetchFn, DAEMON_BASE_URL, 'w1')
-    expect(result).toEqual({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] })
+    // kind is absent from the mocked daemon response (pre-change shape) and
+    // defaults to 'spatial' — the back-compat rule that lets a new client
+    // parse an old daemon's kind-less list.
+    expect(result).toEqual({
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
   })
 
   it('rejects a malformed response body without returning raw JSON', async () => {

--- a/apps/web/src/lib/whiteboard-client.ts
+++ b/apps/web/src/lib/whiteboard-client.ts
@@ -1,3 +1,4 @@
+import { canvasKindSchema } from '@kamiazya/whiteboard-canvas-model'
 import { z } from 'zod'
 
 /**
@@ -15,7 +16,7 @@ export const canvasSnapshotSchema = z.object({
    * Content stays in the Loro doc either way (spatial: nodes/edges maps;
    * markdown: a 'body' text container) — this is still metadata only.
    */
-  kind: z.enum(['spatial', 'markdown']).default('spatial'),
+  kind: canvasKindSchema.default('spatial'),
 })
 
 export type CanvasSnapshot = z.infer<typeof canvasSnapshotSchema>

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -99,8 +99,8 @@ describe('DaemonCanvasPage', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'main', updatedAt: '2026-01-01' },
-        { slug: 'second', updatedAt: '2026-01-02' },
+        { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
   })
@@ -208,12 +208,14 @@ describe('DaemonCanvasPage', () => {
       })
       mockListCanvases.mockImplementation((_fetch, _base, workspaceId) => {
         if (workspaceId === 'w2') {
-          return Promise.resolve({ canvases: [{ slug: 'w2-main', updatedAt: '2026-02-01' }] })
+          return Promise.resolve({
+            canvases: [{ slug: 'w2-main', updatedAt: '2026-02-01', kind: 'spatial' }],
+          })
         }
         return Promise.resolve({
           canvases: [
-            { slug: 'main', updatedAt: '2026-01-01' },
-            { slug: 'second', updatedAt: '2026-01-02' },
+            { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+            { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
           ],
         })
       })
@@ -253,8 +255,8 @@ describe('DaemonCanvasPage', () => {
         if (workspaceId === 'w2') return Promise.resolve({ canvases: [] })
         return Promise.resolve({
           canvases: [
-            { slug: 'main', updatedAt: '2026-01-01' },
-            { slug: 'second', updatedAt: '2026-01-02' },
+            { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+            { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
           ],
         })
       })
@@ -287,8 +289,8 @@ describe('DaemonCanvasPage', () => {
       })
       mockListCanvases.mockResolvedValueOnce({
         canvases: [
-          { slug: 'main', updatedAt: '2026-01-01' },
-          { slug: 'second', updatedAt: '2026-01-02' },
+          { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+          { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
         ],
       })
 
@@ -516,8 +518,8 @@ describe('DaemonCanvasPage', () => {
       if (workspaceId === 'w2') return Promise.resolve({ canvases: [] })
       return Promise.resolve({
         canvases: [
-          { slug: 'main', updatedAt: '2026-01-01' },
-          { slug: 'second', updatedAt: '2026-01-02' },
+          { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+          { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
         ],
       })
     })
@@ -682,7 +684,7 @@ describe('DaemonCanvasPage', () => {
     mockListCanvases.mockResolvedValueOnce({ canvases: [] })
     mockCreateCanvas.mockResolvedValue({ slug: 'untitled' })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'untitled', updatedAt: '2026-01-03' }],
+      canvases: [{ slug: 'untitled', updatedAt: '2026-01-03', kind: 'spatial' }],
     })
 
     await act(async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
@@ -75,7 +75,7 @@ describe('DaemonCanvasPage theme wiring', () => {
     window.localStorage.clear()
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
   })
   afterEach(() => {

--- a/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
@@ -70,7 +70,9 @@ describe('DaemonCanvasPage thumbnail wiring', () => {
   beforeEach(() => {
     capturedProps.length = 0
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
-    mockListCanvases.mockResolvedValue({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
   })
   afterEach(() => {
     cleanup()

--- a/apps/web/src/pages/DaemonCanvasPage.webmcp.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.webmcp.test.tsx
@@ -70,7 +70,7 @@ describe('DaemonCanvasPage WebMCP wiring', () => {
   beforeEach(() => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
   })
 

--- a/apps/web/src/pages/use-daemon-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-daemon-canvas-controller.test.ts
@@ -25,7 +25,9 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
-    mockListCanvases.mockResolvedValue({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
 
     const { result } = renderHook(() =>
       useDaemonCanvasController({ daemonBaseUrl: DAEMON_BASE_URL, daemonFetch: fetchFn }),
@@ -40,8 +42,8 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'first', updatedAt: '2026-01-01' },
-        { slug: 'second', updatedAt: '2026-01-02' },
+        { slug: 'first', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
 
@@ -75,7 +77,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w-explicit' }, { workspaceId: 'w-other' }],
     })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'explicit', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'explicit', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -101,7 +103,9 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
-    mockListCanvases.mockResolvedValue({ canvases: [{ slug: 'main', updatedAt: '2026-01-01' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
 
     const { result } = renderHook(() =>
       useDaemonCanvasController({ daemonBaseUrl: DAEMON_BASE_URL, daemonFetch: fetchFn }),
@@ -117,7 +121,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -128,7 +132,7 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.slug).toBe('w1-canvas')
 
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02' }],
+      canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' }],
     })
 
     await act(async () => {
@@ -138,7 +142,9 @@ describe('useDaemonCanvasController', () => {
     expect(mockListCanvases).toHaveBeenLastCalledWith(fetchFn, DAEMON_BASE_URL, 'w2')
     expect(result.current.workspaceId).toBe('w2')
     expect(result.current.slug).toBe('w2-canvas')
-    expect(result.current.canvases).toEqual([{ slug: 'w2-canvas', updatedAt: '2026-01-02' }])
+    expect(result.current.canvases).toEqual([
+      { slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' },
+    ])
   })
 
   it('switchWorkspace resolves to a null slug (empty state) when the target workspace has zero canvases', async () => {
@@ -146,7 +152,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -169,7 +175,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }, { workspaceId: 'w3' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -177,15 +183,17 @@ describe('useDaemonCanvasController', () => {
     )
     await waitFor(() => expect(result.current.loading).toBe(false))
 
-    let resolveW2: (value: { canvases: { slug: string; updatedAt: string }[] }) => void = () => {}
-    const w2Promise = new Promise<{ canvases: { slug: string; updatedAt: string }[] }>(
-      (resolve) => {
-        resolveW2 = resolve
-      },
-    )
+    let resolveW2: (value: {
+      canvases: { slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
+    }) => void = () => {}
+    const w2Promise = new Promise<{
+      canvases: { slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
+    }>((resolve) => {
+      resolveW2 = resolve
+    })
     mockListCanvases.mockReturnValueOnce(w2Promise)
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w3-canvas', updatedAt: '2026-01-03' }],
+      canvases: [{ slug: 'w3-canvas', updatedAt: '2026-01-03', kind: 'spatial' }],
     })
 
     let switchW2Done: Promise<void> = Promise.resolve()
@@ -199,7 +207,7 @@ describe('useDaemonCanvasController', () => {
 
     // The stale w2 response resolves after w3 already won; it must be discarded.
     await act(async () => {
-      resolveW2({ canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02' }] })
+      resolveW2({ canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' }] })
       await switchW2Done
     })
 
@@ -211,8 +219,8 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'a', updatedAt: '2026-01-01' },
-        { slug: 'b', updatedAt: '2026-01-02' },
+        { slug: 'a', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'b', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
 
@@ -232,7 +240,7 @@ describe('useDaemonCanvasController', () => {
     mockListCanvases.mockResolvedValueOnce({ canvases: [] })
     mockCreateCanvas.mockResolvedValue({ slug: 'brand-new' })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'brand-new', updatedAt: '2026-01-03' }],
+      canvases: [{ slug: 'brand-new', updatedAt: '2026-01-03', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -280,7 +288,7 @@ describe('useDaemonCanvasController', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'untitled', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'untitled', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     await act(async () => {
@@ -289,7 +297,9 @@ describe('useDaemonCanvasController', () => {
 
     expect(result.current.createError).toBe('slug already exists')
     // The refreshed list now shows the slug another client already took.
-    expect(result.current.canvases).toEqual([{ slug: 'untitled', updatedAt: '2026-01-01' }])
+    expect(result.current.canvases).toEqual([
+      { slug: 'untitled', updatedAt: '2026-01-01', kind: 'spatial' },
+    ])
   })
 
   it('createCanvas is a no-op before workspaceId has resolved', async () => {
@@ -325,7 +335,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01' }],
+      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -343,6 +353,8 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.loadError).toBeNull()
     expect(result.current.workspaceId).toBe('w1')
     expect(result.current.slug).toBe('w1-canvas')
-    expect(result.current.canvases).toEqual([{ slug: 'w1-canvas', updatedAt: '2026-01-01' }])
+    expect(result.current.canvases).toEqual([
+      { slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+    ])
   })
 })

--- a/packages/canvas-model/src/meta.test.ts
+++ b/packages/canvas-model/src/meta.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { CANVAS_SCHEMA_VERSION, canvasMetaSchema } from './meta.js'
+import { CANVAS_SCHEMA_VERSION, canvasKindSchema, canvasMetaSchema } from './meta.js'
+
+describe('canvasKindSchema', () => {
+  it('accepts spatial and markdown', () => {
+    expect(canvasKindSchema.safeParse('spatial').success).toBe(true)
+    expect(canvasKindSchema.safeParse('markdown').success).toBe(true)
+  })
+
+  it('rejects an unknown kind', () => {
+    expect(canvasKindSchema.safeParse('html').success).toBe(false)
+  })
+})
 
 describe('canvasMetaSchema', () => {
   it('accepts a markdown canvas meta at the current schema version', () => {

--- a/packages/canvas-model/src/meta.ts
+++ b/packages/canvas-model/src/meta.ts
@@ -9,8 +9,15 @@ import { z } from 'zod'
  */
 export const CANVAS_SCHEMA_VERSION = 1 as const
 
+// Single source of truth for the spatial/markdown split: canvasMetaSchema's
+// `format` and every kind-carrying contract downstream (mcp-server
+// api-contracts, the browser-local IndexedDB schema) reference this instead
+// of restating the two literals.
+export const canvasKindSchema = z.enum(['spatial', 'markdown'])
+export type CanvasKind = z.infer<typeof canvasKindSchema>
+
 export const canvasMetaSchema = z.object({
-  format: z.enum(['markdown', 'spatial']),
+  format: canvasKindSchema,
   schemaVersion: z.literal(CANVAS_SCHEMA_VERSION),
 })
 

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -148,6 +148,55 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(json.title!.length).toBeGreaterThan(0)
   })
 
+  it('creates a kind:markdown canvas, and the list carries it back', async () => {
+    const app = createCanvasRouter()
+    const createRes = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'note', kind: 'markdown' }),
+    })
+    expect(createRes.status).toBe(200)
+    // Response body stays exactly { slug } — kind is not echoed back.
+    expect(await createRes.json()).toEqual({ slug: 'note' })
+
+    const listRes = await app.request('/api/workspaces/ws1/canvases')
+    const listJson = (await listRes.json()) as { canvases: { slug: string; kind: string }[] }
+    const created = listJson.canvases.find((c) => c.slug === 'note')
+    expect(created?.kind).toBe('markdown')
+
+    // The empty LoroDoc a markdown-kind create saves loads without error —
+    // an empty doc is a valid initial document for either kind.
+    const snapshotRes = await app.request('/api/canvas/ws1/note/snapshot')
+    expect(snapshotRes.status).toBe(200)
+  })
+
+  it('creates a canvas without kind — response and list stay byte-identical to spatial back-compat', async () => {
+    const app = createCanvasRouter()
+    const createRes = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'legacy' }),
+    })
+    expect(createRes.status).toBe(200)
+    expect(await createRes.json()).toEqual({ slug: 'legacy' })
+
+    const listRes = await app.request('/api/workspaces/ws1/canvases')
+    const listJson = (await listRes.json()) as { canvases: { slug: string; kind: string }[] }
+    expect(listJson.canvases.find((c) => c.slug === 'legacy')?.kind).toBe('spatial')
+  })
+
+  it('returns 400 with Problem Details title on an invalid kind', async () => {
+    const app = createCanvasRouter()
+    const res = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'bad-kind', kind: 'bogus' }),
+    })
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { title?: string }
+    expect(typeof json.title).toBe('string')
+  })
+
   it('returns 400 with Problem Details { title } (not legacy { error, message }) on invalid workspaceId', async () => {
     const app = createCanvasRouter()
     const res = await app.request('/api/workspaces/bad.workspace/canvases', {

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -185,7 +185,7 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(listJson.canvases.find((c) => c.slug === 'legacy')?.kind).toBe('spatial')
   })
 
-  it('returns 400 with Problem Details title on an invalid kind', async () => {
+  it('returns 400 with Problem Details title naming the actual failing field on an invalid kind', async () => {
     const app = createCanvasRouter()
     const res = await app.request('/api/workspaces/ws1/canvases', {
       method: 'POST',
@@ -195,6 +195,10 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(res.status).toBe(400)
     const json = (await res.json()) as { title?: string }
     expect(typeof json.title).toBe('string')
+    // A valid slug plus an invalid kind must not be told "slug is required" —
+    // that names the wrong field and gives no path to recovery.
+    expect(json.title).toMatch(/kind/i)
+    expect(json.title).not.toMatch(/slug is required/i)
   })
 
   it('returns 400 with Problem Details { title } (not legacy { error, message }) on invalid workspaceId', async () => {

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -1136,6 +1136,48 @@ describe('versions API', () => {
       expect(restoreBody.elementCount).toBe(0)
     })
 
+    it('restoring a markdown-kind canvas into a new target slug carries the source kind forward, not the spatial default', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      await app.request('/api/workspaces/session1/canvases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: 'canvas-a', kind: 'markdown' }),
+      })
+
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      sourceDoc.getText('body').insert(0, 'hello')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-new' }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+
+      const listRes = await app.request('/api/workspaces/session1/canvases')
+      const listBody = (await listRes.json()) as {
+        canvases: { slug: string; kind: string }[]
+      }
+      expect(listBody.canvases.find((c) => c.slug === 'canvas-new')?.kind).toBe('markdown')
+    })
+
     it('restoring into an existing target slug WITHOUT overwrite returns 409 output_exists', async () => {
       const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
 

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -1182,6 +1182,53 @@ describe('versions API', () => {
       expect(listBody.canvases.find((c) => c.slug === 'canvas-new')?.kind).toBe('markdown')
     })
 
+    it('restoring a markdown-kind canvas onto an existing spatial-kind target syncs the target kind to match the restored content', async () => {
+      const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+      await app.request('/api/workspaces/session1/canvases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: 'canvas-a', kind: 'markdown' }),
+      })
+      await app.request('/api/workspaces/session1/canvases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: 'canvas-b', kind: 'spatial' }),
+      })
+
+      const sourceDoc = new LoroDoc()
+      const svv0 = sourceDoc.version()
+      sourceDoc.getText('body').insert(0, 'hello')
+      sourceDoc.commit()
+      await app.request('/api/canvas/session1/canvas-a/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sourceDoc.export({ mode: 'update', from: svv0 }),
+      })
+      const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'v1' }),
+      })
+      const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+      const restoreRes = await app.request(
+        `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetSlug: 'canvas-b', overwrite: true }),
+        },
+      )
+      expect(restoreRes.status).toBe(200)
+
+      const listRes = await app.request('/api/workspaces/session1/canvases')
+      const listBody = (await listRes.json()) as {
+        canvases: { slug: string; kind: string }[]
+      }
+      expect(listBody.canvases.find((c) => c.slug === 'canvas-b')?.kind).toBe('markdown')
+    })
+
     it('restoring into an existing target slug WITHOUT overwrite returns 409 output_exists', async () => {
       const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
 

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -201,6 +201,23 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(json.title).not.toMatch(/slug is required/i)
   })
 
+  it('falls back to the issue message when the invalid field is neither slug nor kind', async () => {
+    // An array body parses as JSON but fails the object schema at the TOP level — path [] —
+    // exercising createCanvasRequestErrorTitle's fallback branch rather than a field-specific
+    // message that would name the wrong thing.
+    const app = createCanvasRouter()
+    const res = await app.request('/api/workspaces/ws-a/canvases', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify([1, 2, 3]),
+    })
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { title: string }
+    expect(json.title).not.toMatch(/slug is required/i)
+    expect(json.title).not.toMatch(/spatial/i)
+    expect(json.title.length).toBeGreaterThan(0)
+  })
+
   it('returns 400 with Problem Details { title } (not legacy { error, message }) on invalid workspaceId', async () => {
     const app = createCanvasRouter()
     const res = await app.request('/api/workspaces/bad.workspace/canvases', {

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { LoroDoc } from 'loro-crdt'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/canvas.js'
-import { ConflictError, canvasExists, saveCanvas } from '../../store/canvas-store.js'
+import { ConflictError, canvasExists, getCanvasKind, saveCanvas } from '../../store/canvas-store.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
 import {
@@ -158,9 +158,17 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
         }
 
         // Genuinely new canvas: no live doc and no connected clients, so
-        // there is nothing to reconcile against.
+        // there is nothing to reconcile against. The restored content is
+        // whatever the source canvas actually stores (spatial nodes/edges
+        // maps vs. a markdown 'body' text container), so the new row must
+        // carry the source's own kind rather than falling back to the
+        // saveCanvas default.
         try {
-          await saveCanvas(workspaceId, targetSlug, past, { overwrite: false })
+          const sourceKind = await getCanvasKind(workspaceId, slug)
+          await saveCanvas(workspaceId, targetSlug, past, {
+            overwrite: false,
+            ...(sourceKind !== null ? { kind: sourceKind } : {}),
+          })
         } catch (err) {
           if (err instanceof ConflictError) {
             return c.json(

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -1,3 +1,4 @@
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import { Hono } from 'hono'
 import type { LoroDoc } from 'loro-crdt'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/canvas.js'
@@ -32,6 +33,7 @@ async function reconcileCommitSaveBroadcast(
   doc: LoroDoc,
   past: LoroDoc,
   label: string | undefined,
+  kind: CanvasKind | null = null,
 ): Promise<void> {
   const { sendRestoreEvent } = await import('../ws.js')
   sendRestoreEvent(workspaceId, targetSlug, 'started', label)
@@ -40,7 +42,10 @@ async function reconcileCommitSaveBroadcast(
     try {
       doc.import(past.export({ mode: 'snapshot' }))
       doc.commit()
-      await saveCanvas(workspaceId, targetSlug, doc, { overwrite: true })
+      await saveCanvas(workspaceId, targetSlug, doc, {
+        overwrite: true,
+        ...(kind !== null ? { kind } : {}),
+      })
     } catch (err) {
       // doc.import mutates the cached doc in place before commit/save
       // run, so any failure in this block leaves the cache ahead of
@@ -150,7 +155,20 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
           const all = await versionStore.list(workspaceId, slug)
           const label = all.find((v) => v.id === id)?.label
           const targetDoc = await getDoc(workspaceId, targetSlug)
-          await reconcileCommitSaveBroadcast(workspaceId, targetSlug, targetDoc, past, label)
+          // The merged content is the source's own shape (spatial nodes/edges
+          // vs. a markdown body), same reasoning as the new-canvas branch
+          // below — the target's stored kind must follow it or a kind-aware
+          // consumer (editor routing) opens the overwritten canvas with the
+          // wrong editor.
+          const sourceKind = await getCanvasKind(workspaceId, slug)
+          await reconcileCommitSaveBroadcast(
+            workspaceId,
+            targetSlug,
+            targetDoc,
+            past,
+            label,
+            sourceKind,
+          )
           return c.json({
             canvasId: `${workspaceId}/${targetSlug}`,
             elementCount: countElements(targetDoc),

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -85,7 +85,7 @@ export function createWorkspacesRouter() {
     }
     try {
       const doc = new LoroDocCtor()
-      await saveCanvas(workspaceId, slug, doc, { overwrite: false })
+      await saveCanvas(workspaceId, slug, doc, { overwrite: false, kind: parsed.data.kind })
       const response: CreateCanvasResponse = { slug }
       return c.json(response)
     } catch (err) {

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { LoroDoc as LoroDocCtor } from 'loro-crdt'
+import type { z } from 'zod'
 import {
   type CreateCanvasResponse,
   createCanvasRequestSchema,
@@ -15,6 +16,18 @@ import {
 } from '../../store/canvas-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
+
+// Names the specific field createCanvasRequestSchema rejected, instead of a
+// single message covering the whole request — a valid slug with an invalid
+// kind must not be told "slug is required", which names the wrong field and
+// gives the caller no path to recovery.
+function createCanvasRequestErrorTitle(error: z.ZodError): string {
+  const issue = error.issues[0]
+  const field = issue?.path[0]
+  if (field === 'kind') return 'kind must be "spatial" or "markdown"'
+  if (field === 'slug') return 'slug is required'
+  return issue?.message ?? 'invalid request body'
+}
 
 // GET /api/workspaces
 // GET /api/workspaces/:workspaceId/canvases
@@ -73,7 +86,7 @@ export function createWorkspacesRouter() {
     }
     const parsed = createCanvasRequestSchema.safeParse(raw)
     if (!parsed.success) {
-      return c.json({ title: 'slug is required' }, 400)
+      return c.json({ title: createCanvasRequestErrorTitle(parsed.error) }, 400)
     }
     const slug = parsed.data.slug
     try {

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -26,6 +26,7 @@ const {
   scheduleAutoCompact,
   setAutoCompactTrigger,
   disposeAutoCompact,
+  getCanvasKind,
   _inFlightAutoCompactCountForTests,
   _isDisposingAutoCompactForTests,
 } = await import('./canvas-store.js')
@@ -346,6 +347,34 @@ describe('listCanvases', () => {
   // tests against directory traversal failures and broken non-directory
   // paths no longer apply now that the listing is a SELECT against the
   // canvases table.
+})
+
+describe('getCanvasKind', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-test-'))
+    await setupIsolatedDb()
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(tempDir, 'session1'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns null when the canvas does not exist', async () => {
+    expect(await getCanvasKind('session1', 'missing')).toBeNull()
+  })
+
+  it('returns the persisted kind for an existing canvas', async () => {
+    await saveCanvas('session1', 'note', new LoroDoc(), { kind: 'markdown' })
+    expect(await getCanvasKind('session1', 'note')).toBe('markdown')
+  })
+
+  it('defaults to spatial when saveCanvas was called without a kind option', async () => {
+    await saveCanvas('session1', 'canvas-a', new LoroDoc())
+    expect(await getCanvasKind('session1', 'canvas-a')).toBe('spatial')
+  })
 })
 
 describe('saveCanvas / loadCanvas - slug validation', () => {

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -315,6 +315,13 @@ describe('listCanvases', () => {
     expect(list.find((c) => c.slug === 'note')?.kind).toBe('markdown')
   })
 
+  it('syncs kind on an overwrite:true re-save when kind is explicitly passed', async () => {
+    await saveCanvas('session1', 'note', new LoroDoc(), { kind: 'spatial' })
+    await saveCanvas('session1', 'note', new LoroDoc(), { overwrite: true, kind: 'markdown' })
+    const list = await listCanvases('session1')
+    expect(list.find((c) => c.slug === 'note')?.kind).toBe('markdown')
+  })
+
   it('recursively lists nested slugs as session-relative paths', async () => {
     await saveCanvas('session1', 'top-level', new LoroDoc())
     await saveCanvas('session1', '621/header', new LoroDoc())

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -295,6 +295,25 @@ describe('listCanvases', () => {
     expect(list[0].updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
+  it('persists kind: markdown and lists it back', async () => {
+    await saveCanvas('session1', 'note', new LoroDoc(), { kind: 'markdown' })
+    const list = await listCanvases('session1')
+    expect(list.find((c) => c.slug === 'note')?.kind).toBe('markdown')
+  })
+
+  it('lists kind: spatial when saveCanvas is called without a kind option (back-compat)', async () => {
+    await saveCanvas('session1', 'canvas-a', new LoroDoc())
+    const list = await listCanvases('session1')
+    expect(list.find((c) => c.slug === 'canvas-a')?.kind).toBe('spatial')
+  })
+
+  it('does not reset kind on an overwrite:true re-save', async () => {
+    await saveCanvas('session1', 'note', new LoroDoc(), { kind: 'markdown' })
+    await saveCanvas('session1', 'note', new LoroDoc(), { overwrite: true })
+    const list = await listCanvases('session1')
+    expect(list.find((c) => c.slug === 'note')?.kind).toBe('markdown')
+  })
+
   it('recursively lists nested slugs as session-relative paths', async () => {
     await saveCanvas('session1', 'top-level', new LoroDoc())
     await saveCanvas('session1', '621/header', new LoroDoc())

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -4,6 +4,7 @@ import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { nanoid } from 'nanoid'
+import type { CanvasSummary } from '../../shared/api-contracts/canvas.js'
 import { getDataDir } from '../config.js'
 import { getLogger } from '../log.js'
 import { validateCanvasId, validateSlug, validateWorkspaceId } from '../validators.js'
@@ -222,6 +223,23 @@ export async function canvasExists(workspaceId: string, slug: string): Promise<b
   const db = await dbReady()
   const canvasId = await getCanvasIdBySlug(db, workspaceId, slug)
   return canvasId !== null
+}
+
+// Returns null when the canvas does not exist, so callers can distinguish
+// "no such canvas" from a stored-but-unset kind (which the null-column
+// back-compat default in listCanvases resolves to 'spatial').
+export async function getCanvasKind(workspaceId: string, slug: string): Promise<CanvasKind | null> {
+  validateWorkspaceId(workspaceId)
+  validateSlug(slug)
+  const db = await dbReady()
+  const row = await db
+    .selectFrom('canvases')
+    .select(['kind'])
+    .where('workspaceId', '=', workspaceId)
+    .where('slug', '=', slug)
+    .executeTakeFirst()
+  if (!row) return null
+  return row.kind ?? 'spatial'
 }
 
 export interface CompactResult {
@@ -452,7 +470,7 @@ export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {
 // ── list canvases from the canvases table ──
 export async function listCanvases(
   workspaceId: string,
-): Promise<{ slug: string; updatedAt: string; kind: CanvasKind }[]> {
+): Promise<Pick<CanvasSummary, 'slug' | 'updatedAt' | 'kind'>[]> {
   validateWorkspaceId(workspaceId)
   const db = await dbReady()
   const rows = await db

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -1,5 +1,6 @@
 import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { nanoid } from 'nanoid'
@@ -62,7 +63,7 @@ export async function saveCanvas(
   workspaceId: string,
   slug: string,
   doc: LoroDoc,
-  options: { overwrite?: boolean; kind?: 'spatial' | 'markdown' } = {},
+  options: { overwrite?: boolean; kind?: CanvasKind } = {},
 ): Promise<void> {
   validateWorkspaceId(workspaceId)
   validateSlug(slug)
@@ -451,7 +452,7 @@ export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {
 // ── list canvases from the canvases table ──
 export async function listCanvases(
   workspaceId: string,
-): Promise<{ slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]> {
+): Promise<{ slug: string; updatedAt: string; kind: CanvasKind }[]> {
   validateWorkspaceId(workspaceId)
   const db = await dbReady()
   const rows = await db

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -62,7 +62,7 @@ export async function saveCanvas(
   workspaceId: string,
   slug: string,
   doc: LoroDoc,
-  options: { overwrite?: boolean } = {},
+  options: { overwrite?: boolean; kind?: 'spatial' | 'markdown' } = {},
 ): Promise<void> {
   validateWorkspaceId(workspaceId)
   validateSlug(slug)
@@ -111,6 +111,10 @@ export async function saveCanvas(
           currentBranch: 'main',
           createdAt: now,
           updatedAt: now,
+          // Written only on insert — an overwrite:true re-save (the
+          // onConflict branch below, and the update branch above) must
+          // never mutate a stored canvas's kind.
+          kind: options.kind ?? null,
         })
         .onConflict((oc) => oc.columns(['workspaceId', 'slug']).doUpdateSet({ updatedAt: now }))
         .execute()
@@ -447,16 +451,17 @@ export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {
 // ── list canvases from the canvases table ──
 export async function listCanvases(
   workspaceId: string,
-): Promise<{ slug: string; updatedAt: string }[]> {
+): Promise<{ slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]> {
   validateWorkspaceId(workspaceId)
   const db = await dbReady()
   const rows = await db
     .selectFrom('canvases')
-    .select(['slug', 'updatedAt'])
+    .select(['slug', 'updatedAt', 'kind'])
     .where('workspaceId', '=', workspaceId)
     .execute()
   return rows.map((r) => ({
     slug: r.slug,
     updatedAt: new Date(r.updatedAt).toISOString(),
+    kind: r.kind ?? 'spatial',
   }))
 }

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -94,9 +94,16 @@ export async function saveCanvas(
     await writeFile(path, snapshot)
     await upsertWorkspaceRow(db, workspaceId)
     if (existingCanvasId) {
+      // A plain re-save (WS updates, applyAndPersist, compactCanvas) omits
+      // `kind` and must never touch the stored value. An explicit `kind` is
+      // an intentional sync request (e.g. restore reconciling a different-
+      // kind source's content onto an existing target) and is honored.
       await db
         .updateTable('canvases')
-        .set({ updatedAt: Date.now() })
+        .set({
+          updatedAt: Date.now(),
+          ...(options.kind !== undefined ? { kind: options.kind } : {}),
+        })
         .where('id', '=', canvasId)
         .execute()
     } else {
@@ -113,9 +120,11 @@ export async function saveCanvas(
           currentBranch: 'main',
           createdAt: now,
           updatedAt: now,
-          // Written only on insert — an overwrite:true re-save (the
-          // onConflict branch below, and the update branch above) must
-          // never mutate a stored canvas's kind.
+          // Written on insert. The update branch above honors an explicit
+          // `kind` too (a plain re-save omits it and leaves the stored value
+          // untouched); the onConflict branch below is the rare
+          // insert-raced-with-a-concurrent-insert fallback and, like a plain
+          // re-save, does not touch `kind`.
           kind: options.kind ?? null,
         })
         .onConflict((oc) => oc.columns(['workspaceId', 'slug']).doUpdateSet({ updatedAt: now }))

--- a/packages/mcp-server/src/server/store/db/migrations/0005-canvases-kind.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0005-canvases-kind.test.ts
@@ -1,0 +1,43 @@
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { describe, expect, it } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+import { migration as initMigration } from './0001-init.js'
+import { migration } from './0005-canvases-kind.js'
+
+async function createMemoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  return db
+}
+
+async function hasColumn(db: Kysely<DatabaseSchema>, table: string, column: string) {
+  const row = await sql<{ name: string }>`select name from pragma_table_info(${table})`.execute(db)
+  return row.rows.some((r) => r.name === column)
+}
+
+describe('0005-canvases-kind migration', () => {
+  it('up adds the canvases.kind column; down drops it', async () => {
+    const db = await createMemoryDb()
+    try {
+      // canvases only exists once 0001-init has run — this migration alters
+      // an existing table rather than creating one.
+      await initMigration.up(db as unknown as Kysely<unknown>)
+      expect(await hasColumn(db, 'canvases', 'kind')).toBe(false)
+
+      await migration.up(db as unknown as Kysely<unknown>)
+      expect(await hasColumn(db, 'canvases', 'kind')).toBe(true)
+
+      await migration.down(db as unknown as Kysely<unknown>)
+      expect(await hasColumn(db, 'canvases', 'kind')).toBe(false)
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0005-canvases-kind.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0005-canvases-kind.ts
@@ -1,0 +1,15 @@
+import type { Kysely, Migration } from 'kysely'
+
+// Add canvases.kind so a canvas can carry which editor (spatial | markdown)
+// opens it. Nullable because existing rows predate the field; the
+// application layer maps a null kind to 'spatial' — the only kind that
+// existed before this column, matching createCanvasRequestSchema's default.
+
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('canvases').addColumn('kind', 'text').execute()
+  },
+  async down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('canvases').dropColumn('kind').execute()
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -3,6 +3,7 @@ import { migration as init } from './0001-init.js'
 import { migration as canvasesLastCompactedAt } from './0002-canvases-last-compacted-at.js'
 import { migration as canvasDocStore } from './0003-canvas-doc-store.js'
 import { migration as workspaceIndex } from './0004-workspace-index.js'
+import { migration as canvasesKind } from './0005-canvases-kind.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0002-canvases-last-compacted-at is a no-op kept only so databases created by the
@@ -12,4 +13,5 @@ export const migrations: Record<string, Migration> = {
   '0002-canvases-last-compacted-at': canvasesLastCompactedAt,
   '0003-canvas-doc-store': canvasDocStore,
   '0004-workspace-index': workspaceIndex,
+  '0005-canvases-kind': canvasesKind,
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -15,4 +15,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0002-canvases-last-compacted-at',
   '0003-canvas-doc-store',
   '0004-workspace-index',
+  '0005-canvases-kind',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/db/schema.ts
+++ b/packages/mcp-server/src/server/store/db/schema.ts
@@ -1,3 +1,4 @@
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import type { ColumnType } from 'kysely'
 
 // Unix milliseconds.
@@ -30,7 +31,7 @@ interface CanvasesTable {
   lastCompactedAt: Timestamp | null
   // Which editor opens this canvas. Null for rows created before this column
   // existed; the application layer maps null to 'spatial'.
-  kind: 'spatial' | 'markdown' | null
+  kind: CanvasKind | null
 }
 
 interface BranchesTable {

--- a/packages/mcp-server/src/server/store/db/schema.ts
+++ b/packages/mcp-server/src/server/store/db/schema.ts
@@ -28,6 +28,9 @@ interface CanvasesTable {
   // Null for canvases that have never been compacted; consumed by the auto-
   // Optimize loop to skip canvases that have not changed since last run.
   lastCompactedAt: Timestamp | null
+  // Which editor opens this canvas. Null for rows created before this column
+  // existed; the application layer maps null to 'spatial'.
+  kind: 'spatial' | 'markdown' | null
 }
 
 interface BranchesTable {

--- a/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
@@ -54,7 +54,7 @@ import {
 import { roundtrip } from './roundtrip.test-helper.js'
 
 describe('createCanvasRequestSchema', () => {
-  const valid: CreateCanvasRequest = { slug: 'my-canvas' }
+  const valid: CreateCanvasRequest = { slug: 'my-canvas', kind: 'spatial' }
 
   it('parses a well-formed value', () => {
     const result: CreateCanvasRequest = createCanvasRequestSchema.parse(valid)
@@ -74,6 +74,20 @@ describe('createCanvasRequestSchema', () => {
   it('rejects empty slug', () => {
     expect(createCanvasRequestSchema.safeParse({ slug: '' }).success).toBe(false)
     expect(createCanvasRequestSchema.safeParse({ slug: '   ' }).success).toBe(false)
+  })
+
+  it('accepts an explicit kind: markdown', () => {
+    const result = createCanvasRequestSchema.parse({ slug: 'notes', kind: 'markdown' })
+    expect(result.kind).toBe('markdown')
+  })
+
+  it('defaults kind to spatial when absent — back-compat for existing callers', () => {
+    const result = createCanvasRequestSchema.parse({ slug: 'legacy' })
+    expect(result.kind).toBe('spatial')
+  })
+
+  it('rejects an unknown kind', () => {
+    expect(createCanvasRequestSchema.safeParse({ slug: 'x', kind: 'bogus' }).success).toBe(false)
   })
 })
 
@@ -355,7 +369,11 @@ describe('listWorkspacesResponseSchema', () => {
 })
 
 describe('canvasSummarySchema', () => {
-  const valid: CanvasSummary = { slug: 'canvas-1', updatedAt: '2024-01-01T00:00:00.000Z' }
+  const valid: CanvasSummary = {
+    slug: 'canvas-1',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    kind: 'spatial',
+  }
 
   it('parses a well-formed value', () => {
     const result: CanvasSummary = canvasSummarySchema.parse(valid)
@@ -370,11 +388,28 @@ describe('canvasSummarySchema', () => {
   it('rejects missing updatedAt', () => {
     expect(canvasSummarySchema.safeParse({ slug: 'canvas-1' }).success).toBe(false)
   })
+
+  it('accepts an explicit kind: markdown', () => {
+    const result = canvasSummarySchema.parse({ ...valid, kind: 'markdown' })
+    expect(result.kind).toBe('markdown')
+  })
+
+  it('defaults kind to spatial when absent — back-compat for rows stored before this change', () => {
+    const result = canvasSummarySchema.parse({
+      slug: 'canvas-1',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    })
+    expect(result.kind).toBe('spatial')
+  })
+
+  it('rejects an unknown kind', () => {
+    expect(canvasSummarySchema.safeParse({ ...valid, kind: 'bogus' }).success).toBe(false)
+  })
 })
 
 describe('listCanvasesResponseSchema', () => {
   const valid: ListCanvasesResponse = {
-    canvases: [{ slug: 'canvas-1', updatedAt: '2024-01-01T00:00:00.000Z' }],
+    canvases: [{ slug: 'canvas-1', updatedAt: '2024-01-01T00:00:00.000Z', kind: 'spatial' }],
   }
 
   it('parses a well-formed value', () => {

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -1,3 +1,4 @@
+import { canvasKindSchema } from '@kamiazya/whiteboard-canvas-model'
 import { z } from 'zod'
 
 // Request/response schemas for the canvas / workspace mutation endpoints.
@@ -13,6 +14,9 @@ export const workspaceNamesSchema = z.object({
 
 export const createCanvasRequestSchema = z.object({
   slug: z.string().trim().min(1),
+  // Defaulted so every existing caller (which posts { slug } alone) keeps
+  // creating a spatial canvas byte-identically to before this field existed.
+  kind: canvasKindSchema.default('spatial'),
 })
 
 // `name: ''` deletes the stored name and falls back to the slug/workspaceId.
@@ -119,6 +123,9 @@ export const listWorkspacesResponseSchema = z.object({
 export const canvasSummarySchema = z.object({
   slug: z.string(),
   updatedAt: z.string(),
+  // Rows stored before this field existed have no recorded kind and read
+  // back as spatial — the only kind that existed then.
+  kind: canvasKindSchema.default('spatial'),
 })
 
 export const listCanvasesResponseSchema = z.object({


### PR DESCRIPTION
Slice S0 of the UI-unification initiative — the bottom of the upcoming list stack: the shared list's create affordance offers a kind picker (product decision), and the daemon API had no `kind` to offer it.

## The change

`POST /api/workspaces/:ws/canvases` accepts `kind: "spatial" | "markdown"`, persisted with the canvas and carried back on list rows. One enum, one home: `canvasKindSchema` lives in **canvas-model** (the model's single source of truth), with `canvasMetaSchema.format` and browser-local's `canvasSnapshotSchema.kind` both converged onto it — the repo previously restated the literal union in two packages.

**Back-compat is the invariant, and it is tested, not asserted**: a request without `kind` behaves byte-identically to today (same `{slug}` response, row reads as spatial), and rows stored before migration `0005-canvases-kind` (NULL) list as spatial. `createCanvasResponseSchema` deliberately stays `{slug}` — the caller knows what it asked for.

**kind is create-time-only.** No overwrite path (WS sync, doc-cache flush, compact, restore-in-place) can mutate a stored kind — with one deliberate exception the review forced: restore-as-new and restore-onto-existing **sync the target's kind to the restored content**, because a markdown canvas restored under a spatial label opens in the wrong editor with no way out.

## Produced by the repaired dev-loop, end to end

This run exercised every gate fixed this session, and they all bit:

- **PlanReview passed a real design** (no null-design bypass — #566's fix held).
- **The review → fix loop ran 3 rounds** (#554's fix working): it caught the restore paths dropping kind, the browser-local migration dropping kind, and a wrong-field error message — each landed as its own commit with tests.
- The loop hit its round cap with two **test-coverage** followups and reported them as `[UNFIXED]` instead of silently dropping them; both are closed in the final commit here (component-level kind-threading test; the error-title fallback branch), each mutation-checked.
- `manualVerification: none` — answered with the reason the execution-mode table expects for a server-side metadata slice; no handback, correctly.

## Scope discipline

apps/web is touched only where kind **metadata** travels (browser-local → daemon migration threading + the one-line enum convergence); no UI reads `kind` yet — that is S3's picker, stacked on this. server-core's `wb_canvas_*` tools are untouched (no MCP contract change, hence no smoke:e2e change, per AGENTS.md's rule).

## Verification (independent, on the rebased branch)

```
mcp-node   264 files  3236 passed
apps/web   1745 passed
typecheck  mcp + web clean · knip clean
```

| mutation (re-run by the integrator, not taken on report) | result |
|---|---|
| revert the route's kind pass-through | ✅ 3 route tests fail |
| hardcode the migration panel's kind threading to 'spatial' | ✅ the new component test fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX
