### PR TITLE
docs(rules): record decision #10 — the render-style seam

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -261,6 +261,53 @@ paths:
    meaningful thumbnail); any failure keeps the card. Image nodes are
    bbox-only leaves for sceneBounds/translate/scale.
 
+10. **The render-style seam** (rendering-foundation initiative, human
+    decisions 2026-08-12). Recorded BEFORE any style ships so the sketchy/
+    hand-drawn style and facet-driven cards land on settled ground instead
+    of re-litigating decisions #6-#8.
+    - **Style is a DOCUMENT property, not a personal preference.** It rides
+      the canvas (the `x-whiteboard`/`view`-facet lineage), so every
+      collaborator and every output sees the same look. It threads as an
+      explicit per-render-call argument (`SpatialLayoutOptions` → backend),
+      never ambient — the same editor-ambient-but-export-explicit shape as
+      theme mode (#8). Export, the MCP render tool, and the viewer widget
+      default to the clean style; a styled render is opt-in per call: the
+      MCP/widget consumer is often an AI agent, for whom jittered
+      multi-stroke geometry is parsing noise it must never pay unasked.
+    - **Geometry variance lives behind ONE shared pure decomposition
+      function per primitive** (rect → stroke set, edge path → stroke set)
+      in `layout/`, consumed by BOTH the SVG backend and every hit/
+      highlight/preview consumer — the `edge-rounding.ts` drawn-vs-hit
+      precedent, generalized. This is NOT the scene→scene transform #8
+      rejected: #8's case (dark mode) was paint-only and a pass would have
+      duplicated per-type knowledge; a style is geometry-bearing, and the
+      answer is shared decomposition at the consumption points, keeping one
+      producer per geometry.
+    - **Ink is decoration; semantics stay authoritative.** `sceneBounds`,
+      hit-testing, `sceneDigest`, translate/scale keep reading the SEMANTIC
+      geometry (bbox / routed path). A style's painted deviation from it
+      must be bounded by a declared constant (the jump-arc/arrowhead
+      class), and that bound is part of the style's contract.
+    - **Style randomness is seeded, id-keyed, and pure** (the `layout/seed`
+      primitive): derived from stable node identity, never ambient RNG;
+      invariant under translate/scale composition; unaffected by edits to
+      unrelated nodes. A canvas renders byte-identically twice, styled or
+      not.
+    - **Layout-quality feedback lands as NAMED RULES of exactly two
+      kinds.** Preference rules affect candidate ordering and tie-breaks
+      only and are never traded against penalties; penalty rules are
+      cost-tuple terms with a declared lexicographic tier. New routing
+      feedback = one named rule + its own test, not a new branch in an
+      existing function. (The strangler extraction that turns today's
+      implicit rules into data is its own slice; until it lands this
+      paragraph is the naming convention new code follows.)
+    - **Facet-driven rendering rides the injected-resolver pattern**
+      (a future `resolveFileFacets`, same seam class as
+      `resolveFileCanvas`/`resolveFileImage`), and export stays a pure
+      function of the canvas snapshot by default — resolving another
+      document's live facet state into exported bytes is opt-in, exactly
+      parallel to the style opt-in above.
+
 ## Conventions
 
 - Every scene-node variant retains semantic provenance (heading `level`,


### PR DESCRIPTION
## What (slice S1 of plan-canvas-render-foundations, gate-passed)

Records the foundation decision the sketchy/hand-drawn style and facet-driven card initiatives will build on, BEFORE any style code ships. Doc-only — no `src/` changes.

Human decisions folded in (2026-08-12):

- **Style is a document property** (the `x-whiteboard`/`view`-facet lineage), threaded as an explicit per-render-call argument — never ambient. Every collaborator and every output sees the same look.
- **Clean stays the default on export / MCP render tool / viewer widget**; styled renders are opt-in per call (an AI consumer must never pay jitter parsing noise unasked).
- **Geometry variance = one shared decomposition function per primitive** in `layout/`, consumed by backend AND hit/highlight — the `edge-rounding.ts` precedent generalized, explicitly distinguished from decision #8's rejected scene→scene pass (that case was paint-only; style is geometry-bearing).
- **Ink is bounded decoration; semantic geometry stays authoritative** for bounds/hit/digest/transform.
- **Style randomness is seeded and id-keyed** (pure; invariant under translate/scale; unaffected by unrelated edits) — the S5 primitive's contract.
- **Layout feedback lands as named rules of two kinds**: preference (ordering/tie-breaks, never traded against penalties) and penalty (cost-tuple terms with a declared tier) — the naming convention until the strangler extraction slice lands.
- **Facet rendering rides the injected-resolver pattern**, and export stays a pure function of the canvas snapshot by default (facet resolution opt-in, parallel to style opt-in).

Sibling slices in flight: S2 pixel goldens, S4 wrap-parity pin, S3 sweepline (dev-loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ