### PR TITLE
ci: re-validate the PR title on edit without re-running the full suite

### DIFF
--- a/.claude/skills/stacking-pull-requests/SKILL.md
+++ b/.claude/skills/stacking-pull-requests/SKILL.md
@@ -83,6 +83,13 @@ drafts with generated titles — **do not use `--auto` here**, because every tit
 future squash-commit message and must be a Conventional Commit (see the PR Title Rule
 in AGENTS.md). `gh stack submit` re-run later updates existing PRs and their bases.
 
+In a non-interactive session (no editor), `gh stack submit` behaves like `--auto`:
+it creates the PR with a generated, non-Conventional title (the branch name with
+hyphens as spaces). Fix it immediately with `gh pr edit <n> --title "feat(...): ..."`
+— the `pr-title` check listens for the `edited` event, so the corrected title
+re-validates on its own; nothing else re-runs. Do NOT `gh run rerun` a failed title
+check: reruns re-read the ORIGINAL event payload and can never see the new title.
+
 ## Keeping the stack current
 
 When `main` moves:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Validate PR title
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: pnpm check:pr-title -- "$PR_TITLE"
+      # PR-title validation lives in pr-title.yml: it must re-run when the
+      # title is EDITED, and adding `edited` here would re-run this whole
+      # workflow (build + every test suite) on every PR body edit instead.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+# PR-title validation as its own check, separate from ci.yml, because it must
+# re-run on `edited`: a title fixed after a rejection would otherwise stay red
+# until some unrelated push — `gh run rerun` re-reads the ORIGINAL event
+# payload, so it can never see the corrected title. ci.yml deliberately does
+# NOT listen to `edited` (a PR body edit must not re-run the full suite), so
+# the two workflows split on exactly that event.
+#
+# tools/check-pr-title.mjs is dependency-free, so this job needs no pnpm
+# install — checkout + node is the whole cost of an edited-event re-run.
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node tools/check-pr-title.mjs "$PR_TITLE"


### PR DESCRIPTION
Two real cycles were burned on the same mechanism: `gh stack submit` (non-interactive) creates a PR with a generated non-Conventional title, the `check` job rejects it, and fixing the title with `gh pr edit` never clears the failure — `on: pull_request` without `types` does not listen for `edited`, and `gh run rerun` re-reads the ORIGINAL event payload, so only an unrelated push could heal it.

- `Validate PR title` moves out of ci.yml's `check` job into its own `pr-title.yml` on `types: [opened, edited, synchronize, reopened]` — a corrected title re-validates by itself.
- ci.yml keeps the default event set on purpose: adding `edited` there would re-run the build and every test suite on each PR body edit. The dependency-free `tools/check-pr-title.mjs` means the new job is checkout + node, no install.
- `stacking-pull-requests` skill: documents the non-interactive-submit title recipe (edit immediately; never `gh run rerun` a title failure).

**Follow-up after merge (repo settings, not in this diff): add `pr-title` to the required status checks beside `verify`** — with the step out of `check`, a bad title no longer blocks the `verify` chain. Wait until in-flight PRs rebase past this commit, or they will block on a check that never reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw