### PR TITLE
feat(web): blue attention dot on the settings gear for outstanding setup todos

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -30,6 +30,8 @@ function renderBar(overrides?: {
   workspaces?: string[]
   onSwitchWorkspace?: (workspaceId: string) => void
   onNavigateHome?: () => void
+  onOpenSettings?: () => void
+  settingsNudge?: boolean
 }) {
   // React 18 delegates events to the root container. Radix portals render into document.body,
   // which is a DOM sibling of the default test container. Using document.body as the React root
@@ -45,6 +47,8 @@ function renderBar(overrides?: {
       workspaces={overrides?.workspaces}
       onSwitchWorkspace={overrides?.onSwitchWorkspace}
       onNavigateHome={overrides?.onNavigateHome}
+      onOpenSettings={overrides?.onOpenSettings}
+      settingsNudge={overrides?.settingsNudge}
     />,
     { container: document.body },
   )
@@ -1391,5 +1395,17 @@ describe('WorkspaceTopBar — brand mark home affordance', () => {
   it('renders no home affordance without the callback', () => {
     renderBar()
     expect(screen.queryByRole('button', { name: 'Home' })).toBeNull()
+  })
+})
+
+describe('WorkspaceTopBar — settings nudge dot', () => {
+  it('shows the blue dot on the settings gear while a setup todo remains', () => {
+    renderBar({ onOpenSettings: () => {}, settingsNudge: true })
+    expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+  })
+
+  it('shows no dot when there is nothing actionable', () => {
+    renderBar({ onOpenSettings: () => {} })
+    expect(screen.queryByTestId('settings-nudge')).toBeNull()
   })
 })

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1407,5 +1407,22 @@ describe('WorkspaceTopBar — settings nudge dot', () => {
   it('shows no dot when there is nothing actionable', () => {
     renderBar({ onOpenSettings: () => {} })
     expect(screen.queryByTestId('settings-nudge')).toBeNull()
+    expect(screen.queryByTestId('settings-nudge-overflow')).toBeNull()
+  })
+
+  it('carries the dot on the collapsed overflow trigger only when settings is reachable there', () => {
+    renderBar({ onOpenSettings: () => {}, settingsNudge: true })
+    expect(screen.getByTestId('settings-nudge-overflow')).toBeTruthy()
+  })
+
+  it('shows no overflow dot when settings is not offered at all', () => {
+    renderBar({ settingsNudge: true })
+    expect(screen.queryByTestId('settings-nudge-overflow')).toBeNull()
+  })
+
+  it('marks the Settings item inside the opened overflow menu', async () => {
+    renderBar({ onOpenSettings: () => {}, settingsNudge: true })
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'View options' }), { button: 0 })
+    expect(await screen.findByTestId('settings-nudge-item')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -72,6 +72,8 @@ interface Props {
   // app's or Excalidraw's own) produces one.
   onExport?: (format: SceneExportFormat) => Promise<Blob | null>
   onOpenSettings?: () => void
+  /** Blue attention dot on the settings gear (outstanding setup todo or waiting update). */
+  settingsNudge?: boolean
   /** Renders the brand mark as a go-home affordance when provided. */
   onNavigateHome?: () => void
   // Right-side slot ahead of the secondary actions — the host page's
@@ -109,6 +111,7 @@ export default function WorkspaceTopBar({
   branchRefreshSignal,
   onExport,
   onOpenSettings,
+  settingsNudge,
   onNavigateHome,
   statusSlot,
   workspaces,
@@ -365,6 +368,7 @@ export default function WorkspaceTopBar({
         onToggleFullscreen={onToggleFullscreen}
         isFullscreen={isFullscreen}
         onOpenSettings={onOpenSettings}
+        settingsNudge={settingsNudge}
       />
     </header>
   )

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -17,6 +17,8 @@ interface TopBarSecondaryActionsProps {
   onToggleFullscreen?: () => void
   isFullscreen?: boolean
   onOpenSettings?: () => void
+  /** Blue attention dot on the settings entry points (outstanding setup todo or waiting update). */
+  settingsNudge?: boolean
 }
 
 // Right side: fullscreen and settings — plus the "View options" kebab that
@@ -29,6 +31,7 @@ export function TopBarSecondaryActions({
   onToggleFullscreen,
   isFullscreen = false,
   onOpenSettings,
+  settingsNudge,
 }: TopBarSecondaryActionsProps) {
   const fullscreenLabel = isFullscreen ? 'Exit fullscreen' : 'Fullscreen'
   const FullscreenIcon = isFullscreen ? Minimize2 : Maximize2
@@ -61,11 +64,18 @@ export function TopBarSecondaryActions({
               <Button
                 variant="ghost"
                 size="sm"
-                className="size-8 p-0"
+                className="relative size-8 p-0"
                 onClick={onOpenSettings}
                 aria-label="Settings"
                 data-testid="settings-trigger"
               >
+                {settingsNudge && (
+                  <span
+                    data-testid="settings-nudge"
+                    aria-hidden="true"
+                    className="absolute right-0.5 top-0.5 size-2 rounded-full bg-[#3b6ecc] ring-2 ring-background"
+                  />
+                )}
                 <Settings className="size-3.5" />
               </Button>
             </TooltipTrigger>
@@ -80,8 +90,14 @@ export function TopBarSecondaryActions({
             type="button"
             aria-label="View options"
             data-testid="topbar-more-actions-trigger"
-            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground min-[400px]:hidden"
+            className="relative shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground min-[400px]:hidden"
           >
+            {settingsNudge && onOpenSettings && (
+              <span
+                aria-hidden="true"
+                className="absolute right-0 top-0 size-2 rounded-full bg-[#3b6ecc] ring-2 ring-background"
+              />
+            )}
             <EllipsisVertical className="size-4" />
           </button>
         </DropdownMenuTrigger>
@@ -96,6 +112,9 @@ export function TopBarSecondaryActions({
             <DropdownMenuItem onSelect={onOpenSettings} className="gap-2">
               <Settings className="size-3.5" />
               Settings
+              {settingsNudge && (
+                <span aria-hidden="true" className="ml-auto size-2 rounded-full bg-[#3b6ecc]" />
+              )}
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -94,6 +94,7 @@ export function TopBarSecondaryActions({
           >
             {settingsNudge && onOpenSettings && (
               <span
+                data-testid="settings-nudge-overflow"
                 aria-hidden="true"
                 className="absolute right-0 top-0 size-2 rounded-full bg-[#3b6ecc] ring-2 ring-background"
               />
@@ -113,7 +114,11 @@ export function TopBarSecondaryActions({
               <Settings className="size-3.5" />
               Settings
               {settingsNudge && (
-                <span aria-hidden="true" className="ml-auto size-2 rounded-full bg-[#3b6ecc]" />
+                <span
+                  data-testid="settings-nudge-item"
+                  aria-hidden="true"
+                  className="ml-auto size-2 rounded-full bg-[#3b6ecc]"
+                />
               )}
             </DropdownMenuItem>
           )}

--- a/apps/web/src/hooks/useSettingsNudge.test.tsx
+++ b/apps/web/src/hooks/useSettingsNudge.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initInstallPromptCapture, resetInstallPromptForTests } from '@/lib/install-prompt-store'
+import { bindApplyUpdate, resetSwStatusForTests } from '../pwa/sw-status-store.js'
+import { useSettingsNudge } from './useSettingsNudge.js'
+
+function stubPersisted(value: boolean | undefined) {
+  Object.defineProperty(navigator, 'storage', {
+    value: value === undefined ? undefined : { persisted: () => Promise.resolve(value) },
+    configurable: true,
+  })
+}
+
+beforeEach(() => {
+  resetSwStatusForTests()
+  resetInstallPromptForTests()
+})
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
+})
+
+describe('useSettingsNudge', () => {
+  it('stays off when every reachable step is complete and no update waits', async () => {
+    stubPersisted(true)
+    const { result } = renderHook(() => useSettingsNudge(true))
+    // let the persistence query settle
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  it('lights for an ungranted persistence todo', async () => {
+    stubPersisted(false)
+    const { result } = renderHook(() => useSettingsNudge(true))
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('does not light where the browser manages persistence itself', async () => {
+    stubPersisted(undefined)
+    const { result } = renderHook(() => useSettingsNudge(true))
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  it('lights when an install prompt is captured, but not for a blocked install', async () => {
+    stubPersisted(true)
+    initInstallPromptCapture()
+    const { result } = renderHook(() => useSettingsNudge(true))
+    await waitFor(() => expect(result.current).toBe(false))
+
+    act(() => {
+      const event = new Event('beforeinstallprompt', { cancelable: true }) as Event & {
+        prompt: () => Promise<void>
+      }
+      event.prompt = () => Promise.resolve()
+      window.dispatchEvent(event)
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('lights while a daemon is not connected', async () => {
+    stubPersisted(true)
+    const { result } = renderHook(() => useSettingsNudge(false))
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('lights when a service worker update is waiting to apply', async () => {
+    stubPersisted(true)
+    const { result } = renderHook(() => useSettingsNudge(true))
+    await waitFor(() => expect(result.current).toBe(false))
+
+    act(() => {
+      bindApplyUpdate(() => Promise.resolve())
+    })
+    expect(result.current).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/useSettingsNudge.ts
+++ b/apps/web/src/hooks/useSettingsNudge.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import { getInstallState, subscribeInstallState } from '@/lib/install-prompt-store'
+import { queryPersistentStorage } from '@/lib/persistent-storage'
+import { getSwStatus, subscribeSwStatus } from '../pwa/sw-status-store.js'
+
+/**
+ * Whether the settings gear should carry the blue attention dot: an
+ * ACTIONABLE setup-journey step remains (persistence grantable but not
+ * granted, an install prompt captured, no daemon connected) or a service
+ * worker update is waiting to apply. Blocked steps — persistence the browser
+ * manages itself, installs with no captured prompt — never light it: a dot
+ * the user cannot extinguish is noise, not a nudge.
+ */
+export function useSettingsNudge(daemonConnected: boolean): boolean {
+  const install = useSyncExternalStore(subscribeInstallState, getInstallState)
+  const sw = useSyncExternalStore(subscribeSwStatus, getSwStatus)
+  // false until the query answers: the dot must not flash on while the
+  // persistence state is still unknown.
+  const [persistTodo, setPersistTodo] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    void queryPersistentStorage().then((state) => {
+      if (!cancelled) setPersistTodo(state === false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return persistTodo || install.status === 'installable' || sw.updateReady || !daemonConnected
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -602,6 +602,17 @@ describe('BrowserLocalCanvasPage', () => {
     expect((router.state.location.state as { from?: string }).from).toBe('/')
   })
 
+  it('always lights the settings nudge dot — a browser-local page has no daemon', async () => {
+    vi.useRealTimers()
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
+  })
+
   it('the header brand mark navigates home', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -34,6 +34,7 @@ import { useSceneExport } from '../components/workspace-top-bar/useSceneExport.j
 import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useFavicon } from '../hooks/useFavicon.js'
+import { useSettingsNudge } from '../hooks/useSettingsNudge.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { browserLocalCanvasPath, parseBrowserLocalRoute, settingsPath } from '../lib/app-routes.js'
@@ -164,6 +165,8 @@ export function BrowserLocalCanvasPage({
   // persists to localStorage and applies the <html class="dark"> toggle
   // itself, so there is no App-level state this page needs to share.
   const { resolvedTheme } = useThemeMode()
+  // Browser-local pages have no daemon by definition.
+  const settingsNudge = useSettingsNudge(false)
 
   // Fullscreen can also be left with Escape or the browser's own chrome, so
   // the button's label follows the DOCUMENT rather than our own click.
@@ -568,6 +571,7 @@ export function BrowserLocalCanvasPage({
         >
           <WorkspaceTopBar
             onNavigateHome={() => navigate('/')}
+            settingsNudge={settingsNudge}
             statusSlot={
               <ConnectionStatus state="local">
                 <p className="text-muted-foreground">

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -591,6 +591,25 @@ describe('DaemonCanvasPage', () => {
     expect(screen.queryByRole('alert')).toBeNull()
   })
 
+  it('lights the settings gear nudge when live sync drops to an auth error', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    // Connected, nothing else actionable in jsdom: no dot.
+    expect(screen.queryByTestId('settings-nudge')).toBeNull()
+
+    await act(async () => {
+      createdBackends[0]?.handlers?.onAuthError?.()
+    })
+    // The daemon connection now needs the user's action (re-pair lives in
+    // Settings -> Connections), so the gear carries the attention dot.
+    expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+  })
+
   it('renders the "Sync off" indicator even when no canvas is selected', async () => {
     mockListWorkspaces.mockResolvedValue({
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -21,6 +21,7 @@ import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useDirtyState } from '../hooks/useDirtyState.js'
 import { useFavicon } from '../hooks/useFavicon.js'
+import { useSettingsNudge } from '../hooks/useSettingsNudge.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { settingsPath } from '../lib/app-routes.js'
@@ -136,6 +137,8 @@ export function DaemonCanvasPage({
   const [settingsStore] = useState(() => createUserSettingsStore())
 
   const { resolvedTheme } = useThemeMode()
+
+  const settingsNudge = useSettingsNudge(true)
 
   // The selected (workspaceId, slug) pair once both are known, computed once so
   // every downstream guard and child prop shares a single non-null narrowing
@@ -457,6 +460,7 @@ export function DaemonCanvasPage({
           {canvas && (
             <WorkspaceTopBar
               onNavigateHome={() => navigate('/')}
+              settingsNudge={settingsNudge}
               statusSlot={connectionStatus}
               workspaceId={canvas.workspaceId}
               slug={canvas.slug}

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -138,8 +138,6 @@ export function DaemonCanvasPage({
 
   const { resolvedTheme } = useThemeMode()
 
-  const settingsNudge = useSettingsNudge(true)
-
   // The selected (workspaceId, slug) pair once both are known, computed once so
   // every downstream guard and child prop shares a single non-null narrowing
   // instead of repeating `workspaceId !== null && slug !== null`.
@@ -149,6 +147,11 @@ export function DaemonCanvasPage({
       : null
 
   const [authError, setAuthError] = useState(false)
+  // An auth error means the daemon connection needs the user's action
+  // (re-pair lives under Settings -> Connections), so it counts as
+  // disconnected for the gear's attention dot. Transient reconnects don't:
+  // they need no user action and would only make the dot flicker.
+  const settingsNudge = useSettingsNudge(!authError)
   // Disables the empty-state "Create a canvas" control while a create is in
   // flight. `disabled` is the whole mechanism: an in-handler
   // `if (creating) return` reads the render closure, so it is stale in exactly

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1066,6 +1066,38 @@ describe('DaemonIndexPage', () => {
     expect((router.state.location.state as { from?: string }).from).toBe('/')
   })
 
+  it('lights the settings nudge dot when persistence is grantable but not granted', async () => {
+    Object.defineProperty(navigator, 'storage', {
+      value: {
+        persisted: () => Promise.resolve(false),
+        persist: () => Promise.resolve(true),
+      },
+      configurable: true,
+    })
+    try {
+      installFetchMock({
+        workspaces: [{ workspaceId: 'ws-a' }],
+        canvasesByWorkspace: {
+          'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
+        },
+      })
+      const router = createMemoryRouter(
+        [
+          {
+            path: '*',
+            element: <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />,
+          },
+        ],
+        { initialEntries: ['/'] },
+      )
+      rtlRender(<RouterProvider router={router} />)
+      await screen.findByText('alpha')
+      expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
+    } finally {
+      Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
+    }
+  })
+
   it('hides the workspace selector when there is only one workspace (raw id demoted, D3)', async () => {
     installFetchMock({
       workspaces: [{ workspaceId: 'dTMMrBP3c5ah8_SXTRVvC' }],

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -9,6 +9,7 @@ import { CanvasListView } from '../components/canvas-list/CanvasListView.js'
 import { DeleteCanvasDialog } from '../components/canvas-list/DeleteCanvasDialog.js'
 import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import { useSettingsNudge } from '../hooks/useSettingsNudge.js'
 import { settingsPath } from '../lib/app-routes.js'
 import {
   createCanvas,
@@ -92,6 +93,7 @@ export function DaemonIndexPage({
   onOpenCanvas,
 }: DaemonIndexPageProps) {
   const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
+  const settingsNudge = useSettingsNudge(true)
   const navigate = useNavigate()
 
   const [view, setView] = useState<ViewKey>('grid')
@@ -360,8 +362,15 @@ export function DaemonIndexPage({
                   state: { from: `${window.location.pathname}${window.location.search}` },
                 })
               }
-              className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              className="relative rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             >
+              {settingsNudge && (
+                <span
+                  data-testid="settings-nudge"
+                  aria-hidden="true"
+                  className="absolute right-0.5 top-0.5 size-2 rounded-full bg-[#3b6ecc] ring-2 ring-background"
+                />
+              )}
               <Settings className="size-4" />
             </button>
           </div>


### PR DESCRIPTION
## What

Slice 3 (final) of the Setup Journey initiative: the settings gear carries an 8px brand-blue dot while an **actionable** setup step remains or an update waits — the quiet cue that Settings has something worth opening.

- New `useSettingsNudge(daemonConnected)`: lit for persistence grantable-but-not-granted, a captured install prompt, no daemon connected, or a waiting service-worker update (the "Later" re-entry cue). **Blocked states never light it** (browser-managed persistence, installs with no captured prompt) — a dot the user cannot extinguish is noise, not a nudge.
- Rendered on: the TopBar gear (new optional `settingsNudge` prop through `WorkspaceTopBar` → `TopBarSecondaryActions`), the <400px overflow trigger + its Settings menu item, and DaemonIndexPage's own gear. Brand blue `#3b6ecc` with a background ring, per the HeaderSaveDot grammar.
- Wiring: browser-local pages count as no-daemon (always lit until connected); **DaemonCanvasPage feeds its real connection state** — an auth error (the durable, user-actionable failure; re-pair lives under Settings → Connections) lights the dot, transient reconnects don't.

## Review-gate catch worth noting

The QA lane caught the first version hardcoding `useSettingsNudge(true)` on DaemonCanvasPage even though the page tracks live `authError`/`syncStatus` — a real disconnect never lit the dot, contradicting the hook's own contract. Fixed red-first using the existing `onAuthError` test harness. The other confirmed findings (page-level wiring coverage on all three call sites, the overflow dots' assertions) are also closed.

## Verification

- Live dev-server (Playwright): browser-local canvas page shows the lit gear dot (screenshot below)
- apps/web jsdom: **161 files / 1939 tests green**; typecheck + knip clean
- Review workflow (12 agents, adversarial verify): 0 CRITICAL/HIGH; 1 QA fail + 3 coverage findings, all fixed as above
- TopBar files coordinated with the owning session (approved; no vocabulary-rule violations touched)

## Visual repro

![gear-nudge-topbar.png](https://github.com/user-attachments/assets/14566d18-129d-477b-b45b-062793d27a34)

![gear-nudge-closeup.png](https://github.com/user-attachments/assets/9f0fb1dc-d1cd-4a02-83ca-b74d7d1e4211)

This completes the Setup Journey's initial three slices (routed /settings, journey + update surface + confetti, gear nudge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc