### PR TITLE
feat(web): switch workspaces from the header canvas dropdown

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -464,6 +464,68 @@ describe('WorkspaceTopBar browser mode', () => {
     delete navigator.clipboard
   })
 
+  describe('workspace picker (real Radix)', () => {
+    function renderWithWorkspaces(onSwitchWorkspace: (workspaceId: string) => void) {
+      return renderTopBar({ workspaceId: 'w1', workspaces: ['w1', 'w2'], onSwitchWorkspace })
+    }
+
+    it('keyboard: Tab, Enter, ArrowDown traversal (pinned via activeElement), Enter selects and closes', async () => {
+      const onSwitchWorkspace = vi.fn()
+      renderWithWorkspaces(onSwitchWorkspace)
+
+      const switcher = await screen.findByRole('button', { name: /^Workspace:/i })
+      for (let i = 0; i < 10 && document.activeElement !== switcher; i++) {
+        await userEvent.tab()
+      }
+      expect(switcher).toHaveFocus()
+
+      await userEvent.keyboard('{Enter}')
+      const w1Item = await screen.findByRole('menuitemradio', { name: 'w1' })
+      const w2Item = screen.getByRole('menuitemradio', { name: 'w2' })
+
+      // The search box's autoFocus wins the open-mount focus race against
+      // Radix, so the first ArrowDown is what forwards focus into the
+      // roving-item list at all — pin the transition itself, not only the
+      // eventual selection.
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(w1Item)
+
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(w2Item)
+
+      await userEvent.keyboard('{Enter}')
+      await expect.poll(() => onSwitchWorkspace.mock.calls).toEqual([['w2']])
+      await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+    })
+
+    it('real pointer click on a workspace item fires onSwitchWorkspace and closes the menu', async () => {
+      const onSwitchWorkspace = vi.fn()
+      renderWithWorkspaces(onSwitchWorkspace)
+
+      const switcher = await screen.findByRole('button', { name: /^Workspace:/i })
+      await userEvent.click(switcher)
+      await screen.findByRole('menuitemradio', { name: 'w1' })
+
+      await page.getByRole('menuitemradio', { name: 'w2' }).click()
+
+      await expect.poll(() => onSwitchWorkspace.mock.calls).toEqual([['w2']])
+      await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+    })
+
+    it('Escape closes the menu without firing onSwitchWorkspace', async () => {
+      const onSwitchWorkspace = vi.fn()
+      renderWithWorkspaces(onSwitchWorkspace)
+
+      const switcher = await screen.findByRole('button', { name: /^Workspace:/i })
+      await userEvent.click(switcher)
+      await screen.findByRole('menuitemradio', { name: 'w1' })
+
+      await userEvent.keyboard('{Escape}')
+      await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+      expect(onSwitchWorkspace).not.toHaveBeenCalled()
+    })
+  })
+
   it('does not leave sibling top-bar controls aria-hidden after the Canvas actions menu closes', async () => {
     renderTopBar()
 

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -27,6 +27,8 @@ function mkNamesOk() {
 function renderBar(overrides?: {
   onNavigateBack?: () => void
   onNavigateToCanvas?: (slug: string) => void
+  workspaces?: string[]
+  onSwitchWorkspace?: (workspaceId: string) => void
 }) {
   // React 18 delegates events to the root container. Radix portals render into document.body,
   // which is a DOM sibling of the default test container. Using document.body as the React root
@@ -39,6 +41,8 @@ function renderBar(overrides?: {
       onToggleFullscreen={() => {}}
       onNavigateBack={overrides?.onNavigateBack ?? (() => {})}
       onNavigateToCanvas={overrides?.onNavigateToCanvas ?? (() => {})}
+      workspaces={overrides?.workspaces}
+      onSwitchWorkspace={overrides?.onSwitchWorkspace}
     />,
     { container: document.body },
   )
@@ -1286,5 +1290,90 @@ describe('WorkspaceTopBar — mountedRef survives StrictMode dev double-invoke',
     await waitFor(() => {
       expect(screen.queryByLabelText('Canvas title')).toBeNull()
     })
+  })
+})
+
+describe('WorkspaceTopBar — workspace picker (RED-first)', () => {
+  async function openSwitcher() {
+    const switcher = screen.getByRole('button', { name: /^Workspace:/i })
+    fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
+    await screen.findByTestId('new-canvas-menu-item')
+  }
+
+  it('renders a Workspaces section above the canvases section, one menuitemradio per workspace, current checked', async () => {
+    renderBar({ workspaces: ['ws_1', 'w2'], onSwitchWorkspace: () => {} })
+    await openSwitcher()
+
+    const label = screen.getByText('Workspaces')
+    const items = screen.getAllByRole('menuitemradio')
+    expect(items.map((item) => item.textContent)).toEqual(['ws_1', 'w2'])
+    expect(items[0]?.getAttribute('aria-checked')).toBe('true')
+    expect(items[1]?.getAttribute('aria-checked')).toBe('false')
+
+    // "Above the canvases section": the label precedes the canvas entry in document order.
+    const canvasEntry = screen.getByText('canvas-a')
+    expect(
+      label.compareDocumentPosition(canvasEntry) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('marks the current workspace with a visible non-color indicator (ItemIndicator check icon), and no indicator on the others', async () => {
+    renderBar({ workspaces: ['ws_1', 'w2'], onSwitchWorkspace: () => {} })
+    await openSwitcher()
+
+    const items = screen.getAllByRole('menuitemradio')
+    expect(items[0]?.querySelector('svg')).not.toBeNull()
+    expect(items[1]?.querySelector('svg')).toBeNull()
+  })
+
+  it('clicking another workspace calls onSwitchWorkspace exactly once with its id and closes the menu', async () => {
+    const onSwitchWorkspace = vi.fn()
+    renderBar({ workspaces: ['ws_1', 'w2'], onSwitchWorkspace })
+    await openSwitcher()
+
+    const w2Item = screen.getByRole('menuitemradio', { name: 'w2' })
+    fireEvent.pointerUp(w2Item)
+
+    await waitFor(() => expect(onSwitchWorkspace).toHaveBeenCalledTimes(1))
+    expect(onSwitchWorkspace).toHaveBeenCalledWith('w2')
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  })
+
+  it('clicking the current workspace never calls onSwitchWorkspace', async () => {
+    const onSwitchWorkspace = vi.fn()
+    renderBar({ workspaces: ['ws_1', 'w2'], onSwitchWorkspace })
+    await openSwitcher()
+
+    const currentItem = screen.getByRole('menuitemradio', { name: 'ws_1' })
+    fireEvent.pointerUp(currentItem)
+
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+    expect(onSwitchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('renders no Workspaces section when workspaces/onSwitchWorkspace are absent — every pre-existing caller stays byte-identical', async () => {
+    renderBar()
+    await openSwitcher()
+
+    expect(screen.queryByText('Workspaces')).toBeNull()
+    expect(screen.queryByRole('menuitemradio')).toBeNull()
+  })
+
+  it('renders no Workspaces section with a single workspace, and hides it while a canvas search is active', async () => {
+    const onSwitchWorkspace = vi.fn()
+    renderBar({ workspaces: ['ws_1'], onSwitchWorkspace })
+    await openSwitcher()
+    expect(screen.queryByText('Workspaces')).toBeNull()
+
+    cleanup()
+
+    renderBar({ workspaces: ['ws_1', 'w2'], onSwitchWorkspace })
+    await openSwitcher()
+    expect(screen.getByText('Workspaces')).toBeTruthy()
+
+    fireEvent.change(screen.getByPlaceholderText('Switch canvas…'), {
+      target: { value: 'canvas-a' },
+    })
+    expect(screen.queryByText('Workspaces')).toBeNull()
   })
 })

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -75,6 +75,10 @@ interface Props {
   // connection-state chip mounts here so the one
   // status affordance lives in the header instead of a banner row.
   statusSlot?: ReactNode
+  // Pass-through to CanvasDropdown's optional Workspaces section — both
+  // omitted (every pre-existing caller) keeps this byte-identical.
+  workspaces?: string[]
+  onSwitchWorkspace?: (workspaceId: string) => void
 }
 
 // Give the canvas visual priority and keep the surrounding chrome lightweight.
@@ -103,6 +107,8 @@ export default function WorkspaceTopBar({
   onExport,
   onOpenSettings,
   statusSlot,
+  workspaces,
+  onSwitchWorkspace,
 }: Props) {
   const isLocalMode = dataMode === 'local'
   const versionsEnabled = capabilities?.versions ?? true
@@ -242,6 +248,8 @@ export default function WorkspaceTopBar({
           onCreateMarkdown={
             onCreateMarkdownCanvas === undefined ? undefined : () => void onCreateMarkdownCanvas()
           }
+          workspaces={workspaces}
+          onSwitchWorkspace={onSwitchWorkspace}
         />
 
         {/* Canvas-specific actions such as rename and copy URL. */}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,4 +1,5 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { Check } from 'lucide-react'
 import type * as React from 'react'
 import { cn } from '@/lib/utils'
 
@@ -55,6 +56,40 @@ function DropdownMenuItem({
   )
 }
 
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {/* The current-item marker is a visible glyph, not color alone —
+          Radix unmounts this indicator entirely (no forceMount) for every
+          unchecked item, so its mere presence in the DOM already signals
+          "checked" without an extra assertion on data-state. */}
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="size-3.5" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
 function DropdownMenuLabel({
   className,
   inset,
@@ -90,6 +125,8 @@ export {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 }

--- a/apps/web/src/components/workspace-top-bar/CanvasDropdown.tsx
+++ b/apps/web/src/components/workspace-top-bar/CanvasDropdown.tsx
@@ -1,11 +1,13 @@
 import type { WorkspaceNames } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { ChevronDown, FilePlus2, Pin, Search } from 'lucide-react'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
@@ -30,6 +32,11 @@ interface CanvasDropdownProps {
   onTogglePin: (slug: string, nextPinned: boolean) => void
   onOpenNewCanvas: () => void /** Renders a second creation entry for markdown-kind canvases (local mode). */
   onCreateMarkdown?: () => void
+  // Both present (and >1 entry) render a "Workspaces" section above the
+  // canvases section. Either omitted keeps every existing caller
+  // (BrowserLocalCanvasPage, docs snapshots) byte-identical.
+  workspaces?: string[]
+  onSwitchWorkspace?: (workspaceId: string) => void
 }
 
 // The canvas switcher dropdown — workspace identity is intentionally hidden
@@ -47,6 +54,8 @@ export function CanvasDropdown({
   onTogglePin,
   onOpenNewCanvas,
   onCreateMarkdown,
+  workspaces,
+  onSwitchWorkspace,
 }: CanvasDropdownProps) {
   const sortedCanvases = useMemo(() => sortCanvasesByRecency(canvases), [canvases])
   const filteredCanvases = useMemo(
@@ -80,6 +89,21 @@ export function CanvasDropdown({
   // what the user sees before anyone has named it.
   const workspaceLabel = isLocalMode ? 'Local' : (effectiveNames.workspace ?? workspaceId)
 
+  // The search box takes autoFocus on open, which wins the mount-focus race
+  // against Radix's own DismissableLayer/FocusScope (it only auto-focuses
+  // the content when nothing inside already has focus) — so a real DOM
+  // item is never focused yet for Radix's roving-focus arrow handling to
+  // act on (that handling only fires for keydowns whose target IS the
+  // roving item itself). ArrowDown from the search box forwards focus onto
+  // the first roving item so keyboard-only users can still reach the list
+  // without a mouse.
+  const contentRef = useRef<HTMLDivElement>(null)
+  const focusFirstItem = () => {
+    contentRef.current
+      ?.querySelector<HTMLElement>('[role="menuitemradio"], [role="menuitem"]')
+      ?.focus()
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -98,6 +122,7 @@ export function CanvasDropdown({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        ref={contentRef}
         // Let Radix handle the single scroll container.
         // Search stays sticky at the top and the footer stays sticky at the bottom.
         className="w-[320px] p-0"
@@ -116,12 +141,42 @@ export function CanvasDropdown({
             <Input
               value={canvasSearch}
               onChange={(e) => onCanvasSearchChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  focusFirstItem()
+                }
+              }}
               placeholder="Switch canvas…"
               className="h-8 pl-7 text-xs"
               autoFocus
             />
           </div>
         </div>
+        {workspaces && onSwitchWorkspace && workspaces.length > 1 && canvasSearch === '' && (
+          <div className="border-b p-1">
+            <DropdownMenuLabel className="px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+              Workspaces
+            </DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={workspaceId}
+              onValueChange={(nextWorkspaceId) => {
+                // Radix's RadioItem fires onSelect (hence this) for the
+                // already-checked item too — the no-op guard lives here,
+                // not in Radix, or re-picking the current workspace would
+                // jump the user to that workspace's first canvas for
+                // nothing.
+                if (nextWorkspaceId !== workspaceId) onSwitchWorkspace(nextWorkspaceId)
+              }}
+            >
+              {workspaces.map((id) => (
+                <DropdownMenuRadioItem key={id} value={id}>
+                  {id}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </div>
+        )}
         <div className="max-h-[300px] overflow-y-auto">
           <div className="flex flex-col p-1">
             {filteredCanvases.length === 0 ? (

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -82,6 +82,11 @@ async function selectCanvasFromSwitcher(label: string) {
   fireEvent.pointerUp(item)
 }
 
+async function selectWorkspaceFromSwitcher(workspaceId: string) {
+  const item = await screen.findByRole('menuitemradio', { name: workspaceId })
+  fireEvent.pointerUp(item)
+}
+
 // The bar's History button opens the version popover, which now also
 // carries the page's own "Save version" button/message via versionPanelExtra.
 function toggleHistoryPanel() {
@@ -174,6 +179,9 @@ describe('DaemonCanvasPage', () => {
     // A single-workspace daemon renders no workspace selector at all —
     // one raw id is not a choice, and every header row costs canvas height.
     expect(screen.queryByLabelText('Workspaces')).toBeNull()
+    await openCanvasSwitcher()
+    expect(screen.queryByText('Workspaces')).toBeNull()
+    expect(screen.queryByRole('menuitemradio')).toBeNull()
   })
 
   describe('workspace switcher', () => {
@@ -198,8 +206,14 @@ describe('DaemonCanvasPage', () => {
       // docks in Select mode, so tests exercising it switch first.
       fireEvent.click(await screen.findByTestId('select-tool-button'))
 
-      const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
-      expect(Array.from(workspaceSelect.options).map((o) => o.value)).toEqual(['w1', 'w2'])
+      // The header dropdown is the switcher once a canvas is mounted; the
+      // secondary-row <select> only survives the no-canvas state (see the
+      // negative-direction test below).
+      await openCanvasSwitcher()
+      expect(screen.getAllByRole('menuitemradio').map((item) => item.textContent)).toEqual([
+        'w1',
+        'w2',
+      ])
     })
 
     it('selecting another workspace re-resolves the canvas and re-keys the backend', async () => {
@@ -233,10 +247,9 @@ describe('DaemonCanvasPage', () => {
       expect(createdBackends).toHaveLength(1)
       expect(createdBackends[0]?.workspaceId).toBe('w1')
 
-      const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+      await openCanvasSwitcher()
       await act(async () => {
-        workspaceSelect.value = 'w2'
-        workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+        await selectWorkspaceFromSwitcher('w2')
       })
 
       await waitFor(() => {
@@ -272,15 +285,26 @@ describe('DaemonCanvasPage', () => {
       // docks in Select mode, so tests exercising it switch first.
       fireEvent.click(await screen.findByTestId('select-tool-button'))
 
-      const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+      // w1 has canvases, so the dropdown (not the row select, which is
+      // absent while a canvas is mounted) is what starts the switch.
+      await openCanvasSwitcher()
       await act(async () => {
-        workspaceSelect.value = 'w2'
-        workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+        await selectWorkspaceFromSwitcher('w2')
       })
 
       await waitFor(() =>
         expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
       )
+      // w2 has zero canvases, so WorkspaceTopBar (and its dropdown) is
+      // unmounted — the row select is the only switcher available here, and
+      // it must still work to get back out of the empty workspace.
+      const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+      expect(Array.from(workspaceSelect.options).map((o) => o.value)).toEqual(['w1', 'w2'])
+      await act(async () => {
+        workspaceSelect.value = 'w1'
+        workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+      })
+      await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
     })
 
     it('keeps the editor mounted and shows an inline error when switching workspace fails', async () => {
@@ -308,10 +332,9 @@ describe('DaemonCanvasPage', () => {
 
       mockListCanvases.mockRejectedValueOnce(new Error('daemon unreachable'))
 
-      const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+      await openCanvasSwitcher()
       await act(async () => {
-        workspaceSelect.value = 'w2'
-        workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+        await selectWorkspaceFromSwitcher('w2')
       })
 
       await waitFor(() =>
@@ -324,6 +347,13 @@ describe('DaemonCanvasPage', () => {
     })
 
     it('shows the static disabled teaser instead of the switcher when capabilities.workspaces is false', async () => {
+      // A daemon with >=2 workspaces still shows no dropdown section or row
+      // select while the capability itself is off — capability gating is a
+      // single rule, not one the new dropdown surface could bypass.
+      mockListWorkspaces.mockResolvedValue({
+        workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
+      })
+
       await act(async () => {
         render(
           <DaemonCanvasPage
@@ -350,6 +380,35 @@ describe('DaemonCanvasPage', () => {
       expect(screen.queryByLabelText('Workspaces')).toBeNull()
       const teaser = screen.getByText('Workspaces')
       expect(teaser.getAttribute('aria-disabled')).toBe('true')
+
+      await openCanvasSwitcher()
+      expect(screen.queryByRole('menuitemradio')).toBeNull()
+    })
+
+    it('with a canvas mounted, capabilities.workspaces=true, and >=2 workspaces, the dropdown is the ONLY switcher: the row select is absent while the dropdown shows the Workspaces section', async () => {
+      mockListWorkspaces.mockResolvedValue({
+        workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
+      })
+
+      await act(async () => {
+        render(
+          <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+          { container: document.body },
+        )
+      })
+      await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+      // Hand (view-only) is the default tool; the host history cluster only
+      // docks in Select mode, so tests exercising it switch first.
+      fireEvent.click(await screen.findByTestId('select-tool-button'))
+
+      expect(screen.queryByLabelText('Workspaces')).toBeNull()
+
+      await openCanvasSwitcher()
+      expect(screen.getByText('Workspaces')).toBeTruthy()
+      expect(screen.getAllByRole('menuitemradio').map((item) => item.textContent)).toEqual([
+        'w1',
+        'w2',
+      ])
     })
   })
 
@@ -543,11 +602,11 @@ describe('DaemonCanvasPage', () => {
     // Switch into a workspace with zero canvases: the canvas backend tears
     // down entirely (no WorkspaceTopBar mounts), but there genuinely is no
     // live sync happening either way, so the indicator must not disappear
-    // just because the canvas-gated UI does.
-    const workspaceSelect = screen.getByLabelText('Workspaces') as HTMLSelectElement
+    // just because the canvas-gated UI does. w1 has a mounted canvas, so the
+    // row select is absent here — the dropdown drives the switch.
+    await openCanvasSwitcher()
     await act(async () => {
-      workspaceSelect.value = 'w2'
-      workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }))
+      await selectWorkspaceFromSwitcher('w2')
     })
 
     await waitFor(() =>

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -479,6 +479,12 @@ export function DaemonCanvasPage({
               // the upload entirely and latest-thumbnail stays 204 forever.
               getThumbnailBlob={getThumbnailBlob}
               onOpenSettings={handleOpenSettings}
+              workspaces={
+                capabilities.workspaces
+                  ? controller.workspaces.map((w) => w.workspaceId)
+                  : undefined
+              }
+              onSwitchWorkspace={(id) => void controller.switchWorkspace(id)}
             />
           )}
           {capabilities.branches && canvas && (
@@ -490,13 +496,18 @@ export function DaemonCanvasPage({
             local case — gets no extra header row at all (raw ids are not
             chrome, and every header row costs canvas height on a phone). */}
           {(!capabilities.workspaces ||
-            controller.workspaces.length > 1 ||
+            (controller.workspaces.length > 1 && !canvas) ||
             !capabilities.versions ||
             !capabilities.branches ||
             !capabilities.merge) && (
             <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
               {capabilities.workspaces ? (
-                controller.workspaces.length > 1 && (
+                // WorkspaceTopBar's dropdown is the switcher once a canvas is
+                // mounted; this select survives only for the no-canvas state
+                // (empty workspace), where that dropdown never mounts and it
+                // is the only way to switch back out.
+                controller.workspaces.length > 1 &&
+                !canvas && (
                   <select
                     aria-label="Workspaces"
                     value={controller.workspaceId ?? ''}


### PR DESCRIPTION
## What

The canvas-page header's row-one trigger is labelled with the workspace name but only listed canvases. This adds a **Workspaces** section (menuitemradio, current workspace marked with a visible check indicator) above the canvases section in `CanvasDropdown`, wired on `DaemonCanvasPage` to the existing `controller.switchWorkspace` path — the editor re-keys onto the new workspace's first canvas (or the empty-state create form) without a page teardown, and a failed switch keeps the old editor session with the existing inline alert.

- `dropdown-menu.tsx` gains the standard shadcn `DropdownMenuRadioGroup`/`DropdownMenuRadioItem` wrappers over the already-installed Radix primitive.
- `WorkspaceTopBar`/`CanvasDropdown` take optional `workspaces?: string[]` + `onSwitchWorkspace?` — pages that don't pass them (browser-local) render exactly as before.
- The section renders only with ≥2 workspaces, `capabilities.workspaces` on, and an empty canvas search; selecting the current workspace is a no-op (guards Radix's onValueChange-fires-on-checked-item behavior).
- The secondary-row `<select aria-label="Workspaces">` is narrowed to the no-canvas state (empty workspace), where the dropdown is unmounted and it is the only escape — in the canvas-mounted state the dropdown is the single switcher (pinned by a negative-direction test).
- **Keyboard fix found during implementation**: the search box's `autoFocus` wins the open-mount focus race against Radix's FocusScope, so arrow keys never reached the roving menu items from a fresh open — a keyboard-only user could not reach any item at all (pre-existing, also affected the canvas list). The search input now forwards `ArrowDown` into the first menu item; the full keyboard flow (Tab → Enter → ArrowDown traversal pinned via `document.activeElement` → Enter selects) is a real-browser test.

Product rulings honored: switching is within one daemon (no multi-daemon memory) and there is no per-workspace online badge (it would carry zero information in this model).

## Visual repro

The open dropdown on a daemon canvas page with two workspaces — current one checked, canvases below:

![workspace-picker-open.png](https://github.com/user-attachments/assets/67fedd16-fe34-482d-a9d6-5b5caa528d8e)

(Captured from real Chromium via a browser-mode render of `WorkspaceTopBar` against deterministic mocked data; interactive in-app pass was environment-blocked this session — hidden-tab CDP artifacts — so flow-level confidence rests on the retargeted `DaemonCanvasPage` jsdom suite driving the real controller path, 11 real-browser keyboard/pointer tests, and the review workflow's QA lanes.)

## Tests

- `WorkspaceTopBar.test.tsx`: 6 new jsdom tests (section order, aria-checked + visible check indicator, fires-once/closes, current-is-noop, props-absent compat, single-workspace/search-active hides section).
- `WorkspaceTopBar.browser.test.tsx`: 3 real-browser tests (full keyboard flow with activeElement-pinned traversal, pointer, Escape-no-fire).
- `DaemonCanvasPage.test.tsx`: the two select-driven tests retargeted un-weakened, 2 more retargeted, 3 extended, plus the negative-direction pin (select absent while a canvas is mounted). No pre-existing assertion deleted.

## Gates

apps/web jsdom 1844 green; browser suites 507/507; `pnpm -r typecheck`, `pnpm knip`, `pnpm lint`, `pnpm lint:noconsole` clean. Review workflow over the diff: zero confirmed findings; QA smoke/error-recovery/startup all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw