### PR TITLE
test(web): stop the fullscreen-ground test racing a sibling file's IndexedDB wipe

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
@@ -9,8 +9,11 @@
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { MemoryStore } from '../lib/browser-local-store.js'
+import { BrowserLocalCanvasPage } from '../pages/BrowserLocalCanvasPage.js'
 import WorkspaceTopBar from './WorkspaceTopBar.js'
 import '../index.css'
 
@@ -76,14 +79,14 @@ describe('top bar scopes', () => {
 
 describe('fullscreen ground', () => {
   it('paints the fullscreen target itself, not just the body behind it', async () => {
-    const { BrowserLocalCanvasPage } = await import('../pages/BrowserLocalCanvasPage.js')
-    const { IndexedDBStore } = await import('../lib/browser-local-store.js')
-    const { MemoryRouter } = await import('react-router-dom')
-
+    // MemoryStore, not IndexedDBStore: every browser test file shares one
+    // origin, so a sibling file's `indexedDB.deleteDatabase('whiteboard')`
+    // lands mid-load here and the page never leaves its loading state. The
+    // assertion is about a CSS ground, so the storage backend is incidental.
     render(
       <div style={{ height: '400px' }}>
         <MemoryRouter initialEntries={['/']}>
-          <BrowserLocalCanvasPage store={new IndexedDBStore()} />
+          <BrowserLocalCanvasPage store={new MemoryStore()} />
         </MemoryRouter>
       </div>,
     )


### PR DESCRIPTION
## Symptom

`test-browser` failed twice in a row on PR #623 — a **docs-only** branch, so the change could not be the cause:

```
× paints the fullscreen target itself, not just the body behind it   5621ms
× paints the fullscreen target itself, not just the body behind it   6014ms
AssertionError: expected null not to be null
```

The null is `document.querySelector('main')` inside a `waitFor`, and 5621/6014ms against the 5000ms `asyncUtilTimeout` says it timed out rather than asserted. The same file passes 6/6 alone locally, and `main` was green — which is what makes this look like a flake and is exactly why it kept coming back.

## Root cause

The test asserts one thing — that `<main>` paints its own background rather than relying on the body behind it — but reached it by mounting the entire `BrowserLocalCanvasPage` against a real `IndexedDBStore`. `<main>` only renders once the store resolves; before that the page returns `CanvasPageSkeleton`.

Every browser test file shares one origin, and several siblings (`BrowserLocalCanvasPage.export`, `.multi-canvas`, …) call `indexedDB.deleteDatabase('whiteboard')` in `beforeEach`. A delete landing mid-load strands this page in its loading state, so `<main>` never appears at all — not slowly, never. Whether that happens depends on cross-file scheduling, which is why it is load-dependent and why one commit's worth of suite change flipped it.

## Fix

- `MemoryStore` instead of `IndexedDBStore`. It has no cross-file shared state and resolves synchronously. The assertion is about a CSS ground, so the storage backend was always incidental.
- The three in-test `await import(...)` calls become static imports, so the module graph is not transformed inside the `waitFor` either.

The assertion itself is untouched.

## Mutation check

Dropping `bg-background` from `<main>` in `BrowserLocalCanvasPage.tsx`:

```
× paints the fullscreen target itself, not just the body behind it   98ms
AssertionError: expected 'rgba(0, 0, 0, 0)' not to be 'rgba(0, 0, 0, 0)'
```

Still guards the real rule — and now fails in 98ms instead of timing out at 5s, so a genuine regression reports as a regression rather than as a slow machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB