### PR TITLE
fix(web): route every vitest config through mcpSourceAlias and guard the coverage

### DIFF
--- a/apps/web/mcp-source-alias-coverage.test.ts
+++ b/apps/web/mcp-source-alias-coverage.test.ts
@@ -5,22 +5,6 @@ import vitestBrowserConfig from './vitest.browser.config.js'
 import vitestConfig from './vitest.config.js'
 import vitestDocsSnapshotsConfig from './vitest.docs-snapshots.config.js'
 
-// vite/vitest's `defineConfig` overloads also accept a factory function or a
-// promise (`(env) => UserConfig`, `Promise<UserConfig>`); none of the four
-// configs below use that form today, but resolving generically keeps the
-// guard from silently no-op'ing if one switches to it later.
-async function resolveAlias(config: unknown): Promise<Record<string, unknown>> {
-  const resolved =
-    typeof config === 'function'
-      ? (config as (env: { mode: string; command: string }) => unknown)({
-          mode: 'test',
-          command: 'serve',
-        })
-      : config
-  const awaited = (await resolved) as { resolve?: { alias?: Record<string, unknown> } }
-  return awaited.resolve?.alias ?? {}
-}
-
 // Each config below independently resolves `@kamiazya/whiteboard-mcp/*`
 // subpaths to source (see mcp-source-alias.ts). A subpath added to
 // mcp-source-alias.ts that a config forgets to spread resolves through the
@@ -33,8 +17,10 @@ describe('mcpSourceAlias coverage across apps/web configs', () => {
     ['vitest.config.ts', vitestConfig],
     ['vitest.browser.config.ts', vitestBrowserConfig],
     ['vitest.docs-snapshots.config.ts', vitestDocsSnapshotsConfig],
-  ] as const)('%s aliases every mcpSourceAlias key to its source path', async (_name, config) => {
-    const alias = await resolveAlias(config)
+  ] as const)('%s aliases every mcpSourceAlias key to its source path', (_name, config) => {
+    // All four configs export a plain object; a switch to defineConfig's
+    // factory/promise form leaves `alias` empty here, which fails red.
+    const alias = (config.resolve?.alias ?? {}) as Record<string, unknown>
     for (const [key, value] of Object.entries(mcpSourceAlias)) {
       expect(alias[key]).toBe(value)
     }

--- a/apps/web/mcp-source-alias-coverage.test.ts
+++ b/apps/web/mcp-source-alias-coverage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { mcpSourceAlias } from './mcp-source-alias.js'
+import viteConfig from './vite.config.js'
+import vitestBrowserConfig from './vitest.browser.config.js'
+import vitestConfig from './vitest.config.js'
+import vitestDocsSnapshotsConfig from './vitest.docs-snapshots.config.js'
+
+// vite/vitest's `defineConfig` overloads also accept a factory function or a
+// promise (`(env) => UserConfig`, `Promise<UserConfig>`); none of the four
+// configs below use that form today, but resolving generically keeps the
+// guard from silently no-op'ing if one switches to it later.
+async function resolveAlias(config: unknown): Promise<Record<string, unknown>> {
+  const resolved =
+    typeof config === 'function'
+      ? (config as (env: { mode: string; command: string }) => unknown)({
+          mode: 'test',
+          command: 'serve',
+        })
+      : config
+  const awaited = (await resolved) as { resolve?: { alias?: Record<string, unknown> } }
+  return awaited.resolve?.alias ?? {}
+}
+
+// Each config below independently resolves `@kamiazya/whiteboard-mcp/*`
+// subpaths to source (see mcp-source-alias.ts). A subpath added to
+// mcp-source-alias.ts that a config forgets to spread resolves through the
+// package's export map instead — silently stale `dist` on a machine that has
+// built once, and an outright failure on a clean checkout. This test is what
+// turns that drift class into a red test instead of a silent stale build.
+describe('mcpSourceAlias coverage across apps/web configs', () => {
+  it.each([
+    ['vite.config.ts', viteConfig],
+    ['vitest.config.ts', vitestConfig],
+    ['vitest.browser.config.ts', vitestBrowserConfig],
+    ['vitest.docs-snapshots.config.ts', vitestDocsSnapshotsConfig],
+  ] as const)('%s aliases every mcpSourceAlias key to its source path', async (_name, config) => {
+    const alias = await resolveAlias(config)
+    for (const [key, value] of Object.entries(mcpSourceAlias)) {
+      expect(alias[key]).toBe(value)
+    }
+  })
+})

--- a/apps/web/mcp-source-alias.ts
+++ b/apps/web/mcp-source-alias.ts
@@ -9,12 +9,15 @@ const src = (file: string) => resolve(here, '../../packages/mcp-server/src/share
  * mcp-server subpaths resolved to SOURCE rather than to `dist`, so `pnpm dev`
  * and the test run work before anything is built.
  *
- * Shared by vite.config.ts and vitest.config.ts because keeping two copies in
- * step is not something either file can enforce: a subpath added to only one
- * of them resolves through the package export map instead, which silently
- * finds a stale `dist` on a machine that has built once and fails outright on
- * a clean checkout — so the miss surfaces in CI rather than locally. Each
- * config still adds its own entries on top (test-only subpaths, canvas-viewer).
+ * Shared by vite.config.ts, vitest.config.ts, vitest.browser.config.ts, and
+ * vitest.docs-snapshots.config.ts because keeping separate copies in step is
+ * not something any one file can enforce: a subpath added to only one of them
+ * resolves through the package export map instead, which silently finds a
+ * stale `dist` on a machine that has built once and fails outright on a
+ * clean checkout — so the miss surfaces in CI rather than locally. Each
+ * config still adds its own entries on top (test-only subpaths, canvas-viewer,
+ * '@docs-assets'). mcp-source-alias-coverage.test.ts pins that every config
+ * spreads this map rather than re-copying it.
  */
 export const mcpSourceAlias: Record<string, string> = {
   '@kamiazya/whiteboard-mcp/browser-shared': src('browser-shared-index.ts'),

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -8,49 +8,18 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
+import { mcpSourceAlias } from './mcp-source-alias.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   resolve: {
     alias: {
+      ...mcpSourceAlias,
       // Matches vitest.config.ts and tsconfig's '@/*' path — needed once any
       // browser-tested component pulls in a components/ui/* file (they all
       // import '@/lib/utils' for the cn() helper).
       '@': resolve(__dirname, 'src'),
-      // Resolve browser-shared from source so tests run before `pnpm build`.
-      '@kamiazya/whiteboard-mcp/browser-shared': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/browser-shared-index.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/daemon-backend': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/daemon-backend.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/api-client': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/api-client.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/api-contracts': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/api-contracts/index.ts',
-      ),
-      // App-mounting browser tests reach DaemonCanvasPage's transport imports
-      // through Vite's dependency scan even though the page itself is lazy —
-      // resolved from source like the entries above, or the scan fails on a
-      // checkout that has not run `pnpm build`.
-      '@kamiazya/whiteboard-mcp/select-canvas-transport': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/select-canvas-transport.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/sse-backend': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/sse-backend.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/sse-stream-hub': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/sse-stream-hub.ts',
-      ),
       // Subpath alias must precede the root alias: rollup-alias prefix-matches,
       // so the root entry alone would rewrite '/scene' to 'index.ts/scene'.
       '@kamiazya/whiteboard-canvas-viewer/scene': resolve(

--- a/apps/web/vitest.docs-snapshots.config.ts
+++ b/apps/web/vitest.docs-snapshots.config.ts
@@ -19,6 +19,7 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
+import { mcpSourceAlias } from './mcp-source-alias.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // Absolute path so test files can ship a single string literal to
@@ -41,28 +42,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...mcpSourceAlias,
+      // '@' matches vitest.config.ts / tsconfig's app-source root.
       '@': resolve(__dirname, 'src'),
+      // '@docs-assets' is unique to this config: only the snapshot fixtures
+      // that generate docs/assets/ need to read files under docs/assets/.
       '@docs-assets': DOCS_ASSETS_DIR,
-      // Mirror vitest.config.ts's full workspace-subpath alias set: today's
-      // snapshot components only reach api-client/api-contracts, but any
-      // future snapshot pulling the other subpaths would otherwise resolve
-      // to built dist output (stale or absent) instead of source.
-      '@kamiazya/whiteboard-mcp/browser-shared': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/browser-shared-index.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/daemon-backend': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/daemon-backend.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/api-client': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/api-client.ts',
-      ),
-      '@kamiazya/whiteboard-mcp/api-contracts': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/api-contracts/index.ts',
-      ),
     },
   },
   plugins: [tailwindcss(), react(), svgr(), wasm(), topLevelAwait()],

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'vite-plugin-strip-wasm-sourcemap.test.ts',
       'index-html.test.ts',
       'pwa-icons.test.ts',
+      'mcp-source-alias-coverage.test.ts',
       'scripts/**/*.test.ts',
     ],
   },


### PR DESCRIPTION
## What

Audit finding (MEDIUM, config-drift — already realized): `vitest.browser.config.ts` and `vitest.docs-snapshots.config.ts` hand-copied the `@kamiazya/whiteboard-mcp/*` source-alias map instead of importing the shared `mcpSourceAlias` module, and the docs-snapshots copy was missing 3 of 7 entries (`sse-backend`, `sse-stream-hub`, `select-canvas-transport`) — so `pnpm docs:snapshots` silently rendered against stale mcp-server dist while every other project ran against source. The same drift class bit once before (#652's dep-scan fix hand-added aliases to the browser config).

- Both configs now import and spread `mcpSourceAlias`; the hand-copied entries are deleted. The map has exactly one definition (grep proof: the subpath keys appear only in `mcp-source-alias.ts`). Genuinely extra entries (`@`, canvas-viewer subpath-before-root pair, `@docs-assets`) stay inline with why-extra comments; alias ordering for the canvas-viewer prefix pair is preserved.
- **New executable guard** `mcp-source-alias-coverage.test.ts` (web-node project): imports all four configs and asserts every `mcpSourceAlias` key is present pointwise-equal in each `resolve.alias` — a future 8th subpath that misses a config goes red instead of silently resolving stale dist. Red-first: it failed against the drifted docs-snapshots config before the fix. Mutation-checked: removing a spread turns it red.

**Reported, not fixed (pre-existing, out of scope):** 2 docs-snapshot tests fail identically before AND after this change with a missing-Router-wrapper setup error — a separately broken test setup, filed to the backlog. Regenerated PNGs from the verification runs were deliberately discarded, not committed — image churn from the alias fix needs its own reviewed pass.

## Gates

apps/web jsdom + web-node green (guard included); `pnpm run test:browser` green; typecheck, knip, lint clean. Review workflow: zero confirmed findings; QA pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw