### PR TITLE
docs: fix first-clone MCP setup instructions (local-scope proxy registration)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,19 @@ This repo ships its local AI-orchestrated dev flow under `.claude/` (Claude Code
 ### First-clone setup
 
 1. `pnpm install` (required before anything else — the dev daemon and tests need the workspace installed).
-2. The MCP dev daemon is auto-started. `.claude/settings.json` wires a `SessionStart` hook to `ensure-http-dev-daemon.mjs`, which probes `http://127.0.0.1:3099` and, if nothing is listening, launches `pnpm mcp:http:dev` detached and waits up to ~30s for it to bind. So the hardcoded `http://127.0.0.1:3099/mcp` endpoint is normally up by the time the first MCP request fires.
-3. **If the daemon is not up** — hooks disabled, project not trusted yet, a fresh clone where step 1 has not run, or port 3099 already taken — Claude Code simply shows a connection error for the `whiteboard` MCP server. This is **not fatal**: ordinary development (tests, build, lint) is unaffected. Start it manually with `pnpm mcp:http:dev` in another terminal.
-4. The `Authorization: Bearer whiteboard-dev` in `.claude/settings.json` is a **non-secret, well-known local-dev constant** that authenticates only to the loopback daemon — it grants nothing on any other machine. To use a different value, override the header in your gitignored `.claude/settings.local.json`.
+2. The MCP dev daemon is auto-started. `.claude/settings.json` wires a `SessionStart` hook to `ensure-http-dev-daemon.mjs`, which probes this checkout's derived dev port (3099 on the main checkout) and, if nothing is listening, launches `pnpm mcp:http:dev` detached and waits up to ~30s for it to bind.
+3. **Register the stdio proxy once per checkout** so Claude Code actually talks to that daemon instead of the published npm package. `.claude/settings.json` has no `mcpServers` field in its schema — a definition there is silently ignored — so this is a one-time `--scope local` CLI registration (machine-private `~/.claude.json`) per checkout:
+
+   ```bash
+   claude mcp add --scope local --transport stdio whiteboard -- \
+     node "$(git rev-parse --show-toplevel)/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
+   ```
+
+   Local scope shadows the repo-tracked `.mcp.json` (precedence: local > project), which stays pointed at the published `npx @kamiazya/whiteboard-mcp@latest` package — do not repoint `.mcp.json` at dev tooling. The proxy runs the ensure hook itself and retries each request across daemon watch-restarts, so registering it as stdio (rather than the HTTP URL directly) survives a `tsx watch` restart mid-session.
+4. **Self-check — am I hitting my checkout, not npx?** Run `claude mcp get whiteboard`: it should show the `node .../mcp-http-stdio-proxy.mjs` command, not `npx -y @kamiazya/whiteboard-mcp@latest`. If it shows the `npx` command, step 3's local-scope registration did not take (or is missing) and your MCP calls are silently hitting the published package instead of your local code changes.
+5. **If the daemon is not up** — hooks disabled, project not trusted yet, or the port is already taken — the `whiteboard` MCP server shows a connection error. This is **not fatal**: ordinary development (tests, build, lint) is unaffected. Start it manually with `pnpm mcp:http:dev` in another terminal.
+
+See AGENTS.md's "MCP Development Mode" section for the full daemon/proxy design (per-worktree ports, the spawn lock, why stdio wraps HTTP) and `docs/contributing/mcp-debugging.md` for debugging the endpoint itself.
 
 ### Discipline (if you author/run workflows)
 

--- a/docs/contributing/adr/0003-track-claude-dev-flow-tooling.md
+++ b/docs/contributing/adr/0003-track-claude-dev-flow-tooling.md
@@ -2,6 +2,16 @@
 
 **Status:** Accepted
 
+> **Superseded detail (2026-08-12):** the Bearer-token-in-tracked-`settings.json` /
+> `_comment_auth` design described below (Context bullet 4, Decision bullet 1,
+> and the "Extract Bearer token to settings.local.json" alternative) no longer
+> reflects the current setup. `.claude/settings.json` carries no `mcpServers`
+> field at all, and MCP dev access instead goes through a `--scope local`
+> `claude mcp add` registration of a stdio proxy script. See CONTRIBUTING.md's
+> "First-clone setup" and AGENTS.md's "MCP Development Mode" for the current
+> mechanism; the rest of this ADR's rationale (tracking `.claude/` in git,
+> repo-relative scriptPaths) still holds.
+
 ## Context
 
 This repository uses Claude Code workflows, agents, skills, and scripts under `.claude/` to orchestrate the local AI-assisted dev loop (plan → TDD implement → review → release). Initially `.claude/` was machine-local (gitignored). The question was whether to track it in the shared repository so contributors inherit the full dev-flow tooling.


### PR DESCRIPTION
## What

Audit finding (HIGH, devx): CONTRIBUTING.md's "First-clone setup" documented nonexistent `.claude/settings.json` MCP wiring (a Bearer-header/`settings.local.json` paragraph — `settings.json` has no `mcpServers` field in its schema, so the described mechanism never did anything) and omitted the one step that actually matters for Claude Code: registering the stdio proxy at local scope. New Claude Code contributors silently fell back to the published npx package — no error, local code edits appear to have no effect. Codex contributors were unaffected (`.codex/config.toml` is tracked and correct).

- CONTRIBUTING.md first-clone setup rewritten to match AGENTS.md: daemon auto-start via the SessionStart hook (port claim generalized to the derived dev port), the required once-per-checkout `claude mcp add --scope local --transport stdio whiteboard -- node .../mcp-http-stdio-proxy.mjs` registration with the local-shadows-`.mcp.json` note, a one-line `claude mcp get whiteboard` self-check ("proxy path, not npx"), and pointers to AGENTS.md / mcp-debugging.md. Stale Bearer/settings.local.json paragraph deleted.
- ADR-0003 gains a dated "Superseded detail" blockquote pointing its stale token bullets at CONTRIBUTING.md/AGENTS.md; the ADR body itself is untouched (its tracking rationale still holds).

Every claim kept in the rewritten section was verified against the real `.claude/settings.json`, AGENTS.md, and the proxy script on disk.

Follow-up filed separately (not in this PR): `docs/contributing/development.md` still describes wire-worktree-mcp.mjs per-worktree HTTP registration that the script itself now skips as inexpressible — needs its own reconciliation.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw