### PR TITLE
feat(web): make the boot splash icon-only — no frame, no wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @kamiazya/whiteboard
 
 <p align="center">
-  <img src="apps/web/public/boot-splash.svg" alt="Whiteboard — a hand sketches nodes and edges, AI tidies them into a diagram, and the mark returns" width="264" height="222" />
+  <img src="docs/assets/readme-mark.svg" alt="Whiteboard — a hand sketches nodes and edges, AI tidies them into a diagram, and the mark returns" width="264" height="222" />
 </p>
 
 > A collaborative OpenCanvas whiteboard for Claude Code, Codex, and Gemini CLI. Draw with your AI agent to align on specs, architecture, and workflows — directly on a shared real-time canvas.

--- a/apps/web/index-html.test.ts
+++ b/apps/web/index-html.test.ts
@@ -44,6 +44,14 @@ describe('public/boot-splash.svg', () => {
     expect(svg).toMatch(/@keyframes wb-drawn\s*\{[^@]*from[^@]*opacity: 1/)
   })
 
+  // The splash follows the OS splash grammar: a single glyph, no container,
+  // no caption. The app name lives in the tab title / the OS's own PWA
+  // splash, and <text> would render in an unpredictable system font.
+  it('is icon-only: no board frame, no wordmark', () => {
+    expect(svg).not.toContain('<text')
+    expect(svg).not.toMatch(/<rect[^>]*width="172"/)
+  })
+
   it('neutralizes all animation under prefers-reduced-motion', () => {
     const idx = svg.indexOf('prefers-reduced-motion: reduce')
     expect(idx).toBeGreaterThan(-1)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -40,7 +40,7 @@
          The animated mark (pen stroke drawing itself + wordmark) is the
          shared external SVG public/boot-splash.svg — same file the README
          embeds — with its animation and reduced-motion guard inside. -->
-    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><img src="/boot-splash.svg" alt="" width="264" height="222" /></div></div>
+    <div id="root"><div class="wb-boot" role="status" aria-label="Loading Whiteboard"><img src="/boot-splash.svg" alt="" width="320" height="225" /></div></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/docs/assets/readme-mark.svg
+++ b/docs/assets/readme-mark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="320" height="225" viewBox="0 0 176 124" role="img" aria-label="Whiteboard">
+<svg xmlns="http://www.w3.org/2000/svg" width="264" height="222" viewBox="0 0 176 148" role="img" aria-label="Whiteboard">
   <title>Whiteboard</title>
   <!--
     The boot-splash mark, as a story: the signature squiggle draws itself
@@ -7,14 +7,10 @@
     color - the AI's hand) tidies them into an aligned diagram; the diagram
     bows out and the signature squiggle returns softly, breathing. Where
     the animation ends, it always lands on the logo.
-    Deliberately ICON-ONLY - no board frame, no wordmark. The splash covers
-    the whole viewport, so the screen itself is the board (framing it again
-    would box the mark inside the bezel), and the app name already lives in
-    the tab title / the OS's own PWA splash. The framed, captioned variant
-    lives in docs/assets/readme-mark.svg for document contexts.
-    Self-contained (CSS animation inside the SVG) so it renders inside an
-    <img> inheriting nothing from the page; mid-gray colors read on both
-    light and dark grounds for the same reason.
+    Self-contained (CSS animation inside the SVG) so the same file serves
+    the index.html splash and the README, where it renders inside an <img>
+    and can inherit nothing from the page. Colors are mid-grays chosen to
+    read on both light and dark grounds for the same reason.
   -->
   <style>
     /* Phase 0 (0-2.2s): signature squiggle - draw, hold a beat, fade.
@@ -161,6 +157,7 @@
     }
   </style>
   <g class="scene">
+    <rect x="2" y="2" width="172" height="120" rx="12" fill="none" stroke="#9ca3af" stroke-opacity="0.55" stroke-width="3"/>
     <g transform="translate(30 22) scale(1.35)">
       <path class="stroke" d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" fill="none" stroke="#909090" stroke-width="3" stroke-linecap="round"/>
     </g>
@@ -179,4 +176,5 @@
   <g class="cursor">
     <path d="M0 0 L0 12 L3.2 9.2 L5.6 14 L7.8 12.9 L5.4 8.2 L9.5 7.6 Z" fill="#5b5b5b" stroke="#fdfdfd" stroke-width="1"/>
   </g>
+  <text x="88" y="143" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" letter-spacing="0.4" fill="#909090">Whiteboard</text>
 </svg>


### PR DESCRIPTION
## Summary

The splash covers the whole viewport, so the screen itself is the board. Two things stopped saying that:

- **The board frame** boxed the mark inside the phone bezel (double framing) and made it read small — dropped; the sketch→tidy story now plays directly on the screen.
- **The wordmark** repeated a name that already lives in the tab title and the OS's own PWA splash (generated from the manifest), while rendering in an unpredictable system font — dropped; the splash is deterministic vector-only now.

This follows the OS splash grammar (a single uncontained glyph). The framed, captioned variant moves to `docs/assets/readme-mark.svg` for the README, where a document context does want containment — the design rule stays: **the squiggle is the signature everywhere; the frame appears only where a container earns its keep** (README, favicon).

Pinned by a new contract test: the splash SVG contains no `<text>` and no board rect.

## Visual repro

Phone-shaped dark viewport, full story:

![splash-frameless.gif](https://github.com/user-attachments/assets/77a836a0-1d1d-4645-a03d-9a2c53f3c4c9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc