### PR TITLE
fix(web): hide the splash's dash-revealed elements until they draw

### DIFF
--- a/apps/web/index-html.test.ts
+++ b/apps/web/index-html.test.ts
@@ -36,6 +36,14 @@ describe('public/boot-splash.svg', () => {
     expect(svg).toMatch(/animation:[^;]*wb-breathe[^;]*infinite/)
   })
 
+  // At full dashoffset some renderers still paint a seam dot / rounded cap
+  // at the dash boundary — stray specks over the opening squiggle on real
+  // devices. Dash-revealed elements must be fully hidden until they draw.
+  it('hides dash-revealed elements until their draw begins', () => {
+    expect(svg).toMatch(/\.node,\s*\.edge,\s*\.tidy-edge\s*\{[^}]*opacity: 0/)
+    expect(svg).toMatch(/@keyframes wb-drawn\s*\{[^@]*from[^@]*opacity: 1/)
+  })
+
   it('neutralizes all animation under prefers-reduced-motion', () => {
     const idx = svg.indexOf('prefers-reduced-motion: reduce')
     expect(idx).toBeGreaterThan(-1)

--- a/apps/web/public/boot-splash.svg
+++ b/apps/web/public/boot-splash.svg
@@ -66,29 +66,33 @@
         transform: translate(5px, 4px) rotate(0deg);
       }
     }
-    .node {
+    /* Dash-revealed elements stay INVISIBLE until their draw begins: at
+       full dashoffset some renderers still paint a seam dot / rounded cap
+       at the dash boundary, which reads as stray specks over the opening
+       squiggle. wb-drawn's `from` flips opacity on exactly at draw start. */
+    .node,
+    .edge,
+    .tidy-edge {
       stroke-dasharray: 100;
       stroke-dashoffset: 100;
+      opacity: 0;
     }
     .n1 { animation: wb-drawn 0.55s ease-out 2.7s forwards; }
     .n2 { animation: wb-drawn 0.55s ease-out 3.5s forwards; }
     .n3 { animation: wb-drawn 0.55s ease-out 4.3s forwards; }
-    .edge {
-      stroke-dasharray: 100;
-      stroke-dashoffset: 100;
-    }
     .e1 { animation: wb-drawn 0.45s ease-in-out 5.1s forwards, wb-fade 0.3s ease-out 7.2s forwards; }
     .e2 { animation: wb-drawn 0.45s ease-in-out 5.7s forwards, wb-fade 0.3s ease-out 7.2s forwards; }
     @keyframes wb-drawn {
+      from {
+        stroke-dashoffset: 100;
+        opacity: 1;
+      }
       to {
         stroke-dashoffset: 0;
+        opacity: 1;
       }
     }
     /* Phase 2 (6.7-8.6s): the spark tidies - nodes align, edges straighten. */
-    .tidy-edge {
-      stroke-dasharray: 100;
-      stroke-dashoffset: 100;
-    }
     .t1 { animation: wb-drawn 0.35s ease-out 7.6s forwards, wb-out 0.5s ease-in 9.2s forwards; }
     .t2 { animation: wb-drawn 0.35s ease-out 7.75s forwards, wb-out 0.5s ease-in 9.2s forwards; }
     .t3 { animation: wb-drawn 0.35s ease-out 7.9s forwards, wb-out 0.5s ease-in 9.2s forwards; }


### PR DESCRIPTION
## Summary

On real devices (reported from Android Chrome, dark mode) the boot splash showed stray specks — fragments of the not-yet-drawn nodes/edges — during the opening squiggle. The elements wait at full `stroke-dashoffset`, but some renderers still paint a seam dot / rounded cap at the dash boundary even when the dash pattern should hide everything.

Fix: dash-revealed elements (`.node`, `.edge`, `.tidy-edge`) start at `opacity: 0` and flip visible exactly when their draw animation begins (`wb-drawn`'s `from` frame carries `opacity: 1`). Pinned by a new contract test on the SVG.

## Visual repro

After the fix, dark ground at 2x scale — mid-draw (t≈0.6s) and drawn (t≈1.3s), no specks:

![speck-fixed-t0.6.png](https://github.com/user-attachments/assets/fcfb2508-0768-4dec-a653-afef66863bd6)
![speck-fixed-t1.3.png](https://github.com/user-attachments/assets/f19a493d-49ea-4c5c-9a34-54ac14fefe63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc