### PR TITLE
fix(mcp-server): stop file-gc from purging every uploaded image

### DIFF
--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -9,11 +9,11 @@
  * take down the page.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
 import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
-import { isImageRef, newImageRef } from './canvas-file-ref.js'
 import { CanvasFileStore } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
 

--- a/apps/web/src/lib/canvas-file-ref.ts
+++ b/apps/web/src/lib/canvas-file-ref.ts
@@ -1,32 +1,6 @@
 /**
- * The one convention distinguishing a file node that points at a stored image
- * from one that points at another canvas.
- *
- * Shared by both backends deliberately: a canvas authored in browser-local
- * mode and one authored against the daemon must mean the same thing by the
- * same `file` value, or moving content between them would silently
- * reinterpret every image node as a canvas reference.
- *
- * The colon is what makes this unambiguous — a daemon slug and a browser-local
- * canvas id both match /^[a-zA-Z0-9_-]+$/, so neither can ever collide with a
- * prefixed reference.
+ * Re-export shim: the `asset:` prefix convention is shared with the daemon's
+ * file-GC reference walk (packages/mcp-server/src/server/store/file-gc.ts),
+ * so it is single-sourced in canvas-model rather than duplicated here.
  */
-const IMAGE_REF_PREFIX = 'asset:'
-
-export function isImageRef(file: string): boolean {
-  return file.startsWith(IMAGE_REF_PREFIX)
-}
-
-/** Mints a reference for a newly stored image. */
-export function newImageRef(id: string): string {
-  return `${IMAGE_REF_PREFIX}${id}`
-}
-
-/**
- * The backend-side id inside an image reference. The daemon's file route
- * validates this against /^[a-zA-Z0-9_-]+$/, so the prefix must be stripped
- * before it travels in a path.
- */
-export function imageRefId(file: string): string {
-  return file.slice(IMAGE_REF_PREFIX.length)
-}
+export { imageRefId, isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'

--- a/apps/web/src/lib/canvas-file-ref.ts
+++ b/apps/web/src/lib/canvas-file-ref.ts
@@ -1,6 +1,0 @@
-/**
- * Re-export shim: the `asset:` prefix convention is shared with the daemon's
- * file-GC reference walk (packages/mcp-server/src/server/store/file-gc.ts),
- * so it is single-sourced in canvas-model rather than duplicated here.
- */
-export { imageRefId, isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'

--- a/apps/web/src/lib/daemon-file-adapter.ts
+++ b/apps/web/src/lib/daemon-file-adapter.ts
@@ -9,11 +9,11 @@
  * reference to bytes the daemon never stored.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { imageRefId, isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
 import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
-import { imageRefId, isImageRef, newImageRef } from './canvas-file-ref.js'
 
 const log = getAppLogger('daemon-file-adapter')
 

--- a/packages/canvas-model/src/asset-ref.test.ts
+++ b/packages/canvas-model/src/asset-ref.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { imageRefId, isImageRef, newImageRef } from './asset-ref.js'
+
+describe('isImageRef', () => {
+  it('accepts a value carrying the asset: prefix', () => {
+    expect(isImageRef('asset:abc123')).toBe(true)
+  })
+
+  it('rejects a plain canvas-slug/id value with no prefix', () => {
+    expect(isImageRef('some-canvas')).toBe(false)
+  })
+})
+
+describe('newImageRef / imageRefId round-trip', () => {
+  it('imageRefId(newImageRef(x)) === x for an arbitrary backend id', () => {
+    expect(imageRefId(newImageRef('01ARZ3NDEKTSV4RRFFQ69G5FAV'))).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+  })
+
+  it('newImageRef prefixes with asset:', () => {
+    expect(newImageRef('x')).toBe('asset:x')
+  })
+})

--- a/packages/canvas-model/src/asset-ref.ts
+++ b/packages/canvas-model/src/asset-ref.ts
@@ -1,0 +1,33 @@
+/**
+ * The one convention distinguishing a file node that points at a stored image
+ * from one that points at another canvas.
+ *
+ * Shared by every backend and every reader deliberately: a canvas authored in
+ * browser-local mode, one authored against the daemon, and the daemon's own
+ * file-GC reference walk must all mean the same thing by the same `file`
+ * value, or moving content between them (or garbage-collecting it) would
+ * silently reinterpret every image node as a canvas reference.
+ *
+ * The colon is what makes this unambiguous — a daemon slug and a browser-local
+ * canvas id both match /^[a-zA-Z0-9_-]+$/, so neither can ever collide with a
+ * prefixed reference.
+ */
+const IMAGE_REF_PREFIX = 'asset:'
+
+export function isImageRef(file: string): boolean {
+  return file.startsWith(IMAGE_REF_PREFIX)
+}
+
+/** Mints a reference for a newly stored image. */
+export function newImageRef(id: string): string {
+  return `${IMAGE_REF_PREFIX}${id}`
+}
+
+/**
+ * The backend-side id inside an image reference. The daemon's file route
+ * validates this against /^[a-zA-Z0-9_-]+$/, so the prefix must be stripped
+ * before it travels in a path.
+ */
+export function imageRefId(file: string): string {
+  return file.slice(IMAGE_REF_PREFIX.length)
+}

--- a/packages/canvas-model/src/index.ts
+++ b/packages/canvas-model/src/index.ts
@@ -1,3 +1,4 @@
+export * from './asset-ref.js'
 export * from './clipboard.js'
 export * from './facets.js'
 export * from './ids.js'

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -208,7 +208,7 @@ export async function loadCanvas(workspaceId: string, slug: string): Promise<Lor
   return doc
 }
 
-export function migrateLegacyListToMovable(doc: LoroDoc): boolean {
+function migrateLegacyListToMovable(doc: LoroDoc): boolean {
   const list = doc.getList('elements')
   const movable = doc.getMovableList('elements')
   if (list.length === 0) return false

--- a/packages/mcp-server/src/server/store/file-gc.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc.test.ts
@@ -24,6 +24,8 @@ const { createBranch, loadCanvasBranches, saveCanvasBranches, updateBranchTip } 
   './branches-store.js'
 )
 const { createIsolatedDb } = await import('./db/test-helpers.js')
+const { makeSpatialDoc, makeSpatialDocWithImage, setSpatialDocImage, clearSpatialDocNodes } =
+  await import('../../shared/test-utils/spatial-doc.js')
 
 let handle: Awaited<ReturnType<typeof createIsolatedDb>>
 
@@ -56,6 +58,10 @@ async function seedFreshFile(
   await writeFile(join(dir, `${fileId}${ext}`), Buffer.alloc(bytes, 0xcd))
 }
 
+// Retired legacy shape — kept ONLY for the two tests below that specifically
+// pin legacy-doc behavior (the additive pass, and tombstone semantics that
+// exist only in this shape). Every other test seeds through the current
+// nodes-model fixture (spatial-doc.js) instead.
 function makeDocWithImage(fileId: string): LoroDoc {
   const doc = new LoroDoc()
   const list = doc.getMovableList('elements')
@@ -79,11 +85,27 @@ afterEach(async () => {
 })
 
 describe('purgeDanglingFiles', () => {
-  it('keeps files referenced by live canvas elements and deletes the rest', async () => {
+  it('keeps a file referenced by a CURRENT nodes-model file node (production doc shape)', async () => {
+    // Production docs write spatial content into the nodes/edges model, not
+    // the retired 'elements' movable list — this is the shape every daemon
+    // actually persists through saveCanvas. Before the fix this must be RED:
+    // the collector only walks 'elements' and returns an empty set, so the
+    // aged file below is (wrongly) classified as dangling and unlinked.
+    await saveCanvas('ws_nodes', 'page', makeSpatialDocWithImage('asset-x'))
+    await seedFile('ws_nodes', 'asset-x', '.png', 500)
+
+    const result = await purgeDanglingFiles('ws_nodes')
+
+    expect(result.purgedCount).toBe(0)
+    const remaining = (await readdir(join(tempDir, 'ws_nodes', 'files'))).sort()
+    expect(remaining).toEqual(['asset-x.png'])
+  })
+
+  it('keeps files referenced by nodes-model file nodes and deletes the rest', async () => {
     // Two canvases reference distinct fileIds; an additional dangling file
-    // and a tombstoned-element fileId both qualify for deletion.
-    await saveCanvas('ws_a', 'used-a', makeDocWithImage('used-a'))
-    await saveCanvas('ws_a', 'used-b', makeDocWithImage('used-b'))
+    // qualifies for deletion.
+    await saveCanvas('ws_a', 'used-a', makeSpatialDocWithImage('used-a'))
+    await saveCanvas('ws_a', 'used-b', makeSpatialDocWithImage('used-b'))
 
     await seedFile('ws_a', 'used-a', '.png', 100)
     await seedFile('ws_a', 'used-b', '.png', 200)
@@ -99,7 +121,25 @@ describe('purgeDanglingFiles', () => {
     expect(remaining).toEqual(['used-a.png', 'used-b.png'])
   })
 
-  it('treats elements flagged isDeleted=true as not referencing their fileId', async () => {
+  it('legacy elements doc: referenced file survives the purge (additive pass)', async () => {
+    // Pre-migration docs that were never resaved through the current
+    // nodes/edges model still store their images in the retired 'elements'
+    // movable list — collectFromDoc's second pass must keep protecting
+    // them even though every current doc uses the nodes-model pass above.
+    await saveCanvas('ws_legacy', 'page', makeDocWithImage('legacy-image'))
+    await seedFile('ws_legacy', 'legacy-image', '.png', 321)
+
+    const result = await purgeDanglingFiles('ws_legacy')
+
+    expect(result.purgedCount).toBe(0)
+    const remaining = (await readdir(join(tempDir, 'ws_legacy', 'files'))).sort()
+    expect(remaining).toEqual(['legacy-image.png'])
+  })
+
+  it('legacy isDeleted=true element does not protect its fileId', async () => {
+    // The tombstone concept exists only in the legacy 'elements' shape —
+    // the nodes model has no isDeleted flag, a removed node is simply
+    // absent from the map.
     const doc = new LoroDoc()
     const list = doc.getMovableList('elements')
     const map = list.insertContainer(0, new LoroMap())
@@ -122,24 +162,67 @@ describe('purgeDanglingFiles', () => {
     expect(result).toEqual({ purgedCount: 0, purgedBytes: 0 })
   })
 
+  it('mixed workspace: a legacy-elements doc and a nodes-model doc each protect their own file, an aged orphan is still purged', async () => {
+    // Pins the two-pass walker running in ONE scan: a workspace mid-
+    // migration has some canvases still in the legacy shape and some
+    // already resaved through the current model.
+    await saveCanvas('ws_mixed', 'legacy-page', makeDocWithImage('legacy-ref'))
+    await saveCanvas('ws_mixed', 'nodes-page', makeSpatialDocWithImage('nodes-ref'))
+
+    await seedFile('ws_mixed', 'legacy-ref', '.png', 10)
+    await seedFile('ws_mixed', 'nodes-ref', '.png', 20)
+    await seedFile('ws_mixed', 'unrelated-orphan', '.png', 30)
+
+    const result = await purgeDanglingFiles('ws_mixed')
+
+    expect(result.purgedCount).toBe(1)
+    expect(result.purgedBytes).toBe(30)
+    const remaining = (await readdir(join(tempDir, 'ws_mixed', 'files'))).sort()
+    expect(remaining).toEqual(['legacy-ref.png', 'nodes-ref.png'])
+  })
+
+  it('does not protect an upload whose id merely matches a plain (non-asset:) file value', async () => {
+    // Precision: a 'file' node's `file` value can also be a canvas
+    // reference (wikilink-style embed) rather than an upload — only the
+    // 'asset:' prefix means "this points at an uploaded blob". A same-named
+    // orphan upload must not be spared by a canvas-slug collision.
+    await saveCanvas(
+      'ws_precision',
+      'page',
+      makeSpatialDoc({
+        nodes: [
+          {
+            id: 'n1',
+            type: 'file',
+            file: 'some-canvas',
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+          },
+        ],
+        edges: [],
+      }),
+    )
+    await seedFile('ws_precision', 'some-canvas', '.png', 42)
+
+    const result = await purgeDanglingFiles('ws_precision')
+
+    expect(result.purgedCount).toBe(1)
+    expect(result.purgedBytes).toBe(42)
+  })
+
   it('keeps files referenced by a saved version when versionStore is supplied', async () => {
-    // Step 1: live state references "version-only" via an image element.
-    await saveCanvas('ws_v', 'evolving', makeDocWithImage('version-only'))
+    // Step 1: live state references "version-only" via a file node.
+    await saveCanvas('ws_v', 'evolving', makeSpatialDocWithImage('version-only'))
     const store = new FileVersionStore()
     await store.save('ws_v', 'evolving', await loadCanvas('ws_v', 'evolving'), { auto: false })
 
-    // Step 2: live state changes — remove the original element and add a
-    // brand-new one. After this commit the live doc has only "live-now",
+    // Step 2: live state changes — the original node is replaced by a
+    // brand-new one. After this the live doc references only "live-now",
     // while the saved version still points at "version-only".
     const live = await loadCanvas('ws_v', 'evolving')
-    const list = live.getMovableList('elements')
-    if (list.length > 0) list.delete(0, list.length)
-    const newMap = list.insertContainer(0, new LoroMap())
-    newMap.set('id', 'el-live-now')
-    newMap.set('type', 'image')
-    newMap.set('fileId', 'live-now')
-    newMap.set('isDeleted', false)
-    live.commit()
+    setSpatialDocImage(live, 'live-now')
     await saveCanvas('ws_v', 'evolving', live, { overwrite: true })
 
     await seedFile('ws_v', 'version-only', '.png', 700)
@@ -167,7 +250,7 @@ describe('purgeDanglingFiles', () => {
     // the very behaviour this test exists to prevent.
     const cap = captureLogsForTests('debug')
 
-    await saveCanvas('ws_brk', 'broken', makeDocWithImage('only-by-broken-version'))
+    await saveCanvas('ws_brk', 'broken', makeSpatialDocWithImage('only-by-broken-version'))
     await seedFile('ws_brk', 'only-by-broken-version', '.png', 222)
     await seedFile('ws_brk', 'really-dangling', '.png', 33)
 
@@ -268,7 +351,7 @@ describe('purgeDanglingFiles', () => {
   it('serialises against a concurrent saveCanvas that adds a new file reference', async () => {
     // Race scenario: user has foo.png on disk left over from an earlier
     // session, but no canvas references it yet. They open a canvas and
-    // add an image element pointing at foo. Just as that saveCanvas is
+    // add a file node pointing at foo. Just as that saveCanvas is
     // committing, a background purgeDanglingFiles fires.
     //
     // Without a workspace write barrier, GC's collectReferencedFileIds
@@ -281,14 +364,8 @@ describe('purgeDanglingFiles', () => {
     await saveCanvas('ws_race', 'page', empty)
 
     // Build the post-save doc by extending the empty doc.
-    const next = await import('./canvas-store.js').then((m) => m.loadCanvas('ws_race', 'page'))
-    const list = next.getMovableList('elements')
-    const map = list.insertContainer(0, new LoroMap())
-    map.set('id', 'el-late-binding')
-    map.set('type', 'image')
-    map.set('fileId', 'about-to-reference')
-    map.set('isDeleted', false)
-    next.commit()
+    const next = await loadCanvas('ws_race', 'page')
+    setSpatialDocImage(next, 'about-to-reference')
 
     // Kick the save first so it acquires the lock; then kick the purge.
     const savePromise = saveCanvas('ws_race', 'page', next, { overwrite: true })
@@ -301,18 +378,16 @@ describe('purgeDanglingFiles', () => {
   })
 
   it('keeps a file referenced only by a non-head branch tip', async () => {
-    // Image element lives at the point where "feature" branches off.
-    const doc = makeDocWithImage('branch-only-image')
+    // File node lives at the point where "feature" branches off.
+    const doc = makeSpatialDocWithImage('branch-only-image')
     await saveCanvas('ws_branch', 'page', doc)
     const branchTip = Buffer.from(encodeFrontiers(doc.frontiers())).toString('base64')
     await createBranch('ws_branch', 'page', { name: 'feature', initialTipFrontiers: branchTip })
 
-    // At head (main), the image element is removed — main's live state no
+    // At head (main), the file node is removed — main's live state no
     // longer references it, but "feature"'s tip still does.
     const live = await loadCanvas('ws_branch', 'page')
-    const list = live.getMovableList('elements')
-    list.delete(0, list.length)
-    live.commit()
+    clearSpatialDocNodes(live)
     await saveCanvas('ws_branch', 'page', live, { overwrite: true })
 
     await seedFile('ws_branch', 'branch-only-image', '.png', 42)
@@ -329,7 +404,7 @@ describe('purgeDanglingFiles', () => {
     // themselves are corrupt — no retry fixes that, so this must surface
     // as CorruptStoredDataError (mapped to 500 corrupt_stored_data by the
     // route), not the retryable IncompleteFileGcScanError (503).
-    await saveCanvas('ws_brk2', 'broken-branch', makeDocWithImage('only-by-broken-branch'))
+    await saveCanvas('ws_brk2', 'broken-branch', makeSpatialDocWithImage('only-by-broken-branch'))
     await createBranch('ws_brk2', 'broken-branch', {
       name: 'feature',
       initialTipFrontiers: 'not-valid-base64-frontiers!!',
@@ -351,7 +426,7 @@ describe('purgeDanglingFiles', () => {
     // throw on the corrupt tip). This is what keeps the periodic sweeper
     // cheap on the common no-uploads workspace; reordering the scan back
     // in front of the readdir turns this test red.
-    await saveCanvas('ws_noscan', 'broken-branch', makeDocWithImage('never-uploaded'))
+    await saveCanvas('ws_noscan', 'broken-branch', makeSpatialDocWithImage('never-uploaded'))
     await createBranch('ws_noscan', 'broken-branch', {
       name: 'feature',
       initialTipFrontiers: 'not-valid-base64-frontiers!!',
@@ -367,7 +442,7 @@ describe('purgeDanglingFiles', () => {
     // A silent `if (past) collectFromDoc(...)` skip is equivalent to
     // treating a version we could not load as "referencing nothing" —
     // the same permanent-data-loss hazard as a thrown load() error.
-    await saveCanvas('ws_nullver', 'page', makeDocWithImage('only-by-null-version'))
+    await saveCanvas('ws_nullver', 'page', makeSpatialDocWithImage('only-by-null-version'))
     await seedFile('ws_nullver', 'only-by-null-version', '.png', 55)
     await seedFile('ws_nullver', 'really-dangling-3', '.png', 11)
 
@@ -409,7 +484,7 @@ describe('purgeDanglingFiles', () => {
     // purge pass. Without branches-store also taking the workspace write
     // lock, the purge could snapshot branch state before the tip update
     // lands and unlink a file the new tip references.
-    const doc = makeDocWithImage('about-to-be-tip-referenced')
+    const doc = makeSpatialDocWithImage('about-to-be-tip-referenced')
     await saveCanvas('ws_branch_race', 'page', doc)
     await createBranch('ws_branch_race', 'page', { name: 'feature' })
     const branchTip = Buffer.from(encodeFrontiers(doc.frontiers())).toString('base64')
@@ -417,9 +492,7 @@ describe('purgeDanglingFiles', () => {
     // Head (main) no longer references the image — only the about-to-land
     // "feature" tip update will.
     const live = await loadCanvas('ws_branch_race', 'page')
-    const liveList = live.getMovableList('elements')
-    liveList.delete(0, liveList.length)
-    live.commit()
+    clearSpatialDocNodes(live)
     await saveCanvas('ws_branch_race', 'page', live, { overwrite: true })
 
     await seedFile('ws_branch_race', 'about-to-be-tip-referenced', '.png', 77)
@@ -459,7 +532,7 @@ describe('purgeDanglingFiles', () => {
     // acquire the lock first despite starting second, scan the state
     // before the tip lands, and permanently delete the file the new
     // tip is about to reference.
-    const doc = makeDocWithImage('about-to-be-tip-referenced-live')
+    const doc = makeSpatialDocWithImage('about-to-be-tip-referenced-live')
     await saveCanvas('ws_branch_race_live', 'page', doc)
     await createBranch('ws_branch_race_live', 'page', { name: 'feature' })
     const branchTip = Buffer.from(encodeFrontiers(doc.frontiers())).toString('base64')
@@ -467,9 +540,7 @@ describe('purgeDanglingFiles', () => {
     // Head (main) no longer references the image — only the about-to-land
     // "feature" tip update will.
     const live = await loadCanvas('ws_branch_race_live', 'page')
-    const liveList = live.getMovableList('elements')
-    liveList.delete(0, liveList.length)
-    live.commit()
+    clearSpatialDocNodes(live)
     await saveCanvas('ws_branch_race_live', 'page', live, { overwrite: true })
 
     await seedFile('ws_branch_race_live', 'about-to-be-tip-referenced-live', '.png', 77)
@@ -502,13 +573,7 @@ describe('purgeDanglingFiles', () => {
     const baselineFrontiers = doc.frontiers()
     const featureTip = Buffer.from(encodeFrontiers(baselineFrontiers)).toString('base64')
 
-    const list = doc.getMovableList('elements')
-    const map = list.insertContainer(0, new LoroMap())
-    map.set('id', 'el-head-race')
-    map.set('type', 'image')
-    map.set('fileId', 'about-to-be-captured-on-head-switch')
-    map.set('isDeleted', false)
-    doc.commit()
+    setSpatialDocImage(doc, 'about-to-be-captured-on-head-switch')
 
     await saveCanvas('ws_head_race', 'page', doc)
     await createBranch('ws_head_race', 'page', {

--- a/packages/mcp-server/src/server/store/file-gc.ts
+++ b/packages/mcp-server/src/server/store/file-gc.ts
@@ -1,5 +1,7 @@
 import { readdir, stat, unlink } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
+import { imageRefId, isImageRef } from '@kamiazya/whiteboard-canvas-model'
+import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { decodeFrontiers, LoroDoc } from 'loro-crdt'
 import type { z } from 'zod'
 import type { purgeResultSchema } from '../../shared/api-contracts/canvas.js'
@@ -38,9 +40,22 @@ function workspaceFilesDir(workspaceId: string): string {
   return assertPathWithinDir(dir, getDataDir(), 'files dir')
 }
 
-// Walk a single doc state and collect fileIds for image elements whose
-// `isDeleted` flag is falsy.
+// Walk a single doc state and collect fileIds referenced by it. Two passes,
+// both additive into the same sink:
+//
+// 1. The CURRENT model — every production doc stores spatial content in the
+//    nodes/edges maps (see readSpatialCanvas), so a 'file' node whose `file`
+//    value carries the 'asset:' upload-reference prefix is a live reference.
+// 2. The legacy 'elements' movable list — retired, but a pre-migration doc
+//    that was never resaved through the current model still stores its
+//    images there, so this pass stays as a fallback rather than a rewrite.
 function collectFromDoc(doc: LoroDoc, sink: Set<string>): void {
+  const { nodes } = readSpatialCanvas(doc)
+  for (const node of nodes) {
+    if (node.type !== 'file') continue
+    if (isImageRef(node.file)) sink.add(imageRefId(node.file))
+  }
+
   const list = doc.getMovableList('elements')
   for (let i = 0; i < list.length; i++) {
     const el = list.get(i)

--- a/packages/mcp-server/src/shared/test-utils/spatial-doc.ts
+++ b/packages/mcp-server/src/shared/test-utils/spatial-doc.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared fixture for seeding a LoroDoc in the CURRENT nodes/edges spatial
+ * model — the shape every production doc is actually written in (see
+ * package-canvas-workspace.md's "LoroDoc spatial layout"). Mirrors
+ * apps/web/src/test-utils/browser-local-canvas.ts in spirit: build via the
+ * real writeSpatialCanvas bridge rather than poking at LoroDoc internals, so
+ * a fixture never drifts from what saveCanvas actually persists.
+ *
+ * The legacy 'elements' movable-list shape (see file-gc.test.ts's
+ * makeDocWithImage) is retired but still guarded additively by file-gc's
+ * collector — keep seeding it directly where a test's whole point is that
+ * legacy shape.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { newImageRef } from '@kamiazya/whiteboard-canvas-model'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { LoroDoc } from 'loro-crdt'
+
+/** A doc holding the given nodes-model spatial canvas, saved through the real bridge. */
+export function makeSpatialDoc(canvas: SpatialCanvas): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvas)
+  return doc
+}
+
+/** Builds the single-node spatial canvas shape `makeSpatialDocWithImage`/`setSpatialDocImage` share. */
+function imageOnlyCanvas(fileId: string, nodeId: string): SpatialCanvas {
+  return {
+    nodes: [
+      {
+        id: nodeId,
+        type: 'file',
+        file: newImageRef(fileId),
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+    ],
+    edges: [],
+  }
+}
+
+/** A doc holding a single 'file' node whose `file` value references the given upload id. */
+export function makeSpatialDocWithImage(fileId: string, nodeId = `node-${fileId}`): LoroDoc {
+  return makeSpatialDoc(imageOnlyCanvas(fileId, nodeId))
+}
+
+/**
+ * Replaces an EXISTING doc's nodes/edges with a single 'file' node
+ * referencing the given upload id — the nodes-model equivalent of clearing
+ * the legacy 'elements' list and inserting a new image element in its
+ * place. Used by tests that need to mutate a live doc mid-scenario (a
+ * concurrent-save race, a branch history point) rather than build a fresh
+ * one.
+ */
+export function setSpatialDocImage(doc: LoroDoc, fileId: string, nodeId = `node-${fileId}`): void {
+  writeSpatialCanvas(doc, imageOnlyCanvas(fileId, nodeId))
+}
+
+/** Clears all nodes/edges from an existing doc — the nodes-model equivalent of emptying the legacy 'elements' list. */
+export function clearSpatialDocNodes(doc: LoroDoc): void {
+  writeSpatialCanvas(doc, { nodes: [], edges: [] })
+}

--- a/packages/mcp-server/src/shared/test-utils/spatial-doc.ts
+++ b/packages/mcp-server/src/shared/test-utils/spatial-doc.ts
@@ -24,11 +24,11 @@ export function makeSpatialDoc(canvas: SpatialCanvas): LoroDoc {
 }
 
 /** Builds the single-node spatial canvas shape `makeSpatialDocWithImage`/`setSpatialDocImage` share. */
-function imageOnlyCanvas(fileId: string, nodeId: string): SpatialCanvas {
+function imageOnlyCanvas(fileId: string): SpatialCanvas {
   return {
     nodes: [
       {
-        id: nodeId,
+        id: `node-${fileId}`,
         type: 'file',
         file: newImageRef(fileId),
         x: 0,
@@ -42,8 +42,8 @@ function imageOnlyCanvas(fileId: string, nodeId: string): SpatialCanvas {
 }
 
 /** A doc holding a single 'file' node whose `file` value references the given upload id. */
-export function makeSpatialDocWithImage(fileId: string, nodeId = `node-${fileId}`): LoroDoc {
-  return makeSpatialDoc(imageOnlyCanvas(fileId, nodeId))
+export function makeSpatialDocWithImage(fileId: string): LoroDoc {
+  return makeSpatialDoc(imageOnlyCanvas(fileId))
 }
 
 /**
@@ -54,8 +54,8 @@ export function makeSpatialDocWithImage(fileId: string, nodeId = `node-${fileId}
  * concurrent-save race, a branch history point) rather than build a fresh
  * one.
  */
-export function setSpatialDocImage(doc: LoroDoc, fileId: string, nodeId = `node-${fileId}`): void {
-  writeSpatialCanvas(doc, imageOnlyCanvas(fileId, nodeId))
+export function setSpatialDocImage(doc: LoroDoc, fileId: string): void {
+  writeSpatialCanvas(doc, imageOnlyCanvas(fileId))
 }
 
 /** Clears all nodes/edges from an existing doc — the nodes-model equivalent of emptying the legacy 'elements' list. */


### PR DESCRIPTION
## What

**CRITICAL data-loss fix** (found by the codebase audit, adversarially verified, reproduced red-first). `file-gc.ts`'s `collectFromDoc` walked only the retired legacy `elements` movable list, but every production doc stores spatial content in the nodes/edges model — so `collectReferencedFileIds` returned an empty set for current docs, and the unconditionally-started 24h sweeper (1h grace, wired in `http-server.ts`) would unlink **every uploaded image** on any daemon left running a day. Silent and unrecoverable.

- `collectFromDoc` is now a two-pass walker: (1) `readSpatialCanvas(doc)` collecting `imageRefId(node.file)` from `type==='file'` nodes with an `asset:`-prefixed value; (2) the original legacy `elements` scan kept verbatim (additive) so pre-migration docs stay protected. The fix lands once in the shared walker, so live docs, branch tips, and saved versions are all covered.
- The `asset:` prefix helpers moved from `apps/web/src/lib/canvas-file-ref.ts` into `packages/canvas-model/src/asset-ref.ts` (pure string helpers; canvas-model's zod-only rule holds) — single-sourced instead of duplicated into the daemon; the apps/web consumers now import from canvas-model and the shim was deleted.
- **Root enabler fixed in the same lane**: the daemon suite seeded docs exclusively in the legacy shape, which is why this was green in CI. New shared fixture `packages/mcp-server/src/shared/test-utils/spatial-doc.ts` (writeSpatialCanvas-based); file-gc's tests are ported onto it, with exactly two deliberate legacy-shape tests kept (additive-pass guard; legacy `isDeleted` tombstone semantics). Version-store/merge/debug fixture ports are separate filed follow-ups.

## Tests

Red-first: nodes-model doc with a `file: 'asset:X'` node + aged `files/X.png` on disk → purge → the file was DELETED under the old code, survives now. Also pinned: version-only and branch-tip-only references survive; mixed legacy+nodes workspace protects both while an unrelated aged orphan is still purged (GC keeps collecting garbage); non-`asset:` file values don't protect same-named uploads; grace/env/refusal/concurrency cases ported un-weakened.

Mutation-checked: reverting to the elements-only walk turns the nodes-model survival tests red; restored to green.

## Gates

mcp-node fully green; `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, lint clean (canvas-model gained a source file — build/typecheck mandatory and clean). Review workflow: zero confirmed findings; QA smoke/error-recovery/startup pass. Rebased onto current main (zero file overlap with #656–#659).

Backend-only fix — no screenshot; the red-first test output is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw