### PR TITLE
fix(web): connect preview draws the committed edge's curve and arrowhead

### DIFF
--- a/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
+++ b/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
@@ -76,14 +76,26 @@ export function DragPreviewLayer({ preview, zoom, contentSvg }: DragPreviewLayer
           opacity={0.9}
         />
       ) : (
-        <polyline
-          points={preview.path.map((p) => `${p.x},${p.y}`).join(' ')}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={strokeWidth}
-          strokeDasharray={dashArray}
-          opacity={0.9}
-        />
+        <>
+          <polyline
+            points={preview.path.map((p) => `${p.x},${p.y}`).join(' ')}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeDasharray={dashArray}
+            opacity={0.9}
+          />
+          {preview.arrows.map((arrow, i) => (
+            <polygon
+              // Arrow identity is positional within one preview frame.
+              // biome-ignore lint/suspicious/noArrayIndexKey: static per-frame list
+              key={i}
+              points={arrow.map((p) => `${p.x},${p.y}`).join(' ')}
+              fill="currentColor"
+              opacity={0.9}
+            />
+          ))}
+        </>
       )}
     </svg>
   )

--- a/apps/web/src/components/spatial-editor/connect-preview.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/connect-preview.browser.test.tsx
@@ -93,3 +93,21 @@ it('previews the actual routed edge while hovering a target node', async () => {
   expect(points[0]).toEqual([300, 290])
   expect(points[points.length - 1]).toEqual([180, 290])
 })
+
+it('the preview line carries the committed arrowhead', async () => {
+  const { container } = render(<Host />)
+  const { root, rootRect } = await beginConnectFromWest(container)
+
+  fireEvent.pointerMove(root, {
+    pointerId: 80,
+    clientX: rootRect.left + 230,
+    clientY: rootRect.top + 290,
+    buttons: 1,
+  })
+  await new Promise((r) => requestAnimationFrame(r))
+
+  const arrow = container.querySelector('[data-testid="drag-preview"] polygon')
+  expect(arrow).not.toBeNull()
+  const corners = (arrow?.getAttribute('points') ?? '').split(' ').filter((p) => p.length > 0)
+  expect(corners.length).toBe(3)
+})

--- a/apps/web/src/components/spatial-editor/drag-preview.test.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.test.ts
@@ -91,13 +91,42 @@ describe('computeDragPreview — connecting', () => {
   it('routes from the border anchor facing the pointer to the pointer itself', () => {
     const state = connectingState()
     const preview = computeDragPreview(state, boxes, { x: 300, y: 25 }, connect)
-    expect(preview).toEqual({
-      kind: 'line',
-      path: [
-        { x: 100, y: 25 },
-        { x: 300, y: 25 },
-      ],
-    })
+    expect(preview?.kind).toBe('line')
+    if (preview?.kind !== 'line') return
+    expect(preview.path).toEqual([
+      { x: 100, y: 25 },
+      { x: 300, y: 25 },
+    ])
+  })
+
+  it("carries the committed edge's target arrowhead", () => {
+    const state = connectingState()
+    const preview = computeDragPreview(state, boxes, { x: 300, y: 25 }, connect)
+    expect(preview?.kind).toBe('line')
+    if (preview?.kind !== 'line') return
+    // Default edge ends: none -> arrow, so exactly one polygon, tipped at
+    // the line's end.
+    expect(preview.arrows.length).toBe(1)
+    expect(preview.arrows[0]?.[0]).toEqual({ x: 300, y: 25 })
+  })
+
+  it('follows the flattened curve under the curved routing style', () => {
+    const curvedConnect = {
+      ...connect,
+      canvas: { ...connect.canvas, 'x-whiteboard': { edgeRouting: { style: 'curved' as const } } },
+    }
+    const state = connectingState()
+    // A pointer below-right forces a bend; curved routing rounds it.
+    const preview = computeDragPreview(state, boxes, { x: 300, y: 220 }, curvedConnect)
+    expect(preview?.kind).toBe('line')
+    if (preview?.kind !== 'line') return
+    // Rounded flattening produces diagonal chords; the raw orthogonal
+    // waypoints are all axis-aligned, so a diagonal segment is proof the
+    // preview follows the drawn curve.
+    const diagonal = preview.path.some(
+      (p, i) => i > 0 && p.x !== preview.path[i - 1]?.x && p.y !== preview.path[i - 1]?.y,
+    )
+    expect(diagonal).toBe(true)
   })
 
   it('returns undefined when the fromNode id is absent from boxes', () => {

--- a/apps/web/src/components/spatial-editor/drag-preview.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.ts
@@ -15,7 +15,13 @@
  * YAGNI + zod-schema-discipline this type deliberately carries no Zod schema.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { assignEdgeAnchors, type EdgeSides, routeEdge } from '@kamiazya/whiteboard-canvas-render'
+import {
+  assignEdgeAnchors,
+  edgeArrowPolygons,
+  type EdgeSides,
+  flattenDrawnEdgePath,
+  routeEdge,
+} from '@kamiazya/whiteboard-canvas-render'
 import type { Box, NodeBox } from './geometry.js'
 import { hitTest, resizeBoxByDelta } from './geometry.js'
 import type { GestureState } from './gestures.js'
@@ -23,7 +29,13 @@ import type { Point } from './viewport.js'
 
 export type DragPreview =
   | { readonly kind: 'box'; readonly box: Box }
-  | { readonly kind: 'line'; readonly path: readonly Point[] }
+  | {
+      readonly kind: 'line'
+      /** The DRAWN line (rounded corners flattened), not raw waypoints. */
+      readonly path: readonly Point[]
+      /** Arrowhead polygons the committed edge will carry, tip first. */
+      readonly arrows: readonly (readonly Point[])[]
+    }
 
 /**
  * What the connecting branch needs to preview the REAL prospective edge:
@@ -136,7 +148,17 @@ export function computeDragPreview(
         canvas['x-whiteboard']?.edgeRouting?.style,
         anchors.get(tentative.id),
       )
-      return { kind: 'line', path: routed.path }
+      // The preview shows the DRAWN line the drop will produce: rounded
+      // corners flattened and the committed arrowheads, from the same
+      // producers the editor's committed render uses.
+      // ponytail: no line-jump hops here — computing them needs every
+      // other edge routed per frame; wire computeEdgeJumps in if the
+      // hopless preview ever reads as a bug.
+      return {
+        kind: 'line',
+        path: flattenDrawnEdgePath(routed.path, [], routed.rounded === true),
+        arrows: edgeArrowPolygons(routed).map((arrow) => arrow.points),
+      }
     }
     default:
       return undefined

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -1,3 +1,4 @@
+export { type ArrowPolygon, edgeArrowPolygons } from './edge-arrows.js'
 export { flattenDrawnEdgePath } from './layout/edge-flatten.js'
 export { edgeLabelAnchor } from './layout/edge-label-anchor.js'
 export { flattenRoundedEdgePath } from './layout/edge-rounding.js'


### PR DESCRIPTION
## What (parity audit — the last 'preview differs from result' surface)

The connect gesture's preview drew raw square-cornered waypoints with no arrowhead, while the drop commits a rounded (curved style) arrowed edge. The preview now runs through the same producers the committed render uses: `flattenDrawnEdgePath` for the drawn curve and `edgeArrowPolygons` (newly exported) for the committed ends. Line-jump hops stay out with a `ponytail:` marker — computing them needs every other edge routed per frame.

## Tests

Red-first at the data level (`drag-preview.test.ts`: arrowhead present and tipped at the line end; curved routing yields diagonal flatten chords) and in the browser (`connect-preview.browser.test.tsx`: the drag preview renders the arrow polygon). Full web jsdom + browser connect suites pass.

## Visual repro

Curved-style canvas, mid connect gesture. Before — square corners, no arrow / After — the drawn curve with the committed arrowhead:

![connect-preview-before.png](https://github.com/user-attachments/assets/b4726174-4109-4da4-85f7-7f101400b180)
![connect-preview-after.png](https://github.com/user-attachments/assets/f34d0c32-a2a3-4bdb-98f8-19c50f3c8ed2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ