### PR TITLE
fix(mcp-server): close the unlocked getDoc->saveCanvas race in ws, restore, and merge

### DIFF
--- a/packages/mcp-server/src/server/app.merge-race.test.ts
+++ b/packages/mcp-server/src/server/app.merge-race.test.ts
@@ -123,14 +123,8 @@ describe('performMerge vs rename race', () => {
     // while the merge request is paused mid-flight, matching the real
     // race: the read resolves before the rename runs, the write happens
     // after.
-    let releaseGetDoc: () => void = () => undefined
-    const getDocGate = new Promise<void>((resolve) => {
-      releaseGetDoc = resolve
-    })
-    let signalGetDocCalled: () => void = () => undefined
-    const getDocCalled = new Promise<void>((resolve) => {
-      signalGetDocCalled = resolve
-    })
+    const { promise: getDocGate, resolve: releaseGetDoc } = Promise.withResolvers<void>()
+    const { promise: getDocCalled, resolve: signalGetDocCalled } = Promise.withResolvers<void>()
     const actual =
       await vi.importActual<typeof import('./store/doc-cache.js')>('./store/doc-cache.js')
     vi.mocked(getDoc).mockImplementationOnce(async (workspaceId, slug) => {

--- a/packages/mcp-server/src/server/app.merge-race.test.ts
+++ b/packages/mcp-server/src/server/app.merge-race.test.ts
@@ -1,0 +1,174 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { encodeFrontiers, LoroDoc, LoroMap } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from './routes/_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-app-merge-race-')
+
+vi.mock('./config.js', () => ({
+  get DATA_DIR() {
+    return join(tmp.dir, 'data')
+  },
+  getDataDir: () => join(tmp.dir, 'data'),
+  get DIST_WEB_APP_DIR() {
+    return join(tmp.dir, 'web-app')
+  },
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+}))
+
+vi.mock('../daemon/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn(async () => ({
+    pid: 1,
+    port: 3099,
+    token: 'secret',
+    version: '0.1.0',
+    startedAt: '2026-04-24T00:00:00.000Z',
+    baseUrl: 'http://daemon.test',
+  })),
+}))
+
+// Mock doc-cache so getDoc can be gated to control interleaving against a
+// concurrent rename, mirroring canvas.test.ts's phantom-duplicate pin.
+vi.mock('./store/doc-cache.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('./store/doc-cache.js')>('./store/doc-cache.js')
+  return { ...actual, getDoc: vi.fn(actual.getDoc) }
+})
+
+const { createApp } = await import('./app.js')
+const { clearCache, getDoc } = await import('./store/doc-cache.js')
+const { clearWorkspaceIdCache } = await import('./mcp/session-resolver.js')
+const { PACKAGE_VERSION } = await import('../shared/package-version.js')
+const { saveCanvas } = await import('./store/canvas-store.js')
+const { loadCanvasBranches, saveCanvasBranches } = await import('./store/branches-store.js')
+
+function createRuntimeOptions() {
+  return {
+    authMode: 'local-daemon' as const,
+    token: undefined,
+    mcpAuth: undefined,
+    touch: vi.fn(),
+    shutdown: vi.fn(async () => undefined),
+    getStatus: () => ({
+      ok: true,
+      pid: 10,
+      host: '127.0.0.1',
+      port: 3099,
+      baseUrl: 'http://127.0.0.1:3099',
+      version: PACKAGE_VERSION,
+      startedAt: '2026-04-23T00:00:00.000Z',
+      uptimeMs: 100,
+      idleForMs: 10,
+      auth: { mode: 'local-token' as const, hasToken: false },
+      storage: { dataDir: '/tmp', dataDirWritable: true },
+      app: { served: true, buildPresent: false, ui: 'web-app' as const },
+      mcp: { httpEnabled: true, endpoint: 'http://127.0.0.1:3099/mcp' },
+      clients: { connected: 0, ready: 0 },
+    }),
+  }
+}
+
+describe('performMerge vs rename race', () => {
+  beforeEach(async () => {
+    await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
+    await mkdir(join(tmp.dir, 'data'), { recursive: true })
+    await writeFile(
+      join(tmp.dir, 'web-app', 'index.html'),
+      '<!DOCTYPE html><html><head><title>Whiteboard</title></head><body><div id="root"></div></body></html>',
+    )
+    clearCache()
+    clearWorkspaceIdCache()
+  })
+
+  afterEach(async () => {
+    await rm(tmp.dir, { recursive: true, force: true })
+    clearCache()
+  })
+
+  it('does not fork a phantom duplicate canvas when a slug rename races an in-flight merge that already resolved the live doc through the old slug', async () => {
+    const app = createApp(createRuntimeOptions())
+
+    // Base canvas: rect-1 only.
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    const el1 = list.insertContainer(0, new LoroMap())
+    el1.set('id', 'rect-1')
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc, { overwrite: true })
+
+    // feature's tip freezes the rect-1-only state.
+    const featureTipFrontiers = Buffer.from(encodeFrontiers(doc.frontiers())).toString('base64')
+
+    await app.request('/api/workspaces/session1/canvases/canvas-a/branches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'feature' }),
+    })
+    const state = await loadCanvasBranches('session1', 'canvas-a')
+    const feature = state.branches.find((b) => b.name === 'feature')!
+    feature.tipFrontiers = featureTipFrontiers
+    await saveCanvasBranches('session1', 'canvas-a', state)
+
+    // Add rect-2 directly on top so main's empty tip (== "current live doc")
+    // diverges from feature's frozen rect-1-only tip. Merging feature into
+    // main (source wins) will reconcile the live doc back down to rect-1
+    // and persist it, exercising performMerge's getDoc -> saveCanvas span.
+    const el2 = list.insertContainer(1, new LoroMap())
+    el2.set('id', 'rect-2')
+    doc.commit()
+    await saveCanvas('session1', 'canvas-a', doc, { overwrite: true })
+
+    // Stall performMerge's getDoc() call so a slug rename can be fired
+    // while the merge request is paused mid-flight, matching the real
+    // race: the read resolves before the rename runs, the write happens
+    // after.
+    let releaseGetDoc: () => void = () => undefined
+    const getDocGate = new Promise<void>((resolve) => {
+      releaseGetDoc = resolve
+    })
+    let signalGetDocCalled: () => void = () => undefined
+    const getDocCalled = new Promise<void>((resolve) => {
+      signalGetDocCalled = resolve
+    })
+    const actual =
+      await vi.importActual<typeof import('./store/doc-cache.js')>('./store/doc-cache.js')
+    vi.mocked(getDoc).mockImplementationOnce(async (workspaceId, slug) => {
+      signalGetDocCalled()
+      await getDocGate
+      return actual.getDoc(workspaceId, slug)
+    })
+
+    const mergePromise = app.request(
+      '/api/workspaces/session1/canvases/canvas-a/branches/feature/merge',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ into: 'main' }),
+      },
+    )
+
+    await getDocCalled
+
+    // Fire the rename while the merge is stalled mid-flight.
+    const renamePromise = app.request('/api/workspaces/session1/canvases/canvas-a/slug', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'canvas-b' }),
+    })
+    // Give the rename a chance to run before letting the stalled read continue.
+    await new Promise((r) => setTimeout(r, 20))
+    releaseGetDoc()
+
+    const [mergeRes, renameRes] = await Promise.all([mergePromise, renamePromise])
+    expect(renameRes.status).toBe(200)
+    expect(mergeRes.status).toBe(200)
+
+    // Exactly one canvas must survive -- at the post-rename slug. The merge
+    // must not have silently inserted a phantom duplicate back at the old
+    // slug.
+    const listRes = await app.request('/api/workspaces/session1/canvases')
+    const listJson = (await listRes.json()) as { canvases: { slug: string }[] }
+    expect(listJson.canvases.map((c) => c.slug)).toEqual(['canvas-b'])
+  })
+})

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -78,6 +78,7 @@ import { canvasExists, saveCanvas } from './store/canvas-store.js'
 import { isCorruptStoredDataError } from './store/corrupt-stored-data.js'
 import { getDoc, peekDoc } from './store/doc-cache.js'
 import { FileVersionStore } from './store/version-store.js'
+import { withWorkspaceWriteLock } from './store/workspace-lock.js'
 
 export type { AppOptions, ServerModeAppOptions } from './app-types.js'
 
@@ -514,182 +515,170 @@ export function createApp(options: AppOptions) {
         // (3) detect LWW edge cases with detectMergeBadges
         // (4) on commit, update target tipFrontiers to source and, if target is HEAD,
         //     reconcile the live doc to the preview and broadcast the change
-        performMerge: async (sid, slug, { source, into, dryRun }) => {
-          const state = await loadCanvasBranches(sid, slug)
-          const sourceBranch = state.branches.find((b) => b.name === source)
-          const intoBranch = state.branches.find((b) => b.name === into)
-          if (!sourceBranch) {
-            throw new BranchNotFoundError(`Branch "${source}" not found on ${sid}/${slug}`)
-          }
-          if (!intoBranch) {
-            throw new BranchNotFoundError(`Branch "${into}" not found on ${sid}/${slug}`)
-          }
-
-          const sourceTip = sourceBranch.tipFrontiers
-          const intoTip = intoBranch.tipFrontiers
-          const liveDoc = await getDoc(sid, slug)
-
-          const cloneAt = (branchName: string, tipBase64: string): LoroDoc => {
-            if (tipBase64.length === 0) {
-              return LoroDoc.fromSnapshot(liveDoc.export({ mode: 'snapshot' }))
+        // The whole read-modify-write (branch lookup, live-doc read, the
+        // pre-merge snapshot, the tip/HEAD writes, and their doc
+        // reconcile+save) runs inside one workspace-lock hold. getDoc(sid,
+        // slug) alone is unlocked, so a concurrent rename/delete that runs
+        // its whole lock-protected section between this unlocked read and
+        // the later saveCanvas() calls below would find no row left at
+        // this slug and silently insert a phantom canvas (or resurrect
+        // deleted content) instead of erroring or landing on the renamed
+        // row. updateBranchTip/setHeadPersist/deleteBranch already acquire
+        // this same per-workspace lock internally (branches-store.ts), so
+        // they re-enter via the AsyncLocalStorage chain rather than
+        // deadlocking — mirrors live-doc.ts's POST /update handler.
+        performMerge: async (sid, slug, { source, into, dryRun }) =>
+          withWorkspaceWriteLock(sid, async () => {
+            const state = await loadCanvasBranches(sid, slug)
+            const sourceBranch = state.branches.find((b) => b.name === source)
+            const intoBranch = state.branches.find((b) => b.name === into)
+            if (!sourceBranch) {
+              throw new BranchNotFoundError(`Branch "${source}" not found on ${sid}/${slug}`)
             }
-            const frontiers = decodeBranchTipOrThrow(sid, slug, branchName, tipBase64)
-            return checkoutCloneOrThrow(
-              liveDoc,
-              frontiers,
-              `${sid}/branches/${slug}.json#${branchName}.tipFrontiers`,
-              `branch "${branchName}" tipFrontiers could not be checked out against the live document`,
-            )
-          }
-
-          const targetDoc = cloneAt(into, intoTip ?? '')
-          const sourceDoc = cloneAt(source, sourceTip ?? '')
-          // Use sourceDoc as the preview representation. Building a fully merged preview
-          // safely would require a snapshot containing the full op-log after combining
-          // target and source frontiers. In practice, sourceDoc closely matches the merge
-          // result for the current "source wins" flow, and detectMergeBadges only needs a
-          // stable target/source/preview triple to surface LWW differences.
-          const previewDoc = sourceDoc
-          const badges = detectMergeBadges({
-            target: targetDoc,
-            source: sourceDoc,
-            preview: previewDoc,
-          })
-
-          const countAlive = (doc: LoroDoc): number => {
-            try {
-              const list = doc.getMovableList('elements').toJSON() as Array<{
-                isDeleted?: boolean
-              }>
-              return list.filter((e) => !e.isDeleted).length
-            } catch {
-              return 0
+            if (!intoBranch) {
+              throw new BranchNotFoundError(`Branch "${into}" not found on ${sid}/${slug}`)
             }
-          }
-          const previewElementCount = countAlive(previewDoc)
-          const targetElementCount = countAlive(targetDoc)
-          const sourceElementCount = countAlive(sourceDoc)
 
-          // Diff alive elements between target and preview so the UI can highlight
-          // new / changed / conflict elements after commit.
-          const aliveMap = (doc: LoroDoc): Map<string, Record<string, unknown>> => {
-            try {
-              const list = doc.getMovableList('elements').toJSON() as Array<
-                Record<string, unknown> & { id?: unknown; isDeleted?: unknown }
-              >
-              const out = new Map<string, Record<string, unknown>>()
-              for (const el of list) {
-                if (el.isDeleted) continue
-                if (typeof el.id !== 'string') continue
-                out.set(el.id, el)
+            const sourceTip = sourceBranch.tipFrontiers
+            const intoTip = intoBranch.tipFrontiers
+            const liveDoc = await getDoc(sid, slug)
+
+            const cloneAt = (branchName: string, tipBase64: string): LoroDoc => {
+              if (tipBase64.length === 0) {
+                return LoroDoc.fromSnapshot(liveDoc.export({ mode: 'snapshot' }))
               }
-              return out
-            } catch {
-              return new Map()
+              const frontiers = decodeBranchTipOrThrow(sid, slug, branchName, tipBase64)
+              return checkoutCloneOrThrow(
+                liveDoc,
+                frontiers,
+                `${sid}/branches/${slug}.json#${branchName}.tipFrontiers`,
+                `branch "${branchName}" tipFrontiers could not be checked out against the live document`,
+              )
             }
-          }
-          const tMap = aliveMap(targetDoc)
-          const pMap = aliveMap(previewDoc)
-          const newElementIds: string[] = []
-          const changedElementIds: string[] = []
-          for (const [id, pEl] of pMap) {
-            const tEl = tMap.get(id)
-            if (!tEl) {
-              newElementIds.push(id)
-            } else if (JSON.stringify(pEl) !== JSON.stringify(tEl)) {
-              changedElementIds.push(id)
-            }
-          }
-          const conflictElementIds = Array.from(
-            new Set(
-              (badges as Array<Record<string, unknown>>)
-                .map((b) => (typeof b.elementId === 'string' ? b.elementId : ''))
-                .filter((v) => v.length > 0),
-            ),
-          )
 
-          if (dryRun) {
-            // For dry runs, return only alive elements so MergeDialog can render a
-            // read-only Excalidraw preview without duplicating tombstoned elements.
-            const previewElements = (() => {
+            const targetDoc = cloneAt(into, intoTip ?? '')
+            const sourceDoc = cloneAt(source, sourceTip ?? '')
+            // Use sourceDoc as the preview representation. Building a fully merged preview
+            // safely would require a snapshot containing the full op-log after combining
+            // target and source frontiers. In practice, sourceDoc closely matches the merge
+            // result for the current "source wins" flow, and detectMergeBadges only needs a
+            // stable target/source/preview triple to surface LWW differences.
+            const previewDoc = sourceDoc
+            const badges = detectMergeBadges({
+              target: targetDoc,
+              source: sourceDoc,
+              preview: previewDoc,
+            })
+
+            const countAlive = (doc: LoroDoc): number => {
               try {
-                const list = previewDoc.getMovableList('elements').toJSON() as Array<{
+                const list = doc.getMovableList('elements').toJSON() as Array<{
                   isDeleted?: boolean
                 }>
-                return list.filter((e) => !e.isDeleted)
+                return list.filter((e) => !e.isDeleted).length
               } catch {
-                return []
+                return 0
               }
-            })()
-            return {
-              previewElementCount,
-              targetElementCount,
-              sourceElementCount,
-              badges,
-              committed: false,
-              previewElements,
             }
-          }
+            const previewElementCount = countAlive(previewDoc)
+            const targetElementCount = countAlive(targetDoc)
+            const sourceElementCount = countAlive(sourceDoc)
 
-          // Capture a "before merge" version so the UI can offer undo by restoring it.
-          // This is most useful when HEAD points at the target, but saving it uniformly
-          // keeps the UI behavior consistent.
-          let preMergeVersionId: string | undefined
-          try {
-            const beforeVersion = await versionStore.save(sid, slug, liveDoc, {
-              auto: true,
-              label: `before merge: ${source} → ${into}`,
-              branchName: into,
-              operator: {
-                kind: 'system',
-                peerId: liveDoc.peerIdStr,
-                displayName: 'merge',
-              },
-            })
-            preMergeVersionId = beforeVersion.id
-          } catch (err) {
-            // Snapshot failure should not block the merge itself.
-            getLogger('merge').warning(
-              { workspaceId: sid, slug, err: err as Error },
-              'pre-merge snapshot failed',
+            // Diff alive elements between target and preview so the UI can highlight
+            // new / changed / conflict elements after commit.
+            const aliveMap = (doc: LoroDoc): Map<string, Record<string, unknown>> => {
+              try {
+                const list = doc.getMovableList('elements').toJSON() as Array<
+                  Record<string, unknown> & { id?: unknown; isDeleted?: unknown }
+                >
+                const out = new Map<string, Record<string, unknown>>()
+                for (const el of list) {
+                  if (el.isDeleted) continue
+                  if (typeof el.id !== 'string') continue
+                  out.set(el.id, el)
+                }
+                return out
+              } catch {
+                return new Map()
+              }
+            }
+            const tMap = aliveMap(targetDoc)
+            const pMap = aliveMap(previewDoc)
+            const newElementIds: string[] = []
+            const changedElementIds: string[] = []
+            for (const [id, pEl] of pMap) {
+              const tEl = tMap.get(id)
+              if (!tEl) {
+                newElementIds.push(id)
+              } else if (JSON.stringify(pEl) !== JSON.stringify(tEl)) {
+                changedElementIds.push(id)
+              }
+            }
+            const conflictElementIds = Array.from(
+              new Set(
+                (badges as Array<Record<string, unknown>>)
+                  .map((b) => (typeof b.elementId === 'string' ? b.elementId : ''))
+                  .filter((v) => v.length > 0),
+              ),
             )
-          }
 
-          // Commit by moving the target tipFrontiers to the source tip, unless the source
-          // branch is still uninitialized.
-          if (typeof sourceTip === 'string' && sourceTip.length > 0) {
-            await updateBranchTip(sid, slug, into, sourceTip)
-          }
-
-          // If the target is HEAD, reconcile and broadcast the live doc. Otherwise only
-          // rewrite the stored tip.
-          const latest = await loadCanvasBranches(sid, slug)
-          if (latest.head === into && sourceTip && sourceTip.length > 0) {
-            const prevVV = liveDoc.version()
-            liveDoc.import(previewDoc.export({ mode: 'snapshot' }))
-            liveDoc.commit()
-            await saveCanvas(sid, slug, liveDoc, { overwrite: true })
-            const update = liveDoc.export({ mode: 'update', from: prevVV }) as Uint8Array
-            if (update.byteLength > 0) {
-              broadcastLoroUpdate(sid, slug, update)
+            if (dryRun) {
+              // For dry runs, return only alive elements so MergeDialog can render a
+              // read-only Excalidraw preview without duplicating tombstoned elements.
+              const previewElements = (() => {
+                try {
+                  const list = previewDoc.getMovableList('elements').toJSON() as Array<{
+                    isDeleted?: boolean
+                  }>
+                  return list.filter((e) => !e.isDeleted)
+                } catch {
+                  return []
+                }
+              })()
+              return {
+                previewElementCount,
+                targetElementCount,
+                sourceElementCount,
+                badges,
+                committed: false,
+                previewElements,
+              }
             }
-            sendHeadChanged(sid, slug, into)
-          }
 
-          // Post-merge cleanup:
-          // 1) if HEAD still points at source, move it to target so the user sees the result
-          // 2) delete the source branch unless it is main or the same as target
-          // Cleanup failures only produce warnings; the merge still succeeds.
-          let switchedHead: { from: string; to: string } | undefined
-          let deletedSource: string | undefined
-          try {
-            const afterCommit = await loadCanvasBranches(sid, slug)
-            if (afterCommit.head === source && source !== into) {
-              await setHeadPersist(sid, slug, into)
-              switchedHead = { from: source, to: into }
-              sendHeadChanged(sid, slug, into)
-              // Reconcile and broadcast the live doc to match the target preview.
-              // This is already done when HEAD===target, but HEAD===source needs it here.
+            // Capture a "before merge" version so the UI can offer undo by restoring it.
+            // This is most useful when HEAD points at the target, but saving it uniformly
+            // keeps the UI behavior consistent.
+            let preMergeVersionId: string | undefined
+            try {
+              const beforeVersion = await versionStore.save(sid, slug, liveDoc, {
+                auto: true,
+                label: `before merge: ${source} → ${into}`,
+                branchName: into,
+                operator: {
+                  kind: 'system',
+                  peerId: liveDoc.peerIdStr,
+                  displayName: 'merge',
+                },
+              })
+              preMergeVersionId = beforeVersion.id
+            } catch (err) {
+              // Snapshot failure should not block the merge itself.
+              getLogger('merge').warning(
+                { workspaceId: sid, slug, err: err as Error },
+                'pre-merge snapshot failed',
+              )
+            }
+
+            // Commit by moving the target tipFrontiers to the source tip, unless the source
+            // branch is still uninitialized.
+            if (typeof sourceTip === 'string' && sourceTip.length > 0) {
+              await updateBranchTip(sid, slug, into, sourceTip)
+            }
+
+            // If the target is HEAD, reconcile and broadcast the live doc. Otherwise only
+            // rewrite the stored tip.
+            const latest = await loadCanvasBranches(sid, slug)
+            if (latest.head === into && sourceTip && sourceTip.length > 0) {
               const prevVV = liveDoc.version()
               liveDoc.import(previewDoc.export({ mode: 'snapshot' }))
               liveDoc.commit()
@@ -698,40 +687,65 @@ export function createApp(options: AppOptions) {
               if (update.byteLength > 0) {
                 broadcastLoroUpdate(sid, slug, update)
               }
+              sendHeadChanged(sid, slug, into)
             }
-          } catch (err) {
-            getLogger('merge').warning(
-              { workspaceId: sid, slug, err: err as Error },
-              'post-merge head switch failed',
-            )
-          }
-          if (source !== 'main' && source !== into) {
+
+            // Post-merge cleanup:
+            // 1) if HEAD still points at source, move it to target so the user sees the result
+            // 2) delete the source branch unless it is main or the same as target
+            // Cleanup failures only produce warnings; the merge still succeeds.
+            let switchedHead: { from: string; to: string } | undefined
+            let deletedSource: string | undefined
             try {
-              await deleteBranch(sid, slug, source)
-              deletedSource = source
+              const afterCommit = await loadCanvasBranches(sid, slug)
+              if (afterCommit.head === source && source !== into) {
+                await setHeadPersist(sid, slug, into)
+                switchedHead = { from: source, to: into }
+                sendHeadChanged(sid, slug, into)
+                // Reconcile and broadcast the live doc to match the target preview.
+                // This is already done when HEAD===target, but HEAD===source needs it here.
+                const prevVV = liveDoc.version()
+                liveDoc.import(previewDoc.export({ mode: 'snapshot' }))
+                liveDoc.commit()
+                await saveCanvas(sid, slug, liveDoc, { overwrite: true })
+                const update = liveDoc.export({ mode: 'update', from: prevVV }) as Uint8Array
+                if (update.byteLength > 0) {
+                  broadcastLoroUpdate(sid, slug, update)
+                }
+              }
             } catch (err) {
-              // For example: still HEAD, already deleted, and similar cleanup races.
               getLogger('merge').warning(
                 { workspaceId: sid, slug, err: err as Error },
-                'post-merge delete source failed',
+                'post-merge head switch failed',
               )
             }
-          }
+            if (source !== 'main' && source !== into) {
+              try {
+                await deleteBranch(sid, slug, source)
+                deletedSource = source
+              } catch (err) {
+                // For example: still HEAD, already deleted, and similar cleanup races.
+                getLogger('merge').warning(
+                  { workspaceId: sid, slug, err: err as Error },
+                  'post-merge delete source failed',
+                )
+              }
+            }
 
-          return {
-            previewElementCount,
-            targetElementCount,
-            sourceElementCount,
-            badges,
-            committed: true,
-            newElementIds,
-            changedElementIds,
-            conflictElementIds,
-            preMergeVersionId,
-            switchedHead,
-            deletedSource,
-          }
-        },
+            return {
+              previewElementCount,
+              targetElementCount,
+              sourceElementCount,
+              badges,
+              committed: true,
+              newElementIds,
+              changedElementIds,
+              conflictElementIds,
+              preMergeVersionId,
+              switchedHead,
+              deletedSource,
+            }
+          }),
       }),
     )
   }

--- a/packages/mcp-server/src/server/routes/branches.ts
+++ b/packages/mcp-server/src/server/routes/branches.ts
@@ -351,6 +351,12 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // ── POST /api/workspaces/:sid/canvases/:slug/branches/:source/merge ──
   // Spec §7. Merge source (URL param) into target (body). dryRun can return a preview without committing.
   // LWW edge-case detection lives in merge-engine.detectMergeBadges; document operations are delegated to performMerge.
+  // Unlike PUT /head above, this route itself holds no lock: performMerge
+  // (app.ts) owns the entire read-modify-write — including the live-doc
+  // read that used to race a concurrent rename/delete — under
+  // withWorkspaceWriteLock, the same way PUT /head's own handler owns its
+  // branches.json read+save. Locking here too would be redundant, not
+  // protective.
   app.post('/api/workspaces/:sid/canvases/:slug/branches/:source/merge', async (c) => {
     const { sid, slug, source } = c.req.param()
     try {

--- a/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
@@ -80,14 +80,8 @@ describe('restore targetSlug-overwrite vs delete race', () => {
     // target can be fired while the request is paused mid-flight, matching
     // the real race: the read resolves before the delete runs, the write
     // happens after.
-    let releaseGetDoc: () => void = () => undefined
-    const getDocGate = new Promise<void>((resolve) => {
-      releaseGetDoc = resolve
-    })
-    let signalGetDocCalled: () => void = () => undefined
-    const getDocCalled = new Promise<void>((resolve) => {
-      signalGetDocCalled = resolve
-    })
+    const { promise: getDocGate, resolve: releaseGetDoc } = Promise.withResolvers<void>()
+    const { promise: getDocCalled, resolve: signalGetDocCalled } = Promise.withResolvers<void>()
     const actual = await vi.importActual<typeof import('../../store/doc-cache.js')>(
       '../../store/doc-cache.js',
     )

--- a/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
@@ -1,0 +1,134 @@
+import { LoroDoc, LoroMap } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-restore-race-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+// Mock doc-cache so getDoc can be gated to control interleaving against a
+// concurrent DELETE, mirroring canvas.test.ts's phantom-duplicate pin.
+vi.mock('../../store/doc-cache.js', async () => {
+  const actual = await vi.importActual<typeof import('../../store/doc-cache.js')>(
+    '../../store/doc-cache.js',
+  )
+  return { ...actual, getDoc: vi.fn(actual.getDoc) }
+})
+
+const { clearCache, getDoc } = await import('../../store/doc-cache.js')
+const { createCanvasRouter } = await import('../canvas.js')
+// Pre-load ws.js before the race below. canvas.ts pulls it in via a
+// fire-and-forget dynamic import (documented cycle workaround), and
+// reconcileCommitSaveBroadcast() dynamically imports it again on every
+// restore; racing the two first-time loads of the same circularly-
+// dependent module is a separate, pre-existing module-init hazard this
+// test does not intend to exercise.
+await import('../ws.js')
+
+describe('restore targetSlug-overwrite vs delete race', () => {
+  beforeEach(() => {
+    clearCache()
+  })
+
+  afterEach(() => {
+    clearCache()
+  })
+
+  it('does not resurrect deleted content when a DELETE of the overwrite target races the restore reading it', async () => {
+    const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+    // Source canvas-a with a saved version to restore from.
+    const sourceDoc = new LoroDoc()
+    const svv0 = sourceDoc.version()
+    const sourceList = sourceDoc.getMovableList('elements')
+    const sm0 = sourceList.insertContainer(0, new LoroMap())
+    sm0.set('id', 'keep-me')
+    sourceDoc.commit()
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: sourceDoc.export({ mode: 'update', from: svv0 }),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+    // Target canvas-b already exists.
+    const targetDoc = new LoroDoc()
+    const tvv0 = targetDoc.version()
+    const targetList = targetDoc.getMovableList('elements')
+    const tm0 = targetList.insertContainer(0, new LoroMap())
+    tm0.set('id', 'b-only')
+    targetDoc.commit()
+    await app.request('/api/canvas/session1/canvas-b/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: targetDoc.export({ mode: 'update', from: tvv0 }),
+    })
+
+    // Stall the restore route's getDoc(targetSlug) call so a DELETE of the
+    // target can be fired while the request is paused mid-flight, matching
+    // the real race: the read resolves before the delete runs, the write
+    // happens after.
+    let releaseGetDoc: () => void = () => undefined
+    const getDocGate = new Promise<void>((resolve) => {
+      releaseGetDoc = resolve
+    })
+    let signalGetDocCalled: () => void = () => undefined
+    const getDocCalled = new Promise<void>((resolve) => {
+      signalGetDocCalled = resolve
+    })
+    const actual = await vi.importActual<typeof import('../../store/doc-cache.js')>(
+      '../../store/doc-cache.js',
+    )
+    let gateArmed = true
+    vi.mocked(getDoc).mockImplementation(async (workspaceId, slug) => {
+      if (gateArmed && slug === 'canvas-b') {
+        gateArmed = false
+        signalGetDocCalled()
+        await getDocGate
+      }
+      return actual.getDoc(workspaceId, slug)
+    })
+
+    const restorePromise = app.request(
+      `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetSlug: 'canvas-b', overwrite: true }),
+      },
+    )
+
+    await getDocCalled
+
+    // Fire the delete of the overwrite target while the restore is stalled mid-flight.
+    const deletePromise = app.request('/api/workspaces/session1/canvases/canvas-b', {
+      method: 'DELETE',
+    })
+    // Give the delete a chance to run before letting the stalled read continue.
+    await new Promise((r) => setTimeout(r, 20))
+    releaseGetDoc()
+
+    const [restoreRes, deleteRes] = await Promise.all([restorePromise, deletePromise])
+    expect(deleteRes.status).toBe(200)
+    expect(restoreRes.status).toBe(200)
+
+    // The restore must not have silently resurrected a phantom canvas-b
+    // after the delete removed it -- the delete serializes after the
+    // restore's write under the workspace lock, so canvas-b must be gone.
+    const listRes = await app.request('/api/workspaces/session1/canvases')
+    const listJson = (await listRes.json()) as { canvases: { slug: string }[] }
+    expect(listJson.canvases.map((c) => c.slug)).toEqual(['canvas-a'])
+  })
+})

--- a/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
@@ -126,3 +126,84 @@ describe('restore targetSlug-overwrite vs delete race', () => {
     expect(listJson.canvases.map((c) => c.slug)).toEqual(['canvas-a'])
   })
 })
+
+describe('restore in-place vs delete race', () => {
+  beforeEach(() => {
+    clearCache()
+  })
+
+  afterEach(() => {
+    clearCache()
+  })
+
+  it('does not resurrect the canvas when a DELETE of the in-place restore target races the restore reading it', async () => {
+    const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+    // Single canvas with a saved version to restore onto itself (no targetSlug).
+    const sourceDoc = new LoroDoc()
+    const svv0 = sourceDoc.version()
+    const sourceList = sourceDoc.getMovableList('elements')
+    const sm0 = sourceList.insertContainer(0, new LoroMap())
+    sm0.set('id', 'keep-me')
+    sourceDoc.commit()
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: sourceDoc.export({ mode: 'update', from: svv0 }),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+    // Stall the restore route's getDoc(slug) call so a DELETE of the same
+    // canvas can be fired while the request is paused mid-flight, matching
+    // the real race: the read resolves before the delete runs, the write
+    // happens after.
+    const { promise: getDocGate, resolve: releaseGetDoc } = Promise.withResolvers<void>()
+    const { promise: getDocCalled, resolve: signalGetDocCalled } = Promise.withResolvers<void>()
+    const actual = await vi.importActual<typeof import('../../store/doc-cache.js')>(
+      '../../store/doc-cache.js',
+    )
+    let gateArmed = true
+    vi.mocked(getDoc).mockImplementation(async (workspaceId, slug) => {
+      if (gateArmed && slug === 'canvas-a') {
+        gateArmed = false
+        signalGetDocCalled()
+        await getDocGate
+      }
+      return actual.getDoc(workspaceId, slug)
+    })
+
+    const restorePromise = app.request(
+      `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+      {
+        method: 'POST',
+      },
+    )
+
+    await getDocCalled
+
+    // Fire the delete of the canvas being restored while the restore is
+    // stalled mid-flight.
+    const deletePromise = app.request('/api/workspaces/session1/canvases/canvas-a', {
+      method: 'DELETE',
+    })
+    // Give the delete a chance to run before letting the stalled read continue.
+    await new Promise((r) => setTimeout(r, 20))
+    releaseGetDoc()
+
+    const [restoreRes, deleteRes] = await Promise.all([restorePromise, deletePromise])
+    expect(deleteRes.status).toBe(200)
+    expect(restoreRes.status).toBe(200)
+
+    // The delete serializes after the restore's write under the workspace
+    // lock, so canvas-a must be gone -- the restore must not have won a
+    // race that resurrects it after the delete.
+    const listRes = await app.request('/api/workspaces/session1/canvases')
+    const listJson = (await listRes.json()) as { canvases: { slug: string }[] }
+    expect(listJson.canvases.map((c) => c.slug)).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -5,6 +5,7 @@ import { restoreVersionRequestSchema } from '../../../shared/api-contracts/canva
 import { ConflictError, canvasExists, getCanvasKind, saveCanvas } from '../../store/canvas-store.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
+import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
 import {
   validateSlug,
   validateVersionId,
@@ -118,77 +119,37 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
       overwrite = parsed.data.overwrite === true
     }
     try {
-      const doc = await getDoc(workspaceId, slug)
-      const past = await versionStore.load(workspaceId, id, doc)
-      if (!past) {
-        return c.json({ error: 'not_found' }, 404)
-      }
-
-      // Restore-as-new-canvas / overwrite-existing-canvas branch.
-      // targetSlug === slug is the same document as the in-place restore
-      // below, so route it there directly instead of forcing callers to
-      // pass overwrite:true against their own canvas.
-      if (targetSlug !== undefined && targetSlug !== slug) {
-        try {
-          validateSlug(targetSlug)
-        } catch (err) {
-          const body = validationErrorBody(err)
-          if (body) return c.json(body, 400)
-          throw err
+      // Every doc read + save below runs inside one workspace-lock hold.
+      // getDoc() alone is unlocked, so a concurrent delete/rename that runs
+      // its whole lock-protected section between an unlocked read here and
+      // the eventual saveCanvas() would find no row left at that slug and
+      // silently insert a brand-new phantom canvas (or resurrect content
+      // onto a slug the delete just cleared). Both the in-place branch and
+      // the targetSlug-overwrite branch have that getDoc(slug)->saveCanvas(slug)
+      // shape, so one lock around the whole handler body closes it for both
+      // — mirrors live-doc.ts's POST /update handler.
+      return await withWorkspaceWriteLock(workspaceId, async () => {
+        const doc = await getDoc(workspaceId, slug)
+        const past = await versionStore.load(workspaceId, id, doc)
+        if (!past) {
+          return c.json({ error: 'not_found' }, 404)
         }
 
-        const targetAlreadyExists = await canvasExists(workspaceId, targetSlug)
-        if (targetAlreadyExists && !overwrite) {
-          return c.json(
-            {
-              error: 'output_exists',
-              message: `Target canvas "${targetSlug}" already exists. Pass overwrite=true to replace it.`,
-            },
-            409,
-          )
-        }
+        // Restore-as-new-canvas / overwrite-existing-canvas branch.
+        // targetSlug === slug is the same document as the in-place restore
+        // below, so route it there directly instead of forcing callers to
+        // pass overwrite:true against their own canvas.
+        if (targetSlug !== undefined && targetSlug !== slug) {
+          try {
+            validateSlug(targetSlug)
+          } catch (err) {
+            const body = validationErrorBody(err)
+            if (body) return c.json(body, 400)
+            throw err
+          }
 
-        if (targetAlreadyExists) {
-          // The version id belongs to the SOURCE canvas's history, so its
-          // label lives in the source's version list even though we are
-          // about to reconcile it onto the target.
-          const all = await versionStore.list(workspaceId, slug)
-          const label = all.find((v) => v.id === id)?.label
-          const targetDoc = await getDoc(workspaceId, targetSlug)
-          // The merged content is the source's own shape (spatial nodes/edges
-          // vs. a markdown body), same reasoning as the new-canvas branch
-          // below — the target's stored kind must follow it or a kind-aware
-          // consumer (editor routing) opens the overwritten canvas with the
-          // wrong editor.
-          const sourceKind = await getCanvasKind(workspaceId, slug)
-          await reconcileCommitSaveBroadcast(
-            workspaceId,
-            targetSlug,
-            targetDoc,
-            past,
-            label,
-            sourceKind,
-          )
-          return c.json({
-            canvasId: `${workspaceId}/${targetSlug}`,
-            elementCount: countElements(targetDoc),
-          })
-        }
-
-        // Genuinely new canvas: no live doc and no connected clients, so
-        // there is nothing to reconcile against. The restored content is
-        // whatever the source canvas actually stores (spatial nodes/edges
-        // maps vs. a markdown 'body' text container), so the new row must
-        // carry the source's own kind rather than falling back to the
-        // saveCanvas default.
-        try {
-          const sourceKind = await getCanvasKind(workspaceId, slug)
-          await saveCanvas(workspaceId, targetSlug, past, {
-            overwrite: false,
-            ...(sourceKind !== null ? { kind: sourceKind } : {}),
-          })
-        } catch (err) {
-          if (err instanceof ConflictError) {
+          const targetAlreadyExists = await canvasExists(workspaceId, targetSlug)
+          if (targetAlreadyExists && !overwrite) {
             return c.json(
               {
                 error: 'output_exists',
@@ -197,22 +158,73 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
               409,
             )
           }
-          throw err
-        }
-        // Guard against a stale cache entry from a since-deleted canvas at
-        // this slug being served instead of the just-written snapshot.
-        evictDoc(workspaceId, targetSlug)
-        return c.json({
-          canvasId: `${workspaceId}/${targetSlug}`,
-          elementCount: countElements(past),
-        })
-      }
 
-      // In-place reconcile branch (default).
-      const all = await versionStore.list(workspaceId, slug)
-      const label = all.find((v) => v.id === id)?.label
-      await reconcileCommitSaveBroadcast(workspaceId, slug, doc, past, label)
-      return c.json({ ok: true })
+          if (targetAlreadyExists) {
+            // The version id belongs to the SOURCE canvas's history, so its
+            // label lives in the source's version list even though we are
+            // about to reconcile it onto the target.
+            const all = await versionStore.list(workspaceId, slug)
+            const label = all.find((v) => v.id === id)?.label
+            const targetDoc = await getDoc(workspaceId, targetSlug)
+            // The merged content is the source's own shape (spatial nodes/edges
+            // vs. a markdown body), same reasoning as the new-canvas branch
+            // below — the target's stored kind must follow it or a kind-aware
+            // consumer (editor routing) opens the overwritten canvas with the
+            // wrong editor.
+            const sourceKind = await getCanvasKind(workspaceId, slug)
+            await reconcileCommitSaveBroadcast(
+              workspaceId,
+              targetSlug,
+              targetDoc,
+              past,
+              label,
+              sourceKind,
+            )
+            return c.json({
+              canvasId: `${workspaceId}/${targetSlug}`,
+              elementCount: countElements(targetDoc),
+            })
+          }
+
+          // Genuinely new canvas: no live doc and no connected clients, so
+          // there is nothing to reconcile against. The restored content is
+          // whatever the source canvas actually stores (spatial nodes/edges
+          // maps vs. a markdown 'body' text container), so the new row must
+          // carry the source's own kind rather than falling back to the
+          // saveCanvas default.
+          try {
+            const sourceKind = await getCanvasKind(workspaceId, slug)
+            await saveCanvas(workspaceId, targetSlug, past, {
+              overwrite: false,
+              ...(sourceKind !== null ? { kind: sourceKind } : {}),
+            })
+          } catch (err) {
+            if (err instanceof ConflictError) {
+              return c.json(
+                {
+                  error: 'output_exists',
+                  message: `Target canvas "${targetSlug}" already exists. Pass overwrite=true to replace it.`,
+                },
+                409,
+              )
+            }
+            throw err
+          }
+          // Guard against a stale cache entry from a since-deleted canvas at
+          // this slug being served instead of the just-written snapshot.
+          evictDoc(workspaceId, targetSlug)
+          return c.json({
+            canvasId: `${workspaceId}/${targetSlug}`,
+            elementCount: countElements(past),
+          })
+        }
+
+        // In-place reconcile branch (default).
+        const all = await versionStore.list(workspaceId, slug)
+        const label = all.find((v) => v.id === id)?.label
+        await reconcileCommitSaveBroadcast(workspaceId, slug, doc, past, label)
+        return c.json({ ok: true })
+      })
     } catch (err) {
       const issue = handleCorruptStoredData(err)
       if (issue) return c.json(issue.body, issue.status)

--- a/packages/mcp-server/src/server/routes/ws-rename-race.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-rename-race.test.ts
@@ -1,0 +1,127 @@
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from './_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-ws-rename-race-')
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+// Mock doc-cache so getDoc can be gated to control interleaving against a
+// concurrent rename, mirroring canvas.test.ts's phantom-duplicate pin.
+vi.mock('../store/doc-cache.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../store/doc-cache.js')>('../store/doc-cache.js')
+  return { ...actual, getDoc: vi.fn(actual.getDoc) }
+})
+
+const { clearCache, getDoc } = await import('../store/doc-cache.js')
+const { saveCanvas, renameCanvasSlug, listCanvases } = await import('../store/canvas-store.js')
+const { handleWsUpgrade } = await import('./ws.js')
+
+class FakeWebSocket {
+  sent: Array<string | Uint8Array> = []
+  closes: Array<{ code?: number; reason?: string }> = []
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+
+  send(data: string | Uint8Array | ArrayBuffer): void {
+    if (data instanceof ArrayBuffer) {
+      this.sent.push(new Uint8Array(data))
+      return
+    }
+    this.sent.push(data)
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void): void {
+    const handlers = this.listeners.get(event) ?? []
+    handlers.push(handler)
+    this.listeners.set(event, handlers)
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason })
+  }
+
+  async emitMessage(data: Buffer, isBinary: boolean): Promise<void> {
+    for (const handler of this.listeners.get('message') ?? []) {
+      await handler(data, isBinary)
+    }
+  }
+}
+
+describe('handleWsUpgrade binary update vs rename race', () => {
+  beforeEach(() => {
+    clearCache()
+  })
+
+  afterEach(() => {
+    clearCache()
+  })
+
+  it('does not fork a phantom duplicate canvas when a rename races an in-flight binary update that already resolved a doc reference through the old slug', async () => {
+    const baseDoc = new LoroDoc()
+    baseDoc.getText('content').insert(0, 'original')
+    baseDoc.commit()
+    await saveCanvas('session1', 'a', baseDoc)
+
+    // A client update built against the pre-rename base.
+    const clientDoc = LoroDoc.fromSnapshot(baseDoc.export({ mode: 'snapshot' }))
+    const fromVV = clientDoc.version()
+    clientDoc.getText('content').insert('original'.length, ' + edit')
+    clientDoc.commit()
+    const update = clientDoc.export({ mode: 'update', from: fromVV }) as Uint8Array
+
+    // Stall the WS handler's getDoc() call so a rename can be fired while
+    // the frame is paused mid-flight, matching the real race: the read
+    // resolves before the rename runs, the write happens after.
+    let releaseGetDoc: () => void = () => undefined
+    const getDocGate = new Promise<void>((resolve) => {
+      releaseGetDoc = resolve
+    })
+    let signalGetDocCalled: () => void = () => undefined
+    const getDocCalled = new Promise<void>((resolve) => {
+      signalGetDocCalled = resolve
+    })
+    const actual =
+      await vi.importActual<typeof import('../store/doc-cache.js')>('../store/doc-cache.js')
+    vi.mocked(getDoc)
+      .mockImplementationOnce(async (workspaceId, slug) => {
+        // First call: the WS upgrade's initial snapshot send. Resolve normally.
+        return actual.getDoc(workspaceId, slug)
+      })
+      .mockImplementationOnce(async (workspaceId, slug) => {
+        signalGetDocCalled()
+        await getDocGate
+        return actual.getDoc(workspaceId, slug)
+      })
+
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      { url: '/ws/session1/a', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+    )
+
+    const updatePromise = ws.emitMessage(Buffer.from(update), true)
+
+    await getDocCalled
+
+    // Fire the rename while the binary frame is stalled mid-flight.
+    const renamePromise = renameCanvasSlug('session1', 'a', 'b')
+    // Give the rename a chance to run before letting the stalled read continue.
+    await new Promise((r) => setTimeout(r, 20))
+    releaseGetDoc()
+
+    await Promise.all([updatePromise, renamePromise])
+
+    // Exactly one canvas must survive -- the update must not have silently
+    // inserted a phantom duplicate back at the old slug.
+    const canvases = await listCanvases('session1')
+    expect(canvases.map((c) => c.slug)).toEqual(['b'])
+  })
+})

--- a/packages/mcp-server/src/server/routes/ws-rename-race.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-rename-race.test.ts
@@ -80,14 +80,8 @@ describe('handleWsUpgrade binary update vs rename race', () => {
     // Stall the WS handler's getDoc() call so a rename can be fired while
     // the frame is paused mid-flight, matching the real race: the read
     // resolves before the rename runs, the write happens after.
-    let releaseGetDoc: () => void = () => undefined
-    const getDocGate = new Promise<void>((resolve) => {
-      releaseGetDoc = resolve
-    })
-    let signalGetDocCalled: () => void = () => undefined
-    const getDocCalled = new Promise<void>((resolve) => {
-      signalGetDocCalled = resolve
-    })
+    const { promise: getDocGate, resolve: releaseGetDoc } = Promise.withResolvers<void>()
+    const { promise: getDocCalled, resolve: signalGetDocCalled } = Promise.withResolvers<void>()
     const actual =
       await vi.importActual<typeof import('../store/doc-cache.js')>('../store/doc-cache.js')
     vi.mocked(getDoc)

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -14,6 +14,7 @@ import {
 import { saveCanvas } from '../store/canvas-store.js'
 import { evictDoc, getDoc } from '../store/doc-cache.js'
 import type { VersionEntry } from '../store/version-store.js'
+import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
 import { setBroadcastFn } from './canvas.js'
 import {
   setSyncSseHooks,
@@ -354,35 +355,49 @@ export async function handleWsUpgrade(
       ? getTracer('whiteboard.ws').startSpan('ws.message.binary', spanStartOptions, parentCtx)
       : getTracer('whiteboard.ws').startSpan('ws.message.binary', spanStartOptions)
     try {
-      const currentDoc = await getDoc(workspaceId, slug)
-      // A second (or later) frame's handler can pass the `isClosing` check
-      // above before this frame's `await getDoc` resolves — both were
-      // still false at the top when they started. Recheck immediately after
-      // the await so a frame that lost that race does not import, persist,
-      // or close a socket the earlier frame already tore down.
-      if (isClosing) return
+      // Resolve the doc AND persist it inside one workspace-lock hold. getDoc()
+      // alone is unlocked, so a rename/delete that runs its whole lock-protected
+      // section between an unlocked read here and saveCanvas()'s own later lock
+      // acquisition would find no row left at this slug and silently insert a
+      // brand-new phantom canvas back at it (or resurrect deleted content).
+      // Sharing the lock across the read and the write closes that window —
+      // mirrors live-doc.ts's POST /update handler. Only the read-import-save
+      // span is covered: broadcast, the test hook, and auto-version trigger
+      // below stay outside since they never wait on another writer.
+      const currentDoc = await withWorkspaceWriteLock(workspaceId, async () => {
+        const doc = await getDoc(workspaceId, slug)
+        // A second (or later) frame's handler can pass the `isClosing` check
+        // above before this frame's `await getDoc` resolves — both were
+        // still false at the top when they started. Recheck immediately after
+        // the await so a frame that lost that race does not import, persist,
+        // or close a socket the earlier frame already tore down.
+        if (isClosing) return null
 
-      // `LoroDoc.import` throws synchronously (loro-crdt's wasm layer may
-      // throw a non-Error value) whenever the bytes are not a valid Loro
-      // update/snapshot. A write-scope credential is real authorization to
-      // send edits, not a guarantee the bytes are well-formed CRDT data, so
-      // this boundary must not be able to crash the daemon on one bad frame.
-      // Treat it as a protocol violation: discard the frame, never persist
-      // or broadcast it, and close — consistent with the 1008 scope-violation
-      // close above, but 1003 (Unsupported Data) since the socket itself was
-      // authorized, only this frame's payload was not decodable.
-      try {
-        currentDoc.import(bytes)
-      } catch (err: unknown) {
-        getLogger('ws').warning(
-          { workspaceId, slug, updateBytes: bytes.byteLength, err },
-          'ws binary update rejected: malformed Loro import data',
-        )
-        closeSocket(1003, 'Malformed canvas update')
-        return
-      }
+        // `LoroDoc.import` throws synchronously (loro-crdt's wasm layer may
+        // throw a non-Error value) whenever the bytes are not a valid Loro
+        // update/snapshot. A write-scope credential is real authorization to
+        // send edits, not a guarantee the bytes are well-formed CRDT data, so
+        // this boundary must not be able to crash the daemon on one bad frame.
+        // Treat it as a protocol violation: discard the frame, never persist
+        // or broadcast it, and close — consistent with the 1008 scope-violation
+        // close above, but 1003 (Unsupported Data) since the socket itself was
+        // authorized, only this frame's payload was not decodable.
+        try {
+          doc.import(bytes)
+        } catch (err: unknown) {
+          getLogger('ws').warning(
+            { workspaceId, slug, updateBytes: bytes.byteLength, err },
+            'ws binary update rejected: malformed Loro import data',
+          )
+          closeSocket(1003, 'Malformed canvas update')
+          return null
+        }
 
-      await saveCanvas(workspaceId, slug, currentDoc, { overwrite: true })
+        await saveCanvas(workspaceId, slug, doc, { overwrite: true })
+        return doc
+      })
+      if (currentDoc === null) return
+
       // Isolated in its own try/catch: this hook exists only so tests can
       // await a deterministic "persisted" signal instead of polling. A
       // callback throwing must never be able to make an already-successful


### PR DESCRIPTION
## What

Closes the remaining members of the unlocked `getDoc()` → `saveCanvas()` race family. A concurrent `DELETE .../canvases/:slug` or `PUT .../:slug/slug` landing between an unlocked read and its later save made `saveCanvas`'s lazy-create branch forge a phantom canvas at the old slug (or resurrect deleted content). The `POST /update` instance was fixed in #646; this PR applies the same `withWorkspaceWriteLock` read-import-save pattern to the three remaining sites:

- **ws.ts binary-update handler** (primary real-time collab path): `getDoc` + `isClosing` recheck + `doc.import` + `saveCanvas` now run in one lock hold. Broadcast, `onPersistedForTests`, and the auto-version trigger stay outside the lock — the critical section never awaits on a client (frames are fully buffered before the handler fires), so the serialization model is unchanged: the workspace write lock already serialized every `saveCanvas`.
- **restore.ts** `POST .../versions/:id/restore`: the whole read-reconcile-save body (both the targetSlug-overwrite branch and the identical-shaped in-place branch) runs under one lock hold.
- **app.ts `performMerge` hook**: the full read-modify-write runs under `withWorkspaceWriteLock(sid)`. The `branches.ts` merge route needs no lock of its own — a comment now records that `performMerge` owns the transaction, resolving the apparent asymmetry with `PUT /head` (which locks to protect its own branches.json read+save).

**Tombstone declined** (recorded in design + comments): with every `getDoc`→`saveCanvas` writer locked, the never-created-vs-just-deleted ambiguity in `saveCanvas`'s lazy-create branch is unobservable in-process; a tombstone would add expiry-bearing state to guard a caller class this change eliminates. Residual exposure is a future unlocked call site (guarded by the new pins + comment pattern) and multi-process deployment (already `workspace-lock.ts`'s documented ceiling, CAS as the named upgrade path).

## Tests

Three red-first interleaving pins, one per site, each mirroring the gated-`getDoc` technique from `canvas.test.ts`'s phantom-duplicate pin (#646):

- `ws-rename-race.test.ts` — WS binary frame vs `renameCanvasSlug`: no phantom at the old slug
- `restore-race.test.ts` — targetSlug-overwrite restore vs DELETE of the target: deleted content not resurrected (plus an in-place restore vs delete pin)
- `app.merge-race.test.ts` — real `performMerge` via `createApp` vs rename: exactly one canvas survives at the post-rename slug

**Mutation-checked per site**: each lock wrap reverted → its pin goes red → restored → green (all three recorded in the dev-loop report).

## Gates

`pnpm test --project mcp-node` 264 files / 3238 tests green un-weakened; `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, `pnpm lint:noconsole` all clean. Review workflow: zero confirmed findings.

No visual evidence: server-side race fix, invisible to humans; the interleavings are only constructible in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw