### PR TITLE
fix(web): re-side carried edges per frame during a drag

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -921,11 +921,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         return undefined
       }
       const liveNodes = [...liveNodesFor(canvas, gestureState, dragPreview.box, dragStatic.carried)]
-      // Sides FROZEN at their committed choices for the whole gesture:
-      // per-frame crossing optimization would both blow the frame budget
-      // and let routes flip sides mid-drag. Anchors and lanes still track
-      // the moved geometry; the drop's committed render re-optimizes.
-      const frozenSides = frozenSidesOf(scene)
+      // BYSTANDER sides stay frozen at their committed choices for the whole
+      // gesture: per-frame crossing optimization would both blow the frame
+      // budget and let unrelated routes flip sides mid-drag. Edges attached
+      // to a CARRIED node are exempt — their geometry is the thing changing,
+      // and a side frozen at gesture start points out of the wrong face for
+      // most of the drag, only to jump at drop. Leaving them out of the
+      // override map re-picks their sides per frame via the cheap local
+      // heuristic (the optimization loop stays skipped either way); the
+      // drop's committed render still runs the full optimization.
+      const carried = dragStatic.carried
+      const carriedEdgeIds = new Set(
+        canvas.edges
+          .filter((edge) => carried.has(edge.fromNode) || carried.has(edge.toNode))
+          .map((edge) => edge.id),
+      )
+      const frozenSides = new Map(
+        [...frozenSidesOf(scene)].filter(([id]) => !carriedEdgeIds.has(id)),
+      )
       const nodes = layoutSpatialEdges(
         { ...canvas, nodes: liveNodes },
         {

--- a/apps/web/src/components/spatial-editor/live-drag-side-tracking.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-drag-side-tracking.browser.test.tsx
@@ -1,0 +1,123 @@
+// Live-drag side tracking: edges attached to the CARRIED node re-pick their
+// sides every frame (the local heuristic), so the mid-drag route matches
+// where the drop will land instead of pointing out of the gesture-start
+// side long after the geometry stopped supporting it. Bystander edges stay
+// frozen for route stability; the drop still runs the full optimization.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const polylines = (root: ParentNode) =>
+  [...root.querySelectorAll('polyline')].map((p) => p.getAttribute('points') ?? '')
+
+it('a carried edge re-sides mid-drag to match the drop result', async () => {
+  // T top-left, D below it, edge T -> D. Dragging D far to T's right makes
+  // the right side of T the natural exit; frozen-at-start sides kept the
+  // BOTTOM exit and produced a mid-drag route the drop then jumped away
+  // from.
+  const initial: SpatialCanvas = {
+    nodes: [
+      { id: 't', type: 'text', x: 60, y: 20, width: 160, height: 60, text: 'T' },
+      { id: 'd', type: 'text', x: 80, y: 480, width: 160, height: 90, text: 'D' },
+    ],
+    edges: [{ id: 'e1', fromNode: 't', toNode: 'd' }],
+    'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+  }
+  const latest = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  await new Promise((res) => setTimeout(res, 200))
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 160,
+    clientY: r.top + 525,
+  })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 170, clientY: r.top + 529 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 560, clientY: r.top + 320 })
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="live-edges"]')).toBeTruthy()
+  })
+  const live = container.querySelector('[data-testid="live-edges"]') as HTMLElement
+  const livePts = polylines(live)
+  expect(livePts).toHaveLength(1)
+  // Fresh side choice: the live route leaves T's RIGHT side (x = 220), the
+  // same side the drop will pick — not the stale bottom exit (140,80).
+  expect((livePts[0] as string).startsWith('220,')).toBe(true)
+
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 560, clientY: r.top + 320 })
+  await new Promise((res) => setTimeout(res, 250))
+  const after = polylines(root)
+  expect(after).toHaveLength(1)
+  // Drop parity: committed route leaves the same side the live preview showed.
+  expect((after[0] as string).startsWith('220,')).toBe(true)
+})
+
+it('bystander edges stay frozen while an unrelated node is dragged', async () => {
+  // A -> B vertical edge; unrelated node D dragged around on the right.
+  // The bystander's sides must not flap mid-drag.
+  const initial: SpatialCanvas = {
+    nodes: [
+      { id: 'a', type: 'text', x: 260, y: 0, width: 120, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 260, y: 520, width: 120, height: 60, text: 'B' },
+      { id: 'd', type: 'text', x: 620, y: 240, width: 160, height: 120, text: 'D' },
+    ],
+    edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+    'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState(initial)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  await new Promise((res) => setTimeout(res, 200))
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 700,
+    clientY: r.top + 300,
+  })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 690, clientY: r.top + 304 })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 660, clientY: r.top + 500 })
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="live-edges"]')).toBeTruthy()
+  })
+  const live = container.querySelector('[data-testid="live-edges"]') as HTMLElement
+  const livePts = polylines(live)
+  expect(livePts).toHaveLength(1)
+  // Still the committed top-to-bottom exit: starts at A's bottom (320,60).
+  expect((livePts[0] as string).startsWith('320,60')).toBe(true)
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 660, clientY: r.top + 500 })
+})

--- a/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
@@ -241,12 +241,13 @@ it('a multi-selection ghost carries every member, not only the grabbed node', as
   expect(container.querySelector('[data-testid="member-outlines"]')).toBeNull()
 })
 
-it('freezes edge sides at their committed choices for the whole drag', async () => {
+it('re-sides a carried edge mid-drag while freezing bystanders', async () => {
   // Committed: yellow sits below-right of red, so the optimizer settles
   // orange onto red's RIGHT side. The drag hauls yellow far to red's LEFT
-  // — a fresh optimization of the moved canvas would flip the arrival to
-  // red's left side, so the live layer still routing to the RIGHT border
-  // is only explainable by the frozen committed sides.
+  // — the carried edge re-picks its sides per frame, so the live arrival
+  // flips to red's LEFT border mid-drag, matching where the drop lands
+  // instead of pointing out of the stale right side for the whole drag.
+  // (Bystander freezing is pinned in live-drag-side-tracking.)
   const crossing: SpatialCanvas = {
     nodes: [
       { id: 'red', type: 'text', x: 300, y: 100, width: 200, height: 100, text: 'Red' },
@@ -268,10 +269,10 @@ it('freezes edge sides at their committed choices for the whole drag', async () 
 
   const live = container.querySelector('[data-testid="live-edges"]')
   expect(live).not.toBeNull()
-  // The orange arrival still terminates ON red's right border (x = 500),
-  // exactly where the committed render put it.
+  // The orange arrival now terminates ON red's LEFT border (x = 300): the
+  // carried edge's fresh side choice, not the stale committed right side.
   const points = [...(live?.querySelectorAll('polyline') ?? [])].flatMap((p) =>
     (p.getAttribute('points') ?? '').split(' ').map((pair) => pair.split(',').map(Number)),
   )
-  expect(points.some(([x, y]) => x === 500 && y! >= 100 && y! <= 200)).toBe(true)
+  expect(points.some(([x, y]) => x === 300 && y! >= 100 && y! <= 200)).toBe(true)
 })


### PR DESCRIPTION
## What

Fixes the mobile report that a drag's connected edge overlaps the canvas mid-gesture and then visibly changes shape at drop.

**Root cause**: the live-drag overlay froze **every** edge's sides at their gesture-start values (route stability + skipping the per-frame optimization loop). For an edge attached to the **carried** node, that meant the route kept leaving a face the geometry stopped supporting — a long haul drew the edge slicing across the canvas out of the stale face — and the drop's re-optimization then snapped it to a different side, the jump the report describes.

**Fix**: the freeze now applies to **bystander edges only**. Edges touching a carried node are left out of the `edgeSideOverrides` map, which makes `assignEdgeAnchors` re-pick their sides per frame via the cheap local heuristic — the optimization loop stays skipped either way (any non-`undefined` override map bypasses it), so per-frame cost is unchanged. The mid-drag route now leaves the same face the drop will pick; the residual drop delta is lane-level, not a side flip.

Verified along the way (repro logs in the branch history): bystander obstacle avoidance already matched the drop exactly — dragging a node onto another edge's corridor re-routes that edge around the live box per frame — so no change there.

## Tests

- New `live-drag-side-tracking.browser.test.tsx`: the carried edge leaves the target's near face mid-drag **and** the drop lands on that same face (parity); bystander edges stay frozen while an unrelated node is dragged. Mutation-checked — restoring the blanket freeze turns the carried-edge test red.
- `live-drag.browser.test.tsx`'s blanket-freeze test now pins the new contract (arrival flips to the near face mid-drag) instead of the old one.
- Full `web-browser` (484), apps/web jsdom (1769), lint/knip clean.

## Visual repro

Mid-drag, before — the edge still leaves Target's **bottom** (gesture-start side), jogging across the canvas:

![side-mid-drag-before-fix.png](https://github.com/user-attachments/assets/c5f9a15b-4a90-4b7b-b3f0-e08a9f7c3d62)

Mid-drag, after — the edge leaves Target's **right** face, exactly where the drop lands:

![side-mid-drag-after-fix.png](https://github.com/user-attachments/assets/284bcba9-0b2e-4222-b7a6-b4c2ab863810)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
