### PR TITLE
fix(render): score self-retrace and realized bends; offer U-pair sides

### DIFF
--- a/packages/canvas-render/src/layout/edge-side-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-side-quality.test.ts
@@ -1,0 +1,125 @@
+// Side-choice quality terms beyond crossings: a route must never RETRACE
+// over its own ink (the doubled-line arrival a facing-away side produces
+// on overlapping nodes), and among equal-crossing configurations the one
+// with fewer REALIZED bends wins — the abstract pair ranking (L before Z)
+// can lie once obstacles force the L into a staircase. Crossing-free,
+// overlap-free canvases are still never reshuffled: the optimizer's
+// short-circuit ignores the bend term on purpose.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, width: number, height: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width,
+  height,
+  text: id,
+})
+
+function routed(nodes: SpatialNode[], edges: CanvasEdge[], id: string) {
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const edge = edges.find((e) => e.id === id) as CanvasEdge
+  return {
+    sides: anchors.get(id),
+    path: routeEdge(nodes, edge, 'orthogonal', anchors.get(id)).path,
+  }
+}
+
+/** Collinear overlap of a path with itself, adjacent retraces included. */
+function selfOverlap(path: readonly { x: number; y: number }[]): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    for (let j = i + 1; j < path.length; j++) {
+      const a1 = path[i - 1] as { x: number; y: number }
+      const a2 = path[i] as { x: number; y: number }
+      const b1 = path[j - 1] as { x: number; y: number }
+      const b2 = path[j] as { x: number; y: number }
+      if (a1.x === a2.x && b1.x === b2.x && a1.x === b1.x) {
+        const lo = Math.max(Math.min(a1.y, a2.y), Math.min(b1.y, b2.y))
+        const hi = Math.min(Math.max(a1.y, a2.y), Math.max(b1.y, b2.y))
+        if (hi > lo) total += hi - lo
+      } else if (a1.y === a2.y && b1.y === b2.y && a1.y === b1.y) {
+        const lo = Math.max(Math.min(a1.x, a2.x), Math.min(b1.x, b2.x))
+        const hi = Math.min(Math.max(a1.x, a2.x), Math.max(b1.x, b2.x))
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total
+}
+
+function bends(path: readonly { x: number; y: number }[]): number {
+  const dirs: string[] = []
+  for (let i = 1; i < path.length; i++) {
+    const dx = Math.sign((path[i] as { x: number }).x - (path[i - 1] as { x: number }).x)
+    const dy = Math.sign((path[i] as { y: number }).y - (path[i - 1] as { y: number }).y)
+    if (dx === 0 && dy === 0) continue
+    const dir = `${dx},${dy}`
+    if (dirs[dirs.length - 1] !== dir) dirs.push(dir)
+  }
+  return Math.max(0, dirs.length - 1)
+}
+
+describe('self-overlap (retrace) cost', () => {
+  it('an edge between overlapping nodes never retraces over its own line', () => {
+    // m2 overlaps m1's lower half. A facing-away arrival (top -> bottom)
+    // overshoots through the body and doubles back by the stub length —
+    // the visible twin-line arrival. A retrace-free pair must win instead.
+    const nodes = [
+      box('m1', 200, 200, 200, 160),
+      box('m2', 240, 300, 200, 300),
+      // A crossing pair elsewhere keeps the optimizer engaged (a fully
+      // clean canvas short-circuits before any trial, by design).
+      box('x1', 700, 100, 100, 60),
+      box('x2', 900, 300, 100, 60),
+      box('x3', 900, 100, 100, 60),
+      box('x4', 700, 300, 100, 60),
+    ]
+    const edges: CanvasEdge[] = [
+      { id: 'hair', fromNode: 'm2', toNode: 'm1' },
+      { id: 'c1', fromNode: 'x1', toNode: 'x2' },
+      { id: 'c2', fromNode: 'x3', toNode: 'x4' },
+    ]
+    const { path } = routed(nodes, edges, 'hair')
+    expect(selfOverlap(path)).toBe(0)
+  })
+})
+
+describe('realized-bend tie-break', () => {
+  it('equal-crossing side pairs prefer the route with fewer real bends', () => {
+    // The (right,top) L is forced into a 3-bend staircase by the wall;
+    // the (top,top) hook over the top is 2 bends. Both cross the vertical
+    // edge exactly once, so bends decide.
+    const nodes = [
+      box('src', 0, 400, 200, 100),
+      box('dst', 700, 700, 200, 100),
+      box('wall', 320, 380, 160, 200),
+      box('up', 550, 0, 100, 60),
+      box('down', 550, 900, 100, 60),
+    ]
+    const edges: CanvasEdge[] = [
+      { id: 'main', fromNode: 'src', toNode: 'dst' },
+      { id: 'vert', fromNode: 'up', toNode: 'down' },
+    ]
+    const { path } = routed(nodes, edges, 'main')
+    expect(bends(path)).toBeLessThanOrEqual(2)
+  })
+
+  it('a crossing-free canvas is never reshuffled for bends alone', () => {
+    // Same shape WITHOUT the crossing pair: the optimizer short-circuits
+    // on the zero [overlap, illegible, crossings] prefix, so the staircase
+    // stays — churn on healthy canvases is worse than a extra bend.
+    const nodes = [
+      box('src', 0, 400, 200, 100),
+      box('dst', 700, 700, 200, 100),
+      box('wall', 320, 380, 160, 200),
+    ]
+    const edges: CanvasEdge[] = [{ id: 'main', fromNode: 'src', toNode: 'dst' }]
+    const { sides } = routed(nodes, edges, 'main')
+    expect(sides?.fromSide).toBe('right')
+    expect(sides?.toSide).toBe('top')
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -466,23 +466,27 @@ function computeAnchorsFor(
  * platforms. */
 const COST_QUANTUM = 4
 
-type ConfigCost = readonly [overlap: number, illegible: number, crossings: number]
+type ConfigCost = readonly [overlap: number, illegible: number, crossings: number, bends: number]
 
 function lessCost(a: ConfigCost, b: ConfigCost): boolean {
   if (a[0] !== b[0]) return a[0] < b[0]
   if (a[1] !== b[1]) return a[1] < b[1]
-  return a[2] < b[2]
+  if (a[2] !== b[2]) return a[2] < b[2]
+  return a[3] < b[3]
 }
 
 /**
  * Global legibility cost of a routed configuration, as a lexicographic
  * integer tuple: total collinear axis-aligned overlap length (a parallel
  * overlap has no crossing point, so a line jump cannot express it —
- * heaviest), crossings too close to a segment end to render their jump
- * arc, then total crossings. Bends and length are deliberately NOT part
- * of the cost: they are governed by the per-edge pair ranking, and letting
- * them drive re-siding would let the optimizer reshuffle crossing-free
- * canvases that nothing is wrong with.
+ * heaviest; an edge RETRACING its own ink counts here too, via
+ * `selfScore`), crossings too close to a segment end to render their jump
+ * arc, total crossings, then total REALIZED bends. Bends sit last and the
+ * optimizer's short-circuit ignores them: they only break ties between
+ * configurations that already tie on every visibility problem — the
+ * abstract pair ranking (L before Z) can lie once obstacles force the L
+ * into a staircase, and this term is what corrects it. Length stays out
+ * of the cost entirely, governed by the per-edge pair ranking.
  */
 function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
   const q = (n: number) => Math.round(n * COST_QUANTUM)
@@ -532,11 +536,40 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
       }
     }
   }
-  return [overlap, illegible, crossings]
+  return [overlap, illegible, crossings, 0]
+}
+
+/**
+ * Per-edge quality of ONE routed path: collinear overlap with ITSELF
+ * (adjacent retraces included — the doubled-line arrival a facing-away
+ * side produces when the connector overshoots the entry stub through the
+ * node body) in the heaviest slot, and realized bend count in the last.
+ */
+function selfScore(path: readonly Point[]): ConfigCost {
+  const q = (n: number) => Math.round(n * COST_QUANTUM)
+  let overlap = 0
+  for (let i = 1; i < path.length; i++) {
+    for (let j = i + 1; j < path.length; j++) {
+      const a1 = path[i - 1] as Point
+      const a2 = path[i] as Point
+      const b1 = path[j - 1] as Point
+      const b2 = path[j] as Point
+      if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
+        const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
+        const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
+        if (hi > lo) overlap += hi - lo
+      } else if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
+        const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
+        const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
+        if (hi > lo) overlap += hi - lo
+      }
+    }
+  }
+  return [overlap, 0, 0, bendCount(path)]
 }
 
 function addCost(a: ConfigCost, b: ConfigCost, sign: 1 | -1): ConfigCost {
-  return [a[0] + sign * b[0], a[1] + sign * b[1], a[2] + sign * b[2]]
+  return [a[0] + sign * b[0], a[1] + sign * b[1], a[2] + sign * b[2], a[3] + sign * b[3]]
 }
 
 /**
@@ -589,7 +622,9 @@ function optimizeSideChoices(
   )
   const pairKey = (i: number, j: number) => i * edges.length + j
   const matrix = new Map<number, ConfigCost>()
-  let currentCost: ConfigCost = [0, 0, 0]
+  const selfCosts: ConfigCost[] = paths.map((path) => selfScore(path))
+  let currentCost: ConfigCost = [0, 0, 0, 0]
+  for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
   for (let i = 0; i < edges.length; i++) {
     for (let j = i + 1; j < edges.length; j++) {
       const score = pairScore(paths[i]!, paths[j]!)
@@ -597,6 +632,9 @@ function optimizeSideChoices(
       currentCost = addCost(currentCost, score, 1)
     }
   }
+  // The bend term (index 3) is deliberately ABSENT from the short-circuit:
+  // a canvas with no overlap and no crossings is healthy, and reshuffling
+  // it purely to shave bends is churn, not repair.
   if (currentCost[0] === 0 && currentCost[1] === 0 && currentCost[2] === 0) return current
 
   const evaluateTrial = (
@@ -607,6 +645,7 @@ function optimizeSideChoices(
     paths: (readonly Point[])[]
     touched: number[]
     updates: Map<number, ConfigCost>
+    selfUpdates: Map<number, ConfigCost>
   } => {
     const trialAnchors = computeAnchorsFor(nodes, edges, trialSides)
     const touched: number[] = []
@@ -620,6 +659,13 @@ function optimizeSideChoices(
     const touchedSet = new Set(touched)
     let cost = currentCost
     const updates = new Map<number, ConfigCost>()
+    const selfUpdates = new Map<number, ConfigCost>()
+    for (const i of touched) {
+      const next = selfScore(trialPaths[i]!)
+      cost = addCost(cost, selfCosts[i] ?? [0, 0, 0, 0], -1)
+      cost = addCost(cost, next, 1)
+      selfUpdates.set(i, next)
+    }
     for (const i of touched) {
       for (let j = 0; j < edges.length; j++) {
         if (j === i) continue
@@ -630,12 +676,12 @@ function optimizeSideChoices(
         // updates map; a pair with an untouched edge reuses its cached path.
         if (touchedSet.has(j) && j < i) continue
         const next = pairScore(trialPaths[lo]!, trialPaths[hi]!)
-        cost = addCost(cost, matrix.get(key) ?? [0, 0, 0], -1)
+        cost = addCost(cost, matrix.get(key) ?? [0, 0, 0, 0], -1)
         cost = addCost(cost, next, 1)
         updates.set(key, next)
       }
     }
-    return { cost, anchors: trialAnchors, paths: trialPaths, touched, updates }
+    return { cost, anchors: trialAnchors, paths: trialPaths, touched, updates, selfUpdates }
   }
 
   const candidatesFor = (edge: CanvasEdge): SidePair[] => {
@@ -655,8 +701,18 @@ function optimizeSideChoices(
       toRect,
       () => 0,
     )
+    // U-pairs (both ends on the SAME compass side) are outside the ranked
+    // vocabulary — the initial heuristic never wants them — but they are
+    // exactly what hooks OVER everything when every ranked pair crosses,
+    // overlaps, or retraces, and what a pair of overlapping nodes needs to
+    // arrive without doubling back. Offered last: the optimizer only
+    // adopts one on a strict cost decrease.
+    const uPairs = (['top', 'right', 'bottom', 'left'] as const).map((side) => ({
+      fromSide: side as Side,
+      toSide: side as Side,
+    }))
     const seen = new Set<string>()
-    return pairs
+    return [...pairs, ...uPairs]
       .map((pair) => ({
         fromSide: edge.fromSide ?? pair.fromSide,
         toSide: edge.toSide ?? pair.toSide,
@@ -685,6 +741,7 @@ function optimizeSideChoices(
           anchors = evaluated.anchors
           paths = evaluated.paths
           for (const [key, score] of evaluated.updates) matrix.set(key, score)
+          for (const [i, score] of evaluated.selfUpdates) selfCosts[i] = score
           improved = true
           break
         }


### PR DESCRIPTION
## What

Two mobile-reported route-quality defects, fixed at their shared root — the side optimizer's cost saw only problems BETWEEN edges, and its candidate list only knew the ranked vocabulary (facing / L / Z):

1. **Twin-line arrival on overlapping nodes** (the edge "overlapping its own line"): a facing-away arrival side makes the connector overshoot the entry stub through the node body and double back — pure retrace, previously costing nothing. A path's collinear overlap with **itself** (adjacent retraces included) now counts in the heaviest cost slot, the same class as edge-edge overlap.
2. **Staircase kept over a cleaner hook** (the red→blue preference): the abstract pair ranking (L before Z) lies once an obstacle forces the L into a staircase. **Realized bend count** joins as the *last* cost term, so equal-crossing configurations settle on the route with fewer actual corners. The optimizer's short-circuit still ignores bends — a canvas with zero overlap and zero crossings is healthy and is never reshuffled just to shave a corner (pinned by test).
3. **U-pairs** (both ends on the same compass side — the hook *over* everything, e.g. top→top) join the optimizer's candidates, offered last and adopted only on a strict cost decrease. They were structurally unreachable before, yet they are exactly what overlapping nodes need to arrive without retracing, and what the reporter asked for on the red→blue edge.

Per the owner's framing: retrace is now a scored demerit rather than a hard reject — when every candidate retraces (dense overlaps), the least-bad one still renders (the router stays total), but any retrace-free candidate beats any retracing one on the heaviest term.

## Tests

- `edge-side-quality.test.ts`: overlapping-pair arrival has **zero self-retrace**; equal-crossing configurations pick ≤2 realized bends; crossing-free canvases are never reshuffled for bends alone (the no-churn guarantee).
- Mutation-checked ×3: removing the self cost, the bend term, or the U-pair candidates each turns its pinned test red.
- Full `canvas-render-node` (375+), canvas-viewer (111), apps/web jsdom (1785) and the edge-rendering browser suites green — no existing pinned route changed.

## Visual repro

Before — the reported twin-line arrival: the edge overshoots into the Green/Plain overlap and doubles back (hairpin notch):

![hairpin-before.png](https://github.com/user-attachments/assets/1c2f50b4-4010-46e7-9441-fed818dd8d47)

After — the same edge hooks over the top and arrives once:

![hairpin-after.png](https://github.com/user-attachments/assets/a7444060-3655-4048-8413-d94774f4a903)

Note: the reporter's exact canvas could not be exported from mobile (UI export is under Canvas actions ✎, not the new row kebab — flagged separately), so the repro is a reconstructed minimal scene; the reported red→blue side preference should be re-checked on the real canvas after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
