### PR TITLE
feat(web): embed the JSON Canvas document in PNG exports

### DIFF
--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -1,3 +1,4 @@
+import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
 import type { CanvasCoreMeta, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
@@ -11,6 +12,7 @@ import {
 } from '../lib/canvas-sync-session.js'
 import type { SyncStatus, UseCanvasSyncOptions } from '../lib/canvas-sync-types.js'
 import { dispatchIdentityEvent } from '../lib/canvas-sync-types.js'
+import { embedTextInPng } from '../lib/png-embed.js'
 
 export type { UseCanvasSyncOptions }
 // Re-exported so existing call sites can keep importing it from the hook
@@ -287,7 +289,8 @@ export function useCanvasSync(
   // a SpatialEditor is currently mounted.
   const exportScene = useCallback(
     async (format: SceneExportFormat): Promise<Blob | null> => {
-      const { svg, bounds } = renderCanvasToSvg(sessionRef.current?.getCanvas() ?? canvas, {
+      const exportedCanvas = sessionRef.current?.getCanvas() ?? canvas
+      const { svg, bounds } = renderCanvasToSvg(exportedCanvas, {
         measure: createBrowserMeasureText(),
         // Pinned to 'light' regardless of the UI theme: an exported SVG/PNG
         // is a saved artifact, and a user's display preference must never
@@ -297,11 +300,24 @@ export function useCanvasSync(
       if (format === 'svg') {
         return new Blob([svg], { type: 'image/svg+xml' })
       }
-      return rasterizeSvgToPng(
+      const png = await rasterizeSvgToPng(
         svg,
         Math.max(1, Math.round(bounds.w)),
         Math.max(1, Math.round(bounds.h)),
       )
+      if (png === null) return null
+      // Editable PNG (the draw.io pattern): embed the extended JSON Canvas
+      // document in an iTXt chunk, so the exported image carries its own
+      // source — exact coordinates included — under the `whiteboard` key.
+      const bytes = new Uint8Array(await png.arrayBuffer())
+      const embedded = embedTextInPng(
+        bytes,
+        'whiteboard',
+        serializeSpatial(exportedCanvas, 'extended'),
+      )
+      // Copy into a fresh ArrayBuffer-backed view: Blob's lib.dom typing
+      // rejects ArrayBufferLike-backed Uint8Arrays.
+      return new Blob([Uint8Array.from(embedded)], { type: 'image/png' })
     },
     [canvas],
   )

--- a/apps/web/src/lib/png-embed.test.ts
+++ b/apps/web/src/lib/png-embed.test.ts
@@ -1,0 +1,66 @@
+// Editable-PNG embedding: an exported PNG carries the JSON Canvas document
+// in an iTXt chunk (the draw.io pattern), so a shared screenshot IS the
+// canvas — exact node coordinates included — not just pixels of it.
+import { describe, expect, it } from 'vitest'
+import { embedTextInPng, extractTextFromPng } from './png-embed.js'
+
+// Smallest valid PNG (1×1 transparent), from the canonical example bytes.
+const TINY_PNG = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  ),
+  (c) => c.charCodeAt(0),
+)
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+function chunkTypes(png: Uint8Array): string[] {
+  const types: string[] = []
+  let offset = 8
+  while (offset + 8 <= png.length) {
+    const len =
+      ((png[offset]! << 24) |
+        (png[offset + 1]! << 16) |
+        (png[offset + 2]! << 8) |
+        png[offset + 3]!) >>>
+      0
+    const type = String.fromCharCode(
+      png[offset + 4]!,
+      png[offset + 5]!,
+      png[offset + 6]!,
+      png[offset + 7]!,
+    )
+    types.push(type)
+    offset += 12 + len
+  }
+  return types
+}
+
+describe('embedTextInPng', () => {
+  it('round-trips arbitrary UTF-8 text under the keyword', () => {
+    const json = JSON.stringify({ nodes: [{ id: 'あ', x: -5, y: 12.5 }], edges: [] })
+    const out = embedTextInPng(TINY_PNG, 'whiteboard', json)
+    expect(extractTextFromPng(out, 'whiteboard')).toBe(json)
+  })
+
+  it('keeps the PNG structurally valid: signature intact, chunk walk closes on IEND', () => {
+    const out = embedTextInPng(TINY_PNG, 'whiteboard', 'payload')
+    expect([...out.slice(0, 8)]).toEqual(PNG_SIGNATURE)
+    const types = chunkTypes(out)
+    expect(types[0]).toBe('IHDR')
+    expect(types[types.length - 1]).toBe('IEND')
+    expect(types).toContain('iTXt')
+  })
+
+  it('replaces an existing chunk with the same keyword instead of stacking', () => {
+    const once = embedTextInPng(TINY_PNG, 'whiteboard', 'first')
+    const twice = embedTextInPng(once, 'whiteboard', 'second')
+    expect(extractTextFromPng(twice, 'whiteboard')).toBe('second')
+    expect(chunkTypes(twice).filter((t) => t === 'iTXt')).toHaveLength(1)
+  })
+
+  it('extraction is total: no chunk → null, garbage bytes → null', () => {
+    expect(extractTextFromPng(TINY_PNG, 'whiteboard')).toBeNull()
+    expect(extractTextFromPng(Uint8Array.from([1, 2, 3]), 'whiteboard')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/png-embed.ts
+++ b/apps/web/src/lib/png-embed.ts
@@ -1,0 +1,145 @@
+/**
+ * Editable-PNG embedding, the draw.io pattern: the exported PNG carries its
+ * source document in an iTXt chunk, so a shared image IS the canvas (exact
+ * coordinates included), not just pixels of it. iTXt over tEXt because the
+ * payload is UTF-8 JSON and tEXt is Latin-1 only (PNG 1.2 §4.2.3).
+ *
+ * Both functions are total over hostile input: a buffer that is not a PNG,
+ * or a truncated chunk stream, extracts to null and embeds by returning the
+ * input untouched — an export must never fail because embedding could not
+ * parse what the rasterizer produced.
+ */
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+/** Standard PNG CRC-32 (ISO 3309 / ITU-T V.42), over chunk type + data. */
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    table[n] = c >>> 0
+  }
+  return table
+})()
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff
+  for (const byte of bytes) {
+    crc = (CRC_TABLE[(crc ^ byte) & 0xff]! ^ (crc >>> 8)) >>> 0
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+interface Chunk {
+  readonly type: string
+  readonly data: Uint8Array
+}
+
+function readChunks(png: Uint8Array): Chunk[] | null {
+  if (png.length < 8 || PNG_SIGNATURE.some((b, i) => png[i] !== b)) return null
+  const chunks: Chunk[] = []
+  let offset = 8
+  while (offset + 12 <= png.length) {
+    const len =
+      ((png[offset]! << 24) |
+        (png[offset + 1]! << 16) |
+        (png[offset + 2]! << 8) |
+        png[offset + 3]!) >>>
+      0
+    if (offset + 12 + len > png.length) return null
+    const type = String.fromCharCode(
+      png[offset + 4]!,
+      png[offset + 5]!,
+      png[offset + 6]!,
+      png[offset + 7]!,
+    )
+    chunks.push({ type, data: png.slice(offset + 8, offset + 8 + len) })
+    offset += 12 + len
+    if (type === 'IEND') return chunks
+  }
+  return null
+}
+
+function writeChunks(chunks: readonly Chunk[]): Uint8Array {
+  const total = 8 + chunks.reduce((sum, chunk) => sum + 12 + chunk.data.length, 0)
+  const out = new Uint8Array(total)
+  out.set(PNG_SIGNATURE, 0)
+  let offset = 8
+  for (const chunk of chunks) {
+    const len = chunk.data.length
+    out[offset] = (len >>> 24) & 0xff
+    out[offset + 1] = (len >>> 16) & 0xff
+    out[offset + 2] = (len >>> 8) & 0xff
+    out[offset + 3] = len & 0xff
+    const typeAndData = new Uint8Array(4 + len)
+    for (let i = 0; i < 4; i++) typeAndData[i] = chunk.type.charCodeAt(i)
+    typeAndData.set(chunk.data, 4)
+    out.set(typeAndData, offset + 4)
+    const crc = crc32(typeAndData)
+    const crcAt = offset + 8 + len
+    out[crcAt] = (crc >>> 24) & 0xff
+    out[crcAt + 1] = (crc >>> 16) & 0xff
+    out[crcAt + 2] = (crc >>> 8) & 0xff
+    out[crcAt + 3] = crc & 0xff
+    offset += 12 + len
+  }
+  return out
+}
+
+/** iTXt layout: keyword\0 compressed(0) method(0) lang\0 translated\0 text. */
+function iTXtChunk(keyword: string, text: string): Chunk {
+  const keywordBytes = new TextEncoder().encode(keyword)
+  const textBytes = new TextEncoder().encode(text)
+  const data = new Uint8Array(keywordBytes.length + 5 + textBytes.length)
+  data.set(keywordBytes, 0)
+  // keyword NUL, compression flag 0, compression method 0, empty language
+  // tag NUL, empty translated keyword NUL — five zero bytes in a row.
+  data.set(textBytes, keywordBytes.length + 5)
+  return { type: 'iTXt', data }
+}
+
+function iTXtKeywordOf(data: Uint8Array): string | null {
+  const nul = data.indexOf(0)
+  if (nul <= 0) return null
+  return new TextDecoder().decode(data.slice(0, nul))
+}
+
+/**
+ * Returns `png` with an iTXt chunk carrying `text` under `keyword`,
+ * replacing any existing chunk with that keyword. Inserted before IEND.
+ */
+export function embedTextInPng(png: Uint8Array, keyword: string, text: string): Uint8Array {
+  const chunks = readChunks(png)
+  if (chunks === null) return png
+  const kept = chunks.filter(
+    (chunk) => !(chunk.type === 'iTXt' && iTXtKeywordOf(chunk.data) === keyword),
+  )
+  const iend = kept.findIndex((chunk) => chunk.type === 'IEND')
+  if (iend === -1) return png
+  kept.splice(iend, 0, iTXtChunk(keyword, text))
+  return writeChunks(kept)
+}
+
+/** The text stored under `keyword`, or null when absent or not a PNG. */
+export function extractTextFromPng(png: Uint8Array, keyword: string): string | null {
+  const chunks = readChunks(png)
+  if (chunks === null) return null
+  for (const chunk of chunks) {
+    if (chunk.type !== 'iTXt') continue
+    if (iTXtKeywordOf(chunk.data) !== keyword) continue
+    const keywordLen = new TextEncoder().encode(keyword).length
+    // Skip keyword NUL + 2 method bytes, then the two NUL-terminated
+    // optional fields (language tag, translated keyword).
+    let offset = keywordLen + 3
+    for (let field = 0; field < 2; field++) {
+      const nul = chunk.data.indexOf(0, offset)
+      if (nul === -1) return null
+      offset = nul + 1
+    }
+    return new TextDecoder().decode(chunk.data.slice(offset))
+  }
+  return null
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { extractTextFromPng } from '../lib/png-embed.js'
 import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
 import '../index.css'
 
@@ -136,6 +137,15 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
     const blob = blobs[blobs.length - 1]!
     expect(blob.type).toBe('image/png')
     expect(blob.size).toBeGreaterThan(0)
+
+    // Editable PNG: the file carries its own JSON Canvas document (the
+    // draw.io pattern), so a shared export IS the canvas — coordinates
+    // included — not just pixels of it.
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    const embedded = extractTextFromPng(bytes, 'whiteboard')
+    expect(embedded).not.toBeNull()
+    const parsed = JSON.parse(embedded as string) as { nodes: { id: string }[] }
+    expect(Array.isArray(parsed.nodes)).toBe(true)
   })
 
   // The menu must only offer formats `exportScene` (SceneExportFormat) can

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -12,6 +12,18 @@ the canvas's persisted document — none of them require a connected browser cli
 A `file` node renders as a labeled box when exported to SVG; its referenced image
 is not embedded in the output.
 
+## Web app exports
+
+The web editor's canvas row (More actions → Export) saves the current canvas as
+SVG or PNG, rendered with the light theme regardless of the UI theme so an
+export's bytes never depend on a display preference.
+
+**PNG exports are editable images**: the file embeds the canvas's JSON Canvas
+document (extended mode, `x-whiteboard` included) in a PNG `iTXt` chunk under
+the `whiteboard` keyword — the same pattern draw.io uses. A shared PNG
+therefore carries its exact node coordinates and edges, not just pixels; any
+PNG chunk reader can recover the document, and image viewers ignore the chunk.
+
 There is currently no raster (PNG) export tool and no tool that returns image
 bytes as MCP `ImageContent` — `canvas_render_svg` is the closest equivalent for
 handing a rendered canvas back to an LLM.


### PR DESCRIPTION
## What

Owner request: PNG exports should carry the canvas itself, draw.io-style, so a shared image doubles as exact repro data (node coordinates included) — precisely what this week's edge-routing debugging lacked.

- Every **Export as PNG** now embeds the canvas's **extended-mode JSON Canvas document** (`x-whiteboard` included) in a PNG **iTXt** chunk under the `whiteboard` keyword. Image viewers ignore the chunk; any PNG chunk reader recovers the document.
- `png-embed.ts` is a small total pure utility (PNG 1.2 chunk walk + CRC-32): non-PNG input embeds as a no-op and extracts to `null`, so an export can never fail because embedding could not parse the rasterizer's output. Re-embedding replaces the existing chunk instead of stacking. iTXt over tEXt because the payload is UTF-8 and tEXt is Latin-1 only.
- SVG exports unchanged. Docs: `docs/reference/export-formats.md` gains a "Web app exports" section describing the editable-PNG contract.

## Tests

- `png-embed.test.ts`: UTF-8 round-trip, structural validity (signature, IHDR-first/IEND-last chunk walk), same-keyword replacement, total extraction on garbage.
- `BrowserLocalCanvasPage.export.browser.test.tsx`: the real export flow (kebab → rasterize → download blob) now also asserts the downloaded PNG's embedded JSON parses back to a node list.
- apps/web jsdom 1823 green; knip/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
