### PR TITLE
feat(web): move export into the canvas row's More actions kebab

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -54,11 +54,11 @@ async function renderLoaded(): Promise<void> {
   })
 }
 
-// Opening WorkspaceTopBar's "Canvas actions" dropdown occasionally does not
-// register on the first pointerdown the first time it's opened in a given
-// test file in real-browser mode (never reproduces in jsdom) — retry with a
-// full remount rather than let that tooling artifact fail a real behavioral
-// assertion. Mirrors the same pattern in BrowserLocalCanvasPage.rename.browser.test.tsx.
+// Export moved into the canvas row's "More actions" kebab (the canvas-level
+// operations home). Opening a Radix dropdown occasionally does not register
+// on the first pointerdown the first time in a given real-browser test file
+// (never reproduces in jsdom) — retry with a full remount rather than let
+// that tooling artifact fail a real behavioral assertion.
 async function openExportMenuItem(label: string): Promise<HTMLElement> {
   let item: HTMLElement | undefined
   for (let attempt = 0; attempt < 8 && !item; attempt++) {
@@ -66,11 +66,11 @@ async function openExportMenuItem(label: string): Promise<HTMLElement> {
       cleanup()
       await renderLoaded()
     }
-    const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Canvas actions'), {
+    const allKebabs = await waitFor(() => screen.getAllByLabelText('More actions'), {
       timeout: 5000,
     })
-    const canvasActions = allCanvasActions[allCanvasActions.length - 1]!
-    fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
+    const kebab = allKebabs[allKebabs.length - 1]!
+    fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
     try {
       const allItems = await waitFor(() => screen.getAllByText(label), { timeout: 1500 })
       item = allItems[allItems.length - 1]!
@@ -78,7 +78,7 @@ async function openExportMenuItem(label: string): Promise<HTMLElement> {
       // retry with a fresh remount
     }
   }
-  if (!item) throw new Error(`Canvas actions dropdown never opened after retries (${label})`)
+  if (!item) throw new Error(`More actions kebab never opened after retries (${label})`)
   return item
 }
 
@@ -143,7 +143,7 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
   // every click fails.
   it('never renders a JSON/Excalidraw export menu item', async () => {
     await renderLoaded()
-    fireEvent.pointerDown(screen.getByLabelText('Canvas actions'), {
+    fireEvent.pointerDown(screen.getByLabelText('More actions'), {
       button: 0,
       ctrlKey: false,
     })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -319,6 +319,29 @@ describe('BrowserLocalCanvasPage', () => {
     expect((await canvasOpsItem(/duplicate/i)).getAttribute('aria-disabled')).toBeNull()
   })
 
+  it('export lives in the canvas row kebab, not the top bar menu', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    // Export is a whole-document operation, so it sits with Duplicate and
+    // Delete in the canvas row's More actions kebab.
+    await openCanvasOpsMenu()
+    expect(await canvasOpsItem(/export as png/i)).toBeTruthy()
+    expect(await canvasOpsItem(/export as svg/i)).toBeTruthy()
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' })
+
+    // The top bar's Canvas actions menu keeps rename/copy-URL only on this
+    // page (daemon mode, which has no canvas row, keeps its export there).
+    const topTrigger = await screen.findByLabelText('Canvas actions')
+    fireEvent.pointerDown(topTrigger, { button: 0, ctrlKey: false })
+    const topMenu = await screen.findByRole('menu')
+    expect(topMenu.textContent).not.toContain('Export')
+  })
+
   it('renders a human-readable save status instead of the raw state enum', async () => {
     const store = new MemoryStore()
     await store.setDefaultCanvasId('c1')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,5 @@
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
-import { Copy, EllipsisVertical, Trash2 } from 'lucide-react'
+import { Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
@@ -29,6 +29,8 @@ import {
   DropdownMenuTrigger,
 } from '../components/ui/dropdown-menu.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
+import { sanitizeExportFilenameBase } from '../components/workspace-top-bar/export-filename.js'
+import { useSceneExport } from '../components/workspace-top-bar/useSceneExport.js'
 import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useFavicon } from '../hooks/useFavicon.js'
@@ -284,6 +286,15 @@ export function BrowserLocalCanvasPage({
     setCoreFacets,
   } = useCanvasSync(backend)
 
+  // Export rides the canvas row's operations kebab on this page (the top
+  // bar keeps its export only in daemon mode, which has no canvas row).
+  const canvasOpsFilenameBase = sanitizeExportFilenameBase(canvasName ?? 'canvas')
+  const { exportError, handleExport } = useSceneExport({
+    onExport: exportScene,
+    filenameBase: canvasOpsFilenameBase,
+    log,
+  })
+
   // The seams themselves are backend-agnostic (see use-canvas-file-seams.ts);
   // this page only supplies the browser-local binding and the staleness
   // stamps that make an edit made elsewhere show up on the next refresh.
@@ -407,6 +418,11 @@ export function BrowserLocalCanvasPage({
           {duplicateError}
         </div>
       )}
+      {exportError && (
+        <div role="alert" aria-live="assertive" className="text-destructive text-xs">
+          {exportError}
+        </div>
+      )}
       <DropdownMenu>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -426,6 +442,14 @@ export function BrowserLocalCanvasPage({
           <TooltipContent>More actions</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => void handleExport('png')}>
+            <Download aria-hidden="true" className="size-3.5" />
+            Export as PNG
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void handleExport('svg')}>
+            <Download aria-hidden="true" className="size-3.5" />
+            Export as SVG
+          </DropdownMenuItem>
           <DropdownMenuItem disabled={isDuplicating} onSelect={() => void handleDuplicate()}>
             <Copy aria-hidden="true" className="size-3.5" />
             Duplicate
@@ -528,7 +552,6 @@ export function BrowserLocalCanvasPage({
               branches: capabilities.branches,
               merge: capabilities.merge,
             }}
-            onExport={exportScene}
             onOpenSettings={handleOpenSettings}
           />
         </Suspense>


### PR DESCRIPTION
## What

The owner looked for Export in the canvas row's ⋮ kebab twice and concluded it had been removed — it hadn't (it lived in the top bar's ✎ Canvas actions menu), but the row redesign taught exactly that expectation: whole-document operations live in the row. So Export moves to its conceptual home:

- **Export as PNG / Export as SVG** now sit above Duplicate in the row's **More actions** kebab, reusing `useSceneExport` (download anchor + error handling), with export errors surfaced beside the row's other alerts.
- The browser-local page stops passing `onExport` to the top bar, whose ✎ menu keeps rename/copy-URL only.
- **Daemon mode untouched**: it has no canvas row, so its export stays in the top bar (the `WorkspaceTopBar`/`CanvasActionsMenu` capability is unchanged — this page just no longer uses it).

## Tests

- New jsdom test: the kebab offers both export formats and the ✎ menu no longer mentions Export on this page.
- `BrowserLocalCanvasPage.export.browser.test.tsx` re-driven through the kebab — the real download-anchor flow (SVG bytes, PNG decode/encode) and the no-JSON-entry guard all still pass.
- apps/web jsdom 1818 green; page browser suites 40 green; lint/knip clean.

## Visual

![kebab-with-export.png](https://github.com/user-attachments/assets/6a7aa3ec-d481-4d53-b082-a08d338bc124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
