### PR TITLE
fix(render): hit/highlight path follows line-jump hops via one shared decomposition

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -69,7 +69,7 @@ import type { MeasureText, SpatialPresetKey, TextMetrics } from '@kamiazya/white
 import {
   BODY_FONT_SIZE_PX,
   edgeLabelAnchor,
-  flattenRoundedEdgePath,
+  flattenDrawnEdgePath,
   layoutSpatialEdges,
   renderSceneToSvg,
   SPATIAL_DARK_PALETTE,
@@ -655,10 +655,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
-    // distance-to-polyline test against a zoom-adjusted tolerance. A rounded
-    // edge is DRAWN as midpoint-quadratic corners, so its hit/highlight path
-    // is the flattened curve — the raw waypoints run through corners the ink
-    // never touches.
+    // distance-to-polyline test against a zoom-adjusted tolerance. The
+    // hit/highlight path is the DRAWN line — rounded corners flattened and
+    // line-jump hops arced over — via the same decomposition the SVG
+    // backend serializes, so a tap and the highlight land on the ink.
     const edgePaths = useMemo(
       () =>
         scene.nodes.flatMap((node) =>
@@ -666,7 +666,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             ? [
                 {
                   id: node.id,
-                  path: node.rounded === true ? flattenRoundedEdgePath(node.path) : node.path,
+                  path: flattenDrawnEdgePath(node.path, node.jumps, node.rounded === true),
                 },
               ]
             : [],

--- a/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
@@ -1,0 +1,80 @@
+// The selection highlight follows the DRAWN line — including line-jump
+// hops. A highlight built from the raw waypoints cuts straight through
+// every hop the ink arcs over.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// Two crossing edges with lineJumps: the later edge hops over the first.
+const doc: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 60, y: 200, width: 120, height: 60, text: 'a' },
+    { id: 'b', type: 'text', x: 520, y: 200, width: 120, height: 60, text: 'b' },
+    { id: 'c', type: 'text', x: 300, y: 40, width: 120, height: 60, text: 'c' },
+    { id: 'd', type: 'text', x: 300, y: 400, width: 120, height: 60, text: 'd' },
+  ],
+  edges: [
+    { id: 'h', fromNode: 'a', toNode: 'b' },
+    { id: 'v', fromNode: 'c', toNode: 'd' },
+  ],
+  'x-whiteboard': { edgeRouting: { style: 'orthogonal', lineJumps: 'arc' } },
+}
+
+function press(el: HTMLElement, type: string, x: number, y: number) {
+  const r = el.getBoundingClientRect()
+  return el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId: 7,
+      button: 0,
+    }),
+  )
+}
+
+it('the selection highlight arcs over jump hops instead of cutting through them', async () => {
+  const { container } = render(
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={doc} onChange={() => {}} theme="light" />
+    </div>,
+  )
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  await vi.waitFor(() => {
+    expect(root.querySelectorAll('path[d*="A 5 5"], polyline').length).toBeGreaterThan(0)
+  })
+
+  // The jumped edge is drawn as a <path> with an arc; find its hop center.
+  const drawn = [...root.querySelectorAll('path')].find((el) =>
+    (el.getAttribute('d') ?? '').includes('A 5 5'),
+  )
+  expect(drawn).toBeDefined()
+  const d = drawn?.getAttribute('d') ?? ''
+  // "L x1 y1 A 5 5 0 0 0 x2 y2": the hop spans x1..x2 / y1..y2.
+  const m = d.match(/L ([\d.-]+) ([\d.-]+) A 5 5 0 0 0 ([\d.-]+) ([\d.-]+)/)
+  expect(m).not.toBeNull()
+  if (!m) return
+  const hop = { x: (Number(m[1]) + Number(m[3])) / 2, y: (Number(m[2]) + Number(m[4])) / 2 }
+
+  // Select the jumped edge by clicking a point on it away from the hop.
+  press(root, 'pointerdown', 360, 380)
+  press(root, 'pointerup', 360, 380)
+  const highlight = await vi.waitFor(() => {
+    const el = container.querySelector('[data-testid="edge-selection-highlight"]')
+    expect(el).not.toBeNull()
+    return el as SVGPolylineElement
+  })
+
+  // The highlight must deviate at the hop: some vertex sits near the arc
+  // apex (5px left of travel from the hop center), and no straight segment
+  // passes through the hop center itself.
+  const pts = (highlight.getAttribute('points') ?? '')
+    .split(' ')
+    .map((pair) => pair.split(',').map(Number))
+    .map(([x, y]) => ({ x: x!, y: y! }))
+  const nearApex = pts.some((p) => Math.hypot(p.x - hop.x, p.y - hop.y) <= 5.5 && Math.hypot(p.x - hop.x, p.y - hop.y) >= 4.5)
+  expect(nearApex).toBe(true)
+})

--- a/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
@@ -75,6 +75,9 @@ it('the selection highlight arcs over jump hops instead of cutting through them'
     .split(' ')
     .map((pair) => pair.split(',').map(Number))
     .map(([x, y]) => ({ x: x!, y: y! }))
-  const nearApex = pts.some((p) => Math.hypot(p.x - hop.x, p.y - hop.y) <= 5.5 && Math.hypot(p.x - hop.x, p.y - hop.y) >= 4.5)
+  const nearApex = pts.some(
+    (p) =>
+      Math.hypot(p.x - hop.x, p.y - hop.y) <= 5.5 && Math.hypot(p.x - hop.x, p.y - hop.y) >= 4.5,
+  )
   expect(nearApex).toBe(true)
 })

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -1,3 +1,4 @@
+export { flattenDrawnEdgePath } from './layout/edge-flatten.js'
 export { edgeLabelAnchor } from './layout/edge-label-anchor.js'
 export { flattenRoundedEdgePath } from './layout/edge-rounding.js'
 export * from './layout/embed-recursion.js'

--- a/packages/canvas-render/src/layout/edge-flatten.test.ts
+++ b/packages/canvas-render/src/layout/edge-flatten.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { flattenDrawnEdgePath } from './edge-flatten.js'
+import { flattenRoundedEdgePath } from './edge-rounding.js'
+
+describe('flattenDrawnEdgePath', () => {
+  it('is the identity without jumps or rounding', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(flattenDrawnEdgePath(path)).toEqual(path)
+  })
+
+  it('matches flattenRoundedEdgePath for a rounded path without jumps', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]
+    expect(flattenDrawnEdgePath(path, [], true)).toEqual(flattenRoundedEdgePath(path))
+  })
+
+  it('arcs over a jump: apex 5px left of travel, entry/exit on the base line', () => {
+    const path = [
+      { x: 0, y: 10 },
+      { x: 100, y: 10 },
+    ]
+    const flat = flattenDrawnEdgePath(path, [{ segment: 0, x: 50, y: 10 }])
+    // Left of rightward travel in y-down coordinates is upward.
+    const apex = flat.find((p) => Math.abs(p.x - 50) < 1e-9)
+    expect(apex?.y).toBeCloseTo(5, 9)
+    expect(flat.some((p) => p.x === 45 && p.y === 10)).toBe(true)
+    expect(flat.some((p) => p.x === 55 && p.y === 10)).toBe(true)
+    // No sampled point strays beyond the hop radius from the base line.
+    for (const p of flat) {
+      expect(p.y).toBeGreaterThanOrEqual(5 - 1e-9)
+      expect(p.y).toBeLessThanOrEqual(10 + 1e-9)
+    }
+  })
+
+  it('drops a hop without arc clearance inside a rounded span, like the backend', () => {
+    // The corner truncates the horizontal span to its midpoint (50,0); a
+    // jump at x=48 leaves < 5px of clearance to the span end and must be
+    // dropped rather than deforming the corner.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]
+    const kept = flattenDrawnEdgePath(path, [{ segment: 0, x: 30, y: 0 }], true)
+    const dropped = flattenDrawnEdgePath(path, [{ segment: 0, x: 48, y: 0 }], true)
+    expect(kept.some((p) => p.y < -1e-9)).toBe(true)
+    expect(dropped).toEqual(flattenDrawnEdgePath(path, [], true))
+  })
+})

--- a/packages/canvas-render/src/layout/edge-flatten.ts
+++ b/packages/canvas-render/src/layout/edge-flatten.ts
@@ -1,0 +1,140 @@
+// The drawn edge line as a dense polyline — rounded corners AND line-jump
+// hops included — for consumers that need points rather than an SVG path
+// (the editor's hit-testing and selection highlight). Mirrors the SVG
+// backend's emission branch for branch: plain segments hop every jump on
+// their segment; rounded paths truncate spans to the corner midpoints and
+// drop hops without arc clearance, exactly like `roundedPathData`.
+import type { EdgeJumpPoint } from '../scene-graph.js'
+import { EDGE_JUMP_RADIUS_PX } from './edge-jumps.js'
+import { flattenRoundedEdgePath, roundedEdgeCorners } from './edge-rounding.js'
+
+type Point = { readonly x: number; readonly y: number }
+
+/** Chord count per hop; matches the corner flattening's sub-pixel budget. */
+const HOP_SUBDIVISIONS = 8
+
+/**
+ * Where a hop's half-circle meets the base line: entry and exit one jump
+ * radius before/after the crossing, along the direction of travel. The
+ * ONE producer of hop endpoints — the SVG backend's `A` command and this
+ * module's sampling both start and land here.
+ */
+export function hopEndpoints(
+  from: Point,
+  to: Point,
+  jump: Point,
+): { readonly entry: Point; readonly exit: Point } | undefined {
+  const len = Math.hypot(to.x - from.x, to.y - from.y)
+  if (len === 0) return undefined
+  const ux = (to.x - from.x) / len
+  const uy = (to.y - from.y) / len
+  const r = EDGE_JUMP_RADIUS_PX
+  return {
+    entry: { x: jump.x - ux * r, y: jump.y - uy * r },
+    exit: { x: jump.x + ux * r, y: jump.y + uy * r },
+  }
+}
+
+/**
+ * Sampled half-circle over `jump` on the run `from`->`to`, bulging to the
+ * LEFT of travel (the same sweep the backend's `A` command draws),
+ * including the entry and exit points on the base line.
+ */
+function hopPoints(from: Point, to: Point, jump: Point): Point[] {
+  const len = Math.hypot(to.x - from.x, to.y - from.y)
+  if (len === 0) return []
+  const ux = (to.x - from.x) / len
+  const uy = (to.y - from.y) / len
+  // Left of travel in SVG's y-down coordinates.
+  const nx = uy
+  const ny = -ux
+  const r = EDGE_JUMP_RADIUS_PX
+  const points: Point[] = []
+  for (let step = 0; step <= HOP_SUBDIVISIONS; step++) {
+    const t = step / HOP_SUBDIVISIONS
+    points.push({
+      x: jump.x - ux * r * Math.cos(Math.PI * t) + nx * r * Math.sin(Math.PI * t),
+      y: jump.y - uy * r * Math.cos(Math.PI * t) + ny * r * Math.sin(Math.PI * t),
+    })
+  }
+  return points
+}
+
+/** The points after `from` along the run to `to`, hopping each jump. */
+function spanPoints(from: Point, to: Point, jumps: readonly Point[]): Point[] {
+  const points: Point[] = []
+  for (const jump of jumps) points.push(...hopPoints(from, to, jump))
+  points.push(to)
+  return points
+}
+
+/**
+ * The jumps on original segment `segment` that fall INSIDE the drawn span
+ * `from`->`to` with enough clearance for the arc. A rounded corner
+ * truncates its segments to midpoints, so a hop computed near a corner may
+ * fall in the curve zone — those are dropped rather than deforming the
+ * corner. Shared with the SVG backend so "which hops are drawn" has one
+ * producer.
+ */
+export function jumpsWithinSpan(
+  jumps: readonly EdgeJumpPoint[],
+  segment: number,
+  from: Point,
+  to: Point,
+): readonly EdgeJumpPoint[] {
+  const len = Math.hypot(to.x - from.x, to.y - from.y)
+  if (len === 0) return []
+  const ux = (to.x - from.x) / len
+  const uy = (to.y - from.y) / len
+  return jumps.filter((jump) => {
+    if (jump.segment !== segment) return false
+    const t = (jump.x - from.x) * ux + (jump.y - from.y) * uy
+    return t > EDGE_JUMP_RADIUS_PX && t < len - EDGE_JUMP_RADIUS_PX
+  })
+}
+
+/**
+ * The drawn edge as a polyline. `rounded` and `jumps` compose exactly as
+ * the backend composes them; with neither, the input path returns as-is.
+ */
+export function flattenDrawnEdgePath(
+  path: readonly Point[],
+  jumps: readonly EdgeJumpPoint[] = [],
+  rounded = false,
+): Point[] {
+  if (jumps.length === 0) return rounded ? flattenRoundedEdgePath(path) : [...path]
+  const first = path[0]
+  const last = path.at(-1)
+  if (first === undefined || last === undefined) return [...path]
+
+  if (!rounded || path.length < 3) {
+    const points: Point[] = [first]
+    const spanJumps = rounded ? jumpsWithinSpan(jumps, 0, first, last) : undefined
+    for (let seg = 0; seg < path.length - 1; seg++) {
+      const from = path[seg]!
+      const to = path[seg + 1]!
+      points.push(
+        ...spanPoints(from, to, spanJumps ?? jumps.filter((jump) => jump.segment === seg)),
+      )
+    }
+    return points
+  }
+
+  const points: Point[] = [first]
+  let current: Point = first
+  const corners = roundedEdgeCorners(path)
+  for (const [index, { enter, control, leave }] of corners.entries()) {
+    points.push(...spanPoints(current, enter, jumpsWithinSpan(jumps, index, current, enter)))
+    for (let step = 1; step <= HOP_SUBDIVISIONS; step++) {
+      const t = step / HOP_SUBDIVISIONS
+      const u = 1 - t
+      points.push({
+        x: u * u * enter.x + 2 * u * t * control.x + t * t * leave.x,
+        y: u * u * enter.y + 2 * u * t * control.y + t * t * leave.y,
+      })
+    }
+    current = leave
+  }
+  points.push(...spanPoints(current, last, jumpsWithinSpan(jumps, corners.length, current, last)))
+  return points
+}

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -239,9 +239,11 @@ export interface ResolvedEdgeNode {
   readonly kind: 'edge'
   readonly id: string
   /**
-   * Line-jump hops, present only when the canvas enables them. Paint-only
-   * decoration bounded by the jump radius: hit-testing and bounds keep
-   * reading the raw `path` (the deviation never exceeds the hit tolerance).
+   * Line-jump hops, present only when the canvas enables them. Bounds keep
+   * reading the raw `path` (the deviation is bounded by the jump radius);
+   * the editor's hit/highlight path follows the drawn hops via
+   * `flattenDrawnEdgePath`, the same decomposition the SVG backend
+   * serializes.
    */
   readonly jumps?: readonly EdgeJumpPoint[]
   readonly path: readonly { readonly x: number; readonly y: number }[]

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -170,7 +170,6 @@ function jumpedPathData(path: readonly EdgePoint[], jumps: readonly EdgeJump[]):
   return parts.join(' ')
 }
 
-
 /**
  * The same polyline with its corners rounded off, per the shared
  * `roundedEdgeCorners` decomposition (see layout/edge-rounding.ts — the

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,4 +1,5 @@
 import { edgeArrowPolygons } from '../edge-arrows.js'
+import { hopEndpoints, jumpsWithinSpan } from '../layout/edge-flatten.js'
 import { EDGE_JUMP_RADIUS_PX } from '../layout/edge-jumps.js'
 import { roundedEdgeCorners } from '../layout/edge-rounding.js'
 import { sceneBounds } from '../scene-bounds.js'
@@ -139,17 +140,14 @@ function lineWithJumps(
   to: EdgePoint,
   jumps: readonly EdgeJump[],
 ): readonly string[] {
-  const len = Math.hypot(to.x - from.x, to.y - from.y)
-  if (len === 0 || jumps.length === 0) {
-    return [`L ${formatCoord(to.x)} ${formatCoord(to.y)}`]
-  }
-  const ux = (to.x - from.x) / len
-  const uy = (to.y - from.y) / len
-  const r = EDGE_JUMP_RADIUS_PX
   const parts: string[] = []
   for (const jump of jumps) {
-    parts.push(`L ${formatCoord(jump.x - ux * r)} ${formatCoord(jump.y - uy * r)}`)
-    parts.push(`A ${r} ${r} 0 0 0 ${formatCoord(jump.x + ux * r)} ${formatCoord(jump.y + uy * r)}`)
+    const hop = hopEndpoints(from, to, jump)
+    if (hop === undefined) continue
+    parts.push(`L ${formatCoord(hop.entry.x)} ${formatCoord(hop.entry.y)}`)
+    parts.push(
+      `A ${EDGE_JUMP_RADIUS_PX} ${EDGE_JUMP_RADIUS_PX} 0 0 0 ${formatCoord(hop.exit.x)} ${formatCoord(hop.exit.y)}`,
+    )
   }
   parts.push(`L ${formatCoord(to.x)} ${formatCoord(to.y)}`)
   return parts
@@ -172,28 +170,6 @@ function jumpedPathData(path: readonly EdgePoint[], jumps: readonly EdgeJump[]):
   return parts.join(' ')
 }
 
-/**
- * The jumps on original segment `segment` that fall INSIDE the drawn span
- * `from`->`to` with enough clearance for the arc. A rounded corner truncates
- * its segments to midpoints, so a hop computed near a corner may fall in the
- * curve zone — those are dropped rather than deforming the corner.
- */
-function jumpsWithinSpan(
-  jumps: readonly EdgeJump[],
-  segment: number,
-  from: EdgePoint,
-  to: EdgePoint,
-): readonly EdgeJump[] {
-  const len = Math.hypot(to.x - from.x, to.y - from.y)
-  if (len === 0) return []
-  const ux = (to.x - from.x) / len
-  const uy = (to.y - from.y) / len
-  return jumps.filter((jump) => {
-    if (jump.segment !== segment) return false
-    const t = (jump.x - from.x) * ux + (jump.y - from.y) * uy
-    return t > EDGE_JUMP_RADIUS_PX && t < len - EDGE_JUMP_RADIUS_PX
-  })
-}
 
 /**
  * The same polyline with its corners rounded off, per the shared


### PR DESCRIPTION
## Problem (rendering-pipeline parity audit, item: jump-blind hit path)

The editor's `edgePaths` ignored `node.jumps`: the selection highlight cut straight through every hop the ink arcs over, and hit-testing near a hop was off by up to the jump radius (5px).

## Fix

`flattenDrawnEdgePath` (`layout/edge-flatten.ts`) produces the drawn line — rounded corners and sampled hop half-circles composed exactly as the backend composes them — and the editor's hit/highlight path consumes it. The backend's private twins were deleted: its `A` commands now start/land on the shared `hopEndpoints`, and `jumpsWithinSpan` (which hops are drawn in a rounded span) moved to the shared module, so 'which hops are drawn where' has one owner. Golden SVG determinism tests pin that backend bytes are unchanged.

## Tests

- `edge-flatten.test.ts`: identity without jumps/rounding, rounded parity with `flattenRoundedEdgePath`, hop apex/entry/exit geometry, corner-clearance drop matching the backend.
- `edge-jump-highlight.browser.test.tsx`: selecting a jumped edge, the highlight polyline has a vertex on the hop arc (**red before this change**).
- canvas-render node (395) + browser suites, full apps/web jsdom (1857), knip, typechecks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge selection and highlighting to accurately follow rounded paths and arced line jumps.
  * Corrected visual rendering of jumped edges, including filtering invalid or insufficiently clear jumps.

* **Tests**
  * Added coverage for edge highlights, jump-arc geometry, rounded paths, clearance boundaries, and degenerate paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->