### PR TITLE
docs(mcp-server): correct why the test data dir has to be isolated

### DIFF
--- a/packages/mcp-server/vitest-data-dir.test.ts
+++ b/packages/mcp-server/vitest-data-dir.test.ts
@@ -4,11 +4,12 @@
  * `getDataDir()` falls back to `~/.whiteboard` when `WHITEBOARD_DATA_DIR` is
  * unset, and several tests boot the server far enough to run migrations. On a
  * machine whose `~/.whiteboard/whiteboard.db` was last migrated by a DIFFERENT
- * build — the PUBLISHED `@kamiazya/whiteboard-mcp` that `.mcp.json` registers
- * uses that same default dir with its own release's migrations — the run dies
- * with two unhandled `IncompatibleDatabaseError` rejections while every test
- * still passes. That fails the lefthook pre-push gate for reasons that have
- * nothing to do with the branch being pushed.
+ * build — a sibling checkout on another branch, or the published
+ * `@kamiazya/whiteboard-mcp` that `.mcp.json` registers, both of which use
+ * that same default dir — the run dies with two unhandled
+ * `IncompatibleDatabaseError` rejections while every test still passes. That
+ * fails the lefthook pre-push gate for reasons that have nothing to do with
+ * the branch being pushed.
  *
  * Asserting on the resolved env var rather than on a log line keeps this
  * independent of which test happens to boot the server today.

--- a/packages/mcp-server/vitest.node.config.ts
+++ b/packages/mcp-server/vitest.node.config.ts
@@ -10,12 +10,19 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
  *
  * `getDataDir()` falls back to `~/.whiteboard` when `WHITEBOARD_DATA_DIR` is
  * unset, and enough of this suite boots the server to run migrations against
- * whatever lives there — the developer's REAL database, shared with anything
- * on the machine that uses the default. `.mcp.json` registers the PUBLISHED
- * `@kamiazya/whiteboard-mcp@latest`, which does exactly that with the
- * migration set of its own release, so this checkout then finds a migration
- * history it does not recognise and the whole run dies with unhandled
- * `IncompatibleDatabaseError` rejections while every test passes.
+ * whatever lives there — the developer's REAL database, shared with every
+ * other thing on the machine that uses the default.
+ *
+ * Any writer whose migration set differs from this checkout's is enough to
+ * stop work: the run then finds a migration history it does not recognise
+ * and dies with unhandled `IncompatibleDatabaseError` rejections while every
+ * test passes, failing the pre-push gate for reasons unrelated to the branch
+ * being pushed. The observed instance was a migration this checkout did not
+ * yet have because it was still unmerged on another branch — a sibling
+ * checkout on this same machine is as capable of leaving one behind as the
+ * published `@kamiazya/whiteboard-mcp` that `.mcp.json` registers. WHICH
+ * writer it was does not change the fix, which is why the fix is isolation
+ * rather than identifying a culprit.
  *
  * The repo's own dev daemons already avoid this: `with-dev-data-dir` points
  * them at a per-worktree `<repoRoot>/.dev-data` so parallel lanes cannot


### PR DESCRIPTION
Comments only, no behaviour change — but the comments were confidently wrong,
which is the kind that costs someone an afternoon later.

## What #597 claimed

That the published `@kamiazya/whiteboard-mcp@latest`, registered in
`.mcp.json`, had left an unrecognised migration in `~/.whiteboard`. The
evidence offered was that `0005-canvases-kind` appeared in the database's
history while current source shipped only `0001`–`0004`.

## What was actually true

`0005-canvases-kind` was not absent because a release had it and this repo did
not. It was **still unmerged on another branch** — #599, "accept and persist a
spatial|markdown kind on canvas create", authored 08-12 00:58 and merged
since. The likeliest writer was a sibling checkout on this same machine.

That was the **second** wrong mechanism for the same failure. The first blamed
stale dev daemons outliving `git worktree remove` — which `with-dev-data-dir`
already prevents by giving every worktree its own `.dev-data`. Only the
observation survived both: the SUITE was using the real data dir.

## What the comments say now

That any writer with a different migration set is enough, and that **which**
one it was does not change the fix. Naming a culprit in a source comment
invites the next reader to check whether that culprit is still around and
conclude the problem is gone.

The correction is itself the argument for isolation: the writer turned out to
be ordinary in-repo work on another branch, not an outside actor anyone could
be asked to stop.
