### PR TITLE
test(web): pin CodeMirror typing tests to the exact contentDOM focus target

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -212,9 +212,8 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // Click-focus (matching every other CodeMirror typing suite in this
     // repo) rather than relying on autofocus: this test's subject is
     // body/facet independence, not the fresh-note autofocus guarantee that
-    // test 1 above already pins. The wait then checks activeElement IS the
-    // contentDOM (.cm-content, same element as `editable`), not merely
-    // contained by .cm-editor.
+    // test 1 above already pins (see its focus-wait comment for why exact
+    // contentDOM identity is required).
     await userEvent.click(editable)
     await waitFor(() => {
       expect(document.activeElement).toBe(editable)

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -95,8 +95,14 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // immediately, and the dropdown's close-time focus return must never
     // steal keystrokes mid-word (the bug shipped as "type a sentence,
     // only the first three characters persist").
+    //
+    // The wait checks activeElement IS the CodeMirror contentDOM (.cm-content,
+    // same element as `editable`), not merely contained by .cm-editor — that
+    // exact identity is what real keyboard-event delivery depends on, and a
+    // looser containment check can pass while focus still sits on some other
+    // in-flight descendant (e.g. mid-mount) and races the first keystrokes.
     await waitFor(() => {
-      expect(editable.closest('.cm-editor')?.contains(document.activeElement)).toBe(true)
+      expect(document.activeElement).toBe(editable)
     })
     await userEvent.keyboard('# Persisted note')
     await waitFor(() => {
@@ -203,8 +209,15 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
       expect(el).not.toBeNull()
       return el as HTMLElement
     })
+    // Click-focus (matching every other CodeMirror typing suite in this
+    // repo) rather than relying on autofocus: this test's subject is
+    // body/facet independence, not the fresh-note autofocus guarantee that
+    // test 1 above already pins. The wait then checks activeElement IS the
+    // contentDOM (.cm-content, same element as `editable`), not merely
+    // contained by .cm-editor.
+    await userEvent.click(editable)
     await waitFor(() => {
-      expect(editable.closest('.cm-editor')?.contains(document.activeElement)).toBe(true)
+      expect(document.activeElement).toBe(editable)
     })
     await userEvent.keyboard('body first')
     await waitFor(() => {

--- a/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
@@ -74,8 +74,12 @@ describe('browser-local list landing (browser — real IndexedDB)', () => {
       },
       { timeout: 15_000 },
     )
+    // A fresh note is focused for typing immediately (no click) — the wait
+    // checks activeElement IS the CodeMirror contentDOM (.cm-content, same
+    // element as `editable`), not merely contained by .cm-editor, since exact
+    // identity is what real keyboard-event delivery depends on.
     await waitFor(() => {
-      expect(editable.closest('.cm-editor')?.contains(document.activeElement)).toBe(true)
+      expect(document.activeElement).toBe(editable)
     })
     await userEvent.keyboard('# From the list')
     await waitFor(() => {

--- a/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
@@ -74,10 +74,10 @@ describe('browser-local list landing (browser — real IndexedDB)', () => {
       },
       { timeout: 15_000 },
     )
-    // A fresh note is focused for typing immediately (no click) — the wait
-    // checks activeElement IS the CodeMirror contentDOM (.cm-content, same
-    // element as `editable`), not merely contained by .cm-editor, since exact
-    // identity is what real keyboard-event delivery depends on.
+    // A fresh note is focused for typing immediately (no click). Exact
+    // contentDOM identity — not .cm-editor containment — is what real
+    // keyboard-event delivery depends on; containment can pass while focus
+    // still sits on another in-flight descendant and race the first keys.
     await waitFor(() => {
       expect(document.activeElement).toBe(editable)
     })


### PR DESCRIPTION
## What

Root-causes the recurring "typed body never reaches the document" failure class in `BrowserLocalCanvasPage.markdown.browser.test.tsx` (three occurrences today: once under full-suite load locally, twice on CI across PR #652 and #675 — two different tests in the file, same class; one report of a deterministic local repro on clean main).

**Findings:**
- The deterministic-local-vs-CI-green report could NOT be reproduced across a wide matrix (isolated runs idle, 5 consecutive runs under 12-way CPU load with the original racing arrangement, plus runs concurrent with a full 513-test browser suite). The likely cause of that report was checkout hygiene — stale `node_modules`/Vite-optimizer state against a freshly pulled lockfile, which self-heals after `pnpm install` + first re-optimized run. Practical rule for anyone hitting a local-only browser-test failure: `pnpm install`, re-run, then trust it.
- The genuine flake class: two tests typed into CodeMirror behind a weak pre-typing focus wait — "activeElement is somewhere inside `.cm-editor`" — while CDP keyboard delivery depends on focus being exactly the `.cm-content` contentDOM; under unlucky timing the keystrokes land nowhere.

**Fix (test-only, strengthening-only):** the failing facet-interleave test adopts the same click-then-type arrangement every other green CodeMirror suite uses; the two deliberately click-free tests (they pin the fresh-note autofocus + dropdown focus-steal guarantees, one here and the codebase's only other instance in `BrowserLocalIndexPage.flow.browser.test.tsx`, found by survey) keep their click-free shape but tighten the wait to exact contentDOM identity — a strictly stronger precondition, so nothing the old tests rejected can newly pass. Assertions are byte-for-byte unchanged. `source-pane-keymap.browser.test.tsx`'s `.closest('.cm-editor')` is a post-typing retention assertion after an explicit click — verified not an instance, untouched.

No production changes: `SourcePane`'s mount focus + `CanvasDropdown`'s `onCloseAutoFocus` preventDefault already implement the autofocus guarantee correctly.

## Verification

Repro command green 3x consecutively; both edited files green; ≥10 consecutive targeted runs green post-change; one full `pnpm run test:browser` green; typecheck + lint clean. Mutation loop (arrangement reverted, under load) never re-manifested the env failure — documented as strengthening-only, so the degraded mutation check cannot have masked anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved browser test coverage by verifying that the markdown editor’s exact content area receives focus before typing.
  * Added explicit editor interaction where needed to validate focus behavior reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->