### PR TITLE
test(web): pin the remaining low-risk rendering-parity gaps

### DIFF
--- a/apps/web/src/components/spatial-editor/scene-render.test.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.test.ts
@@ -12,6 +12,20 @@ function canvas(): SpatialCanvas {
     nodes: [
       { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' },
       { id: 'b', type: 'file', x: 200, y: 0, width: 80, height: 40, file: 'x.png' },
+      // Every node kind participates: the minimap and hit-testing read the
+      // MODEL rects, so a kind whose scene chrome diverged from its model
+      // rect (a padded frame, an outside label) would silently misplace
+      // there — the parity pin below is the tripwire.
+      { id: 'c', type: 'group', x: 0, y: 120, width: 220, height: 90, label: 'g' },
+      {
+        id: 'd',
+        type: 'link',
+        x: 300,
+        y: 120,
+        width: 140,
+        height: 60,
+        url: 'https://example.com/',
+      },
     ],
     edges: [],
   }

--- a/apps/web/src/components/spatial-editor/text-edit-style-parity.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-edit-style-parity.browser.test.tsx
@@ -1,0 +1,53 @@
+// The text-edit overlay covers the node's rendered chrome; its box styling
+// must come from the SAME theme producers the SVG render uses, not
+// hand-restated values that drift when the theme changes. (The wrapping
+// engines still differ — CSS vs the injected measurer — a documented
+// ceiling, not pinned here.)
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { BODY_FONT_SIZE_PX, SPATIAL_THEME_GEOMETRY } from '@kamiazya/whiteboard-canvas-render'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { createEditorAppearance } from './editor-appearance.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const node = {
+  id: 'n1',
+  type: 'text' as const,
+  x: 100,
+  y: 100,
+  width: 200,
+  height: 100,
+  text: 'hello world',
+}
+const start: SpatialCanvas = { nodes: [node], edges: [] }
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+it('the edit overlay box styling equals the rendered chrome (shared theme producers)', async () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
+  const textarea = await vi.waitFor(() => {
+    const el = container.querySelector('textarea')
+    expect(el).not.toBeNull()
+    return el as HTMLTextAreaElement
+  })
+  const resolved = createEditorAppearance('light').resolveNode(node)
+  expect(textarea.style.borderRadius).toBe(`${resolved.radius}px`)
+  expect(textarea.style.padding).toBe(`${SPATIAL_THEME_GEOMETRY.paddingPx}px`)
+  // The rendered layout advances one font-size per line (mdast-blocks);
+  // the overlay's line height restates that invariant.
+  expect(textarea.style.lineHeight).toBe(`${BODY_FONT_SIZE_PX}px`)
+  expect(textarea.style.fontSize).toBe(`${BODY_FONT_SIZE_PX}px`)
+})


### PR DESCRIPTION
## What (parity audit — LOW tier nets)

- **Minimap/hit-test model-rect pin covers all node kinds**: `scene-render.test`'s `model rect == scene shape bbox` tripwire (what the minimap overlay and hit-testing rely on) only exercised `text`+`file`; `group` and `link` now participate, so a future kind whose chrome diverges from its model rect fails the pin instead of silently misplacing overview rects.
- **Text-edit overlay styling pinned to the shared theme producers**: border radius, padding, line height, and font size of the edit textarea are asserted equal to `createEditorAppearance().resolveNode` / `SPATIAL_THEME_GEOMETRY` / `BODY_FONT_SIZE_PX` — mutation-checked by skewing the hand-restated line height (red). The CSS-vs-measurer wrapping engine difference remains a documented ceiling, deliberately not pinned.

Tests only; no production change. Full web jsdom (1877) + browser pins pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ