### PR TITLE
fix(render): jump hops bulge left of travel, as every comment already said

### DIFF
--- a/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-jump-highlight.browser.test.tsx
@@ -53,11 +53,20 @@ it('the selection highlight arcs over jump hops instead of cutting through them'
   )
   expect(drawn).toBeDefined()
   const d = drawn?.getAttribute('d') ?? ''
-  // "L x1 y1 A 5 5 0 0 0 x2 y2": the hop spans x1..x2 / y1..y2.
-  const m = d.match(/L ([\d.-]+) ([\d.-]+) A 5 5 0 0 0 ([\d.-]+) ([\d.-]+)/)
+  // "L x1 y1 A 5 5 0 0 1 x2 y2": the hop spans x1..x2 / y1..y2.
+  const m = d.match(/L ([\d.-]+) ([\d.-]+) A 5 5 0 0 1 ([\d.-]+) ([\d.-]+)/)
   expect(m).not.toBeNull()
   if (!m) return
-  const hop = { x: (Number(m[1]) + Number(m[3])) / 2, y: (Number(m[2]) + Number(m[4])) / 2 }
+  const entry = { x: Number(m[1]), y: Number(m[2]) }
+  const exit = { x: Number(m[3]), y: Number(m[4]) }
+  const hop = { x: (entry.x + exit.x) / 2, y: (entry.y + exit.y) / 2 }
+  // The drawn arc's apex: one radius to the LEFT of travel from the hop
+  // center (sweep 1 in y-down coordinates), matching the ink exactly.
+  const len = Math.hypot(exit.x - entry.x, exit.y - entry.y)
+  const apex = {
+    x: hop.x + ((exit.y - entry.y) / len) * 5,
+    y: hop.y - ((exit.x - entry.x) / len) * 5,
+  }
 
   // Select the jumped edge by clicking a point on it away from the hop.
   press(root, 'pointerdown', 360, 380)
@@ -68,16 +77,13 @@ it('the selection highlight arcs over jump hops instead of cutting through them'
     return el as SVGPolylineElement
   })
 
-  // The highlight must deviate at the hop: some vertex sits near the arc
-  // apex (5px left of travel from the hop center), and no straight segment
-  // passes through the hop center itself.
+  // The highlight must deviate at the hop ON THE DRAWN SIDE: a vertex sits
+  // at the arc apex itself, not merely at hop-radius distance (which a
+  // wrong-side sample would also satisfy).
   const pts = (highlight.getAttribute('points') ?? '')
     .split(' ')
     .map((pair) => pair.split(',').map(Number))
     .map(([x, y]) => ({ x: x!, y: y! }))
-  const nearApex = pts.some(
-    (p) =>
-      Math.hypot(p.x - hop.x, p.y - hop.y) <= 5.5 && Math.hypot(p.x - hop.x, p.y - hop.y) >= 4.5,
-  )
+  const nearApex = pts.some((p) => Math.hypot(p.x - apex.x, p.y - apex.y) <= 0.75)
   expect(nearApex).toBe(true)
 })

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -780,8 +780,11 @@ describe('line-jump hops', () => {
     const svg = renderSceneToSvg({ nodes: [crossing] })
     expect(svg).not.toContain('<polyline')
     // Straight run to the hop entry, a half-circle over the crossing,
-    // straight run out: entry at x-r, exit at x+r, sweep 0 bulges up.
-    expect(svg).toContain('d="M 0 100 L 95 100 A 5 5 0 0 0 105 100 L 200 100"')
+    // straight run out: entry at x-r, exit at x+r. Sweep 1 is what bulges
+    // to the LEFT of travel (up, here) in SVG's y-down coordinates —
+    // sweep 0 rendered the hop UNDER the line while every comment and the
+    // flattened hit path said over.
+    expect(svg).toContain('d="M 0 100 L 95 100 A 5 5 0 0 1 105 100 L 200 100"')
   })
 
   it('a jump-free edge stays the byte-identical polyline', () => {
@@ -808,7 +811,7 @@ describe('line-jump hops', () => {
     }
     const svg = renderSceneToSvg({ nodes: [bent] })
     // The hop arc and the corner quadratic coexist in one path.
-    expect(svg).toContain('A 5 5 0 0 0 85 100')
+    expect(svg).toContain('A 5 5 0 0 1 85 100')
     expect(svg).toContain('Q 200 100')
   })
 })

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -132,8 +132,10 @@ type EdgeJump = { readonly segment: number; readonly x: number; readonly y: numb
 
 /**
  * Path commands for one straight run from `from` to `to`, hopping over each
- * jump point with a half-circle arc (sweep 0 — the hop bulges to the left
- * of travel, drawio-style "over"). Jumps arrive ordered along the run.
+ * jump point with a half-circle arc. Sweep 1 bulges to the LEFT of travel
+ * in SVG's y-down coordinates (up, for a rightward run) — drawio-style
+ * "over", and the side `flattenDrawnEdgePath` samples for hit-testing and
+ * the selection highlight. Jumps arrive ordered along the run.
  */
 function lineWithJumps(
   from: EdgePoint,
@@ -146,7 +148,7 @@ function lineWithJumps(
     if (hop === undefined) continue
     parts.push(`L ${formatCoord(hop.entry.x)} ${formatCoord(hop.entry.y)}`)
     parts.push(
-      `A ${EDGE_JUMP_RADIUS_PX} ${EDGE_JUMP_RADIUS_PX} 0 0 0 ${formatCoord(hop.exit.x)} ${formatCoord(hop.exit.y)}`,
+      `A ${EDGE_JUMP_RADIUS_PX} ${EDGE_JUMP_RADIUS_PX} 0 0 1 ${formatCoord(hop.exit.x)} ${formatCoord(hop.exit.y)}`,
     )
   }
   parts.push(`L ${formatCoord(to.x)} ${formatCoord(to.y)}`)


### PR DESCRIPTION
## What (fix-forward for CodeRabbit's finding on #658)

CodeRabbit caught a real sweep-direction inversion, verified against the SVG spec: `A … 0 0 **0**` draws the negative-angle arc, which in y-down coordinates bulges to the **right** of travel — rendered hops dipped *under* a horizontal line — while the emitting function's comment ("bulges to the left of travel, drawio-style over"), the backend test's own prose, and `flattenDrawnEdgePath`'s sampled normal all said **left**. The ink was the outlier, and after #658 the highlight arced on the opposite side of the line from the ink.

## Fix

Sweep flag 0 → 1. Rendered hops now hop **over** (left of travel), matching the documented intent and the shared flatten.

## Why the tests missed it

The browser assertion checked distance-from-hop-center (5px on either side — side-blind), and the backend pin's comment asserted "sweep 0 bulges up" — the same misconception, pinned. Both are now side-aware: backend d-strings assert sweep 1, and the highlight test computes the drawn apex from the arc's own entry/exit and requires a vertex within 0.75px of it. Mutation-checked: flipping the flatten normal turns both layers red.

Note: this visibly changes which side rendered hops bulge on (under → over for horizontal lines) — aligning the shipped pixels with the recorded design intent.

canvas-render (395) + web browser suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ