### PR TITLE
fix(render): route sliver-overlap facing pairs through the perpendicular L

### DIFF
--- a/packages/canvas-render/src/layout/edge-facing-window.test.ts
+++ b/packages/canvas-render/src/layout/edge-facing-window.test.ts
@@ -1,0 +1,55 @@
+// A facing opposing pair only counts as a zero-bend candidate when the two
+// sides genuinely share a lane wide enough to host an anchor away from the
+// corners. Nodes whose spans merely graze (a sliver of overlap) cannot
+// realize the promised straight segment — the anchors land outside the
+// sliver and the route degrades to a shallow near-horizontal diagonal —
+// so they must take the one-bend L through the perpendicular sides instead.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+// The reported triangle: A above B (fully aligned), C to the right and
+// vertically between them, overlapping both in x by only 20px.
+const NODES: SpatialNode[] = [
+  { id: 'A', type: 'text', x: 100, y: 340, width: 200, height: 100, text: '' },
+  { id: 'B', type: 'text', x: 100, y: 570, width: 200, height: 100, text: '' },
+  { id: 'C', type: 'text', x: 280, y: 460, width: 200, height: 100, text: '' },
+]
+const EDGES: CanvasEdge[] = [
+  { id: 'A-B', fromNode: 'A', toNode: 'B' },
+  { id: 'B-C', fromNode: 'B', toNode: 'C' },
+  { id: 'A-C', fromNode: 'A', toNode: 'C' },
+]
+
+function isAxisAligned(path: readonly { x: number; y: number }[]): boolean {
+  return path.every((p, i) => i === 0 || p.x === path[i - 1]!.x || p.y === path[i - 1]!.y)
+}
+
+describe('facing pairs with a sliver of span overlap', () => {
+  it('route through the perpendicular L, not the unhostable facing lane', () => {
+    const anchors = assignEdgeAnchors(NODES, EDGES, 'straight')
+    const ac = anchors.get('A-C')
+    expect([ac?.fromSide, ac?.toSide]).toEqual(['right', 'top'])
+    const bc = anchors.get('B-C')
+    expect([bc?.fromSide, bc?.toSide]).toEqual(['right', 'bottom'])
+    // The genuinely-aligned pair keeps its zero-bend vertical.
+    const ab = anchors.get('A-B')
+    expect([ab?.fromSide, ab?.toSide]).toEqual(['bottom', 'top'])
+    expect(ab?.from?.x).toBeDefined()
+    expect(ab?.from?.x).toBe(ab?.to?.x)
+  })
+
+  it('orthogonal style realizes the L as a fully rectilinear route', () => {
+    const anchors = assignEdgeAnchors(NODES, EDGES, 'orthogonal')
+    for (const edge of EDGES) {
+      const routed = routeEdge(NODES, edge, 'orthogonal', anchors.get(edge.id))
+      expect(isAxisAligned(routed.path)).toBe(true)
+    }
+  })
+
+  it('straight style draws the L pair as one direct segment, not a stub-diagonal-stub', () => {
+    const anchors = assignEdgeAnchors(NODES, EDGES, 'straight')
+    const routed = routeEdge(NODES, EDGES[2]!, 'straight', anchors.get('A-C'))
+    expect(routed.path.length).toBe(2)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -98,7 +98,16 @@ function facingSides(dx: number, dy: number): readonly [Side, Side, Side, Side] 
  * derivation falls back to the preferred side, so fully-boxed-in nodes
  * keep the old behaviour.
  */
-/** Inset tangent spans of two facing sides overlap — a zero-bend lane exists. */
+/** Minimum shared-lane width for a facing pair to count as zero-bend. A
+ * narrower window forces the aligned anchor into both nodes' corner zones —
+ * the "straight" segment runs down the seam between two corners, or (since
+ * anchors are placed by side fraction, not dragged into the window) is not
+ * realized at all and degrades to a shallow diagonal. Such pairs read far
+ * better through the one-bend perpendicular L. */
+const ZERO_LANE_MIN_OVERLAP_PX = 20
+
+/** Inset tangent spans of two facing sides share a lane wide enough to host
+ * an anchor — a zero-bend segment is actually realizable. */
 function facingSpansOverlap(fromRect: Rect, toRect: Rect, axis: 'h' | 'v'): boolean {
   const span = (r: Rect): readonly [number, number] =>
     axis === 'h'
@@ -112,7 +121,7 @@ function facingSpansOverlap(fromRect: Rect, toRect: Rect, axis: 'h' | 'v'): bool
         ]
   const [aLo, aHi] = span(fromRect)
   const [bLo, bHi] = span(toRect)
-  return Math.max(aLo, bLo) <= Math.min(aHi, bHi)
+  return Math.min(aHi, bHi) - Math.max(aLo, bLo) >= ZERO_LANE_MIN_OVERLAP_PX
 }
 
 /**


### PR DESCRIPTION
## Problem

In the reported triangle (two stacked nodes, a third to the right whose x-range overlaps them by only 20px), edges to the right node drew shallow near-horizontal diagonals instead of exiting the right side and connecting with one corner.

## Root cause

`rankedSidePairs` counted a facing opposing pair as a zero-bend candidate whenever the two sides' inset spans overlapped **at all — even at a single point**. Anchors are placed by side fraction and never dragged into that shared window, so the promised straight segment was unrealizable: straight style degraded to a stub-diagonal-stub (a ~8° near-horizontal line), orthogonal style to a corner-grazing route down the seam between the two nodes' corners. The side optimizer could not correct it either, because a crossing-free, overlap-free canvas deliberately skips optimization (side stability).

## Fix

A facing pair only ranks as zero-bend when the shared lane is at least `ZERO_LANE_MIN_OVERLAP_PX` (20px) wide — wide enough to host an anchor away from both corner zones. Narrower slivers fall through to the one-bend perpendicular L: exit right, one corner, enter top/bottom — exactly the reported expectation.

Pinned with the reported triangle: side assignment (right→top / right→bottom, and the genuinely-aligned pair keeps its zero-bend vertical), fully rectilinear orthogonal realization, and straight-style drawing the L pair as one direct segment. Red-first; full canvas-render + viewer + server-core suites pass.

## Visual repro (reporter's exact JSON)

**Orthogonal** — before: corner-seam arrivals / after: right exit, one corner:

![triangle-orthogonal-before.png](https://github.com/user-attachments/assets/c3e30fec-5c6a-431f-a71a-c6590daf8b35)
![triangle-orthogonal-after.png](https://github.com/user-attachments/assets/b8bb2064-eec2-4bb1-96f1-3e28ae1f46bf)

**Straight (the canvas's default)** — before: shallow stub-diagonal-stub / after: one deliberate direct segment:

![triangle-straight-before.png](https://github.com/user-attachments/assets/c6754f68-6192-418e-a030-441c8a005e13)
![triangle-straight-after.png](https://github.com/user-attachments/assets/e73757a1-fefe-448c-93c8-037b22e8a539)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ