### PR TITLE
test(canvas-render): cover zero-size rects in the rule-framework property domain

### DIFF
--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -19,8 +19,10 @@ import {
 const rectArb: fc.Arbitrary<Rect> = fc.record({
   x: fc.integer({ min: -100, max: 100 }),
   y: fc.integer({ min: -100, max: 100 }),
-  w: fc.integer({ min: 10, max: 120 }),
-  h: fc.integer({ min: 10, max: 120 }),
+  // Zero stays a legal JSON Canvas size (canvas-model pins it): the
+  // framework invariants must hold for collapsed boxes too.
+  w: fc.integer({ min: 0, max: 120 }),
+  h: fc.integer({ min: 0, max: 120 }),
 })
 
 // Dense enough to land on every branch composeSidePairs takes: aligned


### PR DESCRIPTION
## What (fix-forward for CodeRabbit's Minor on #695 — valid)

The framework-invariant generators floored node w/h at 10px, so totality/determinism/order-only were never exercised on zero-width/zero-height boxes — which `canvas-model` explicitly keeps legal ("Zero stays valid: a node collapsed on one axis is a layout concern, not a parse error"). Floors both at 0 with a comment naming the model contract; all 22 rule-framework tests hold on the widened domain.

Replied on the #695 thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ