### PR TITLE
fix(render): slide facing-pair anchors into the shared lane

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -933,9 +933,11 @@ describe('SpatialEditor (browser)', () => {
       }),
     )
     // Hovering node "b", the preview snaps to the edge the drop will
-    // create: it ends at b's derived left anchor, not at the pointer.
+    // create: it ends at b's derived left anchor, not at the pointer —
+    // slid to the facing pair's shared lane, so it aligns with the
+    // source anchor rather than sitting at b's side midpoint.
     await waitFor(() => {
-      expect(lastPreviewPoint()).toBe('250,40')
+      expect(lastPreviewPoint()).toBe('250,45')
     })
 
     // Node "b" chrome rect sits at canvas (250,20)-(330,60); drop inside it.

--- a/apps/web/src/components/spatial-editor/edge-group-routing.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-group-routing.browser.test.tsx
@@ -51,12 +51,12 @@ it('routes an edge between two group members inside the group frame', async () =
   const paths = [...container.querySelectorAll('svg polyline')].map((el) =>
     parsePoints(el as SVGPolylineElement),
   )
-  const memberEdge = paths.find((p) => p[0]?.x === 420 && p[0]?.y === 350)
+  const memberEdge = paths.find((p) => p[0]?.y === 350 && p.at(-1)?.y === 420)
   expect(memberEdge).toBeDefined()
 
   // A clear straight run: endpoint to endpoint, never leaving the frame.
-  expect(memberEdge).toEqual([
-    { x: 420, y: 350 },
-    { x: 430, y: 420 },
-  ])
+  // The facing pair slides both anchors to the shared lane, so the run is
+  // vertical rather than the 10px diagonal the side midpoints used to make.
+  expect(memberEdge?.length).toBe(2)
+  expect(memberEdge?.[0]?.x).toBe(memberEdge?.at(-1)?.x)
 })

--- a/packages/canvas-render/src/layout/edge-facing-align.test.ts
+++ b/packages/canvas-render/src/layout/edge-facing-align.test.ts
@@ -1,0 +1,47 @@
+// A facing pair ranked zero-bend promises a straight segment, but anchors
+// were placed at per-side fractions and never slid into the shared lane —
+// the promise held only when midpoints happened to align (offset stacked
+// nodes got a Z in orthogonal, a diagonal in straight, where a clean
+// vertical exists).
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+describe('facing-pair anchor alignment', () => {
+  // Offset stacked nodes: raw x-overlap 50px, inset lane [160,190].
+  const NODES: SpatialNode[] = [
+    { id: 'A', type: 'text', x: 0, y: 0, width: 200, height: 100, text: '' },
+    { id: 'B', type: 'text', x: 150, y: 300, width: 200, height: 100, text: '' },
+  ]
+  const EDGE: CanvasEdge = { id: 'A-B', fromNode: 'A', toNode: 'B' }
+
+  it('slides both anchors to one coordinate inside the shared lane', () => {
+    const anchors = assignEdgeAnchors(NODES, [EDGE], 'orthogonal')
+    const a = anchors.get('A-B')
+    expect([a?.fromSide, a?.toSide]).toEqual(['bottom', 'top'])
+    expect(a?.from?.x).toBe(a?.to?.x)
+    expect(a?.from?.x).toBeGreaterThanOrEqual(160)
+    expect(a?.from?.x).toBeLessThanOrEqual(190)
+  })
+
+  it('realizes the promised zero-bend route', () => {
+    const anchors = assignEdgeAnchors(NODES, [EDGE], 'orthogonal')
+    const routed = routeEdge(NODES, EDGE, 'orthogonal', anchors.get('A-B'))
+    expect(routed.path.length).toBe(2)
+    expect(routed.path[0]?.x).toBe(routed.path[1]?.x)
+  })
+
+  it('leaves multi-edge sides on their fan-out fractions', () => {
+    // A second edge sharing A's bottom side: fan-out fractions must win
+    // over pair alignment, or the two corridors collapse onto each other.
+    const nodes: SpatialNode[] = [
+      ...NODES,
+      { id: 'C', type: 'text', x: -250, y: 300, width: 200, height: 100, text: '' },
+    ]
+    const edges: CanvasEdge[] = [EDGE, { id: 'A-C', fromNode: 'A', toNode: 'C' }]
+    const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+    const ab = anchors.get('A-B')
+    const ac = anchors.get('A-C')
+    expect(ab?.from?.x).not.toBe(ac?.from?.x)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -106,9 +106,17 @@ function facingSides(dx: number, dy: number): readonly [Side, Side, Side, Side] 
  * better through the one-bend perpendicular L. */
 const ZERO_LANE_MIN_OVERLAP_PX = 20
 
-/** Inset tangent spans of two facing sides share a lane wide enough to host
- * an anchor — a zero-bend segment is actually realizable. */
-function facingSpansOverlap(fromRect: Rect, toRect: Rect, axis: 'h' | 'v'): boolean {
+/**
+ * The tangent interval where BOTH facing sides can host an anchor (corner
+ * insets applied), or undefined when it is narrower than the zero-bend
+ * minimum. One producer for the ranking (is a zero-bend lane available?)
+ * and the anchor alignment that realizes it.
+ */
+function facingLaneWindow(
+  fromRect: Rect,
+  toRect: Rect,
+  axis: 'h' | 'v',
+): readonly [number, number] | undefined {
   const span = (r: Rect): readonly [number, number] =>
     axis === 'h'
       ? [
@@ -121,7 +129,13 @@ function facingSpansOverlap(fromRect: Rect, toRect: Rect, axis: 'h' | 'v'): bool
         ]
   const [aLo, aHi] = span(fromRect)
   const [bLo, bHi] = span(toRect)
-  return Math.min(aHi, bHi) - Math.max(aLo, bLo) >= ZERO_LANE_MIN_OVERLAP_PX
+  const lo = Math.max(aLo, bLo)
+  const hi = Math.min(aHi, bHi)
+  return hi - lo >= ZERO_LANE_MIN_OVERLAP_PX ? [lo, hi] : undefined
+}
+
+function facingSpansOverlap(fromRect: Rect, toRect: Rect, axis: 'h' | 'v'): boolean {
+  return facingLaneWindow(fromRect, toRect, axis) !== undefined
 }
 
 /**
@@ -493,6 +507,47 @@ function computeAnchorsFor(
           : { ...entry, to: member.point, toLaneDepth: depth, toSide: member.end.side },
       )
     }
+  }
+
+  // A facing opposing pair whose ends are each ALONE on their side slides
+  // both anchors to one tangent coordinate inside the shared lane —
+  // realizing the straight segment the zero-bend rank promised, which the
+  // per-side fraction placement above only delivers when the two side
+  // midpoints happen to align. Multi-edge sides keep their fan-out
+  // fractions: collapsing two corridors onto one lane is worse than a jog.
+  for (const edge of edges) {
+    const chosen = sides.get(edge.id)
+    const entry = anchors.get(edge.id)
+    if (chosen === undefined || entry?.from === undefined || entry.to === undefined) continue
+    if (chosen.toSide !== oppositeSide(chosen.fromSide)) continue
+    const fromNode = byId.get(edge.fromNode)
+    const toNode = byId.get(edge.toNode)
+    if (fromNode === undefined || toNode === undefined) continue
+    if ((groups.get(`${edge.fromNode} ${chosen.fromSide}`)?.length ?? 0) > 1) continue
+    if ((groups.get(`${edge.toNode} ${chosen.toSide}`)?.length ?? 0) > 1) continue
+    const fromRect = rectOf(fromNode)
+    const toRect = rectOf(toNode)
+    const axis = chosen.fromSide === 'left' || chosen.fromSide === 'right' ? 'h' : 'v'
+    // Interpenetrating boxes (authored sides can force them) have no
+    // forward-facing lane to slide into.
+    const gapOk =
+      axis === 'h'
+        ? chosen.fromSide === 'right'
+          ? fromRect.x + fromRect.w <= toRect.x
+          : toRect.x + toRect.w <= fromRect.x
+        : chosen.fromSide === 'bottom'
+          ? fromRect.y + fromRect.h <= toRect.y
+          : toRect.y + toRect.h <= fromRect.y
+    if (!gapOk) continue
+    const window = facingLaneWindow(fromRect, toRect, axis)
+    if (window === undefined) continue
+    const natural = (axis === 'h' ? entry.from.y + entry.to.y : entry.from.x + entry.to.x) / 2
+    const t = Math.min(window[1], Math.max(window[0], natural))
+    anchors.set(edge.id, {
+      ...entry,
+      from: axis === 'h' ? { x: entry.from.x, y: t } : { x: t, y: entry.from.y },
+      to: axis === 'h' ? { x: entry.to.x, y: t } : { x: t, y: entry.to.y },
+    })
   }
   return anchors
 }

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -539,10 +539,10 @@ function computeAnchorsFor(
           ? fromRect.y + fromRect.h <= toRect.y
           : toRect.y + toRect.h <= fromRect.y
     if (!gapOk) continue
-    const window = facingLaneWindow(fromRect, toRect, axis)
-    if (window === undefined) continue
+    const lane = facingLaneWindow(fromRect, toRect, axis)
+    if (lane === undefined) continue
     const natural = (axis === 'h' ? entry.from.y + entry.to.y : entry.from.x + entry.to.x) / 2
-    const t = Math.min(window[1], Math.max(window[0], natural))
+    const t = Math.min(lane[1], Math.max(lane[0], natural))
     anchors.set(edge.id, {
       ...entry,
       from: axis === 'h' ? { x: entry.from.x, y: t } : { x: t, y: entry.from.y },

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -418,6 +418,13 @@ function computeAnchorsFor(
   nodes: readonly SpatialNode[],
   edges: readonly CanvasEdge[],
   sides: ReadonlyMap<string, SidePair>,
+  // Alignment applies only to FINAL anchors, never inside the optimizer's
+  // trials: sliding anchors mid-optimization changes trial costs, which
+  // shifts side-choice equilibria on multi-edge canvases in ways the
+  // ranking never anticipated (observed: a bystander edge re-siding onto a
+  // worse face). Post-processing settled sides keeps the optimizer's
+  // decisions identical and only straightens the pairs it already chose.
+  align = true,
 ): ReadonlyMap<string, EdgeAnchorPair> {
   const byId = new Map(nodes.map((n) => [n.id, n]))
   type End = {
@@ -508,6 +515,8 @@ function computeAnchorsFor(
       )
     }
   }
+
+  if (!align) return anchors
 
   // A facing opposing pair whose ends are each ALONE on their side slides
   // both anchors to one tangent coordinate inside the shared lane —
@@ -736,7 +745,7 @@ function optimizeSideChoices(
   // pairs — everything else is carried over. This is what keeps a trial
   // O(affected * E) instead of O(E^2).
   let current = new Map(initial)
-  let anchors = computeAnchorsFor(nodes, edges, current)
+  let anchors = computeAnchorsFor(nodes, edges, current, false)
   let paths: (readonly Point[])[] = edges.map(
     (e) => routeEdge(nodes, e, style, anchors.get(e.id)).path,
   )
@@ -770,7 +779,7 @@ function optimizeSideChoices(
     updates: Map<number, ConfigCost>
     selfUpdates: Map<number, ConfigCost>
   } => {
-    const trialAnchors = computeAnchorsFor(nodes, edges, trialSides)
+    const trialAnchors = computeAnchorsFor(nodes, edges, trialSides, false)
     const touched: number[] = []
     for (let i = 0; i < edges.length; i++) {
       if (!sameAnchor(anchors.get(edges[i]!.id), trialAnchors.get(edges[i]!.id))) touched.push(i)


### PR DESCRIPTION
## Problem (parity audit — the estimate-vs-realization residual)

The zero-bend rank promises a straight segment for a facing pair with a wide-enough shared lane, but anchors were placed at per-side fractions and never slid into it — the promise held only when the two side midpoints happened to align. Offset stacked nodes drew a **diagonal** (straight style) or corner-hugged via the route-time slide while the stored anchors disagreed with the drawn route (orthogonal).

## Fix

`computeAnchorsFor` slides both anchors of a facing opposing pair to one tangent coordinate inside the shared lane (clamped average of the natural anchors) — only when each end is **alone** on its side: fan-out fractions win on shared sides, since collapsing two corridors onto one lane is worse than a jog. `facingLaneWindow` is the extracted single producer for "is there a lane, and where", shared by the zero-bend rank and the alignment.

## Tests

Red-first in `edge-facing-align.test.ts`: aligned coordinate inside the lane, realized two-point zero-bend route, fan-out preserved on multi-edge sides. Full canvas-render (398) + viewer + server-core + web jsdom (1877) suites pass; knip/typecheck clean.

## Visual repro

Offset stacked nodes, straight style. Before — a diagonal into B's corner / After — a clean drop in the shared lane:

![facing-align-straight-before.png](https://github.com/user-attachments/assets/caa37d21-b440-4868-8426-18e9bdd714f2)
![facing-align-straight-after.png](https://github.com/user-attachments/assets/c2b84e55-7177-4eb2-a084-2b9601acecef)

(Orthogonal style already reached a vertical via a route-time slide; it now lands centered in the lane instead of hugging the corner-most edge, and anchors agree with the route.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved connector routing between facing nodes, aligning endpoints within shared lanes for cleaner, straighter connections.
  - Preserved appropriate fan-out spacing when multiple connectors originate from the same side.
  - Updated connection previews to accurately reflect the target node’s anchor position.
- **Tests**
  - Added coverage for aligned anchors, zero-bend routes, overlapping lanes, and multi-connector layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->