### PR TITLE
fix(web): stop the ?new=canvas shortcut leaking real IndexedDB access in jsdom

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -973,7 +973,7 @@ describe('?new=canvas launch shortcut', () => {
     window.history.replaceState(null, '', '/?new=canvas')
     rtlRender(
       <MemoryRouter initialEntries={['/?new=canvas']}>
-        <BrowserLocalCanvasPage store={store} />
+        <BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />
       </MemoryRouter>,
     )
     await waitFor(async () => {
@@ -985,9 +985,34 @@ describe('?new=canvas launch shortcut', () => {
 
   it('does not create extras on a plain load', async () => {
     const store = new MemoryStore()
-    render(<BrowserLocalCanvasPage store={store} />)
+    render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
     await waitFor(async () => {
       expect((await store.listCanvases()).length).toBe(1)
     })
+  })
+
+  it('a failed create rolls back the canvas and still strips the param', async () => {
+    // The shortcut create is fire-and-forget; a rejected Loro save must be
+    // caught by the page (not surface as an unhandled rejection) and the
+    // controller's rollback must remove the half-created metadata row.
+    class RejectingLoroStore extends FakeLoroStore {
+      override async save(): Promise<void> {
+        throw new Error('loro save failed')
+      }
+    }
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    window.history.replaceState(null, '', '/?new=canvas')
+    rtlRender(
+      <MemoryRouter initialEntries={['/?new=canvas']}>
+        <BrowserLocalCanvasPage store={store} loro={new RejectingLoroStore()} />
+      </MemoryRouter>,
+    )
+    expect(window.location.search).not.toContain('new=canvas')
+    await waitFor(async () => {
+      expect((await store.listCanvases()).length).toBe(1)
+    })
+    window.history.replaceState(null, '', '/')
   })
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -361,7 +361,11 @@ export function BrowserLocalCanvasPage({
       '',
       window.location.pathname + (rest ? `?${rest}` : ''),
     )
-    void createCanvas()
+    // Fire-and-forget: the failure path already rolls back inside
+    // createCanvas, so the shortcut degrades to a plain load.
+    createCanvas().catch((err) => {
+      log.error('launcher shortcut create failed', err)
+    })
   }, [createCanvas])
 
   // Tab favicon: persistence state as the status dot (degraded reads as


### PR DESCRIPTION
## Problem

`test-jsdom` went red on **main** after #648 merged ([run 31559058952](https://github.com/kamiazya/whiteboard/actions/runs/31559058952)): all 1849 tests pass, but one **Unhandled Rejection** fails the run:

```
ReferenceError: indexedDB is not defined
 ❯ src/lib/browser-idb.ts:64:17
 ❯ LoroStore.save src/lib/loro-store.ts:135:22
 ❯ src/pages/use-browser-local-canvas-controller.ts:327:31
```

The two `?new=canvas` page tests added in #648 never injected `FakeLoroStore`, so the shortcut's fire-and-forget `createCanvas()` fell through to the real `LoroStore` → `indexedDB.open` (jsdom has no IndexedDB) and rejected **after the test finished**. Timing-dependent, which is why the PR run was green and main went red.

## Fix

- Inject `FakeLoroStore` in both shortcut tests (root cause).
- Catch the shortcut's fire-and-forget create in `BrowserLocalCanvasPage` and `log.error` it — a rejected create already rolls back inside `createCanvas`, so the shortcut degrades to a plain load instead of surfacing an unhandled rejection in production too.
- Pin the catch with a rejecting-loro test: **red without the catch** (the unhandled rejection reproduces deterministically), green with it. The same test asserts the canvas count returns to 1, covering the controller's metadata rollback.

## Verification

- `pnpm vitest run` (apps/web): 157 files / 1850 tests passed, **0 errors** (was 1 unhandled error)
- `pnpm test --project mcp-node`: 261 files / 3235 passed
- `pnpm --filter @kamiazya/whiteboard-web typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc