### PR TITLE
fix(web): drag ghost renders expanded canvas embeds

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -753,9 +753,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const carried = carriedByGesture(canvas, gestureState, extraIds, isLocked)
       const nodes = canvas.nodes.filter((n) => carried.has(n.id))
       if (nodes.length === 0) return undefined
+      // Same embed options as the committed scene: a ghost that drops an
+      // expanded miniature back to a bare card mid-drag reads as data loss.
       const rendered = renderCanvasToSvg(
         { nodes, edges: [] },
-        { measure: resolvedMeasure, theme, resolveFileLabel, resolveFileImage },
+        {
+          measure: resolvedMeasure,
+          theme,
+          resolveFileLabel,
+          resolveFileCanvas,
+          expandFileNode,
+          resolveFileImage,
+        },
       )
       return {
         svg: rendered.svg,
@@ -772,6 +781,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       resolvedMeasure,
       theme,
       resolveFileLabel,
+      resolveFileCanvas,
+      expandFileNode,
       resolveFileImage,
     ])
 

--- a/apps/web/src/components/spatial-editor/drag-ghost-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-ghost-embed.browser.test.tsx
@@ -1,0 +1,74 @@
+// The drag ghost renders the carried node's REAL content — including an
+// expanded canvas embed. Omitting the embed resolvers from the ghost's
+// one-shot render made an inline miniature drag as a plain card and snap
+// back to a miniature on drop.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const inner: SpatialCanvas = {
+  nodes: [{ id: 'i1', type: 'text', x: 0, y: 0, width: 200, height: 100, text: 'inner content' }],
+  edges: [],
+}
+
+const outer: SpatialCanvas = {
+  nodes: [
+    {
+      id: 'f1',
+      type: 'file',
+      x: 100,
+      y: 100,
+      width: 320,
+      height: 300,
+      file: 'child',
+    },
+  ],
+  edges: [],
+}
+
+function press(el: HTMLElement, type: string, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  return el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId: 7,
+      button: 0,
+    }),
+  )
+}
+
+it('drags an expanded embed with its miniature content in the ghost', async () => {
+  const { container } = render(
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        defaultTool="select"
+        canvas={outer}
+        onChange={() => {}}
+        theme="light"
+        fileRefOptions={[{ file: 'child', label: 'child canvas' }]}
+        resolveFileCanvas={(file) => (file === 'child' ? inner : undefined)}
+      />
+    </div>,
+  )
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  // The committed render expands the embed (large on-screen node).
+  await vi.waitFor(() => {
+    expect((container.textContent ?? '').includes('inner content')).toBe(true)
+  })
+
+  press(root, 'pointerdown', 260, 250)
+  await new Promise((r) => requestAnimationFrame(r))
+  press(root, 'pointermove', 300, 290)
+  await vi.waitFor(() => {
+    const preview = container.querySelector('[data-testid="drag-preview"]')
+    expect(preview).not.toBeNull()
+    // The ghost carries the embedded miniature, not a bare card.
+    expect(preview?.innerHTML ?? '').toContain('inner content')
+  })
+  press(root, 'pointerup', 300, 290)
+})


### PR DESCRIPTION
## Problem (rendering-pipeline parity audit, item 2)

The drag ghost's one-shot content render (`dragContentSvg`) omitted `resolveFileCanvas`/`expandFileNode`, so a file node showing an inline canvas miniature dragged as a **bare card** and snapped back to a miniature on drop — mid-drag the ghost reads as data loss.

## Fix

Pass the same embed options the committed scene render uses (they were already in scope). One options object + memo deps.

## Tests

Real-pointer browser test (`drag-ghost-embed.browser.test.tsx`): drag an expanded embed, assert the drag preview carries the miniature's content — red before the fix. Full web jsdom (1859) + browser (508) suites pass.

## Visual repro

Mid-drag ghost. Before — bare card / After — miniature travels:

![ghost-embed-before.png](https://github.com/user-attachments/assets/7d1bd082-91f8-4e2a-bc6f-2f5ddf4d5715)
![ghost-embed-after.png](https://github.com/user-attachments/assets/03ba6ec8-f8eb-492a-9bef-62fc1a655a42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ