### PR TITLE
fix(render): score bystander-body tunnelling in the heaviest cost slot

### DIFF
--- a/packages/canvas-render/src/layout/edge-body-intrusion.test.ts
+++ b/packages/canvas-render/src/layout/edge-body-intrusion.test.ts
@@ -1,0 +1,64 @@
+// A routed edge must not tunnel through a bystander node's body when any
+// candidate side pair routes clean: a line through a node reads as though
+// it CONNECTS that node, which no line jump can express — worse than an
+// extra edge crossing, which can. The optimizer therefore scores body
+// intrusion in its heaviest slot, trading an edge crossing away to avoid
+// a tunnel.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+function intrusions(
+  path: readonly { x: number; y: number }[],
+  r: { x: number; y: number; w: number; h: number },
+) {
+  let n = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    const minX = Math.min(a.x, b.x)
+    const maxX = Math.max(a.x, b.x)
+    const minY = Math.min(a.y, b.y)
+    const maxY = Math.max(a.y, b.y)
+    if (minX < r.x + r.w - 1 && maxX > r.x + 1 && minY < r.y + r.h - 1 && maxY > r.y + 1) n++
+  }
+  return n
+}
+
+it('prefers an edge crossing over tunnelling through a bystander body', () => {
+  // Reconstructed from a real canvas: blue sits above the tall box; the
+  // bottom-arrival elbows and every detour are walled in by green and the
+  // tall box, so that pair can only route THROUGH the tall body. The
+  // left-arrival pair routes clean but costs one crossing with the gate
+  // edge — which must be the accepted price.
+  const nodes = [
+    box('brown', 55, 862, 378, 188),
+    box('green', -50, 1167, 526, 283),
+    box('blue', 778, 862, 463, 288),
+    box('tallRight', 778, 1662, 417, 868),
+    box('bottomLeft', 155, 1788, 415, 625),
+    box('gate1', 600, 600, 100, 60),
+    box('gate2', 600, 2600, 100, 60),
+  ]
+  const edges: CanvasEdge[] = [
+    { id: 'q', fromNode: 'bottomLeft', toNode: 'blue' },
+    { id: 'h', fromNode: 'tallRight', toNode: 'bottomLeft' },
+    { id: 'g', fromNode: 'bottomLeft', toNode: 'green' },
+    { id: 'bg', fromNode: 'brown', toNode: 'green' },
+    { id: 'gate', fromNode: 'gate1', toNode: 'gate2' },
+  ]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const q = edges[0] as CanvasEdge
+  const { path } = routeEdge(nodes, q, 'orthogonal', anchors.get('q'))
+  expect(intrusions(path, { x: 778, y: 1662, w: 417, h: 868 })).toBe(0)
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -540,14 +540,36 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
 }
 
 /**
- * Per-edge quality of ONE routed path: collinear overlap with ITSELF
- * (adjacent retraces included — the doubled-line arrival a facing-away
- * side produces when the connector overshoots the entry stub through the
- * node body) in the heaviest slot, and realized bend count in the last.
+ * Per-edge quality of ONE routed path, in the heaviest slot: collinear
+ * overlap with ITSELF (adjacent retraces included — the doubled-line
+ * arrival a facing-away side produces when the connector overshoots the
+ * entry stub through the node body) plus the length of any segment
+ * TUNNELLING through a bystander node's raw body — a line through a node
+ * reads as though it connects that node, which no line jump can express,
+ * so it outranks even an edge crossing. Realized bend count sits last.
  */
-function selfScore(path: readonly Point[]): ConfigCost {
+function selfScore(path: readonly Point[], foreignBodies: readonly Rect[]): ConfigCost {
   const q = (n: number) => Math.round(n * COST_QUANTUM)
   let overlap = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    for (const r of foreignBodies) {
+      // Axis-aligned intrusion length, boundary grazing excluded: an
+      // anchor ON a neighbour's border or a segment riding the margin
+      // band is bestCandidate's business, not a tunnel.
+      const minX = Math.max(Math.min(a.x, b.x), r.x)
+      const maxX = Math.min(Math.max(a.x, b.x), r.x + r.w)
+      const minY = Math.max(Math.min(a.y, b.y), r.y)
+      const maxY = Math.min(Math.max(a.y, b.y), r.y + r.h)
+      if (maxX <= minX && maxY <= minY) continue
+      if (a.y === b.y && a.y > r.y && a.y < r.y + r.h && maxX > minX) {
+        overlap += q(maxX - minX)
+      } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w && maxY > minY) {
+        overlap += q(maxY - minY)
+      }
+    }
+  }
   for (let i = 1; i < path.length; i++) {
     for (let j = i + 1; j < path.length; j++) {
       const a1 = path[i - 1] as Point
@@ -622,7 +644,10 @@ function optimizeSideChoices(
   )
   const pairKey = (i: number, j: number) => i * edges.length + j
   const matrix = new Map<number, ConfigCost>()
-  const selfCosts: ConfigCost[] = paths.map((path) => selfScore(path))
+  const foreignBodiesFor = edges.map((e) =>
+    nodes.filter((n) => n.id !== e.fromNode && n.id !== e.toNode).map(rectOf),
+  )
+  const selfCosts: ConfigCost[] = paths.map((path, i) => selfScore(path, foreignBodiesFor[i]!))
   let currentCost: ConfigCost = [0, 0, 0, 0]
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
   for (let i = 0; i < edges.length; i++) {
@@ -661,7 +686,7 @@ function optimizeSideChoices(
     const updates = new Map<number, ConfigCost>()
     const selfUpdates = new Map<number, ConfigCost>()
     for (const i of touched) {
-      const next = selfScore(trialPaths[i]!)
+      const next = selfScore(trialPaths[i]!, foreignBodiesFor[i]!)
       cost = addCost(cost, selfCosts[i] ?? [0, 0, 0, 0], -1)
       cost = addCost(cost, next, 1)
       selfUpdates.set(i, next)


### PR DESCRIPTION
## What

Fixes the mobile report of an edge tunnelling straight through a bystander node on the way to its target.

**Root cause** (reconstructed from the reported canvas): the target-bottom side pair had every elbow and every detour walled in by surrounding nodes, so `routeOrthogonal` fell back to its shortest-route guarantee — straight through the tall bystander's body. The optimizer kept that pair because **body intrusion appeared in no cost term**: the tunnel had fewer *edge* crossings than the clean alternative arriving on the target's left.

**Fix**: a routed path's intrusion length through any **non-endpoint node's raw body** now counts in the optimizer's heaviest cost slot (alongside collinear overlap and self-retrace). A line through a node reads as though it *connects* that node — something no line jump can express — so it outranks even an edge crossing, and the optimizer trades a jumpable crossing away to avoid a tunnel whenever any candidate routes clean. Boundary grazing and margin-band riding stay `bestCandidate`'s business and score nothing.

## Tests

- `edge-body-intrusion.test.ts` pins the reconstructed scene: the walled-in bottom pair loses to the left arrival (one jumpable crossing, zero intrusion). Mutation-checked — dropping the intrusion accumulation turns it red.
- Full `canvas-render-node` (376), edge browser suites (16), apps/web jsdom (1817) all green — no existing pinned route changed.

Visual evidence is the reporter's own screenshot (the gray edge cutting through the tall box's corner en route to the blue node); the pinned test is the reconstruction of that exact geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
