### PR TITLE
fix(mcp-server): count alive nodes from the current model in versions, restore, and debug

### DIFF
--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -1598,7 +1598,10 @@ describe('versions API', () => {
       expect(restoreRes.status).toBe(200)
       const restoreBody = (await restoreRes.json()) as { canvasId: string; elementCount: number }
       expect(restoreBody.canvasId).toBe('session1/canvas-new')
-      expect(restoreBody.elementCount).toBe(0)
+      // The restored doc has one alive legacy element ("keep-me"); the
+      // fixed countAliveNodes reports the real count instead of the
+      // retired countElements(_doc) stub's always-0.
+      expect(restoreBody.elementCount).toBe(1)
     })
 
     it('restoring a markdown-kind canvas into a new target slug carries the source kind forward, not the spatial default', async () => {

--- a/packages/mcp-server/src/server/routes/canvas/restore.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.test.ts
@@ -1,21 +1,144 @@
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Hono } from 'hono'
-import { describe, expect, it, vi } from 'vitest'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
 
 vi.mock('../../config.js', () => ({
   get DATA_DIR() {
-    return '/tmp/test-restore'
+    return tmp.dir
   },
-  getDataDir: () => '/tmp/test-restore',
+  getDataDir: () => tmp.dir,
   WHITEBOARD_ROOT: '/tmp/whiteboard',
   REPO_ROOT: '/tmp',
 }))
 
+const tmp = withTempDataDir('whiteboard-restore-test-')
+
 const { createRestoreRouter } = await import('./restore.js')
+const { clearCache } = await import('../../store/doc-cache.js')
+const { createCanvasRouter } = await import('../canvas.js')
+// Pre-load ws.js before any restore call, mirroring restore-race.test.ts's
+// documented cycle workaround for canvas.ts's dynamic import.
+await import('../ws.js')
 
 describe('restore router', () => {
   it('returns a Hono instance', () => {
     const versionStore = { listVersions: vi.fn(), saveVersion: vi.fn() }
     const app = createRestoreRouter({ versionStore: versionStore as never })
     expect(app).toBeInstanceOf(Hono)
+  })
+})
+
+// Returns [doc, updateFromEmpty] so a caller can POST the whole doc as one
+// update, matching restore-race.test.ts's convention of capturing the
+// version vector before any writes.
+function nodesModelDocUpdate(nodeIds: string[]): Uint8Array {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  writeSpatialCanvas(doc, {
+    nodes: nodeIds.map((id) => ({
+      id,
+      type: 'text' as const,
+      text: id,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    })),
+    edges: [],
+  })
+  return doc.export({ mode: 'update', from: vv0 }) as Uint8Array
+}
+
+describe('restore router (real node counts)', () => {
+  beforeEach(() => {
+    clearCache()
+  })
+
+  afterEach(() => {
+    clearCache()
+  })
+
+  it("restore into a brand-new targetSlug responds with the past state's real node count", async () => {
+    const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+    const sourceDoc = new LoroDoc()
+    const svv0 = sourceDoc.version()
+    writeSpatialCanvas(sourceDoc, {
+      nodes: [
+        { id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'n2', type: 'text', text: 'b', x: 0, y: 0, width: 10, height: 10 },
+      ],
+      edges: [],
+    })
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: sourceDoc.export({ mode: 'update', from: svv0 }),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+    const restoreRes = await app.request(
+      `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetSlug: 'canvas-new' }),
+      },
+    )
+    expect(restoreRes.status).toBe(200)
+    const restoreBody = (await restoreRes.json()) as { canvasId: string; elementCount: number }
+    expect(restoreBody.elementCount).toBe(2)
+  })
+
+  it("restore-overwrite into an existing targetSlug responds with the reconciled target's real node count", async () => {
+    const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
+
+    // Source canvas with one node, saved as a version.
+    await app.request('/api/canvas/session1/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: nodesModelDocUpdate(['keep-me']),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/canvases/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const saveBody = (await saveRes.json()) as { version: { id: string } }
+
+    // Target canvas already exists with a different node.
+    await app.request('/api/canvas/session1/canvas-b/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: nodesModelDocUpdate(['b-only']),
+    })
+
+    const restoreRes = await app.request(
+      `/api/workspaces/session1/canvases/canvas-a/versions/${saveBody.version.id}/restore`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetSlug: 'canvas-b', overwrite: true }),
+      },
+    )
+    expect(restoreRes.status).toBe(200)
+    const restoreBody = (await restoreRes.json()) as { canvasId: string; elementCount: number }
+
+    // Reconcile-onto-live-doc is CRDT merge, not a straight overwrite, so
+    // assert the response tracks whatever the live target doc actually
+    // ended up holding rather than assuming an exact merged node set.
+    const { loadCanvas } = await import('../../store/canvas-store.js')
+    const { countAliveNodes } = await import('../../store/count-alive-nodes.js')
+    const finalTargetDoc = await loadCanvas('session1', 'canvas-b')
+    expect(restoreBody.elementCount).toBe(countAliveNodes(finalTargetDoc))
+    // And it must be the real (non-zero) count, not the retired stub's 0.
+    expect(restoreBody.elementCount).toBeGreaterThan(0)
   })
 })

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import type { LoroDoc } from 'loro-crdt'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/canvas.js'
 import { ConflictError, canvasExists, getCanvasKind, saveCanvas } from '../../store/canvas-store.js'
+import { countAliveNodes } from '../../store/count-alive-nodes.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
 import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
@@ -16,10 +17,6 @@ import { getBroadcastFn, handleCorruptStoredData } from './_shared.js'
 
 export interface RestoreRouterOptions {
   versionStore: VersionStore
-}
-
-function countElements(_doc: LoroDoc): number {
-  return 0
 }
 
 // Reconciles `past` onto `doc` (the LIVE cached doc for workspaceId/targetSlug),
@@ -182,7 +179,7 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
             )
             return c.json({
               canvasId: `${workspaceId}/${targetSlug}`,
-              elementCount: countElements(targetDoc),
+              elementCount: countAliveNodes(targetDoc),
             })
           }
 
@@ -215,7 +212,7 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
           evictDoc(workspaceId, targetSlug)
           return c.json({
             canvasId: `${workspaceId}/${targetSlug}`,
-            elementCount: countElements(past),
+            elementCount: countAliveNodes(past),
           })
         }
 

--- a/packages/mcp-server/src/server/routes/debug.test.ts
+++ b/packages/mcp-server/src/server/routes/debug.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
 
 let tempDir: string
 
@@ -95,6 +96,42 @@ describe('GET /api/debug', () => {
         slug: 'canvas-2',
         totalElements: 1,
         visibleElements: 1,
+        tombstones: 0,
+      }),
+    )
+  })
+
+  it('reports the real node count for a nodes-model canvas instead of 0', async () => {
+    await mkdir(join(tempDir, 'sess-nodes'), { recursive: true })
+    const doc = makeSpatialDoc({
+      nodes: [
+        { id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'n2', type: 'text', text: 'b', x: 0, y: 0, width: 10, height: 10 },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    await saveCanvas('sess-nodes', 'canvas-1', doc)
+
+    const app = createDebugRouter()
+    const res = await app.request('/api/debug')
+    const json = (await res.json()) as {
+      workspaces: Array<{
+        workspaceId: string
+        canvases: Array<{
+          slug: string
+          totalElements: number
+          visibleElements: number
+          tombstones: number
+        }>
+      }>
+    }
+    const session = json.workspaces.find((s) => s.workspaceId === 'sess-nodes')
+    const canvas = session?.canvases.find((c) => c.slug === 'canvas-1')
+    expect(canvas).toEqual(
+      expect.objectContaining({
+        slug: 'canvas-1',
+        totalElements: 2,
+        visibleElements: 2,
         tombstones: 0,
       }),
     )

--- a/packages/mcp-server/src/server/routes/debug.test.ts
+++ b/packages/mcp-server/src/server/routes/debug.test.ts
@@ -137,6 +137,45 @@ describe('GET /api/debug', () => {
     )
   })
 
+  it('ignores stale legacy tombstones once a canvas has migrated to the nodes model', async () => {
+    await mkdir(join(tempDir, 'sess-mixed'), { recursive: true })
+    const doc = makeSpatialDoc({
+      nodes: [{ id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 }],
+      edges: [],
+    })
+    const legacy = doc.getMovableList('elements')
+    const map = legacy.insertContainer(legacy.length, new LoroMap())
+    map.set('id', 'stale-dead')
+    map.set('type', 'rectangle')
+    map.set('isDeleted', true)
+    doc.commit()
+    await saveCanvas('sess-mixed', 'canvas-1', doc)
+
+    const app = createDebugRouter()
+    const res = await app.request('/api/debug')
+    const json = (await res.json()) as {
+      workspaces: Array<{
+        workspaceId: string
+        canvases: Array<{
+          slug: string
+          totalElements: number
+          visibleElements: number
+          tombstones: number
+        }>
+      }>
+    }
+    const session = json.workspaces.find((s) => s.workspaceId === 'sess-mixed')
+    const canvas = session?.canvases.find((c) => c.slug === 'canvas-1')
+    expect(canvas).toEqual(
+      expect.objectContaining({
+        slug: 'canvas-1',
+        totalElements: 1,
+        visibleElements: 1,
+        tombstones: 0,
+      }),
+    )
+  })
+
   it('marks only canvases touched through getDoc as cached in the cache section', async () => {
     await mkdir(join(tempDir, 'sess-cache'), { recursive: true })
     await saveCanvas('sess-cache', 'touched', makeDocWithElements(1, 0))

--- a/packages/mcp-server/src/server/routes/debug.ts
+++ b/packages/mcp-server/src/server/routes/debug.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { type LoroDoc, LoroMap } from 'loro-crdt'
 import { listCanvases, listWorkspaces, loadCanvas } from '../store/canvas-store.js'
+import { countAliveNodes } from '../store/count-alive-nodes.js'
 import { getCacheKeys, peekDoc } from '../store/doc-cache.js'
 import { isAuthorized } from './auth.js'
 
@@ -17,30 +18,31 @@ type WorkspaceInfo = {
   canvases: CanvasInfo[]
 }
 
-function countElements(doc: LoroDoc): {
-  totalElements: number
-  visibleElements: number
-  tombstones: number
-} {
+// Legacy 'elements' movable-list entries never get pruned, only tombstoned
+// (isDeleted=true) -- so a tombstone count is legacy-list-only by
+// definition; a nodes-model doc has none, since deleteSpatialNode removes
+// the entry outright rather than marking it dead.
+function countLegacyTombstones(doc: LoroDoc): number {
   const list = doc.getMovableList('elements')
-  let total = 0
   let tombstones = 0
   for (let i = 0; i < list.length; i++) {
     const item = list.get(i)
     if (!(item instanceof LoroMap)) continue
-    total += 1
     if (item.get('isDeleted') === true) tombstones += 1
   }
-  return { totalElements: total, visibleElements: total - tombstones, tombstones }
+  return tombstones
 }
 
 async function summarizeCanvas(workspaceId: string, slug: string): Promise<CanvasInfo> {
   const cached = peekDoc(workspaceId, slug)
   const doc = cached ?? (await loadCanvas(workspaceId, slug))
-  const counts = countElements(doc)
+  const visibleElements = countAliveNodes(doc)
+  const tombstones = countLegacyTombstones(doc)
   return {
     slug,
-    ...counts,
+    totalElements: visibleElements + tombstones,
+    visibleElements,
+    tombstones,
     cached: cached !== undefined,
   }
 }

--- a/packages/mcp-server/src/server/routes/debug.ts
+++ b/packages/mcp-server/src/server/routes/debug.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { type LoroDoc, LoroMap } from 'loro-crdt'
+import type { LoroDoc } from 'loro-crdt'
 import { listCanvases, listWorkspaces, loadCanvas } from '../store/canvas-store.js'
 import { countAliveNodes } from '../store/count-alive-nodes.js'
 import { getCacheKeys, peekDoc } from '../store/doc-cache.js'
@@ -23,14 +23,8 @@ type WorkspaceInfo = {
 // definition; a nodes-model doc has none, since deleteSpatialNode removes
 // the entry outright rather than marking it dead.
 function countLegacyTombstones(doc: LoroDoc): number {
-  const list = doc.getMovableList('elements')
-  let tombstones = 0
-  for (let i = 0; i < list.length; i++) {
-    const item = list.get(i)
-    if (!(item instanceof LoroMap)) continue
-    if (item.get('isDeleted') === true) tombstones += 1
-  }
-  return tombstones
+  const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
+  return list.filter((el) => el?.isDeleted === true).length
 }
 
 async function summarizeCanvas(workspaceId: string, slug: string): Promise<CanvasInfo> {

--- a/packages/mcp-server/src/server/routes/debug.ts
+++ b/packages/mcp-server/src/server/routes/debug.ts
@@ -1,7 +1,6 @@
 import { Hono } from 'hono'
-import type { LoroDoc } from 'loro-crdt'
 import { listCanvases, listWorkspaces, loadCanvas } from '../store/canvas-store.js'
-import { countAliveNodes } from '../store/count-alive-nodes.js'
+import { countAliveNodes, countLegacyTombstones } from '../store/count-alive-nodes.js'
 import { getCacheKeys, peekDoc } from '../store/doc-cache.js'
 import { isAuthorized } from './auth.js'
 
@@ -16,15 +15,6 @@ type CanvasInfo = {
 type WorkspaceInfo = {
   workspaceId: string
   canvases: CanvasInfo[]
-}
-
-// Legacy 'elements' movable-list entries never get pruned, only tombstoned
-// (isDeleted=true) -- so a tombstone count is legacy-list-only by
-// definition; a nodes-model doc has none, since deleteSpatialNode removes
-// the entry outright rather than marking it dead.
-function countLegacyTombstones(doc: LoroDoc): number {
-  const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
-  return list.filter((el) => el?.isDeleted === true).length
 }
 
 async function summarizeCanvas(workspaceId: string, slug: string): Promise<CanvasInfo> {

--- a/packages/mcp-server/src/server/store/count-alive-nodes.test.ts
+++ b/packages/mcp-server/src/server/store/count-alive-nodes.test.ts
@@ -1,7 +1,7 @@
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
-import { countAliveNodes } from './count-alive-nodes.js'
+import { countAliveNodes, countLegacyTombstones } from './count-alive-nodes.js'
 
 function legacyElement(doc: LoroDoc, id: string, isDeleted = false): void {
   const list = doc.getMovableList('elements')
@@ -45,5 +45,47 @@ describe('countAliveNodes', () => {
     legacyElement(doc, 'stale-1', false)
     legacyElement(doc, 'stale-2', false)
     expect(countAliveNodes(doc)).toBe(1)
+  })
+
+  it('drops a raw (non-map) legacy list entry instead of miscounting it as alive', () => {
+    // A LoroMovableList can hold plain values alongside LoroMap containers.
+    // A blind `as Array<{ isDeleted?: boolean }>` cast would read
+    // `(42).isDeleted` as `undefined` and count this entry alive; the
+    // schema-validated walk rejects it outright, same as the old
+    // `instanceof LoroMap` guard did.
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    list.insert(0, 42)
+    doc.commit()
+    expect(countAliveNodes(doc)).toBe(0)
+  })
+})
+
+describe('countLegacyTombstones', () => {
+  it('counts tombstoned entries in a legacy-only doc', () => {
+    const doc = new LoroDoc()
+    legacyElement(doc, 'el-1', false)
+    legacyElement(doc, 'el-2', true)
+    legacyElement(doc, 'el-3', true)
+    expect(countLegacyTombstones(doc)).toBe(2)
+  })
+
+  it('returns 0 once nodes are present, ignoring stale legacy tombstones', () => {
+    const doc = makeSpatialDoc({
+      nodes: [{ id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 }],
+      edges: [],
+    })
+    legacyElement(doc, 'stale-dead', true)
+    expect(countLegacyTombstones(doc)).toBe(0)
+  })
+
+  it('skips entries with a non-boolean isDeleted field instead of casting it', () => {
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    const map = list.insertContainer(list.length, new LoroMap())
+    map.set('id', 'weird')
+    map.set('isDeleted', 'true') // string, not boolean — must not count as a tombstone
+    doc.commit()
+    expect(countLegacyTombstones(doc)).toBe(0)
   })
 })

--- a/packages/mcp-server/src/server/store/count-alive-nodes.test.ts
+++ b/packages/mcp-server/src/server/store/count-alive-nodes.test.ts
@@ -1,0 +1,49 @@
+import { LoroDoc, LoroMap } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
+import { countAliveNodes } from './count-alive-nodes.js'
+
+function legacyElement(doc: LoroDoc, id: string, isDeleted = false): void {
+  const list = doc.getMovableList('elements')
+  const map = list.insertContainer(list.length, new LoroMap())
+  map.set('id', id)
+  map.set('type', 'rectangle')
+  map.set('isDeleted', isDeleted)
+  doc.commit()
+}
+
+describe('countAliveNodes', () => {
+  it('counts nodes-model nodes and excludes edges', () => {
+    const doc = makeSpatialDoc({
+      nodes: [
+        { id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'n2', type: 'text', text: 'b', x: 0, y: 0, width: 10, height: 10 },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    expect(countAliveNodes(doc)).toBe(2)
+  })
+
+  it('returns 0 for a fully empty doc', () => {
+    const doc = makeSpatialDoc({ nodes: [], edges: [] })
+    expect(countAliveNodes(doc)).toBe(0)
+  })
+
+  it('falls back to the legacy alive count when the nodes map is empty', () => {
+    const doc = new LoroDoc()
+    legacyElement(doc, 'el-1', false)
+    legacyElement(doc, 'el-2', false)
+    legacyElement(doc, 'el-3', true)
+    expect(countAliveNodes(doc)).toBe(2)
+  })
+
+  it('counts only the nodes map, not stale legacy entries, once nodes are present', () => {
+    const doc = makeSpatialDoc({
+      nodes: [{ id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 }],
+      edges: [],
+    })
+    legacyElement(doc, 'stale-1', false)
+    legacyElement(doc, 'stale-2', false)
+    expect(countAliveNodes(doc)).toBe(1)
+  })
+})

--- a/packages/mcp-server/src/server/store/count-alive-nodes.ts
+++ b/packages/mcp-server/src/server/store/count-alive-nodes.ts
@@ -2,27 +2,17 @@ import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import type { LoroDoc } from 'loro-crdt'
 
 // Shared "how many elements does this doc have" reader for the daemon's
-// advisory UI counts (History panel / restore response / /api/debug) — see
-// file-gc.ts's collectFromDoc for the sibling reader in this module family.
+// advisory UI counts (History panel / restore response / /api/debug).
 //
-// Two decisions, both pinned by count-alive-nodes.test.ts:
-//
-// - Edges are excluded. The bridge's edge-cascade invariant
-//   (writeSpatialCanvas/deleteSpatialNode delete an edge whenever either
-//   endpoint node is removed) means an edge can never outlive both of its
-//   nodes, so a nodes-only count is never 0 for a non-empty scene — it does
-//   not need edges to avoid under-reporting, and the UI label ("N els")
-//   historically counted the legacy 'elements' list, which had no
-//   edge/node distinction to begin with.
+// - Edges are excluded: the bridge's edge-cascade invariant (an edge is
+//   deleted whenever either endpoint node is removed) means an edge can
+//   never outlive both of its nodes, so a nodes-only count is never 0 for
+//   a non-empty scene.
 // - The legacy 'elements' movable-list walk is a FALLBACK, not an additive
-//   pass like file-gc's collectFromDoc. file-gc unions fileIds into a Set,
-//   where visiting the same file from both passes is a harmless no-op; a
-//   count that summed both passes would double-count a doc mid-migration
-//   that happens to have both shapes populated (nodes map written by a
-//   resave, stale legacy entries never cleared). Falling back only when the
-//   nodes map is empty means a pre-migration doc (nodes empty, legacy
-//   populated) still reports its real count, and a migrated doc (nodes
-//   populated) never consults potentially-stale legacy entries.
+//   pass — summing both would double-count a doc mid-migration with both
+//   shapes populated. Falling back only when the nodes map is empty keeps
+//   a pre-migration doc's real count without ever consulting stale legacy
+//   entries on a migrated doc.
 export function countAliveNodes(doc: LoroDoc): number {
   const { nodes } = readSpatialCanvas(doc)
   if (nodes.length > 0) return nodes.length

--- a/packages/mcp-server/src/server/store/count-alive-nodes.ts
+++ b/packages/mcp-server/src/server/store/count-alive-nodes.ts
@@ -1,5 +1,23 @@
 import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import type { LoroDoc } from 'loro-crdt'
+import { z } from 'zod'
+
+// The legacy movable-list entry crossed a persistence boundary (loaded from
+// a .loro snapshot on disk), so its shape is asserted at runtime rather than
+// cast — a corrupt or foreign-shaped entry is dropped instead of silently
+// flowing through as `{ isDeleted: undefined }`.
+const legacyElementSchema = z.object({ isDeleted: z.boolean().optional() }).passthrough()
+
+function readLegacyElements(doc: LoroDoc): Array<z.infer<typeof legacyElementSchema>> {
+  // LoroMovableList#toJSON() is typed `any` upstream; narrow to `unknown[]`
+  // (never a shaped type) so per-item validation below is what does the
+  // real work, not the compiler.
+  const list = doc.getMovableList('elements').toJSON() as unknown[]
+  return list.flatMap((item) => {
+    const parsed = legacyElementSchema.safeParse(item)
+    return parsed.success ? [parsed.data] : []
+  })
+}
 
 // Shared "how many elements does this doc have" reader for the daemon's
 // advisory UI counts (History panel / restore response / /api/debug).
@@ -17,6 +35,17 @@ export function countAliveNodes(doc: LoroDoc): number {
   const { nodes } = readSpatialCanvas(doc)
   if (nodes.length > 0) return nodes.length
 
-  const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
-  return list.filter((el) => !el.isDeleted).length
+  return readLegacyElements(doc).filter((el) => !el.isDeleted).length
+}
+
+// Tombstone count is legacy-list-only by definition (a nodes-model doc has
+// none: deleteSpatialNode removes the entry outright rather than marking it
+// dead), so it follows the same nodes-present guard as countAliveNodes above
+// — otherwise a migrated doc's stale, disconnected legacy list would leak
+// into a debug count that is supposed to describe the current doc.
+export function countLegacyTombstones(doc: LoroDoc): number {
+  const { nodes } = readSpatialCanvas(doc)
+  if (nodes.length > 0) return 0
+
+  return readLegacyElements(doc).filter((el) => el.isDeleted === true).length
 }

--- a/packages/mcp-server/src/server/store/count-alive-nodes.ts
+++ b/packages/mcp-server/src/server/store/count-alive-nodes.ts
@@ -1,0 +1,32 @@
+import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import type { LoroDoc } from 'loro-crdt'
+
+// Shared "how many elements does this doc have" reader for the daemon's
+// advisory UI counts (History panel / restore response / /api/debug) — see
+// file-gc.ts's collectFromDoc for the sibling reader in this module family.
+//
+// Two decisions, both pinned by count-alive-nodes.test.ts:
+//
+// - Edges are excluded. The bridge's edge-cascade invariant
+//   (writeSpatialCanvas/deleteSpatialNode delete an edge whenever either
+//   endpoint node is removed) means an edge can never outlive both of its
+//   nodes, so a nodes-only count is never 0 for a non-empty scene — it does
+//   not need edges to avoid under-reporting, and the UI label ("N els")
+//   historically counted the legacy 'elements' list, which had no
+//   edge/node distinction to begin with.
+// - The legacy 'elements' movable-list walk is a FALLBACK, not an additive
+//   pass like file-gc's collectFromDoc. file-gc unions fileIds into a Set,
+//   where visiting the same file from both passes is a harmless no-op; a
+//   count that summed both passes would double-count a doc mid-migration
+//   that happens to have both shapes populated (nodes map written by a
+//   resave, stale legacy entries never cleared). Falling back only when the
+//   nodes map is empty means a pre-migration doc (nodes empty, legacy
+//   populated) still reports its real count, and a migrated doc (nodes
+//   populated) never consults potentially-stale legacy entries.
+export function countAliveNodes(doc: LoroDoc): number {
+  const { nodes } = readSpatialCanvas(doc)
+  if (nodes.length > 0) return nodes.length
+
+  const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
+  return list.filter((el) => !el.isDeleted).length
+}

--- a/packages/mcp-server/src/server/store/version-store.test.ts
+++ b/packages/mcp-server/src/server/store/version-store.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
 
 // Tests for the native Loro version store backed by the sqlite metadata DB.
 // Frontiers and metadata live in the versions table; thumbnails live as PNG
@@ -63,6 +64,45 @@ describe('FileVersionStore (Loro native, sqlite-backed)', () => {
     expect(entry.label).toBeUndefined()
     expect(entry.hasThumbnail).toBe(false)
     expect(entry.branchName).toBe('main')
+  })
+
+  it('save counts nodes-model nodes, not the retired legacy elements list', async () => {
+    const doc = makeSpatialDoc({
+      nodes: [
+        { id: 'n1', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'n2', type: 'text', text: 'b', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'n3', type: 'text', text: 'c', x: 0, y: 0, width: 10, height: 10 },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n2' }],
+    })
+    const entry = await store.save('sess-1', 'canvas-a', doc, { auto: true })
+    expect(entry.elementCount).toBe(3)
+    const [listed] = await store.list('sess-1', 'canvas-a')
+    expect(listed?.elementCount).toBe(3)
+  })
+
+  it('save falls back to counting alive legacy elements for a pre-migration doc', async () => {
+    const doc = new LoroDoc()
+    appendElement(doc, 'e1')
+    appendElement(doc, 'e2')
+    const list = doc.getMovableList('elements')
+    const dead = list.insertContainer(list.length, new LoroMap())
+    dead.set('id', 'e3')
+    dead.set('isDeleted', true)
+    doc.commit()
+
+    const entry = await store.save('sess-1', 'canvas-a', doc, { auto: true })
+    expect(entry.elementCount).toBe(2)
+  })
+
+  it('save keeps its fail-soft 0 when the spatial read throws', async () => {
+    const doc = new LoroDoc()
+    appendElement(doc, 'e1')
+    vi.spyOn(doc, 'getMap').mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const entry = await store.save('sess-1', 'canvas-a', doc, { auto: true })
+    expect(entry.elementCount).toBe(0)
   })
 
   it('round-trips save({ operator }) through list()', async () => {

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -11,8 +11,8 @@ import {
   validateVersionId,
   validateWorkspaceId,
 } from '../validators.js'
-import { countAliveNodes } from './count-alive-nodes.js'
 import { corruptStoredData, isMissingFileError } from './corrupt-stored-data.js'
+import { countAliveNodes } from './count-alive-nodes.js'
 import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getCanvasIdBySlug, upsertCanvasRow } from './db/upsert-workspace.js'

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -11,6 +11,7 @@ import {
   validateVersionId,
   validateWorkspaceId,
 } from '../validators.js'
+import { countAliveNodes } from './count-alive-nodes.js'
 import { corruptStoredData, isMissingFileError } from './corrupt-stored-data.js'
 import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
@@ -191,10 +192,11 @@ export class FileVersionStore implements VersionStore {
       const id = nanoid(12)
       validateVersionId(id)
 
+      // Fail-soft: a doc whose spatial read throws still saves, with an
+      // advisory 0 rather than blocking the save entirely.
       const elementCount = (() => {
         try {
-          const list = doc.getMovableList('elements').toJSON() as Array<{ isDeleted?: boolean }>
-          return list.filter((e) => !e.isDeleted).length
+          return countAliveNodes(doc)
         } catch {
           return 0
         }


### PR DESCRIPTION
## What

Audit finding (same elements→nodes migration-debt family as #662): element counts across the daemon read the retired legacy `elements` container, so every production doc reported 0 — the History panel and restore dialog showed "0 els" for every version, and `/api/debug` reported an empty canvas for every canvas.

- New shared `countAliveNodes(doc)` in `src/server/store/` (next to #662's collector): counts `readSpatialCanvas(doc).nodes`, with a **fallback** (not additive) legacy non-tombstoned count only when the nodes map is empty — counts sum where GC unions, so an additive pass would double-count dual-shape docs; the module comment records the contrast with #662.
- Called from all three sites: `version-store.ts` save (inside the existing fail-soft try/catch), `restore.ts` (the `countElements(_doc)` stub is deleted), and `debug.ts` (`visibleElements` = alive nodes; `totalElements` = visible + tombstones, now a stated invariant — byte-identical output for pure-legacy docs).
- Decisions recorded: edges excluded (the bridge's edge-cascade invariant makes nodes-only counting safe); historic version rows with stored 0 accepted as-is (no backfill migration for advisory UI values).
- Vocabulary (ADR-0009): touched internals use node vocabulary; the persisted `elementCount` column, wire field, and debug response field names are deliberately NOT renamed (published/persisted surfaces — skip noted per the bounded rule).

## Tests

Red-first per site via the shared nodes-model fixture: version save stores/returns N (was 0); restore responses carry real counts on both branches; debug reports N/N/0 for a nodes doc while the legacy 5/3/2 case is unchanged. Helper unit tests pin edges-excluded, fallback-not-additive, and no-double-count. Mutation-checked: legacy-only revert turns all three site tests red.

## Gates

mcp-node fully green (266 files / 3274 tests after rebase onto current main); `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, lint clean. Review workflow: zero confirmed findings; QA pass. No edits under `packages/server-core` (concurrent tool-surface rename) or `app.ts` (task #17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw