### PR TITLE
chore(web): spell the metrics-cache key separator as an escape, not a raw NUL

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -808,7 +808,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       })
       const metricsCache = new Map<string, TextMetrics>()
       const measure: MeasureText = (text, font) => {
-        const key = `${font.family}|${font.weight}|${font.style}|${font.sizePx} ${text}`
+        const key = `${font.family}|${font.weight}|${font.style}|${font.sizePx}\u0000${text}`
         const hit = metricsCache.get(key)
         if (hit !== undefined) return hit
         const metrics = resolvedMeasure(text, font)


### PR DESCRIPTION
## What

One byte: the literal NUL embedded in SpatialEditor.tsx's measure-cache template key becomes the `\u0000` escape. The runtime key is identical.

## Why

The raw byte made grep/ripgrep classify the whole 4k-line file as binary, so every repo-wide search silently skipped it — an invisible hole that has already cost multiple debugging sessions (surfaced during today's rendering-pipeline parity audit). `file` now reports UTF-8 text and plain `grep` works again.

Full apps/web suite passes (1857 jsdom + 71 node tests); invisible to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ