### PR TITLE
fix(web): await the merged row's kebab in the delete-confirm browser suite

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.delete-confirm.browser.test.tsx
@@ -45,7 +45,9 @@ async function renderLoaded(store = new IndexedDBStore()) {
 // Open the canvas row's operations kebab, pick "Delete", and wait
 // for the confirmation dialog to appear.
 async function openDeleteDialog(): Promise<HTMLElement> {
-  const kebab = screen.getByRole('button', { name: 'More actions' })
+  // The kebab lives in the (lazy) WorkspaceTopBar's merged row — a
+  // synchronous lookup races the chunk fetch.
+  const kebab = await screen.findByRole('button', { name: 'More actions' })
   fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
   const item = await screen.findByRole('menuitem', { name: /^delete$/i })
   fireEvent.pointerUp(item)
@@ -135,7 +137,9 @@ describe('BrowserLocalCanvasPage delete confirmation (browser — real IndexedDB
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 5000 })
     // The menu item that opened the dialog is long unmounted — focus must
     // land back on the kebab, not fall to <body>.
-    const kebab = screen.getByRole('button', { name: 'More actions' })
+    // The kebab lives in the (lazy) WorkspaceTopBar's merged row — a
+    // synchronous lookup races the chunk fetch.
+    const kebab = await screen.findByRole('button', { name: 'More actions' })
     await waitFor(() => expect(document.activeElement).toBe(kebab), { timeout: 5000 })
   })
 


### PR DESCRIPTION
## Problem

main's `test-browser` is timing-red: `BrowserLocalCanvasPage.delete-confirm.browser.test.tsx` looks up the More-actions kebab with a synchronous `getByRole`, but #690 moved the kebab into the **lazily-loaded** merged header row — green when the chunk wins the race, red when CI is slow. Peer-session bisect confirmed both call sites unchanged on main.

## Why the fix is arriving twice

This exact change was written during #690's review pass, but the amended commit's push never reached the remote and automerge merged the branch from its earlier head once a lucky rerun went green. Process fix on my side: **verify the remote tip (`git log origin/<branch>`) after every push that follows an amend** — done for this PR (remote tip = 604ccef, verified via ls-remote too).

## Fix

Both kebab lookups become `await screen.findByRole(...)` with a comment naming the race.

## Verification

- `pnpm test --project web-browser`: **94 files / 507 tests green** locally (full suite, not just the file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc