### PR TITLE
feat(web): per-card Delete with a confirmation dialog on both canvas lists

### DIFF
--- a/apps/web/src/components/canvas-list/DeleteCanvasDialog.tsx
+++ b/apps/web/src/components/canvas-list/DeleteCanvasDialog.tsx
@@ -1,0 +1,63 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+export interface DeleteCanvasDialogProps {
+  // The canvas pending deletion, or null when the dialog is closed.
+  pending: { displayName: string } | null
+  busy: boolean
+  error: string | null
+  description: string
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+// Confirmation for the per-card Delete action both list pages render. The
+// dialog stays pinned while the delete is in flight: dismissing mid-request
+// would let the user re-open and fire a second delete before the first
+// settles (same rule as the version-restore dialog).
+export function DeleteCanvasDialog({
+  pending,
+  busy,
+  error,
+  description,
+  onCancel,
+  onConfirm,
+}: DeleteCanvasDialogProps) {
+  return (
+    <AlertDialog
+      open={pending !== null}
+      onOpenChange={(open) => {
+        if (!open && busy) return
+        if (!open) onCancel()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {pending ? `Delete "${pending.displayName}"?` : 'Delete canvas?'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {description}
+            {error && <span className="mt-2 block text-destructive">{error}</span>}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          {/* Not AlertDialogAction: it closes on click, but the dialog must
+              stay open (pinned) until the async delete settles. */}
+          <Button type="button" variant="destructive" disabled={busy} onClick={onConfirm}>
+            Delete
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/web/src/lib/daemon-api-client.test.ts
+++ b/apps/web/src/lib/daemon-api-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createCanvas,
   createDaemonFetch,
+  deleteCanvas,
   getCanvasSnapshot,
   listCanvases,
   listWorkspaces,
@@ -190,6 +191,24 @@ describe('createCanvas', () => {
     fetchFn.mockResolvedValue(jsonResponse({ slug: 'y' }))
     await createCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'y')
     expect(sentBody(fetchFn)).toEqual({ slug: 'y' })
+  })
+})
+
+describe('deleteCanvas', () => {
+  it('sends DELETE to the canvas URL and parses the ok body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    const result = await deleteCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'old-canvas')
+    expect(result).toEqual({ ok: true })
+    const [url, init] = fetchFn.mock.calls[0]!
+    expect(String(url)).toBe(`${DAEMON_BASE_URL}/api/workspaces/w1/canvases/old-canvas`)
+    expect((init as RequestInit).method).toBe('DELETE')
+  })
+
+  it('rejects on a 404, surfacing the problem-details title', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ title: 'Canvas not found' }, 404))
+    await expect(deleteCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'gone')).rejects.toThrow(
+      /canvas not found/i,
+    )
   })
 })
 

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -4,6 +4,8 @@ import {
   type CreateCanvasResponse,
   canvasOkfV1ResponseSchema,
   createCanvasResponseSchema,
+  type DeleteCanvasResponse,
+  deleteCanvasResponseSchema,
   type ListCanvasesResponse,
   type ListCanvasesV1Response,
   type ListWorkspacesResponse,
@@ -90,6 +92,20 @@ export function createCanvas(
       // rejects unknown fields never sees one it can't parse.
       body: JSON.stringify(kind === undefined ? { slug } : { slug, kind }),
     },
+  )
+}
+
+export function deleteCanvas(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  slug: string,
+): Promise<DeleteCanvasResponse> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}`,
+    deleteCanvasResponseSchema,
+    { method: 'DELETE' },
   )
 }
 

--- a/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
@@ -102,5 +102,20 @@ describe('browser-local list landing (browser — real IndexedDB)', () => {
       },
       { timeout: 15_000 },
     )
+
+    // Back to the list, then delete both canvases through the real
+    // AlertDialog: the empty state returns.
+    await router.navigate(-1)
+    await screen.findAllByTestId('canvas-list-card', undefined, { timeout: 15_000 })
+    for (let remaining = 2; remaining > 0; remaining--) {
+      const deleteButtons = await screen.findAllByRole('button', { name: /^Delete / })
+      await userEvent.click(deleteButtons[0]!)
+      const dialog = await screen.findByRole('alertdialog')
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), {
+        timeout: 15_000,
+      })
+    }
+    await screen.findByText('No canvases yet', undefined, { timeout: 15_000 })
   })
 })

--- a/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
@@ -127,6 +127,41 @@ describe('BrowserLocalIndexPage', () => {
     await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false))
   })
 
+  it('Delete opens a dialog naming the canvas; Cancel removes nothing', async () => {
+    const store = await seededStore([
+      { id: 'id-a', name: 'Keep Me', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+    ])
+    renderPage(store)
+    await screen.findAllByTestId('canvas-list-card')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Keep Me' }))
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/Delete "Keep Me"\?/)).toBeTruthy()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(await store.listCanvases()).toHaveLength(1)
+    expect(screen.getAllByTestId('canvas-list-card')).toHaveLength(1)
+  })
+
+  it('confirming Delete removes the canvas; deleting the last one returns the empty state', async () => {
+    const store = await seededStore([
+      { id: 'id-a', name: 'Doomed', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+    ])
+    const { onOpenCanvas } = renderPage(store)
+    await screen.findAllByTestId('canvas-list-card')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Doomed' }))
+    const dialog = await screen.findByRole('alertdialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(await store.listCanvases()).toHaveLength(0)
+    expect(await screen.findByText('No canvases yet')).toBeTruthy()
+    // The delete flow must never open the canvas.
+    expect(onOpenCanvas).not.toHaveBeenCalled()
+  })
+
   it('suffixes colliding display slugs instead of repeating them', async () => {
     const store = await seededStore([
       { id: 'id-a', name: 'Notes', updatedAt: '2026-08-02T00:00:00Z', kind: 'spatial' },

--- a/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
@@ -162,6 +162,29 @@ describe('BrowserLocalIndexPage', () => {
     expect(onOpenCanvas).not.toHaveBeenCalled()
   })
 
+  it('a failed delete shows the fixed error in the dialog, which stays open, and Cancel clears it', async () => {
+    const store = await seededStore([
+      { id: 'id-a', name: 'Sticky', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+    ])
+    store.removeCanvas = () => Promise.reject(new Error('quota exceeded'))
+    renderPage(store)
+    await screen.findAllByTestId('canvas-list-card')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Sticky' }))
+    const dialog = await screen.findByRole('alertdialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    // Fixed copy — never the raw error text — and the dialog stays open.
+    expect(
+      await within(dialog).findByText('Failed to delete the canvas from this browser.'),
+    ).toBeTruthy()
+    expect(within(dialog).queryByText(/quota exceeded/)).toBeNull()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(screen.getAllByTestId('canvas-list-card')).toHaveLength(1)
+  })
+
   it('suffixes colliding display slugs instead of repeating them', async () => {
     const store = await seededStore([
       { id: 'id-a', name: 'Notes', updatedAt: '2026-08-02T00:00:00Z', kind: 'spatial' },

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -1,6 +1,7 @@
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { CanvasListView } from '../components/canvas-list/CanvasListView.js'
+import { DeleteCanvasDialog } from '../components/canvas-list/DeleteCanvasDialog.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { deriveDisplaySlug } from '../lib/derive-display-slug.js'
 import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
@@ -55,6 +56,30 @@ export function BrowserLocalIndexPage({ store, onOpenCanvas }: BrowserLocalIndex
     })
   }, [snapshots])
 
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; displayName: string } | null>(
+    null,
+  )
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      // Unconditional removal by id. If this was the canvas the default
+      // pointer resumes into, the pointer dangles deliberately — the
+      // editor's resume path already falls back safely on a dead id.
+      await store.removeCanvas?.(pendingDelete.id)
+      setSnapshots(await store.listCanvases())
+      setPendingDelete(null)
+    } catch {
+      setDeleteError('Failed to delete the canvas from this browser.')
+    } finally {
+      setDeleting(false)
+    }
+  }, [store, pendingDelete])
+
   const handleCreate = useCallback(
     async (kind: CanvasKind) => {
       setCreating(true)
@@ -106,6 +131,20 @@ export function BrowserLocalIndexPage({ store, onOpenCanvas }: BrowserLocalIndex
           onOpen={onOpenCanvas}
           onCreate={(kind) => void handleCreate(kind)}
           createDisabled={creating}
+          renderActions={(row) => (
+            <button
+              type="button"
+              aria-label={`Delete ${row.displayName}`}
+              onClick={(event) => {
+                // Prevents the click from bubbling to the wrapping open-button.
+                event.stopPropagation()
+                setPendingDelete({ id: row.slug, displayName: row.displayName })
+              }}
+              className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100"
+            >
+              Delete
+            </button>
+          )}
         />
       ) : (
         // Load failed (error set, snapshots never arrived): creating does
@@ -120,6 +159,17 @@ export function BrowserLocalIndexPage({ store, onOpenCanvas }: BrowserLocalIndex
           Create a canvas
         </button>
       )}
+      <DeleteCanvasDialog
+        pending={pendingDelete}
+        busy={deleting}
+        error={deleteError}
+        description="This permanently removes the canvas from this browser. There is no undo."
+        onCancel={() => {
+          setPendingDelete(null)
+          setDeleteError(null)
+        }}
+        onConfirm={() => void handleConfirmDelete()}
+      />
     </div>
   )
 }

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -19,8 +19,9 @@ interface MockRoutes {
     { workspace?: string; canvases: Record<string, string>; pinned: string[] } | 'fail'
   >
   onCreateCanvas?: (workspaceId: string, slug: string, kind?: string) => void
-  // Return a Response to override the default 200 {ok:true}.
-  onDeleteCanvas?: (workspaceId: string, slug: string) => Response | undefined
+  // Return a Response (or a pending promise of one) to override the
+  // default 200 {ok:true}.
+  onDeleteCanvas?: (workspaceId: string, slug: string) => Response | Promise<Response> | undefined
   snapshotByCanvas?: Record<string, Uint8Array>
   onUpdateCanvas?: (workspaceId: string, slug: string, bytes: Uint8Array) => void
   onSetCanvasName?: (workspaceId: string, slug: string, name: string) => void
@@ -944,6 +945,43 @@ describe('DaemonIndexPage', () => {
     expect(deleted).toEqual(['alpha'])
     await waitFor(() => expect(screen.queryByText('alpha')).toBeNull())
     expect(screen.getByText('beta')).toBeTruthy()
+  })
+
+  it('sends exactly one DELETE for two confirm presses inside a single tick', async () => {
+    // Same mechanism as the create tests: React flushes `deleting` before a
+    // second click can dispatch on the now-disabled confirm button.
+    let resolveDelete: ((res: Response) => void) | undefined
+    const deleted: string[] = []
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      onDeleteCanvas: (_ws, slug) => {
+        deleted.push(slug)
+        return new Promise<Response>((resolve) => {
+          resolveDelete = resolve
+        })
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete alpha' }))
+    const confirm = within(await screen.findByRole('alertdialog')).getByRole('button', {
+      name: 'Delete',
+    })
+    // No await between them: the disabled flush is the guard under test.
+    fireEvent.click(confirm)
+    fireEvent.click(confirm)
+
+    await waitFor(() => expect(deleted).toEqual(['alpha']))
+    resolveDelete?.(jsonResponse({ ok: true }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(deleted).toEqual(['alpha'])
   })
 
   it('a failed Delete shows the sanitized error in the dialog and refreshes after dismissal', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -19,6 +19,8 @@ interface MockRoutes {
     { workspace?: string; canvases: Record<string, string>; pinned: string[] } | 'fail'
   >
   onCreateCanvas?: (workspaceId: string, slug: string, kind?: string) => void
+  // Return a Response to override the default 200 {ok:true}.
+  onDeleteCanvas?: (workspaceId: string, slug: string) => Response | undefined
   snapshotByCanvas?: Record<string, Uint8Array>
   onUpdateCanvas?: (workspaceId: string, slug: string, bytes: Uint8Array) => void
   onSetCanvasName?: (workspaceId: string, slug: string, name: string) => void
@@ -46,6 +48,13 @@ function installFetchMock(routes: MockRoutes) {
       const body = JSON.parse(String(init.body)) as { slug: string; kind?: string }
       routes.onCreateCanvas?.(workspaceId, body.slug, body.kind)
       return Promise.resolve(jsonResponse({ slug: body.slug }))
+    }
+    const canvasDeleteMatch = url.match(/\/api\/workspaces\/([^/]+)\/canvases\/([^/]+)$/)
+    if (canvasDeleteMatch && init?.method === 'DELETE') {
+      const workspaceId = decodeURIComponent(canvasDeleteMatch[1])
+      const slug = decodeURIComponent(canvasDeleteMatch[2])
+      const override = routes.onDeleteCanvas?.(workspaceId, slug)
+      return Promise.resolve(override ?? jsonResponse({ ok: true }))
     }
     const namesMatch = url.match(/\/api\/workspaces\/([^/]+)\/names$/)
     if (namesMatch) {
@@ -867,6 +876,109 @@ describe('DaemonIndexPage', () => {
 
     expect(created).toEqual(['untitled', 'untitled-2'])
     expect(onOpenCanvas).toHaveBeenCalledWith('ws-a', 'untitled-2')
+  })
+
+  it('Delete opens an AlertDialog naming the canvas; Cancel sends no DELETE', async () => {
+    const deleted: string[] = []
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      namesByWorkspace: { 'ws-a': { canvases: { alpha: 'Alpha Board' }, pinned: [] } },
+      onDeleteCanvas: (_ws, slug) => {
+        deleted.push(slug)
+        return undefined
+      },
+    })
+    const onOpenCanvas = vi.fn()
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={onOpenCanvas} />, {
+      container: document.body,
+    })
+    await screen.findByText('Alpha Board')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Alpha Board' }))
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/Delete "Alpha Board"\?/)).toBeTruthy()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(deleted).toEqual([])
+    expect(screen.getByText('Alpha Board')).toBeTruthy()
+    expect(onOpenCanvas).not.toHaveBeenCalled()
+  })
+
+  it('confirming Delete sends DELETE and the card disappears from the refreshed list', async () => {
+    const deleted: string[] = []
+    let rows = [
+      { slug: 'alpha', updatedAt: new Date().toISOString() },
+      { slug: 'beta', updatedAt: new Date().toISOString() },
+    ]
+    const routes: Parameters<typeof installFetchMock>[0] = {
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        get 'ws-a'() {
+          return rows
+        },
+      },
+      onDeleteCanvas: (_ws, slug) => {
+        deleted.push(slug)
+        rows = rows.filter((r) => r.slug !== slug)
+        return undefined
+      },
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete alpha' }))
+    fireEvent.click(
+      within(await screen.findByRole('alertdialog')).getByRole('button', { name: 'Delete' }),
+    )
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(deleted).toEqual(['alpha'])
+    await waitFor(() => expect(screen.queryByText('alpha')).toBeNull())
+    expect(screen.getByText('beta')).toBeTruthy()
+  })
+
+  it('a failed Delete shows the sanitized error in the dialog and refreshes after dismissal', async () => {
+    let listFetches = 0
+    let rows = [{ slug: 'alpha', updatedAt: new Date().toISOString() }]
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      canvasesByWorkspace: {
+        get 'ws-a'() {
+          listFetches += 1
+          return rows
+        },
+      },
+      onDeleteCanvas: () => jsonResponse({ title: 'Canvas not found' }, 404),
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+    const fetchesBefore = listFetches
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete alpha' }))
+    const dialog = await screen.findByRole('alertdialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    // The dialog stays open showing the daemon's sanitized title...
+    expect(await within(dialog).findByText('Canvas not found')).toBeTruthy()
+    // ...and dismissing it refreshes the list so a stale row (404 = already
+    // gone on the daemon) cannot linger.
+    rows = []
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    await waitFor(() => expect(listFetches).toBeGreaterThan(fetchesBefore))
+    await waitFor(() => expect(screen.queryByText('alpha')).toBeNull())
   })
 
   it('has no Storage tab — storage and pairing live in Settings (design refactor D2)', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { z } from 'zod'
 import { CanvasThumb } from '../components/CanvasThumb.js'
 import { CanvasListView } from '../components/canvas-list/CanvasListView.js'
+import { DeleteCanvasDialog } from '../components/canvas-list/DeleteCanvasDialog.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 import { SettingsPanel } from '../components/settings/SettingsPanel.js'
@@ -14,6 +15,7 @@ import { useThemeMode } from '../hooks/useThemeMode.js'
 import {
   createCanvas,
   createDaemonFetch,
+  deleteCanvas,
   getCanvasSnapshot,
   listCanvases,
   listWorkspaces,
@@ -277,6 +279,44 @@ export function DaemonIndexPage({
     [daemonFetch, daemonBaseUrl, selectedWorkspace, rows, loadWorkspace, duplicatingSlug],
   )
 
+  const [pendingDelete, setPendingDelete] = useState<{
+    slug: string
+    displayName: string
+  } | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  // Dismissing the dialog always refreshes the list: after a success the row
+  // must go, and after a FAILURE the daemon's state is unknown from here —
+  // a 404 means the canvas was already gone (another tab, an agent), and a
+  // stale row lingering after any failed delete is worse than one refetch.
+  const closeDeleteDialog = useCallback(() => {
+    setPendingDelete(null)
+    setDeleteError(null)
+    const workspaceAtStart = selectedWorkspace
+    if (!workspaceAtStart) return
+    const isStale = () => selectedWorkspaceRef.current !== workspaceAtStart
+    void loadWorkspace(workspaceAtStart, isStale)
+  }, [selectedWorkspace, loadWorkspace])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return
+    const workspaceAtStart = selectedWorkspace
+    if (!workspaceAtStart) return
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteCanvas(daemonFetch, daemonBaseUrl, workspaceAtStart, pendingDelete.slug)
+      closeDeleteDialog()
+    } catch (err) {
+      // daemon-api-client errors are already sanitized (problem-details
+      // title or a generic status message) — safe to surface directly.
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete canvas.')
+    } finally {
+      setDeleting(false)
+    }
+  }, [daemonFetch, daemonBaseUrl, selectedWorkspace, pendingDelete, closeDeleteDialog])
+
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       <div className="flex h-full flex-col overflow-y-auto p-4">
@@ -411,23 +451,44 @@ export function DaemonIndexPage({
                 <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
               )}
               renderActions={(row) => (
-                <button
-                  type="button"
-                  aria-label={`Duplicate ${row.displayName}`}
-                  disabled={duplicatingSlug === row.slug}
-                  onClick={(event) => {
-                    // Prevents the click from bubbling to the wrapping open-button.
-                    event.stopPropagation()
-                    void handleDuplicate(row.slug)
-                  }}
-                  className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-100 disabled:cursor-not-allowed"
-                >
-                  Duplicate
-                </button>
+                <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                  <button
+                    type="button"
+                    aria-label={`Duplicate ${row.displayName}`}
+                    disabled={duplicatingSlug === row.slug}
+                    onClick={(event) => {
+                      // Prevents the click from bubbling to the wrapping open-button.
+                      event.stopPropagation()
+                      void handleDuplicate(row.slug)
+                    }}
+                    className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100"
+                  >
+                    Duplicate
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${row.displayName}`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setPendingDelete({ slug: row.slug, displayName: row.displayName })
+                    }}
+                    className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent"
+                  >
+                    Delete
+                  </button>
+                </div>
               )}
             />
           </div>
         )}
+        <DeleteCanvasDialog
+          pending={pendingDelete}
+          busy={deleting}
+          error={deleteError}
+          description="This permanently removes the canvas, including its versions and branches. There is no undo."
+          onCancel={closeDeleteDialog}
+          onConfirm={() => void handleConfirmDelete()}
+        />
         <SettingsPanel
           open={settingsOpen}
           onOpenChange={setSettingsOpen}


### PR DESCRIPTION
Top layer of the S8 stack (base: #620, the DELETE route + store deletion). Wires the whole feature to users on both shipped list pages.

- **Shared `DeleteCanvasDialog`** (Radix AlertDialog): names the canvas, destructive confirm, pinned while the request is in flight (the version-restore dialog's double-fire rule).
- **Daemon gallery**: Delete beside Duplicate in the card actions; dismissing the dialog ALWAYS refreshes the list — after success the row must go, and after a failure the daemon's state is unknown (a 404 means another tab or an agent already deleted it), so a stale row can never linger. Client `deleteCanvas` parses the base branch's `deleteCanvasResponseSchema` (closing its knip placeholder).
- **Browser-local list**: Delete via the store's unconditional `removeCanvas`; deleting the resumed canvas deliberately leaves a dangling default pointer for the editor's existing dead-id fallback.
- jsdom pins: dialog-not-confirm invariant (cancel leaves everything untouched), confirm+refresh, error copy fixed (never raw error text), stopPropagation. The real-IndexedDB `web-browser` flow test now ends by deleting both canvases through the real dialog back to the empty state.
- Verified live in Chrome against a real daemon (create → cancel → confirm → survivor remains; list refreshed) and in browser-local (create → delete → empty state).

Note from live verification: a closed dialog appears to linger when the tab is **hidden** — that is Chrome freezing CSS animations in background tabs (exit-animation-gated unmount), not a product behavior; visible tabs (and the Playwright tests) unmount normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete canvases from browser-local and daemon-backed canvas lists.
  * Added confirmation dialogs with cancel and confirm actions.
  * Lists refresh after successful deletion, including returning to the empty state when the last canvas is removed.
  * Deletion controls prevent duplicate submissions and navigation while processing.
  * Clear, sanitized errors remain visible when deletion fails.

* **Tests**
  * Added coverage for cancellation, successful deletion, empty states, loading behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->