### PR TITLE
fix(render): break orthogonal elbow ties by bend count, not candidate order

### DIFF
--- a/packages/canvas-render/src/layout/edge-bend-tiebreak.test.ts
+++ b/packages/canvas-render/src/layout/edge-bend-tiebreak.test.ts
@@ -1,9 +1,8 @@
-// The two stub-to-stub elbow candidates always tie on Manhattan length, so
-// ranking by length alone let the arbitrary first candidate win — even when
-// the other one runs collinear with BOTH stubs and draws one bend instead
-// of three. Pinned from a real phone repro: a node below-right of its
-// target, edge top-side → right-side, drew a 3-bend staircase where a
-// single L was available.
+// The two stub-to-stub elbow candidates always tie on Manhattan length,
+// so length alone cannot rank them. The routing invariant pinned here:
+// among equal-length clear candidates, the one with fewer bends wins — in
+// particular, an elbow collinear with BOTH stubs draws one corner, never a
+// three-bend staircase.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'

--- a/packages/canvas-render/src/layout/edge-bend-tiebreak.test.ts
+++ b/packages/canvas-render/src/layout/edge-bend-tiebreak.test.ts
@@ -1,0 +1,80 @@
+// The two stub-to-stub elbow candidates always tie on Manhattan length, so
+// ranking by length alone let the arbitrary first candidate win — even when
+// the other one runs collinear with BOTH stubs and draws one bend instead
+// of three. Pinned from a real phone repro: a node below-right of its
+// target, edge top-side → right-side, drew a 3-bend staircase where a
+// single L was available.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, width: number, height: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width,
+  height,
+  text: id,
+})
+
+/** Direction changes along the polyline, ignoring repeated/collinear points. */
+function bendCount(path: readonly { x: number; y: number }[]): number {
+  const dirs: string[] = []
+  for (let i = 1; i < path.length; i++) {
+    const dx = Math.sign((path[i] as { x: number }).x - (path[i - 1] as { x: number }).x)
+    const dy = Math.sign((path[i] as { y: number }).y - (path[i - 1] as { y: number }).y)
+    if (dx === 0 && dy === 0) continue
+    const dir = `${dx},${dy}`
+    if (dirs[dirs.length - 1] !== dir) dirs.push(dir)
+  }
+  return Math.max(0, dirs.length - 1)
+}
+
+describe('orthogonal elbow tie-break', () => {
+  it('prefers the elbow that stays collinear with both stubs: one bend, not three', () => {
+    // Tall target on the left, source below-right of it. Exit stub points up
+    // (top side), entry stub points right (right side): the vertical-first
+    // elbow extends both stubs in a straight line and needs ONE corner; the
+    // horizontal-first elbow jogs immediately and needs three. Both are the
+    // same length and both are clear — only the bend count separates them.
+    const nodes = [box('b', 0, 0, 200, 300), box('a', 150, 500, 200, 100)]
+    const edges: CanvasEdge[] = [
+      { id: 'e1', fromNode: 'a', toNode: 'b', fromSide: 'top', toSide: 'right' },
+    ]
+    const anchors = assignEdgeAnchors(nodes, edges)
+    const { path } = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e1'))
+
+    expect(bendCount(path)).toBe(1)
+    // The long vertical run rides the source stub's own x, not a jogged lane.
+    expect(path.some((p) => p.x === 250 && p.y === 150)).toBe(true)
+  })
+
+  it('keeps the elbow ranking otherwise intact when only one candidate is clear', () => {
+    // An obstacle sits on the vertical-first lane, so the staircase is the
+    // only clear elbow — fewer bends must never beat clearance.
+    const nodes = [
+      box('b', 0, 0, 200, 300),
+      box('a', 150, 500, 200, 100),
+      box('wall', 230, 330, 60, 120),
+    ]
+    const edges: CanvasEdge[] = [
+      { id: 'e1', fromNode: 'a', toNode: 'b', fromSide: 'top', toSide: 'right' },
+    ]
+    const anchors = assignEdgeAnchors(nodes, edges)
+    const { path } = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e1'))
+
+    // Route exists and never crosses the wall body.
+    expect(path.length).toBeGreaterThan(2)
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as { x: number; y: number }
+      const b = path[i] as { x: number; y: number }
+      const minX = Math.min(a.x, b.x)
+      const maxX = Math.max(a.x, b.x)
+      const minY = Math.min(a.y, b.y)
+      const maxY = Math.max(a.y, b.y)
+      const crosses = minX < 290 && maxX > 230 && minY < 450 && maxY > 330
+      expect(crosses).toBe(false)
+    }
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -810,6 +810,21 @@ const pathLength = (path: readonly Point[]) =>
  * that actually occur (a node or two sitting between two others). A denser
  * search belongs behind the routing-style setting, not in the default path.
  */
+/** Direction changes along a polyline, ignoring repeated/collinear points. */
+function bendCount(path: readonly Point[]): number {
+  let bends = 0
+  let lastDir: string | undefined
+  for (let i = 1; i < path.length; i++) {
+    const dx = Math.sign((path[i] as Point).x - (path[i - 1] as Point).x)
+    const dy = Math.sign((path[i] as Point).y - (path[i - 1] as Point).y)
+    if (dx === 0 && dy === 0) continue
+    const dir = `${dx},${dy}`
+    if (lastDir !== undefined && dir !== lastDir) bends++
+    lastDir = dir
+  }
+  return bends
+}
+
 /**
  * The best candidate by a two-tier clearance ranking, shortest first:
  * clear of the inflated obstacles (full margin kept), else clear of the
@@ -817,13 +832,22 @@ const pathLength = (path: readonly Point[]) =>
  * to cross the band to escape — that is acceptable; crossing the node
  * itself is not), else the shortest overall (layout has to return
  * SOMETHING).
+ *
+ * Equal-length candidates are ranked by BEND COUNT: the two stub-to-stub
+ * elbows are always the same Manhattan length, so without this key the
+ * arbitrary first candidate won even when the other ran collinear with
+ * both stubs and drew one corner instead of three.
  */
 function bestCandidate(
   candidates: readonly Point[][],
   inflated: readonly Rect[],
   raw: readonly Rect[],
 ): Point[] {
-  const byLength = [...candidates].sort((a, b) => pathLength(a) - pathLength(b))
+  const byLength = [...candidates].sort((a, b) => {
+    const byLen = pathLength(a) - pathLength(b)
+    if (Math.abs(byLen) > 1e-6) return byLen
+    return bendCount(a) - bendCount(b)
+  })
   return (
     byLength.find((path) => pathIsClear(path, inflated)) ??
     byLength.find((path) => pathIsClear(path, raw)) ??


### PR DESCRIPTION
## What

Fixes the 3-bend staircase reported from a real canvas on mobile: a node below-right of its target with an edge routed top-side → right-side drew three corners where one was available.

**Root cause** (`packages/canvas-render/src/layout/spatial-edges.ts`, `bestCandidate`): the two stub-to-stub elbow candidates are always the **same Manhattan length**, so the length-only ranking was a permanent tie and the stable sort picked the arbitrary first candidate (horizontal-first) — even when the vertical-first elbow extended both stubs collinearly and needed a single corner. The side-choice optimizer counts bends; the final stub-to-stub connector never did.

**Fix**: equal-length candidates rank by **bend count** (direction changes along the polyline, collinear/repeated points ignored). Clearance still dominates — a bend-poor candidate through an obstacle never beats a clear staircase (pinned by test).

## Tests

- `edge-bend-tiebreak.test.ts` pins the repro geometry (1 bend, vertical run collinear with the source stub) and the clearance-dominates case (obstacle on the good lane → staircase wins, never crossing the obstacle). Mutation-checked: reverting to the length-only sort turns the repro test red.
- Full `canvas-render-node` (374), canvas-viewer node+jsdom (483), apps/web jsdom (1756), and the edge-rendering browser tests (8) all green — no pinned path expectation depended on the old arbitrary tie order.

## Visual repro

Before — the reported staircase (three corners for a clear L):

![bend-before.png](https://github.com/user-attachments/assets/44e9d9fe-fa16-4514-b92d-0ad7da22ad28)

After — one corner, collinear with both stubs:

![bend-after.png](https://github.com/user-attachments/assets/79f35fd9-3ae7-43a1-845b-2a32acf3bab3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orthogonal edge routing to prefer simpler, straighter paths when candidate routes have equal length.
  * Preserved obstacle clearance as the priority, preventing routes from intersecting obstacles.
  * Added fallback behavior for selecting the shortest available route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->