### PR TITLE
docs(mcp): put the brand mark on the npm package page

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <!-- Absolute URL on purpose: npm renders this README and resolves no
+       relative repo paths. -->
+  <img src="https://raw.githubusercontent.com/kamiazya/whiteboard/main/docs/assets/readme-mark.svg" alt="Whiteboard" width="200" height="169" />
+</p>
+
 # `@kamiazya/whiteboard-mcp`
 
 OpenCanvas-based whiteboard MCP server for Claude Code, Codex, and other MCP hosts.


### PR DESCRIPTION
## Summary

Lab item H: the `@kamiazya/whiteboard-mcp` README (which is the npm package page) opened with a bare heading. It now leads with the framed, captioned mark — the same `docs/assets/readme-mark.svg` the repo README embeds — via an **absolute** raw.githubusercontent URL, since npm resolves no relative repo paths. If npm's sanitizer strips the SVG's CSS animation, it degrades to the static drawn mark, never to a broken image.

Docs-only change; verifiable on the next npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered Whiteboard logo to the MCP server README.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->