### PR TITLE
fix(mcp-server): parse pairing token responses with the shared schema on both ends

### DIFF
--- a/apps/web/src/lib/pairing-grant.test.ts
+++ b/apps/web/src/lib/pairing-grant.test.ts
@@ -106,6 +106,47 @@ describe('renewPairingToken', () => {
     })
     expect(result).toEqual({ status: 'none' })
   })
+
+  it('reports none on a 200 response missing the required token field', async () => {
+    const fetchFn = vi.fn(async () =>
+      Response.json({ expiresAt: '2099-01-01T00:00:00.000Z', origin: HOSTED }),
+    )
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result).toEqual({ status: 'none' })
+  })
+
+  // origin is required by pairingTokenResponseSchema but unused by this
+  // function's own verification logic (no pin) — without schema.safeParse a
+  // response silently missing it would have been accepted as paired.
+  it('reports none on a 200 response missing the required origin field, even though this function never reads it', async () => {
+    const fetchFn = vi.fn(async () =>
+      Response.json({ token: 'renewed', expiresAt: '2099-01-01T00:00:00.000Z' }),
+    )
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result).toEqual({ status: 'none' })
+  })
+
+  it('reports none on a 200 response carrying an unexpected extra field (strict schema)', async () => {
+    const fetchFn = vi.fn(async () =>
+      Response.json({
+        token: 'renewed',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        origin: HOSTED,
+        unexpected: 'drift',
+      }),
+    )
+    const result = await renewPairingToken({
+      daemonBaseUrl: DAEMON,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result).toEqual({ status: 'none' })
+  })
 })
 
 describe('consumeGrantFragment', () => {
@@ -189,6 +230,71 @@ describe('consumeGrantFragment', () => {
       }),
     })
     const fetchFn = vi.fn(async () => new Response('nope', { status: 403 }))
+    const result = await consumeGrantFragment({
+      hash: '#wb-grant=code&state=st',
+      sessionStorage: storage,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result.status).toBe('error')
+  })
+
+  it('rejects a 200 response missing the required token field', async () => {
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st',
+        codeVerifier: 'v',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const fetchFn = vi.fn(async () =>
+      Response.json({ expiresAt: '2099-01-01T00:00:00.000Z', origin: HOSTED }),
+    )
+    const result = await consumeGrantFragment({
+      hash: '#wb-grant=code&state=st',
+      sessionStorage: storage,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result.status).toBe('error')
+  })
+
+  // origin is required by pairingTokenResponseSchema but unused by this
+  // function's own verification logic — without schema.safeParse a response
+  // silently missing it would have been accepted as paired.
+  it('rejects a 200 response missing the required origin field, even though this function never reads it', async () => {
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st',
+        codeVerifier: 'v',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const fetchFn = vi.fn(async () =>
+      Response.json({ token: 'tok', expiresAt: '2099-01-01T00:00:00.000Z' }),
+    )
+    const result = await consumeGrantFragment({
+      hash: '#wb-grant=code&state=st',
+      sessionStorage: storage,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+    expect(result.status).toBe('error')
+  })
+
+  it('rejects a 200 response carrying an unexpected extra field (strict schema)', async () => {
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st',
+        codeVerifier: 'v',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const fetchFn = vi.fn(async () =>
+      Response.json({
+        token: 'tok',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        origin: HOSTED,
+        unexpected: 'drift',
+      }),
+    )
     const result = await consumeGrantFragment({
       hash: '#wb-grant=code&state=st',
       sessionStorage: storage,

--- a/apps/web/src/lib/pairing-grant.ts
+++ b/apps/web/src/lib/pairing-grant.ts
@@ -17,6 +17,7 @@
  * the caller).
  */
 
+import { pairingTokenResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import {
   createChallengeNonce,
   getPinnedIdentity,
@@ -156,19 +157,18 @@ export async function consumeGrantFragment({
     if (!response.ok) {
       return { status: 'error', detail: `token exchange rejected (${response.status})` }
     }
-    const body = (await response.json()) as {
-      token?: unknown
-      expiresAt?: unknown
-      identity?: { publicKey?: unknown; signature?: unknown }
+    const parsed = pairingTokenResponseSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      return { status: 'error', detail: 'token exchange returned a malformed response' }
     }
-    if (typeof body.token !== 'string' || body.token.length === 0) {
+    const body = parsed.data
+    if (body.token.length === 0) {
       return { status: 'error', detail: 'token exchange returned no token' }
     }
     if (fragment.identity !== null) {
       // The key the user just approved (fragment) must be the key that
       // signs the credential handed over — anything else is refused.
       const verified =
-        typeof body.expiresAt === 'string' &&
         body.identity?.publicKey === fragment.identity &&
         typeof body.identity?.signature === 'string' &&
         (await verifyIdentitySignature({
@@ -227,18 +227,15 @@ export async function renewPairingToken({
       body: JSON.stringify({ grantType: 'origin', ...(nonce !== undefined ? { nonce } : {}) }),
     })
     if (!response.ok) return { status: 'none' }
-    const body = (await response.json()) as {
-      token?: unknown
-      expiresAt?: unknown
-      identity?: { publicKey?: unknown; signature?: unknown }
-    }
-    if (typeof body.token !== 'string' || body.token.length === 0) return { status: 'none' }
+    const parsed = pairingTokenResponseSchema.safeParse(await response.json())
+    if (!parsed.success) return { status: 'none' }
+    const body = parsed.data
+    if (body.token.length === 0) return { status: 'none' }
     if (pinned !== null && nonce !== undefined) {
       // Verified against the PIN, never the advertised key: a squatter (or
       // a rotated daemon) fails closed here and the user re-approves on
       // /pair, which re-pins.
       const verified =
-        typeof body.expiresAt === 'string' &&
         body.identity?.publicKey === pinned.publicKey &&
         typeof body.identity?.signature === 'string' &&
         (await verifyIdentitySignature({

--- a/packages/mcp-server/src/server/routes/pairing.test.ts
+++ b/packages/mcp-server/src/server/routes/pairing.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { pairingTokenResponseSchema } from '../../shared/api-contracts/pairing.js'
 import { buildSignedPayload, createDaemonIdentity } from '../security/daemon-identity.js'
 import { createPairingGrantStore } from '../security/pairing-grant-store.js'
 import {
@@ -65,7 +66,10 @@ describe('pairing routes', () => {
       codeVerifier,
     })
     expect(tokenRes.status).toBe(200)
-    const token = (await tokenRes.json()) as { token: string; origin: string; expiresAt: string }
+    // Executable mutation-check guard: parses the REAL HTTP body against the
+    // shared schema, so a server-side field drift (or a removed route-level
+    // .parse) turns this red instead of shipping silently.
+    const token = pairingTokenResponseSchema.parse(await tokenRes.json())
     expect(token.origin).toBe(HOSTED)
     expect(token.token.length).toBeGreaterThan(20)
   })
@@ -92,7 +96,9 @@ describe('pairing routes', () => {
 
     const res = await post(app, '/api/pairing/token', { grantType: 'origin' }, { Origin: HOSTED })
     expect(res.status).toBe(200)
-    expect(((await res.json()) as { origin: string }).origin).toBe(HOSTED)
+    // Same executable guard as the code-exchange leg above, for the
+    // renewal leg's response body.
+    expect(pairingTokenResponseSchema.parse(await res.json()).origin).toBe(HOSTED)
   })
 
   it('renewal rejects an ungranted origin and a missing Origin header', async () => {

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -62,14 +62,12 @@ const listGrantsResponseSchema = z
   .strict()
 type ListGrantsResponse = z.infer<typeof listGrantsResponseSchema>
 
-type TokenResponse = PairingTokenResponse
-
 function signTokenResponse(
   identity: DaemonIdentity,
   nonce: string,
   minted: { token: string; expiresAt: string },
   origin: string,
-): NonNullable<TokenResponse['identity']> {
+): NonNullable<PairingTokenResponse['identity']> {
   const tokenHash = createHash('sha256').update(minted.token, 'utf8').digest('base64url')
   return {
     alg: identity.alg,
@@ -148,7 +146,7 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
         return c.json({ error: 'invalid or expired code' }, 403)
       }
       const minted = tokens.mint(redeemed.origin)
-      const response: TokenResponse = pairingTokenResponseSchema.parse({
+      const response = pairingTokenResponseSchema.parse({
         ...minted,
         origin: redeemed.origin,
         ...(parsed.data.nonce !== undefined
@@ -173,7 +171,7 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
       return c.json({ error: 'origin has no pairing grant' }, 403)
     }
     const minted = tokens.mint(origin)
-    const response: TokenResponse = pairingTokenResponseSchema.parse({
+    const response = pairingTokenResponseSchema.parse({
       ...minted,
       origin,
       ...(parsed.data.nonce !== undefined

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -31,6 +31,7 @@ import { z } from 'zod'
 import {
   type PairingTokenResponse,
   pairingTokenRequestSchema,
+  pairingTokenResponseSchema,
 } from '../../shared/api-contracts/pairing.js'
 import type { DaemonIdentity } from '../security/daemon-identity.js'
 import type { PairingGrantStore } from '../security/pairing-grant-store.js'
@@ -147,13 +148,13 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
         return c.json({ error: 'invalid or expired code' }, 403)
       }
       const minted = tokens.mint(redeemed.origin)
-      const response: TokenResponse = {
+      const response: TokenResponse = pairingTokenResponseSchema.parse({
         ...minted,
         origin: redeemed.origin,
         ...(parsed.data.nonce !== undefined
           ? { identity: signTokenResponse(identity, parsed.data.nonce, minted, redeemed.origin) }
           : {}),
-      }
+      })
       return c.json(response, 200)
     }
 
@@ -172,13 +173,13 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
       return c.json({ error: 'origin has no pairing grant' }, 403)
     }
     const minted = tokens.mint(origin)
-    const response: TokenResponse = {
+    const response: TokenResponse = pairingTokenResponseSchema.parse({
       ...minted,
       origin,
       ...(parsed.data.nonce !== undefined
         ? { identity: signTokenResponse(identity, parsed.data.nonce, minted, origin) }
         : {}),
-    }
+    })
     return c.json(response, 200)
   })
 

--- a/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Roundtrip serialization tests for the pairing api-contract schemas.
+ *
+ * Each test verifies three invariants:
+ *   1. A well-formed value parses successfully.
+ *   2. JSON stringify → parse → schema.parse produces an equal result
+ *      (no field drift through the wire format).
+ *   3. A malformed / missing-required / extra-field value is rejected by
+ *      safeParse (the schemas are `.strict()`, so an unexpected field is
+ *      itself a drift signal).
+ *
+ * z.infer type alignment is checked at the TypeScript level by annotating
+ * parsed results with the exported type alias.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  type PairingTokenResponse,
+  pairingTokenNonceSchema,
+  pairingTokenRequestSchema,
+  pairingTokenResponseSchema,
+} from './pairing.js'
+import { roundtrip } from './roundtrip.test-helper.js'
+
+describe('pairingTokenResponseSchema', () => {
+  const valid: PairingTokenResponse = {
+    token: 'tok-123',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    origin: 'https://latest.kamiazya-whiteboard.pages.dev',
+  }
+
+  it('parses a well-formed value without identity', () => {
+    const result: PairingTokenResponse = pairingTokenResponseSchema.parse(valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('roundtrip preserves fields without identity', () => {
+    const result: PairingTokenResponse = roundtrip(pairingTokenResponseSchema, valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('roundtrip preserves fields with an identity signature', () => {
+    const withIdentity: PairingTokenResponse = {
+      ...valid,
+      identity: { alg: 'Ed25519', publicKey: 'pk-abc', signature: 'sig-xyz' },
+    }
+    const result: PairingTokenResponse = roundtrip(pairingTokenResponseSchema, withIdentity)
+    expect(result).toEqual(withIdentity)
+  })
+
+  it('rejects a missing required field (token)', () => {
+    const { token: _omit, ...missing } = valid
+    expect(pairingTokenResponseSchema.safeParse(missing).success).toBe(false)
+  })
+
+  it('rejects a missing required field (origin)', () => {
+    const { origin: _omit, ...missing } = valid
+    expect(pairingTokenResponseSchema.safeParse(missing).success).toBe(false)
+  })
+
+  it('rejects an unexpected extra field (strict schema catches server drift)', () => {
+    expect(pairingTokenResponseSchema.safeParse({ ...valid, extra: 'unexpected' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an incomplete identity object', () => {
+    expect(
+      pairingTokenResponseSchema.safeParse({ ...valid, identity: { alg: 'Ed25519' } }).success,
+    ).toBe(false)
+  })
+})
+
+describe('pairingTokenRequestSchema', () => {
+  it('parses and roundtrips a code grant', () => {
+    const valid = { grantType: 'code' as const, code: 'c1', codeVerifier: 'v1' }
+    const result = pairingTokenRequestSchema.parse(valid)
+    expect(result).toEqual(valid)
+    expect(roundtrip(pairingTokenRequestSchema, { ...valid, nonce: undefined })).toEqual(valid)
+  })
+
+  it('parses and roundtrips an origin grant', () => {
+    const valid = { grantType: 'origin' as const }
+    const result = roundtrip(pairingTokenRequestSchema, valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('rejects a code grant missing codeVerifier', () => {
+    expect(pairingTokenRequestSchema.safeParse({ grantType: 'code', code: 'c1' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an unknown grantType', () => {
+    expect(pairingTokenRequestSchema.safeParse({ grantType: 'other' }).success).toBe(false)
+  })
+})
+
+describe('pairingTokenNonceSchema bounds', () => {
+  function nonceOfBytes(byteLength: number): string {
+    return Buffer.alloc(byteLength, 7).toString('base64url')
+  }
+
+  it('accepts nonces that decode to 16-32 bytes', () => {
+    expect(pairingTokenNonceSchema.safeParse(nonceOfBytes(16)).success).toBe(true)
+    expect(pairingTokenNonceSchema.safeParse(nonceOfBytes(32)).success).toBe(true)
+  })
+
+  it('rejects a nonce one byte short of the minimum', () => {
+    expect(pairingTokenNonceSchema.safeParse(nonceOfBytes(15)).success).toBe(false)
+  })
+
+  it('rejects a nonce one byte over the maximum', () => {
+    expect(pairingTokenNonceSchema.safeParse(nonceOfBytes(33)).success).toBe(false)
+  })
+
+  it('rejects a non-base64url string', () => {
+    expect(pairingTokenNonceSchema.safeParse('not base64url!!!').success).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Audit finding (HIGH, contract-drift): `pairingTokenResponseSchema` was defined but never runtime-parsed on either end of the credential-handover path (bearer token + Ed25519 identity signature) — a server field change would type-check and ship silently, and TypeScript's excess-property check doesn't fire through the response spread. Enforcement-only change; no schema shape changes.

- Server: both token responses in `routes/pairing.ts` (code-exchange and renewal legs) now pass through `pairingTokenResponseSchema.parse(...)` before `c.json`, matching `routes/runtime.ts`'s existing pattern.
- Client: `pairing-grant.ts` imports the same schema from `@kamiazya/whiteboard-mcp/api-contracts` and safeParses at both call sites; the two unchecked casts are deleted. Parse failure collapses into the existing error shapes (`{status:'error'}` exchange failure / `{status:'none'}` renewal) — no new error UI. The fail-closed invariant is untouched: a malformed response can never yield `{status:'paired'}`.
- New `api-contracts/pairing.test.ts` (roundtrip.test-helper) — was the only api-contracts file with no sibling conformance test — plus route-level assertions that both real HTTP bodies conform (the executable mutation-check guard), and red-first client cases for missing-field and strict-mode extra-field responses.

Because the schema is `.strict()`, additive server drift now hard-fails in the browser instead of passing silently — the intended semantics of both ends moving through one schema.

Mutation-checked: dropping the route `.parse` and drifting a field turns the route conformance assertion red; restored.

## Gates

mcp-node + apps/web jsdom green (existing pairing-grant cases un-weakened); `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, lint clean. Review workflow: zero confirmed findings; QA pass.

Backend/contract enforcement — no screenshot; the red-first rejection tests are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw