### PR TITLE
fix(canvas-codec): escape bare '$' in phrasing so math-adjacent link text round-trips

### DIFF
--- a/packages/canvas-codec/src/markdown/pipeline.test.ts
+++ b/packages/canvas-codec/src/markdown/pipeline.test.ts
@@ -1,7 +1,42 @@
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import { describe, expect, it } from 'vitest'
+import { normalizeMdast } from './normalize.js'
 import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 
 describe('markdown pipeline pinned examples', () => {
+  // fast-check counterexample (seed 1010669059, shrunk 17x) from the
+  // round-trip property: a link with `$` in its url adjacent to `]` in its
+  // text. mdast-util-math registers a toMarkdown `unsafe` pattern for `$`
+  // with an `after: undefined` key; mdast-util-to-markdown's `safe()` reads
+  // that as `'after' in pattern`, so it thinks an "after" constraint is
+  // present, matches it against undefined, and skips escaping the `$` that
+  // sits right before the link text's own escaped `]`. The unescaped `$]`
+  // then re-parses as a shorter link, changing the tree shape.
+  it('round-trips a link whose text ends in "$]" next to a "$"-terminated url', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            {
+              type: 'link',
+              url: 'http://a.aa/$',
+              title: null,
+              children: [{ type: 'text', value: '$]' }],
+            },
+          ],
+        },
+        { type: 'thematicBreak' },
+      ],
+    }
+    const text = stringifyMarkdownBody(root)
+    expect(text).toContain('[\\$\\]]')
+    const reparsed = parseMarkdownBody(text)
+    expect(normalizeMdast(reparsed)).toEqual(normalizeMdast(root))
+  })
+
   it('keeps a ```mermaid fence a code node with lang "mermaid"', () => {
     const root = parseMarkdownBody('```mermaid\ngraph TD;\nA-->B;\n```\n')
     expect(root.children[0]).toMatchObject({ type: 'code', lang: 'mermaid' })

--- a/packages/canvas-codec/src/markdown/pipeline.ts
+++ b/packages/canvas-codec/src/markdown/pipeline.ts
@@ -4,7 +4,6 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
-import type { Plugin } from 'unified'
 import { unified } from 'unified'
 import { fromRemarkRoot } from './from-remark.js'
 import { toRemarkRoot } from './to-remark.js'
@@ -18,22 +17,16 @@ const parser = unified().use(remarkParse).use(remarkGfm).use(remarkMath)
  * treats that as a real "look at what follows" constraint, evaluates it
  * against `undefined`, and the match silently fails — dropping the escape
  * for a `$` that sits next to another escaped character (e.g. link text
- * `$]`). This plugin adds an unconditional `$`-in-phrasing pattern so a
- * bare `$` is always escaped regardless of adjacency. Safe to remove once
- * mdast-util-math drops the stray `after` key upstream.
+ * `$]`). Seeding an unconditional `$`-in-phrasing pattern here keeps a bare
+ * `$` always escaped regardless of adjacency (the remark plugins push into
+ * this same array at freeze). Safe to remove once mdast-util-math drops the
+ * stray `after` key upstream.
  */
-const remarkEscapeDollarInPhrasing: Plugin<[]> = function remarkEscapeDollarInPhrasing() {
-  const data = this.data() as Record<string, unknown>
-  const extensions = (data.toMarkdownExtensions as unknown[] | undefined) ?? []
-  data.toMarkdownExtensions = extensions
-  extensions.push({ unsafe: [{ character: '$', inConstruct: 'phrasing' }] })
-}
-
 const stringifier = unified()
   .use(remarkStringify)
   .use(remarkGfm)
   .use(remarkMath)
-  .use(remarkEscapeDollarInPhrasing)
+  .data('toMarkdownExtensions', [{ unsafe: [{ character: '$', inConstruct: 'phrasing' }] }])
 
 /**
  * Closed syntax set: CommonMark + GFM (tables/strikethrough/task lists) +

--- a/packages/canvas-codec/src/markdown/pipeline.ts
+++ b/packages/canvas-codec/src/markdown/pipeline.ts
@@ -4,12 +4,36 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
+import type { Plugin } from 'unified'
 import { unified } from 'unified'
 import { fromRemarkRoot } from './from-remark.js'
 import { toRemarkRoot } from './to-remark.js'
 
 const parser = unified().use(remarkParse).use(remarkGfm).use(remarkMath)
-const stringifier = unified().use(remarkStringify).use(remarkGfm).use(remarkMath)
+
+/**
+ * mdast-util-math registers a toMarkdown `unsafe` pattern for `$` with an
+ * `after: undefined` key. mdast-util-to-markdown's `safe()` matches patterns
+ * by `'after' in pattern` rather than checking the value is defined, so it
+ * treats that as a real "look at what follows" constraint, evaluates it
+ * against `undefined`, and the match silently fails — dropping the escape
+ * for a `$` that sits next to another escaped character (e.g. link text
+ * `$]`). This plugin adds an unconditional `$`-in-phrasing pattern so a
+ * bare `$` is always escaped regardless of adjacency. Safe to remove once
+ * mdast-util-math drops the stray `after` key upstream.
+ */
+const remarkEscapeDollarInPhrasing: Plugin<[]> = function remarkEscapeDollarInPhrasing() {
+  const data = this.data() as Record<string, unknown>
+  const extensions = (data.toMarkdownExtensions as unknown[] | undefined) ?? []
+  data.toMarkdownExtensions = extensions
+  extensions.push({ unsafe: [{ character: '$', inConstruct: 'phrasing' }] })
+}
+
+const stringifier = unified()
+  .use(remarkStringify)
+  .use(remarkGfm)
+  .use(remarkMath)
+  .use(remarkEscapeDollarInPhrasing)
 
 /**
  * Closed syntax set: CommonMark + GFM (tables/strikethrough/task lists) +


### PR DESCRIPTION
## What

fast-check found a real round-trip counterexample on an unrelated PR's CI (seed 1010669059, shrunk 17x): a heading containing a link with url `http://a.aa/$` and text `$]` did not survive `normalizeMdast(parse(stringify(x)))` — the re-parse split the link.

**Diagnosis: class (a), a genuine stringify bug** (not a normalizer gap, not an inherent CommonMark ambiguity — no generator exclusion, no normalizer change). Root cause: `mdast-util-math`'s unsafe pattern carries an `after: undefined` key, which `mdast-util-to-markdown`'s `safe()` reads as `'after' in pattern` — so a `$` adjacent to another escaped character loses its own escape, and the bare `$` promotes to a math delimiter on re-parse.

Fix (~6 lines in `pipeline.ts`): the stringifier registers one unconditional `{character: '$', inConstruct: 'phrasing'}` toMarkdown unsafe pattern via an inline unified plugin, with a comment naming the upstream mechanism and removal path. Always parse-safe: `$` is CommonMark-escapable punctuation and micromark-extension-math honors the escape. Math handlers bypass `safe()`, so `$x^2$` inline/block emission is unchanged (existing pins stay green).

Per the PBT discipline: the shrunk counterexample is **pinned as an example test first** (red against the unmodified pipeline), the property keeps its unchanged generator and numRuns (no seed pinned), and a local replay with the failing seed+path passes post-fix. Mutation-checked: reverting the pattern turns the pin red.

Follow-up flagged (docs, one word): package-canvas-codec.md says counterexamples are pinned in `normalize.test.ts`; this stringify-side pin correctly lives in `pipeline.test.ts`.

## Gates

canvas-codec-node fully green (property at normal numRuns); full `pnpm test`; typecheck, build, knip, lint clean. `stringifyMarkdownBody` has zero in-repo production callers today (public API + tests), so blast radius is the emission-side escape only. Review workflow: zero confirmed findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw