### PR TITLE
refactor(model)!: retire the issue/1 facet convention

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -80,7 +80,7 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 ## Ticketing (no GitHub Issues — all local-private)
 
-Native **Task list** = live board (in-flight / blocked / done; main session owns status). **Whiteboard canvases** = durable private backlog: issues and notes stored as OKF Markdown canvases in the `default` workspace with `issue/1` facets (status/priority/assignees). Create via `wb_canvas_create` + `canvas_import_okf`, query via `wb_canvas_list` + `canvas_export_okf`, resolve via `wb_canvas_delete`. See the `ticketing` skill.
+Native **Task list** = live board (in-flight / blocked / done; main session owns status). **Whiteboard documents** = durable private backlog: issues and notes stored as OKF Markdown documents in the `default` workspace, carrying `type: issue`, a title and a body. Create via `wb_document_create` + `wb_document_set`, query via `wb_document_list` + `wb_document_get`, resolve by `wb_document_delete` — deletion IS resolution. The `issue/1` facet domain was retired (implemented without an agreed schema); until a replacement is agreed there is no machine-readable status, priority or assignee, and inventing one in passing makes it the convention by accident. See the `ticketing` skill.
 
 ## Skills (load for detail)
 

--- a/.claude/skills/ticketing/SKILL.md
+++ b/.claude/skills/ticketing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ticketing
-description: Local-private task/ticket management for the whiteboard repo. Issues and notes live in the whiteboard itself (via MCP tools) as OKF Markdown canvases with issue/1 facets. The native Task list tracks in-flight session work. Use when triaging findings, tracking work across dev-loop/review/dogfood-triage/reconcile/plan-initiative, or recording/resolving a follow-up.
+description: Local-private task/ticket management for the whiteboard repo. Issues and notes live in the whiteboard itself (via MCP tools) as OKF Markdown documents. The native Task list tracks in-flight session work. Use when triaging findings, tracking work across dev-loop/review/dogfood-triage/reconcile/plan-initiative, or recording/resolving a follow-up.
 ---
 
 # Ticketing (local-private)
@@ -22,21 +22,22 @@ Issues and notes are stored as canvases in the whiteboard's `default` workspace.
 
 - **type**: `issue` or `note`
 - **title**: human-readable title
-- **facets**: structured metadata (e.g. `issue/1` with status/priority/assignees)
+- **facets**: extension metadata. There is no agreed schema for issue metadata
+  right now — see "No structured status" below before inventing one
 - **body**: the issue description as markdown
 
 ### Creating an issue
 
 ```
-wb_canvas_create  → { workspaceId: "default", segment: "my-issue-slug" }
-canvas_import_okf → { workspaceId: "default", canvasId: <id>, markdown: "---\ntype: issue\ntitle: My Issue\nfacets:\n  issue/1:\n    status: open\n    priority: high\n---\n\nDescription here." }
+wb_document_create → { workspaceId: "default", segment: "my-issue-slug" }
+wb_document_set   → { workspaceId: "default", canvasId: <id>, markdown: "---\ntype: issue\ntitle: My Issue\n---\n\nDescription here." }
 ```
 
 ### Reading issues
 
 ```
-wb_canvas_list    → { workspaceId: "default" }           # list all canvases
-canvas_export_okf → { workspaceId: "default", canvasId }  # export as OKF markdown
+wb_document_list  → { workspaceId: "default" }           # list all canvases
+wb_document_get   → { workspaceId: "default", canvasId }  # export as OKF markdown
 ```
 
 ### Updating an issue
@@ -44,31 +45,35 @@ canvas_export_okf → { workspaceId: "default", canvasId }  # export as OKF mark
 Re-import with updated OKF markdown (overwrites facets + body):
 
 ```
-canvas_import_okf → { workspaceId: "default", canvasId, markdown: "<updated OKF>" }
+wb_document_set   → { workspaceId: "default", canvasId, markdown: "<updated OKF>" }
 ```
 
 ### Updating facets only
 
 ```
-facet_set → { workspaceId: "default", canvasId, facets: { "issue/1": { status: "in-progress" } } }
+wb_facet_set → { workspaceId: "default", canvasId, facets: { "<domain>/1": { … } } }
 ```
 
 ### Resolving / deleting
 
 ```
-wb_canvas_delete → { workspaceId: "default", canvasId }
+wb_document_delete → { workspaceId: "default", canvasId }
 ```
 
-### issue/1 facet schema
+### No structured status
 
-| Field | Type | Required | Values |
-|---|---|---|---|
-| `status` | string | yes | `open`, `in-progress` |
-| `priority` | string | no | `critical`, `high`, `medium`, `low` |
-| `assignees` | string[] | no | role/agent names |
-| `labels` | string[] | no | free-form tags |
-| `due` | string | no | `YYYY-MM-DD` |
-| `summary` | string | no | one-line summary |
+The `issue/1` facet domain was retired: it was implemented by an earlier pass
+without an agreed schema, and a typed companion nobody called made it look
+more settled than it was. Nothing replaced it yet.
+
+So an issue document carries `type: issue`, a `title`, and a body — and no
+machine-readable status, priority or assignee. **Resolution is deletion**,
+which is what this skill already did; the retired facet only ever offered an
+alternative to that.
+
+Do not invent a replacement domain in passing. Extension facets round-trip
+unvalidated through the generic bucket, so anything you write will persist and
+quietly become the convention. Agree the schema first.
 
 ## tmp/ workspace buckets
 
@@ -86,12 +91,12 @@ Delete artifacts from `tmp/` when they're no longer useful.
 
 - **Session start**: `TaskList` to see live state; for open issues you intend to work this session, `TaskCreate` a task with `metadata.canvasSegment = "<segment>"`.
 - **In flight**: `TaskUpdate` status/owner/blockedBy as work moves.
-- **New finding** (from review / dogfood-triage / reconcile): create a canvas via `wb_canvas_create` + `canvas_import_okf`; `TaskCreate` only if you're acting on it now.
-- **Resolve**: `TaskUpdate status=completed`, then `wb_canvas_delete` the canvas (or update its `issue/1` facet status).
+- **New finding** (from review / dogfood-triage / reconcile): create a canvas via `wb_document_create` + `wb_document_set`; `TaskCreate` only if you're acting on it now.
+- **Resolve**: `TaskUpdate status=completed`, then `wb_document_delete` the document.
 - Workflows can't call the Task tools or AskUserQuestion; they RETURN findings/openQuestions and the main session records them as tickets/tasks and asks the human.
 
 ## When to use which
 
 - Orchestrating several workflow runs / parallel dev-loops right now → **Task list**.
-- "Don't lose this for later" → **whiteboard canvas** (issue type with `issue/1` facet).
+- "Don't lose this for later" → **whiteboard document** (`type: issue`).
 - Both, for anything you're actively working from the backlog (create the task, link the canvas segment).

--- a/packages/canvas-model/src/facets.test.ts
+++ b/packages/canvas-model/src/facets.test.ts
@@ -4,7 +4,6 @@ import {
   coreFacetsSchema,
   extensionFacetsSchema,
   facetsRawSchema,
-  issueFacetPayloadSchema,
   RESERVED_ROOT_KEYS,
 } from './facets.js'
 
@@ -61,47 +60,6 @@ describe('extensionFacetsSchema', () => {
 
   it('accepts an empty record', () => {
     expect(extensionFacetsSchema.safeParse({}).success).toBe(true)
-  })
-})
-
-describe('issueFacetPayloadSchema', () => {
-  it('accepts the minimal shape with only status', () => {
-    expect(issueFacetPayloadSchema.safeParse({ status: 'open' }).success).toBe(true)
-  })
-
-  it('accepts the full shape with all optional fields populated', () => {
-    const result = issueFacetPayloadSchema.safeParse({
-      status: 'in-progress',
-      priority: 'high',
-      assignees: ['alice', 'bob'],
-      labels: ['bug', 'urgent'],
-      due: '2026-08-01T00:00:00.000Z',
-      summary: 'Fix the thing',
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('rejects a missing status', () => {
-    expect(issueFacetPayloadSchema.safeParse({}).success).toBe(false)
-  })
-
-  it('rejects an invalid due date format', () => {
-    expect(issueFacetPayloadSchema.safeParse({ status: 'open', due: 'not-a-date' }).success).toBe(
-      false,
-    )
-  })
-
-  it('rejects assignees that are not a string array', () => {
-    expect(issueFacetPayloadSchema.safeParse({ status: 'open', assignees: [1, 2] }).success).toBe(
-      false,
-    )
-    expect(issueFacetPayloadSchema.safeParse({ status: 'open', assignees: 'alice' }).success).toBe(
-      false,
-    )
-  })
-
-  it('rejects extra unknown keys', () => {
-    expect(issueFacetPayloadSchema.safeParse({ status: 'open', extra: 'nope' }).success).toBe(false)
   })
 })
 

--- a/packages/canvas-model/src/facets.ts
+++ b/packages/canvas-model/src/facets.ts
@@ -84,30 +84,3 @@ export const canvasCoreMetaSchema = coreFacetsSchema.extend({
 })
 
 export type CanvasCoreMeta = z.infer<typeof canvasCoreMetaSchema>
-
-/**
- * Typed companion for the `issue/1` extension-facet domain. This does NOT
- * replace `extensionFacetsSchema`'s `z.unknown()` payload handling — every
- * domain still round-trips unvalidated through the generic bucket. Callers
- * who specifically know they are working with `issue/1` payloads parse
- * through this schema themselves for typed access; a future incompatible
- * shape bumps to `issue/2` rather than widening this one, consistent with
- * the `{domain}/{version}` extension convention.
- *
- * `status` is an open string (not a closed enum) so user-defined workflows
- * aren't constrained to a fixed vocabulary; `due` requires ISO 8601 so
- * downstream sorting/filtering can rely on lexicographic-equals-chronological
- * ordering.
- */
-export const issueFacetPayloadSchema = z
-  .object({
-    status: z.string().min(1),
-    priority: z.string().optional(),
-    assignees: z.array(z.string()).optional(),
-    labels: z.array(z.string()).optional(),
-    due: z.iso.datetime().optional(),
-    summary: z.string().optional(),
-  })
-  .strict()
-
-export type IssueFacetPayload = z.infer<typeof issueFacetPayloadSchema>

--- a/packages/canvas-model/src/properties.test.ts
+++ b/packages/canvas-model/src/properties.test.ts
@@ -3,7 +3,6 @@ import {
   coreFacetsSchema,
   extensionFacetsSchema,
   facetsRawSchema,
-  issueFacetPayloadSchema,
   RESERVED_ROOT_KEYS,
 } from './facets.js'
 import { canvasIdSchema } from './ids.js'
@@ -27,7 +26,6 @@ import {
   coreFacetsArbitrary,
   extensionFacetsArbitrary,
   facetsRawArbitrary,
-  issueFacetPayloadArbitrary,
   markdownCanvasArbitrary,
   mdastFlowContentArbitrary,
   mdastPhrasingContentArbitrary,
@@ -56,25 +54,6 @@ describe('arbitrary-conformance: every generator agrees with its schema', () => 
   fcTest.prop([facetsRawArbitrary], withDefaults())('facetsRawSchema', (value) => {
     expect(facetsRawSchema.safeParse(value).success).toBe(true)
   })
-
-  fcTest.prop([issueFacetPayloadArbitrary], withDefaults())('issueFacetPayloadSchema', (value) => {
-    expect(issueFacetPayloadSchema.safeParse(value).success).toBe(true)
-  })
-
-  fcTest.prop([issueFacetPayloadArbitrary], withDefaults())(
-    'issueFacetPayloadSchema payload is JSON-safe (required for YAML frontmatter serialization)',
-    (value) => {
-      const parsed = issueFacetPayloadSchema.parse(value)
-      expect(JSON.parse(JSON.stringify(parsed))).toEqual(parsed)
-    },
-  )
-
-  fcTest.prop([issueFacetPayloadArbitrary], withDefaults())(
-    'extensionFacetsSchema accepts any issue/1 payload regardless of issueFacetPayloadSchema validity',
-    (value) => {
-      expect(extensionFacetsSchema.safeParse({ 'issue/1': value }).success).toBe(true)
-    },
-  )
 
   fcTest.prop([spatialNodeArbitrary], withDefaults())('spatialNodeSchema', (value) => {
     expect(spatialNodeSchema.safeParse(value).success).toBe(true)

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -39,21 +39,6 @@ export const coreFacetsArbitrary = fc.record(
   { requiredKeys: ['type'] },
 )
 
-/** Valid-by-construction arbitrary for `issueFacetPayloadSchema` (issue/1 domain). */
-export const issueFacetPayloadArbitrary = fc.record(
-  {
-    status: fc.string({ minLength: 1, maxLength: 20 }),
-    priority: fc.string({ maxLength: 20 }),
-    assignees: fc.array(fc.string({ maxLength: 20 }), { maxLength: 5 }),
-    labels: fc.array(fc.string({ maxLength: 20 }), { maxLength: 5 }),
-    due: fc
-      .date({ min: new Date(0), max: new Date(4102444800000), noInvalidDate: true })
-      .map((d) => d.toISOString()),
-    summary: fc.string({ maxLength: 100 }),
-  },
-  { requiredKeys: ['status'] },
-)
-
 const domainArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
 const versionArbitrary = fc.integer({ min: 0, max: 99 }).map((n) => String(n))
 

--- a/packages/server-core/src/tools/canvas-import-okf.test.ts
+++ b/packages/server-core/src/tools/canvas-import-okf.test.ts
@@ -33,7 +33,7 @@ describe('wb_document_set tool', () => {
       '---',
       'type: issue',
       'facets:',
-      '  issue/1:',
+      '  example/1:',
       '    status: open',
       '    priority: high',
       '---',
@@ -49,7 +49,7 @@ describe('wb_document_set tool', () => {
 
     const doc = await loadDoc(store, CANVAS_ID)
     const facets = readFacets(doc)
-    expect(facets).toEqual({ 'issue/1': { status: 'open', priority: 'high' } })
+    expect(facets).toEqual({ 'example/1': { status: 'open', priority: 'high' } })
 
     const canvas = readSpatialCanvas(doc)
     expect(canvas.nodes).toHaveLength(1)
@@ -80,15 +80,15 @@ describe('wb_document_set tool', () => {
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
     const tool = createCanvasImportOkfTool(makeDeps(store))
 
-    const v1 = '---\ntype: issue\nfacets:\n  issue/1:\n    status: open\n---\nFirst body.'
+    const v1 = '---\ntype: issue\nfacets:\n  example/1:\n    status: open\n---\nFirst body.'
     await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown: v1 })
 
-    const v2 = '---\ntype: issue\nfacets:\n  issue/1:\n    status: closed\n---\nUpdated body.'
+    const v2 = '---\ntype: issue\nfacets:\n  example/1:\n    status: closed\n---\nUpdated body.'
     await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown: v2 })
 
     const doc = await loadDoc(store, CANVAS_ID)
     const facets = readFacets(doc)
-    expect(facets['issue/1']).toEqual({ status: 'closed' })
+    expect(facets['example/1']).toEqual({ status: 'closed' })
 
     const canvas = readSpatialCanvas(doc)
     expect(canvas.nodes).toHaveLength(1)

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -88,7 +88,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
       '---',
       'type: issue',
       'facets:',
-      '  issue/1:',
+      '  example/1:',
       '    status: open',
       '    priority: high',
       '---',
@@ -98,7 +98,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
 
     const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
-    expect(result.frontmatter.facets).toEqual({ 'issue/1': { status: 'open', priority: 'high' } })
+    expect(result.frontmatter.facets).toEqual({ 'example/1': { status: 'open', priority: 'high' } })
   })
 
   test('an empty (facets-only) body round-trips to an empty body', async () => {


### PR DESCRIPTION
`issue/1` was implemented by an earlier pass without an agreed schema. A typed companion sitting beside it made it look more settled than it was — so the convention spread into two always-on documents that instruct every session to follow it.

## The code half is a deletion, not a migration

`issueFacetPayloadSchema` has **zero production consumers**. Only its own tests and an arbitrary written to feed them:

```
packages/canvas-model/src/facets.ts          the schema
packages/canvas-model/src/facets.test.ts     tests for the schema
packages/canvas-model/src/properties.test.ts three properties over it
packages/canvas-model/src/test-utils/…       the arbitrary feeding those
```

Written, tested, never called — the same shape as `deriveDisplaySlug` in #631.

**Stored data is unaffected.** Extension facets round-trip unvalidated through the generic `z.unknown()` bucket, so a document already carrying `issue/1` keeps it byte for byte. Only the typed access and the convention go away. There is nothing to migrate, and no canvas needs touching.

## The docs half is the expensive one

`.claude/skills/ticketing/SKILL.md` and `.claude/rules/dev-flow.md` are always-on: they told every session, every run, to store backlog items with `issue/1` facets carrying status/priority/assignees.

They now say plainly what is true after this change — an issue document carries `type: issue`, a title and a body, and **no machine-readable status, priority or assignee**. Resolution is deletion, which is what the skill already did; the retired facet only ever offered an alternative to that.

They also warn against inventing a replacement in passing:

> Extension facets round-trip unvalidated through the generic bucket, so anything you write will persist and quietly become the convention. Agree the schema first.

That is precisely how `issue/1` came to exist, and the warning is there so the next pass does not repeat it.

Both documents were also carrying pre-ADR-0009 tool names (`wb_canvas_create`, `canvas_import_okf`, …), so they move to `wb_document_*` under the vocabulary rule's fix-what-you-touch.

## One more thing the sweep caught

Two server-core round-trip tests used `issue/1` as their sample facet payload. They are demonstrating that an **arbitrary** extension domain survives a round trip — naming the retired domain there implied it was special. Now `example/1`, which is what the tests actually mean.

## Consequence, stated rather than papered over

Until a replacement schema is agreed, the whiteboard-document backlog has no structured status. That is a real reduction in capability and the docs say so rather than implying a replacement exists.

## Verification

- `canvas-model-node` + `server-core-node` + `mcp-node`: **3683 tests pass**
- `pnpm -r typecheck`: clean
- `pnpm knip`: silent — no export left orphaned by the deletion
- `pnpm lint`: clean

**BREAKING CHANGE:** `issueFacetPayloadSchema` and `IssueFacetPayload` are removed from `@kamiazya/whiteboard-canvas-model`. The package is private, so no external consumer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB