### PR TITLE
docs: name the canvas domain model and the daemon's two-store split (ADR-0007)

### DIFF
--- a/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
+++ b/docs/contributing/adr/0004-unified-capability-gated-canvas-page.md
@@ -104,3 +104,21 @@ consolidation is a separate, currently out-of-scope effort.
 **Runtime mode switching within a single session.** Rejected: no product
 requirement calls for switching without a reload, and treating mode as
 load-time-fixed simplifies event-listener lifecycle handling.
+
+## Addendum (2026-08-12): what shipped differs from three premises above
+
+Recorded as-built rather than rewriting the decision:
+
+- **Route shape.** Point 4's single shared `/canvas/:id/*` editor URL was
+  not what shipped. The modes have distinct routes — `/canvas/:workspaceId/:slug`
+  (daemon) and `/local/:canvasId` (browser-local) — matching their distinct
+  identities (see [ADR-0007](0007-canvas-identity-and-store-split.md)).
+  `/` landing on a canvas list is now true in both modes via the shared
+  `CanvasListView`.
+- **"Unimplemented follow-up slices."** The router, capability-gated
+  chrome, and the shared list have since landed; that consequence bullet
+  is historical.
+- **Open UX details.** Two of the listed open product decisions are now
+  decided: workspaces surface in browser-local as a fixed single
+  workspace modeled as present (ADR-0007), and Delete's placement is a
+  per-card action on the shared list with a confirmation dialog.

--- a/docs/contributing/adr/0007-canvas-identity-and-store-split.md
+++ b/docs/contributing/adr/0007-canvas-identity-and-store-split.md
@@ -4,8 +4,10 @@
 
 ## Context
 
-The daemon holds "canvases" in two representations that share one SQLite
-file and nothing else:
+The daemon holds "canvases" in two representations that are co-located in
+one SQLite file but share no logical state — no common tables, no common
+byte store, and (as detailed below) no shared identity beyond the raw
+`workspaceId` string:
 
 - **Workspace/slug store.** Identity is `(workspaceId, slug)` (unique
   constraint `canvases_ws_slug_unq`); rows carry `displayName`, `kind`,

--- a/docs/contributing/adr/0007-canvas-identity-and-store-split.md
+++ b/docs/contributing/adr/0007-canvas-identity-and-store-split.md
@@ -1,0 +1,116 @@
+# ADR-0007: Canvas identity and the daemon's two-store split
+
+**Status:** Accepted
+
+## Context
+
+The daemon holds "canvases" in two representations that share one SQLite
+file and nothing else:
+
+- **Workspace/slug store.** Identity is `(workspaceId, slug)` (unique
+  constraint `canvases_ws_slug_unq`); rows carry `displayName`, `kind`,
+  pins, and branch/version linkage; canvas bytes live as Loro snapshots
+  on the filesystem under `blobs/<workspaceId>/canvas/`. Written only by
+  the daemon's HTTP API (`/api/workspaces/*`, `/api/canvas/*`), read only
+  by `apps/web`. The internal row PK is a nanoid the wire never sees.
+- **OpenCanvas doc store.** Identity is a ULID `canvasId` plus a
+  `segment` unique among siblings; the human-readable `alias` path is
+  derived from segments at read time and never persisted. Canvases and
+  the per-workspace tree are Loro docs chunked into SQLite
+  (`canvasDocSnapshots*`). Written by every registered MCP tool
+  (`wb_canvas_*`, `canvas_import_okf`, node/edge/facet/body patches) and
+  by the identical `/api/v1` routes; read by the gallery's tree view.
+
+There is **no bridge by construction**: neither store's write path
+touches the other's tables, `server-core` imports nothing from the
+legacy store, and no reconcile job exists (`reindexAllWorkspaces` has no
+production caller). Empirically: `wb_canvas_create` with
+`createWorkspace: true` yields a canvas invisible to
+`GET /api/workspaces`, and a canvas created from the web UI is invisible
+to `wb_canvas_list`. The only shared token is the raw `workspaceId`
+string, which is authoritative in neither.
+
+Meanwhile the third runtime, browser-local, identifies canvases by a
+random UUID with no slug and no workspace, and the UI-unification work
+(shared canvas list, ADR-0006 creation flow) needed a decided identity
+story to build on.
+
+## Decision
+
+1. **`(workspaceId, slug)` is the canonical user-facing canvas identity.**
+   URLs, sync, versions, branches, and the shared canvas list all address
+   canvases by slug. A ULID/opaque-id-canonical model was considered and
+   explicitly not chosen (product decision, 2026-08-11): slugs are what
+   users see, share, and reason about, and the daemon's storage already
+   enforces their uniqueness per workspace.
+2. **Slugs are assigned at creation and are immutable for now — rename is
+   deliberately OPEN, not decided.** Creation collects no name up front
+   (ADR-0006), so slugs derive automatically (`untitled`, `untitled-2`,
+   …) and naming happens afterwards via display names. Making slugs
+   renamable is attractive but changes what sync, branches, versions, and
+   bookmarks key on; it is deferred pending the slug-as-storage-key spike
+   and must not be treated as settled by this ADR.
+3. **Browser-local models "exactly one workspace that is always present",
+   not the absence of workspaces.** Its canvases keep UUID identity with
+   a *derived, cosmetic* display slug that matches the daemon slug
+   charset, so a later promotion to real slugs needs no re-derivation.
+4. **The two daemon stores are recorded as a known split with a named
+   convergence direction: converge on the user-facing world.** The
+   workspace/slug store is what users see and what the canonical identity
+   (point 1) lives in; the OpenCanvas doc store's agent surface must
+   eventually read and write canvases users can see, rather than a
+   parallel population. The concrete mechanism (adapter, migration, or
+   replacement of the legacy store's internals under the same identity)
+   is not chosen here — but any step that widens the split (new features
+   landing in only one store's world without a plan to meet the other) now
+   requires justification against this ADR.
+5. **Prose must stop calling two different things "canvasId".** The
+   legacy store's internal nanoid row PK is a storage detail; the ULID in
+   the OpenCanvas store is the `canvasId`. Docs and code comments should
+   say "canvas row id" for the former.
+
+## Consequences
+
+- The shared `CanvasListView` and both list pages (daemon gallery,
+  browser-local) are built on slug-shaped identity, consistent with
+  point 1 and 3.
+- The gallery's grid and its tree view render **different populations**
+  today: the workspace picker lists workspace/slug-store workspaces, and
+  feeding one into the tree view silently renders an empty tree when that
+  workspace exists only in the legacy store (the tree loader falls back
+  to an empty tree instead of failing). A v1-only workspace never appears
+  in the picker at all. This is the split made visible, and it is the
+  first UX debt the convergence direction (point 4) is expected to pay
+  down.
+- The `workspaceIndex*` tables are write-only in production (their query
+  surface has no caller); they must not be described or relied upon as a
+  lookup path until something consumes them.
+- The slug-rename question stays open with a recorded owner: the
+  slug-as-storage-key spike informs it. Anything that would make rename
+  harder (new slug-keyed persistence) should be flagged in review.
+- Agent/human collaboration on one canvas currently requires both sides
+  to use the same surface; documentation states this plainly
+  ([domain model](../../explanation/domain-model.md)) rather than
+  implying the MCP tools operate on the gallery's canvases.
+
+## Alternatives considered
+
+**Opaque id (ULID) as the canonical identity with slugs as mutable
+labels.** Rejected by product decision: it makes rename trivial but
+demotes the identifier users actually see and share; every user-facing
+surface would need a second lookup step, and the existing daemon
+storage, sync, and URL scheme are already slug-keyed.
+
+**Declare the OpenCanvas doc store the canonical world and migrate the
+web app onto `/api/v1`.** Not chosen now: the user-facing feature set
+(names, pins, kinds, branches, versions, thumbnails, sync) lives in the
+workspace/slug store, and the v1 world lacks equivalents; converging by
+moving the smaller, newer surface toward the identity users already hold
+is the cheaper direction. This remains the plausible long-term shape
+*under the same slug identity* — the ADR fixes the identity, not the
+final storage engine.
+
+**Build an immediate two-way sync bridge between the stores.** Rejected:
+a background reconciler between two live CRDT-backed stores with
+different identity schemes is the most complex option and would ossify
+the split instead of removing it.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -38,4 +38,5 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0003](0003-track-claude-dev-flow-tooling.md) | Track .claude AI dev-flow tooling in git with repo-relative workflow scriptPaths | Accepted |
 | [ADR-0004](0004-unified-capability-gated-canvas-page.md) | Unified capability-gated CanvasPage | Accepted |
 | [ADR-0005](0005-hosted-origin-authorization.md) | Authorizing a hosted origin against the local daemon | Accepted — not yet implemented |
-| [ADR-0006](0006-object-oriented-ui.md) | Object-oriented UI — create from the palette, act from the object | Accepted — one known violation |
+| [ADR-0006](0006-object-oriented-ui.md) | Object-oriented UI — create from the palette, act from the object | Accepted |
+| [ADR-0007](0007-canvas-identity-and-store-split.md) | Canvas identity and the daemon's two-store split | Accepted |

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -7,6 +7,7 @@ following step by step.
 Explanation pages:
 
 - **[architecture](architecture.md)** — components, data flow, MCP tool surface, and design boundaries.
+- **[domain-model](domain-model.md)** — what a canvas is in each runtime mode, how canvases are identified, and the daemon's current two-store split.
 - **[security-model](security-model.md)** — the three runtimes (browser-local, local daemon, server mode), their separate trust boundaries, HTTP protections, and file-system safety.
 
 Planned:

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -35,7 +35,8 @@ name up front) and is currently immutable; whether slugs become renamable
 is deliberately an open question (see
 [ADR-0007](../contributing/adr/0007-canvas-identity-and-store-split.md)).
 
-Browser-local canvases have no slug at all. The slug-shaped label under a
+Browser-local canvases have no persisted or canonical slug. The
+slug-shaped label under a
 card in the browser-local list is **cosmetic**: it is derived from the
 display name on every render, is never stored, and collisions are
 suffixed (`notes`, `notes-2`). It deliberately uses the same character

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -1,0 +1,82 @@
+# Domain model
+
+Understanding-oriented: what a canvas *is* in each of whiteboard's runtime
+modes, how canvases are identified, and why the same product concept is
+backed by more than one representation today. Read
+[architecture](architecture.md) first for the runtime layers themselves.
+
+## The nouns
+
+- **Canvas** — one drawable document. It has a `kind`: `spatial` (the
+  OpenCanvas node-and-edge editor) or `markdown` (a single markdown body).
+  The kind is chosen at creation and does not change afterwards — except
+  that restoring a version also restores that version's kind.
+- **Workspace** — a named collection of canvases. Only daemon mode has
+  real, multiple workspaces; browser-local mode behaves as one fixed,
+  implicit workspace (that constraint is modeled as "a single workspace
+  that is always present", not as the absence of the concept).
+- **Display name** — the human title of a canvas. Optional; a canvas
+  without one shows its identifier instead. Renaming changes only the
+  display name, never the identity.
+
+## Identity, per mode
+
+| mode | identity of a canvas | shown to the user |
+|---|---|---|
+| Browser-local | a random UUID, generated at creation | display name, plus a *display slug* derived from the name |
+| Daemon (gallery, editing, sync) | the pair `(workspaceId, slug)` | display name, plus the slug |
+| Daemon (agent/MCP tree) | a ULID `canvasId` plus a `segment` path | alias path derived from segments |
+
+**Slugs are the canonical user-facing identity** in daemon mode: URLs,
+sync, versions, and branches all address a canvas as
+`(workspaceId, slug)`. A slug is assigned at creation (derived
+automatically — `untitled`, `untitled-2`, … — since creation asks for no
+name up front) and is currently immutable; whether slugs become renamable
+is deliberately an open question (see
+[ADR-0007](../contributing/adr/0007-canvas-identity-and-store-split.md)).
+
+Browser-local canvases have no slug at all. The slug-shaped label under a
+card in the browser-local list is **cosmetic**: it is derived from the
+display name on every render, is never stored, and collisions are
+suffixed (`notes`, `notes-2`). It deliberately uses the same character
+set as daemon slugs so that, if browser-local canvases ever gain real
+slugs, the labels users already see can be promoted without changing.
+
+## One product concept, two daemon-side representations
+
+The daemon currently keeps **two separate stores** that both hold
+"canvases", and they do not see each other:
+
+- The **workspace/slug store** backs everything the web app shows and
+  edits: the gallery, the editor, names, pins, kinds, branches, versions,
+  and sync. Its writers are the daemon's HTTP API only.
+- The **OpenCanvas doc store** backs the agent-facing MCP tools
+  (`wb_canvas_*`, `canvas_import_okf`, node/edge patches, facets) and the
+  `/api/v1` routes. It organizes canvases as a CRDT tree of
+  ULID-identified documents with derived alias paths, and it is what the
+  gallery's *tree view* renders.
+
+A canvas created by an agent through MCP therefore does **not** appear in
+the daemon gallery's grid, and a canvas created from the web UI does not
+appear to `wb_canvas_list`. The only value the two representations share
+is the raw `workspaceId` string, and neither side treats the other's use
+of it as authoritative. This split is a known, recorded state — not an
+accident and not yet a converged design — and the decision record for it,
+including what is settled (slug-canonical identity, single-workspace
+browser-local) and what is still open (slug rename, the convergence
+path), is [ADR-0007](../contributing/adr/0007-canvas-identity-and-store-split.md).
+
+## Practical consequences today
+
+- Agents and humans collaborate on the same canvas only when they go
+  through the same surface (for example, an agent driving the daemon's
+  HTTP API, or a human using the tree view over `/api/v1` documents).
+- The workspace selector in the daemon gallery lists workspaces from the
+  workspace/slug store; the tree view reads the OpenCanvas store. A
+  workspace that exists in only one of the two renders as missing or
+  empty in the other.
+- Browser-local canvases cross into daemon mode only by an explicit,
+  user-initiated copy, which re-creates the canvas under a new slug —
+  no identifier carries over.
+
+← Back to [documentation home](../)


### PR DESCRIPTION
S6 of the UI-unification initiative — the documentation half that the code slices (S0–S5) built on.

- **`docs/explanation/domain-model.md`** (new): what a canvas is per runtime mode, identity per mode (UUID / `(workspaceId, slug)` / ULID+segment), display slugs as cosmetic derivation, and — honestly documented — that the agent/MCP surface and the daemon gallery are backed by **separate stores with no bridge** today (verified empirically and at the storage level: disjoint tables, disjoint byte stores, no cross-imports, no reconcile job).
- **ADR-0007** (new, Accepted): records the decided parts — slug-canonical user-facing identity (product decision), browser-local as one always-present workspace, convergence direction = toward the user-facing world, "canvasId" naming discipline — and records **slug rename as deliberately OPEN**, pending the slug-as-storage-key spike. Consequences name the concrete UX debt the split already causes (workspace picker vs tree view rendering different populations).
- **ADR-0004**: as-built addendum for three stale premises (route shape shipped as `/canvas/:ws/:slug` + `/local/:id`, not the shared `/canvas/:id/*`; the "unimplemented follow-up" bullet is now historical; two open UX decisions since settled).
- ADR index: adds 0007, and syncs the ADR-0006 row with its body (violation long since fixed).

Docs-only; no runtime change. Follow-ups from the underlying survey are filed on the board: the gallery's legacy-picker→v1-tree half-bridge bug, and the write-only `workspaceIndex` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance for canvas identity, workspace and document storage, and browser-local versus daemon modes.
  * Documented current routing, canvas-list behavior, collaboration, copying, and workspace limitations.
  * Added the domain model to the documentation index and updated the ADR index with the latest decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->