### PR TITLE
feat(canvas-viewer): mini splash while the widget mounts

### DIFF
--- a/packages/canvas-viewer/canvas-viewer.widget.html
+++ b/packages/canvas-viewer/canvas-viewer.widget.html
@@ -16,10 +16,53 @@
         margin: 0;
         overflow: hidden;
       }
+
+      /* Mini splash (BRAND.md): the bare signature drawing itself once,
+         then breathing, centered in the fixed-height root until the viewer
+         mounts and React's first commit replaces it. Fully inline — the
+         widget is a self-contained single file — and mid-gray because the
+         host's theme is unknown here. */
+      .wb-widget-splash {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .wb-widget-splash svg {
+        transform-box: fill-box;
+        transform-origin: center;
+        animation: wb-widget-breathe 3.2s ease-in-out 1.4s infinite;
+      }
+      .wb-widget-splash path {
+        stroke-dasharray: 80;
+        stroke-dashoffset: 0;
+        animation: wb-widget-draw 1.2s ease-out;
+      }
+      @keyframes wb-widget-draw {
+        from {
+          stroke-dashoffset: 80;
+        }
+      }
+      @keyframes wb-widget-breathe {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.6;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .wb-widget-splash svg,
+        .wb-widget-splash path {
+          animation: none;
+        }
+      }
     </style>
   </head>
   <body>
-    <div id="root" style="width: 100%; height: 480px"></div>
+    <div id="root" style="width: 100%; height: 480px"><div class="wb-widget-splash" role="status" aria-label="Loading canvas"><svg width="88" height="56" viewBox="0 0 88 56" fill="none" aria-hidden="true"><path d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" stroke="#8a8a8a" stroke-width="3.5" stroke-linecap="round"/></svg></div></div>
     <!--
       Embedded-scene slot (see mountCanvasViewer's readEmbeddedScene). Empty
       by default; a downstream export/widget-bundling step replaces this

--- a/packages/canvas-viewer/src/widget/widget-splash.test.ts
+++ b/packages/canvas-viewer/src/widget/widget-splash.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// The widget is a self-contained single file; until mountCanvasViewer's
+// first commit replaces #root's children, whatever sits inside #root is the
+// loading state. These pin the mini-splash contract (BRAND.md): the bare
+// signature, drawn once then breathing, no container (the widget frame IS
+// the container), fully inline (no external resources), reduced-motion
+// collapses to the static mark.
+const html = readFileSync(new URL('../../canvas-viewer.widget.html', import.meta.url), 'utf8')
+
+describe('widget mini splash', () => {
+  it('paints the splash INSIDE #root so the viewer mount replaces it', () => {
+    const root = html.slice(html.indexOf('<div id="root"'), html.indexOf('</body>'))
+    expect(root).toContain('wb-widget-splash')
+  })
+
+  it('draws once and breathes (no redraw loop)', () => {
+    expect(html).toMatch(/animation:[^;]*wb-widget-draw/)
+    expect(html).not.toMatch(/wb-widget-draw[^;]*infinite/)
+    expect(html).toMatch(/wb-widget-breathe[^;]*infinite/)
+  })
+
+  it('neutralizes the animation under prefers-reduced-motion', () => {
+    const idx = html.indexOf('prefers-reduced-motion: reduce')
+    expect(idx).toBeGreaterThan(-1)
+    expect(html.slice(idx)).toContain('animation: none')
+  })
+})


### PR DESCRIPTION
## Summary

Lab item F (approved F1): the MCP Apps widget's `#root` was a blank 480px box until `mountCanvasViewer`'s first commit. It now holds the signature drawing itself once (1.2s) then breathing — the boot splash's grammar at widget scale, **frameless** because the widget frame IS the container.

Constraints honored: fully inline CSS + SVG (the widget is a self-contained single file — external assets are impossible here), fixed mid-gray (the host's theme is unreachable), `prefers-reduced-motion` collapses to the static drawn mark, and React's first commit replaces the splash with zero removal code — the same pattern as the app's index.html.

Pinned by `widget-splash.test.ts` next to the existing resource-position (`check-html`) and shell-height guards, which all still pass; `smoke:widget` (zero network requests, srcdoc hosting) passes on the built single file.

## Visual repro

The widget's pre-mount state (built file with the module script stripped — what a slow host shows):

![widget-splash.png](https://github.com/user-attachments/assets/cb1a124b-3a59-472b-a086-dda71dde7b9b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc