### PR TITLE
fix(render): one edge-label anchor shared by export and editor

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -68,6 +68,7 @@ import type {
 import type { MeasureText, SpatialPresetKey, TextMetrics } from '@kamiazya/whiteboard-canvas-render'
 import {
   BODY_FONT_SIZE_PX,
+  edgeLabelAnchor,
   flattenRoundedEdgePath,
   layoutSpatialEdges,
   renderSceneToSvg,
@@ -156,7 +157,6 @@ import {
   HANDLE_SIGN,
   hitTest,
   indexNodeBoxes,
-  polylineMidpoint,
   resizeBoxByDelta,
   scaleBoxWithin,
   unionBox,
@@ -3881,8 +3881,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             (() => {
               const edge = canvas.edges.find((entry) => entry.id === edgeLabelEditId)
               const path = edgePaths.find((entry) => entry.id === edgeLabelEditId)?.path
-              if (edge === undefined || path === undefined || path.length < 2) return null
-              const mid = polylineMidpoint(path)
+              if (edge === undefined || path === undefined) return null
+              // edgePaths is already the DRAWN (flattened) line, so the
+              // shared anchor needs no second rounding pass here.
+              const mid = edgeLabelAnchor(path)
+              if (mid === undefined) return null
               return (
                 <TextNodeEditor
                   box={{

--- a/apps/web/src/components/spatial-editor/geometry.test.ts
+++ b/apps/web/src/components/spatial-editor/geometry.test.ts
@@ -5,7 +5,6 @@ import {
   findFreeSpot,
   hitTest,
   indexNodeBoxes,
-  polylineMidpoint,
   resizeBoxByDelta,
   resizeHandleBoxes,
 } from './geometry.js'
@@ -164,28 +163,5 @@ describe('findFreeSpot', () => {
     const spot = findFreeSpot({ x: 500, y: 300 }, size, occupied)
     expect(Number.isFinite(spot.x)).toBe(true)
     expect(Number.isFinite(spot.y)).toBe(true)
-  })
-})
-
-describe('polylineMidpoint', () => {
-  it('returns the arc-length midpoint of a two-segment path', () => {
-    // Segments of length 10 then 30: midpoint is 20 along, i.e. 10 into segment 2.
-    const path = [
-      { x: 0, y: 0 },
-      { x: 10, y: 0 },
-      { x: 10, y: 30 },
-    ]
-    expect(polylineMidpoint(path)).toEqual({ x: 10, y: 10 })
-  })
-
-  it('degrades on degenerate paths instead of throwing', () => {
-    expect(polylineMidpoint([])).toEqual({ x: 0, y: 0 })
-    expect(polylineMidpoint([{ x: 3, y: 4 }])).toEqual({ x: 3, y: 4 })
-    expect(
-      polylineMidpoint([
-        { x: 5, y: 5 },
-        { x: 5, y: 5 },
-      ]),
-    ).toEqual({ x: 5, y: 5 })
   })
 })

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -261,36 +261,3 @@ export function distanceToPolyline(
   }
   return min
 }
-
-/**
- * The point at half the polyline's arc length — where an edge's inline
- * label editor anchors. Degenerate paths degrade instead of throwing:
- * empty → origin, single point → that point.
- */
-export function polylineMidpoint(path: readonly { x: number; y: number }[]): {
-  x: number
-  y: number
-} {
-  if (path.length === 0) return { x: 0, y: 0 }
-  if (path.length === 1) return { x: path[0].x, y: path[0].y }
-  const segmentLengths: number[] = []
-  let total = 0
-  for (let i = 0; i + 1 < path.length; i += 1) {
-    const length = Math.hypot(path[i + 1].x - path[i].x, path[i + 1].y - path[i].y)
-    segmentLengths.push(length)
-    total += length
-  }
-  if (total === 0) return { x: path[0].x, y: path[0].y }
-  let remaining = total / 2
-  for (let i = 0; i < segmentLengths.length; i += 1) {
-    if (remaining <= segmentLengths[i]) {
-      const t = segmentLengths[i] === 0 ? 0 : remaining / segmentLengths[i]
-      return {
-        x: path[i].x + t * (path[i + 1].x - path[i].x),
-        y: path[i].y + t * (path[i + 1].y - path[i].y),
-      }
-    }
-    remaining -= segmentLengths[i]
-  }
-  return { x: path[path.length - 1].x, y: path[path.length - 1].y }
-}

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -1,3 +1,4 @@
+export { edgeLabelAnchor } from './layout/edge-label-anchor.js'
 export { flattenRoundedEdgePath } from './layout/edge-rounding.js'
 export * from './layout/embed-recursion.js'
 export type { MdastLayoutOptions } from './layout/mdast-blocks.js'

--- a/packages/canvas-render/src/layout/edge-label-anchor.test.ts
+++ b/packages/canvas-render/src/layout/edge-label-anchor.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { edgeLabelAnchor } from './edge-label-anchor.js'
+import { flattenRoundedEdgePath } from './edge-rounding.js'
+
+describe('edgeLabelAnchor', () => {
+  it('returns the arc-length midpoint of a two-segment path', () => {
+    // Segments of length 10 then 30: midpoint is 20 along, i.e. 10 into segment 2.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 30 },
+    ]
+    expect(edgeLabelAnchor(path)).toEqual({ x: 10, y: 10 })
+  })
+
+  it('sits on the drawn curve, not the corner vertex, for a rounded path', () => {
+    // A symmetric right angle: the raw arc-length midpoint IS the corner
+    // vertex, which the rounded ink never touches. The anchor must follow
+    // the flattened curve instead.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]
+    const anchor = edgeLabelAnchor(path, true)
+    expect(anchor).not.toEqual({ x: 100, y: 0 })
+    expect(anchor).toEqual(edgeLabelAnchor(flattenRoundedEdgePath(path)))
+  })
+
+  it('returns undefined when the path draws no line', () => {
+    expect(edgeLabelAnchor([])).toBeUndefined()
+    expect(edgeLabelAnchor([{ x: 3, y: 4 }])).toBeUndefined()
+    expect(
+      edgeLabelAnchor([
+        { x: 5, y: 5 },
+        { x: 5, y: 5 },
+      ]),
+    ).toBeUndefined()
+  })
+})

--- a/packages/canvas-render/src/layout/edge-label-anchor.ts
+++ b/packages/canvas-render/src/layout/edge-label-anchor.ts
@@ -1,0 +1,44 @@
+// The single producer of "where an edge's label sits": the arc-length
+// midpoint of the DRAWN line. Both the SVG backend (composeEdgeLabel) and
+// the editor's inline label editor anchor here — two independent midpoint
+// derivations is the drift class that put exported labels on the sharp
+// corner a curved edge's ink never touches.
+import { flattenRoundedEdgePath } from './edge-rounding.js'
+
+type Point = { readonly x: number; readonly y: number }
+
+/**
+ * The point halfway along the drawn edge, by arc length. `rounded` applies
+ * the same corner flattening the backend and hit-testing draw with, so the
+ * anchor stays on the curve rather than the raw corner vertex.
+ *
+ * Returns `undefined` when the path draws no line — fewer than two points,
+ * or every point at the same place. `routeEdge`'s missing-endpoint fallback
+ * is that second case specifically: it degrades to `[origin, origin]`, a
+ * two-point path of zero length. A point-count check alone would miss it
+ * and leave a label floating at the canvas origin.
+ */
+export function edgeLabelAnchor(path: readonly Point[], rounded?: boolean): Point | undefined {
+  const first = path[0]
+  if (path.length < 2 || first === undefined) return undefined
+  if (path.every((p) => p.x === first.x && p.y === first.y)) return undefined
+  const drawn = rounded === true ? flattenRoundedEdgePath(path) : path
+  const lengths: number[] = []
+  let total = 0
+  for (let i = 0; i + 1 < drawn.length; i++) {
+    const length = Math.hypot(drawn[i + 1]!.x - drawn[i]!.x, drawn[i + 1]!.y - drawn[i]!.y)
+    lengths.push(length)
+    total += length
+  }
+  let remaining = total / 2
+  for (let i = 0; i < lengths.length; i++) {
+    if (remaining <= lengths[i]!) {
+      const t = lengths[i] === 0 ? 0 : remaining / lengths[i]!
+      const from = drawn[i]!
+      const to = drawn[i + 1]!
+      return { x: from.x + t * (to.x - from.x), y: from.y + t * (to.y - from.y) }
+    }
+    remaining -= lengths[i]!
+  }
+  return drawn[drawn.length - 1]
+}

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -164,6 +164,48 @@ describe('layoutSpatialCanvas', () => {
     expect(label?.appearance?.fill).toBe('#303030')
   })
 
+  it('centers a multi-segment edge label at the arc-length midpoint, not a corner vertex', () => {
+    // Diagonal neighbours route as an L with unequal legs; the label must
+    // sit halfway along the DRAWN line (the same anchor the editor's
+    // inline label editor uses), not on the index-middle waypoint, which
+    // for an L-route is the corner itself.
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 300, y: 200, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b', label: 'L' }
+    const scene = layoutSpatialCanvas(
+      { ...canvas([a, b], [edge]), 'x-whiteboard': { edgeRouting: { style: 'orthogonal' } } },
+      baseOptions(),
+    )
+    const routed = scene.nodes.find(
+      (n): n is import('../scene-graph.js').ResolvedEdgeNode => n.kind === 'edge',
+    )
+    const label = scene.nodes.find((n): n is TextRunNode => n.kind === 'textRun' && n.text === 'L')
+    expect(routed).toBeDefined()
+    expect(label).toBeDefined()
+    if (routed === undefined || label === undefined) return
+    // Independent arc-length midpoint of the routed path.
+    let total = 0
+    const lengths = routed.path.slice(1).map((p, i) => {
+      const l = Math.hypot(p.x - routed.path[i]!.x, p.y - routed.path[i]!.y)
+      total += l
+      return l
+    })
+    let remaining = total / 2
+    let expected = routed.path[0]!
+    for (let i = 0; i < lengths.length; i++) {
+      if (remaining <= lengths[i]!) {
+        const t = lengths[i] === 0 ? 0 : remaining / lengths[i]!
+        const from = routed.path[i]!
+        const to = routed.path[i + 1]!
+        expected = { x: from.x + t * (to.x - from.x), y: from.y + t * (to.y - from.y) }
+        break
+      }
+      remaining -= lengths[i]!
+    }
+    expect(label.bbox.x + label.bbox.w / 2).toBeCloseTo(expected.x, 6)
+    expect(label.bbox.y + label.bbox.h / 2).toBeCloseTo(expected.y, 6)
+  })
+
   it('emits no label run for an edge with no label', () => {
     const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
     const b = textNode({ id: 'b', x: 200, y: 0, width: 50, height: 50, text: 'b' })

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -37,6 +37,7 @@ import type {
 } from '../scene-graph.js'
 import { SPATIAL_THEME_GEOMETRY, type SpatialGeometry } from '../theme/spatial-geometry.js'
 import { computeEdgeJumps } from './edge-jumps.js'
+import { edgeLabelAnchor } from './edge-label-anchor.js'
 import { layoutMdastBlocks } from './mdast-blocks.js'
 import { scaleScene } from './scale-scene.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
@@ -474,35 +475,11 @@ function composeEdge(
 }
 
 /**
- * The point along `path` used to center an edge's label. Not an exact
- * arc-length midpoint — the midpoint of the two vertices straddling the
- * path's index midpoint — which is exact for the common 2-point straight
- * edge and a stable, deterministic approximation for a multi-point routed
- * path (e.g. a self-edge loop).
- *
- * Returns `undefined` when the path draws no line — fewer than two points,
- * or every point at the same place. `routeEdge`'s missing-endpoint fallback
- * is that second case specifically: it degrades to `[origin, origin]`, a
- * two-point path of zero length. A point-count check alone would miss it and
- * center the label on the canvas origin, leaving text floating with nothing
- * attached to it.
- */
-function edgeMidpoint(
-  path: readonly { readonly x: number; readonly y: number }[],
-): { readonly x: number; readonly y: number } | undefined {
-  const first = path[0]
-  if (path.length < 2 || first === undefined) return undefined
-  if (path.every((p) => p.x === first.x && p.y === first.y)) return undefined
-  const mid = (path.length - 1) / 2
-  const lower = path[Math.floor(mid)]!
-  const upper = path[Math.ceil(mid)]!
-  return { x: (lower.x + upper.x) / 2, y: (lower.y + upper.y) / 2 }
-}
-
-/**
  * Composes a centered label run for an edge that carries one. Returns
  * `undefined` for no label, an empty/whitespace-only label, or a
- * degenerate path — `layoutSpatialCanvas` stays total either way.
+ * degenerate path — `layoutSpatialCanvas` stays total either way. The
+ * anchor comes from `edgeLabelAnchor`, the same producer the editor's
+ * inline label editor uses.
  */
 function composeEdgeLabel(
   edge: CanvasEdge,
@@ -510,7 +487,7 @@ function composeEdgeLabel(
   options: ResolvedLayoutOptions,
 ): TextRunNode | undefined {
   if (edge.label === undefined || edge.label.trim().length === 0) return undefined
-  const center = edgeMidpoint(routed.path)
+  const center = edgeLabelAnchor(routed.path, routed.rounded === true)
   if (!center) return undefined
 
   const labelAppearance = options.appearance.resolveLabel()


### PR DESCRIPTION
## Problem (from the rendering-pipeline parity audit)

Two independent midpoint producers for one visual: the backend centered edge labels on the waypoint **index** midpoint — on a 3-point L-route that is the corner vertex itself, so a curved edge's exported label sat detached from the line, on the sharp corner the ink never touches — while the editor's inline label editor anchored at the **arc-length** midpoint of the flattened curve. They agree only on 2-point straight edges. This is the drift class `package-canvas-render.md`'s one-producer rule names.

## Fix

`edgeLabelAnchor` (`layout/edge-label-anchor.ts`) is the single producer: arc-length midpoint of the **drawn** line, flattening rounded corners with the same `edge-rounding` decomposition hit-testing already uses. `composeEdgeLabel` (backend) and the editor's inline label editor both consume it; the editor's duplicated `polylineMidpoint` is deleted and its tests ported.

## Tests

- `edge-label-anchor.test.ts`: arc-length cases, rounded-curve anchor (not the corner vertex, equals the flattened-path anchor), degenerate paths → `undefined`.
- `spatial-canvas.test.ts`: layout-level pin — a multi-segment edge's label run centers on an independently computed arc-length midpoint (**red before this change**).
- Full canvas-render (390) + apps/web (1857 jsdom) suites pass; knip and typechecks clean.

## Visual repro

Curved L-route with a label. Before — label floats off the corner, detached from the line / After — label sits on the drawn curve, same spot the inline editor opens:

![edge-label-curved-before.png](https://github.com/user-attachments/assets/94f18c8a-de4f-4d0f-9a37-9b55ac9c2bbf)
![edge-label-curved-after.png](https://github.com/user-attachments/assets/565322ea-78f5-409c-bfa0-bad42a9bc451)

Follow-up candidate (not this PR): a background halo for edge labels so the on-line placement stays readable over the stroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ