### PR TITLE
refactor(web): move SpatialEditor closure families into pure modules

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -49,8 +49,8 @@ import {
 import type { MutableRefObject } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { hasClipboardFragment } from '../../lib/clipboard-store.js'
-import type { AlignableBox, BoxMove } from './align.js'
-import { alignBoxes, distributeBoxes } from './align.js'
+import type { BoxMove } from './align.js'
+import { alignableBoxesOf, alignBoxes, distributeBoxes } from './align.js'
 import type { FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
@@ -89,7 +89,6 @@ export interface CanvasContextMenuProps {
   readonly applyResult: (result: GestureResult) => void
   readonly isEdgeLocked: (edgeId: string) => boolean
   readonly onToggleEdgeLock?: (edgeId: string, locked: boolean) => void
-  readonly edgeLockEnabled: boolean
   readonly setEdgeLabelEditId: (id: string | null) => void
   readonly setSelectedEdgeId: (id: string | null) => void
   readonly setGroupLabelEditId: (id: string | null) => void
@@ -104,10 +103,8 @@ export interface CanvasContextMenuProps {
   readonly imageInputRef: MutableRefObject<HTMLInputElement | null>
   readonly pendingBackgroundGroupIdRef: MutableRefObject<string | null>
   readonly isLocked: (nodeId: string) => boolean
-  readonly lockEnabled: boolean
   readonly onToggleNodeLock?: (nodeId: string, locked: boolean) => void
   readonly applyBoxMoves: (moves: readonly BoxMove[]) => boolean
-  readonly selectedAlignableBoxes: () => AlignableBox[]
   readonly extraIds: ReadonlySet<string>
   readonly selectedId: string | null
   readonly groupSelection: (memberIds: readonly string[]) => void
@@ -130,7 +127,6 @@ export function CanvasContextMenu({
   applyResult,
   isEdgeLocked,
   onToggleEdgeLock,
-  edgeLockEnabled,
   setEdgeLabelEditId,
   setSelectedEdgeId,
   setGroupLabelEditId,
@@ -145,10 +141,8 @@ export function CanvasContextMenu({
   imageInputRef,
   pendingBackgroundGroupIdRef,
   isLocked,
-  lockEnabled,
   onToggleNodeLock,
   applyBoxMoves,
-  selectedAlignableBoxes,
   extraIds,
   selectedId,
   groupSelection,
@@ -160,6 +154,15 @@ export function CanvasContextMenu({
   duplicateSelection,
   reorderSelection,
 }: CanvasContextMenuProps) {
+  // Both derive from whether the host wired the matching toggle callback —
+  // without one, the menu has nothing to call, so the affordance stays
+  // hidden rather than offering a lock that can never be released.
+  const lockEnabled = onToggleNodeLock !== undefined
+  const edgeLockEnabled = onToggleEdgeLock !== undefined
+  // Read from canvasRef (not the `canvas` prop) so a menu action never
+  // computes against a stale render closure.
+  const selectedAlignableBoxes = () =>
+    alignableBoxesOf(canvasRef.current.nodes, selectedId === null ? [] : [selectedId, ...extraIds])
   return (
     <ContextMenu
       x={contextMenu.x}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -95,13 +95,9 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
-import {
-  extractClipboardFragment,
-  parseClipboardText,
-  remintClipboardFragment,
-} from '../../lib/clipboard-fragment.js'
+import { extractClipboardFragment, parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { readClipboardFragment, writeClipboardFragment } from '../../lib/clipboard-store.js'
-import type { AlignableBox, BoxMove } from './align.js'
+import type { BoxMove } from './align.js'
 import {
   CanvasContextMenu,
   type CanvasPickerState,
@@ -111,7 +107,7 @@ import {
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
 import type { EditorCommand } from './commands.js'
-import { applyCommand } from './commands.js'
+import { applyCommand, buildFragmentInsertCommand } from './commands.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
 import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
@@ -142,6 +138,20 @@ import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
+import {
+  fileNodeDefaults,
+  GROUP_FRAME_HEIGHT,
+  GROUP_FRAME_WIDTH,
+  groupEnclosure,
+  groupNodeDefaults,
+  IMAGE_NODE_HEIGHT,
+  IMAGE_NODE_WIDTH,
+  imageNodeDefaults,
+  LINK_NODE_HEIGHT,
+  linkNodeDefaults,
+  resolveSpawnPoint,
+  textNodeDefaults,
+} from './node-factories.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import {
@@ -156,13 +166,15 @@ import { TextNodeEditor } from './TextNodeEditor.js'
 import { type EditorTool, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
-  canvasToScreen,
-  clampZoom,
+  type ContainerSize,
   fitViewportToBoxes,
+  frameViewport,
   IDENTITY_VIEWPORT,
   type Point,
   panBy,
+  panToShowTarget,
   screenToCanvas,
+  contentBounds as unionContentBounds,
   type Viewport,
   viewportTransformCss,
   zoomAt,
@@ -336,9 +348,6 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  * common OS double-click interval; not user-configurable today.
  */
 const DOUBLE_PRESS_WINDOW_MS = 400
-
-/** Duplicated copies land offset by this much, cascading on repeat. */
-const DUPLICATE_OFFSET_PX = 16
 
 /** Breathing room kept around framed content (zoom to fit / selection). */
 const FRAME_MARGIN_PX = 24
@@ -1739,20 +1748,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
-     * The selected nodes as align/distribute inputs, read from canvasRef so
-     * a menu action never computes against a stale render closure. Locked
-     * nodes cannot be in a selection (see the pruning effect above), so they
-     * are absent here too — neither moved nor counted toward the bounds.
-     */
-    const selectedAlignableBoxes = (): AlignableBox[] => {
-      if (selection === undefined) return []
-      const ids = new Set([selection.id, ...extraIds])
-      return canvasRef.current.nodes
-        .filter((node) => ids.has(node.id))
-        .map(({ id, x, y, width, height }) => ({ id, x, y, width, height }))
-    }
-
-    /**
      * Applies a set of moves as ONE batch command — an align is one user
      * action and must undo as one step. An empty move list (already aligned)
      * emits nothing rather than an empty history entry, matching
@@ -1779,37 +1774,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (selection === undefined) return false
       const current = canvasRef.current
       const fragment = extractClipboardFragment(current, new Set([selection.id, ...extraIds]))
-      if (fragment.nodes.length === 0) return false
-      const existingIds = new Set([
-        ...current.nodes.map((node) => node.id),
-        ...current.edges.map((edge) => edge.id),
-      ])
-      const reminted = remintClipboardFragment(
+      const command = buildFragmentInsertCommand(
+        current,
         fragment,
         () => createId?.() ?? crypto.randomUUID(),
-        existingIds,
       )
-      const command: EditorCommand = {
-        kind: 'batch',
-        commands: [
-          ...reminted.nodes.map(
-            (node) =>
-              ({
-                kind: 'create-node',
-                node: {
-                  ...node,
-                  x: node.x + DUPLICATE_OFFSET_PX,
-                  y: node.y + DUPLICATE_OFFSET_PX,
-                },
-              }) as const,
-          ),
-          ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
-        ],
-      }
+      if (command === undefined) return false
       const running = applyCommand(current, command)
       if (running === current) return false
       onChange(running, command)
-      const remintedIds = reminted.nodes.map((node) => node.id)
+      const remintedIds =
+        command.kind === 'batch'
+          ? command.commands.filter((c) => c.kind === 'create-node').map((c) => c.node.id)
+          : []
       if (remintedIds.length > 0) {
         applySelection({ type: 'set-members', ids: remintedIds })
         setSelectedEdgeId(null)
@@ -1852,15 +1829,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /** A note carrying pasted foreign text, at the viewport center. */
     const createTextNodeAtViewportCenter = (text: string): void => {
       const point = screenToCanvas(viewportCenterScreen(), viewport)
-      const node: SpatialNode = {
-        id: createId?.() ?? crypto.randomUUID(),
-        type: 'text',
-        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
-        y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
-        width: NEW_NODE_WIDTH,
-        height: NEW_NODE_HEIGHT,
-        text,
-      }
+      const node = textNodeDefaults(createId?.() ?? crypto.randomUUID(), point, text)
       const command: EditorCommand = { kind: 'create-node', node }
       const running = applyCommand(canvasRef.current, command)
       if (running === canvasRef.current) return
@@ -1886,41 +1855,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
       at?: Point,
     ): boolean => {
-      if (fragment.nodes.length === 0) return false
       const current = canvasRef.current
-      const existingIds = new Set([
-        ...current.nodes.map((node) => node.id),
-        ...current.edges.map((edge) => edge.id),
-      ])
-      const reminted = remintClipboardFragment(
+      const command = buildFragmentInsertCommand(
+        current,
         fragment,
         () => createId?.() ?? crypto.randomUUID(),
-        existingIds,
+        at,
       )
-      let dx = DUPLICATE_OFFSET_PX
-      let dy = DUPLICATE_OFFSET_PX
-      if (at !== undefined) {
-        const minX = Math.min(...reminted.nodes.map((node) => node.x))
-        const minY = Math.min(...reminted.nodes.map((node) => node.y))
-        const maxX = Math.max(...reminted.nodes.map((node) => node.x + node.width))
-        const maxY = Math.max(...reminted.nodes.map((node) => node.y + node.height))
-        dx = Math.round(at.x - (minX + maxX) / 2)
-        dy = Math.round(at.y - (minY + maxY) / 2)
-      }
-      const command: EditorCommand = {
-        kind: 'batch',
-        commands: [
-          ...reminted.nodes.map(
-            (node) =>
-              ({ kind: 'create-node', node: { ...node, x: node.x + dx, y: node.y + dy } }) as const,
-          ),
-          ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
-        ],
-      }
+      if (command === undefined) return false
       const running = applyCommand(current, command)
       if (running === current) return false
       onChange(running, command)
-      const remintedIds = reminted.nodes.map((node) => node.id)
+      const remintedIds =
+        command.kind === 'batch'
+          ? command.commands.filter((c) => c.kind === 'create-node').map((c) => c.node.id)
+          : []
       if (remintedIds.length > 0) {
         applySelection({ type: 'set-members', ids: remintedIds })
         setSelectedEdgeId(null)
@@ -2339,23 +2288,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * keeping the current zoom (the hand-mode "where did my content go"
      * recovery). No boxes → no-op.
      */
-    /** Union of the given nodes' boxes, or undefined when there is none. */
-    const contentBounds = (ids?: ReadonlySet<string>) => {
-      let minX = Number.POSITIVE_INFINITY
-      let minY = Number.POSITIVE_INFINITY
-      let maxX = Number.NEGATIVE_INFINITY
-      let maxY = Number.NEGATIVE_INFINITY
-      for (const { id, box } of boxes) {
-        if (ids !== undefined && !ids.has(id)) continue
-        if (!Number.isFinite(box.x) || !Number.isFinite(box.y)) continue
-        minX = Math.min(minX, box.x)
-        minY = Math.min(minY, box.y)
-        maxX = Math.max(maxX, box.x + box.width)
-        maxY = Math.max(maxY, box.y + box.height)
-      }
-      if (!Number.isFinite(minX) || !Number.isFinite(minY)) return undefined
-      return { minX, minY, maxX, maxY }
-    }
+    const containerSizeOf = (root: HTMLDivElement | null): ContainerSize | null =>
+      root === null ? null : { width: root.clientWidth, height: root.clientHeight }
 
     /**
      * Frames the given content: pans so its center sits at the viewport
@@ -2366,29 +2300,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * and stays inside the viewport module's own [MIN_ZOOM, MAX_ZOOM].
      */
     const frameContent = (ids?: ReadonlySet<string>) => {
-      const bounds = contentBounds(ids)
+      const bounds = unionContentBounds(boxes, ids)
       if (bounds === undefined) return false
-      const root = rootRef.current
-      const center = viewportCenterScreen()
-      const contentCenter = {
-        x: (bounds.minX + bounds.maxX) / 2,
-        y: (bounds.minY + bounds.maxY) / 2,
-      }
-      const width = Math.max(1, bounds.maxX - bounds.minX)
-      const height = Math.max(1, bounds.maxY - bounds.minY)
-      setViewport((vp) => {
-        let zoom = vp.zoom
-        if (root !== null) {
-          const usableWidth = Math.max(1, root.clientWidth - FRAME_MARGIN_PX * 2)
-          const usableHeight = Math.max(1, root.clientHeight - FRAME_MARGIN_PX * 2)
-          zoom = clampZoom(Math.min(1, usableWidth / width, usableHeight / height))
-        }
-        return {
-          zoom,
-          x: contentCenter.x - center.x / zoom,
-          y: contentCenter.y - center.y / zoom,
-        }
-      })
+      const containerSize = containerSizeOf(rootRef.current)
+      setViewport((vp) => frameViewport(bounds, containerSize, vp.zoom, FRAME_MARGIN_PX))
       return true
     }
 
@@ -2415,31 +2330,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       })
     }
 
-    /** Link nodes are label-only chrome — a note-height box would be mostly
-     * empty, so they get a shorter default. */
-    const LINK_NODE_HEIGHT = 60
     const createLinkAtViewportCenter = (url: string, at?: Point) => {
       const root = rootRef.current
       const centerScreen =
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point =
-        at ?? findFreeSpot(preferred, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }, occupied)
+      const point = resolveSpawnPoint(
+        at,
+        preferred,
+        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
+        occupied,
+      )
       const id =
         createId?.() ??
         (typeof crypto !== 'undefined' && 'randomUUID' in crypto
           ? crypto.randomUUID()
           : String(Math.random()))
-      const node: SpatialNode = {
-        id,
-        type: 'link',
-        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
-        y: Math.round(point.y - LINK_NODE_HEIGHT / 2),
-        width: NEW_NODE_WIDTH,
-        height: LINK_NODE_HEIGHT,
-        url,
-      }
+      const node = linkNodeDefaults(id, point, url)
       applyResult({
         state: { kind: 'idle' },
         commands: [{ kind: 'create-node', node }],
@@ -2458,18 +2366,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point =
-        at ?? findFreeSpot(preferred, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }, occupied)
+      const point = resolveSpawnPoint(
+        at,
+        preferred,
+        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
+        occupied,
+      )
       const id = newId()
-      const node: SpatialNode = {
-        id,
-        type: 'file',
-        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
-        y: Math.round(point.y - LINK_NODE_HEIGHT / 2),
-        width: NEW_NODE_WIDTH,
-        height: LINK_NODE_HEIGHT,
-        file,
-      }
+      const node = fileNodeDefaults(id, point, file)
       applyResult({
         state: { kind: 'idle' },
         commands: [{ kind: 'create-node', node }],
@@ -2481,9 +2385,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
     }
 
-    /** Default frame for a created image node; the picture letterboxes into it. */
-    const IMAGE_NODE_WIDTH = 240
-    const IMAGE_NODE_HEIGHT = 180
     const imageInputRef = useRef<HTMLInputElement | null>(null)
     /** When set, the next picked image becomes this group's background instead of a new node. */
     const pendingBackgroundGroupIdRef = useRef<string | null>(null)
@@ -2496,19 +2397,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point =
-        at ??
-        findFreeSpot(preferred, { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT }, occupied)
+      const point = resolveSpawnPoint(
+        at,
+        preferred,
+        { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT },
+        occupied,
+      )
       const id = newId()
-      const node: SpatialNode = {
-        id,
-        type: 'file',
-        x: Math.round(point.x - IMAGE_NODE_WIDTH / 2),
-        y: Math.round(point.y - IMAGE_NODE_HEIGHT / 2),
-        width: IMAGE_NODE_WIDTH,
-        height: IMAGE_NODE_HEIGHT,
-        file,
-      }
+      const node = imageNodeDefaults(id, point, file)
       applyResult({
         state: { kind: 'idle' },
         commands: [{ kind: 'create-node', node }],
@@ -2545,29 +2441,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * zoom) so it sits centered — creation is always visible feedback.
      */
     const panToShow = (box: Box) => {
-      const root = rootRef.current
-      if (root === null) return
-      const topLeft = canvasToScreen({ x: box.x, y: box.y }, viewport)
-      const bottomRight = canvasToScreen({ x: box.x + box.width, y: box.y + box.height }, viewport)
-      const fits =
-        topLeft.x >= 0 &&
-        topLeft.y >= 0 &&
-        bottomRight.x <= root.clientWidth &&
-        bottomRight.y <= root.clientHeight
-      if (fits) return
-      const centerX = box.x + box.width / 2
-      const centerY = box.y + box.height / 2
-      setViewport((vp) => ({
-        ...vp,
-        x: centerX - root.clientWidth / 2 / vp.zoom,
-        y: centerY - root.clientHeight / 2 / vp.zoom,
-      }))
+      const containerSize = containerSizeOf(rootRef.current)
+      if (containerSize === null) return
+      setViewport((vp) => panToShowTarget(box, vp, containerSize) ?? vp)
     }
-
-    const GROUP_FRAME_WIDTH = 320
-    const GROUP_FRAME_HEIGHT = 200
-    /** Padding between a grouped selection's bounds and its new frame. */
-    const GROUP_PADDING_PX = 24
 
     const newId = () =>
       createId?.() ??
@@ -2581,62 +2458,34 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
       const preferred = screenToCanvas(centerScreen, viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point =
-        at ??
-        findFreeSpot(preferred, { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT }, occupied)
+      const point = resolveSpawnPoint(
+        at,
+        preferred,
+        { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT },
+        occupied,
+      )
       const id = newId()
+      const node = groupNodeDefaults(id, point)
       applyResult({
         state: { kind: 'idle' },
-        commands: [
-          {
-            kind: 'create-group',
-            node: {
-              id,
-              type: 'group',
-              x: Math.round(point.x - GROUP_FRAME_WIDTH / 2),
-              y: Math.round(point.y - GROUP_FRAME_HEIGHT / 2),
-              width: GROUP_FRAME_WIDTH,
-              height: GROUP_FRAME_HEIGHT,
-            },
-          },
-        ],
+        commands: [{ kind: 'create-group', node }],
         selectedId: id,
       })
       // Creation selects the new node EXCLUSIVELY — set-primary alone would
       // keep the old extras riding along into the next move/delete.
       applySelection({ type: 'collapse-extras' })
-      panToShow({
-        x: Math.round(point.x - GROUP_FRAME_WIDTH / 2),
-        y: Math.round(point.y - GROUP_FRAME_HEIGHT / 2),
-        width: GROUP_FRAME_WIDTH,
-        height: GROUP_FRAME_HEIGHT,
-      })
+      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
     }
 
     /** Frames the current multi-selection: enclosing box + padding. */
     const groupSelection = (memberIds: readonly string[]) => {
       const members = canvasRef.current.nodes.filter((n) => memberIds.includes(n.id))
-      if (members.length === 0) return
-      const minX = Math.min(...members.map((n) => n.x)) - GROUP_PADDING_PX
-      const minY = Math.min(...members.map((n) => n.y)) - GROUP_PADDING_PX
-      const maxX = Math.max(...members.map((n) => n.x + n.width)) + GROUP_PADDING_PX
-      const maxY = Math.max(...members.map((n) => n.y + n.height)) + GROUP_PADDING_PX
+      const frame = groupEnclosure(members)
+      if (frame === undefined) return
       const id = newId()
       applyResult({
         state: { kind: 'idle' },
-        commands: [
-          {
-            kind: 'create-group',
-            node: {
-              id,
-              type: 'group',
-              x: minX,
-              y: minY,
-              width: maxX - minX,
-              height: maxY - minY,
-            },
-          },
-        ],
+        commands: [{ kind: 'create-group', node: { id, type: 'group', ...frame } }],
         selectedId: id,
       })
       applySelection({ type: 'collapse-extras' })
@@ -2880,7 +2729,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             applyResult={applyResult}
             isEdgeLocked={isEdgeLocked}
             onToggleEdgeLock={onToggleEdgeLock}
-            edgeLockEnabled={edgeLockEnabled}
             setEdgeLabelEditId={setEdgeLabelEditId}
             setSelectedEdgeId={setSelectedEdgeId}
             setGroupLabelEditId={setGroupLabelEditId}
@@ -2895,10 +2743,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             imageInputRef={imageInputRef}
             pendingBackgroundGroupIdRef={pendingBackgroundGroupIdRef}
             isLocked={isLocked}
-            lockEnabled={lockEnabled}
             onToggleNodeLock={onToggleNodeLock}
             applyBoxMoves={applyBoxMoves}
-            selectedAlignableBoxes={selectedAlignableBoxes}
             extraIds={extraIds}
             selectedId={selectedId}
             groupSelection={groupSelection}

--- a/apps/web/src/components/spatial-editor/align.test.ts
+++ b/apps/web/src/components/spatial-editor/align.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { type AlignableBox, alignBoxes, distributeBoxes } from './align.js'
+import { type AlignableBox, alignableBoxesOf, alignBoxes, distributeBoxes } from './align.js'
 
 const box = (id: string, x: number, y: number, width = 100, height = 50): AlignableBox => ({
   id,
@@ -127,5 +127,30 @@ describe('distributeBoxes', () => {
     const crowded = [box('a', 0, 0, 100, 50), box('b', 0, 0, 100, 50), box('c', 0, 0, 100, 50)]
     const moves = distributeBoxes(crowded, 'horizontal')
     for (const move of moves) expect(Number.isFinite(move.x)).toBe(true)
+  })
+})
+
+describe('alignableBoxesOf', () => {
+  const nodes = [
+    { id: 'a', x: 0, y: 0, width: 100, height: 50, extra: 'dropped' },
+    { id: 'b', x: 40, y: 0, width: 60, height: 50 },
+    { id: 'c', x: 300, y: 0, width: 20, height: 50 },
+  ]
+
+  it('returns only the member boxes, in canvas (nodes) order', () => {
+    expect(alignableBoxesOf(nodes, ['c', 'a'])).toEqual([
+      { id: 'a', x: 0, y: 0, width: 100, height: 50 },
+      { id: 'c', x: 300, y: 0, width: 20, height: 50 },
+    ])
+  })
+
+  it('projects to the id+x+y+width+height shape, dropping other node fields', () => {
+    expect(alignableBoxesOf(nodes, ['a'])).toEqual([
+      { id: 'a', x: 0, y: 0, width: 100, height: 50 },
+    ])
+  })
+
+  it('returns an empty list for no member ids', () => {
+    expect(alignableBoxesOf(nodes, [])).toEqual([])
   })
 })

--- a/apps/web/src/components/spatial-editor/align.ts
+++ b/apps/web/src/components/spatial-editor/align.ts
@@ -20,6 +20,31 @@ export interface AlignableBox {
   readonly height: number
 }
 
+interface PositionedNode {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+/**
+ * The alignable boxes for a selection: every node in `nodes` whose id is in
+ * `memberIds`, in canvas order. Pure projection so a caller (the context
+ * menu) can derive its align/distribute input from a canvas + selection ids
+ * it already holds, instead of needing a bound closure passed down as a
+ * prop.
+ */
+export function alignableBoxesOf(
+  nodes: readonly PositionedNode[],
+  memberIds: readonly string[],
+): AlignableBox[] {
+  const ids = new Set(memberIds)
+  return nodes
+    .filter((node) => ids.has(node.id))
+    .map(({ id, x, y, width, height }) => ({ id, x, y, width, height }))
+}
+
 export interface BoxMove {
   readonly id: string
   readonly x: number

--- a/apps/web/src/components/spatial-editor/commands.property.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.property.test.ts
@@ -1,0 +1,71 @@
+// Metamorphic property for buildFragmentInsertCommand: relative geometry and
+// node count survive the remint+offset pipeline regardless of which offset
+// mode fires. Mutation-checked by temporarily breaking the offset/remint
+// rule in commands.ts and confirming this goes red (recorded in the commit).
+import type { ClipboardFragment, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../../test-utils/fast-check.js'
+import { applyCommand, buildFragmentInsertCommand } from './commands.js'
+
+const rawNodeArb = fc.record({
+  x: fc.integer({ min: -500, max: 500 }),
+  y: fc.integer({ min: -500, max: 500 }),
+  width: fc.integer({ min: 10, max: 200 }),
+  height: fc.integer({ min: 10, max: 200 }),
+})
+
+const fragmentArb: fc.Arbitrary<Pick<ClipboardFragment, 'nodes' | 'edges'>> = fc
+  .array(rawNodeArb, { minLength: 1, maxLength: 5 })
+  .map((raws) => ({
+    nodes: raws.map((raw, i) => ({ id: `n${i}`, type: 'text' as const, text: '', ...raw })),
+    edges: [] as ClipboardFragment['edges'],
+  }))
+
+const anchorArb = fc.option(
+  fc.record({ x: fc.integer({ min: -500, max: 500 }), y: fc.integer({ min: -500, max: 500 }) }),
+  { nil: undefined },
+)
+
+describe('buildFragmentInsertCommand properties', () => {
+  fcTest.prop([fragmentArb, anchorArb], withDefaults({ numRuns: 100 }))(
+    'preserves node count, relative positions, and id disjointness from the source canvas',
+    (fragment, anchor) => {
+      const canvas: SpatialCanvas = {
+        nodes: [{ id: 'existing', type: 'text', x: 0, y: 0, width: 10, height: 10, text: '' }],
+        edges: [],
+      }
+      let counter = 0
+      const createId = () => `remint-${counter++}`
+      const command = buildFragmentInsertCommand(canvas, fragment, createId, anchor)
+      if (command === undefined) return
+      const next = applyCommand(canvas, command)
+      expect(next.nodes).toHaveLength(canvas.nodes.length + fragment.nodes.length)
+
+      const inserted = next.nodes.slice(canvas.nodes.length)
+      expect(inserted.map((n) => n.id)).not.toContain('existing')
+
+      // Relative positions between every pair of source nodes are preserved
+      // under the single uniform (dx, dy) translation the builder applies.
+      for (let i = 0; i < fragment.nodes.length; i++) {
+        for (let j = 0; j < fragment.nodes.length; j++) {
+          expect(inserted[j].x - inserted[i].x).toBe(fragment.nodes[j].x - fragment.nodes[i].x)
+          expect(inserted[j].y - inserted[i].y).toBe(fragment.nodes[j].y - fragment.nodes[i].y)
+        }
+      }
+
+      if (anchor !== undefined) {
+        // Compare 2x(center) to 2x(anchor) instead of rounding twice: the
+        // builder itself rounds once (dx = round(anchor - center)), so the
+        // final center can land up to 0.5px off the anchor — bounding the
+        // doubled difference by 1 captures exactly that tolerance without a
+        // second, compounding round() in the assertion.
+        const minX = Math.min(...inserted.map((n) => n.x))
+        const maxX = Math.max(...inserted.map((n) => n.x + n.width))
+        const minY = Math.min(...inserted.map((n) => n.y))
+        const maxY = Math.max(...inserted.map((n) => n.y + n.height))
+        expect(Math.abs(minX + maxX - 2 * anchor.x)).toBeLessThanOrEqual(1)
+        expect(Math.abs(minY + maxY - 2 * anchor.y)).toBeLessThanOrEqual(1)
+      }
+    },
+  )
+})

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -1,7 +1,7 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { ClipboardFragment, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { spatialCanvasSchema } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
-import { applyCommand } from './commands.js'
+import { applyCommand, buildFragmentInsertCommand } from './commands.js'
 
 function baseCanvas(): SpatialCanvas {
   return {
@@ -721,5 +721,102 @@ describe('set-line-jumps', () => {
     })
     const off = applyCommand(both, { kind: 'set-line-jumps', lineJumps: 'none' })
     expect(off['x-whiteboard']?.edgeRouting).toEqual({ style: 'curved' })
+  })
+})
+
+describe('buildFragmentInsertCommand', () => {
+  // Shared core of pasteFragment (with/without an anchor) and
+  // duplicateSelection (always cascades, never anchors).
+  const fragment = (): Pick<ClipboardFragment, 'nodes' | 'edges'> => ({
+    nodes: [
+      { id: 'src-a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' },
+      { id: 'src-b', type: 'text', x: 150, y: 20, width: 60, height: 40, text: 'b' },
+    ],
+    edges: [{ id: 'src-e', fromNode: 'src-a', toNode: 'src-b', label: 'link' }],
+  })
+  const sequentialIds = () => {
+    let n = 0
+    return () => `new-${n++}`
+  }
+
+  it('returns undefined for an empty-node fragment', () => {
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    expect(buildFragmentInsertCommand(canvas, { nodes: [], edges: [] }, sequentialIds())).toBe(
+      undefined,
+    )
+  })
+
+  it('without an anchor, offsets every node +16/+16 (the duplicate cascade)', () => {
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    const command = buildFragmentInsertCommand(canvas, fragment(), sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const nodeCommands = command.commands.filter((c) => c.kind === 'create-node')
+    expect(nodeCommands.map((c) => ({ x: c.node.x, y: c.node.y }))).toEqual([
+      { x: 16, y: 16 },
+      { x: 166, y: 36 },
+    ])
+  })
+
+  it('with an anchor, the reminted bbox center lands on the anchor (rounded)', () => {
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    const command = buildFragmentInsertCommand(canvas, fragment(), sequentialIds(), {
+      x: 500,
+      y: 500,
+    })
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const nodeCommands = command.commands.filter((c) => c.kind === 'create-node')
+    const xs = nodeCommands.map((c) => c.node.x)
+    const ys = nodeCommands.map((c) => c.node.y)
+    const minX = Math.min(...xs)
+    const maxX = Math.max(...xs.map((x, i) => x + nodeCommands[i].node.width))
+    const minY = Math.min(...ys)
+    const maxY = Math.max(...ys.map((y, i) => y + nodeCommands[i].node.height))
+    expect(Math.round((minX + maxX) / 2)).toBe(500)
+    expect(Math.round((minY + maxY) / 2)).toBe(500)
+  })
+
+  it('preserves edge properties and remaps endpoints to the reminted ids', () => {
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    const command = buildFragmentInsertCommand(canvas, fragment(), sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const nodeIds = command.commands.filter((c) => c.kind === 'create-node').map((c) => c.node.id)
+    const edgeCommands = command.commands.filter((c) => c.kind === 'create-edge')
+    expect(edgeCommands).toHaveLength(1)
+    expect(edgeCommands[0].edge.label).toBe('link')
+    expect(nodeIds).toContain(edgeCommands[0].edge.fromNode)
+    expect(nodeIds).toContain(edgeCommands[0].edge.toNode)
+  })
+
+  it('reminted ids are disjoint from existing canvas node+edge ids', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [{ id: 'new-0', type: 'text', x: 0, y: 0, width: 10, height: 10, text: '' }],
+      edges: [],
+    }
+    const command = buildFragmentInsertCommand(canvas, fragment(), sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const nodeIds = command.commands.filter((c) => c.kind === 'create-node').map((c) => c.node.id)
+    expect(nodeIds).not.toContain('new-0')
+  })
+
+  it('applying the built command to the source canvas adds exactly fragment.nodes.length nodes', () => {
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    const command = buildFragmentInsertCommand(canvas, fragment(), sequentialIds())
+    if (command === undefined) throw new Error('expected a command')
+    const next = applyCommand(canvas, command)
+    expect(next.nodes).toHaveLength(2)
+  })
+
+  it('duplicateSelection parity: an edge with one endpoint outside the fragment is dropped', () => {
+    // Mirrors extractClipboardFragment's own contract — the fragment never
+    // arrives with a dangling edge, so the builder need not special-case it,
+    // but this pins that the whole pipeline still drops it end to end.
+    const canvas: SpatialCanvas = { nodes: [], edges: [] }
+    const partial: Pick<ClipboardFragment, 'nodes' | 'edges'> = {
+      nodes: [{ id: 'src-a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'a' }],
+      edges: [{ id: 'src-e', fromNode: 'src-a', toNode: 'not-included' }],
+    }
+    const command = buildFragmentInsertCommand(canvas, partial, sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    expect(command.commands.filter((c) => c.kind === 'create-edge')).toHaveLength(0)
   })
 })

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -21,11 +21,14 @@
 import type {
   CanvasColor,
   CanvasEdge,
+  ClipboardFragment,
   EdgeRoutingStyle,
   LineJumps,
   SpatialCanvas,
   SpatialNode,
 } from '@kamiazya/whiteboard-canvas-model'
+import { remintClipboardFragment } from '../../lib/clipboard-fragment.js'
+import type { Point } from './viewport.js'
 
 export type EditorLeafCommand =
   | { readonly kind: 'move-node'; readonly id: string; readonly x: number; readonly y: number }
@@ -587,4 +590,51 @@ function reorderNodes(
   // anything move" (and undo history stays free of empty steps).
   if (next.every((node, index) => node === canvas.nodes[index])) return canvas
   return { ...canvas, nodes: next }
+}
+
+/** Standard duplicate-again cascade offset — also `pasteFragment`'s
+ * fallback when it is given no anchor point. */
+const DUPLICATE_OFFSET_PX = 16
+
+/**
+ * The shared core of `pasteFragment` and `duplicateSelection`: remint a
+ * fragment's ids against `canvas`'s existing ones, then batch it in as
+ * `create-node`/`create-edge`, offset either by the standard +16/+16
+ * duplicate cascade (no anchor) or so its bounding-box center lands on
+ * `anchor` (rounded) — the "Paste here" placement. Undefined for an
+ * empty-node fragment, matching every other command builder's totality
+ * contract: nothing to insert is nothing to command.
+ */
+export function buildFragmentInsertCommand(
+  canvas: SpatialCanvas,
+  fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
+  createId: () => string,
+  anchor?: Point,
+): EditorCommand | undefined {
+  if (fragment.nodes.length === 0) return undefined
+  const existingIds = new Set([
+    ...canvas.nodes.map((node) => node.id),
+    ...canvas.edges.map((edge) => edge.id),
+  ])
+  const reminted = remintClipboardFragment(fragment, createId, existingIds)
+  let dx = DUPLICATE_OFFSET_PX
+  let dy = DUPLICATE_OFFSET_PX
+  if (anchor !== undefined) {
+    const minX = Math.min(...reminted.nodes.map((node) => node.x))
+    const minY = Math.min(...reminted.nodes.map((node) => node.y))
+    const maxX = Math.max(...reminted.nodes.map((node) => node.x + node.width))
+    const maxY = Math.max(...reminted.nodes.map((node) => node.y + node.height))
+    dx = Math.round(anchor.x - (minX + maxX) / 2)
+    dy = Math.round(anchor.y - (minY + maxY) / 2)
+  }
+  return {
+    kind: 'batch',
+    commands: [
+      ...reminted.nodes.map(
+        (node) =>
+          ({ kind: 'create-node', node: { ...node, x: node.x + dx, y: node.y + dy } }) as const,
+      ),
+      ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
+    ],
+  }
 }

--- a/apps/web/src/components/spatial-editor/node-factories.test.ts
+++ b/apps/web/src/components/spatial-editor/node-factories.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fileNodeDefaults,
+  GROUP_FRAME_HEIGHT,
+  GROUP_FRAME_WIDTH,
+  GROUP_PADDING_PX,
+  groupEnclosure,
+  groupNodeDefaults,
+  IMAGE_NODE_HEIGHT,
+  IMAGE_NODE_WIDTH,
+  imageNodeDefaults,
+  LINK_NODE_HEIGHT,
+  linkNodeDefaults,
+  resolveSpawnPoint,
+  textNodeDefaults,
+} from './node-factories.js'
+
+describe('node factories', () => {
+  it('textNodeDefaults centers a NEW_NODE_WIDTH/HEIGHT box on the given point, rounding to integers', () => {
+    const node = textNodeDefaults('id-1', { x: 100.4, y: 50.6 }, 'hello')
+    expect(node).toMatchObject({ id: 'id-1', type: 'text', text: 'hello' })
+    expect(Number.isInteger(node.x)).toBe(true)
+    expect(Number.isInteger(node.y)).toBe(true)
+  })
+
+  it('linkNodeDefaults uses the shorter LINK_NODE_HEIGHT default (60)', () => {
+    const node = linkNodeDefaults('id-2', { x: 0, y: 0 }, 'https://example.com')
+    expect(LINK_NODE_HEIGHT).toBe(60)
+    expect(node).toMatchObject({ type: 'link', url: 'https://example.com', height: 60 })
+  })
+
+  it('fileNodeDefaults uses the shorter LINK_NODE_HEIGHT default (60)', () => {
+    const node = fileNodeDefaults('id-3', { x: 0, y: 0 }, 'notes.canvas')
+    expect(node).toMatchObject({ type: 'file', file: 'notes.canvas', height: 60 })
+  })
+
+  it('imageNodeDefaults uses the 240x180 default', () => {
+    expect(IMAGE_NODE_WIDTH).toBe(240)
+    expect(IMAGE_NODE_HEIGHT).toBe(180)
+    const node = imageNodeDefaults('id-4', { x: 0, y: 0 }, 'photo.png')
+    expect(node).toMatchObject({ type: 'file', file: 'photo.png', width: 240, height: 180 })
+  })
+
+  it('groupNodeDefaults uses the 320x200 default', () => {
+    expect(GROUP_FRAME_WIDTH).toBe(320)
+    expect(GROUP_FRAME_HEIGHT).toBe(200)
+    const node = groupNodeDefaults('id-5', { x: 0, y: 0 })
+    expect(node).toMatchObject({ type: 'group', width: 320, height: 200 })
+  })
+
+  it('every factory centers its box: point sits at (x + width/2, y + height/2)', () => {
+    const point = { x: 400, y: 300 }
+    const node = imageNodeDefaults('id-6', point, 'photo.png')
+    expect(node.x + node.width / 2).toBe(point.x)
+    expect(node.y + node.height / 2).toBe(point.y)
+  })
+})
+
+describe('resolveSpawnPoint', () => {
+  const size = { width: 100, height: 50 }
+
+  it('returns the anchor verbatim when given, ignoring findFreeSpot entirely', () => {
+    const anchor = { x: 42, y: 42 }
+    const occupied = [{ x: 42, y: 42, width: 500, height: 500 }] // would collide if findFreeSpot ran
+    expect(resolveSpawnPoint(anchor, { x: 0, y: 0 }, size, occupied)).toEqual(anchor)
+  })
+
+  it('falls back to findFreeSpot(preferred, size, occupied) when no anchor is given', () => {
+    const preferred = { x: 0, y: 0 }
+    expect(resolveSpawnPoint(undefined, preferred, size, [])).toEqual(preferred)
+  })
+
+  it('cascades away from an occupied preferred spot when no anchor is given', () => {
+    const preferred = { x: 0, y: 0 }
+    const occupied = [{ x: -50, y: -25, width: 100, height: 50 }]
+    const spot = resolveSpawnPoint(undefined, preferred, size, occupied)
+    expect(spot).not.toEqual(preferred)
+  })
+})
+
+describe('groupEnclosure', () => {
+  it('frames the union of member boxes, grown by GROUP_PADDING_PX on every side', () => {
+    expect(GROUP_PADDING_PX).toBe(24)
+    const members = [
+      { x: 0, y: 0, width: 100, height: 50 },
+      { x: 200, y: 100, width: 40, height: 40 },
+    ]
+    // union: x in [0, 240], y in [0, 140] -> padded by 24 on every side.
+    expect(groupEnclosure(members)).toEqual({ x: -24, y: -24, width: 288, height: 188 })
+  })
+
+  it('returns undefined for an empty member list (no-op signal)', () => {
+    expect(groupEnclosure([])).toBeUndefined()
+  })
+
+  it('every side clearance to the nearest member equals GROUP_PADDING_PX exactly', () => {
+    const members = [{ x: 10, y: 10, width: 30, height: 20 }]
+    const frame = groupEnclosure(members)
+    expect(frame).toEqual({
+      x: 10 - GROUP_PADDING_PX,
+      y: 10 - GROUP_PADDING_PX,
+      width: 30 + GROUP_PADDING_PX * 2,
+      height: 20 + GROUP_PADDING_PX * 2,
+    })
+  })
+})

--- a/apps/web/src/components/spatial-editor/node-factories.ts
+++ b/apps/web/src/components/spatial-editor/node-factories.ts
@@ -1,0 +1,149 @@
+/**
+ * Default-node construction, spawn-point resolution, and group-enclosure
+ * math for the editor's node-creation family (palette buttons, the "Add X
+ * here" context-menu items, group-from-selection). This fits none of the
+ * three existing pure modules: `commands.ts` builds `EditorCommand`s over an
+ * EXISTING canvas, not the `SpatialNode` values a command eventually
+ * carries; `viewport.ts` is the pan/zoom transform, not node geometry;
+ * `geometry.ts` is hit-testing/selection geometry over nodes that already
+ * exist, not construction of new ones (though it supplies `findFreeSpot`,
+ * which this module composes with an anchor override).
+ *
+ * Id minting is always caller-injected (every factory takes `id: string`)
+ * — this file must never reference `crypto` or any other ambient id
+ * source, so the purity-guard scan mechanically enforces the
+ * injected-id-minting discipline the callers rely on for deterministic
+ * tests.
+ */
+import type { SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type { Box } from './geometry.js'
+import { findFreeSpot } from './geometry.js'
+import { NEW_NODE_HEIGHT, NEW_NODE_WIDTH } from './gestures.js'
+import type { Point } from './viewport.js'
+
+/** Link nodes are label-only chrome — a note-height box would be mostly
+ * empty, so they (and file-reference cards) get a shorter default. */
+export const LINK_NODE_HEIGHT = 60
+/** Default frame for a created image node; the picture letterboxes into it. */
+export const IMAGE_NODE_WIDTH = 240
+export const IMAGE_NODE_HEIGHT = 180
+export const GROUP_FRAME_WIDTH = 320
+export const GROUP_FRAME_HEIGHT = 200
+/** Padding between a grouped selection's bounds and its new frame. */
+export const GROUP_PADDING_PX = 24
+
+interface Size {
+  readonly width: number
+  readonly height: number
+}
+
+/** Shared box shape every factory below centers on `point`. */
+function centeredBox(id: string, point: Point, size: Size) {
+  return {
+    id,
+    x: Math.round(point.x - size.width / 2),
+    y: Math.round(point.y - size.height / 2),
+    width: size.width,
+    height: size.height,
+  }
+}
+
+export function textNodeDefaults(
+  id: string,
+  point: Point,
+  text: string,
+): Extract<SpatialNode, { type: 'text' }> {
+  return {
+    ...centeredBox(id, point, { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT }),
+    type: 'text',
+    text,
+  }
+}
+
+export function linkNodeDefaults(
+  id: string,
+  point: Point,
+  url: string,
+): Extract<SpatialNode, { type: 'link' }> {
+  return {
+    ...centeredBox(id, point, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }),
+    type: 'link',
+    url,
+  }
+}
+
+export function fileNodeDefaults(
+  id: string,
+  point: Point,
+  file: string,
+): Extract<SpatialNode, { type: 'file' }> {
+  return {
+    ...centeredBox(id, point, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT }),
+    type: 'file',
+    file,
+  }
+}
+
+/** Images ARE file nodes (JSON Canvas has no dedicated image type) — only
+ * the default box shape differs from a plain file reference card. */
+export function imageNodeDefaults(
+  id: string,
+  point: Point,
+  file: string,
+): Extract<SpatialNode, { type: 'file' }> {
+  return {
+    ...centeredBox(id, point, { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT }),
+    type: 'file',
+    file,
+  }
+}
+
+export function groupNodeDefaults(
+  id: string,
+  point: Point,
+): Extract<SpatialNode, { type: 'group' }> {
+  return {
+    ...centeredBox(id, point, { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT }),
+    type: 'group',
+  }
+}
+
+/**
+ * Where a newly created node should spawn: the given anchor verbatim (the
+ * user already chose "here" via the empty-space context menu), or else the
+ * nearest non-colliding spot to `preferred` (the viewport-center button
+ * path, which needs `findFreeSpot`'s cascade so repeated clicks do not
+ * stack identical, unreachable boxes).
+ */
+export function resolveSpawnPoint(
+  anchor: Point | undefined,
+  preferred: Point,
+  size: Size,
+  occupied: readonly Box[],
+): Point {
+  return anchor ?? findFreeSpot(preferred, size, occupied)
+}
+
+export interface GroupEnclosure {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+/**
+ * The padded frame enclosing every member box — `groupSelection`'s "frame
+ * the current multi-selection" math. Undefined for an empty member list is
+ * the no-op signal callers use to skip creating a degenerate group.
+ */
+export function groupEnclosure(
+  members: readonly Box[],
+  paddingPx: number = GROUP_PADDING_PX,
+): GroupEnclosure | undefined {
+  if (members.length === 0) return undefined
+  const minX = Math.min(...members.map((m) => m.x)) - paddingPx
+  const minY = Math.min(...members.map((m) => m.y)) - paddingPx
+  const maxX = Math.max(...members.map((m) => m.x + m.width)) + paddingPx
+  const maxY = Math.max(...members.map((m) => m.y + m.height)) + paddingPx
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -3,11 +3,22 @@ import { describe, expect, it } from 'vitest'
 const modules = import.meta.glob('./**/*.{ts,tsx}', { query: '?raw', import: 'default' })
 
 // The theme threading in editor-appearance.ts/scene-render.ts must stay a
-// pure function of its `theme` argument — no ambient DOM read. Scoped to
-// exactly these two files (not the whole directory) so a rename or a new
-// file silently falling out of the scan is caught by the explicit-path
-// assertion below, rather than the guard quietly covering zero files.
-const SCANNED_PATHS = ['./editor-appearance.ts', './scene-render.ts']
+// pure function of its `theme` argument — no ambient DOM read. viewport.ts
+// and node-factories.ts join for the same reason (pan/zoom math and node
+// construction must never read a global) — commands.ts does NOT join: its
+// existing prose ("...at another document. A stale subpath...") trips the
+// `document.`-tripwire below on a sentence boundary, not a real impurity,
+// and loosening the regex to admit it would weaken the guard for every
+// other file. Scoped to exactly this list (not the whole directory) so a
+// rename or a new file silently falling out of the scan is caught by the
+// explicit-path assertion below, rather than the guard quietly covering
+// zero files.
+const SCANNED_PATHS = [
+  './editor-appearance.ts',
+  './scene-render.ts',
+  './viewport.ts',
+  './node-factories.ts',
+]
 
 describe('theme resolver purity (no ambient DOM read)', () => {
   it('scans exactly the expected files', () => {
@@ -24,6 +35,24 @@ describe('theme resolver purity (no ambient DOM read)', () => {
       expect(source).not.toMatch(/\bdocument\./)
       expect(source).not.toMatch(/\bmatchMedia\(/)
       expect(source).not.toMatch(/\bnavigator\./)
+    })
+
+    // Id minting stays injected (a `createId` argument) precisely so a pure
+    // module never needs an ambient id source — these two catch a
+    // regression mechanically instead of relying on review. React
+    // imports/hooks are the other ambient-state door a "pure" module could
+    // sneak through (closing over component state via a hook).
+    it(`${path} imports no React and calls no React hook`, async () => {
+      const loader = modules[path]
+      const source = (await loader?.()) as string
+      expect(source).not.toMatch(/\bfrom ['"]react['"]/)
+      expect(source).not.toMatch(/\buse(State|Ref|Effect|Callback|Memo)\(/)
+    })
+
+    it(`${path} references no ambient crypto`, async () => {
+      const loader = modules[path]
+      const source = (await loader?.()) as string
+      expect(source).not.toMatch(/\bcrypto\./)
     })
   }
 

--- a/apps/web/src/components/spatial-editor/viewport.property.test.ts
+++ b/apps/web/src/components/spatial-editor/viewport.property.test.ts
@@ -1,0 +1,70 @@
+// Containment property for frameViewport: whenever the fit-zoom is not
+// clamped at MIN_ZOOM, the framed box stays fully inside the container
+// (inset by the frame margin), and the content center always lands on the
+// container's screen center. Mutation-checked by dropping the margin or the
+// min(1, ...) clamp in viewport.ts and confirming this goes red.
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../../test-utils/fast-check.js'
+import { canvasToScreen, frameViewport, MIN_ZOOM } from './viewport.js'
+
+// Both smaller-than-container and larger-than-container boxes are needed:
+// an all-larger generator never exercises the min(1, ...) magnify guard,
+// and an all-smaller one never exercises the shrink-to-fit arm — either
+// gap would make the containment check pass vacuously on the untested arm.
+const boundsArb = fc
+  .record({
+    x: fc.integer({ min: -2000, max: 2000 }),
+    y: fc.integer({ min: -2000, max: 2000 }),
+    width: fc.integer({ min: 1, max: 4000 }),
+    height: fc.integer({ min: 1, max: 4000 }),
+  })
+  .map((box) => ({
+    minX: box.x,
+    minY: box.y,
+    maxX: box.x + box.width,
+    maxY: box.y + box.height,
+  }))
+
+const containerArb = fc.record({
+  width: fc.integer({ min: 100, max: 1600 }),
+  height: fc.integer({ min: 100, max: 1200 }),
+})
+
+const marginArb = fc.integer({ min: 0, max: 40 })
+
+describe('frameViewport properties', () => {
+  fcTest.prop([boundsArb, containerArb, marginArb], withDefaults({ numRuns: 100 }))(
+    'the content center always maps to the container center',
+    (bounds, containerSize, marginPx) => {
+      const vp = frameViewport(bounds, containerSize, 1, marginPx)
+      const contentCenter = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      }
+      const mapped = canvasToScreen(contentCenter, vp)
+      expect(mapped.x).toBeCloseTo(containerSize.width / 2, 6)
+      expect(mapped.y).toBeCloseTo(containerSize.height / 2, 6)
+    },
+  )
+
+  fcTest.prop([boundsArb, containerArb, marginArb], withDefaults({ numRuns: 100 }))(
+    'when the fit-zoom is not clamped at MIN_ZOOM, every box corner maps inside the margin-inset container',
+    (bounds, containerSize, marginPx) => {
+      const vp = frameViewport(bounds, containerSize, 1, marginPx)
+      if (vp.zoom <= MIN_ZOOM) return // clamp arm: containment is not guaranteed by design
+      const corners = [
+        { x: bounds.minX, y: bounds.minY },
+        { x: bounds.maxX, y: bounds.minY },
+        { x: bounds.minX, y: bounds.maxY },
+        { x: bounds.maxX, y: bounds.maxY },
+      ]
+      for (const corner of corners) {
+        const mapped = canvasToScreen(corner, vp)
+        expect(mapped.x).toBeGreaterThanOrEqual(marginPx - 1e-6)
+        expect(mapped.x).toBeLessThanOrEqual(containerSize.width - marginPx + 1e-6)
+        expect(mapped.y).toBeGreaterThanOrEqual(marginPx - 1e-6)
+        expect(mapped.y).toBeLessThanOrEqual(containerSize.height - marginPx + 1e-6)
+      }
+    },
+  )
+})

--- a/apps/web/src/components/spatial-editor/viewport.test.ts
+++ b/apps/web/src/components/spatial-editor/viewport.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest'
 import {
   canvasToScreen,
   clampZoom,
+  contentBounds,
   fitViewportToBoxes,
+  frameViewport,
   IDENTITY_VIEWPORT,
   MAX_ZOOM,
   MIN_ZOOM,
   panBy,
+  panToShowTarget,
   screenToCanvas,
   viewportTransformCss,
   zoomAt,
@@ -98,5 +101,90 @@ describe('fitViewportToBoxes', () => {
       { x: 15, y: 25, width: 5, height: 5 },
     ]
     expect(fitViewportToBoxes(boxes)).toEqual({ x: 15, y: 25, zoom: 1 })
+  })
+})
+
+describe('contentBounds', () => {
+  const boxes = [
+    { id: 'a', box: { x: 0, y: 0, width: 10, height: 10 } },
+    { id: 'b', box: { x: 100, y: 40, width: 10, height: 10 } },
+    { id: 'c', box: { x: Number.NaN, y: 0, width: 10, height: 10 } },
+  ]
+
+  it('unions every finite box when no ids filter is given', () => {
+    expect(contentBounds(boxes)).toEqual({ minX: 0, minY: 0, maxX: 110, maxY: 50 })
+  })
+
+  it('restricts the union to the given ids, ignoring non-members', () => {
+    expect(contentBounds(boxes, new Set(['a']))).toEqual({ minX: 0, minY: 0, maxX: 10, maxY: 10 })
+  })
+
+  it('ignores a non-finite box even when it is a named member', () => {
+    expect(contentBounds(boxes, new Set(['c']))).toBeUndefined()
+  })
+
+  it('degrades to undefined for an empty list', () => {
+    expect(contentBounds([])).toBeUndefined()
+  })
+})
+
+describe('frameViewport', () => {
+  const bounds = { minX: 0, minY: 0, maxX: 200, maxY: 100 }
+
+  it('never magnifies past 1:1 even when the container is far larger than the content', () => {
+    const vp = frameViewport(bounds, { width: 2000, height: 2000 }, 1, 24)
+    expect(vp.zoom).toBe(1)
+  })
+
+  it('shrinks to fit an oversized box, clamped to [MIN_ZOOM, MAX_ZOOM]', () => {
+    const vp = frameViewport(
+      { minX: 0, minY: 0, maxX: 100_000, maxY: 100_000 },
+      { width: 800, height: 600 },
+      1,
+      24,
+    )
+    expect(vp.zoom).toBeGreaterThanOrEqual(MIN_ZOOM)
+    expect(vp.zoom).toBeLessThanOrEqual(MAX_ZOOM)
+  })
+
+  it("the bounds' center maps to the container's screen center", () => {
+    const containerSize = { width: 800, height: 600 }
+    const vp = frameViewport(bounds, containerSize, 1, 24)
+    const mapped = canvasToScreen({ x: 100, y: 50 }, vp)
+    expect(mapped.x).toBeCloseTo(containerSize.width / 2)
+    expect(mapped.y).toBeCloseTo(containerSize.height / 2)
+  })
+
+  it('a null containerSize (root not yet measured) keeps currentZoom and still pans', () => {
+    const vp = frameViewport(bounds, null, 3, 24)
+    expect(vp.zoom).toBe(3)
+    // center defaults to screen (0,0) — content center maps there too.
+    expect(canvasToScreen({ x: 100, y: 50 }, vp)).toEqual({ x: 0, y: 0 })
+  })
+})
+
+describe('panToShowTarget', () => {
+  const containerSize = { width: 800, height: 600 }
+
+  it('returns undefined (no-op) when the box already fits fully on screen', () => {
+    const vp = { x: 0, y: 0, zoom: 1 }
+    expect(panToShowTarget({ x: 10, y: 10, width: 50, height: 50 }, vp, containerSize)).toBe(
+      undefined,
+    )
+  })
+
+  it('pans to center the box, keeping the current zoom, when it does not fit', () => {
+    const vp = { x: 0, y: 0, zoom: 2 }
+    const box = { x: 5000, y: 5000, width: 100, height: 100 }
+    const next = panToShowTarget(box, vp, containerSize)
+    expect(next?.zoom).toBe(2)
+    const centerScreen = canvasToScreen({ x: 5050, y: 5050 }, next as typeof vp)
+    expect(centerScreen.x).toBeCloseTo(containerSize.width / 2)
+    expect(centerScreen.y).toBeCloseTo(containerSize.height / 2)
+  })
+
+  it('returns undefined when containerSize is null (root not yet measured)', () => {
+    const vp = { x: 0, y: 0, zoom: 1 }
+    expect(panToShowTarget({ x: 5000, y: 5000, width: 10, height: 10 }, vp, null)).toBe(undefined)
   })
 })

--- a/apps/web/src/components/spatial-editor/viewport.ts
+++ b/apps/web/src/components/spatial-editor/viewport.ts
@@ -96,3 +96,111 @@ export function fitViewportToBoxes(boxes: readonly BBoxLike[]): Viewport {
 export function viewportTransformCss(viewport: Viewport): string {
   return `scale(${viewport.zoom}) translate(${-viewport.x}px, ${-viewport.y}px)`
 }
+
+export interface Bounds {
+  readonly minX: number
+  readonly minY: number
+  readonly maxX: number
+  readonly maxY: number
+}
+
+interface IdentifiedBox {
+  readonly id: string
+  readonly box: BBoxLike
+}
+
+/**
+ * Union of the given boxes' extents, restricted to `ids` when given.
+ * Ignores a box with a non-finite x/y. Undefined signals "nothing to
+ * frame" — the no-op callers use to skip a frame/pan action rather than
+ * producing NaN/Infinity bounds.
+ */
+export function contentBounds(
+  boxes: readonly IdentifiedBox[],
+  ids?: ReadonlySet<string>,
+): Bounds | undefined {
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const { id, box } of boxes) {
+    if (ids !== undefined && !ids.has(id)) continue
+    if (!Number.isFinite(box.x) || !Number.isFinite(box.y)) continue
+    minX = Math.min(minX, box.x)
+    minY = Math.min(minY, box.y)
+    maxX = Math.max(maxX, box.x + box.width)
+    maxY = Math.max(maxY, box.y + box.height)
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) return undefined
+  return { minX, minY, maxX, maxY }
+}
+
+export interface ContainerSize {
+  readonly width: number
+  readonly height: number
+}
+
+/**
+ * Fit-zoom+center viewport that frames `bounds`: pans so its center sits at
+ * the container's screen center, and zooms so the whole box fits inside the
+ * container minus `marginPx` on every side — magnifying a small selection as
+ * readily as it shrinks an oversized canvas. Never magnifies past 1:1 (a
+ * two-word note would otherwise fill the screen) and stays inside
+ * [MIN_ZOOM, MAX_ZOOM]. `containerSize: null` (root not yet measured) keeps
+ * `currentZoom` and still pans, matching this module's other total-by-
+ * degradation functions rather than requiring a measured container.
+ */
+export function frameViewport(
+  bounds: Bounds,
+  containerSize: ContainerSize | null,
+  currentZoom: number,
+  marginPx: number,
+): Viewport {
+  const center =
+    containerSize === null
+      ? { x: 0, y: 0 }
+      : { x: containerSize.width / 2, y: containerSize.height / 2 }
+  const contentCenter = { x: (bounds.minX + bounds.maxX) / 2, y: (bounds.minY + bounds.maxY) / 2 }
+  const width = Math.max(1, bounds.maxX - bounds.minX)
+  const height = Math.max(1, bounds.maxY - bounds.minY)
+  let zoom = currentZoom
+  if (containerSize !== null) {
+    const usableWidth = Math.max(1, containerSize.width - marginPx * 2)
+    const usableHeight = Math.max(1, containerSize.height - marginPx * 2)
+    zoom = clampZoom(Math.min(1, usableWidth / width, usableHeight / height))
+  }
+  return {
+    zoom,
+    x: contentCenter.x - center.x / zoom,
+    y: contentCenter.y - center.y / zoom,
+  }
+}
+
+/**
+ * The viewport that pans (keeping zoom) so `box` sits centered on screen —
+ * only when it does not already fit. Undefined is the no-op signal:
+ * "already visible" (nothing to pan) or `containerSize: null` (root not yet
+ * measured, nothing to pan against).
+ */
+export function panToShowTarget(
+  box: BBoxLike,
+  viewport: Viewport,
+  containerSize: ContainerSize | null,
+): Viewport | undefined {
+  if (containerSize === null) return undefined
+  const topLeft = canvasToScreen({ x: box.x, y: box.y }, viewport)
+  const bottomRight = canvasToScreen({ x: box.x + box.width, y: box.y + box.height }, viewport)
+  const fits =
+    topLeft.x >= 0 &&
+    topLeft.y >= 0 &&
+    bottomRight.x <= containerSize.width &&
+    bottomRight.y <= containerSize.height
+  if (fits) return undefined
+  const centerX = box.x + box.width / 2
+  const centerY = box.y + box.height / 2
+  return {
+    ...viewport,
+    x: centerX - containerSize.width / 2 / viewport.zoom,
+    y: centerY - containerSize.height / 2 / viewport.zoom,
+  }
+}


### PR DESCRIPTION
## What

Track 2 of the SpatialEditor decomposition (Track 1 = #697). The pure-logic closure families move out of `SpatialEditor.tsx` into explicit-arg pure functions, with node-layer tests as the payoff:

- `commands.ts`: `buildFragmentInsertCommand` — the shared core of paste/duplicate (remint + offset/anchor + batch build); empty-fragment → `undefined` no-op preserved
- `viewport.ts`: `contentBounds`, `frameViewport` (fit-zoom ≤ 1, margin, [MIN,MAX] clamps), `panToShowTarget`
- `node-factories.ts` (new, header states why it fits none of the existing three): node defaults per kind, `resolveSpawnPoint`, `groupEnclosure`, with id-minting injected (`createId` arg)
- `align.ts`: `alignableBoxesOf`
- z-order: already extracted in Track 1 — nothing moved, recorded

**Purity is now mechanically enforced**: `purity-guard.test.ts` gains two NEW pattern groups (React import/hook; `crypto.`) beyond the existing DOM-global scan — the PlanReview gate caught that the old regex set would have made the purity claim vacuous. `viewport.ts` + `node-factories.ts` joined `SCANNED_PATHS` cleanly; `commands.ts` is scoped out with a documented reason (a pre-existing comment trips the `document.` tripwire on a sentence boundary — false positive, rewording is out of scope).

**Deltas**: `SpatialEditor.tsx` 3,326 → 3,172; `CanvasContextMenu` props 38 → 35 (`edgeLockEnabled`/`lockEnabled` derived from callback presence; `selectedAlignableBoxes` derived via the pure helper — the `applyResult` no-op-parity risk the design flagged applies to none of the three; `duplicateSelection`/`reorderSelection` deliberately stay callbacks).

## Tests

Red-first node tests per extracted function (7 files / 123 tests on the touched set) plus two mutation-checked fast-check properties (fragment-insert translation/remint invariants; framing containment). **Five mutation-checks recorded** (React import → red, `crypto.randomUUID` → red, zeroed offsets → red, dropped margin → red, dropped ≤1 clamp → red). Zero browser tests modified or deleted — 53 files / 312 tests green unmodified, full `pnpm run test:browser` 97 files / 518 green.

## Gates

apps/web jsdom 2,000 green; `pnpm -r typecheck`, `pnpm build`, `pnpm knip`, lint clean; bundle-size smoke all budgets green (118.6KB/126KB critical-path). Review workflow: zero confirmed findings; QA smoke/error-recovery/startup pass. Contended full-monorepo runs showed only known environmental flake shapes, each re-verified green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw