### PR TITLE
fix(mcp-server): single-source the runtime ping, verify, and grants-list wire contracts

### DIFF
--- a/apps/web/src/components/PairedOriginsCard.test.tsx
+++ b/apps/web/src/components/PairedOriginsCard.test.tsx
@@ -123,4 +123,41 @@ describe('PairedOriginsCard', () => {
     renderCard(async () => jsonResponse({ error: 'boom' }, 500))
     await screen.findByText(/could not load paired web apps/i)
   })
+
+  it('renders a quiet error state when the grants body drifts from the shared schema', async () => {
+    renderCard(async (url) => {
+      if (String(url).endsWith('/api/runtime/ping')) return jsonResponse({ ok: false })
+      // Missing createdAt: a 200 that still fails listGrantsResponseSchema.
+      return jsonResponse({ grants: [{ grantId: 'g1', origin: 'https://a.example' }] })
+    })
+    await screen.findByText(/could not load paired web apps/i)
+  })
+
+  it('shows the daemon identity fingerprint for a conformant ping response', async () => {
+    renderCard(async (url) => {
+      if (String(url).endsWith('/api/runtime/ping')) {
+        return jsonResponse({
+          ok: true,
+          instanceId: 'inst-1',
+          identity: { alg: 'Ed25519', publicKey: 'a'.repeat(43) },
+        })
+      }
+      return jsonResponse({ grants: [] })
+    })
+    await waitFor(() => expect(screen.getByTestId('daemon-fingerprint')).not.toBeNull())
+  })
+
+  it('never renders a fingerprint from a ping body that fails the shared schema', async () => {
+    renderCard(async (url) => {
+      if (String(url).endsWith('/api/runtime/ping')) {
+        // Missing instanceId: fails daemonPingResponseSchema even though it
+        // carries an identity.publicKey a naive hand-cast would still read.
+        return jsonResponse({ ok: true, identity: { alg: 'Ed25519', publicKey: 'a'.repeat(43) } })
+      }
+      return jsonResponse({ grants: [] })
+    })
+    await screen.findByText(/no web apps are paired/i)
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('daemon-fingerprint')).toBeNull()
+  })
 })

--- a/apps/web/src/components/PairedOriginsCard.tsx
+++ b/apps/web/src/components/PairedOriginsCard.tsx
@@ -1,19 +1,13 @@
+import {
+  daemonPingResponseSchema,
+  listGrantsResponseSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { z } from 'zod'
+import type { z } from 'zod'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { fingerprintPublicKey } from '@/lib/daemon-identity-pin'
 import { SquiggleLoader } from './SquiggleLoader.js'
 
-// Mirrors the daemon's GET /api/pairing/grants response (see
-// packages/mcp-server/src/server/routes/pairing.ts) — hydrated through the
-// schema per zod-schema-discipline, never cast.
-const listGrantsResponseSchema = z
-  .object({
-    grants: z.array(
-      z.object({ grantId: z.string(), origin: z.string(), createdAt: z.string() }).strict(),
-    ),
-  })
-  .strict()
 type PairedGrant = z.infer<typeof listGrantsResponseSchema>['grants'][number]
 
 type CardState =
@@ -41,17 +35,23 @@ export function PairedOriginsCard() {
   // shown on the /pair consent page out-of-band. Best-effort: absent on
   // legacy daemons or while unreachable.
   useEffect(() => {
-    const generation = generationRef.current
+    // `cancelled` (scoped to this effect run, flipped by its own cleanup) is
+    // the correct staleness guard here — it fires exactly when fetchApi
+    // changes (a different daemon) or the component unmounts. Comparing
+    // against the grants-load generationRef instead would be wrong: that
+    // counter is bumped by the unrelated load()/revoke() effect on every
+    // mount, so this effect's captured value could never match again once
+    // that ran, and the fingerprint would silently never render.
     let cancelled = false
     void (async () => {
       try {
         const res = await fetchApi('/api/runtime/ping')
         if (!res.ok) return
-        const body = (await res.json()) as { identity?: { publicKey?: unknown } }
-        const publicKey = body.identity?.publicKey
-        if (typeof publicKey !== 'string' || publicKey.length === 0) return
+        const parsed = daemonPingResponseSchema.safeParse(await res.json())
+        const publicKey = parsed.success ? parsed.data.identity?.publicKey : undefined
+        if (publicKey === undefined) return
         const value = await fingerprintPublicKey(publicKey)
-        if (!cancelled && generation === generationRef.current) setFingerprint(value)
+        if (!cancelled) setFingerprint(value)
       } catch {
         // Leave the fingerprint absent.
       }

--- a/apps/web/src/components/PairedOriginsCard.tsx
+++ b/apps/web/src/components/PairedOriginsCard.tsx
@@ -35,13 +35,10 @@ export function PairedOriginsCard() {
   // shown on the /pair consent page out-of-band. Best-effort: absent on
   // legacy daemons or while unreachable.
   useEffect(() => {
-    // `cancelled` (scoped to this effect run, flipped by its own cleanup) is
-    // the correct staleness guard here — it fires exactly when fetchApi
-    // changes (a different daemon) or the component unmounts. Comparing
-    // against the grants-load generationRef instead would be wrong: that
+    // `cancelled` is the staleness guard here, NOT generationRef: that
     // counter is bumped by the unrelated load()/revoke() effect on every
-    // mount, so this effect's captured value could never match again once
-    // that ran, and the fingerprint would silently never render.
+    // mount, so a value captured here could never match again and the
+    // fingerprint would silently never render.
     let cancelled = false
     void (async () => {
       try {

--- a/apps/web/src/lib/daemon-identity-pin.test.ts
+++ b/apps/web/src/lib/daemon-identity-pin.test.ts
@@ -166,6 +166,45 @@ describe('challengeDaemonIdentity', () => {
     ).resolves.toBe('verified')
   })
 
+  it('fails when the verify response drifts from the schema (alg change or extra field)', async () => {
+    const pair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair
+    const jwk = await crypto.subtle.exportKey('jwk', pair.publicKey)
+    const publicKey = jwk.x as string
+    const storage = pinsWith(publicKey)
+
+    async function respondingWith(overrides: Record<string, unknown>) {
+      const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+        const { nonce } = JSON.parse(String(init?.body)) as { nonce: string }
+        const payload = new TextEncoder().encode(
+          JSON.stringify(['wb-verify-v1', nonce, 'https://app.example']),
+        )
+        const sig = new Uint8Array(
+          await crypto.subtle.sign({ name: 'Ed25519' }, pair.privateKey, payload),
+        )
+        const signature = btoa(String.fromCharCode(...sig))
+          .replaceAll('+', '-')
+          .replaceAll('/', '_')
+          .replaceAll('=', '')
+        return Response.json({ alg: 'Ed25519', publicKey, signature, ...overrides })
+      })
+      return challengeDaemonIdentity({
+        daemonBaseUrl: BASE,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+        hostedOrigin: 'https://app.example',
+        storage,
+      })
+    }
+
+    // A genuinely-signed response is still rejected once the alg field
+    // drifts: a real signature under a changed algorithm must not read as
+    // 'verified' just because the key and signature bytes check out.
+    await expect(respondingWith({ alg: 'ES256' })).resolves.toBe('failed')
+    await expect(respondingWith({ extra: 'unexpected' })).resolves.toBe('failed')
+  })
+
   it('fails a pinned responder answering with another key, an error, or nothing', async () => {
     const squatter = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
       'sign',

--- a/apps/web/src/lib/daemon-identity-pin.ts
+++ b/apps/web/src/lib/daemon-identity-pin.ts
@@ -6,6 +6,7 @@
  * verification and is refused (fail closed; the pin is kept so the
  * key-changed warning has its evidence, per the approved design).
  */
+import { runtimeVerifyResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { z } from 'zod'
 
 const PINS_KEY = 'whiteboard:daemon-identity-pins'
@@ -181,10 +182,15 @@ export async function challengeDaemonIdentity({
       body: JSON.stringify({ nonce }),
     })
     if (!response.ok) return 'failed'
-    const body = (await response.json()) as { publicKey?: unknown; signature?: unknown }
+    // safeParse against the shared wire contract, not a hand-cast: an
+    // algorithm change (alg !== 'Ed25519') or any other drift from the
+    // daemon's actual response shape must fail closed rather than silently
+    // dropping the unrecognized field and verifying anyway.
+    const parsed = runtimeVerifyResponseSchema.safeParse(await response.json())
+    if (!parsed.success) return 'failed'
+    const body = parsed.data
     const verified =
       body.publicKey === pinned.publicKey &&
-      typeof body.signature === 'string' &&
       (await verifyIdentitySignature({
         publicKey: pinned.publicKey,
         parts: ['wb-verify-v1', nonce, hostedOrigin],

--- a/apps/web/src/pages/PairConsentPage.test.tsx
+++ b/apps/web/src/pages/PairConsentPage.test.tsx
@@ -72,6 +72,37 @@ describe('PairConsentPage', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
+  it('shows the identity fingerprint for a conformant ping response', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/runtime/ping')) {
+        return Response.json({
+          ok: true,
+          instanceId: 'inst-1',
+          identity: { alg: 'Ed25519', publicKey: 'a'.repeat(43) },
+        })
+      }
+      return new Response('not used', { status: 404 })
+    })
+    renderPage({ fetchFn: fetchFn as never })
+    await waitFor(() => expect(screen.getByTestId('daemon-fingerprint')).not.toBeNull())
+  })
+
+  it('never renders a fingerprint from a ping body that fails the shared schema', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/runtime/ping')) {
+        // Missing instanceId: fails daemonPingResponseSchema even though it
+        // carries an identity.publicKey a naive hand-cast would still read.
+        return Response.json({ ok: true, identity: { alg: 'Ed25519', publicKey: 'a'.repeat(43) } })
+      }
+      return new Response('not used', { status: 404 })
+    })
+    renderPage({ fetchFn: fetchFn as never })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(screen.queryByTestId('daemon-fingerprint')).toBeNull()
+    // The page stays functional — Approve is still offered.
+    expect(screen.getByRole('button', { name: /approve/i })).not.toBeNull()
+  })
+
   it('rejects a non-http(s) origin outright — no approve affordance', () => {
     renderPage({
       search: `?origin=${encodeURIComponent('javascript:alert(1)')}&challenge=c&state=s`,

--- a/apps/web/src/pages/PairConsentPage.tsx
+++ b/apps/web/src/pages/PairConsentPage.tsx
@@ -1,3 +1,4 @@
+import { daemonPingResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { createPairingGrant } from '../lib/daemon-api-client.js'
@@ -67,9 +68,9 @@ export function PairConsentPage({
       try {
         const res = await fetchFn('/api/runtime/ping')
         if (!res.ok) return
-        const body = (await res.json()) as { identity?: { publicKey?: unknown } }
-        const publicKey = body.identity?.publicKey
-        if (typeof publicKey !== 'string' || publicKey.length === 0) return
+        const parsed = daemonPingResponseSchema.safeParse(await res.json())
+        const publicKey = parsed.success ? parsed.data.identity?.publicKey : undefined
+        if (publicKey === undefined) return
         const fingerprint = await fingerprintPublicKey(publicKey)
         if (!cancelled) setIdentity({ publicKey, fingerprint })
       } catch {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -15,14 +15,6 @@ export default defineConfig({
     alias: {
       ...mcpSourceAlias,
       '@': resolve(__dirname, 'src'),
-      // Declared test/internal-only subpath (not in mcp-server's published
-      // npm exports) used by daemon-probe.schema-drift.test.ts to import the
-      // server's runtime schema through a contract surface instead of a
-      // relative deep import into another package's src/.
-      '@kamiazya/whiteboard-mcp/api-contracts-internal': resolve(
-        __dirname,
-        '../../packages/mcp-server/src/shared/api-contracts/runtime.ts',
-      ),
       // Also test-only: the SseStreamSource behavioural contract, declared once
       // in the package that owns the port and run here against the
       // SharedWorker-backed implementation this app ships.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -63,10 +63,6 @@
       "types": "./src/shared/api-contracts/index.ts",
       "import": "./dist/shared/api-contracts/index.js"
     },
-    "./api-contracts-internal": {
-      "types": "./src/shared/api-contracts/runtime.ts",
-      "import": "./dist/shared/api-contracts/runtime.js"
-    },
     "./package.json": "./package.json"
   },
   "bin": {

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -115,17 +115,10 @@ describe('publish contract', () => {
         types: './src/shared/api-contracts/index.ts',
         import: './dist/shared/api-contracts/index.js',
       },
-      './api-contracts-internal': {
-        types: './src/shared/api-contracts/runtime.ts',
-        import: './dist/shared/api-contracts/runtime.js',
-      },
       './package.json': './package.json',
     })
     // publishConfig.exports is the shape pnpm substitutes on npm publish, so
-    // npm consumers get the compiled .d.ts declarations. api-contracts-internal
-    // is deliberately absent here: it is a workspace-only contract surface for
-    // this monorepo's own drift-pin tests, not part of the published npm
-    // package's semver liability.
+    // npm consumers get the compiled .d.ts declarations.
     expect(mcpPackage.publishConfig.exports).toEqual({
       '.': {
         types: './dist/server/mcp/index.d.ts',

--- a/packages/mcp-server/src/server/routes/pairing.test.ts
+++ b/packages/mcp-server/src/server/routes/pairing.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { pairingTokenResponseSchema } from '../../shared/api-contracts/pairing.js'
+import {
+  listGrantsResponseSchema,
+  pairingTokenResponseSchema,
+} from '../../shared/api-contracts/pairing.js'
 import { buildSignedPayload, createDaemonIdentity } from '../security/daemon-identity.js'
 import { createPairingGrantStore } from '../security/pairing-grant-store.js'
 import {
@@ -124,7 +127,11 @@ describe('pairing routes', () => {
 
     const listRes = await app.request('/api/pairing/grants')
     expect(listRes.status).toBe(200)
-    const listed = (await listRes.json()) as { grants: { grantId: string; origin: string }[] }
+    // Executable mutation-check guard: parses the REAL HTTP body against the
+    // shared schema, so a server-side field drift turns this red instead of
+    // shipping silently to the client's separate copy (there is no longer
+    // one — PairedOriginsCard imports this same schema).
+    const listed = listGrantsResponseSchema.parse(await listRes.json())
     expect(listed.grants).toEqual([
       expect.objectContaining({ grantId: grant.grantId, origin: HOSTED }),
     ])

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -29,6 +29,8 @@ import { createHash } from 'node:crypto'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import {
+  type ListGrantsResponse,
+  listGrantsResponseSchema,
   type PairingTokenResponse,
   pairingTokenRequestSchema,
   pairingTokenResponseSchema,
@@ -52,15 +54,6 @@ const createGrantResponseSchema = z
   })
   .strict()
 type CreateGrantResponse = z.infer<typeof createGrantResponseSchema>
-
-const listGrantsResponseSchema = z
-  .object({
-    grants: z.array(
-      z.object({ grantId: z.string(), origin: z.string(), createdAt: z.string() }).strict(),
-    ),
-  })
-  .strict()
-type ListGrantsResponse = z.infer<typeof listGrantsResponseSchema>
 
 function signTokenResponse(
   identity: DaemonIdentity,
@@ -114,7 +107,9 @@ export function createPairingRouter({ grants, codes, tokens, identity }: Pairing
   // latter). Revocation also kills the origin's live session tokens: a
   // revoked origin keeping a working 24h token would make revoke a lie.
   app.get('/api/pairing/grants', (c) => {
-    const response: ListGrantsResponse = { grants: [...grants.list()] }
+    const response: ListGrantsResponse = listGrantsResponseSchema.parse({
+      grants: [...grants.list()],
+    })
     return c.json(response, 200)
   })
 

--- a/packages/mcp-server/src/server/routes/runtime.test.ts
+++ b/packages/mcp-server/src/server/routes/runtime.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runtimeVerifyResponseSchema } from '../../shared/api-contracts/runtime.js'
 
 // Hermetic harness — these tests must NEVER touch the developer's real
 // data directory. Stub `../config.js` (DATA_DIR) and the helpers behind
@@ -326,7 +327,10 @@ describe('daemon identity surfaces', () => {
       body: JSON.stringify({ nonce: NONCE }),
     })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { alg: string; publicKey: string; signature: string }
+    // Executable mutation-check guard: parses the REAL HTTP body against the
+    // shared schema, so a server-side field drift (or an alg change) turns
+    // this red instead of shipping silently to the client's separate copy.
+    const body = runtimeVerifyResponseSchema.parse(await res.json())
     expect(body.publicKey).toBe(testIdentity.publicKey)
     expect(
       verifyIdentitySignature(['wb-verify-v1', NONCE, 'https://caller.example'], body.signature),

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -7,7 +7,10 @@
 // here must be an intentional decision, not incidental scope creep.
 // daemonPingResponseSchema is promoted here so apps/web can consume the
 // ping contract from its single definition instead of maintaining a
-// hand-written mirror.
+// hand-written mirror. runtimeVerifyResponseSchema and
+// listGrantsResponseSchema are promoted for the same reason: each had a
+// hand-written or independently-redeclared mirror on the apps/web side that
+// could silently drift from the server's shape.
 
 // The OpenCanvas /api/v1 list contract, re-exported from server-core so
 // apps/web keeps consuming every daemon HTTP contract through this one
@@ -19,14 +22,15 @@ export {
 } from '@kamiazya/whiteboard-server-core'
 export * from './branches.js'
 export * from './canvas.js'
-export type { PairingTokenResponse } from './pairing.js'
+export type { ListGrantsResponse, PairingTokenResponse } from './pairing.js'
 export {
+  listGrantsResponseSchema,
   pairingTokenNonceSchema,
   pairingTokenRequestSchema,
   pairingTokenResponseSchema,
 } from './pairing.js'
-export type { DaemonPingResponse } from './runtime.js'
-export { daemonPingResponseSchema } from './runtime.js'
+export type { DaemonPingResponse, RuntimeVerifyResponse } from './runtime.js'
+export { daemonPingResponseSchema, runtimeVerifyResponseSchema } from './runtime.js'
 
 import type {
   canvasExportOkfOutputSchema as _canvasOkfV1ResponseSchema,

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -5,12 +5,10 @@
 // rest of runtime.ts stay off the published npm surface — widening this
 // barrel widens semver liability for a public package, so any addition
 // here must be an intentional decision, not incidental scope creep.
-// daemonPingResponseSchema is promoted here so apps/web can consume the
-// ping contract from its single definition instead of maintaining a
-// hand-written mirror. runtimeVerifyResponseSchema and
-// listGrantsResponseSchema are promoted for the same reason: each had a
-// hand-written or independently-redeclared mirror on the apps/web side that
-// could silently drift from the server's shape.
+// daemonPingResponseSchema, runtimeVerifyResponseSchema, and
+// listGrantsResponseSchema are promoted so apps/web consumes each contract
+// from its single definition instead of a hand-written mirror that can
+// silently drift from the server's shape.
 
 // The OpenCanvas /api/v1 list contract, re-exported from server-core so
 // apps/web keeps consuming every daemon HTTP contract through this one

--- a/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
@@ -14,6 +14,8 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  type ListGrantsResponse,
+  listGrantsResponseSchema,
   type PairingTokenResponse,
   pairingTokenNonceSchema,
   pairingTokenRequestSchema,
@@ -92,6 +94,54 @@ describe('pairingTokenRequestSchema', () => {
 
   it('rejects an unknown grantType', () => {
     expect(pairingTokenRequestSchema.safeParse({ grantType: 'other' }).success).toBe(false)
+  })
+})
+
+describe('listGrantsResponseSchema', () => {
+  const valid: ListGrantsResponse = {
+    grants: [
+      { grantId: 'g1', origin: 'https://a.example', createdAt: '2026-01-01T00:00:00.000Z' },
+      { grantId: 'g2', origin: 'https://b.example', createdAt: '2026-01-02T00:00:00.000Z' },
+    ],
+  }
+
+  it('parses a well-formed value', () => {
+    expect(listGrantsResponseSchema.parse(valid)).toEqual(valid)
+  })
+
+  it('roundtrip preserves multiple grants', () => {
+    const result: ListGrantsResponse = roundtrip(listGrantsResponseSchema, valid)
+    expect(result).toEqual(valid)
+  })
+
+  it('roundtrip preserves an empty grants list', () => {
+    const empty: ListGrantsResponse = { grants: [] }
+    expect(roundtrip(listGrantsResponseSchema, empty)).toEqual(empty)
+  })
+
+  it('rejects a missing createdAt on a grant', () => {
+    const { createdAt: _omit, ...grantWithoutCreatedAt } = valid.grants[0] as {
+      grantId: string
+      origin: string
+      createdAt: string
+    }
+    expect(listGrantsResponseSchema.safeParse({ grants: [grantWithoutCreatedAt] }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an extra field on a grant (strict)', () => {
+    expect(
+      listGrantsResponseSchema.safeParse({
+        grants: [{ ...valid.grants[0], extra: 'unexpected' }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an extra top-level field (strict)', () => {
+    expect(listGrantsResponseSchema.safeParse({ ...valid, extra: 'unexpected' }).success).toBe(
+      false,
+    )
   })
 })
 

--- a/packages/mcp-server/src/shared/api-contracts/pairing.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.ts
@@ -52,3 +52,17 @@ export const pairingTokenResponseSchema = z
   .strict()
 
 export type PairingTokenResponse = z.infer<typeof pairingTokenResponseSchema>
+
+// GET /api/pairing/grants response — shared so the daemon route and the
+// PairedOriginsCard settings UI can never drift apart: a server field
+// addition previously had to land in two independent `.strict()` copies at
+// once, and a mismatch silently fell the UI to its error state.
+export const listGrantsResponseSchema = z
+  .object({
+    grants: z.array(
+      z.object({ grantId: z.string(), origin: z.string(), createdAt: z.string() }).strict(),
+    ),
+  })
+  .strict()
+
+export type ListGrantsResponse = z.infer<typeof listGrantsResponseSchema>

--- a/packages/mcp-server/src/shared/api-contracts/runtime.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/runtime.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { daemonPingResponseSchema, runtimeStatusResponseSchema } from './runtime.js'
+import { roundtrip } from './roundtrip.test-helper.js'
+import {
+  daemonPingResponseSchema,
+  type RuntimeVerifyResponse,
+  runtimeStatusResponseSchema,
+  runtimeVerifyResponseSchema,
+} from './runtime.js'
 
 function baseStatus(app: { served: boolean; buildPresent: boolean; ui: string }) {
   return {
@@ -36,6 +42,54 @@ describe('daemonPingResponseSchema', () => {
 
   it('rejects a legacy pid-shaped payload with no instanceId', () => {
     expect(() => daemonPingResponseSchema.parse({ ok: true, pid: 123 })).toThrow()
+  })
+})
+
+describe('runtimeVerifyResponseSchema', () => {
+  const valid: RuntimeVerifyResponse = {
+    alg: 'Ed25519',
+    publicKey: 'pk-abc',
+    signature: 'sig-xyz',
+  }
+
+  it('parses a well-formed value', () => {
+    expect(runtimeVerifyResponseSchema.parse(valid)).toEqual(valid)
+  })
+
+  it('roundtrips through the wire format', () => {
+    expect(roundtrip(runtimeVerifyResponseSchema, valid)).toEqual(valid)
+  })
+
+  it('rejects an extra field (strict schema catches server drift)', () => {
+    expect(runtimeVerifyResponseSchema.safeParse({ ...valid, extra: 'unexpected' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects a missing signature', () => {
+    const { signature: _omit, ...missing } = valid
+    expect(runtimeVerifyResponseSchema.safeParse(missing).success).toBe(false)
+  })
+
+  it('rejects an alg other than Ed25519 (an algorithm change must not pass silently)', () => {
+    expect(runtimeVerifyResponseSchema.safeParse({ ...valid, alg: 'ES256' }).success).toBe(false)
+  })
+})
+
+// The barrel is a published npm subpath (0.0.x semver liability), so widening
+// it is a deliberate decision — see index.ts's own comment. This guard makes
+// the other deliberate decision executable too: runtimeVerifyRequestSchema's
+// refine touches Buffer (Node-only) and must never reach a browser bundle
+// through the barrel, only through its module path (routes/runtime.ts's
+// import). The positive-control assertion (…DOES contain
+// runtimeVerifyResponseSchema) keeps the negative assertion from passing
+// vacuously if the barrel export is ever renamed away.
+describe('api-contracts barrel excludes the Buffer-refining request schema', () => {
+  it('exports runtimeVerifyResponseSchema but not runtimeVerifyRequestSchema', async () => {
+    const barrel = await import('./index.js')
+    const keys = Object.keys(barrel)
+    expect(keys).toContain('runtimeVerifyResponseSchema')
+    expect(keys).not.toContain('runtimeVerifyRequestSchema')
   })
 })
 


### PR DESCRIPTION
## What

Three audit findings (MEDIUM, contract-drift), one lane — the same enforcement shape as #669:

- **`/api/runtime/ping`**: `PairConsentPage` and `PairedOriginsCard` hand-cast the response that derives the identity fingerprint the user cross-checks out-of-band on `/pair` — the exact duplicate-cast the published `daemonPingResponseSchema` exists to prevent. Both now safeParse it (mirroring `daemon-probe.ts`); a non-conformant ping leaves the fingerprint absent via each file's existing affordance.
- **`/api/runtime/verify`**: the client kept a hand-written mirror in `daemon-identity-pin.ts` that silently dropped `alg: 'Ed25519'` — an algorithm change on the daemon's challenge-response would have gone unnoticed. `runtimeVerifyResponseSchema` is promoted to the api-contracts barrel and safeParsed at the cast site; red-first: a valid-signature response with a drifted `alg` now fails closed. `runtimeVerifyRequestSchema` deliberately stays OFF the barrel (its refine references `Buffer`) — and that exclusion is now itself executable: a barrel-key test with a positive control goes red if anyone exports it toward browser bundles.
- **`GET` pairing grants**: `listGrantsResponseSchema` existed as two independent `.strict()` copies — a server field addition would ship fine and the client copy would reject the whole response, silently dropping the pairing-grants UI to its error state with no test catching it. The schema now lives once in `api-contracts/pairing.ts`, imported by both ends.

Also resolved on evidence: the dead `./api-contracts-internal` exports subpath (its only consumer test died when #669 promoted the ping schema) is deleted from package.json, the publish-contract expectation, and the apps/web vitest alias. It was never in `publishConfig.exports`, so zero published-npm change.

## Tests

Roundtrip conformance for both promoted/moved schemas; route-level parses of the real HTTP bodies (the executable drift guards); red-first jsdom cases for alg-drift → `'failed'`, drifted ping → no fingerprint, drifted grants body → the existing accessible error text. Mutation-checked: drifting a server field turns the route conformance parse red; re-adding the request-schema export turns the barrel-exclusion test red.

## Gates

mcp-node + apps/web jsdom green (re-verified after rebasing over #681's vitest-config change); `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, lint clean. Review workflow: zero confirmed findings; QA pass. No `packages/server-core` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw