### PR TITLE
feat(web): watermark the empty canvas gallery with the signature

### DIFF
--- a/apps/web/src/components/canvas-list/CanvasListView.test.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.test.tsx
@@ -180,3 +180,13 @@ describe('CanvasListView', () => {
     expect(onOpen).not.toHaveBeenCalled()
   })
 })
+
+describe('CanvasListView — branded empty state', () => {
+  it('shows the faint signature watermark above the empty-state copy', () => {
+    render(
+      <CanvasListView rows={[]} onCreate={() => {}} onOpen={() => {}} renderThumb={() => null} />,
+    )
+    expect(document.querySelector('[data-mark="empty-squiggle"]')).toBeTruthy()
+    expect(screen.getByText('No canvases yet')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/canvas-list/CanvasListView.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.tsx
@@ -79,6 +79,24 @@ export function CanvasListView({
   if (rows.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 py-16 text-center">
+        {/* The signature as a faint watermark: an empty gallery is the
+            blank board, not an error — the mark stays quiet (BRAND.md). */}
+        <svg
+          data-mark="empty-squiggle"
+          width="150"
+          height="76"
+          viewBox="0 0 88 46"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M20 40 C 27 18, 37 18, 44 29 S 58 46, 68 21"
+            stroke="currentColor"
+            className="text-muted-foreground/30"
+            strokeWidth="4"
+            strokeLinecap="round"
+          />
+        </svg>
         <p className="text-sm font-medium">No canvases yet</p>
         <p className="text-sm text-muted-foreground">Create a canvas and it opens ready to draw.</p>
         <button


### PR DESCRIPTION
## Summary

Lab item E (approved direction E1): the gallery's empty state gains the signature as a **faint watermark** above the existing copy and CTA — an empty gallery is the blank board, not an error, so the mark stays quiet (muted-foreground at 30%). One change point: the shared `CanvasListView`, so both the daemon gallery and the browser-local list get it.

Deliberately **inline SVG**, not a `public/` asset: this mark inherits theme tokens via `currentColor` (follows light/dark), which an `<img>`-embedded file cannot.

## Visual repro

![empty-light.png](https://github.com/user-attachments/assets/fa6888e4-f844-497b-9bb1-a4b74fadad08)
![empty-dark.png](https://github.com/user-attachments/assets/13d61c4d-8376-404f-80d5-7cdab3d02041)

## Tests

- `CanvasListView.test.tsx`: empty state renders the watermark alongside the existing copy.
- typecheck / knip / biome clean; bundle-size gate passes (115.8 KB / 126 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc