### PR TITLE
perf(render): lift the 40-edge optimizer cliff — sweep-and-prune matrix + bounded worst-offender trials

### DIFF
--- a/packages/canvas-render/src/layout/edge-crossing-min.test.ts
+++ b/packages/canvas-render/src/layout/edge-crossing-min.test.ts
@@ -160,9 +160,24 @@ describe('optimization gate', () => {
     return { nodes, edges }
   }
 
-  it('past the edge-count gate the pass is skipped and the crossing persists', () => {
+  it('above the full-optimization size the worst offenders still get fixed', () => {
+    // 41 edges used to fall off a cliff (no optimization at all); the
+    // bounded pass now tries candidates for the highest-cost edges, so
+    // the one crossing pair — the worst offenders by construction —
+    // resolves exactly as it would on a small canvas.
     const base = crossingPair()
-    const pad = padding(39) // 2 + 39 = 41 > 40
+    const pad = padding(39) // 2 + 39 = 41 > FULL_OPT_MAX_EDGES
+    const nodes = [...base.nodes, ...pad.nodes]
+    const edges = [...base.edges, ...pad.edges]
+    const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+    const orange = routeEdge(nodes, edges[0]!, 'orthogonal', anchors.get('e-orange'))
+    const red = routeEdge(nodes, edges[1]!, 'orthogonal', anchors.get('e-red'))
+    expect(crossings(orange.path, red.path)).toBe(0)
+  })
+
+  it('past the hard gate the pass is skipped and the crossing persists', () => {
+    const base = crossingPair()
+    const pad = padding(199) // 2 + 199 = 201 > 200
     const nodes = [...base.nodes, ...pad.nodes]
     const edges = [...base.edges, ...pad.edges]
     const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')

--- a/packages/canvas-render/src/layout/edge-crossing-sweep.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-crossing-sweep.properties.test.ts
@@ -1,0 +1,195 @@
+// The sweep-and-prune broad phase must be EXACTLY equal to the full
+// pairwise scan — not approximately: the optimizer's lexicographic cost
+// comparisons are integer-exact, so a single missed candidate pair changes
+// side-choice equilibria. The full double loop over the shared narrow
+// phase stays here as the oracle.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { buildPairwiseScores, scoreSegmentPair } from './edge-crossing-sweep.js'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+type Point = { readonly x: number; readonly y: number }
+
+/** The O(E^2) oracle: the exact per-pair sum the old matrix build made. */
+function oracle(
+  paths: readonly (readonly Point[])[],
+): Map<number, readonly [number, number, number]> {
+  const scores = new Map<number, readonly [number, number, number]>()
+  for (let i = 0; i < paths.length; i++) {
+    for (let j = i + 1; j < paths.length; j++) {
+      let overlap = 0
+      let illegible = 0
+      let crossings = 0
+      const a = paths[i]!
+      const b = paths[j]!
+      for (let ai = 1; ai < a.length; ai++) {
+        for (let bi = 1; bi < b.length; bi++) {
+          const [o, il, c] = scoreSegmentPair(a[ai - 1]!, a[ai]!, b[bi - 1]!, b[bi]!)
+          overlap += o
+          illegible += il
+          crossings += c
+        }
+      }
+      scores.set(i * paths.length + j, [overlap, illegible, crossings])
+    }
+  }
+  return scores
+}
+
+/** Small field + few nodes so edges share sides (fan-out lanes, collinear
+ * corridors) and cross each other — the arrangements that matter. */
+const scenarioArbitrary = fc
+  .record({
+    nodeCount: fc.integer({ min: 3, max: 8 }),
+    positions: fc.array(
+      fc.record({
+        x: fc.integer({ min: 0, max: 60 }).map((n) => n * 10),
+        y: fc.integer({ min: 0, max: 60 }).map((n) => n * 10),
+        w: fc.integer({ min: 6, max: 20 }).map((n) => n * 10),
+        h: fc.integer({ min: 5, max: 12 }).map((n) => n * 10),
+      }),
+      { minLength: 8, maxLength: 8 },
+    ),
+    pairs: fc.array(fc.record({ from: fc.nat({ max: 7 }), to: fc.nat({ max: 7 }) }), {
+      minLength: 2,
+      maxLength: 24,
+    }),
+    style: fc.constantFrom('straight' as const, 'orthogonal' as const, 'curved' as const),
+  })
+  .map(({ nodeCount, positions, pairs, style }) => {
+    const nodes: SpatialNode[] = positions.slice(0, nodeCount).map((p, i) => ({
+      id: `n${i}`,
+      type: 'text',
+      x: p.x,
+      y: p.y,
+      width: p.w,
+      height: p.h,
+      text: '',
+    }))
+    const edges: CanvasEdge[] = pairs
+      .map((p, i) => ({
+        id: `e${i}`,
+        fromNode: `n${p.from % nodeCount}`,
+        toNode: `n${p.to % nodeCount}`,
+      }))
+      .filter((e) => e.fromNode !== e.toNode)
+    return { nodes, edges, style }
+  })
+
+/** Routed paths exactly as optimizeSideChoices consumes them. */
+function routedPaths(
+  nodes: readonly SpatialNode[],
+  edges: readonly CanvasEdge[],
+  style: 'straight' | 'orthogonal' | 'curved',
+): (readonly Point[])[] {
+  const anchors = assignEdgeAnchors(nodes, edges, style)
+  return edges.map((e) => routeEdge(nodes, e, style, anchors.get(e.id)).path)
+}
+
+// Generator-density accounting: a sweep property whose inputs never reach
+// collinear overlaps or shared endpoints passes vacuously.
+let sawOverlap = 0
+let sawCrossing = 0
+let sawSharedEndpoint = 0
+
+/** Raw grid-snapped polylines: denser in the sweep's degenerate cases
+ * (collinear corridors, shared endpoints, vertical stacks, zero-length
+ * segments) than anything the router emits. */
+const rawPathsArbitrary = fc.array(
+  fc
+    .array(
+      fc.record({
+        // Grid coordinates plus optional sub-quantum jitter (< 0.25px):
+        // q(n) = round(4n) rates jittered coordinates equal to their grid
+        // neighbours, which is exactly the class the broad phase's bbox
+        // slack exists for — a generator without it can never catch a
+        // dropped-slack regression.
+        x: fc
+          .tuple(fc.integer({ min: 0, max: 8 }), fc.constantFrom(0, 0, 0.1, 0.24))
+          .map(([n, j]) => n * 5 + j),
+        y: fc
+          .tuple(fc.integer({ min: 0, max: 8 }), fc.constantFrom(0, 0, 0.1, 0.24))
+          .map(([n, j]) => n * 5 + j),
+      }),
+      { minLength: 2, maxLength: 5 },
+    )
+    .map((points) => points as readonly Point[]),
+  { minLength: 2, maxLength: 10 },
+)
+
+describe('edge-crossing sweep — differential equality with the pairwise oracle', () => {
+  fcTest.prop([scenarioArbitrary], withDefaults())(
+    'the sweep matrix equals the full O(E^2) scan for every pair',
+    ({ nodes, edges, style }) => {
+      if (edges.length < 2) return
+      const paths = routedPaths(nodes, edges, style)
+      const expected = oracle(paths)
+      const actual = buildPairwiseScores(paths)
+      for (const [key, exp] of expected) {
+        const got = actual.get(key) ?? [0, 0, 0]
+        expect(got).toEqual(exp)
+        if (exp[0] > 0) sawOverlap++
+        if (exp[2] > 0) sawCrossing++
+      }
+      // The sweep must not invent pairs the oracle scored zero either.
+      for (const [key, got] of actual) {
+        const exp = expected.get(key) ?? [0, 0, 0]
+        expect(got).toEqual(exp)
+      }
+      const endpoints = new Set<string>()
+      for (const path of paths) {
+        const first = path[0]
+        if (first === undefined) continue
+        const k = `${first.x},${first.y}`
+        if (endpoints.has(k)) sawSharedEndpoint++
+        endpoints.add(k)
+      }
+    },
+  )
+
+  fcTest.prop([rawPathsArbitrary], withDefaults())(
+    'raw grid polylines: dense collinear/shared-endpoint arrangements agree too',
+    (paths) => {
+      const expected = oracle(paths)
+      const actual = buildPairwiseScores(paths)
+      for (const [key, exp] of expected) {
+        expect(actual.get(key) ?? [0, 0, 0]).toEqual(exp)
+        if (exp[0] > 0) sawOverlap++
+        if (exp[2] > 0) sawCrossing++
+      }
+      for (const [key, got] of actual) {
+        expect(got).toEqual(expected.get(key) ?? [0, 0, 0])
+      }
+      const endpoints = new Set<string>()
+      for (const path of paths) {
+        for (const p of [path[0]!, path[path.length - 1]!]) {
+          const k = `${p.x},${p.y}`
+          if (endpoints.has(k)) sawSharedEndpoint++
+          endpoints.add(k)
+        }
+      }
+    },
+  )
+
+  it('the generator actually reaches the degenerate arrangements', () => {
+    expect(sawOverlap).toBeGreaterThan(0)
+    expect(sawCrossing).toBeGreaterThan(0)
+    expect(sawSharedEndpoint).toBeGreaterThan(0)
+  })
+
+  it('is deterministic: identical inputs produce deeply-equal matrices', () => {
+    const nodes: SpatialNode[] = [
+      { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: '' },
+      { id: 'b', type: 'text', x: 300, y: 0, width: 100, height: 60, text: '' },
+      { id: 'c', type: 'text', x: 150, y: 200, width: 100, height: 60, text: '' },
+    ]
+    const edges: CanvasEdge[] = [
+      { id: 'e0', fromNode: 'a', toNode: 'b' },
+      { id: 'e1', fromNode: 'c', toNode: 'a' },
+      { id: 'e2', fromNode: 'c', toNode: 'b' },
+    ]
+    const paths = routedPaths(nodes, edges, 'orthogonal')
+    expect(buildPairwiseScores(paths)).toEqual(buildPairwiseScores(paths))
+  })
+})

--- a/packages/canvas-render/src/layout/edge-crossing-sweep.ts
+++ b/packages/canvas-render/src/layout/edge-crossing-sweep.ts
@@ -1,0 +1,150 @@
+// The pairwise crossing/overlap scorer's broad phase. optimizeSideChoices
+// needs the ConfigCost contribution of every edge pair once per
+// optimization run; a full double loop is O(E^2) narrow-phase calls and is
+// what forced the 40-edge gate. Segments are axis-aligned-dominant here,
+// so a sweep-and-prune over x with a y-interval gate prunes almost every
+// non-interacting pair while calling the EXACT same narrow phase for the
+// survivors — equality with the full pairwise scan is by construction, not
+// by approximation.
+//
+// Deliberately NOT Bentley-Ottmann: this workload's normal case is B-O's
+// degenerate case (lane fan-out shares endpoints at anchors, lane
+// corridors are collinear overlapping segments scored by quantized LENGTH
+// — which intersection events do not natively produce — and vertical
+// segments are everywhere). Sweep-and-prune has no float-keyed event
+// ordering to create cross-platform ties: per-pair integer tuples are
+// summed per pair key, enumeration-order-independent.
+import { EDGE_JUMP_RADIUS_PX } from './edge-jumps.js'
+
+type Point = { readonly x: number; readonly y: number }
+
+/** Matches spatial-edges' COST_QUANTUM discipline (quarter-pixel integers). */
+const COST_QUANTUM = 4
+
+/**
+ * Broad-phase bbox slack, in px. q(n) = round(n * 4) can rate two
+ * coordinates equal when their raw values differ by just under a quantum
+ * step, and a transversal crossing requires a genuinely shared point — so
+ * any segment pair with a nonzero narrow-phase contribution has
+ * intersecting bboxes after this inflation. Slack only ADDS candidates,
+ * never removes one (the completeness lemma the differential property
+ * pins).
+ */
+const BROAD_PHASE_SLACK_PX = 1 / COST_QUANTUM
+
+/**
+ * The narrow phase: one segment pair's [overlap, illegible, crossings]
+ * contribution — extracted verbatim from pairScore's inner loop so the
+ * sweep and the per-pair oracle cannot drift. Collinear axis-aligned
+ * overlap short-circuits the crossing test for the pair, exactly like the
+ * original `continue`.
+ */
+export function scoreSegmentPair(
+  a1: Point,
+  a2: Point,
+  b1: Point,
+  b2: Point,
+): readonly [number, number, number] {
+  const q = (n: number) => Math.round(n * COST_QUANTUM)
+  const clearance = EDGE_JUMP_RADIUS_PX + 1
+  // Collinear axis-aligned overlap.
+  if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
+    const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
+    const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
+    return [hi > lo ? hi - lo : 0, 0, 0]
+  }
+  if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
+    const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
+    const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
+    return [hi > lo ? hi - lo : 0, 0, 0]
+  }
+  // Proper transversal crossing.
+  const dax = a2.x - a1.x
+  const day = a2.y - a1.y
+  const dbx = b2.x - b1.x
+  const dby = b2.y - b1.y
+  const denom = dax * dby - day * dbx
+  if (denom === 0) return [0, 0, 0]
+  const t = ((b1.x - a1.x) * dby - (b1.y - a1.y) * dbx) / denom
+  const u = ((b1.x - a1.x) * day - (b1.y - a1.y) * dax) / denom
+  if (t <= 0 || t >= 1 || u <= 0 || u >= 1) return [0, 0, 0]
+  const lenA = Math.hypot(dax, day)
+  const lenB = Math.hypot(dbx, dby)
+  const illegible =
+    t * lenA < clearance ||
+    (1 - t) * lenA < clearance ||
+    u * lenB < clearance ||
+    (1 - u) * lenB < clearance
+      ? 1
+      : 0
+  return [0, illegible, 1]
+}
+
+interface SweepSegment {
+  readonly edge: number
+  readonly a: Point
+  readonly b: Point
+  readonly minX: number
+  readonly maxX: number
+  readonly minY: number
+  readonly maxY: number
+}
+
+/**
+ * Every edge pair's summed [overlap, illegible, crossings], keyed by
+ * `i * paths.length + j` with `i < j` (the caller's pairKey formula).
+ * Pairs whose every candidate segment pair scores zero may be absent —
+ * consumers default absent keys to zero, as evaluateTrial already does.
+ */
+export function buildPairwiseScores(
+  paths: readonly (readonly Point[])[],
+): ReadonlyMap<number, readonly [number, number, number]> {
+  const segments: SweepSegment[] = []
+  for (let edge = 0; edge < paths.length; edge++) {
+    const path = paths[edge]!
+    for (let s = 1; s < path.length; s++) {
+      const a = path[s - 1]!
+      const b = path[s]!
+      segments.push({
+        edge,
+        a,
+        b,
+        minX: Math.min(a.x, b.x) - BROAD_PHASE_SLACK_PX,
+        maxX: Math.max(a.x, b.x) + BROAD_PHASE_SLACK_PX,
+        minY: Math.min(a.y, b.y) - BROAD_PHASE_SLACK_PX,
+        maxY: Math.max(a.y, b.y) + BROAD_PHASE_SLACK_PX,
+      })
+    }
+  }
+  segments.sort((s1, s2) => s1.minX - s2.minX || s1.maxX - s2.maxX || s1.edge - s2.edge)
+
+  const scores = new Map<number, [number, number, number]>()
+  const active: SweepSegment[] = []
+  for (const segment of segments) {
+    // Evict everything that ended left of this segment's start.
+    let keep = 0
+    for (let i = 0; i < active.length; i++) {
+      if (active[i]!.maxX >= segment.minX) active[keep++] = active[i]!
+    }
+    active.length = keep
+    for (const other of active) {
+      if (other.edge === segment.edge) continue
+      if (other.maxY < segment.minY || other.minY > segment.maxY) continue
+      // Canonical argument order: the lower edge index's segment first,
+      // matching the oracle's pairScore(paths[i], paths[j]) with i < j.
+      const [lo, hi] = other.edge < segment.edge ? [other, segment] : [segment, other]
+      const [overlap, illegible, crossings] = scoreSegmentPair(lo.a, lo.b, hi.a, hi.b)
+      if (overlap === 0 && illegible === 0 && crossings === 0) continue
+      const key = lo.edge * paths.length + hi.edge
+      const entry = scores.get(key)
+      if (entry === undefined) scores.set(key, [overlap, illegible, crossings])
+      else {
+        entry[0] += overlap
+        entry[1] += illegible
+        entry[2] += crossings
+      }
+    }
+    active.push(segment)
+  }
+  return scores
+}

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1,6 +1,6 @@
 import type { CanvasEdge, EdgeRoutingStyle, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { ResolvedEdgeNode } from '../scene-graph.js'
-import { EDGE_JUMP_RADIUS_PX } from './edge-jumps.js'
+import { buildPairwiseScores, scoreSegmentPair } from './edge-crossing-sweep.js'
 
 type Side = 'top' | 'right' | 'bottom' | 'left'
 type Point = { readonly x: number; readonly y: number }
@@ -628,51 +628,18 @@ function lessCost(a: ConfigCost, b: ConfigCost): boolean {
  * of the cost entirely, governed by the per-edge pair ranking.
  */
 function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
-  const q = (n: number) => Math.round(n * COST_QUANTUM)
+  // Sums the SHARED narrow phase over every segment pair — the same
+  // function the initial sweep calls, so the incremental trial path and
+  // the broad-phase build cannot drift (see edge-crossing-sweep.ts).
   let overlap = 0
   let illegible = 0
   let crossings = 0
-  const clearance = EDGE_JUMP_RADIUS_PX + 1
   for (let ai = 1; ai < a.length; ai++) {
-    const a1 = a[ai - 1]!
-    const a2 = a[ai]!
     for (let bi = 1; bi < b.length; bi++) {
-      const b1 = b[bi - 1]!
-      const b2 = b[bi]!
-      // Collinear axis-aligned overlap.
-      if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
-        const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
-        const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
-        if (hi > lo) overlap += hi - lo
-        continue
-      }
-      if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
-        const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
-        const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
-        if (hi > lo) overlap += hi - lo
-        continue
-      }
-      // Proper transversal crossing.
-      const dax = a2.x - a1.x
-      const day = a2.y - a1.y
-      const dbx = b2.x - b1.x
-      const dby = b2.y - b1.y
-      const denom = dax * dby - day * dbx
-      if (denom === 0) continue
-      const t = ((b1.x - a1.x) * dby - (b1.y - a1.y) * dbx) / denom
-      const u = ((b1.x - a1.x) * day - (b1.y - a1.y) * dax) / denom
-      if (t <= 0 || t >= 1 || u <= 0 || u >= 1) continue
-      crossings++
-      const lenA = Math.hypot(dax, day)
-      const lenB = Math.hypot(dbx, dby)
-      if (
-        t * lenA < clearance ||
-        (1 - t) * lenA < clearance ||
-        u * lenB < clearance ||
-        (1 - u) * lenB < clearance
-      ) {
-        illegible++
-      }
+      const [o, il, c] = scoreSegmentPair(a[ai - 1]!, a[ai]!, b[bi - 1]!, b[bi]!)
+      overlap += o
+      illegible += il
+      crossings += c
     }
   }
   return [overlap, illegible, crossings, 0]
@@ -734,18 +701,25 @@ function addCost(a: ConfigCost, b: ConfigCost, sign: 1 | -1): ConfigCost {
 }
 
 /**
- * Edge-count gate for the improvement pass. Trials evaluate incrementally
- * (only changed-anchor edges re-route; the pairwise matrix is patched),
- * but the initial matrix build is O(E^2) segment pairs and a committed
- * render pays the loop on every edit, so the bound keeps worst-case work
- * small (~24ms at the gate on a dev machine; the live-drag overlay pays
- * it only once per travel step — see the editor's carried-side cache —
- * and skips it on cached frames via a full override map). ponytail: a
- * sweepline pair scan is the
- * next rung if this gate ever needs raising.
+ * Hard edge-count gate for the improvement pass. The initial matrix build
+ * is a sweep-and-prune (edge-crossing-sweep.ts, ~3ms at 200 edges); the
+ * remaining cost is the TRIAL loop, bounded above FULL_OPT_MAX_EDGES by
+ * trying candidates only for the worst-offending edges (pathological
+ * 200-edge canvases: ~150-200ms per committed layout on a dev machine —
+ * paid only while the canvas actually has crossings/overlap, and never on
+ * live-drag cached frames via the editor's carried-side cache). ponytail:
+ * trial-loop incrementalization (persist the matrix across edits instead
+ * of rebuilding per layout) is the next rung if this gate ever needs
+ * raising further.
  */
-const CROSSING_OPT_MAX_EDGES = 40
+const CROSSING_OPT_MAX_EDGES = 200
 const CROSSING_OPT_MAX_PASSES = 2
+/** At or under this many edges, every edge tries candidates (the exact
+ * pre-sweep behavior); above it, only the worst offenders do. */
+const FULL_OPT_MAX_EDGES = 40
+/** How many worst-offender edges try candidates per pass above the full
+ * size — the knob that bounds trial cost at any canvas size. */
+const TRIAL_BUDGET_EDGES = 16
 
 /**
  * Bounded global improvement over per-edge side choices: iterate edges in
@@ -796,12 +770,14 @@ function optimizeSideChoices(
   const selfCosts: ConfigCost[] = paths.map((path, i) => selfScore(path, foreignBodiesFor[i]!))
   let currentCost: ConfigCost = [0, 0, 0, 0]
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
-  for (let i = 0; i < edges.length; i++) {
-    for (let j = i + 1; j < edges.length; j++) {
-      const score = pairScore(paths[i]!, paths[j]!)
-      matrix.set(pairKey(i, j), score)
-      currentCost = addCost(currentCost, score, 1)
-    }
+  // Sweep-and-prune instead of the O(E^2) double loop: identical scores
+  // by construction (same narrow phase, canonical pair order), sparse for
+  // non-interacting pairs — evaluateTrial already zero-defaults absent
+  // keys.
+  for (const [key, [o, il, c]] of buildPairwiseScores(paths)) {
+    const score: ConfigCost = [o, il, c, 0]
+    matrix.set(key, score)
+    currentCost = addCost(currentCost, score, 1)
   }
   // The bend term (index 3) is deliberately ABSENT from the short-circuit:
   // a canvas with no overlap and no crossings is healthy, and reshuffling
@@ -896,9 +872,39 @@ function optimizeSideChoices(
       })
   }
 
+  // Above the full-optimization size, each pass tries candidates only for
+  // the WORST OFFENDERS — the edges contributing the most cost right now —
+  // so trial work stays bounded at any canvas size while the edges that
+  // actually look bad still improve. At or under the full size every edge
+  // iterates in document order, bit-identical to the unbounded loop.
+  const trialEdgesForPass = (): readonly CanvasEdge[] => {
+    if (edges.length <= FULL_OPT_MAX_EDGES) return edges
+    const contribution = (i: number): ConfigCost => {
+      let cost = selfCosts[i]!
+      for (let j = 0; j < edges.length; j++) {
+        if (j === i) continue
+        const [lo, hi] = i < j ? [i, j] : [j, i]
+        const pair = matrix.get(pairKey(lo, hi))
+        if (pair !== undefined) cost = addCost(cost, pair, 1)
+      }
+      return cost
+    }
+    const ranked = edges
+      .map((edge, i) => ({ edge, i, cost: contribution(i) }))
+      // An edge with no overlap, no illegibility, and no crossings has
+      // nothing to repair — reshuffling it to shave bends is churn, the
+      // same judgement the whole-config short-circuit makes.
+      .filter((r) => r.cost[0] > 0 || r.cost[1] > 0 || r.cost[2] > 0)
+      .sort((a, b) => (lessCost(a.cost, b.cost) ? 1 : lessCost(b.cost, a.cost) ? -1 : a.i - b.i))
+      .slice(0, TRIAL_BUDGET_EDGES)
+      // Document order within the budget keeps adoption sequencing stable.
+      .sort((a, b) => a.i - b.i)
+    return ranked.map((r) => r.edge)
+  }
+
   for (let pass = 0; pass < CROSSING_OPT_MAX_PASSES; pass++) {
     let improved = false
-    for (const edge of edges) {
+    for (const edge of trialEdgesForPass()) {
       if (locked?.has(edge.id)) continue
       const chosen = current.get(edge.id)
       if (chosen === undefined) continue


### PR DESCRIPTION
## What (plan slice S3, design gate-approved; implemented inline per the dev-loop's manual-verification handback)

Two pure substitutions; behavior at ≤40 edges is bit-identical to before.

1. **Sweep-and-prune initial matrix** (`edge-crossing-sweep.ts`): the O(E²) double loop building optimizeSideChoices' initial ConfigCost matrix becomes a sweep over routed segments. Deliberately **not Bentley-Ottmann** — its degenerate cases (shared anchor endpoints from lane fan-out, collinear lane corridors scored by quantized *length*, vertical segments) are this workload's normal case. The narrow phase is extracted verbatim into `scoreSegmentPair` and shared with `pairScore`, so the incremental trial path and the broad phase cannot drift. ~3ms at 200 edges.

2. **Bounded worst-offender trials**: measurement showed the *trial loop*, not the build, was 99% of a 1.1s 200-edge layout. Above `FULL_OPT_MAX_EDGES` (40 — the exact old behavior at or below it), each pass tries candidates only for the 16 worst-offending edges that actually carry overlap/illegibility/crossings; zero-problem edges are never reshuffled (the same judgement as the whole-config short-circuit). Hard gate raised 40 → 200; the old cliff (no optimization at all at 41+) becomes a degradation.

## Numbers (dev machine, pathological crossing-heavy grids)

| edges | before | after |
|---|---|---|
| 40 | ~50-70ms | unchanged (same code path) |
| 100 | **no optimization** (cliff) | ~55-65ms |
| 200 | no optimization / would be 1.1-1.5s if enabled | ~150-210ms |

Live 100-edge canvas: initial render 388ms, drag ~63ms/frame (pre-change level — routing dominates; live-drag frames don't run the optimizer thanks to the carried-side cache).

## Tests

- **Differential fast-check property**: sweep == full-pairwise-oracle *exactly*, over router-realistic scenes AND raw grid-jitter polylines dense in collinear/shared-endpoint/**sub-quantum (<0.25px)** cases. Mutation-checked red on dropped bbox slack and on over-eviction; generator density-asserted (a sparse generator that never reaches collinear overlaps fails its own check).
- Gate pins updated: **41 edges now resolves its worst crossing** (red at gate=40), >200 still skips.
- All ~40 existing routing/side-choice pins pass unweakened; canvas-render node+browser (410), web jsdom (1942) green.
- Transparency note: one differential-property failure was observed once during a worker-saturated full-suite run and never reproduced (seed replay ×1000, 5,000-scenario hunt, 3 full-suite reruns). The property runs in CI as the standing net.

## Visual (synthetic 100-edge wraparound grid — crossings largely intrinsic, so the visible diff is modest; the functional gain is pinned by the 41-edge test)

![bigcanvas-100-before.png](https://github.com/user-attachments/assets/4beaf1d9-adb3-4bde-b3c8-63d463d2539d)
![bigcanvas-100-after.png](https://github.com/user-attachments/assets/995fddc2-3fbc-489e-a955-f486eff0e114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ