### PR TITLE
feat(web): shared capability-gated CanvasListView (stack base)

### DIFF
--- a/apps/web/src/components/canvas-list/CanvasListView.test.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CanvasListView } from './CanvasListView.js'
+
+afterEach(cleanup)
+
+const NOW = '2026-08-11T00:00:00Z'
+const OLDER = '2026-08-01T00:00:00Z'
+
+function rows() {
+  return [
+    { slug: 'alpha', displayName: 'Alpha', updatedAt: OLDER, kind: 'spatial' as const },
+    { slug: 'notes', displayName: 'Notes', updatedAt: NOW, kind: 'markdown' as const },
+  ]
+}
+
+function renderList(overrides: Partial<Parameters<typeof CanvasListView>[0]> = {}) {
+  const onOpen = vi.fn()
+  const onCreate = vi.fn()
+  const utils = render(
+    <CanvasListView rows={rows()} onOpen={onOpen} onCreate={onCreate} {...overrides} />,
+    // React 18 delegates events to the root; Radix portals render into
+    // document.body, so the body must be the React root for portal events.
+    { container: document.body },
+  )
+  return { onOpen, onCreate, ...utils }
+}
+
+describe('CanvasListView', () => {
+  it('renders rows in caller order (pinned-first arrays survive) and filters by search', () => {
+    // rows() lists alpha (older) BEFORE notes (newer): a component that
+    // re-sorts by recency would flip them, discarding the caller's
+    // pinned-first ordering. Order is the caller's contract.
+    renderList()
+    const cards = screen.getAllByTestId('canvas-list-card')
+    expect(within(cards[0]!).getByText('Alpha')).toBeTruthy()
+    expect(within(cards[1]!).getByText('Notes')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search canvases' }), {
+      target: { value: 'alp' },
+    })
+    expect(screen.getAllByTestId('canvas-list-card')).toHaveLength(1)
+    expect(screen.getByText('Alpha')).toBeTruthy()
+  })
+
+  it('says "No canvases match." when search filters everything out', () => {
+    renderList()
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search canvases' }), {
+      target: { value: 'zzz' },
+    })
+    expect(screen.queryAllByTestId('canvas-list-card')).toHaveLength(0)
+    expect(screen.getByText('No canvases match.')).toBeTruthy()
+  })
+
+  it('createDisabled reaches menu items already open when the busy state flips', async () => {
+    // The menu can be open BEFORE a create starts (pick an entry, create runs,
+    // menu still mounted): the items must go dead with the trigger, or they
+    // remain a live path to a second create.
+    const onOpen = vi.fn()
+    const onCreate = vi.fn()
+    const view = render(<CanvasListView rows={rows()} onOpen={onOpen} onCreate={onCreate} />, {
+      container: document.body,
+    })
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'New canvas' }), {
+      button: 0,
+      ctrlKey: false,
+    })
+    const item = await screen.findByRole('menuitem', { name: 'New canvas' })
+    view.rerender(
+      <CanvasListView rows={rows()} onOpen={onOpen} onCreate={onCreate} createDisabled />,
+    )
+    fireEvent.pointerUp(item)
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it('createDisabled disables both create affordances', () => {
+    const { onCreate } = renderList({ createDisabled: true })
+    const plus = screen.getByRole('button', { name: 'New canvas' })
+    expect(plus.hasAttribute('disabled')).toBe(true)
+    cleanup()
+    const empty = renderList({ rows: [], createDisabled: true })
+    const action = screen.getByRole('button', { name: /create a canvas/i })
+    expect(action.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(action)
+    expect(empty.onCreate).not.toHaveBeenCalled()
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it('opens a canvas from the wrapper div AND from the nested button', () => {
+    const { onOpen } = renderList()
+    const card = screen.getAllByTestId('canvas-list-card')[0]!
+    fireEvent.click(card)
+    expect(onOpen).toHaveBeenCalledWith('alpha')
+    onOpen.mockClear()
+    fireEvent.click(within(card).getByRole('button', { name: /alpha/i }))
+    expect(onOpen).toHaveBeenCalledWith('alpha')
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers both kinds from the + menu, icon-and-label, creating immediately', async () => {
+    const { onCreate } = renderList()
+    const trigger = screen.getByRole('button', { name: 'New canvas' })
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+    const spatial = await screen.findByRole('menuitem', { name: /new canvas/i })
+    const markdown = await screen.findByRole('menuitem', { name: /new markdown note/i })
+    expect(spatial.textContent).toMatch(/new canvas/i)
+    expect(markdown.textContent).toMatch(/new markdown note/i)
+    fireEvent.pointerUp(markdown)
+    expect(onCreate).toHaveBeenCalledWith('markdown')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('capability permutation: renderThumb renders per card; omitting it yields label-only cards', () => {
+    renderList({
+      renderThumb: (row) => <div data-testid={`thumb-${row.slug}`} />,
+    })
+    expect(screen.getByTestId('thumb-notes')).toBeTruthy()
+    expect(screen.getByTestId('thumb-alpha')).toBeTruthy()
+    cleanup()
+    renderList()
+    expect(screen.queryByTestId('thumb-notes')).toBeNull()
+    expect(screen.getAllByTestId('canvas-list-card')).toHaveLength(2)
+  })
+
+  it('empty rows: a text-labelled create action, calling onCreate(spatial)', () => {
+    const { onCreate } = renderList({ rows: [] })
+    const action = screen.getByRole('button', { name: /create a canvas/i })
+    fireEvent.click(action)
+    expect(onCreate).toHaveBeenCalledWith('spatial')
+  })
+
+  it('announces a markdown row as text, not color alone', () => {
+    renderList()
+    const card = screen.getAllByTestId('canvas-list-card')[1]!
+    expect(within(card).getByText(/markdown/i)).toBeTruthy()
+  })
+
+  it('renders the caller-supplied secondary line and a relative timestamp', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-11T00:00:30Z'))
+    try {
+      renderList({
+        rows: [
+          {
+            slug: 'alpha',
+            displayName: 'Alpha',
+            secondary: 'alpha',
+            updatedAt: '2026-08-11T00:00:00Z',
+            kind: 'spatial',
+          },
+        ],
+      })
+      const card = screen.getAllByTestId('canvas-list-card')[0]!
+      expect(within(card).getByTestId('canvas-secondary').textContent).toBe('alpha')
+      expect(within(card).getByText('30s ago')).toBeTruthy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('renders per-card actions whose clicks do not open the canvas', () => {
+    const onAction = vi.fn()
+    const { onOpen } = renderList({
+      renderActions: (row) => (
+        <button
+          type="button"
+          aria-label={`Act on ${row.displayName}`}
+          onClick={(e) => {
+            e.stopPropagation()
+            onAction(row.slug)
+          }}
+        >
+          Act
+        </button>
+      ),
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Act on Notes' }))
+    expect(onAction).toHaveBeenCalledWith('notes')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/canvas-list/CanvasListView.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.tsx
@@ -1,0 +1,193 @@
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
+import { FileBox, FileText, Plus } from 'lucide-react'
+import { type ReactNode, useMemo, useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { filterCanvasesBySearch } from '../workspace-top-bar/canvas-list.js'
+
+export interface CanvasListRow {
+  slug: string
+  displayName: string
+  // The muted second line: the daemon page passes the slug, browser-local
+  // passes the derived display slug — the same visual slot either way.
+  secondary?: string
+  updatedAt: string
+  kind: CanvasKind
+}
+
+// Lifted verbatim from DaemonIndexPage (whose private copy S4 deletes).
+// Clock drift between client and daemon can make (now - t) negative; clamp
+// so the label never reads "-5s ago".
+export function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return ''
+  const diff = Math.max(0, Math.floor((Date.now() - t) / 1000))
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+export interface CanvasListViewProps {
+  rows: readonly CanvasListRow[]
+  onOpen: (slug: string) => void
+  // Immediate create per ADR-0006: no name is collected up front. The kind
+  // menu exists because the daemon create API carries kind since S0.
+  onCreate: (kind: CanvasKind) => void
+  // Capability slot: the daemon page passes CanvasThumb; browser-local omits
+  // it and gets the label-only card. A render prop, NOT a scene render —
+  // this component never imports canvas-render/canvas-viewer.
+  renderThumb?: (row: CanvasListRow) => ReactNode
+  // Per-card actions overlay (daemon: Duplicate; S8 adds Delete). Rendered as
+  // a sibling of the open-button so its own buttons manage stopPropagation.
+  renderActions?: (row: CanvasListRow) => ReactNode
+  // Disables the create affordances while a create is in flight — the caller
+  // owns the busy state because it owns the POST.
+  createDisabled?: boolean
+}
+
+// The shared, capability-gated canvas list both modes render (stack base of
+// the UI-unification initiative; wired by the daemon and /local pages above
+// it). Purely presentational: rows in, callbacks out — no daemon client, no
+// zod, so the browser-local chunk never pays for the daemon's dependencies.
+export function CanvasListView({
+  rows,
+  onOpen,
+  onCreate,
+  renderThumb,
+  renderActions,
+  createDisabled,
+}: CanvasListViewProps) {
+  const [search, setSearch] = useState('')
+
+  // Caller order is the contract — the daemon page sorts pinned-first, the
+  // browser-local page sorts by recency, and a component-side re-sort would
+  // silently discard whichever policy the caller chose.
+  const visible = useMemo(() => {
+    const infos = rows.map((r) => ({ slug: r.slug, updatedAt: r.updatedAt, name: r.displayName }))
+    const names = Object.fromEntries(rows.map((r) => [r.slug, r.displayName]))
+    const filtered = filterCanvasesBySearch(infos, search, names)
+    const bySlug = new Map(rows.map((r) => [r.slug, r]))
+    return filtered.map((c) => bySlug.get(c.slug)).filter((r): r is CanvasListRow => !!r)
+  }, [rows, search])
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-center">
+        <p className="text-sm font-medium">No canvases yet</p>
+        <p className="text-sm text-muted-foreground">Create a canvas and it opens ready to draw.</p>
+        <button
+          type="button"
+          disabled={createDisabled}
+          onClick={() => onCreate('spatial')}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+        >
+          Create a canvas
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <input
+          type="search"
+          aria-label="Search canvases"
+          placeholder="Search canvases…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="New canvas"
+                  disabled={createDisabled}
+                  className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <Plus aria-hidden="true" className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>New canvas</TooltipContent>
+          </Tooltip>
+          {/* A menu is a reading surface: icon AND label (ADR-0006 point 4).
+              Items are disabled alongside the trigger: a menu opened BEFORE a
+              create started stays open while it runs, so the items are a
+              second live path to a double-create the trigger's own disabled
+              attribute cannot cover. */}
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="gap-2"
+              disabled={createDisabled}
+              onSelect={() => onCreate('spatial')}
+            >
+              <FileBox aria-hidden="true" className="size-3.5" />
+              New canvas
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="gap-2"
+              disabled={createDisabled}
+              onSelect={() => onCreate('markdown')}
+            >
+              <FileText aria-hidden="true" className="size-3.5" />
+              New markdown note
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No canvases match.</p>
+      ) : null}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {visible.map((row) => (
+          // biome-ignore lint/a11y/noStaticElementInteractions: enlarges the click target only; the nested <button> below already provides keyboard access to the same action
+          // biome-ignore lint/a11y/useKeyWithClickEvents: enlarges the click target only; the nested <button> below already provides keyboard access to the same action
+          <div
+            key={row.slug}
+            data-testid="canvas-list-card"
+            onClick={() => onOpen(row.slug)}
+            className="group relative rounded-lg border hover:bg-accent"
+          >
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onOpen(row.slug)
+              }}
+              className="flex w-full flex-col gap-2 p-2 text-left"
+            >
+              {renderThumb?.(row)}
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{row.displayName}</div>
+                {row.secondary !== undefined && (
+                  <div
+                    data-testid="canvas-secondary"
+                    className="truncate text-xs text-muted-foreground"
+                  >
+                    {row.secondary}
+                  </div>
+                )}
+                <div className="text-xs text-muted-foreground">
+                  {row.kind === 'markdown' && <span className="mr-1">markdown ·</span>}
+                  {formatRelative(row.updatedAt)}
+                </div>
+              </div>
+            </button>
+            {renderActions?.(row)}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/canvas-list/CanvasListView.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.tsx
@@ -20,7 +20,6 @@ export interface CanvasListRow {
   kind: CanvasKind
 }
 
-// Lifted verbatim from DaemonIndexPage (whose private copy S4 deletes).
 // Clock drift between client and daemon can make (now - t) negative; clamp
 // so the label never reads "-5s ago".
 export function formatRelative(iso: string): string {
@@ -36,8 +35,9 @@ export function formatRelative(iso: string): string {
 export interface CanvasListViewProps {
   rows: readonly CanvasListRow[]
   onOpen: (slug: string) => void
-  // Immediate create per ADR-0006: no name is collected up front. The kind
-  // menu exists because the daemon create API carries kind since S0.
+  // Immediate create per ADR-0006: no name is collected up front. The menu
+  // picks which CanvasKind the caller creates; everything else about the
+  // creation (slug derivation, the POST) is the caller's.
   onCreate: (kind: CanvasKind) => void
   // Capability slot: the daemon page passes CanvasThumb; browser-local omits
   // it and gets the label-only card. A render prop, NOT a scene render —
@@ -51,10 +51,10 @@ export interface CanvasListViewProps {
   createDisabled?: boolean
 }
 
-// The shared, capability-gated canvas list both modes render (stack base of
-// the UI-unification initiative; wired by the daemon and /local pages above
-// it). Purely presentational: rows in, callbacks out — no daemon client, no
-// zod, so the browser-local chunk never pays for the daemon's dependencies.
+// The shared, capability-gated canvas list that both the daemon and the
+// browser-local pages render. Purely presentational: rows in, callbacks
+// out — no daemon client, no zod, so the browser-local chunk never pays
+// for the daemon's dependencies.
 export function CanvasListView({
   rows,
   onOpen,


### PR DESCRIPTION
**Stack base** — slice S3 of the UI-unification initiative. S4 (DaemonIndexPage rewire), S5 (browser-local `/local` list) and S8 (Delete) stack on top of this PR; the stack map shows the layers as they arrive.

The searchable, recency-sorted canvas grid both modes will render, extracted as a purely presentational component:

- **Reuses `canvas-list.ts`'s sort/filter helpers** — not the repo's third copy of that logic (DaemonIndexPage's private `filterRows`/`sortRows` copies get deleted in S4).
- **Create per ADR-0006 + S0's API**: icon-only `+` (aria-label + tooltip) opening a reading-surface menu — icon AND label — with two entries that create a **spatial canvas** or a **markdown note** immediately. No name gate.
- **Capability gating by prop presence**: `renderThumb` is a render prop the daemon page fills with `CanvasThumb` and browser-local omits. Deliberately NOT a scene render — the component imports nothing from canvas-render/canvas-viewer, and no daemon client or zod, so browser-local's chunk never pays for daemon dependencies (the bundle-size gate the plan flagged).
- The card keeps the documented **div-wrapper + nested-button** pattern verbatim: the wrapper enlarges the click target; the real button carries keyboard access. (The plan's panel had one voice asking to "fix" this — reading the code, it is already the accessible shape, with its rationale in the biome-ignores.)
- Markdown rows announce their kind **as text**, not color alone.

**Both capability permutations are tested now**, before S5 exists — the coverage gap the plan's gate insisted on closing at this layer, so a slot regression cannot hide until the second consumer lands.

`userReach: foundation` — wired by the layers directly above in this stack, which is the strongest form of that sentinel: the named follow-up is literally the next PR up.

## Verification

6 component tests (permutations, immediate-create menu, dual click paths, empty state, kind-as-text); lint, typecheck, knip clean. Rebased onto `fac81da` via `gh stack sync` before submit.

## Stack-operations note

`gh stack submit` in a non-interactive terminal auto-generates the PR title from the branch name — not a Conventional Commit, which this repo's CI rejects. Title fixed via `gh pr edit`; a follow-up will fold this recipe into the `stacking-pull-requests` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYyXw7m5ndo2T8UxN18FX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable canvas list view with caller-defined ordering.
  - Added canvas search with empty-result messaging.
  - Added options to create spatial or Markdown canvases.
  - Added optional thumbnails, metadata, relative timestamps, and per-canvas actions.
  - Added empty-state creation controls and support for opening canvases from cards or nested buttons.
- **Bug Fixes**
  - Improved handling of disabled creation controls and action menus to prevent unintended canvas opening.
- **Tests**
  - Added coverage for searching, creation flows, ordering, accessibility text, timestamps, thumbnails, and card actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->