### PR TITLE
fix(web): mount the AppShell once per App branch so it never shifts between pages

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,10 +1,11 @@
 import { resetTokenStoreForTests } from '@kamiazya/whiteboard-mcp/api-client'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, MemoryRouter, RouterProvider, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App, LazyPageFallback } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
+import { resetShellStatusForTests, setShellDaemonAuthError } from './lib/shell-status-store.js'
 // App reaches every page through React.lazy(), so a page renders only once
 // its dynamic import resolves. The other three pages are vi.mock'd below, so
 // their imports are already trivial; PairConsentPage is the one this file
@@ -149,6 +150,7 @@ const INVALID_CONFIG_STATE: ProviderState = {
 
 describe('silent renewal on a hosted origin', () => {
   beforeEach(() => {
+    resetShellStatusForTests()
     localStorage.clear()
     renewPairingTokenMock.mockClear()
     mockRenewResult = { status: 'none' }
@@ -929,6 +931,52 @@ describe('App URL routing', () => {
     renderAppWithRouter(LOCAL_DAEMON_STATE, '/something/unrelated/entirely')
     expect(await screen.findByRole('button', { name: /back to canvases/i })).toBeTruthy()
     expect(screen.queryByTestId('daemon-index-page')).toBeNull()
+  })
+})
+
+describe('App shell (single instance above the routed pages)', () => {
+  it('browser-local branch renders exactly one shell whose gear navigates with the entry point', async () => {
+    const router = createMemoryRouter(
+      [{ path: '*', element: <App providerState={BROWSER_LOCAL_STATE} /> }],
+      {
+        initialEntries: ['/'],
+      },
+    )
+    render(<RouterProvider router={router} />)
+    await screen.findByTestId('browser-local-index-page')
+    expect(screen.getAllByTestId('shell-settings')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('shell-settings'))
+    expect(router.state.location.pathname).toBe('/settings')
+    expect((router.state.location.state as { from?: string }).from).toBe('/')
+    // The settings branch keeps exactly one shell too — the page brings none
+    // of its own.
+    expect(screen.getAllByTestId('shell-settings')).toHaveLength(1)
+  })
+
+  it('daemon branch renders the shell and a reported auth error lights its attention dot', async () => {
+    Object.defineProperty(navigator, 'storage', {
+      value: { persisted: () => Promise.resolve(true) },
+      configurable: true,
+    })
+    try {
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <App providerState={LOCAL_DAEMON_STATE} />
+        </MemoryRouter>,
+      )
+      await screen.findByTestId('daemon-index-page')
+      expect(screen.getAllByTestId('shell-settings')).toHaveLength(1)
+      await waitFor(() => expect(screen.queryByTestId('settings-nudge')).toBeNull())
+
+      act(() => {
+        setShellDaemonAuthError(true)
+      })
+      expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+    } finally {
+      Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
+    }
   })
 })
 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -955,7 +955,29 @@ describe('App shell (single instance above the routed pages)', () => {
     expect(screen.getAllByTestId('shell-settings')).toHaveLength(1)
   })
 
+  it('the paired-fragment branch renders the shell too — Settings/Home must survive every entry path', async () => {
+    mockDaemonConnectionResult = {
+      status: 'paired',
+      payload: {
+        baseUrl: 'http://127.0.0.1:3099',
+        workspaceId: 'w1',
+        slug: 'main',
+        authMode: 'bootstrap',
+        bootstrapToken: 'tok',
+      },
+    }
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App providerState={BROWSER_LOCAL_STATE} />
+      </MemoryRouter>,
+    )
+    await screen.findByTestId('daemon-canvas-page')
+    expect(screen.getAllByTestId('shell-settings')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy()
+  })
+
   it('daemon branch renders the shell and a reported auth error lights its attention dot', async () => {
+    mockDaemonConnectionResult = { status: 'none' }
     Object.defineProperty(navigator, 'storage', {
       value: { persisted: () => Promise.resolve(true) },
       configurable: true,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -425,37 +425,37 @@ export function App({ providerState }: AppProps) {
         // propagates through Suspense's own error path to the nearest
         // boundary, which must be here to catch it.
         <ErrorBoundary>
-          {/* Pages size to their allotted height (h-full) so app-level rows
-              like the beta banner can never clip them — this bannerless
-              branch supplies the viewport height itself. */}
-          <div className="h-dvh">
-            <Suspense
-              fallback={<LazyPageFallback heightClass="h-dvh" message="Connecting to daemon…" />}
-            >
-              {daemonView.kind === 'index' ? (
-                <DaemonIndexPage
-                  daemonBaseUrl={payload.baseUrl}
-                  token={pairedToken}
-                  initialWorkspaceId={daemonView.workspaceId}
-                  onOpenCanvas={(workspaceId, slug) =>
-                    setDaemonView({ kind: 'canvas', workspaceId, slug })
-                  }
-                />
-              ) : (
-                <DaemonCanvasPage
-                  key={`${daemonView.workspaceId}:${daemonView.slug}`}
-                  daemonBaseUrl={payload.baseUrl}
-                  workspaceId={daemonView.workspaceId}
-                  slug={daemonView.slug}
-                  token={pairedToken}
-                  onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-                  browserLocalStore={browserLocalStore}
-                  onNavigateBack={() =>
-                    setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
-                  }
-                />
-              )}
-            </Suspense>
+          <div className="flex h-dvh flex-col">
+            <AppShell daemon={true} />
+            <div className="min-h-0 flex-1">
+              <Suspense
+                fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
+              >
+                {daemonView.kind === 'index' ? (
+                  <DaemonIndexPage
+                    daemonBaseUrl={payload.baseUrl}
+                    token={pairedToken}
+                    initialWorkspaceId={daemonView.workspaceId}
+                    onOpenCanvas={(workspaceId, slug) =>
+                      setDaemonView({ kind: 'canvas', workspaceId, slug })
+                    }
+                  />
+                ) : (
+                  <DaemonCanvasPage
+                    key={`${daemonView.workspaceId}:${daemonView.slug}`}
+                    daemonBaseUrl={payload.baseUrl}
+                    workspaceId={daemonView.workspaceId}
+                    slug={daemonView.slug}
+                    token={pairedToken}
+                    onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+                    browserLocalStore={browserLocalStore}
+                    onNavigateBack={() =>
+                      setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
+                    }
+                  />
+                )}
+              </Suspense>
+            </div>
           </div>
         </ErrorBoundary>
       )

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { readDaemonTokenOnce } from '@kamiazya/whiteboard-mcp/api-client'
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { AppShell } from './components/AppShell.js'
 
 // Lazy: the not-found page renders on rare, dead-end navigations only —
 // it must not ride the critical-path bundle.
@@ -385,10 +386,13 @@ export function App({ providerState }: AppProps) {
   if (parseSettingsRoute(location.pathname) !== null) {
     return (
       <ErrorBoundary>
-        <div className="h-dvh">
-          <Suspense fallback={<LazyPageFallback heightClass="h-dvh" message="Loading…" />}>
-            <SettingsPage daemon={settingsDaemon} />
-          </Suspense>
+        <div className="flex h-dvh flex-col">
+          <AppShell daemon={settingsDaemon !== undefined} />
+          <div className="min-h-0 flex-1">
+            <Suspense fallback={<LazyPageFallback heightClass="h-full" message="Loading…" />}>
+              <SettingsPage daemon={settingsDaemon} />
+            </Suspense>
+          </div>
         </div>
       </ErrorBoundary>
     )
@@ -509,6 +513,7 @@ export function App({ providerState }: AppProps) {
     return (
       <ErrorBoundary>
         <div className="flex h-dvh flex-col">
+          <AppShell daemon={true} />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Suspense
               fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
@@ -552,6 +557,7 @@ export function App({ providerState }: AppProps) {
   return (
     <ErrorBoundary>
       <div className="flex h-dvh flex-col">
+        <AppShell daemon={false} />
         {grantConnection?.status === 'identity-mismatch' && !grantErrorDismissed && (
           // Fail-closed renewal refusal: a PINNED daemon answered with a
           // wrong or missing identity signature. Either the daemon rotated

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resetInstallPromptForTests } from '@/lib/install-prompt-store'
+import { resetShellStatusForTests, setShellDaemonAuthError } from '@/lib/shell-status-store'
 import { resetSwStatusForTests } from '../pwa/sw-status-store.js'
 import { AppShell } from './AppShell.js'
 
@@ -9,6 +10,7 @@ beforeEach(() => {
   localStorage.clear()
   resetSwStatusForTests()
   resetInstallPromptForTests()
+  resetShellStatusForTests()
 })
 
 afterEach(() => {
@@ -18,7 +20,7 @@ afterEach(() => {
 
 function renderShell(daemonConnected: boolean, at = '/local/c1') {
   const router = createMemoryRouter(
-    [{ path: '*', element: <AppShell daemonConnected={daemonConnected} /> }],
+    [{ path: '*', element: <AppShell daemon={daemonConnected} /> }],
     {
       initialEntries: [at],
     },
@@ -52,6 +54,16 @@ describe('AppShell', () => {
   it('carries the nudge dot while a setup todo remains (no daemon)', () => {
     renderShell(false)
     expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+  })
+
+  it('lights the nudge when the daemon page reports a live auth error', async () => {
+    Object.defineProperty(navigator, 'storage', {
+      value: { persisted: () => Promise.resolve(true) },
+      configurable: true,
+    })
+    setShellDaemonAuthError(true)
+    renderShell(true)
+    expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
   })
 
   it('shows no nudge when everything reachable is complete', async () => {

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,8 +1,10 @@
 import { Settings } from 'lucide-react'
+import { useSyncExternalStore } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSettingsNudge } from '@/hooks/useSettingsNudge'
 import { settingsPath } from '@/lib/app-routes'
+import { getShellDaemonAuthError, subscribeShellStatus } from '@/lib/shell-status-store'
 import HomeMark from '../brand/home-mark.svg?react'
 
 /**
@@ -13,10 +15,14 @@ import HomeMark from '../brand/home-mark.svg?react'
  * mount this shared component instead of owning any brand/settings chrome
  * themselves.
  */
-export function AppShell({ daemonConnected }: { daemonConnected: boolean }) {
+export function AppShell({ daemon }: { daemon: boolean }) {
   const navigate = useNavigate()
   const location = useLocation()
-  const nudge = useSettingsNudge(daemonConnected)
+  // A live auth error (reported by DaemonCanvasPage through the shell-status
+  // store) means the daemon needs the user's action, so it counts as
+  // disconnected for the attention dot.
+  const authError = useSyncExternalStore(subscribeShellStatus, getShellDaemonAuthError)
+  const nudge = useSettingsNudge(daemon && !authError)
 
   return (
     <header className="flex h-10 shrink-0 items-center gap-2 border-b bg-background px-3">

--- a/apps/web/src/lib/shell-status-store.test.ts
+++ b/apps/web/src/lib/shell-status-store.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getShellDaemonAuthError,
+  resetShellStatusForTests,
+  setShellDaemonAuthError,
+  subscribeShellStatus,
+} from './shell-status-store.js'
+
+beforeEach(() => {
+  resetShellStatusForTests()
+})
+
+describe('shell-status-store', () => {
+  it('starts without an auth error', () => {
+    expect(getShellDaemonAuthError()).toBe(false)
+  })
+
+  it('setting the auth error notifies subscribers', () => {
+    const listener = vi.fn()
+    subscribeShellStatus(listener)
+    setShellDaemonAuthError(true)
+    expect(getShellDaemonAuthError()).toBe(true)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('setting the same value does not notify', () => {
+    const listener = vi.fn()
+    subscribeShellStatus(listener)
+    setShellDaemonAuthError(false)
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/shell-status-store.ts
+++ b/apps/web/src/lib/shell-status-store.ts
@@ -1,0 +1,26 @@
+// The AppShell is mounted once per App branch, above the routed pages, so a
+// page that learns something shell-relevant (DaemonCanvasPage's live auth
+// error) cannot pass it as a prop. This module store is that one signal's
+// channel; keep it to shell concerns only.
+let daemonAuthError = false
+const listeners = new Set<() => void>()
+
+export function subscribeShellStatus(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getShellDaemonAuthError(): boolean {
+  return daemonAuthError
+}
+
+export function setShellDaemonAuthError(next: boolean): void {
+  if (next === daemonAuthError) return
+  daemonAuthError = next
+  for (const listener of listeners) listener()
+}
+
+export function resetShellStatusForTests(): void {
+  daemonAuthError = false
+  listeners.clear()
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -577,63 +577,6 @@ describe('BrowserLocalCanvasPage', () => {
     expect(await store.getDefaultCanvasId()).toBe('c2')
   })
 
-  it('the header Settings trigger navigates to /settings', async () => {
-    vi.useRealTimers()
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    // createMemoryRouter (not this file's declarative `render` helper) so
-    // the resulting navigation is observable via router.state.
-    const router = createMemoryRouter(
-      [{ path: '*', element: <BrowserLocalCanvasPage store={store} /> }],
-      {
-        initialEntries: ['/'],
-      },
-    )
-    await act(async () => {
-      rtlRender(<RouterProvider router={router} />)
-    })
-    await screen.findByRole('button', { name: /^Workspace:/i })
-
-    const before = router.state.location.pathname
-    fireEvent.click(screen.getByTestId('shell-settings'))
-    expect(router.state.location.pathname).toBe('/settings')
-    // The entry point rides along so the settings Back button can return
-    // here deterministically instead of popping history.
-    expect((router.state.location.state as { from?: string }).from).toBe(before)
-  })
-
-  it('always lights the settings nudge dot — a browser-local page has no daemon', async () => {
-    vi.useRealTimers()
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    await act(async () => {
-      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
-    })
-    expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
-  })
-
-  it('the header brand mark navigates home', async () => {
-    vi.useRealTimers()
-    const store = new MemoryStore()
-    await store.setDefaultCanvasId('c1')
-    await store.save(snap)
-    const router = createMemoryRouter(
-      [{ path: '*', element: <BrowserLocalCanvasPage store={store} /> }],
-      {
-        initialEntries: ['/local/c1'],
-      },
-    )
-    await act(async () => {
-      rtlRender(<RouterProvider router={router} />)
-    })
-    await screen.findByRole('button', { name: /^Workspace:/i })
-
-    fireEvent.click(screen.getByRole('link', { name: 'Home' }))
-    expect(router.state.location.pathname).toBe('/')
-  })
-
   it('honors an explicit initialCanvasId prop over the store default canvas', async () => {
     // This only proves the page itself respects initialCanvasId — it does NOT
     // cover the URL->initialCanvasId wiring (App.tsx's parseBrowserLocalRoute),

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -3,7 +3,6 @@ import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import { Braces, Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { AppShell } from '../components/AppShell.js'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { CanvasProperties } from '../components/canvas-properties/CanvasProperties.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
@@ -567,7 +566,6 @@ export function BrowserLocalCanvasPage({
             <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
           }
         >
-          <AppShell daemonConnected={false} />
           <WorkspaceTopBar
             statusSlot={
               <ConnectionStatus state="local">

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -1,6 +1,5 @@
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { AppShell } from '../components/AppShell.js'
 import { CanvasListView } from '../components/canvas-list/CanvasListView.js'
 import { DeleteCanvasDialog } from '../components/canvas-list/DeleteCanvasDialog.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
@@ -105,7 +104,6 @@ export function BrowserLocalIndexPage({ store, onOpenCanvas }: BrowserLocalIndex
 
   return (
     <div className="flex h-full flex-col overflow-y-auto p-4">
-      <AppShell daemonConnected={false} />
       <h1 className="sr-only">Canvases</h1>
       {error && (
         <div role="alert" className="mb-2 text-sm text-destructive">

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -16,6 +16,7 @@ import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-d
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
+import { getShellDaemonAuthError } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { DaemonCanvasPage } from './DaemonCanvasPage.js'
 
@@ -591,7 +592,7 @@ describe('DaemonCanvasPage', () => {
     expect(screen.queryByRole('alert')).toBeNull()
   })
 
-  it('lights the settings gear nudge when live sync drops to an auth error', async () => {
+  it('reports a live auth error to the shell-status store (and clears on unmount)', async () => {
     await act(async () => {
       render(
         <DaemonCanvasPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -599,15 +600,16 @@ describe('DaemonCanvasPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    // Connected, nothing else actionable in jsdom: no dot.
-    expect(screen.queryByTestId('settings-nudge')).toBeNull()
+    expect(getShellDaemonAuthError()).toBe(false)
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
-    // The daemon connection now needs the user's action (re-pair lives in
-    // Settings -> Connections), so the gear carries the attention dot.
-    expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+    // The App-mounted shell reads this to light the gear's attention dot.
+    expect(getShellDaemonAuthError()).toBe(true)
+
+    cleanup()
+    expect(getShellDaemonAuthError()).toBe(false)
   })
 
   it('renders the "Sync off" indicator even when no canvas is selected', async () => {
@@ -654,11 +656,6 @@ describe('DaemonCanvasPage', () => {
       expect(screen.getByText('This workspace has no canvases yet.')).toBeTruthy(),
     )
     expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
-    // The AppShell sits above the canvas gate, so Settings and Home stay
-    // reachable on the empty-workspace view — the recovery path when the
-    // canvas-gated chrome is gone.
-    expect(screen.getByTestId('shell-settings')).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy()
   })
 
   it('clears the auth-error banner when switching to a new canvas (new backend identity)', async () => {
@@ -1857,59 +1854,6 @@ describe('DaemonCanvasPage', () => {
       const button = screen.getByRole('button', { name: 'Back to canvas list' })
       fireEvent.click(button)
       expect(onNavigateBack).toHaveBeenCalledTimes(1)
-    })
-
-    it('the header Settings trigger navigates to /settings', async () => {
-      // createMemoryRouter (not this file's declarative `render` helper)
-      // so the resulting navigation is observable via router.state.
-      const router = createMemoryRouter(
-        [
-          {
-            path: '*',
-            element: (
-              <DaemonCanvasPage
-                daemonBaseUrl={DAEMON_BASE_URL}
-                createBackend={makeCreateBackend()}
-              />
-            ),
-          },
-        ],
-        { initialEntries: ['/'] },
-      )
-      await act(async () => {
-        rtlRender(<RouterProvider router={router} />, { container: document.body })
-      })
-      await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-
-      fireEvent.click(screen.getByTestId('shell-settings'))
-      expect(router.state.location.pathname).toBe('/settings')
-      // The entry point rides along so the settings Back button can return
-      // here deterministically instead of popping history.
-      expect((router.state.location.state as { from?: string }).from).toBe('/')
-    })
-
-    it('the header brand mark navigates home', async () => {
-      const router = createMemoryRouter(
-        [
-          {
-            path: '*',
-            element: (
-              <DaemonCanvasPage
-                daemonBaseUrl={DAEMON_BASE_URL}
-                createBackend={makeCreateBackend()}
-              />
-            ),
-          },
-        ],
-        { initialEntries: ['/canvas/ws-1/doc-a'] },
-      )
-      await act(async () => {
-        rtlRender(<RouterProvider router={router} />, { container: document.body })
-      })
-      await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-
-      fireEvent.click(screen.getByRole('link', { name: 'Home' }))
-      expect(router.state.location.pathname).toBe('/')
     })
 
     it('performs exactly one POST /versions on a single Cmd/Ctrl+S keydown', async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -12,7 +12,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
-import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryStore } from '../lib/browser-local-store.js'
 import * as daemonApiClient from '../lib/daemon-api-client.js'

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -4,7 +4,6 @@ import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { selectCanvasTransport } from '@kamiazya/whiteboard-mcp/select-canvas-transport'
 import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { AppShell } from '../components/AppShell.js'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
@@ -31,6 +30,7 @@ import { deriveNewCanvasSlug } from '../lib/derive-new-canvas-slug.js'
 import { daemonFaviconStatus, type FaviconStyle, resolveRectColor } from '../lib/favicon.js'
 import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { setShellDaemonAuthError } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
@@ -144,6 +144,14 @@ export function DaemonCanvasPage({
       : null
 
   const [authError, setAuthError] = useState(false)
+  // Report the live auth error to the App-mounted shell: it means the daemon
+  // needs the user's action (re-pair lives under Settings -> Connections),
+  // so it counts as disconnected for the attention dot; transient reconnects
+  // don't.
+  useEffect(() => {
+    setShellDaemonAuthError(authError)
+    return () => setShellDaemonAuthError(false)
+  }, [authError])
   // Disables the empty-state "Create a canvas" control while a create is in
   // flight. `disabled` is the whole mechanism: an in-handler
   // `if (creating) return` reads the render closure, so it is stale in exactly
@@ -435,11 +443,6 @@ export function DaemonCanvasPage({
       <main className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
         <div className="min-w-0">
           <h1 className="sr-only">Whiteboard (daemon)</h1>
-          {/* An auth error means the daemon needs the user's action (re-pair
-              lives under Settings -> Connections), so it counts as
-              disconnected for the shell's attention dot; transient
-              reconnects don't. */}
-          <AppShell daemonConnected={!authError} />
           {controller.switchError && (
             <div
               role="alert"

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1058,44 +1058,10 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByRole('tab')).toBeNull()
     expect(screen.queryByRole('button', { name: 'Storage' })).toBeNull()
 
-    // The operational surfaces (storage, pairing) now live on their own
-    // route rather than an inline dialog — the gear button navigates.
-    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
-    expect(router.state.location.pathname).toBe('/settings')
-    // Entry point for the settings Back button.
-    expect((router.state.location.state as { from?: string }).from).toBe('/')
-  })
-
-  it('lights the settings nudge dot when persistence is grantable but not granted', async () => {
-    Object.defineProperty(navigator, 'storage', {
-      value: {
-        persisted: () => Promise.resolve(false),
-        persist: () => Promise.resolve(true),
-      },
-      configurable: true,
-    })
-    try {
-      installFetchMock({
-        workspaces: [{ workspaceId: 'ws-a' }],
-        canvasesByWorkspace: {
-          'ws-a': [{ slug: 'alpha', updatedAt: new Date().toISOString() }],
-        },
-      })
-      const router = createMemoryRouter(
-        [
-          {
-            path: '*',
-            element: <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenCanvas={vi.fn()} />,
-          },
-        ],
-        { initialEntries: ['/'] },
-      )
-      rtlRender(<RouterProvider router={router} />)
-      await screen.findByText('alpha')
-      expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
-    } finally {
-      Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
-    }
+    // The operational surfaces (storage, pairing) live on their own route,
+    // reached through the App-mounted shell's gear — the page itself owns no
+    // settings affordance at all (AppShell ownership rule in DESIGN.md).
+    expect(screen.queryByRole('button', { name: 'Settings' })).toBeNull()
   })
 
   it('hides the workspace selector when there is only one workspace (raw id demoted, D3)', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -3,7 +3,6 @@ import { workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { LayoutGrid, ListTree } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { z } from 'zod'
-import { AppShell } from '../components/AppShell.js'
 import { CanvasThumb } from '../components/CanvasThumb.js'
 import { CanvasListView } from '../components/canvas-list/CanvasListView.js'
 import { DeleteCanvasDialog } from '../components/canvas-list/DeleteCanvasDialog.js'
@@ -309,171 +308,168 @@ export function DaemonIndexPage({
 
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
-      <div className="flex h-full flex-col overflow-y-auto">
-        <AppShell daemonConnected={true} />
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
-          <h1 className="sr-only">Canvases</h1>
-          <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
-            {workspaces.length > 1 && (
-              <select
-                aria-label="Workspace"
-                value={selectedWorkspace ?? ''}
-                onChange={(event) => setSelectedWorkspace(event.target.value)}
-                className="rounded-md border bg-background px-2 py-1 text-sm"
-              >
-                {workspaces.map((w) => (
-                  <option key={w} value={w}>
-                    {w}
-                  </option>
-                ))}
-              </select>
-            )}
-            <div className="ml-auto flex items-center gap-1">
-              {/* One canvas surface, two projections: the toggle switches how
+      <div className="flex h-full flex-col overflow-y-auto p-4">
+        <h1 className="sr-only">Canvases</h1>
+        <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
+          {workspaces.length > 1 && (
+            <select
+              aria-label="Workspace"
+              value={selectedWorkspace ?? ''}
+              onChange={(event) => setSelectedWorkspace(event.target.value)}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {workspaces.map((w) => (
+                <option key={w} value={w}>
+                  {w}
+                </option>
+              ))}
+            </select>
+          )}
+          <div className="ml-auto flex items-center gap-1">
+            {/* One canvas surface, two projections: the toggle switches how
                 the SAME list renders (thumbnail grid / alias tree+preview)
                 instead of the former Canvases-vs-Files tab split. */}
-              <div className="flex items-center gap-0.5 rounded-md border p-0.5">
-                <button
-                  type="button"
-                  aria-label="Grid view"
-                  aria-pressed={view === 'grid'}
-                  onClick={() => setView('grid')}
-                  className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
-                >
-                  <LayoutGrid className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  aria-label="Tree view"
-                  aria-pressed={view === 'tree'}
-                  onClick={() => setView('tree')}
-                  className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
-                >
-                  <ListTree className="size-4" />
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {createError && (
-            <div role="alert" className="mb-2 text-sm text-destructive">
-              {createError}
-            </div>
-          )}
-          {duplicateError && (
-            <div role="alert" className="mb-2 text-sm text-destructive">
-              {duplicateError}
-            </div>
-          )}
-
-          {view === 'tree' ? (
-            selectedWorkspace ? (
-              // The wrapper remounts on every grid/tree toggle, so the fade
-              // re-runs and the view switch reads as one continuous surface
-              // changing shape rather than an instant swap.
-              <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
-                <WorkspaceFilesPanel
-                  daemonFetch={daemonFetch}
-                  daemonBaseUrl={daemonBaseUrl}
-                  workspaceId={selectedWorkspace}
-                />
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">No workspace selected.</p>
-            )
-          ) : loadError ? (
-            // A failed list load must not dead-end the page: the POST needs no
-            // rows and success navigates away, so creating remains a recovery
-            // path around the broken list. The transient loading state below
-            // deliberately has no create control — deriving a slug from rows
-            // that are still in flight invites a collision the loaded states
-            // cannot produce.
-            <div className="flex flex-col items-start gap-3">
-              <div role="alert" className="text-sm text-destructive">
-                {loadError}
-              </div>
+            <div className="flex items-center gap-0.5 rounded-md border p-0.5">
               <button
                 type="button"
-                disabled={creating}
-                onClick={() => void handleCreate('spatial')}
-                className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+                aria-label="Grid view"
+                aria-pressed={view === 'grid'}
+                onClick={() => setView('grid')}
+                className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
               >
-                Create a canvas
+                <LayoutGrid className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label="Tree view"
+                aria-pressed={view === 'tree'}
+                onClick={() => setView('tree')}
+                className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+              >
+                <ListTree className="size-4" />
               </button>
             </div>
-          ) : !loaded ? (
-            <div
-              role="status"
-              aria-label="Loading canvases"
-              className="skeleton-appear grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
-            >
-              {[0, 1, 2, 3].map((i) => (
-                <div key={i} className="animate-pulse rounded-lg border p-2">
-                  <div className="aspect-[4/3] rounded-md bg-muted" />
-                  <div className="mt-2 h-4 w-2/3 rounded bg-muted" />
-                </div>
-              ))}
-            </div>
-          ) : (
-            // Mounts when the skeleton unmounts: the fade carries the
-            // skeleton-to-content handoff instead of an instant swap.
+          </div>
+        </div>
+
+        {createError && (
+          <div role="alert" className="mb-2 text-sm text-destructive">
+            {createError}
+          </div>
+        )}
+        {duplicateError && (
+          <div role="alert" className="mb-2 text-sm text-destructive">
+            {duplicateError}
+          </div>
+        )}
+
+        {view === 'tree' ? (
+          selectedWorkspace ? (
+            // The wrapper remounts on every grid/tree toggle, so the fade
+            // re-runs and the view switch reads as one continuous surface
+            // changing shape rather than an instant swap.
             <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
-              <CanvasListView
-                rows={rows.map((row) => ({
-                  slug: row.slug,
-                  displayName: row.displayName,
-                  // The slug is worth a second line only when a display name
-                  // covers the first; unnamed canvases already show it once.
-                  secondary: row.displayName !== row.slug ? row.slug : undefined,
-                  updatedAt: row.updatedAt,
-                  kind: row.kind,
-                }))}
-                onOpen={(slug) => selectedWorkspace && onOpenCanvas(selectedWorkspace, slug)}
-                onCreate={(kind) => void handleCreate(kind)}
-                createDisabled={creating}
-                renderThumb={(row) => (
-                  <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
-                )}
-                renderActions={(row) => (
-                  <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-                    <button
-                      type="button"
-                      aria-label={`Duplicate ${row.displayName}`}
-                      disabled={duplicatingSlug === row.slug}
-                      onClick={(event) => {
-                        // Prevents the click from bubbling to the wrapping open-button.
-                        event.stopPropagation()
-                        void handleDuplicate(row.slug)
-                      }}
-                      className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100"
-                    >
-                      Duplicate
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`Delete ${row.displayName}`}
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        setPendingDelete({ slug: row.slug, displayName: row.displayName })
-                      }}
-                      className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                )}
+              <WorkspaceFilesPanel
+                daemonFetch={daemonFetch}
+                daemonBaseUrl={daemonBaseUrl}
+                workspaceId={selectedWorkspace}
               />
             </div>
-          )}
-          <DeleteCanvasDialog
-            pending={pendingDelete}
-            busy={deleting}
-            error={deleteError}
-            description="This permanently removes the canvas, including its versions and branches. There is no undo."
-            onCancel={closeDeleteDialog}
-            onConfirm={() => void handleConfirmDelete()}
-          />
-        </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No workspace selected.</p>
+          )
+        ) : loadError ? (
+          // A failed list load must not dead-end the page: the POST needs no
+          // rows and success navigates away, so creating remains a recovery
+          // path around the broken list. The transient loading state below
+          // deliberately has no create control — deriving a slug from rows
+          // that are still in flight invites a collision the loaded states
+          // cannot produce.
+          <div className="flex flex-col items-start gap-3">
+            <div role="alert" className="text-sm text-destructive">
+              {loadError}
+            </div>
+            <button
+              type="button"
+              disabled={creating}
+              onClick={() => void handleCreate('spatial')}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+            >
+              Create a canvas
+            </button>
+          </div>
+        ) : !loaded ? (
+          <div
+            role="status"
+            aria-label="Loading canvases"
+            className="skeleton-appear grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+          >
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="animate-pulse rounded-lg border p-2">
+                <div className="aspect-[4/3] rounded-md bg-muted" />
+                <div className="mt-2 h-4 w-2/3 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          // Mounts when the skeleton unmounts: the fade carries the
+          // skeleton-to-content handoff instead of an instant swap.
+          <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
+            <CanvasListView
+              rows={rows.map((row) => ({
+                slug: row.slug,
+                displayName: row.displayName,
+                // The slug is worth a second line only when a display name
+                // covers the first; unnamed canvases already show it once.
+                secondary: row.displayName !== row.slug ? row.slug : undefined,
+                updatedAt: row.updatedAt,
+                kind: row.kind,
+              }))}
+              onOpen={(slug) => selectedWorkspace && onOpenCanvas(selectedWorkspace, slug)}
+              onCreate={(kind) => void handleCreate(kind)}
+              createDisabled={creating}
+              renderThumb={(row) => (
+                <CanvasThumb workspaceId={selectedWorkspace ?? ''} slug={row.slug} size="card" />
+              )}
+              renderActions={(row) => (
+                <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                  <button
+                    type="button"
+                    aria-label={`Duplicate ${row.displayName}`}
+                    disabled={duplicatingSlug === row.slug}
+                    onClick={(event) => {
+                      // Prevents the click from bubbling to the wrapping open-button.
+                      event.stopPropagation()
+                      void handleDuplicate(row.slug)
+                    }}
+                    className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100"
+                  >
+                    Duplicate
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${row.displayName}`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setPendingDelete({ slug: row.slug, displayName: row.displayName })
+                    }}
+                    className="rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium hover:bg-accent"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            />
+          </div>
+        )}
+        <DeleteCanvasDialog
+          pending={pendingDelete}
+          busy={deleting}
+          error={deleteError}
+          description="This permanently removes the canvas, including its versions and branches. There is no undo."
+          onCancel={closeDeleteDialog}
+          onConfirm={() => void handleConfirmDelete()}
+        />
       </div>
     </DaemonApiContext.Provider>
   )

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -23,7 +23,6 @@ import type { FaviconStyle } from '@/lib/favicon'
 import { getInstallState, promptInstall, subscribeInstallState } from '@/lib/install-prompt-store'
 import { ensurePersistentStorage, queryPersistentStorage } from '@/lib/persistent-storage'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
-import { AppShell } from '../components/AppShell.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 
@@ -382,8 +381,7 @@ export function SettingsPage({ daemon }: SettingsPageProps) {
   }
 
   return (
-    <div className="flex h-dvh flex-col overflow-y-auto">
-      <AppShell daemonConnected={daemon !== undefined} />
+    <div className="flex h-full flex-col overflow-y-auto">
       {/* Mobile (<sm): section list at /settings, full-width detail at
           /settings/<section>. */}
       <div className="sm:hidden" data-testid="settings-mobile">


### PR DESCRIPTION
## What

Fix for the shell jitter reported from a real phone: the AppShell (#679) was mounted **per page**, so each page's layout positioned it differently — the landing page wrapped it in its own `p-4` padding — and every route change remounted it. Navigating visibly jumped the header.

- AppShell now renders **once at each App.tsx branch root** (settings / daemon / browser-local / **paired-fragment**), flush at the top; all five pages mount no shell (and are barred from doing so by DESIGN.md's ownership rule)
- DaemonCanvasPage's live auth-error signal, which rode a prop while the page owned the shell, now reaches the App-mounted shell through a tiny `shell-status-store` (page writes on its `authError` effect, clears on unmount, shell subscribes via `useSyncExternalStore`)
- **Measured**: gear bounding box identical — `(x=380, y=5.5)` — across landing, settings, and canvas at a 420px viewport

## Review-gate catch worth noting

The adversarial review caught a **CRITICAL** in my first version: App.tsx's fourth branch (the `#wb=` pairing-fragment / grant-paired entry path) had no shell mount at all — users arriving that way would have lost Settings/Home entirely, and the attention dot would have been silently inert there. Fixed red-first with an App-level pin; every component-returning branch now mounts the shell.

## Verification

- apps/web jsdom: **162 files / 1935 tests green** (App-level pins: single shell instance per branch incl. paired-fragment, gear navigation with `state.from`, store-driven attention dot; page-level pins: store write + unmount clear)
- typecheck clean; live measurement of shell coordinates across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc