### PR TITLE
test(web): pin the favicon's return-to-default on canvas page unmount

### DIFF
--- a/apps/web/src/hooks/useFavicon.test.ts
+++ b/apps/web/src/hooks/useFavicon.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { STATIC_FAVICON_HREF } from '../lib/favicon.js'
+import { useFavicon } from './useFavicon.js'
+
+// The dynamic favicon exists only while a canvas page is mounted. Every
+// other surface (gallery, /pair, error pages) must see the static icon —
+// which is exactly the unmount cleanup's job, pinned here.
+describe('useFavicon lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    for (const l of document.head.querySelectorAll('link[rel="icon"]')) l.remove()
+  })
+
+  it('restores the static favicon on unmount (navigation away from the canvas)', () => {
+    const { unmount } = renderHook(() => useFavicon({ style: 'dot', status: 'saved', rects: [] }))
+    vi.advanceTimersByTime(500)
+    unmount()
+    const links = document.head.querySelectorAll('link[rel="icon"]')
+    expect(links).toHaveLength(1)
+    expect(links[0]?.getAttribute('href')).toBe(STATIC_FAVICON_HREF)
+  })
+
+  it('does not install a broken icon where canvas 2D is unavailable (jsdom)', () => {
+    renderHook(() => useFavicon({ style: 'minimap', status: 'saved', rects: [] }))
+    vi.advanceTimersByTime(500)
+    // renderFavicon returns null here, so the hook must leave the head alone.
+    expect(document.head.querySelector('link[data-wb-favicon]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #602. The dynamic favicon is owned by the canvas pages' `useFavicon` hook; navigating to any other surface (daemon gallery, /pair, error pages) unmounts it and the cleanup restores the static `/favicon.svg`. That contract — and the jsdom/no-canvas no-op (never install a broken icon) — had no regression guard. Test-only change; both tests pass against the shipped implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc