### PR TITLE
refactor(canvas-render): extract penalty tiers as declared rules (decision #10)

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -305,8 +305,17 @@ paths:
       `composeSidePairs` is the composition `rankedSidePairs`
       (`layout/spatial-edges.ts`) wraps, and `shouldAdoptCandidate` is the
       incumbent-wins-ties predicate `optimizeSideChoices` consults. The
-      PENALTY half (`pairScore`/`selfScore`'s cost-tuple terms, still inline
-      in `spatial-edges.ts`) is a named follow-up, "penalty-rules-extraction".
+      PENALTY half is `PENALTY_RULES`: overlap-and-intrusion (tier 0,
+      collinear overlap plus self-retrace/body-intrusion), illegibility
+      (tier 1), crossings (tier 2), and realized-bends (tier 3, self-only
+      and deliberately last). `pairScore`/`selfScore` (`spatial-edges.ts`)
+      are thin compositions over the list (`pairPenalty`/`selfPenalty`);
+      `ConfigCost`'s slot order/length, the zero tuple, `addCost`, and
+      `lessCost` all derive from the declared tiers rather than a hardcoded
+      4-slot shape, and `hasRepairableProblem` ("any tier below the last
+      declared one is nonzero") is what the whole-config short-circuit and
+      the worst-offender contribution filter both consult in place of the
+      old hardcoded "first three slots" check.
     - **Facet-driven rendering rides the injected-resolver pattern**
       (a future `resolveFileFacets`, same seam class as
       `resolveFileCanvas`/`resolveFileImage`), and export stays a pure

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -309,13 +309,10 @@ paths:
       collinear overlap plus self-retrace/body-intrusion), illegibility
       (tier 1), crossings (tier 2), and realized-bends (tier 3, self-only
       and deliberately last). `pairScore`/`selfScore` (`spatial-edges.ts`)
-      are thin compositions over the list (`pairPenalty`/`selfPenalty`);
-      `ConfigCost`'s slot order/length, the zero tuple, `addCost`, and
-      `lessCost` all derive from the declared tiers rather than a hardcoded
-      4-slot shape, and `hasRepairableProblem` ("any tier below the last
-      declared one is nonzero") is what the whole-config short-circuit and
-      the worst-offender contribution filter both consult in place of the
-      old hardcoded "first three slots" check.
+      compose over the list, and every cost-tuple helper (`ConfigCost`
+      shape, `addCost`, `lessCost`, `hasRepairableProblem`) derives from
+      the declared tiers, so a new penalty rule is one list entry, never
+      a new slot threaded by hand.
     - **Facet-driven rendering rides the injected-resolver pattern**
       (a future `resolveFileFacets`, same seam class as
       `resolveFileCanvas`/`resolveFileImage`), and export stays a pure

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -10,10 +10,15 @@ import { describe, expect } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import {
   composeSidePairs,
+  hasRepairableProblem,
+  PENALTY_RULES,
+  type Point,
   type PreferenceRuleContext,
+  pairPenalty,
   type Rect,
   SIDE_PREFERENCE_RULES,
   type SidePair,
+  selfPenalty,
 } from './edge-rules.js'
 
 const rectArb: fc.Arbitrary<Rect> = fc.record({
@@ -99,6 +104,104 @@ describe('composeSidePairs: preference-rule removal', () => {
         )
         for (const key of without) expect(full.has(key)).toBe(true)
       }
+    },
+  )
+})
+
+// PENALTY-rule framework invariants (edge-rules.ts's PENALTY_RULES): the
+// slot a rule writes into is derived from its declared `tier`, never a
+// hardcoded array position, so the domain below leans on zero-size rects
+// and degenerate paths per the canvas-model contract (zero is a legal
+// JSON Canvas node size) rather than well-formed routed geometry.
+const pointArb: fc.Arbitrary<Point> = fc.record({
+  x: fc.integer({ min: -200, max: 200 }),
+  y: fc.integer({ min: -200, max: 200 }),
+})
+
+const pathArb: fc.Arbitrary<readonly Point[]> = fc.array(pointArb, { minLength: 0, maxLength: 6 })
+
+const foreignRectArb: fc.Arbitrary<Rect> = fc.record({
+  x: fc.integer({ min: -200, max: 200 }),
+  y: fc.integer({ min: -200, max: 200 }),
+  // Zero-size rects are legal (canvas-model): a degenerate foreign body
+  // must never make a scorer throw or return a non-finite total.
+  w: fc.integer({ min: 0, max: 200 }),
+  h: fc.integer({ min: 0, max: 200 }),
+})
+
+const foreignBodiesArb: fc.Arbitrary<readonly Rect[]> = fc.array(foreignRectArb, {
+  minLength: 0,
+  maxLength: 4,
+})
+
+const tripleArb: fc.Arbitrary<readonly [number, number, number]> = fc.tuple(
+  fc.integer({ min: 0, max: 1000 }),
+  fc.integer({ min: 0, max: 1000 }),
+  fc.integer({ min: 0, max: 1000 }),
+)
+
+describe('PENALTY_RULES: each rule writes only its declared tier slot', () => {
+  fcTest.prop([tripleArb], withDefaults())(
+    'pairPenalty places every rule contribution at rule.tier, for any narrow-phase triple',
+    (triple) => {
+      const cost = pairPenalty(triple)
+      for (const rule of PENALTY_RULES) expect(cost[rule.tier]).toBe(rule.pairTerm(triple))
+    },
+  )
+
+  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
+    'selfPenalty places every rule contribution at rule.tier, for any path/foreign-body pair',
+    (path, foreignBodies) => {
+      const cost = selfPenalty(path, foreignBodies)
+      for (const rule of PENALTY_RULES) {
+        expect(cost[rule.tier]).toBe(rule.selfTerm(path, foreignBodies))
+      }
+    },
+  )
+})
+
+describe('PENALTY_RULES: scorers are deterministic', () => {
+  fcTest.prop([tripleArb], withDefaults())('pairPenalty is pure', (triple) => {
+    expect(pairPenalty(triple)).toEqual(pairPenalty(triple))
+  })
+
+  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
+    'selfPenalty is pure',
+    (path, foreignBodies) => {
+      expect(selfPenalty(path, foreignBodies)).toEqual(selfPenalty(path, foreignBodies))
+    },
+  )
+})
+
+describe('PENALTY_RULES: totals are finite non-negative integers', () => {
+  fcTest.prop([tripleArb], withDefaults())(
+    'pairPenalty totality, incl. degenerate triples',
+    (triple) => {
+      for (const n of pairPenalty(triple)) {
+        expect(Number.isInteger(n)).toBe(true)
+        expect(n).toBeGreaterThanOrEqual(0)
+      }
+    },
+  )
+
+  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
+    'selfPenalty totality, incl. zero-size rects, empty/single-point/zero-length paths',
+    (path, foreignBodies) => {
+      for (const n of selfPenalty(path, foreignBodies)) {
+        expect(Number.isInteger(n)).toBe(true)
+        expect(n).toBeGreaterThanOrEqual(0)
+      }
+    },
+  )
+})
+
+describe('hasRepairableProblem: derived from every tier below the last declared one', () => {
+  fcTest.prop([tripleArb], withDefaults())(
+    'agrees with a direct check of the non-final tiers, for any pairPenalty output',
+    (triple) => {
+      const cost = pairPenalty(triple)
+      const expected = cost.slice(0, -1).some((n) => n !== 0)
+      expect(hasRepairableProblem(cost)).toBe(expected)
     },
   )
 })

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest'
+import { scoreSegmentPair } from './edge-crossing-sweep.js'
 import {
+  COST_QUANTUM,
   dominantAxisOrder,
+  hasRepairableProblem,
+  PENALTY_RULES,
   type PreferenceRule,
+  pairPenalty,
   type Rect,
   SIDE_PREFERENCE_RULES,
+  selfPenalty,
   shouldAdoptCandidate,
   ZERO_LANE_MIN_OVERLAP_PX,
+  zeroPenalty,
 } from './edge-rules.js'
 
 function candidateRule(name: string): Extract<PreferenceRule, { kind: 'candidates' }> {
@@ -176,5 +183,173 @@ describe('SIDE_PREFERENCE_RULES', () => {
       'gap-valid-opposing-before-invalid',
       'incumbent-wins-ties',
     ])
+  })
+})
+
+describe('PENALTY_RULES', () => {
+  it('declares the four named tiers in tier order, realized-bends last', () => {
+    expect(PENALTY_RULES.map((r) => r.name)).toEqual([
+      'overlap-and-intrusion',
+      'illegibility',
+      'crossings',
+      'realized-bends',
+    ])
+    PENALTY_RULES.forEach((rule, i) => {
+      expect(rule.tier).toBe(i)
+    })
+    expect(PENALTY_RULES[PENALTY_RULES.length - 1]?.name).toBe('realized-bends')
+  })
+})
+
+describe('overlap-and-intrusion', () => {
+  it('pair term: collinear horizontal segments with 10px x-overlap contribute 10*COST_QUANTUM to tier 0', () => {
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+      { x: 10, y: 0 },
+      { x: 30, y: 0 },
+    )
+    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0])
+  })
+
+  it('self term: a path retracing its own ink contributes the quantized retrace length to tier 0', () => {
+    // Out to (20,0), back to (5,0): the [20,0]-[5,0] segment retraces
+    // [0,0]-[20,0] over x in [5,20], a 15px overlap.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+      { x: 5, y: 0 },
+    ]
+    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 1])
+  })
+
+  it('self term: a segment through a foreign rect interior contributes the quantized chord length to tier 0', () => {
+    const path = [
+      { x: -10, y: 50 },
+      { x: 110, y: 50 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0])
+  })
+
+  it('self term: a segment riding exactly on the rect boundary contributes 0 (grazing exclusion)', () => {
+    const path = [
+      { x: -10, y: 0 },
+      { x: 110, y: 0 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual(zeroPenalty())
+  })
+})
+
+describe('illegibility', () => {
+  it('pair term: a transversal crossing near a segment end contributes 1 to tier 1 (and to tier 2, as a crossing), 0 to tier 0', () => {
+    // a: (0,0)-(10,10); b: (1,9)-(9,1) crosses near a's start.
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+      { x: 1, y: 9 },
+      { x: 9, y: 1 },
+    )
+    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0])
+  })
+
+  it('pair term: a transversal crossing far from every end contributes 0 to tier 1', () => {
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+      { x: 100, y: 0 },
+    )
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0])
+  })
+})
+
+describe('crossings', () => {
+  it('pair term: one clean X-crossing contributes 1 to tier 2', () => {
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+      { x: 100, y: 0 },
+    )
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0])
+  })
+
+  it('collinear overlap short-circuits the crossing count for that segment pair', () => {
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+      { x: 10, y: 0 },
+      { x: 30, y: 0 },
+    )
+    expect(triple[0]).toBeGreaterThan(0)
+    expect(pairPenalty(triple)[2]).toBe(0)
+  })
+})
+
+describe('realized-bends', () => {
+  it.each([
+    [
+      'straight',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      0,
+    ],
+    [
+      'L',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      1,
+    ],
+    [
+      'Z',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 20, y: 10 },
+      ],
+      2,
+    ],
+    ['single-point', [{ x: 0, y: 0 }], 0],
+    ['empty', [], 0],
+    [
+      'zero-length segment',
+      [
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      0,
+    ],
+  ] as const)('%s path contributes %i to tier 3', (_label, path, expected) => {
+    const cost = selfPenalty(path, [])
+    expect(cost[3]).toBe(expected)
+    expect(cost.every((n) => Number.isFinite(n) && n >= 0)).toBe(true)
+  })
+})
+
+describe('hasRepairableProblem', () => {
+  it('is false when the only nonzero tier is the last (realized-bends) tier', () => {
+    expect(hasRepairableProblem([0, 0, 0, 5])).toBe(false)
+  })
+
+  it.each([
+    [[1, 0, 0, 0]],
+    [[0, 1, 0, 0]],
+    [[0, 0, 1, 0]],
+    [[1, 1, 1, 5]],
+  ] as const)('is true when a non-final tier is nonzero: %j', (cost) => {
+    expect(hasRepairableProblem(cost)).toBe(true)
+  })
+
+  it('is false for the zero cost', () => {
+    expect(hasRepairableProblem(zeroPenalty())).toBe(false)
   })
 })

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { scoreSegmentPair } from './edge-crossing-sweep.js'
 import {
+  addCost,
   COST_QUANTUM,
   dominantAxisOrder,
   hasRepairableProblem,
+  lessCost,
   PENALTY_RULES,
+  type PenaltyRule,
   type PreferenceRule,
   pairPenalty,
   type Rect,
@@ -351,5 +354,46 @@ describe('hasRepairableProblem', () => {
 
   it('is false for the zero cost', () => {
     expect(hasRepairableProblem(zeroPenalty())).toBe(false)
+  })
+})
+
+describe('addCost', () => {
+  it('sums two cost arrays tier-by-tier with sign=1', () => {
+    expect(addCost([1, 2, 3, 4], [10, 20, 30, 40], 1)).toEqual([11, 22, 33, 44])
+  })
+
+  it('subtracts b from a tier-by-tier with sign=-1', () => {
+    expect(addCost([10, 20, 30, 40], [1, 2, 3, 4], -1)).toEqual([9, 18, 27, 36])
+  })
+
+  it('defaults a missing index in either operand to 0', () => {
+    const tier1Rule: PenaltyRule = {
+      name: 'tier1',
+      tier: 1,
+      pairTerm: () => 0,
+      selfTerm: () => 0,
+    }
+    // a has no index 1 at all; b does. a[rule.tier] ?? 0 must supply the 0.
+    expect(addCost([100], [0, 5], 1, [tier1Rule])).toEqual([0, 5])
+  })
+
+  it('composes over a non-default rules array', () => {
+    const rule0: PenaltyRule = { name: 'r0', tier: 0, pairTerm: () => 0, selfTerm: () => 0 }
+    expect(addCost([7], [3], 1, [rule0])).toEqual([10])
+  })
+})
+
+describe('lessCost', () => {
+  it('compares in tier order even when the rules array is passed out of order', () => {
+    const tier0Rule: PenaltyRule = { name: 'r0', tier: 0, pairTerm: () => 0, selfTerm: () => 0 }
+    const tier1Rule: PenaltyRule = { name: 'r1', tier: 1, pairTerm: () => 0, selfTerm: () => 0 }
+    // Declared out of tier order: tier1 first, tier0 second.
+    const outOfOrderRules = [tier1Rule, tier0Rule]
+    // tier0: a(5) > b(3) already decides "not less"; tier1 (a=1 < b=100)
+    // must never be consulted first, or this would wrongly read true.
+    const a = [5, 1]
+    const b = [3, 100]
+    expect(lessCost(a, b, outOfOrderRules)).toBe(false)
+    expect(lessCost(b, a, outOfOrderRules)).toBe(true)
   })
 })

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -355,6 +355,10 @@ describe('hasRepairableProblem', () => {
   it('is false for the zero cost', () => {
     expect(hasRepairableProblem(zeroPenalty())).toBe(false)
   })
+
+  it('is false when rules is empty (guards Math.max(...[]) === -Infinity)', () => {
+    expect(hasRepairableProblem([1, 2, 3], [])).toBe(false)
+  })
 })
 
 describe('addCost', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -6,13 +6,12 @@
  * New routing feedback lands as one named rule + its own test here, not a
  * new branch in spatial-edges.ts.
  *
- * This file covers the PREFERENCE half of the taxonomy — candidate
- * generation for `rankedSidePairs` (spatial-edges.ts, a thin wrapper over
- * `composeSidePairs` below) plus the solver's adoption predicate
- * (`shouldAdoptCandidate`, the "incumbent-wins-ties" rule). Penalty-rule
- * extraction (pairScore/selfScore's cost terms in spatial-edges.ts) is a
- * separate, not-yet-landed slice — see the "penalty-rules-extraction"
- * follow-up.
+ * This file covers both halves of the taxonomy: candidate generation for
+ * `rankedSidePairs` (spatial-edges.ts, a thin wrapper over `composeSidePairs`
+ * below) plus the solver's adoption predicate (`shouldAdoptCandidate`, the
+ * "incumbent-wins-ties" rule) are the PREFERENCE half; `PENALTY_RULES` below
+ * is the PENALTY half — `pairScore`/`selfScore` (spatial-edges.ts) compose
+ * over it to build the cost tuple `optimizeSideChoices` compares.
  */
 
 export type Side = 'top' | 'right' | 'bottom' | 'left'
@@ -293,4 +292,230 @@ export function shouldAdoptCandidate<T>(
   lessCost: (a: T, b: T) => boolean,
 ): boolean {
   return lessCost(candidateCost, incumbentCost)
+}
+
+/** Quarter-pixel quantization: every PENALTY_RULES term is integral, so
+ * candidate comparison is exact integer arithmetic — no float tie can
+ * differ between platforms (see edge-crossing-sweep.ts's matching
+ * COST_QUANTUM, which the narrow phase quantizes with independently). */
+export const COST_QUANTUM = 4
+
+/** Direction changes along a polyline, ignoring repeated/collinear points. */
+export function bendCount(path: readonly Point[]): number {
+  let bends = 0
+  let lastDir: string | undefined
+  for (let i = 1; i < path.length; i++) {
+    const dx = Math.sign((path[i] as Point).x - (path[i - 1] as Point).x)
+    const dy = Math.sign((path[i] as Point).y - (path[i - 1] as Point).y)
+    if (dx === 0 && dy === 0) continue
+    const dir = `${dx},${dy}`
+    if (lastDir !== undefined && dir !== lastDir) bends++
+    lastDir = dir
+  }
+  return bends
+}
+
+/**
+ * A named PENALTY rule (decision #10): a cost-tuple term with a declared
+ * lexicographic tier. `pairTerm` reads this rule's contribution out of the
+ * narrow-phase [overlap, illegible, crossings] triple that
+ * `scoreSegmentPair`/`buildPairwiseScores` (edge-crossing-sweep.ts, the
+ * SINGLE producer of pair geometry) already computed — a rule with no pair
+ * contribution returns 0 without touching the triple. `selfTerm` computes
+ * this rule's contribution from one routed path's own geometry plus the
+ * bystander rects it might tunnel through; a rule with no self contribution
+ * returns 0 without walking the path. Every rule's `tier` is also its slot
+ * index into the composed cost array — enforced by the `PENALTY_RULES`
+ * tier-order pin in edge-rules.test.ts, not by this type.
+ */
+export type PenaltyRule = {
+  readonly name: string
+  readonly tier: number
+  readonly pairTerm: (triple: readonly [number, number, number]) => number
+  readonly selfTerm: (path: readonly Point[], foreignBodies: readonly Rect[]) => number
+}
+
+/**
+ * overlap-and-intrusion: collinear axis-aligned overlap (a parallel overlap
+ * has no crossing point, so a line jump cannot express it) plus, from a
+ * single path's own geometry, retracing its own ink (the doubled-line
+ * arrival a facing-away side produces when the connector overshoots the
+ * entry stub through the node body) and tunnelling through a bystander
+ * node's raw body (a line through a node reads as though it connects that
+ * node, which no line jump can express). Heaviest tier: it outranks even an
+ * edge crossing.
+ */
+const overlapAndIntrusion: PenaltyRule = {
+  name: 'overlap-and-intrusion',
+  tier: 0,
+  pairTerm: (triple) => triple[0],
+  selfTerm: (path, foreignBodies) => {
+    const q = (n: number) => Math.round(n * COST_QUANTUM)
+    let overlap = 0
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as Point
+      const b = path[i] as Point
+      for (const r of foreignBodies) {
+        // Axis-aligned intrusion length, boundary grazing excluded: an
+        // anchor ON a neighbour's border or a segment riding the margin
+        // band is bestCandidate's business, not a tunnel.
+        const minX = Math.max(Math.min(a.x, b.x), r.x)
+        const maxX = Math.min(Math.max(a.x, b.x), r.x + r.w)
+        const minY = Math.max(Math.min(a.y, b.y), r.y)
+        const maxY = Math.min(Math.max(a.y, b.y), r.y + r.h)
+        if (maxX <= minX && maxY <= minY) continue
+        if (a.y === b.y && a.y > r.y && a.y < r.y + r.h && maxX > minX) {
+          overlap += q(maxX - minX)
+        } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w && maxY > minY) {
+          overlap += q(maxY - minY)
+        }
+      }
+    }
+    for (let i = 1; i < path.length; i++) {
+      for (let j = i + 1; j < path.length; j++) {
+        const a1 = path[i - 1] as Point
+        const a2 = path[i] as Point
+        const b1 = path[j - 1] as Point
+        const b2 = path[j] as Point
+        if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
+          const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
+          const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
+          if (hi > lo) overlap += hi - lo
+        } else if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
+          const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
+          const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
+          if (hi > lo) overlap += hi - lo
+        }
+      }
+    }
+    return overlap
+  },
+}
+
+/** illegibility: a transversal crossing too close to a segment end to
+ * render a legible jump arc. Pair-only — no path retraces "close to its own
+ * end" in a way this tier is meant to capture. */
+const illegibility: PenaltyRule = {
+  name: 'illegibility',
+  tier: 1,
+  pairTerm: (triple) => triple[1],
+  selfTerm: () => 0,
+}
+
+/** crossings: total transversal crossings between two routed paths.
+ * Pair-only, and already short-circuited by `scoreSegmentPair` for a
+ * collinear overlapping pair (see edge-crossing-sweep.ts). */
+const crossings: PenaltyRule = {
+  name: 'crossings',
+  tier: 2,
+  pairTerm: (triple) => triple[2],
+  selfTerm: () => 0,
+}
+
+/** realized-bends: direction changes along ONE routed path. Self-only, and
+ * deliberately the last tier — the optimizer's short-circuit
+ * (`hasRepairableProblem`) and worst-offender filter both ignore it, since
+ * a configuration with no overlap/illegibility/crossings is already healthy
+ * and reshuffling it purely to shave bends is churn, not repair. */
+const realizedBends: PenaltyRule = {
+  name: 'realized-bends',
+  tier: 3,
+  pairTerm: () => 0,
+  selfTerm: (path) => bendCount(path),
+}
+
+/**
+ * The declared, tier-ordered PENALTY-rule catalog (decision #10). Index
+ * MUST equal `tier` for every entry — pinned in edge-rules.test.ts — since
+ * every composition helper below writes a rule's contribution at
+ * `cost[rule.tier]`, never at its array position.
+ */
+export const PENALTY_RULES: readonly PenaltyRule[] = [
+  overlapAndIntrusion,
+  illegibility,
+  crossings,
+  realizedBends,
+]
+
+/** The all-zero cost, sized to `rules` — the composition path's only
+ * length-4 literal is this `.map`, derived from the declared list rather
+ * than hardcoded. */
+export function zeroPenalty(rules: readonly PenaltyRule[] = PENALTY_RULES): number[] {
+  return rules.map(() => 0)
+}
+
+/**
+ * `pairScore`'s composition step (spatial-edges.ts): map the narrow
+ * phase's summed [overlap, illegible, crossings] triple into a full cost
+ * array, one rule per declared tier.
+ */
+export function pairPenalty(
+  triple: readonly [number, number, number],
+  rules: readonly PenaltyRule[] = PENALTY_RULES,
+): number[] {
+  const cost = zeroPenalty(rules)
+  for (const rule of rules) cost[rule.tier] = rule.pairTerm(triple)
+  return cost
+}
+
+/**
+ * `selfScore`'s composition step (spatial-edges.ts): map one routed path's
+ * self-geometry into a full cost array, one rule per declared tier.
+ */
+export function selfPenalty(
+  path: readonly Point[],
+  foreignBodies: readonly Rect[],
+  rules: readonly PenaltyRule[] = PENALTY_RULES,
+): number[] {
+  const cost = zeroPenalty(rules)
+  for (const rule of rules) cost[rule.tier] = rule.selfTerm(path, foreignBodies)
+  return cost
+}
+
+export function addCost(
+  a: readonly number[],
+  b: readonly number[],
+  sign: 1 | -1,
+  rules: readonly PenaltyRule[] = PENALTY_RULES,
+): number[] {
+  const out = zeroPenalty(rules)
+  for (const rule of rules) out[rule.tier] = (a[rule.tier] ?? 0) + sign * (b[rule.tier] ?? 0)
+  return out
+}
+
+/**
+ * Lexicographic integer compare over the declared tiers, in TIER order
+ * (sorted by `rule.tier`, so a caller passing an accidentally-reordered
+ * `rules` array still compares correctly — only the canonical
+ * `PENALTY_RULES` array itself is pinned to already be in tier order).
+ */
+export function lessCost(
+  a: readonly number[],
+  b: readonly number[],
+  rules: readonly PenaltyRule[] = PENALTY_RULES,
+): boolean {
+  const ordered = [...rules].sort((x, y) => x.tier - y.tier)
+  for (const rule of ordered) {
+    const av = a[rule.tier] ?? 0
+    const bv = b[rule.tier] ?? 0
+    if (av !== bv) return av < bv
+  }
+  return false
+}
+
+/**
+ * Whether a configuration has a REPAIRABLE problem: any declared tier
+ * BELOW the last one is nonzero. Generalizes the old "first three slots
+ * zero" short-circuit — the last tier is realized-bends (pinned in
+ * edge-rules.test.ts), and bends-only churn is deliberately excluded from
+ * both `optimizeSideChoices`'s whole-config short-circuit and its
+ * worst-offender contribution filter (spatial-edges.ts).
+ */
+export function hasRepairableProblem(
+  cost: readonly number[],
+  rules: readonly PenaltyRule[] = PENALTY_RULES,
+): boolean {
+  if (rules.length === 0) return false
+  const lastTier = Math.max(...rules.map((r) => r.tier))
+  return rules.some((r) => r.tier < lastTier && (cost[r.tier] ?? 0) !== 0)
 }

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -515,7 +515,6 @@ export function hasRepairableProblem(
   cost: readonly number[],
   rules: readonly PenaltyRule[] = PENALTY_RULES,
 ): boolean {
-  if (rules.length === 0) return false
   const lastTier = Math.max(...rules.map((r) => r.tier))
   return rules.some((r) => r.tier < lastTier && (cost[r.tier] ?? 0) !== 0)
 }

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -2,14 +2,21 @@ import type { CanvasEdge, EdgeRoutingStyle, SpatialNode } from '@kamiazya/whiteb
 import type { ResolvedEdgeNode } from '../scene-graph.js'
 import { buildPairwiseScores, scoreSegmentPair } from './edge-crossing-sweep.js'
 import {
+  addCost,
+  bendCount,
   composeSidePairs,
   facingLaneWindow,
+  hasRepairableProblem,
+  lessCost,
   oppositeSide,
   type Point,
+  pairPenalty,
   type Rect,
   type Side,
   SLIDE_CORNER_INSET_PX,
+  selfPenalty,
   shouldAdoptCandidate,
+  zeroPenalty,
 } from './edge-rules.js'
 
 function rectOf(node: SpatialNode): Rect {
@@ -496,37 +503,32 @@ function computeAnchorsFor(
   return anchors
 }
 
-/** Quarter-pixel quantization: every cost term is integral, so candidate
- * comparison is exact integer arithmetic — no float tie can differ between
- * platforms. */
-const COST_QUANTUM = 4
-
-type ConfigCost = readonly [overlap: number, illegible: number, crossings: number, bends: number]
-
-function lessCost(a: ConfigCost, b: ConfigCost): boolean {
-  if (a[0] !== b[0]) return a[0] < b[0]
-  if (a[1] !== b[1]) return a[1] < b[1]
-  if (a[2] !== b[2]) return a[2] < b[2]
-  return a[3] < b[3]
-}
+/**
+ * The routing cost of a configuration as a lexicographic integer tuple, one
+ * slot per PENALTY_RULES tier (edge-rules.ts): total collinear axis-aligned
+ * overlap length (a parallel overlap has no crossing point, so a line jump
+ * cannot express it — heaviest; an edge RETRACING its own ink counts here
+ * too, via `selfScore`), crossings too close to a segment end to render
+ * their jump arc, total crossings, then total REALIZED bends. Bends sit
+ * last and the optimizer's short-circuit ignores them (`hasRepairableProblem`):
+ * they only break ties between configurations that already tie on every
+ * visibility problem — the abstract pair ranking (L before Z) can lie once
+ * obstacles force the L into a staircase, and this term is what corrects
+ * it. Length stays out of the cost entirely, governed by the per-edge pair
+ * ranking. `ConfigCost`'s length and slot order are DERIVED from
+ * PENALTY_RULES (edge-rules.ts's `zeroPenalty`/`pairPenalty`/`selfPenalty`),
+ * never hardcoded here.
+ */
+type ConfigCost = readonly number[]
 
 /**
- * Global legibility cost of a routed configuration, as a lexicographic
- * integer tuple: total collinear axis-aligned overlap length (a parallel
- * overlap has no crossing point, so a line jump cannot express it —
- * heaviest; an edge RETRACING its own ink counts here too, via
- * `selfScore`), crossings too close to a segment end to render their jump
- * arc, total crossings, then total REALIZED bends. Bends sit last and the
- * optimizer's short-circuit ignores them: they only break ties between
- * configurations that already tie on every visibility problem — the
- * abstract pair ranking (L before Z) can lie once obstacles force the L
- * into a staircase, and this term is what corrects it. Length stays out
- * of the cost entirely, governed by the per-edge pair ranking.
+ * `pairScore`'s composition over PENALTY_RULES: sums the SHARED narrow
+ * phase over every segment pair — the same function the initial sweep
+ * calls, so the incremental trial path and the broad-phase build cannot
+ * drift (see edge-crossing-sweep.ts) — then maps the summed triple into
+ * the declared tiers.
  */
 function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
-  // Sums the SHARED narrow phase over every segment pair — the same
-  // function the initial sweep calls, so the incremental trial path and
-  // the broad-phase build cannot drift (see edge-crossing-sweep.ts).
   let overlap = 0
   let illegible = 0
   let crossings = 0
@@ -538,62 +540,17 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
       crossings += c
     }
   }
-  return [overlap, illegible, crossings, 0]
+  return pairPenalty([overlap, illegible, crossings])
 }
 
 /**
- * Per-edge quality of ONE routed path, in the heaviest slot: collinear
- * overlap with ITSELF (adjacent retraces included — the doubled-line
- * arrival a facing-away side produces when the connector overshoots the
- * entry stub through the node body) plus the length of any segment
- * TUNNELLING through a bystander node's raw body — a line through a node
- * reads as though it connects that node, which no line jump can express,
- * so it outranks even an edge crossing. Realized bend count sits last.
+ * `selfScore`'s composition over PENALTY_RULES: per-edge quality of ONE
+ * routed path — collinear overlap with itself, tunnelling through a
+ * bystander node's raw body, and realized bend count, each contributed by
+ * its own named rule.
  */
 function selfScore(path: readonly Point[], foreignBodies: readonly Rect[]): ConfigCost {
-  const q = (n: number) => Math.round(n * COST_QUANTUM)
-  let overlap = 0
-  for (let i = 1; i < path.length; i++) {
-    const a = path[i - 1] as Point
-    const b = path[i] as Point
-    for (const r of foreignBodies) {
-      // Axis-aligned intrusion length, boundary grazing excluded: an
-      // anchor ON a neighbour's border or a segment riding the margin
-      // band is bestCandidate's business, not a tunnel.
-      const minX = Math.max(Math.min(a.x, b.x), r.x)
-      const maxX = Math.min(Math.max(a.x, b.x), r.x + r.w)
-      const minY = Math.max(Math.min(a.y, b.y), r.y)
-      const maxY = Math.min(Math.max(a.y, b.y), r.y + r.h)
-      if (maxX <= minX && maxY <= minY) continue
-      if (a.y === b.y && a.y > r.y && a.y < r.y + r.h && maxX > minX) {
-        overlap += q(maxX - minX)
-      } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w && maxY > minY) {
-        overlap += q(maxY - minY)
-      }
-    }
-  }
-  for (let i = 1; i < path.length; i++) {
-    for (let j = i + 1; j < path.length; j++) {
-      const a1 = path[i - 1] as Point
-      const a2 = path[i] as Point
-      const b1 = path[j - 1] as Point
-      const b2 = path[j] as Point
-      if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
-        const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
-        const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
-        if (hi > lo) overlap += hi - lo
-      } else if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
-        const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
-        const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
-        if (hi > lo) overlap += hi - lo
-      }
-    }
-  }
-  return [overlap, 0, 0, bendCount(path)]
-}
-
-function addCost(a: ConfigCost, b: ConfigCost, sign: 1 | -1): ConfigCost {
-  return [a[0] + sign * b[0], a[1] + sign * b[1], a[2] + sign * b[2], a[3] + sign * b[3]]
+  return selfPenalty(path, foreignBodies)
 }
 
 /**
@@ -664,21 +621,22 @@ function optimizeSideChoices(
     nodes.filter((n) => n.id !== e.fromNode && n.id !== e.toNode).map(rectOf),
   )
   const selfCosts: ConfigCost[] = paths.map((path, i) => selfScore(path, foreignBodiesFor[i]!))
-  let currentCost: ConfigCost = [0, 0, 0, 0]
+  let currentCost: ConfigCost = zeroPenalty()
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
   // Sweep-and-prune instead of the O(E^2) double loop: identical scores
   // by construction (same narrow phase, canonical pair order), sparse for
   // non-interacting pairs — evaluateTrial already zero-defaults absent
   // keys.
   for (const [key, [o, il, c]] of buildPairwiseScores(paths)) {
-    const score: ConfigCost = [o, il, c, 0]
+    const score: ConfigCost = pairPenalty([o, il, c])
     matrix.set(key, score)
     currentCost = addCost(currentCost, score, 1)
   }
-  // The bend term (index 3) is deliberately ABSENT from the short-circuit:
-  // a canvas with no overlap and no crossings is healthy, and reshuffling
-  // it purely to shave bends is churn, not repair.
-  if (currentCost[0] === 0 && currentCost[1] === 0 && currentCost[2] === 0) return current
+  // The realized-bends tier is deliberately ABSENT from the short-circuit
+  // (hasRepairableProblem, edge-rules.ts): a canvas with no overlap and no
+  // crossings is healthy, and reshuffling it purely to shave bends is
+  // churn, not repair.
+  if (!hasRepairableProblem(currentCost)) return current
 
   const evaluateTrial = (
     trialSides: ReadonlyMap<string, SidePair>,
@@ -705,7 +663,7 @@ function optimizeSideChoices(
     const selfUpdates = new Map<number, ConfigCost>()
     for (const i of touched) {
       const next = selfScore(trialPaths[i]!, foreignBodiesFor[i]!)
-      cost = addCost(cost, selfCosts[i] ?? [0, 0, 0, 0], -1)
+      cost = addCost(cost, selfCosts[i] ?? zeroPenalty(), -1)
       cost = addCost(cost, next, 1)
       selfUpdates.set(i, next)
     }
@@ -719,7 +677,7 @@ function optimizeSideChoices(
         // updates map; a pair with an untouched edge reuses its cached path.
         if (touchedSet.has(j) && j < i) continue
         const next = pairScore(trialPaths[lo]!, trialPaths[hi]!)
-        cost = addCost(cost, matrix.get(key) ?? [0, 0, 0, 0], -1)
+        cost = addCost(cost, matrix.get(key) ?? zeroPenalty(), -1)
         cost = addCost(cost, next, 1)
         updates.set(key, next)
       }
@@ -789,8 +747,9 @@ function optimizeSideChoices(
       .map((edge, i) => ({ edge, i, cost: contribution(i) }))
       // An edge with no overlap, no illegibility, and no crossings has
       // nothing to repair — reshuffling it to shave bends is churn, the
-      // same judgement the whole-config short-circuit makes.
-      .filter((r) => r.cost[0] > 0 || r.cost[1] > 0 || r.cost[2] > 0)
+      // same judgement the whole-config short-circuit makes
+      // (hasRepairableProblem, edge-rules.ts).
+      .filter((r) => hasRepairableProblem(r.cost))
       .sort((a, b) => (lessCost(a.cost, b.cost) ? 1 : lessCost(b.cost, a.cost) ? -1 : a.i - b.i))
       .slice(0, TRIAL_BUDGET_EDGES)
       // Document order within the budget keeps adoption sequencing stable.
@@ -822,7 +781,7 @@ function optimizeSideChoices(
           break
         }
       }
-      if (currentCost[0] === 0 && currentCost[1] === 0 && currentCost[2] === 0) return current
+      if (!hasRepairableProblem(currentCost)) return current
     }
     if (!improved) break
   }
@@ -954,21 +913,6 @@ const pathLength = (path: readonly Point[]) =>
  * that actually occur (a node or two sitting between two others). A denser
  * search belongs behind the routing-style setting, not in the default path.
  */
-/** Direction changes along a polyline, ignoring repeated/collinear points. */
-function bendCount(path: readonly Point[]): number {
-  let bends = 0
-  let lastDir: string | undefined
-  for (let i = 1; i < path.length; i++) {
-    const dx = Math.sign((path[i] as Point).x - (path[i - 1] as Point).x)
-    const dy = Math.sign((path[i] as Point).y - (path[i - 1] as Point).y)
-    if (dx === 0 && dy === 0) continue
-    const dir = `${dx},${dy}`
-    if (lastDir !== undefined && dir !== lastDir) bends++
-    lastDir = dir
-  }
-  return bends
-}
-
 /**
  * The best candidate by a two-tier clearance ranking, shortest first:
  * clear of the inflated obstacles (full margin kept), else clear of the


### PR DESCRIPTION
## Summary

Completes decision #10's routing-rule taxonomy: the PENALTY half now lives beside the preference half (#695) in `edge-rules.ts` as declared data.

- `PENALTY_RULES` declares the four cost tiers as named scorers in tier order: `overlap-and-intrusion` (0), `illegibility` (1), `crossings` (2), `realized-bends` (3). Scorer bodies moved verbatim from `spatial-edges.ts` — identical quantization arithmetic.
- `pairScore`/`selfScore` are now thin compositions over the list; the `ConfigCost` slot order, length, zero tuple, `addCost`/`lessCost` compare order, the optimizer's clean-config short-circuit, and the worst-offender filter all **derive from the declared tiers** (`hasRepairableProblem` = any tier below realized-bends is nonzero) instead of hardcoded 4-slot literals and indices.
- `edge-crossing-sweep.ts` (the single narrow-phase producer) is untouched — penalty rules only map its outputs.
- `COST_QUANTUM` and `bendCount` moved to `edge-rules.ts` to keep the import direction acyclic.

## Verification

- Strangler discipline: landed tier-by-tier, full `canvas-render-node` suite (~45 routing/side-choice/parity pins + the differential sweep property) green and unweakened after every commit.
- New: per-rule unit tests (35 cases incl. grazing exclusion, collinear-overlap short-circuit, degenerate paths), `addCost`/`lessCost` direct coverage, and fast-check framework properties (slot-order-equals-declared-order, determinism, totality over zero-size rects / zero-length / single-point paths).
- Mutation-checked: permuting `PENALTY_RULES` turns the tier-order pin red; neutralizing overlap-and-intrusion's self term turns a pre-existing routing pin red (composition is live).
- Also green: canvas-render-browser SVG determinism golden, `pnpm -r typecheck`, mcp-node, arch-lint-node, `pnpm run test:browser`, server-core, knip. No public API change (`index.ts` untouched).

Behavior-preserving refactor with byte-identical rendering — no visual evidence applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ