### PR TITLE
refactor(web): lift SpatialEditor's large inline JSX regions into sibling components

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -1,0 +1,725 @@
+/** Right-click menu: node, edge, and empty-canvas actions. */
+import type {
+  CanvasColor,
+  ClipboardFragment,
+  SpatialCanvas,
+  SpatialNode,
+} from '@kamiazya/whiteboard-canvas-model'
+import type { SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
+import {
+  SPATIAL_DARK_PALETTE,
+  SPATIAL_LIGHT_PALETTE,
+  tidyNodes,
+} from '@kamiazya/whiteboard-canvas-render'
+import {
+  AlignCenterHorizontal,
+  AlignCenterVertical,
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignHorizontalDistributeCenter,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  AlignVerticalDistributeCenter,
+  BringToFront,
+  ChevronDown,
+  ChevronUp,
+  ClipboardPaste,
+  Copy as CopyIcon,
+  ExternalLink,
+  FileBox,
+  Frame,
+  Image as ImageIcon,
+  ImageOff,
+  Link,
+  Lock as LockIcon,
+  LockOpen,
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  PanelTop,
+  Pencil,
+  Scissors,
+  SendToBack,
+  Sparkles,
+  SquareDashed,
+  StickyNote,
+  Tag,
+  Trash2,
+} from 'lucide-react'
+import type { MutableRefObject } from 'react'
+import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { hasClipboardFragment } from '../../lib/clipboard-store.js'
+import type { AlignableBox, BoxMove } from './align.js'
+import { alignBoxes, distributeBoxes } from './align.js'
+import type { FileRefOption } from './CanvasPickerDialog.js'
+import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
+import type { EditorCommand } from './commands.js'
+import { type GestureState, reduceGesture } from './gestures.js'
+import type { Point } from './viewport.js'
+
+/** Open right-click menu: screen position (root-relative) + hit target. */
+export interface ContextMenuTarget {
+  readonly x: number
+  readonly y: number
+  readonly nodeId: string | undefined
+  readonly edgeId: string | undefined
+  readonly point: Point
+}
+
+/**
+ * `point` (canvas space) is present when creation came from the
+ * empty-space context menu: the user already chose WHERE, so the node
+ * lands there instead of the viewport-center free spot.
+ */
+export type LinkDialogState =
+  | { readonly mode: 'create'; readonly point?: Point }
+  | { readonly mode: 'edit'; readonly nodeId: string }
+
+export type CanvasPickerState =
+  | { readonly mode: 'create'; readonly point?: Point }
+  | { readonly mode: 'retarget'; readonly nodeId: string }
+
+export interface CanvasContextMenuProps {
+  readonly contextMenu: ContextMenuTarget
+  readonly setContextMenu: (target: ContextMenuTarget | null) => void
+  readonly canvas: SpatialCanvas
+  readonly canvasRef: MutableRefObject<SpatialCanvas>
+  readonly theme: ResolvedTheme
+  readonly gestureState: GestureState
+  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+  readonly isEdgeLocked: (edgeId: string) => boolean
+  readonly onToggleEdgeLock?: (edgeId: string, locked: boolean) => void
+  readonly edgeLockEnabled: boolean
+  readonly setEdgeLabelEditId: (id: string | null) => void
+  readonly setSelectedEdgeId: (id: string | null) => void
+  readonly setGroupLabelEditId: (id: string | null) => void
+  readonly pasteClipboard: (at?: Point) => boolean
+  readonly createNodeAt: (point: Point) => void
+  readonly createGroupAtViewportCenter: (at?: Point) => void
+  readonly setLinkDialog: (state: LinkDialogState | null) => void
+  readonly fileRefOptions?: readonly FileRefOption[]
+  readonly setCanvasPicker: (state: CanvasPickerState | null) => void
+  readonly onAddImage?: (file: File) => Promise<string | undefined>
+  readonly pendingImagePointRef: MutableRefObject<Point | null>
+  readonly imageInputRef: MutableRefObject<HTMLInputElement | null>
+  readonly pendingBackgroundGroupIdRef: MutableRefObject<string | null>
+  readonly isLocked: (nodeId: string) => boolean
+  readonly lockEnabled: boolean
+  readonly onToggleNodeLock?: (nodeId: string, locked: boolean) => void
+  readonly applyBoxMoves: (moves: readonly BoxMove[]) => boolean
+  readonly selectedAlignableBoxes: () => AlignableBox[]
+  readonly extraIds: ReadonlySet<string>
+  readonly selectedId: string | null
+  readonly groupSelection: (memberIds: readonly string[]) => void
+  readonly isImageFileRef?: (file: string) => boolean
+  readonly onOpenFileRef?: (file: string, subpath?: string) => void
+  readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
+  readonly copySelection: () => ClipboardFragment | null
+  readonly deleteSelectionAsBatch: () => boolean
+  readonly duplicateSelection: () => boolean
+  readonly reorderSelection: (placement: 'forward' | 'backward' | 'front' | 'back') => void
+}
+
+export function CanvasContextMenu({
+  contextMenu,
+  setContextMenu,
+  canvas,
+  canvasRef,
+  theme,
+  gestureState,
+  applyResult,
+  isEdgeLocked,
+  onToggleEdgeLock,
+  edgeLockEnabled,
+  setEdgeLabelEditId,
+  setSelectedEdgeId,
+  setGroupLabelEditId,
+  pasteClipboard,
+  createNodeAt,
+  createGroupAtViewportCenter,
+  setLinkDialog,
+  fileRefOptions,
+  setCanvasPicker,
+  onAddImage,
+  pendingImagePointRef,
+  imageInputRef,
+  pendingBackgroundGroupIdRef,
+  isLocked,
+  lockEnabled,
+  onToggleNodeLock,
+  applyBoxMoves,
+  selectedAlignableBoxes,
+  extraIds,
+  selectedId,
+  groupSelection,
+  isImageFileRef,
+  onOpenFileRef,
+  openLinkNode,
+  copySelection,
+  deleteSelectionAsBatch,
+  duplicateSelection,
+  reorderSelection,
+}: CanvasContextMenuProps) {
+  return (
+    <ContextMenu
+      x={contextMenu.x}
+      y={contextMenu.y}
+      onClose={() => setContextMenu(null)}
+      items={(() => {
+        const node =
+          contextMenu.nodeId === undefined
+            ? undefined
+            : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
+        const edge =
+          contextMenu.edgeId === undefined
+            ? undefined
+            : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
+        // The swatch chips preview the CURRENT mode's preset strokes so
+        // the picker shows what will actually render; the stored value
+        // stays the semantic slot ('1'..'6'), never a resolved hex.
+        const presetSwatches = (theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE)
+          .presets
+        const presetEntries: readonly {
+          readonly key: SpatialPresetKey
+          readonly name: string
+        }[] = [
+          { key: '1', name: 'Red' },
+          { key: '2', name: 'Orange' },
+          { key: '3', name: 'Yellow' },
+          { key: '4', name: 'Green' },
+          { key: '5', name: 'Cyan' },
+          { key: '6', name: 'Purple' },
+        ]
+        const colorRow = (
+          current: CanvasColor | undefined,
+          apply: (color: CanvasColor | undefined) => void,
+        ) => ({
+          kind: 'options' as const,
+          label: 'Color',
+          options: [
+            {
+              label: 'default',
+              ariaLabel: 'Default',
+              icon: <SquareDashed />,
+              selected: current === undefined,
+              onSelect: () => apply(undefined),
+            },
+            ...presetEntries.map((entry) => ({
+              label: entry.key,
+              ariaLabel: entry.name,
+              icon: (
+                // Paint-critical props are inline, not utility classes:
+                // a default-inline span ignores width/height entirely
+                // (it laid out 0x0 live), and the chip must also paint
+                // where the app stylesheet is absent.
+                <span
+                  style={{
+                    display: 'block',
+                    width: 14,
+                    height: 14,
+                    borderRadius: '50%',
+                    backgroundColor: presetSwatches[entry.key].stroke,
+                  }}
+                />
+              ),
+              selected: current === entry.key,
+              onSelect: () => apply(entry.key),
+            })),
+          ],
+          // The JSON Canvas color union is presets OR a 6-digit hex;
+          // the native color input covers the hex half the swatches
+          // cannot.
+          customColor: {
+            value: current !== undefined && current.startsWith('#') ? current : '#808080',
+            ariaLabel: 'Custom color',
+            selected: current !== undefined && current.startsWith('#'),
+            onPick: (hex: string) => apply(hex as CanvasColor),
+          },
+        })
+        if (node === undefined && edge !== undefined) {
+          // A locked edge offers exactly one action. Everything else in
+          // this branch — delete, label, arrowheads, sides, colour —
+          // is a mutation the lock exists to refuse.
+          if (isEdgeLocked(edge.id)) {
+            return [
+              {
+                label: 'Unlock',
+                icon: <LockOpen />,
+                onSelect: () => onToggleEdgeLock?.(edge.id, false),
+              },
+            ]
+          }
+          // Property pickers are inline option rows (one tap per
+          // choice, menu stays open) — a cycling item costs an
+          // open-tap-reopen per step. Sections group the menu:
+          // actions, then properties, then the destructive entry.
+          // Arrow direction reads the JSON Canvas defaults (fromEnd
+          // none, toEnd arrow).
+          const fromEnd = edge.fromEnd ?? 'none'
+          const toEnd = edge.toEnd ?? 'arrow'
+          const arrowStates = [
+            { label: '→', ariaLabel: 'Forward', fromEnd: 'none', toEnd: 'arrow' },
+            { label: '↔', ariaLabel: 'Both', fromEnd: 'arrow', toEnd: 'arrow' },
+            { label: '←', ariaLabel: 'Backward', fromEnd: 'arrow', toEnd: 'none' },
+            { label: '−', ariaLabel: 'None', fromEnd: 'none', toEnd: 'none' },
+          ] as const
+          const applyEdgeCommand = (command: EditorCommand) =>
+            applyResult({ state: { kind: 'idle' }, commands: [command] })
+          // Excel-border-style side pickers: a rectangle with the
+          // pinned side emphasized; dashed = unpinned (auto).
+          const SIDES = [
+            { label: 'auto', ariaLabel: 'Auto', icon: <SquareDashed />, side: undefined },
+            { label: 'top', ariaLabel: 'Top', icon: <PanelTop />, side: 'top' },
+            { label: 'right', ariaLabel: 'Right', icon: <PanelRight />, side: 'right' },
+            { label: 'bottom', ariaLabel: 'Bottom', icon: <PanelBottom />, side: 'bottom' },
+            { label: 'left', ariaLabel: 'Left', icon: <PanelLeft />, side: 'left' },
+          ] as const
+          const sideRow = (endpoint: 'from' | 'to') => {
+            const current = endpoint === 'from' ? edge.fromSide : edge.toSide
+            return {
+              kind: 'options' as const,
+              label: endpoint === 'from' ? 'From side' : 'To side',
+              options: SIDES.map((entry) => ({
+                label: entry.label,
+                icon: entry.icon,
+                ariaLabel: entry.ariaLabel,
+                selected: current === entry.side,
+                onSelect: () =>
+                  applyEdgeCommand({
+                    kind: 'set-edge-side',
+                    id: edge.id,
+                    endpoint,
+                    side: entry.side,
+                  }),
+              })),
+            }
+          }
+          return [
+            {
+              label: 'Edit label',
+              icon: <Tag />,
+              onSelect: () => setEdgeLabelEditId(edge.id),
+            },
+            { kind: 'separator' as const },
+            {
+              kind: 'options' as const,
+              label: 'Arrows',
+              options: arrowStates.map((state) => ({
+                label: state.label,
+                ariaLabel: state.ariaLabel,
+                selected: state.fromEnd === fromEnd && state.toEnd === toEnd,
+                onSelect: () =>
+                  applyEdgeCommand({
+                    kind: 'set-edge-ends',
+                    id: edge.id,
+                    fromEnd: state.fromEnd,
+                    toEnd: state.toEnd,
+                  }),
+              })),
+            },
+            sideRow('from'),
+            sideRow('to'),
+            colorRow(edge.color, (color) =>
+              applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
+            ),
+            ...(edgeLockEnabled
+              ? [
+                  {
+                    label: 'Lock',
+                    icon: <LockIcon />,
+                    onSelect: () => {
+                      onToggleEdgeLock?.(edge.id, true)
+                      setSelectedEdgeId(null)
+                    },
+                  },
+                ]
+              : []),
+            { kind: 'separator' as const },
+            {
+              label: 'Delete',
+              icon: <Trash2 />,
+              danger: true,
+              onSelect: () => {
+                applyResult({
+                  state: { kind: 'idle' },
+                  commands: [{ kind: 'delete-edge', id: edge.id } as const],
+                })
+                setSelectedEdgeId(null)
+              },
+            },
+          ]
+        }
+        if (node === undefined) {
+          // The same creation set as the dock's + menu, anchored at
+          // the click point — "here" is exactly the information the
+          // bottom dock cannot express.
+          const emptyItems: ContextMenuItem[] = [
+            ...(hasClipboardFragment()
+              ? [
+                  {
+                    label: 'Paste here',
+                    icon: <ClipboardPaste />,
+                    onSelect: () => {
+                      pasteClipboard(contextMenu.point)
+                    },
+                  },
+                  { kind: 'separator' } as const,
+                ]
+              : []),
+            {
+              label: 'Add note here',
+              icon: <StickyNote />,
+              onSelect: () => createNodeAt(contextMenu.point),
+            },
+            {
+              label: 'Add link here',
+              icon: <Link />,
+              onSelect: () => setLinkDialog({ mode: 'create', point: contextMenu.point }),
+            },
+            {
+              label: 'Add group here',
+              icon: <Frame />,
+              onSelect: () => createGroupAtViewportCenter(contextMenu.point),
+            },
+          ]
+          if (fileRefOptions !== undefined) {
+            emptyItems.push({
+              label: 'Add canvas here',
+              icon: <FileBox />,
+              onSelect: () => setCanvasPicker({ mode: 'create', point: contextMenu.point }),
+            })
+          }
+          if (onAddImage !== undefined) {
+            emptyItems.push({
+              label: 'Add image here',
+              icon: <ImageIcon />,
+              onSelect: () => {
+                pendingImagePointRef.current = contextMenu.point
+                imageInputRef.current?.click()
+              },
+            })
+          }
+          // Tidy needs a second node to tidy AGAINST — the item appears
+          // only once it can do something, like Align/Distribute above.
+          if (canvas.nodes.length >= 2) {
+            emptyItems.push({ kind: 'separator' })
+            emptyItems.push({
+              label: 'Tidy canvas',
+              icon: <Sparkles />,
+              onSelect: () =>
+                applyBoxMoves(tidyNodes(canvasRef.current.nodes, { locked: isLocked })),
+            })
+          }
+          return emptyItems
+        }
+        const items: ContextMenuItem[] = []
+        if (node.type === 'group') {
+          items.push({
+            label: 'Edit label',
+            icon: <Tag />,
+            onSelect: () => setGroupLabelEditId(node.id),
+          })
+          if (onAddImage !== undefined) {
+            items.push({
+              label: 'Set background image',
+              icon: <ImageIcon />,
+              onSelect: () => {
+                pendingBackgroundGroupIdRef.current = node.id
+                imageInputRef.current?.click()
+              },
+            })
+          }
+          if (node.background !== undefined) {
+            const background = node.background
+            const applyStyle = (backgroundStyle: 'cover' | 'ratio') =>
+              applyResult({
+                state: { kind: 'idle' },
+                commands: [
+                  { kind: 'set-group-background', id: node.id, background, backgroundStyle },
+                ],
+              })
+            items.push({
+              kind: 'options',
+              label: 'Background',
+              options: [
+                {
+                  label: 'Cover',
+                  ariaLabel: 'Cover',
+                  selected: node.backgroundStyle !== 'ratio',
+                  onSelect: () => applyStyle('cover'),
+                },
+                {
+                  label: 'Fit',
+                  ariaLabel: 'Fit',
+                  selected: node.backgroundStyle === 'ratio',
+                  onSelect: () => applyStyle('ratio'),
+                },
+              ],
+            })
+            items.push({
+              label: 'Remove background',
+              icon: <ImageOff />,
+              onSelect: () =>
+                applyResult({
+                  state: { kind: 'idle' },
+                  commands: [{ kind: 'set-group-background', id: node.id }],
+                }),
+            })
+          }
+          items.push({ kind: 'separator' })
+        }
+        // Framing an existing multi-selection is reached from any of
+        // its members — the frame encloses every selected node,
+        // including group frames: nesting is geometric in JSON Canvas,
+        // and containment moves already handle nested frames.
+        if (extraIds.size > 0) {
+          items.push({
+            label: 'Group selection',
+            icon: <Frame />,
+            onSelect: () => groupSelection([node.id, ...extraIds]),
+          })
+          items.push({ kind: 'separator' })
+        }
+        if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
+          if (onOpenFileRef !== undefined) {
+            items.push({
+              label: 'Open canvas',
+              icon: <ExternalLink />,
+              onSelect: () => onOpenFileRef(node.file, node.subpath),
+            })
+          }
+          if (fileRefOptions !== undefined) {
+            items.push({
+              label: 'Change target',
+              icon: <FileBox />,
+              onSelect: () => setCanvasPicker({ mode: 'retarget', nodeId: node.id }),
+            })
+          }
+          if (onOpenFileRef !== undefined || fileRefOptions !== undefined) {
+            items.push({ kind: 'separator' })
+          }
+        }
+        if (node.type === 'link') {
+          items.push({
+            label: 'Open link',
+            icon: <ExternalLink />,
+            onSelect: () => openLinkNode(node),
+          })
+          items.push({
+            label: 'Edit URL',
+            icon: <Pencil />,
+            onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
+          })
+          items.push({ kind: 'separator' })
+        }
+        if (node.type === 'text') {
+          items.push({
+            label: 'Edit text',
+            icon: <Pencil />,
+            onSelect: () => {
+              applyResult(
+                reduceGesture(gestureState, canvas, {
+                  type: 'start-text-edit',
+                  nodeId: node.id,
+                  text: node.text,
+                }),
+              )
+            },
+          })
+          // Same grouping rule as the edge menu: the destructive
+          // entry sits in its own section.
+          items.push({ kind: 'separator' })
+        }
+        // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
+        // right-click already made this node the primary selection,
+        // so the shared handler clones the full multi-selection.
+        // A locked node's menu offers exactly one action: unlock.
+        // Showing Delete/Edit next to a lock the user deliberately
+        // set would make the lock read as decorative.
+        if (isLocked(node.id)) {
+          return [
+            {
+              label: 'Unlock',
+              icon: <LockOpen />,
+              onSelect: () => onToggleNodeLock?.(node.id, false),
+            },
+          ]
+        }
+        items.push({
+          label: 'Copy',
+          icon: <CopyIcon />,
+          onSelect: () => {
+            copySelection()
+          },
+        })
+        items.push({
+          label: 'Cut',
+          icon: <Scissors />,
+          onSelect: () => {
+            // Menu path mirrors the native cut: copy, then remove.
+            if (copySelection() !== null) deleteSelectionAsBatch()
+          },
+        })
+        items.push({
+          label: 'Duplicate',
+          icon: <CopyIcon />,
+          onSelect: () => {
+            duplicateSelection()
+          },
+        })
+        items.push(
+          colorRow(node.color, (color) => {
+            // Recoloring FROM a multi-selection styles the whole
+            // selected AREA: every member, and every edge that runs
+            // between two members — the closest executable reading of
+            // "select a region, recolor it". An edge leaving the
+            // selection keeps its color (only one endpoint is inside),
+            // and a target outside the selection styles itself alone.
+            const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
+            const nodeTargets = members.has(node.id) ? [...members] : [node.id]
+            const edgeTargets =
+              nodeTargets.length > 1
+                ? canvas.edges.filter(
+                    (edge) =>
+                      !isEdgeLocked(edge.id) &&
+                      members.has(edge.fromNode) &&
+                      members.has(edge.toNode),
+                  )
+                : []
+            applyResult({
+              state: { kind: 'idle' },
+              commands: [
+                ...nodeTargets.map((id) => ({ kind: 'set-node-color' as const, id, color })),
+                ...edgeTargets.map((edge) => ({
+                  kind: 'set-edge-color' as const,
+                  id: edge.id,
+                  color,
+                })),
+              ],
+            })
+          }),
+        )
+        // Z-order as one-tap options — the touch path to the [ / ]
+        // keyboard shortcuts (see shortcuts.ts). Not a picker: no
+        // option is ever "selected", each tap applies a move.
+        items.push({
+          kind: 'options',
+          label: 'Order',
+          options: [
+            {
+              label: 'back',
+              ariaLabel: 'Send to back',
+              icon: <SendToBack />,
+              selected: false,
+              onSelect: () => reorderSelection('back'),
+            },
+            {
+              label: 'backward',
+              ariaLabel: 'Send backward',
+              icon: <ChevronDown />,
+              selected: false,
+              onSelect: () => reorderSelection('backward'),
+            },
+            {
+              label: 'forward',
+              ariaLabel: 'Bring forward',
+              icon: <ChevronUp />,
+              selected: false,
+              onSelect: () => reorderSelection('forward'),
+            },
+            {
+              label: 'front',
+              ariaLabel: 'Bring to front',
+              icon: <BringToFront />,
+              selected: false,
+              onSelect: () => reorderSelection('front'),
+            },
+          ],
+        })
+        // Align needs a second box to align TO, and distribute needs a
+        // middle one to place — so each row appears only once its
+        // action means something, rather than sitting there inert.
+        const alignableCount = extraIds.size + 1
+        if (alignableCount >= 2) {
+          items.push({
+            kind: 'options',
+            label: 'Align',
+            options: (
+              [
+                ['left', 'Align left', <AlignStartVertical key="l" />],
+                ['center-x', 'Align centre horizontally', <AlignCenterVertical key="cx" />],
+                ['right', 'Align right', <AlignEndVertical key="r" />],
+                ['top', 'Align top', <AlignStartHorizontal key="t" />],
+                ['center-y', 'Align centre vertically', <AlignCenterHorizontal key="cy" />],
+                ['bottom', 'Align bottom', <AlignEndHorizontal key="b" />],
+              ] as const
+            ).map(([mode, ariaLabel, icon]) => ({
+              label: mode,
+              ariaLabel,
+              icon,
+              selected: false,
+              onSelect: () => applyBoxMoves(alignBoxes(selectedAlignableBoxes(), mode)),
+            })),
+          })
+        }
+        if (alignableCount >= 3) {
+          items.push({
+            kind: 'options',
+            label: 'Distribute',
+            options: (
+              [
+                [
+                  'horizontal',
+                  'Distribute horizontally',
+                  <AlignHorizontalDistributeCenter key="h" />,
+                ],
+                ['vertical', 'Distribute vertically', <AlignVerticalDistributeCenter key="v" />],
+              ] as const
+            ).map(([axis, ariaLabel, icon]) => ({
+              label: axis,
+              ariaLabel,
+              icon,
+              selected: false,
+              onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
+            })),
+          })
+        }
+        if (alignableCount >= 2) {
+          items.push({
+            label: 'Tidy',
+            icon: <Sparkles />,
+            onSelect: () =>
+              applyBoxMoves(
+                tidyNodes(canvasRef.current.nodes, {
+                  scope: new Set([node.id, ...extraIds]),
+                  locked: isLocked,
+                }),
+              ),
+          })
+        }
+        if (lockEnabled) {
+          items.push({
+            label: 'Lock',
+            icon: <LockIcon />,
+            onSelect: () => onToggleNodeLock?.(node.id, true),
+          })
+        }
+        items.push({ kind: 'separator' })
+        items.push({
+          label: 'Delete',
+          icon: <Trash2 />,
+          danger: true,
+          onSelect: () => {
+            applyResult(
+              reduceGesture(gestureState, canvas, {
+                type: 'delete-selection',
+                nodeId: node.id,
+              }),
+            )
+          },
+        })
+        return items
+      })()}
+    />
+  )
+}

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -54,7 +54,7 @@ import { alignBoxes, distributeBoxes } from './align.js'
 import type { FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
-import { type GestureState, reduceGesture } from './gestures.js'
+import { type GestureResult, type GestureState, reduceGesture } from './gestures.js'
 import type { Point } from './viewport.js'
 
 /** Open right-click menu: screen position (root-relative) + hit target. */
@@ -86,7 +86,7 @@ export interface CanvasContextMenuProps {
   readonly canvasRef: MutableRefObject<SpatialCanvas>
   readonly theme: ResolvedTheme
   readonly gestureState: GestureState
-  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+  readonly applyResult: (result: GestureResult) => void
   readonly isEdgeLocked: (edgeId: string) => boolean
   readonly onToggleEdgeLock?: (edgeId: string, locked: boolean) => void
   readonly edgeLockEnabled: boolean

--- a/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
@@ -1,0 +1,105 @@
+/**
+ * In-flight connect gesture: an indicator on the source node plus a
+ * focusable connect-target per other node, reached by Tab then Enter/Space
+ * (matching `reducePointerUpConnecting`'s `targetNodeId` contract).
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { Box } from './geometry.js'
+import { type GestureState, reduceGesture } from './gestures.js'
+
+export interface ConnectOverlayProps {
+  readonly gestureState: Extract<GestureState, { kind: 'connecting' }>
+  readonly canvas: SpatialCanvas
+  readonly boxes: readonly { readonly id: string; readonly box: Box }[]
+  readonly selectableBoxes: readonly { readonly id: string; readonly box: Box }[]
+  readonly createId?: () => string
+  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+}
+
+export function ConnectOverlay({
+  gestureState,
+  canvas,
+  boxes,
+  selectableBoxes,
+  createId,
+  applyResult,
+}: ConnectOverlayProps) {
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        overflow: 'visible',
+        left: 0,
+        top: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      <title>Connection targets</title>
+      {/* Immediate acknowledgment that the connect ARMED: the
+        rubber-band line only appears once the pointer moves, so a
+        still hand needs the source node marked right away. */}
+      {(() => {
+        const source = boxes.find((b) => b.id === gestureState.fromNodeId)
+        if (source === undefined) return null
+        return (
+          <rect
+            data-testid="connect-source-indicator"
+            x={source.box.x - 2}
+            y={source.box.y - 2}
+            width={source.box.width + 4}
+            height={source.box.height + 4}
+            fill="none"
+            stroke="#2563eb"
+            strokeWidth={2}
+            strokeDasharray="6 3"
+          />
+        )
+      })()}
+      {/* Named rather than aria-hidden for the same reason as the
+        selection overlay: this subtree holds the focusable connection
+        targets, so hiding it would remove the keyboard path. */}
+      {/*
+       * Keyboard path for completing a connection: while `connecting`,
+       * every OTHER node gets a focusable target the pointer path
+       * already reaches by hit-testing on pointerup. Tab to one and
+       * press Enter/Space, matching `reducePointerUpConnecting`'s
+       * targetNodeId contract exactly (invalid targets are the
+       * fromNode itself, which is excluded below).
+       */}
+      {selectableBoxes
+        .filter((b) => b.id !== gestureState.fromNodeId)
+        .map((b) => (
+          // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to hit-test at this node's canvas-space box under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+          <rect
+            key={b.id}
+            data-testid={`connect-target-${b.id}`}
+            role="button"
+            tabIndex={0}
+            aria-label={`Connect to node ${b.id}`}
+            x={b.box.x}
+            y={b.box.y}
+            width={b.box.width}
+            height={b.box.height}
+            fill="transparent"
+            style={{ pointerEvents: 'auto', cursor: 'pointer' }}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter' && e.key !== ' ') return
+              e.preventDefault()
+              applyResult(
+                reduceGesture(
+                  gestureState,
+                  canvas,
+                  {
+                    type: 'pointerup',
+                    point: { x: b.box.x, y: b.box.y },
+                    targetNodeId: b.id,
+                  },
+                  { createId },
+                ),
+              )
+            }}
+          />
+        ))}
+    </svg>
+  )
+}

--- a/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
@@ -4,16 +4,16 @@
  * (matching `reducePointerUpConnecting`'s `targetNodeId` contract).
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import type { Box } from './geometry.js'
-import { type GestureState, reduceGesture } from './gestures.js'
+import type { NodeBox } from './geometry.js'
+import { type GestureResult, type GestureState, reduceGesture } from './gestures.js'
 
 export interface ConnectOverlayProps {
   readonly gestureState: Extract<GestureState, { kind: 'connecting' }>
   readonly canvas: SpatialCanvas
-  readonly boxes: readonly { readonly id: string; readonly box: Box }[]
-  readonly selectableBoxes: readonly { readonly id: string; readonly box: Box }[]
+  readonly boxes: readonly NodeBox[]
+  readonly selectableBoxes: readonly NodeBox[]
   readonly createId?: () => string
-  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+  readonly applyResult: (result: GestureResult) => void
 }
 
 export function ConnectOverlay({

--- a/apps/web/src/components/spatial-editor/HandViewControls.tsx
+++ b/apps/web/src/components/spatial-editor/HandViewControls.tsx
@@ -1,0 +1,58 @@
+/** Hand mode's dock leading slot: view-only zoom controls (in/out/reset/fit). */
+import { Focus, ZoomIn, ZoomOut } from 'lucide-react'
+import { DOCK_WIDE_BUTTON_CLASS } from '@/components/ui/dock-button'
+import { TOOL_BUTTON_CLASS } from './ToolPalette.js'
+
+/** Wheel/pinch step multiplier per zoom-in/out button press. */
+const ZOOM_STEP_FACTOR = 1.25
+
+export interface HandViewControlsProps {
+  readonly zoom: number
+  readonly onZoom: (factor: number) => void
+  readonly onZoomToFit: () => void
+}
+
+export function HandViewControls({ zoom, onZoom, onZoomToFit }: HandViewControlsProps) {
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="zoom-out-button"
+        aria-label="Zoom out"
+        onClick={() => onZoom(1 / ZOOM_STEP_FACTOR)}
+        className={TOOL_BUTTON_CLASS}
+      >
+        <ZoomOut aria-hidden="true" className="size-4" />
+      </button>
+      <button
+        type="button"
+        data-testid="zoom-reset-button"
+        aria-label="Reset zoom to 100%"
+        onClick={() => onZoom(1 / zoom)}
+        className={`${DOCK_WIDE_BUTTON_CLASS} text-xs tabular-nums`}
+      >
+        {Math.round(zoom * 100)}%
+      </button>
+      <button
+        type="button"
+        data-testid="zoom-in-button"
+        aria-label="Zoom in"
+        onClick={() => onZoom(ZOOM_STEP_FACTOR)}
+        className={TOOL_BUTTON_CLASS}
+      >
+        <ZoomIn aria-hidden="true" className="size-4" />
+      </button>
+      <button
+        type="button"
+        data-testid="zoom-fit-button"
+        aria-label="Zoom to fit"
+        onClick={() => {
+          onZoomToFit()
+        }}
+        className={TOOL_BUTTON_CLASS}
+      >
+        <Focus aria-hidden="true" className="size-4" />
+      </button>
+    </>
+  )
+}

--- a/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
@@ -1,0 +1,84 @@
+/**
+ * Which nodes are in the selection. The selection overlay outlines the
+ * region the handles act on, which says nothing about membership —
+ * outlining only the extras left the primary looking untouched, so a
+ * Select All over three nodes read as though it had skipped one.
+ */
+import type { Box } from './geometry.js'
+import type { Point } from './viewport.js'
+
+interface RoutedEdgePath {
+  readonly id: string
+  readonly path: readonly Point[]
+}
+
+export interface MemberOutlinesOverlayProps {
+  readonly selectionMembers: readonly { readonly id: string; readonly box: Box }[]
+  readonly edges: readonly {
+    readonly id: string
+    readonly fromNode: string
+    readonly toNode: string
+  }[]
+  readonly edgePaths: readonly RoutedEdgePath[]
+  readonly zoom: number
+}
+
+export function MemberOutlinesOverlay({
+  selectionMembers,
+  edges,
+  edgePaths,
+  zoom,
+}: MemberOutlinesOverlayProps) {
+  return (
+    <svg
+      data-testid="member-outlines"
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        overflow: 'visible',
+        left: 0,
+        top: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      {/* Edges INSIDE the area (both endpoints are members) follow
+        area actions like recolor, so the highlight marks them along
+        with the member boxes — an edge leaving the area does not
+        follow and stays unmarked. */}
+      {(() => {
+        const memberIds = new Set(selectionMembers.map((member) => member.id))
+        return edges
+          .filter((edge) => memberIds.has(edge.fromNode) && memberIds.has(edge.toNode))
+          .flatMap((edge) => {
+            const routed = edgePaths.find((entry) => entry.id === edge.id)
+            return routed === undefined ? [] : [{ id: edge.id, path: routed.path }]
+          })
+          .map(({ id, path }) => (
+            <polyline
+              key={`edge-${id}`}
+              data-edge-id={id}
+              points={path.map((p) => `${p.x},${p.y}`).join(' ')}
+              fill="none"
+              stroke="#2563eb"
+              strokeWidth={2.5 / zoom}
+              strokeLinecap="round"
+              opacity={0.5}
+            />
+          ))
+      })()}
+      {selectionMembers.map(({ id, box }) => (
+        <rect
+          key={id}
+          x={box.x}
+          y={box.y}
+          width={box.width}
+          height={box.height}
+          fill="none"
+          stroke="#2563eb"
+          strokeWidth={1.5 / zoom}
+          opacity={0.7}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
@@ -4,22 +4,17 @@
  * outlining only the extras left the primary looking untouched, so a
  * Select All over three nodes read as though it had skipped one.
  */
-import type { Box } from './geometry.js'
+import type { NodeBox } from './geometry.js'
 import type { Point } from './viewport.js'
 
-interface RoutedEdgePath {
-  readonly id: string
-  readonly path: readonly Point[]
-}
-
 export interface MemberOutlinesOverlayProps {
-  readonly selectionMembers: readonly { readonly id: string; readonly box: Box }[]
+  readonly selectionMembers: readonly NodeBox[]
   readonly edges: readonly {
     readonly id: string
     readonly fromNode: string
     readonly toNode: string
   }[]
-  readonly edgePaths: readonly RoutedEdgePath[]
+  readonly edgePaths: readonly { readonly id: string; readonly path: readonly Point[] }[]
   readonly zoom: number
 }
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -60,7 +60,6 @@
 
 import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type {
-  CanvasColor,
   ClipboardFragment,
   SpatialCanvas,
   SpatialNode,
@@ -83,47 +82,8 @@ import {
   SPATIAL_THEME_FONT_FAMILY,
   SPATIAL_THEME_GEOMETRY,
   sceneBounds,
-  tidyNodes,
 } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
-import {
-  AlignCenterHorizontal,
-  AlignCenterVertical,
-  AlignEndHorizontal,
-  AlignEndVertical,
-  AlignHorizontalDistributeCenter,
-  AlignStartHorizontal,
-  AlignStartVertical,
-  AlignVerticalDistributeCenter,
-  BringToFront,
-  ChevronDown,
-  ChevronUp,
-  ClipboardPaste,
-  Copy as CopyIcon,
-  ExternalLink,
-  FileBox,
-  Focus,
-  Frame,
-  Image as ImageIcon,
-  ImageOff,
-  Link,
-  Lock as LockIcon,
-  LockOpen,
-  PanelBottom,
-  PanelLeft,
-  PanelRight,
-  PanelTop,
-  Pencil,
-  Scissors,
-  SendToBack,
-  Sparkles,
-  SquareDashed,
-  StickyNote,
-  Tag,
-  Trash2,
-  ZoomIn,
-  ZoomOut,
-} from 'lucide-react'
 import {
   forwardRef,
   type ReactNode,
@@ -134,22 +94,22 @@ import {
   useRef,
   useState,
 } from 'react'
-import { DOCK_WIDE_BUTTON_CLASS } from '@/components/ui/dock-button'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import {
   extractClipboardFragment,
   parseClipboardText,
   remintClipboardFragment,
 } from '../../lib/clipboard-fragment.js'
-import {
-  hasClipboardFragment,
-  readClipboardFragment,
-  writeClipboardFragment,
-} from '../../lib/clipboard-store.js'
+import { readClipboardFragment, writeClipboardFragment } from '../../lib/clipboard-store.js'
 import type { AlignableBox, BoxMove } from './align.js'
-import { alignBoxes, distributeBoxes } from './align.js'
+import {
+  CanvasContextMenu,
+  type CanvasPickerState,
+  type ContextMenuTarget,
+  type LinkDialogState,
+} from './CanvasContextMenu.js'
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
-import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
+import { ConnectOverlay } from './ConnectOverlay.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
@@ -177,8 +137,10 @@ import {
 } from './gesture-view.js'
 import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
+import { HandViewControls } from './HandViewControls.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
+import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
@@ -191,7 +153,7 @@ import {
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
-import { type EditorTool, TOOL_BUTTON_CLASS, ToolPalette } from './ToolPalette.js'
+import { type EditorTool, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   canvasToScreen,
@@ -375,9 +337,6 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  */
 const DOUBLE_PRESS_WINDOW_MS = 400
 
-/** One click of the hand-mode zoom buttons scales by this factor. */
-const ZOOM_STEP_FACTOR = 1.25
-
 /** Duplicated copies land offset by this much, cascading on repeat. */
 const DUPLICATE_OFFSET_PX = 16
 
@@ -482,14 +441,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // arms object-first click-A, click-B edge creation. Creation is
     // deliberately NOT a mode — the palette's Add note works in every mode.
     const [tool, setTool] = useState<EditorTool>(defaultTool)
-    /** Open right-click menu: screen position (root-relative) + hit target. */
-    const [contextMenu, setContextMenu] = useState<{
-      x: number
-      y: number
-      nodeId: string | undefined
-      edgeId: string | undefined
-      point: Point
-    } | null>(null)
+    const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null)
     /**
      * Additional selected node ids beyond the reducer's single primary
      * selection. Multi-select lives at the component layer on purpose: the
@@ -691,19 +643,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // The URL dialog serves both palette-create and context-menu-edit; which
     // one decides what its submit does.
     const [groupLabelEditId, setGroupLabelEditId] = useState<string | null>(null)
-    // `point` (canvas space) is present when creation came from the
-    // empty-space context menu: the user already chose WHERE, so the node
-    // lands there instead of the viewport-center free spot.
-    const [linkDialog, setLinkDialog] = useState<
-      | { readonly mode: 'create'; readonly point?: Point }
-      | { readonly mode: 'edit'; readonly nodeId: string }
-      | null
-    >(null)
-    const [canvasPicker, setCanvasPicker] = useState<
-      | { readonly mode: 'create'; readonly point?: Point }
-      | { readonly mode: 'retarget'; readonly nodeId: string }
-      | null
-    >(null)
+    const [linkDialog, setLinkDialog] = useState<LinkDialogState | null>(null)
+    const [canvasPicker, setCanvasPicker] = useState<CanvasPickerState | null>(null)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
     /**
      * Lock only binds when the host wired the seam — an editor mounted
@@ -2846,46 +2787,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           // on in a mode where no press can change the canvas.
           leading={
             tool === 'hand' ? (
-              <>
-                <button
-                  type="button"
-                  data-testid="zoom-out-button"
-                  aria-label="Zoom out"
-                  onClick={() => zoomAtViewportCenter(1 / ZOOM_STEP_FACTOR)}
-                  className={TOOL_BUTTON_CLASS}
-                >
-                  <ZoomOut aria-hidden="true" className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  data-testid="zoom-reset-button"
-                  aria-label="Reset zoom to 100%"
-                  onClick={() => zoomAtViewportCenter(1 / viewport.zoom)}
-                  className={`${DOCK_WIDE_BUTTON_CLASS} text-xs tabular-nums`}
-                >
-                  {Math.round(viewport.zoom * 100)}%
-                </button>
-                <button
-                  type="button"
-                  data-testid="zoom-in-button"
-                  aria-label="Zoom in"
-                  onClick={() => zoomAtViewportCenter(ZOOM_STEP_FACTOR)}
-                  className={TOOL_BUTTON_CLASS}
-                >
-                  <ZoomIn aria-hidden="true" className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  data-testid="zoom-fit-button"
-                  aria-label="Zoom to fit"
-                  onClick={() => {
-                    frameContent()
-                  }}
-                  className={TOOL_BUTTON_CLASS}
-                >
-                  <Focus aria-hidden="true" className="size-4" />
-                </button>
-              </>
+              <HandViewControls
+                zoom={viewport.zoom}
+                onZoom={zoomAtViewportCenter}
+                onZoomToFit={frameContent}
+              />
             ) : (
               paletteLeading
             )
@@ -2964,570 +2870,45 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           />
         )}
         {contextMenu !== null && (
-          <ContextMenu
-            x={contextMenu.x}
-            y={contextMenu.y}
-            onClose={() => setContextMenu(null)}
-            items={(() => {
-              const node =
-                contextMenu.nodeId === undefined
-                  ? undefined
-                  : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
-              const edge =
-                contextMenu.edgeId === undefined
-                  ? undefined
-                  : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
-              // The swatch chips preview the CURRENT mode's preset strokes so
-              // the picker shows what will actually render; the stored value
-              // stays the semantic slot ('1'..'6'), never a resolved hex.
-              const presetSwatches = (
-                theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
-              ).presets
-              const presetEntries: readonly {
-                readonly key: SpatialPresetKey
-                readonly name: string
-              }[] = [
-                { key: '1', name: 'Red' },
-                { key: '2', name: 'Orange' },
-                { key: '3', name: 'Yellow' },
-                { key: '4', name: 'Green' },
-                { key: '5', name: 'Cyan' },
-                { key: '6', name: 'Purple' },
-              ]
-              const colorRow = (
-                current: CanvasColor | undefined,
-                apply: (color: CanvasColor | undefined) => void,
-              ) => ({
-                kind: 'options' as const,
-                label: 'Color',
-                options: [
-                  {
-                    label: 'default',
-                    ariaLabel: 'Default',
-                    icon: <SquareDashed />,
-                    selected: current === undefined,
-                    onSelect: () => apply(undefined),
-                  },
-                  ...presetEntries.map((entry) => ({
-                    label: entry.key,
-                    ariaLabel: entry.name,
-                    icon: (
-                      // Paint-critical props are inline, not utility classes:
-                      // a default-inline span ignores width/height entirely
-                      // (it laid out 0x0 live), and the chip must also paint
-                      // where the app stylesheet is absent.
-                      <span
-                        style={{
-                          display: 'block',
-                          width: 14,
-                          height: 14,
-                          borderRadius: '50%',
-                          backgroundColor: presetSwatches[entry.key].stroke,
-                        }}
-                      />
-                    ),
-                    selected: current === entry.key,
-                    onSelect: () => apply(entry.key),
-                  })),
-                ],
-                // The JSON Canvas color union is presets OR a 6-digit hex;
-                // the native color input covers the hex half the swatches
-                // cannot.
-                customColor: {
-                  value: current !== undefined && current.startsWith('#') ? current : '#808080',
-                  ariaLabel: 'Custom color',
-                  selected: current !== undefined && current.startsWith('#'),
-                  onPick: (hex: string) => apply(hex as CanvasColor),
-                },
-              })
-              if (node === undefined && edge !== undefined) {
-                // A locked edge offers exactly one action. Everything else in
-                // this branch — delete, label, arrowheads, sides, colour —
-                // is a mutation the lock exists to refuse.
-                if (isEdgeLocked(edge.id)) {
-                  return [
-                    {
-                      label: 'Unlock',
-                      icon: <LockOpen />,
-                      onSelect: () => onToggleEdgeLock?.(edge.id, false),
-                    },
-                  ]
-                }
-                // Property pickers are inline option rows (one tap per
-                // choice, menu stays open) — a cycling item costs an
-                // open-tap-reopen per step. Sections group the menu:
-                // actions, then properties, then the destructive entry.
-                // Arrow direction reads the JSON Canvas defaults (fromEnd
-                // none, toEnd arrow).
-                const fromEnd = edge.fromEnd ?? 'none'
-                const toEnd = edge.toEnd ?? 'arrow'
-                const arrowStates = [
-                  { label: '→', ariaLabel: 'Forward', fromEnd: 'none', toEnd: 'arrow' },
-                  { label: '↔', ariaLabel: 'Both', fromEnd: 'arrow', toEnd: 'arrow' },
-                  { label: '←', ariaLabel: 'Backward', fromEnd: 'arrow', toEnd: 'none' },
-                  { label: '−', ariaLabel: 'None', fromEnd: 'none', toEnd: 'none' },
-                ] as const
-                const applyEdgeCommand = (command: EditorCommand) =>
-                  applyResult({ state: { kind: 'idle' }, commands: [command] })
-                // Excel-border-style side pickers: a rectangle with the
-                // pinned side emphasized; dashed = unpinned (auto).
-                const SIDES = [
-                  { label: 'auto', ariaLabel: 'Auto', icon: <SquareDashed />, side: undefined },
-                  { label: 'top', ariaLabel: 'Top', icon: <PanelTop />, side: 'top' },
-                  { label: 'right', ariaLabel: 'Right', icon: <PanelRight />, side: 'right' },
-                  { label: 'bottom', ariaLabel: 'Bottom', icon: <PanelBottom />, side: 'bottom' },
-                  { label: 'left', ariaLabel: 'Left', icon: <PanelLeft />, side: 'left' },
-                ] as const
-                const sideRow = (endpoint: 'from' | 'to') => {
-                  const current = endpoint === 'from' ? edge.fromSide : edge.toSide
-                  return {
-                    kind: 'options' as const,
-                    label: endpoint === 'from' ? 'From side' : 'To side',
-                    options: SIDES.map((entry) => ({
-                      label: entry.label,
-                      icon: entry.icon,
-                      ariaLabel: entry.ariaLabel,
-                      selected: current === entry.side,
-                      onSelect: () =>
-                        applyEdgeCommand({
-                          kind: 'set-edge-side',
-                          id: edge.id,
-                          endpoint,
-                          side: entry.side,
-                        }),
-                    })),
-                  }
-                }
-                return [
-                  {
-                    label: 'Edit label',
-                    icon: <Tag />,
-                    onSelect: () => setEdgeLabelEditId(edge.id),
-                  },
-                  { kind: 'separator' as const },
-                  {
-                    kind: 'options' as const,
-                    label: 'Arrows',
-                    options: arrowStates.map((state) => ({
-                      label: state.label,
-                      ariaLabel: state.ariaLabel,
-                      selected: state.fromEnd === fromEnd && state.toEnd === toEnd,
-                      onSelect: () =>
-                        applyEdgeCommand({
-                          kind: 'set-edge-ends',
-                          id: edge.id,
-                          fromEnd: state.fromEnd,
-                          toEnd: state.toEnd,
-                        }),
-                    })),
-                  },
-                  sideRow('from'),
-                  sideRow('to'),
-                  colorRow(edge.color, (color) =>
-                    applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
-                  ),
-                  ...(edgeLockEnabled
-                    ? [
-                        {
-                          label: 'Lock',
-                          icon: <LockIcon />,
-                          onSelect: () => {
-                            onToggleEdgeLock?.(edge.id, true)
-                            setSelectedEdgeId(null)
-                          },
-                        },
-                      ]
-                    : []),
-                  { kind: 'separator' as const },
-                  {
-                    label: 'Delete',
-                    icon: <Trash2 />,
-                    danger: true,
-                    onSelect: () => {
-                      applyResult({
-                        state: { kind: 'idle' },
-                        commands: [{ kind: 'delete-edge', id: edge.id } as const],
-                      })
-                      setSelectedEdgeId(null)
-                    },
-                  },
-                ]
-              }
-              if (node === undefined) {
-                // The same creation set as the dock's + menu, anchored at
-                // the click point — "here" is exactly the information the
-                // bottom dock cannot express.
-                const emptyItems: ContextMenuItem[] = [
-                  ...(hasClipboardFragment()
-                    ? [
-                        {
-                          label: 'Paste here',
-                          icon: <ClipboardPaste />,
-                          onSelect: () => {
-                            pasteClipboard(contextMenu.point)
-                          },
-                        },
-                        { kind: 'separator' } as const,
-                      ]
-                    : []),
-                  {
-                    label: 'Add note here',
-                    icon: <StickyNote />,
-                    onSelect: () => createNodeAt(contextMenu.point),
-                  },
-                  {
-                    label: 'Add link here',
-                    icon: <Link />,
-                    onSelect: () => setLinkDialog({ mode: 'create', point: contextMenu.point }),
-                  },
-                  {
-                    label: 'Add group here',
-                    icon: <Frame />,
-                    onSelect: () => createGroupAtViewportCenter(contextMenu.point),
-                  },
-                ]
-                if (fileRefOptions !== undefined) {
-                  emptyItems.push({
-                    label: 'Add canvas here',
-                    icon: <FileBox />,
-                    onSelect: () => setCanvasPicker({ mode: 'create', point: contextMenu.point }),
-                  })
-                }
-                if (onAddImage !== undefined) {
-                  emptyItems.push({
-                    label: 'Add image here',
-                    icon: <ImageIcon />,
-                    onSelect: () => {
-                      pendingImagePointRef.current = contextMenu.point
-                      imageInputRef.current?.click()
-                    },
-                  })
-                }
-                // Tidy needs a second node to tidy AGAINST — the item appears
-                // only once it can do something, like Align/Distribute above.
-                if (canvas.nodes.length >= 2) {
-                  emptyItems.push({ kind: 'separator' })
-                  emptyItems.push({
-                    label: 'Tidy canvas',
-                    icon: <Sparkles />,
-                    onSelect: () =>
-                      applyBoxMoves(tidyNodes(canvasRef.current.nodes, { locked: isLocked })),
-                  })
-                }
-                return emptyItems
-              }
-              const items: ContextMenuItem[] = []
-              if (node.type === 'group') {
-                items.push({
-                  label: 'Edit label',
-                  icon: <Tag />,
-                  onSelect: () => setGroupLabelEditId(node.id),
-                })
-                if (onAddImage !== undefined) {
-                  items.push({
-                    label: 'Set background image',
-                    icon: <ImageIcon />,
-                    onSelect: () => {
-                      pendingBackgroundGroupIdRef.current = node.id
-                      imageInputRef.current?.click()
-                    },
-                  })
-                }
-                if (node.background !== undefined) {
-                  const background = node.background
-                  const applyStyle = (backgroundStyle: 'cover' | 'ratio') =>
-                    applyResult({
-                      state: { kind: 'idle' },
-                      commands: [
-                        { kind: 'set-group-background', id: node.id, background, backgroundStyle },
-                      ],
-                    })
-                  items.push({
-                    kind: 'options',
-                    label: 'Background',
-                    options: [
-                      {
-                        label: 'Cover',
-                        ariaLabel: 'Cover',
-                        selected: node.backgroundStyle !== 'ratio',
-                        onSelect: () => applyStyle('cover'),
-                      },
-                      {
-                        label: 'Fit',
-                        ariaLabel: 'Fit',
-                        selected: node.backgroundStyle === 'ratio',
-                        onSelect: () => applyStyle('ratio'),
-                      },
-                    ],
-                  })
-                  items.push({
-                    label: 'Remove background',
-                    icon: <ImageOff />,
-                    onSelect: () =>
-                      applyResult({
-                        state: { kind: 'idle' },
-                        commands: [{ kind: 'set-group-background', id: node.id }],
-                      }),
-                  })
-                }
-                items.push({ kind: 'separator' })
-              }
-              // Framing an existing multi-selection is reached from any of
-              // its members — the frame encloses every selected node,
-              // including group frames: nesting is geometric in JSON Canvas,
-              // and containment moves already handle nested frames.
-              if (extraIds.size > 0) {
-                items.push({
-                  label: 'Group selection',
-                  icon: <Frame />,
-                  onSelect: () => groupSelection([node.id, ...extraIds]),
-                })
-                items.push({ kind: 'separator' })
-              }
-              if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
-                if (onOpenFileRef !== undefined) {
-                  items.push({
-                    label: 'Open canvas',
-                    icon: <ExternalLink />,
-                    onSelect: () => onOpenFileRef(node.file, node.subpath),
-                  })
-                }
-                if (fileRefOptions !== undefined) {
-                  items.push({
-                    label: 'Change target',
-                    icon: <FileBox />,
-                    onSelect: () => setCanvasPicker({ mode: 'retarget', nodeId: node.id }),
-                  })
-                }
-                if (onOpenFileRef !== undefined || fileRefOptions !== undefined) {
-                  items.push({ kind: 'separator' })
-                }
-              }
-              if (node.type === 'link') {
-                items.push({
-                  label: 'Open link',
-                  icon: <ExternalLink />,
-                  onSelect: () => openLinkNode(node),
-                })
-                items.push({
-                  label: 'Edit URL',
-                  icon: <Pencil />,
-                  onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
-                })
-                items.push({ kind: 'separator' })
-              }
-              if (node.type === 'text') {
-                items.push({
-                  label: 'Edit text',
-                  icon: <Pencil />,
-                  onSelect: () => {
-                    applyResult(
-                      reduceGesture(gestureState, canvas, {
-                        type: 'start-text-edit',
-                        nodeId: node.id,
-                        text: node.text,
-                      }),
-                    )
-                  },
-                })
-                // Same grouping rule as the edge menu: the destructive
-                // entry sits in its own section.
-                items.push({ kind: 'separator' })
-              }
-              // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
-              // right-click already made this node the primary selection,
-              // so the shared handler clones the full multi-selection.
-              // A locked node's menu offers exactly one action: unlock.
-              // Showing Delete/Edit next to a lock the user deliberately
-              // set would make the lock read as decorative.
-              if (isLocked(node.id)) {
-                return [
-                  {
-                    label: 'Unlock',
-                    icon: <LockOpen />,
-                    onSelect: () => onToggleNodeLock?.(node.id, false),
-                  },
-                ]
-              }
-              items.push({
-                label: 'Copy',
-                icon: <CopyIcon />,
-                onSelect: () => {
-                  copySelection()
-                },
-              })
-              items.push({
-                label: 'Cut',
-                icon: <Scissors />,
-                onSelect: () => {
-                  // Menu path mirrors the native cut: copy, then remove.
-                  if (copySelection() !== null) deleteSelectionAsBatch()
-                },
-              })
-              items.push({
-                label: 'Duplicate',
-                icon: <CopyIcon />,
-                onSelect: () => {
-                  duplicateSelection()
-                },
-              })
-              items.push(
-                colorRow(node.color, (color) => {
-                  // Recoloring FROM a multi-selection styles the whole
-                  // selected AREA: every member, and every edge that runs
-                  // between two members — the closest executable reading of
-                  // "select a region, recolor it". An edge leaving the
-                  // selection keeps its color (only one endpoint is inside),
-                  // and a target outside the selection styles itself alone.
-                  const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
-                  const nodeTargets = members.has(node.id) ? [...members] : [node.id]
-                  const edgeTargets =
-                    nodeTargets.length > 1
-                      ? canvas.edges.filter(
-                          (edge) =>
-                            !isEdgeLocked(edge.id) &&
-                            members.has(edge.fromNode) &&
-                            members.has(edge.toNode),
-                        )
-                      : []
-                  applyResult({
-                    state: { kind: 'idle' },
-                    commands: [
-                      ...nodeTargets.map((id) => ({ kind: 'set-node-color' as const, id, color })),
-                      ...edgeTargets.map((edge) => ({
-                        kind: 'set-edge-color' as const,
-                        id: edge.id,
-                        color,
-                      })),
-                    ],
-                  })
-                }),
-              )
-              // Z-order as one-tap options — the touch path to the [ / ]
-              // keyboard shortcuts (see shortcuts.ts). Not a picker: no
-              // option is ever "selected", each tap applies a move.
-              items.push({
-                kind: 'options',
-                label: 'Order',
-                options: [
-                  {
-                    label: 'back',
-                    ariaLabel: 'Send to back',
-                    icon: <SendToBack />,
-                    selected: false,
-                    onSelect: () => reorderSelection('back'),
-                  },
-                  {
-                    label: 'backward',
-                    ariaLabel: 'Send backward',
-                    icon: <ChevronDown />,
-                    selected: false,
-                    onSelect: () => reorderSelection('backward'),
-                  },
-                  {
-                    label: 'forward',
-                    ariaLabel: 'Bring forward',
-                    icon: <ChevronUp />,
-                    selected: false,
-                    onSelect: () => reorderSelection('forward'),
-                  },
-                  {
-                    label: 'front',
-                    ariaLabel: 'Bring to front',
-                    icon: <BringToFront />,
-                    selected: false,
-                    onSelect: () => reorderSelection('front'),
-                  },
-                ],
-              })
-              // Align needs a second box to align TO, and distribute needs a
-              // middle one to place — so each row appears only once its
-              // action means something, rather than sitting there inert.
-              const alignableCount = extraIds.size + 1
-              if (alignableCount >= 2) {
-                items.push({
-                  kind: 'options',
-                  label: 'Align',
-                  options: (
-                    [
-                      ['left', 'Align left', <AlignStartVertical key="l" />],
-                      ['center-x', 'Align centre horizontally', <AlignCenterVertical key="cx" />],
-                      ['right', 'Align right', <AlignEndVertical key="r" />],
-                      ['top', 'Align top', <AlignStartHorizontal key="t" />],
-                      ['center-y', 'Align centre vertically', <AlignCenterHorizontal key="cy" />],
-                      ['bottom', 'Align bottom', <AlignEndHorizontal key="b" />],
-                    ] as const
-                  ).map(([mode, ariaLabel, icon]) => ({
-                    label: mode,
-                    ariaLabel,
-                    icon,
-                    selected: false,
-                    onSelect: () => applyBoxMoves(alignBoxes(selectedAlignableBoxes(), mode)),
-                  })),
-                })
-              }
-              if (alignableCount >= 3) {
-                items.push({
-                  kind: 'options',
-                  label: 'Distribute',
-                  options: (
-                    [
-                      [
-                        'horizontal',
-                        'Distribute horizontally',
-                        <AlignHorizontalDistributeCenter key="h" />,
-                      ],
-                      [
-                        'vertical',
-                        'Distribute vertically',
-                        <AlignVerticalDistributeCenter key="v" />,
-                      ],
-                    ] as const
-                  ).map(([axis, ariaLabel, icon]) => ({
-                    label: axis,
-                    ariaLabel,
-                    icon,
-                    selected: false,
-                    onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
-                  })),
-                })
-              }
-              if (alignableCount >= 2) {
-                items.push({
-                  label: 'Tidy',
-                  icon: <Sparkles />,
-                  onSelect: () =>
-                    applyBoxMoves(
-                      tidyNodes(canvasRef.current.nodes, {
-                        scope: new Set([node.id, ...extraIds]),
-                        locked: isLocked,
-                      }),
-                    ),
-                })
-              }
-              if (lockEnabled) {
-                items.push({
-                  label: 'Lock',
-                  icon: <LockIcon />,
-                  onSelect: () => onToggleNodeLock?.(node.id, true),
-                })
-              }
-              items.push({ kind: 'separator' })
-              items.push({
-                label: 'Delete',
-                icon: <Trash2 />,
-                danger: true,
-                onSelect: () => {
-                  applyResult(
-                    reduceGesture(gestureState, canvas, {
-                      type: 'delete-selection',
-                      nodeId: node.id,
-                    }),
-                  )
-                },
-              })
-              return items
-            })()}
+          <CanvasContextMenu
+            contextMenu={contextMenu}
+            setContextMenu={setContextMenu}
+            canvas={canvas}
+            canvasRef={canvasRef}
+            theme={theme}
+            gestureState={gestureState}
+            applyResult={applyResult}
+            isEdgeLocked={isEdgeLocked}
+            onToggleEdgeLock={onToggleEdgeLock}
+            edgeLockEnabled={edgeLockEnabled}
+            setEdgeLabelEditId={setEdgeLabelEditId}
+            setSelectedEdgeId={setSelectedEdgeId}
+            setGroupLabelEditId={setGroupLabelEditId}
+            pasteClipboard={pasteClipboard}
+            createNodeAt={createNodeAt}
+            createGroupAtViewportCenter={createGroupAtViewportCenter}
+            setLinkDialog={setLinkDialog}
+            fileRefOptions={fileRefOptions}
+            setCanvasPicker={setCanvasPicker}
+            onAddImage={onAddImage}
+            pendingImagePointRef={pendingImagePointRef}
+            imageInputRef={imageInputRef}
+            pendingBackgroundGroupIdRef={pendingBackgroundGroupIdRef}
+            isLocked={isLocked}
+            lockEnabled={lockEnabled}
+            onToggleNodeLock={onToggleNodeLock}
+            applyBoxMoves={applyBoxMoves}
+            selectedAlignableBoxes={selectedAlignableBoxes}
+            extraIds={extraIds}
+            selectedId={selectedId}
+            groupSelection={groupSelection}
+            isImageFileRef={isImageFileRef}
+            onOpenFileRef={onOpenFileRef}
+            openLinkNode={openLinkNode}
+            copySelection={copySelection}
+            deleteSelectionAsBatch={deleteSelectionAsBatch}
+            duplicateSelection={duplicateSelection}
+            reorderSelection={reorderSelection}
           />
         )}
         {canvasPicker !== null && fileRefOptions !== undefined && (
@@ -3724,56 +3105,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             both derived from the committed scene) would mark geometry that
             is no longer drawn there. */}
           {isMultiSelection && gestureState.kind !== 'moving' && (
-            <svg
-              data-testid="member-outlines"
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                overflow: 'visible',
-                left: 0,
-                top: 0,
-                pointerEvents: 'none',
-              }}
-            >
-              {/* Edges INSIDE the area (both endpoints are members) follow
-                area actions like recolor, so the highlight marks them along
-                with the member boxes — an edge leaving the area does not
-                follow and stays unmarked. */}
-              {(() => {
-                const memberIds = new Set(selectionMembers.map((member) => member.id))
-                return canvas.edges
-                  .filter((edge) => memberIds.has(edge.fromNode) && memberIds.has(edge.toNode))
-                  .flatMap((edge) => {
-                    const routed = edgePaths.find((entry) => entry.id === edge.id)
-                    return routed === undefined ? [] : [{ id: edge.id, path: routed.path }]
-                  })
-                  .map(({ id, path }) => (
-                    <polyline
-                      key={`edge-${id}`}
-                      data-edge-id={id}
-                      points={path.map((p) => `${p.x},${p.y}`).join(' ')}
-                      fill="none"
-                      stroke="#2563eb"
-                      strokeWidth={2.5 / viewport.zoom}
-                      strokeLinecap="round"
-                      opacity={0.5}
-                    />
-                  ))
-              })()}
-              {selectionMembers.map(({ id, box }) => (
-                <rect
-                  key={id}
-                  x={box.x}
-                  y={box.y}
-                  width={box.width}
-                  height={box.height}
-                  fill="none"
-                  stroke="#2563eb"
-                  strokeWidth={1.5 / viewport.zoom}
-                  opacity={0.7}
-                />
-              ))}
-            </svg>
+            <MemberOutlinesOverlay
+              selectionMembers={selectionMembers}
+              edges={canvas.edges}
+              edgePaths={edgePaths}
+              zoom={viewport.zoom}
+            />
           )}
           {selection !== undefined && selectionBox !== undefined && (
             <SelectionOverlay
@@ -3873,82 +3210,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               )
             })()}
           {gestureState.kind === 'connecting' && (
-            <svg
-              style={{
-                position: 'absolute',
-                overflow: 'visible',
-                left: 0,
-                top: 0,
-                pointerEvents: 'none',
-              }}
-            >
-              <title>Connection targets</title>
-              {/* Immediate acknowledgment that the connect ARMED: the
-                rubber-band line only appears once the pointer moves, so a
-                still hand needs the source node marked right away. */}
-              {(() => {
-                const source = boxes.find((b) => b.id === gestureState.fromNodeId)
-                if (source === undefined) return null
-                return (
-                  <rect
-                    data-testid="connect-source-indicator"
-                    x={source.box.x - 2}
-                    y={source.box.y - 2}
-                    width={source.box.width + 4}
-                    height={source.box.height + 4}
-                    fill="none"
-                    stroke="#2563eb"
-                    strokeWidth={2}
-                    strokeDasharray="6 3"
-                  />
-                )
-              })()}
-              {/* Named rather than aria-hidden for the same reason as the
-                selection overlay: this subtree holds the focusable connection
-                targets, so hiding it would remove the keyboard path. */}
-              {/*
-               * Keyboard path for completing a connection: while `connecting`,
-               * every OTHER node gets a focusable target the pointer path
-               * already reaches by hit-testing on pointerup. Tab to one and
-               * press Enter/Space, matching `reducePointerUpConnecting`'s
-               * targetNodeId contract exactly (invalid targets are the
-               * fromNode itself, which is excluded below).
-               */}
-              {selectableBoxes
-                .filter((b) => b.id !== gestureState.fromNodeId)
-                .map((b) => (
-                  // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to hit-test at this node's canvas-space box under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
-                  <rect
-                    key={b.id}
-                    data-testid={`connect-target-${b.id}`}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Connect to node ${b.id}`}
-                    x={b.box.x}
-                    y={b.box.y}
-                    width={b.box.width}
-                    height={b.box.height}
-                    fill="transparent"
-                    style={{ pointerEvents: 'auto', cursor: 'pointer' }}
-                    onKeyDown={(e) => {
-                      if (e.key !== 'Enter' && e.key !== ' ') return
-                      e.preventDefault()
-                      applyResult(
-                        reduceGesture(
-                          gestureState,
-                          canvas,
-                          {
-                            type: 'pointerup',
-                            point: { x: b.box.x, y: b.box.y },
-                            targetNodeId: b.id,
-                          },
-                          { createId },
-                        ),
-                      )
-                    }}
-                  />
-                ))}
-            </svg>
+            <ConnectOverlay
+              gestureState={gestureState}
+              canvas={canvas}
+              boxes={boxes}
+              selectableBoxes={selectableBoxes}
+              createId={createId}
+              applyResult={applyResult}
+            />
           )}
           {edgeLabelEditId !== null &&
             (() => {


### PR DESCRIPTION
## What

Audit finding (HIGH, maintainability — three independent findings agreed): `SpatialEditor.tsx` was ~4,057 lines with a ~1,350-line inline JSX return, 2.9x the next-largest source file. Track 1 of the audit's two independently-shippable tracks: pure behavior-preserving JSX extraction, following `SelectionOverlay.tsx`'s established props-in/callbacks-out shape.

Four extractions (each exactly the values/closures its region already referenced — no new contracts, no context, no memoization, guards stay parent-side, mutable refs passed as ref objects):

- **CanvasContextMenu.tsx** (~570 moved lines): the right-click menu — node/edge/empty-canvas actions, color pickers, align/distribute/tidy/z-order/lock items
- **ConnectOverlay.tsx**: the in-flight connect gesture's source indicator + keyboard-reachable connect-target rects (Tab → Enter/Space path verbatim)
- **MemberOutlinesOverlay.tsx**: multi-selection member outlines
- **HandViewControls.tsx**: the dock's hand-mode zoom cluster

**Audit-list corrections** (recorded, not silently skipped): resize handles were already extracted (`SelectionOverlay.tsx`); the edge-label/group-label editors are already ~30-line `TextNodeEditor` wrappers — below the substantial bar, deliberately left in place.

Track 2 (closure families → pure modules, which also owns CanvasContextMenu's wide ~28-prop surface) stays a separate filed follow-up.

## Verification

**Zero test files modified** — the ~53 spatial-editor browser test files plus the full apps/web jsdom suites passing UNMODIFIED is the executable proof of behavior preservation (the design treats any needed test edit as evidence of a behavior change). Full `pnpm run test:browser` green; `pnpm -r typecheck` (the compiler transcription-checks the widest prop wiring), `pnpm build`, `pnpm knip`, lint clean; `smoke:bundle-size` verified bundle-neutral rather than assumed (the #688 lesson). Review workflow: zero confirmed findings; QA pass.

No screenshot: zero-visual-change refactor; the unmodified browser suites are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw