### PR TITLE
feat(render): surface-colored halo pill behind edge labels

### DIFF
--- a/apps/web/src/lib/canvas-sync-export.ts
+++ b/apps/web/src/lib/canvas-sync-export.ts
@@ -1,3 +1,4 @@
+import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import type { ExportRequestPayload } from '@kamiazya/whiteboard-mcp/browser-contract'
 
 // Ported verbatim from the original daemon-served UI's useWhiteboardSync
@@ -75,7 +76,8 @@ async function sendExportResponse(
     msg.theme !== undefined
       ? {
           theme: msg.theme,
-          viewBackgroundColor: msg.theme === 'dark' ? '#121212' : '#ffffff',
+          viewBackgroundColor:
+            msg.theme === 'dark' ? SPATIAL_DARK_PALETTE.surface : SPATIAL_LIGHT_PALETTE.surface,
         }
       : null
   const appState = {

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -44,6 +44,13 @@ export interface Appearance {
   readonly strokeWidth?: number
   readonly fontFamily?: string
   readonly fontSize?: number
+  /**
+   * Label underlay color (the canvas surface), so a label sitting ON an
+   * edge line stays readable: the backend emits a stroke-only copy of the
+   * text behind the fill text. Consumed for text runs only; absent keeps
+   * the single-element output byte-identical.
+   */
+  readonly halo?: string
 }
 
 /** A single styled run of inline text, positioned within its parent block. */

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -46,6 +46,43 @@ describe('renderSceneToSvg', () => {
     expect(svg).toContain('<text x="0" y="10">hi</text>')
   })
 
+  it('a halo emits a surface-colored pill behind the text box', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'textRun',
+          bbox: { x: 5, y: 10, w: 20, h: 16 },
+          text: 'hi',
+          appearance: { fill: '#404040', fontSize: 12, halo: '#ffffff' },
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    // The pill covers the bbox plus 2px of breathing room (a glyph-outline
+    // halo would leave the crossed line peeking through word spaces), then
+    // the ordinary text paints over it.
+    expect(svg).toContain(
+      '<rect x="3" y="8" width="24" height="20" rx="2" fill="#ffffff"/>' +
+        '<text x="5" y="10" fill="#404040" font-size="12">hi</text>',
+    )
+  })
+
+  it('a run without a halo emits exactly one text element (byte-identical additivity)', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'textRun',
+          bbox: { x: 5, y: 10, w: 20, h: 16 },
+          text: 'hi',
+          appearance: { fill: '#404040', fontSize: 12 },
+        },
+      ],
+    }
+    const svg = renderSceneToSvg(scene)
+    expect(svg).toContain('<text x="5" y="10" fill="#404040" font-size="12">hi</text>')
+    expect(svg.match(/<text /g)?.length).toBe(1)
+  })
+
   it('shifts a text run down by its baseline offset when present', () => {
     const scene: Scene = {
       nodes: [{ kind: 'textRun', bbox: { x: 0, y: 10, w: 20, h: 16 }, text: 'hi', baseline: 12.8 }],

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -90,9 +90,24 @@ function textBaselineY(run: TextRunNode): number {
     : run.bbox.y
 }
 
+/** Breathing room the halo pill adds around the text box, in px. Paint-only
+ * decoration in the arrowhead class: bounds keep reading the bbox, and the
+ * 2px overhang never exceeds the hit tolerance. */
+const TEXT_HALO_PAD_PX = 2
+
 function renderTextRun(run: TextRunNode): string {
   const appearance = withLeadingSpace(appearanceAttrs(run.appearance))
-  const text = `<text x="${formatCoord(run.bbox.x)}" y="${formatCoord(textBaselineY(run))}"${appearance}>${escapeXmlText(run.text)}</text>`
+  const position = `x="${formatCoord(run.bbox.x)}" y="${formatCoord(textBaselineY(run))}"`
+  const body = escapeXmlText(run.text)
+  const halo = run.appearance?.halo
+  // A surface-colored pill under the whole text box (a glyph-outline halo
+  // leaves the crossed line peeking through word spaces), so a label
+  // sitting ON an edge stays readable end to end.
+  const underlay =
+    halo !== undefined && halo.length > 0
+      ? `<rect x="${formatCoord(run.bbox.x - TEXT_HALO_PAD_PX)}" y="${formatCoord(run.bbox.y - TEXT_HALO_PAD_PX)}" width="${formatCoord(run.bbox.w + 2 * TEXT_HALO_PAD_PX)}" height="${formatCoord(run.bbox.h + 2 * TEXT_HALO_PAD_PX)}" rx="${formatCoord(TEXT_HALO_PAD_PX)}" fill="${escapeXmlAttr(halo)}"/>`
+      : ''
+  const text = `${underlay}<text ${position}${appearance}>${body}</text>`
   if (!run.link) return text
   const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.canvasId
   return `<a href="${escapeXmlAttr(href)}">${text}</a>`

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -30,6 +30,13 @@ export interface SpatialPalette {
   readonly edgeStroke: string
   /** Fill applied to every label run (node labels and edge labels). */
   readonly labelFill: string
+  /**
+   * The canvas surface color this mode paints under everything — the label
+   * halo color, and the export default background. Hex, not oklch: resvg
+   * (PNG export) parses no oklch(); dark is the hex equivalent of the
+   * app's `oklch(0.145 0 0)` surface.
+   */
+  readonly surface: string
   /** Uniform corner radius (px) applied to every node's chrome shape. */
   readonly cornerRadiusPx: number
   /**
@@ -61,6 +68,7 @@ export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
   },
   edgeStroke: '#737373',
   labelFill: '#404040',
+  surface: '#ffffff',
   cornerRadiusPx: 6,
   // Tailwind 600 strokes (3.2-5.4:1 on white) over 100 tints (body text
   // 8.5-9.3:1) — the same ramp as the app's approved state colors.
@@ -90,6 +98,7 @@ export const SPATIAL_DARK_PALETTE: SpatialPalette = {
   },
   edgeStroke: '#9BA3AF',
   labelFill: '#E6E8EB',
+  surface: '#0a0a0a',
   cornerRadiusPx: 4,
   // Tailwind 400 strokes (7.2-11.9:1 on the near-black canvas) over 950
   // tints (near-white body text 10.9-13.2:1).

--- a/packages/canvas-render/src/theme/spatial-theme.test.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.test.ts
@@ -108,6 +108,7 @@ describe('createSpatialTheme', () => {
     expect(theme.resolveLabel()).toEqual({
       fill: SPATIAL_LIGHT_PALETTE.labelFill,
       fontFamily: SPATIAL_THEME_FONT_FAMILY,
+      halo: SPATIAL_LIGHT_PALETTE.surface,
     })
   })
 

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -78,7 +78,11 @@ function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {
     resolveEdge: (edge: CanvasEdge) => ({
       stroke: presetAccent(edge.color, palette)?.stroke ?? rawHex(edge.color) ?? palette.edgeStroke,
     }),
-    resolveLabel: () => ({ fill: palette.labelFill, fontFamily: SPATIAL_THEME_FONT_FAMILY }),
+    resolveLabel: () => ({
+      fill: palette.labelFill,
+      fontFamily: SPATIAL_THEME_FONT_FAMILY,
+      halo: palette.surface,
+    }),
   }
 }
 

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -78,7 +78,7 @@ describe('headless-renderer', () => {
     const lightSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'light' })
     const darkSvg = await renderSpatialCanvasToSvg(canvas, { theme: 'dark' })
     expect(lightSvg.svg).toContain('fill="#ffffff"')
-    expect(darkSvg.svg).toContain('fill="#121212"')
+    expect(darkSvg.svg).toContain('fill="#0a0a0a"')
   })
 
   it('produces PNG dimensions proportional to scale', async () => {

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -34,6 +34,7 @@ import {
   layoutSpatialCanvas,
   renderSceneToSvg as renderSceneToSvgString,
   SPATIAL_DARK_PALETTE,
+  SPATIAL_LIGHT_PALETTE,
 } from '@kamiazya/whiteboard-canvas-render'
 
 import { getLogger } from '../log.js'
@@ -70,8 +71,11 @@ export interface HeadlessExportOptions {
   theme?: 'light' | 'dark'
 }
 
-const DARK_DEFAULT_BACKGROUND = '#121212'
-const LIGHT_DEFAULT_BACKGROUND = '#ffffff'
+// The mode surfaces come from the shared palette — the same color the
+// label halo knocks text backgrounds out with, so an exported label pill
+// is invisible against the export background.
+const DARK_DEFAULT_BACKGROUND = SPATIAL_DARK_PALETTE.surface
+const LIGHT_DEFAULT_BACKGROUND = SPATIAL_LIGHT_PALETTE.surface
 const DEFAULT_PADDING_PX = 10
 
 export interface HeadlessExportResult {


### PR DESCRIPTION
## What (readability follow-up to #656)

An edge label sits ON the drawn line since the arc-length anchor unification, striking the text through. The backend now paints a surface-colored rounded rect (label bbox + 2px, rx 2) under any text run whose appearance carries a `halo` — paint-only decoration in the arrowhead class: no scene node, so the shape==node-chrome invariant, bounds, and hit-testing stay untouched. A glyph-outline halo (stroked text underlay) was tried first and rejected: the crossed line peeks through word spaces.

## One surface color

The halo is the new palette `surface` (light `#ffffff`, dark `#0a0a0a` — the hex of the app's `oklch(0.145 0 0)` dark surface; hex because resvg parses no oklch), provided through the shared theme's `resolveLabel`, so editor, viewer, and exports all knock labels out identically. The export default backgrounds and the web export payload's `viewBackgroundColor` now read the same palette field instead of carrying their own `#121212` duplicates — **dark exports shift from #121212 to #0a0a0a**, matching the editor's dark surface (called out as a deliberate change).

## Tests

Backend pill emission + no-halo single-element additivity (determinism goldens unchanged), theme `resolveLabel` halo pin — red-first. canvas-render (401), dependents (390), web jsdom (1939) pass.

(The one local browser failure, `BrowserLocalCanvasPage.markdown`, reproduces on clean origin/main and passes in main's CI — a local-env divergence unrelated to this change, flagged to the peer sessions.)

## Visual repro

Curved labeled edge. Before — the line strikes through the label / After — a surface pill knocks it out:

![label-halo-before.png](https://github.com/user-attachments/assets/cd39b9ba-3696-4480-93b4-970fb213d42b)
![label-halo-after.png](https://github.com/user-attachments/assets/3f375bf4-cecd-4029-b077-22c93454ca20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ