### PR TITLE
feat(web): Copy as JSON Canvas from the canvas operations kebab

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.export.browser.test.tsx
@@ -148,10 +148,11 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
     expect(Array.isArray(parsed.nodes)).toBe(true)
   })
 
-  // The menu must only offer formats `exportScene` (SceneExportFormat) can
-  // actually produce — an entry outside that union is an affordance whose
-  // every click fails.
-  it('never renders a JSON/Excalidraw export menu item', async () => {
+  // Export DOWNLOADS must only offer formats `exportScene`
+  // (SceneExportFormat) can actually produce — a download entry outside
+  // that union is an affordance whose every click fails. Copy as JSON
+  // Canvas is a clipboard action, not a download, and is exempt.
+  it('never renders a JSON/Excalidraw export download entry', async () => {
     await renderLoaded()
     fireEvent.pointerDown(screen.getByLabelText('More actions'), {
       button: 0,
@@ -159,6 +160,7 @@ describe('BrowserLocalCanvasPage export (browser — real SpatialEditor, no Exca
     })
     await waitFor(() => expect(screen.getByText('Export as PNG')).toBeInTheDocument())
 
-    expect(screen.queryByText(/json|excalidraw/i)).toBeNull()
+    expect(screen.queryByText(/excalidraw/i)).toBeNull()
+    expect(screen.queryByText(/export as json/i)).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -319,6 +319,31 @@ describe('BrowserLocalCanvasPage', () => {
     expect((await canvasOpsItem(/duplicate/i)).getAttribute('aria-disabled')).toBeNull()
   })
 
+  it('Copy as JSON Canvas puts the extended document on the clipboard', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    const written: string[] = []
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: (text: string) => {
+          written.push(text)
+          return Promise.resolve()
+        },
+      },
+    })
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} />)
+    })
+    await openCanvasOpsMenu()
+    fireEvent.pointerUp(await canvasOpsItem(/copy as json canvas/i))
+    await waitFor(() => expect(written).toHaveLength(1))
+    const parsed = JSON.parse(written[0] as string) as { nodes: unknown[]; edges: unknown[] }
+    expect(Array.isArray(parsed.nodes)).toBe(true)
+    expect(Array.isArray(parsed.edges)).toBe(true)
+  })
+
   it('export lives in the canvas row kebab, not the top bar menu', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,6 @@
+import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
-import { Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
+import { Braces, Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
@@ -459,6 +460,19 @@ export function BrowserLocalCanvasPage({
           <DropdownMenuItem onSelect={() => void handleExport('svg')}>
             <Download aria-hidden="true" className="size-3.5" />
             Export as SVG
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              // Text on the clipboard survives any chat/paste channel intact,
+              // which a binary download cannot — the phone-friendly way to
+              // hand the exact canvas (coordinates included) to a debugger.
+              void navigator.clipboard
+                ?.writeText(serializeSpatial(canvas, 'extended'))
+                .catch(() => {})
+            }}
+          >
+            <Braces aria-hidden="true" className="size-3.5" />
+            Copy as JSON Canvas
           </DropdownMenuItem>
           <DropdownMenuItem disabled={isDuplicating} onSelect={() => void handleDuplicate()}>
             <Copy aria-hidden="true" className="size-3.5" />

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -18,6 +18,10 @@ The web editor's canvas row (More actions → Export) saves the current canvas a
 SVG or PNG, rendered with the light theme regardless of the UI theme so an
 export's bytes never depend on a display preference.
 
+**Copy as JSON Canvas** (same menu) puts the extended-mode JSON Canvas
+document on the clipboard as plain text — the quickest way to hand the exact
+canvas to another tool or a debugging session from any device.
+
 **PNG exports are editable images**: the file embeds the canvas's JSON Canvas
 document (extended mode, `x-whiteboard` included) in a PNG `iTXt` chunk under
 the `whiteboard` keyword — the same pattern draw.io uses. A shared PNG


### PR DESCRIPTION
## What

Adds **Copy as JSON Canvas** to the canvas row's More actions kebab, next to the export entries: one tap puts the extended-mode JSON Canvas document (x-whiteboard included, exact coordinates) on the clipboard as plain text.

Motivation: the owner debugs from a phone, where a PNG/SVG file cannot reach a debugging session intact (chat attachments rasterize), but pasted text can. This closes the repro loop the PNG-embedded document (#619) opened for desktop.

## Tests

- New jsdom test: the kebab item writes a parseable JSON Canvas document (nodes/edges arrays) to the clipboard.
- apps/web jsdom 1820 green; lint clean. Docs: `export-formats.md` mentions the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
