### PR TITLE
feat(web): merge the browser-local canvas page's two chrome rows into one

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1377,3 +1377,22 @@ describe('WorkspaceTopBar — workspace picker (RED-first)', () => {
     expect(screen.queryByText('Workspaces')).toBeNull()
   })
 })
+
+describe('WorkspaceTopBar — titleSlot (merged canvas row)', () => {
+  it('renders the page-provided title segment inside the header', () => {
+    render(
+      <WorkspaceTopBar
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z' }]}
+        onToggleFullscreen={() => {}}
+        onNavigateBack={() => {}}
+        onNavigateToCanvas={() => {}}
+        titleSlot={<input aria-label="Merged title" readOnly value="t" />}
+      />,
+      { container: document.body },
+    )
+    const header = screen.getByRole('banner')
+    expect(header.contains(screen.getByLabelText('Merged title'))).toBe(true)
+  })
+})

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -75,6 +75,12 @@ interface Props {
   // connection-state chip mounts here so the one
   // status affordance lives in the header instead of a banner row.
   statusSlot?: ReactNode
+  /**
+   * The merged canvas row's flexible middle (title + properties triggers),
+   * provided by the page — the header is one row, so pages inject their
+   * canvas identity here instead of stacking a second chrome strip.
+   */
+  titleSlot?: ReactNode
   // Pass-through to CanvasDropdown's optional Workspaces section — both
   // omitted (every pre-existing caller) keeps this byte-identical.
   workspaces?: string[]
@@ -106,6 +112,7 @@ export default function WorkspaceTopBar({
   branchRefreshSignal,
   onExport,
   statusSlot,
+  titleSlot,
   workspaces,
   onSwitchWorkspace,
 }: Props) {
@@ -312,6 +319,8 @@ export default function WorkspaceTopBar({
             {exportError}
           </span>
         )}
+
+        {titleSlot}
 
         {/* Branch chip with switch, create, rename, delete, and merge actions.
             This is the top bar's only destructive control (branch delete,

--- a/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
@@ -171,3 +171,21 @@ describe('CanvasProperties as the canvas row', () => {
     expect(screen.getByTestId('row-actions')).toBeTruthy()
   })
 })
+
+describe('CanvasProperties inline variant (merged header row)', () => {
+  it('renders as a row segment without its own chrome, and the disclosure overlays', () => {
+    const { container } = render(
+      <CanvasProperties inline meta={{ type: 'canvas' }} onChange={() => {}} />,
+    )
+    const wrapper = container.firstElementChild as HTMLElement
+    // No own border/背景 chrome — the merged header row provides it.
+    expect(wrapper.className).not.toContain('border-b')
+    expect(wrapper.className).toContain('flex-1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Properties' }))
+    const disclosure = container.querySelector('[id$="-disclosure"]') as HTMLElement
+    expect(disclosure).toBeTruthy()
+    // Overlay below the header instead of growing the row.
+    expect(disclosure.className).toContain('absolute')
+  })
+})

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -5,6 +5,13 @@ import { useId, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 
 export interface CanvasPropertiesProps {
+  /**
+   * Renders as a segment of the merged header row instead of a standalone
+   * chrome strip: no own border/background, and the Type/Tags disclosure
+   * overlays below the header rather than growing the row (which would
+   * push the canvas down mid-edit).
+   */
+  inline?: boolean
   readonly meta: CanvasCoreMeta
   readonly onChange: (next: CanvasCoreMeta) => void
   /** Offered as datalist completions for `type`; the field stays free text. */
@@ -51,6 +58,7 @@ const DEFAULT_TYPE_SUGGESTIONS = ['markdown', 'note', 'issue', 'spec', 'meeting'
  * choose between.
  */
 export function CanvasProperties({
+  inline = false,
   meta,
   onChange,
   typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
@@ -94,8 +102,14 @@ export function CanvasProperties({
   }
 
   return (
-    <div className="border-border bg-background flex flex-col gap-2 border-b px-3 py-2">
-      <div className="flex items-center gap-2">
+    <div
+      className={
+        inline
+          ? 'flex min-w-0 flex-1 items-center gap-2'
+          : 'border-border bg-background flex flex-col gap-2 border-b px-3 py-2'
+      }
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         {status}
         <label className="sr-only" htmlFor={`${suggestionsId}-title`}>
           Title
@@ -109,7 +123,9 @@ export function CanvasProperties({
             if (tidied.title !== meta.title) onChange(tidied)
           }}
           placeholder="Untitled"
-          className="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-base font-medium outline-none"
+          className={`text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent font-medium outline-none ${
+            inline ? 'text-sm' : 'text-base'
+          }`}
         />
         <Tooltip>
           <TooltipTrigger asChild>
@@ -133,8 +149,15 @@ export function CanvasProperties({
       </div>
 
       {open && (
-        <div id={`${suggestionsId}-disclosure`} className="flex flex-col gap-2 pb-1">
-          <div className="flex items-center gap-2">
+        <div
+          id={`${suggestionsId}-disclosure`}
+          className={
+            inline
+              ? 'border-border bg-background absolute left-0 right-0 top-full z-20 flex flex-col gap-2 border-b px-3 py-2 shadow-md'
+              : 'flex flex-col gap-2 pb-1'
+          }
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-2">
             <label
               className="text-muted-foreground w-12 shrink-0 text-xs"
               htmlFor={`${suggestionsId}-type`}
@@ -161,7 +184,7 @@ export function CanvasProperties({
             </datalist>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
             <label
               className="text-muted-foreground w-12 shrink-0 text-xs"
               htmlFor={`${suggestionsId}-tag`}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -163,6 +163,9 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     await userEvent.click(await screen.findByTestId('new-markdown-menu-item'))
 
     const title = await screen.findByRole('textbox', { name: /title/i })
+    // The markdown arm of the merged row: the title lives INSIDE the
+    // workspace header (one chrome row), not a detached strip below it.
+    expect(title.closest('header')).toBeTruthy()
     await userEvent.click(title)
     await userEvent.keyboard('リリース計画')
     await waitFor(() => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -82,7 +82,8 @@ const snap: CanvasSnapshot = {
 // Radix DropdownMenuTrigger opens on pointerDown (not click); the menu
 // mounts asynchronously, and items select on pointerUp.
 async function openCanvasOpsMenu() {
-  const trigger = screen.getByRole('button', { name: 'More actions' })
+  // The kebab now lives in the (lazy) WorkspaceTopBar's merged row.
+  const trigger = await screen.findByRole('button', { name: 'More actions' })
   fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
   return screen.findByRole('menu')
 }
@@ -198,11 +199,10 @@ describe('BrowserLocalCanvasPage', () => {
     await act(async () => {
       render(<BrowserLocalCanvasPage store={store} />)
     })
-    // After act, load is complete and the canvas row is rendered — the
-    // rare operations live behind the kebab.
-    await act(async () => {
-      await openDeleteConfirm()
-    })
+    // The kebab lives in the LAZY WorkspaceTopBar: findByRole inside act()
+    // deadlocks (act holds commits while waitFor polls), so the helper runs
+    // outside act and lets RTL's own act-wrapping handle updates.
+    await openDeleteConfirm()
     expect(screen.getByRole('alertdialog')).toBeTruthy()
     const confirmBtn = screen.getByRole('button', { name: /^delete$/i })
     await act(async () => {
@@ -395,11 +395,16 @@ describe('BrowserLocalCanvasPage', () => {
     // the dot LEFT of the title, the rare operations behind one kebab at
     // the right edge — not in a second header strip of its own.
     const title = screen.getByRole('textbox', { name: /title/i })
-    const row = title.closest('div.border-b') as HTMLElement
+    // The merged row IS the workspace header: identity, state and operations
+    // all live in the one <header> next to the workspace switcher — there is
+    // no second chrome strip.
+    const row = title.closest('header') as HTMLElement
+    expect(row).toBeTruthy()
+    expect(row.contains(screen.getByRole('button', { name: /^Workspace:/i }))).toBe(true)
     const chip = screen.getByTestId('save-status-chip')
     expect(row.contains(chip)).toBe(true)
     expect(chip.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    const kebab = screen.getByRole('button', { name: 'More actions' })
+    const kebab = await screen.findByRole('button', { name: 'More actions' })
     expect(row.contains(kebab)).toBe(true)
     // Duplicate/Delete are menu items, not always-visible buttons.
     expect(screen.queryByRole('button', { name: /^duplicate$/i })).toBeNull()

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -545,6 +545,54 @@ export function BrowserLocalCanvasPage({
     </>
   )
 
+  // The merged header row's flexible middle: canvas identity (title, core
+  // facets, display settings) lives in the SAME row as workspace context —
+  // the second chrome strip is gone. Kind decides the exact segment.
+  const canvasTitleSlot =
+    canvasKind === 'markdown' ? (
+      markdownDoc.body !== null && markdownDoc.coreMeta !== null ? (
+        <CanvasProperties
+          inline
+          key={canvasId ?? 'no-canvas'}
+          status={<SaveStatusChip state={pageState.persistence} />}
+          actions={canvasRowActions}
+          meta={markdownDoc.coreMeta ?? fallbackCoreMeta(canvasKind, canvasName)}
+          onChange={(next) => {
+            markdownDoc.setCoreMeta(next)
+            // title and the canvas name are ONE concept: the facet is the
+            // document's own truth, the snapshot row is the copy the canvas
+            // list reads without loading every document. `renameCanvas`
+            // normalises a cleared title to 'untitled', which is exactly
+            // what an absent facet should list as.
+            if (next.title !== markdownDoc.coreMeta?.title) {
+              void renameCanvas(next.title ?? '').catch(() => {
+                // Surfaced through persistence state; the facet write is
+                // independent and has already landed in the document.
+              })
+            }
+          }}
+        />
+      ) : null
+    ) : (
+      <CanvasProperties
+        inline
+        key={canvasId ?? 'no-canvas'}
+        status={<SaveStatusChip state={pageState.persistence} />}
+        settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}
+        actions={canvasRowActions}
+        meta={coreFacets ?? fallbackCoreMeta(canvasKind, canvasName)}
+        onChange={(next) => {
+          setCoreFacets(next)
+          if (next.title !== coreFacets?.title) {
+            void renameCanvas(next.title ?? '').catch(() => {
+              // Surfaced through persistence state; the facet write is
+              // independent and has already landed in the document.
+            })
+          }
+        }}
+      />
+    )
+
   return (
     // Two-row grid shell (h-dvh makes the page own its viewport height):
     // every header-shaped row stacks inside the auto row, and the editor
@@ -567,6 +615,7 @@ export function BrowserLocalCanvasPage({
           }
         >
           <WorkspaceTopBar
+            titleSlot={canvasTitleSlot}
             statusSlot={
               <ConnectionStatus state="local">
                 <p className="text-muted-foreground">
@@ -624,27 +673,6 @@ export function BrowserLocalCanvasPage({
           markdownDoc.body !== null &&
           markdownDoc.coreMeta !== null && (
             <div className="flex h-full min-h-0 flex-col">
-              <CanvasProperties
-                key={canvasId ?? 'no-canvas'}
-                status={<SaveStatusChip state={pageState.persistence} />}
-                actions={canvasRowActions}
-                meta={markdownDoc.coreMeta ?? fallbackCoreMeta(canvasKind, canvasName)}
-                onChange={(next) => {
-                  markdownDoc.setCoreMeta(next)
-                  // title and the canvas name are ONE concept: the facet is
-                  // the document's own truth, the snapshot row is the copy
-                  // the canvas list reads without loading every document.
-                  // `renameCanvas` normalises a cleared title to 'untitled',
-                  // which is exactly what an absent facet should list as.
-                  if (next.title !== markdownDoc.coreMeta?.title) {
-                    void renameCanvas(next.title ?? '').catch(() => {
-                      // The rename surfaces its own failure through
-                      // persistence state; the facet write is independent
-                      // and has already landed in the document.
-                    })
-                  }
-                }}
-              />
               <div className="min-h-0 flex-1">
                 <MarkdownEditor
                   key={canvasId ?? 'no-canvas'}
@@ -659,25 +687,6 @@ export function BrowserLocalCanvasPage({
           )
         ) : (
           <div className="flex h-full min-h-0 flex-col">
-            {/* Same bar as the markdown branch. A spatial canvas has no body
-                to sit above, so it sits above the viewport instead — the
-                facets belong to the CANVAS, not to either editor. */}
-            <CanvasProperties
-              key={canvasId ?? 'no-canvas'}
-              status={<SaveStatusChip state={pageState.persistence} />}
-              settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}
-              actions={canvasRowActions}
-              meta={coreFacets ?? fallbackCoreMeta(canvasKind, canvasName)}
-              onChange={(next) => {
-                setCoreFacets(next)
-                if (next.title !== coreFacets?.title) {
-                  void renameCanvas(next.title ?? '').catch(() => {
-                    // Surfaced through persistence state; the facet write is
-                    // independent and has already landed in the document.
-                  })
-                }
-              }}
-            />
             <div className="relative min-h-0 flex-1">
               {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
                   gesture and open text editor all describe ONE canvas, and

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -71,7 +71,12 @@ const DaemonDetectedBanner = lazy(() =>
 // weight is needed for the entry chunk of a page whose local mode never
 // exercises those affordances (see App.tsx's equivalent rationale for
 // lazy-loading DaemonCanvasPage).
-const WorkspaceTopBar = lazy(() => import('../components/WorkspaceTopBar.js'))
+// Kick the fetch at page-module evaluation (this module is itself a lazy
+// route chunk, so this is a parallel prefetch, not an entry-chunk cost):
+// the merged row now carries the title field and canvas operations, which
+// used to render eagerly and must not wait for a render-time chunk fetch.
+const workspaceTopBarImport = import('../components/WorkspaceTopBar.js')
+const WorkspaceTopBar = lazy(() => workspaceTopBarImport)
 
 // Fixed height so the lazy WorkspaceTopBar chunk resolving after first paint
 // causes no layout shift.


### PR DESCRIPTION
## What

Slice B2 of the shell redesign: the workspace row and the canvas-identity row (save dot / title / core-facet disclosure / display settings / operations kebab) stacked **two chrome strips** above the canvas. They are now one row.

- **`CanvasProperties` gains an `inline` variant** — no chrome of its own, and the Type/Tags disclosure becomes an absolute overlay below the header instead of growing the row (the editor top stays put while editing facets)
- **`WorkspaceTopBar` gains `titleSlot`** — the page fills it per canvas kind (markdown: no display settings, guarded on doc load; spatial: with `CanvasDisplaySettings`); name-sync semantics copied verbatim
- The daemon canvas page never mounted `CanvasProperties`, so it was already single-row — this touches the browser-local page only
- **Real-data check**: a long Japanese title truncates cleanly; nothing wraps down to a 420px viewport; editor top moves ~130px (three-strips + banner era) → **88px**

## Review-gate findings closed

- The merged row's controls used to render eagerly but now live in the **lazy** WorkspaceTopBar → its chunk fetch is kicked at page-module evaluation (parallel prefetch; this module is itself a route chunk, so zero entry-budget cost)
- The markdown arm had no structural pin → the real-browser markdown test now asserts the title sits inside the workspace `<header>`

## Verification

- apps/web jsdom: **162 files / 1944 tests green** (merged with current main incl. #688); web-browser markdown suite green
- `pnpm build` + `scripts/smoke-bundle-size.mjs`: **gate OK** (learned that lesson on #686)
- typecheck clean; ONE-row page pin strengthened to assert title+chip+kebab share the `<header>` with the workspace switcher

## Visual repro

1280px — one row (workspace ▾ / ✎ / save dot / long title / ⓘ 🎛 ⋮ / connection chip / ⛶):

![merged-row-1280.png](https://github.com/user-attachments/assets/86be06e5-3aa2-4635-9997-540ce4d8c2f1)

420px — no wrap, no horizontal overflow:

![merged-row-420.png](https://github.com/user-attachments/assets/40180e25-ce70-478c-99fb-3aa4db7fb1ff)

Type/Tags disclosure overlays instead of pushing the canvas down:

![merged-row-disclosure.png](https://github.com/user-attachments/assets/9db78ecb-86e1-419b-ad5e-0fe5e77e274c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc