### PR TITLE
fix(render): keep embedded-canvas line jumps inside the frame

### DIFF
--- a/packages/canvas-render/src/layout/scale-scene.test.ts
+++ b/packages/canvas-render/src/layout/scale-scene.test.ts
@@ -57,6 +57,30 @@ describe('scaleScene', () => {
     ])
   })
 
+  it('scales edge line-jump points together with the path', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 10 },
+            { x: 100, y: 10 },
+          ],
+          jumps: [{ segment: 0, x: 40, y: 10 }],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    const half = scaleScene(scene, 0.5)
+    const edge = half.nodes[0]
+    if (edge.kind !== 'edge') throw new Error('edge expected')
+    expect(edge.jumps).toEqual([{ segment: 0, x: 20, y: 5 }])
+  })
+
   it('scales wrapper-relative children by the same factor (uniform scaling commutes with the x-transform boundary)', () => {
     // listItem children store x RELATIVE to the wrapper; uniform scaling
     // about the origin scales wrapper offset and relative offset alike, so

--- a/packages/canvas-render/src/layout/scale-scene.ts
+++ b/packages/canvas-render/src/layout/scale-scene.ts
@@ -50,6 +50,9 @@ function scaleNode(node: ScalableNode, f: number): ScalableNode {
       return {
         ...node,
         path: node.path.map((point) => ({ x: point.x * f, y: point.y * f })),
+        ...(node.jumps !== undefined
+          ? { jumps: node.jumps.map((jump) => ({ ...jump, x: jump.x * f, y: jump.y * f })) }
+          : {}),
         appearance: scaleAppearance(node.appearance, f),
       }
     case 'textRun':

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -105,6 +105,40 @@ describe('file-node inline embeds', () => {
     expect(embedOf(unresolvable)).toBeUndefined()
   })
 
+  it("keeps a line-jump child's hop points inside the frame (jumps transform with the path)", () => {
+    // Two crossing edges in a large child force a jump; laid out at native
+    // size the hop sits at child coordinates far outside the parent frame,
+    // so a scale/translate that misses `jumps` draws the arc outside it.
+    const crossing: SpatialCanvas = {
+      nodes: [
+        { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: '' },
+        { id: 'b', type: 'text', x: 400, y: 0, width: 100, height: 50, text: '' },
+        { id: 'c', type: 'text', x: 200, y: -300, width: 100, height: 50, text: '' },
+        { id: 'd', type: 'text', x: 200, y: 300, width: 100, height: 50, text: '' },
+      ],
+      edges: [
+        { id: 'h', fromNode: 'a', toNode: 'b' },
+        { id: 'v', fromNode: 'c', toNode: 'd' },
+      ],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal', lineJumps: 'arc' } },
+    }
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({ resolveFileCanvas: () => crossing, expandFileNode: () => true }),
+    )
+    const edges = (embedOf(scene)?.children ?? []).filter(
+      (n): n is import('../scene-graph.js').ResolvedEdgeNode => n.kind === 'edge',
+    )
+    const jumps = edges.flatMap((edge) => edge.jumps ?? [])
+    expect(jumps.length).toBeGreaterThan(0)
+    for (const jump of jumps) {
+      expect(jump.x).toBeGreaterThanOrEqual(100)
+      expect(jump.x).toBeLessThanOrEqual(320)
+      expect(jump.y).toBeGreaterThanOrEqual(100)
+      expect(jump.y).toBeLessThanOrEqual(280)
+    }
+  })
+
   it('degrades a cycle on the current path to the card instead of recursing forever', () => {
     const a: SpatialCanvas = { nodes: [fileNode({ id: 'fa', file: 'b' })], edges: [] }
     const b: SpatialCanvas = { nodes: [fileNode({ id: 'fb', file: 'a' })], edges: [] }

--- a/packages/canvas-render/src/layout/translate-scene.test.ts
+++ b/packages/canvas-render/src/layout/translate-scene.test.ts
@@ -3,6 +3,7 @@ import type {
   ListBlockNode,
   ListItemNode,
   ParagraphBlockNode,
+  ResolvedEdgeNode,
   Scene,
   TableBlockNode,
 } from '../scene-graph.js'
@@ -63,6 +64,29 @@ describe('translateScene', () => {
     expect(item.bbox.x).toBe(24 + 10)
     const paragraph = item.children[0]! as ParagraphBlockNode
     expect(paragraph.bbox.x).toBe(0) // unchanged: relative to the item's own transform
+  })
+
+  it('shifts edge line-jump points together with the path', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 10 },
+            { x: 100, y: 10 },
+          ],
+          jumps: [{ segment: 0, x: 40, y: 10 }],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'arrow',
+        },
+      ],
+    }
+    const shifted = translateScene(scene, 5, 7)
+    const edge = shifted.nodes[0] as ResolvedEdgeNode
+    expect(edge.jumps).toEqual([{ segment: 0, x: 45, y: 17 }])
   })
 
   it('composes additively: translate(translate(s,a,b),c,d) === translate(s,a+c,b+d)', () => {

--- a/packages/canvas-render/src/layout/translate-scene.ts
+++ b/packages/canvas-render/src/layout/translate-scene.ts
@@ -61,6 +61,15 @@ function translateNode(
     return {
       ...node,
       path: node.path.map((point) => ({ x: point.x + appliedDx, y: point.y + dy })),
+      ...(node.jumps !== undefined
+        ? {
+            jumps: node.jumps.map((jump) => ({
+              ...jump,
+              x: jump.x + appliedDx,
+              y: jump.y + dy,
+            })),
+          }
+        : {}),
     }
   }
 


### PR DESCRIPTION
## Problem

Embedding a canvas whose edge routing uses `lineJumps: 'arc'` produced runaway edges: long lines shooting from far outside the embed frame into its interior (reported with real user data — the `hoge` canvas embedding `test canvas 1`).

## Root cause

A child canvas computes its line-jump hop points in **child coordinates** during its own layout. `composeFileEmbed` then scales and translates the child scene into the parent frame, but `scaleScene` and `translateScene` transformed only the edge `path` — the `jumps` stayed in the old coordinate space. The SVG backend then drew each arc hop from the scaled segment out to an unscaled child coordinate and back, e.g. `L 423.8 588.7 L 408.7 68 A 5 5 0 0 0 418.7 68 L 474.8 588.7`.

## Fix

Transform `jumps` alongside `path` in both `scaleScene` and `translateScene` (translate honors the same x-transform-boundary `appliedDx` as the path).

## Tests

- Unit pins in `scale-scene.test.ts` / `translate-scene.test.ts`: jump points scale/shift with the path.
- Composition pin in `spatial-embed.test.ts`: a crossing child with `lineJumps: 'arc'` keeps every hop point inside the parent frame. Mutation-checked red against each fix reverted individually.
- Reproduced and verified with the reporter's real canvas JSON in a browser-mode harness (screenshots below).

## Visual repro

Before — jump arcs anchored at unscaled child coordinates shoot out of the embed:

![embed-jumps-before.png](https://github.com/user-attachments/assets/83ff863c-0fb5-4794-8949-17bd9c65be6a)

After — hops stay on their segments inside the miniature:

![embed-jumps-after.png](https://github.com/user-attachments/assets/bde436b3-6a8a-4fec-9496-736d509820c0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ