### PR TITLE
docs(adr): as-built addendum on ADR-0007 for the withdrawn display-slug rationale

### DIFF
--- a/docs/contributing/adr/0007-canvas-identity-and-store-split.md
+++ b/docs/contributing/adr/0007-canvas-identity-and-store-split.md
@@ -116,3 +116,13 @@ final storage engine.
 a background reconciler between two live CRDT-backed stores with
 different identity schemes is the most complex option and would ossify
 the split instead of removing it.
+
+## Addendum (2026-08-12): point 3's promotion rationale is withdrawn
+
+[ADR-0008](0008-slug-derivation-and-rename.md) measured what point 3's
+derived display slug actually produces for non-Latin names (mutually
+indistinguishable `untitled-N`) and decided that a slug is never derived
+from a name. The derivation this point said "needs no re-derivation on
+promotion" has been deleted; browser-local rows show the display name
+alone until browser-local canvases have real slugs. Point 3's first
+sentence — one always-present workspace, UUID identity — stands.


### PR DESCRIPTION
ADR-0008's consequences list this follow-through: ADR-0007 point 3 justified the derived display slug by a future "promotion needs no re-derivation", and ADR-0008 withdrew that by deciding slugs are never derived from names (the derivation itself was deleted in #631). Same as-built-addendum convention ADR-0004 uses. Point 3's workspace/UUID half is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw