### PR TITLE
fix(render): pin bystander edge anchors for the drag's duration

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -72,6 +72,7 @@ import type {
   TextMetrics,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
+  assignEdgeAnchors,
   BODY_FONT_SIZE_PX,
   edgeLabelAnchor,
   flattenDrawnEdgePath,
@@ -846,7 +847,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         metricsCache.set(key, metrics)
         return metrics
       }
-      return { carried, svg: rendered.svg, bounds: rendered.bounds, measure }
+      // The committed anchor state, captured once per gesture: liveEdges
+      // pins bystander edges to these exact points so a carried edge
+      // joining their (node, side) group cannot re-fraction them mid-drag.
+      const committedAnchors = assignEdgeAnchors(
+        canvas.nodes,
+        canvas.edges,
+        canvas['x-whiteboard']?.edgeRouting?.style,
+      )
+      return { carried, svg: rendered.svg, bounds: rendered.bounds, measure, committedAnchors }
       // isLocked closes over lockedNodeIds/lockEnabled, both listed.
     }, [
       gestureState,
@@ -968,7 +977,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           .map((edge) => edge.id),
       )
       const frozenSides = new Map(
-        [...frozenSidesOf(scene)].filter(([id]) => !carriedEdgeIds.has(id)),
+        [...frozenSidesOf(scene)]
+          .filter(([id]) => !carriedEdgeIds.has(id))
+          .map(([id, pair]) => {
+            const pin = dragStatic.committedAnchors.get(id)
+            return [
+              id,
+              {
+                ...pair,
+                from: pin?.from,
+                fromLaneDepth: pin?.fromLaneDepth,
+                to: pin?.to,
+                toLaneDepth: pin?.toLaneDepth,
+              },
+            ] as const
+          }),
       )
       const cacheKey = carriedSideCacheKey(carriedEdgeIds)
       const cache = carriedSideCacheRef.current

--- a/apps/web/src/components/spatial-editor/live-drag-side-tracking.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-drag-side-tracking.browser.test.tsx
@@ -121,3 +121,68 @@ it('bystander edges stay frozen while an unrelated node is dragged', async () =>
   expect((livePts[0] as string).startsWith('320,60')).toBe(true)
   fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 660, clientY: r.top + 500 })
 })
+
+it('a bystander edge holds its exact anchor when the carried edge joins its side', async () => {
+  // N -> T is stationary, anchored alone at T's left midpoint. Dragging M
+  // beside T re-sides M's edge onto T's left; the bystander's polyline
+  // must not move — sides alone froze the SIDE but the anchor was a group
+  // fraction, so the newcomer used to slide the stationary edge.
+  const initial: SpatialCanvas = {
+    nodes: [
+      { id: 'n', type: 'text', x: 40, y: 40, width: 100, height: 100, text: 'N' },
+      { id: 't', type: 'text', x: 340, y: 40, width: 100, height: 100, text: 'T' },
+      { id: 'm', type: 'text', x: 340, y: 380, width: 100, height: 100, text: 'M' },
+    ],
+    edges: [
+      { id: 'f', fromNode: 'n', toNode: 't' },
+      { id: 'c', fromNode: 'm', toNode: 't' },
+    ],
+    'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+  }
+  function Host() {
+    const [canvas, setCanvas] = useState(initial)
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  await new Promise((res) => setTimeout(res, 200))
+
+  // The bystander's committed polyline (from N at x=140 toward T's left).
+  const committed = polylines(root).find((p) => p.startsWith('140,'))
+  expect(committed).toBeDefined()
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 390,
+    clientY: r.top + 430,
+  })
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 396, clientY: r.top + 434 })
+  // Directly left of T: the carried edge's zero-bend pair joins T's left.
+  fireEvent.pointerMove(root, { pointerId: 1, clientX: r.left + 230, clientY: r.top + 94 })
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="live-edges"]')).toBeTruthy()
+  })
+  const live = container.querySelector('[data-testid="live-edges"]') as HTMLElement
+  const liveBystander = polylines(live).find((p) => p.startsWith('140,'))
+  expect(liveBystander).toBeDefined()
+  // The route may detour around the moving node, but the ANCHORS — where
+  // the stationary edge meets its stationary nodes — must not move.
+  const ends = (points: string) => {
+    const parts = points.split(' ')
+    return [parts[0], parts[parts.length - 1]]
+  }
+  expect(ends(liveBystander as string)).toEqual(ends(committed as string))
+
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 230, clientY: r.top + 94 })
+})

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -12,7 +12,12 @@ export type {
 } from './layout/spatial-appearance.js'
 export type { SpatialLayoutDegradation, SpatialLayoutOptions } from './layout/spatial-canvas.js'
 export { layoutSpatialCanvas, layoutSpatialEdges } from './layout/spatial-canvas.js'
-export { assignEdgeAnchors, type EdgeSides, routeEdge } from './layout/spatial-edges.js'
+export {
+  assignEdgeAnchors,
+  type EdgeAnchorOverride,
+  type EdgeSides,
+  routeEdge,
+} from './layout/spatial-edges.js'
 export { translateScene } from './layout/translate-scene.js'
 export type { FontDescriptor, MeasureText, TextMetrics } from './measure.js'
 export { clampAdvance } from './measure.js'

--- a/packages/canvas-render/src/layout/live-drag-anchor-freeze.test.ts
+++ b/packages/canvas-render/src/layout/live-drag-anchor-freeze.test.ts
@@ -1,0 +1,75 @@
+// A frozen (bystander) edge must not MOVE mid-drag. Freezing sides alone
+// is not enough: anchor positions are fractions of a (node, side) group,
+// so a carried edge re-siding onto the same side mid-gesture used to
+// re-fraction the bystander's anchor — a stationary edge visibly sliding
+// along its node. Overrides can now pin the committed anchor points too.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors } from './spatial-edges.js'
+
+// N -> T is the stationary bystander; M carries edge C. At M's committed
+// position C arrives at T's bottom; dragged below-left, C re-sides onto
+// T's LEFT — the side the bystander already occupies.
+const N: SpatialNode = { id: 'N', type: 'text', x: 0, y: 0, width: 100, height: 100, text: '' }
+const T: SpatialNode = { id: 'T', type: 'text', x: 300, y: 0, width: 100, height: 100, text: '' }
+// Dragged to directly LEFT of T: the zero-bend facing pair (right->left)
+// outranks the crowding tie-break, so C must join the occupied side.
+const M_DRAGGED: SpatialNode = {
+  id: 'M',
+  type: 'text',
+  x: 50,
+  y: 0,
+  width: 100,
+  height: 100,
+  text: '',
+}
+const EDGES: CanvasEdge[] = [
+  { id: 'F', fromNode: 'N', toNode: 'T' },
+  { id: 'C', fromNode: 'M', toNode: 'T' },
+]
+
+describe('live-drag anchor freeze', () => {
+  it('a pinned bystander keeps its committed anchor when a carried edge joins its side', () => {
+    // Committed: F alone on T's left, anchored at the side midpoint (M
+    // sits below T, its edge arriving at T's bottom).
+    const committed = assignEdgeAnchors(
+      [N, T, { ...M_DRAGGED, x: 300, y: 300 }],
+      EDGES,
+      'orthogonal',
+    )
+    const f = committed.get('F')
+    expect([f?.fromSide, f?.toSide]).toEqual(['right', 'left'])
+    expect(f?.to).toEqual({ x: 300, y: 50 })
+
+    // Mid-drag frame: C has re-sided onto T's left (sides-only override,
+    // as a freshly re-sided carried edge). F's override pins its committed
+    // anchors alongside its sides.
+    const live = assignEdgeAnchors(
+      [N, T, M_DRAGGED],
+      EDGES,
+      'orthogonal',
+      new Map([
+        [
+          'F',
+          {
+            fromSide: f?.fromSide ?? ('right' as const),
+            toSide: f?.toSide ?? ('left' as const),
+            from: f?.from,
+            fromLaneDepth: f?.fromLaneDepth,
+            to: f?.to,
+            toLaneDepth: f?.toLaneDepth,
+          },
+        ],
+        ['C', { fromSide: 'right' as const, toSide: 'left' as const }],
+      ]),
+    )
+    const liveC = live.get('C')
+    expect(liveC?.toSide).toBe('left')
+    const liveF = live.get('F')
+    expect(liveF?.to).toEqual(f?.to)
+    expect(liveF?.from).toEqual(f?.from)
+    expect(liveF?.toLaneDepth).toBe(f?.toLaneDepth)
+    // The carried newcomer lands elsewhere on the side, not on the pin.
+    expect(liveC?.to).not.toEqual(liveF?.to)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -43,8 +43,8 @@ import { scaleScene } from './scale-scene.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
 import {
   assignEdgeAnchors,
+  type EdgeAnchorOverride,
   type EdgeAnchorPair,
-  type EdgeSides,
   routeEdge,
 } from './spatial-edges.js'
 import { translateScene } from './translate-scene.js'
@@ -89,7 +89,7 @@ export interface SpatialLayoutOptions {
    * pointer frames skip the improvement loop). Absent means sides settle
    * through the full pipeline.
    */
-  readonly edgeSideOverrides?: ReadonlyMap<string, EdgeSides>
+  readonly edgeSideOverrides?: ReadonlyMap<string, EdgeAnchorOverride>
   readonly onDegrade?: (event: SpatialLayoutDegradation) => void
   /**
    * Human-readable label for a file node's reference. A composition root

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -345,6 +345,19 @@ export interface EdgeSides {
   readonly toSide: Side
 }
 
+/**
+ * A frozen edge's full anchor state, for overrides that must not MOVE
+ * mid-gesture: sides alone leave the anchor a fraction of its (node, side)
+ * group, so a carried edge joining the group re-fractions a stationary
+ * edge. Point/depth fields, when present, pin the committed positions.
+ */
+export interface EdgeAnchorOverride extends EdgeSides {
+  readonly from?: Point
+  readonly fromLaneDepth?: number
+  readonly to?: Point
+  readonly toLaneDepth?: number
+}
+
 type SidePair = EdgeSides
 
 /**
@@ -425,6 +438,11 @@ function computeAnchorsFor(
   // worse face). Post-processing settled sides keeps the optimizer's
   // decisions identical and only straightens the pairs it already chose.
   align = true,
+  // Committed anchor state to pin verbatim (live-drag bystanders): the
+  // pinned ends still COUNT toward their group's fan-out fractions, so a
+  // carried newcomer lands on a distinct lane, but their own placed
+  // point/depth is the committed one — a stationary edge never moves.
+  pins?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, EdgeAnchorPair> {
   const byId = new Map(nodes.map((n) => [n.id, n]))
   type End = {
@@ -516,7 +534,25 @@ function computeAnchorsFor(
     }
   }
 
-  if (!align) return anchors
+  const applyPins = (): void => {
+    if (pins === undefined) return
+    for (const [id, pin] of pins) {
+      const entry = anchors.get(id)
+      if (entry === undefined) continue
+      anchors.set(id, {
+        ...entry,
+        ...(pin.from !== undefined ? { from: pin.from } : {}),
+        ...(pin.fromLaneDepth !== undefined ? { fromLaneDepth: pin.fromLaneDepth } : {}),
+        ...(pin.to !== undefined ? { to: pin.to } : {}),
+        ...(pin.toLaneDepth !== undefined ? { toLaneDepth: pin.toLaneDepth } : {}),
+      })
+    }
+  }
+
+  if (!align) {
+    applyPins()
+    return anchors
+  }
 
   // A facing opposing pair whose ends are each ALONE on their side slides
   // both anchors to one tangent coordinate inside the shared lane —
@@ -525,6 +561,8 @@ function computeAnchorsFor(
   // midpoints happen to align. Multi-edge sides keep their fan-out
   // fractions: collapsing two corridors onto one lane is worse than a jog.
   for (const edge of edges) {
+    // A pinned edge holds its committed anchors; alignment must not move it.
+    if (pins?.get(edge.id)?.from !== undefined || pins?.get(edge.id)?.to !== undefined) continue
     const chosen = sides.get(edge.id)
     const entry = anchors.get(edge.id)
     if (chosen === undefined || entry?.from === undefined || entry.to === undefined) continue
@@ -558,6 +596,7 @@ function computeAnchorsFor(
       to: axis === 'h' ? { x: entry.to.x, y: t } : { x: t, y: entry.to.y },
     })
   }
+  applyPins()
   return anchors
 }
 
@@ -896,7 +935,7 @@ export function assignEdgeAnchors(
   // side exactly as the committed render will; a map covering every edge
   // skips optimization wholesale (the live overlay's cached frames).
   // Sides settle again on the next committed render.
-  sideOverrides?: ReadonlyMap<string, EdgeSides>,
+  sideOverrides?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, EdgeAnchorPair> {
   let sides: ReadonlyMap<string, SidePair> = initialSideChoices(nodes, edges)
   if (sideOverrides !== undefined) {
@@ -919,7 +958,7 @@ export function assignEdgeAnchors(
     if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES && locked.size < edges.length) {
       liveSides = optimizeSideChoices(nodes, edges, style, merged, locked)
     }
-    return computeAnchorsFor(nodes, edges, liveSides)
+    return computeAnchorsFor(nodes, edges, liveSides, true, sideOverrides)
   }
   if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES) {
     sides = optimizeSideChoices(nodes, edges, style, sides)


### PR DESCRIPTION
## Problem (parity audit — the last open item)

Freezing SIDES alone left bystander anchors as fractions of their (node, side) group, so a carried edge re-siding onto the same side mid-gesture re-fractioned a stationary edge — visibly sliding it along its node, then possibly moving it again at drop.

## Fix

`EdgeAnchorOverride` extends `EdgeSides` with optional committed anchor points and lane depths. Pinned ends still **count** toward group fan-out (a carried newcomer lands on a distinct lane, not on the pin), the facing-pair alignment skips pinned edges, and pins apply after alignment so frozen edges match the committed scene exactly. The editor captures the committed anchor map once per gesture (`dragStatic`) and pins every non-carried edge.

## Tests

Red-first at both layers:
- `live-drag-anchor-freeze.test.ts` (canvas-render): the group-joining re-fraction — a pinned bystander keeps its committed anchor/lane depth while the newcomer lands elsewhere on the side.
- `live-drag-side-tracking.browser.test.tsx`: a bystander's polyline **endpoints** hold mid-drag while its route may still detour around the moving node — mutation-checked by dropping the pin wiring (red).

canvas-render (399), web jsdom (1924), browser (513) suites pass; knip/typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ