### PR TITLE
feat(web): open a canvas in the tool its own shape implies

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -94,6 +94,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { extractClipboardFragment, parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { readClipboardFragment, writeClipboardFragment } from '../../lib/clipboard-store.js'
@@ -251,12 +252,22 @@ export interface SpatialEditorProps {
    */
   readonly theme?: ResolvedTheme
   /**
-   * The tool active on mount. Defaults to 'hand' — the product opens in
-   * navigation mode (user decision 2026-08-08): a plain drag pans and no
-   * press can select, move, or edit until the user switches to Select.
-   * Tests exercising editing flows pass 'select' explicitly.
+   * The tool active on mount. Pages resolve it from the canvas's own shape
+   * and the tab's last choice (`resolveInitialTool`): an empty canvas opens
+   * ready to place, one with content opens in navigation mode so a plain
+   * drag pans instead of moving someone's work. Defaults to 'hand' for
+   * callers that express no preference; tests exercising editing flows pass
+   * 'select' explicitly.
    */
   readonly defaultTool?: EditorTool
+  /**
+   * The tool this canvas should open in, resolved by the page only once its
+   * document has loaded (the node count that decides it is not known at
+   * mount). Applied exactly once, and never over a choice the user already
+   * made with the palette — an opening preference must not reach in and
+   * change the mode someone is working in.
+   */
+  readonly initialTool?: EditorTool
   /**
    * Node ids the user has locked. Lock is HOST state — it lives in the
    * Loro doc's sidecar map, not in the canvas value — so it arrives as a
@@ -396,6 +407,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       testId = DEFAULT_TEST_ID,
       theme = 'light',
       defaultTool = 'hand',
+      initialTool,
       lockedNodeIds,
       lockedEdgeIds,
       onToggleEdgeLock,
@@ -450,6 +462,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // arms object-first click-A, click-B edge creation. Creation is
     // deliberately NOT a mode — the palette's Add note works in every mode.
     const [tool, setTool] = useState<EditorTool>(defaultTool)
+    const toolChosenByUserRef = useRef(false)
+    const initialToolAppliedRef = useRef(false)
+    useEffect(() => {
+      if (initialTool === undefined) return
+      if (initialToolAppliedRef.current || toolChosenByUserRef.current) return
+      initialToolAppliedRef.current = true
+      setTool(initialTool)
+    }, [initialTool])
     const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null)
     /**
      * Additional selected node ids beyond the reducer's single primary
@@ -2662,6 +2682,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           tool={tool}
           onToolChange={(next) => {
             setTool(next)
+            toolChosenByUserRef.current = true
+            // A stated preference outranks the canvas-shape guess on the
+            // next open in this tab.
+            writeLastTool(next)
             // A context menu is an edit affordance of the mode it was
             // opened in — switching tools (especially into view-only hand
             // mode) must not leave it floating.

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -26,6 +26,13 @@ export type SceneExportFormat = 'png' | 'svg'
 
 export interface UseCanvasSyncResult {
   syncStatus: SyncStatus
+  /**
+   * True once the backend has published this canvas's document at least
+   * once. The document arrives AFTER mount, so anything deriving a decision
+   * from the canvas's shape (its node count, say) must wait for this rather
+   * than reading the empty placeholder the hook starts with.
+   */
+  loaded: boolean
   canvas: SpatialCanvas
   onChange: (next: SpatialCanvas, command: EditorCommand) => void
   // Bumps only on an externally-originated canvas publish (initial hydrate,
@@ -160,6 +167,7 @@ export function useCanvasSync(
 
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
   const [canvas, setCanvas] = useState<SpatialCanvas>(EMPTY_CANVAS)
+  const [loaded, setLoaded] = useState(false)
   const [externalVersion, setExternalVersion] = useState(0)
   // Render signal only — the value itself is never read.
   const [, setHistoryVersion] = useState(0)
@@ -182,6 +190,7 @@ export function useCanvasSync(
     setRestoreInProgress(false)
     setRestoreLabel(null)
     setCanvas(EMPTY_CANVAS)
+    setLoaded(false)
     // Locks belong to the session being torn down. Left standing they would
     // be reported against whatever canvas comes next — or against nothing at
     // all, when the backend goes to null.
@@ -213,6 +222,7 @@ export function useCanvasSync(
     sessionRef.current = session
     const unsubscribe = session.subscribe((next, origin) => {
       setCanvas(next)
+      setLoaded(true)
       if (origin === 'external') setExternalVersion((v) => v + 1)
     })
     // Undo-stack pushes land on COMMIT, after the canvas publish that drove
@@ -354,6 +364,7 @@ export function useCanvasSync(
 
   return {
     syncStatus,
+    loaded,
     canvas,
     onChange,
     externalVersion,

--- a/apps/web/src/lib/initial-tool.test.ts
+++ b/apps/web/src/lib/initial-tool.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readLastTool, resolveInitialTool, writeLastTool } from './initial-tool.js'
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe('resolveInitialTool', () => {
+  it('starts an empty canvas in select — nothing to pan, everything to make', () => {
+    expect(resolveInitialTool({ isEmpty: true, lastTool: null })).toBe('select')
+  })
+
+  it('starts a canvas that already has content in hand — reading before editing', () => {
+    expect(resolveInitialTool({ isEmpty: false, lastTool: null })).toBe('hand')
+  })
+
+  it("prefers this tab's last tool over the emptiness guess, in both directions", () => {
+    expect(resolveInitialTool({ isEmpty: true, lastTool: 'hand' })).toBe('hand')
+    expect(resolveInitialTool({ isEmpty: false, lastTool: 'select' })).toBe('select')
+  })
+
+  it('never restores connect — a transient drawing mode is not a resting state', () => {
+    expect(resolveInitialTool({ isEmpty: false, lastTool: 'connect' })).toBe('hand')
+    expect(resolveInitialTool({ isEmpty: true, lastTool: 'connect' })).toBe('select')
+  })
+})
+
+describe('last-tool session storage', () => {
+  it('round-trips select and hand within the tab', () => {
+    writeLastTool('select')
+    expect(readLastTool()).toBe('select')
+    writeLastTool('hand')
+    expect(readLastTool()).toBe('hand')
+  })
+
+  it('does not persist connect', () => {
+    writeLastTool('hand')
+    writeLastTool('connect')
+    expect(readLastTool()).toBe('hand')
+  })
+
+  it('reads null when nothing is stored or the value is junk', () => {
+    expect(readLastTool()).toBeNull()
+    sessionStorage.setItem('wb.lastTool', 'lasso')
+    expect(readLastTool()).toBeNull()
+  })
+
+  it('survives a storage that throws (private mode, quota)', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota')
+    })
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    try {
+      expect(() => writeLastTool('select')).not.toThrow()
+      expect(readLastTool()).toBeNull()
+    } finally {
+      setItem.mockRestore()
+      getItem.mockRestore()
+    }
+  })
+})

--- a/apps/web/src/lib/initial-tool.ts
+++ b/apps/web/src/lib/initial-tool.ts
@@ -1,0 +1,57 @@
+import type { EditorTool } from '@/components/spatial-editor/ToolPalette'
+
+const KEY = 'wb.lastTool'
+
+/**
+ * Only the two resting tools are remembered. `connect` is a transient
+ * drawing mode — restoring it would drop the user into edge-drawing on a
+ * canvas they just opened.
+ */
+type RestingTool = Extract<EditorTool, 'select' | 'hand'>
+
+function isRestingTool(value: unknown): value is RestingTool {
+  return value === 'select' || value === 'hand'
+}
+
+/**
+ * The tool a canvas opens in. An empty canvas is one the user came to
+ * FILL, so it opens ready to place and edit; a canvas with content is one
+ * they came to READ, so a plain drag pans instead of moving someone's work.
+ * Whatever they last chose in this tab wins over both guesses — it is a
+ * stated preference, not an inference.
+ */
+export function resolveInitialTool({
+  isEmpty,
+  lastTool,
+}: {
+  isEmpty: boolean
+  lastTool: EditorTool | null
+}): EditorTool {
+  if (isRestingTool(lastTool)) return lastTool
+  return isEmpty ? 'select' : 'hand'
+}
+
+/**
+ * Session-scoped on purpose: the tool is a property of "what I am doing in
+ * this tab right now", so a second tab opened for a different task starts
+ * from the canvas's own guess rather than inheriting the first tab's mode.
+ */
+export function readLastTool(): EditorTool | null {
+  try {
+    const stored = sessionStorage.getItem(KEY)
+    return isRestingTool(stored) ? stored : null
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies); the
+    // canvas-shape guess is a complete fallback.
+    return null
+  }
+}
+
+export function writeLastTool(tool: EditorTool): void {
+  if (!isRestingTool(tool)) return
+  try {
+    sessionStorage.setItem(KEY, tool)
+  } catch {
+    // Losing the preference is survivable; failing the click is not.
+  }
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.initial-tool.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.initial-tool.browser.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+import '../index.css'
+
+// Real browser + real IndexedDB: the canvas's node count comes from the Loro
+// document the backend actually loads, which is exactly the input the initial
+// tool is derived from — a jsdom mock would have to fake that input away.
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('whiteboard')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+async function mountLoaded(): Promise<void> {
+  render(<BrowserLocalCanvasPage store={new IndexedDBStore()} />)
+  await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(), {
+    timeout: 5000,
+  })
+}
+
+function pressed(name: string): string | null {
+  return screen.getByRole('button', { name }).getAttribute('aria-pressed')
+}
+
+beforeEach(async () => {
+  sessionStorage.clear()
+  await clearDb()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('initial tool follows the canvas shape (real browser)', () => {
+  it('opens an empty canvas in Select, and the same canvas in Hand once it holds a node', async () => {
+    await mountLoaded()
+    await waitFor(() => expect(pressed('Select')).toBe('true'), { timeout: 5000 })
+
+    // Add one node through the real editor so the stored document — not a
+    // fixture — is what the next mount reads. Radix menus need real pointer
+    // events (trigger opens on pointerdown, items select on pointerup).
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    // The new node's inline editor opens focused; commit it by clicking away.
+    await userEvent.click(screen.getByTestId('spatial-editor-container'))
+    await waitFor(
+      () => expect(screen.getByTestId('save-status-chip').getAttribute('aria-label')).toBe('Saved'),
+      {
+        timeout: 5000,
+      },
+    )
+
+    cleanup()
+    await mountLoaded()
+    await waitFor(() => expect(pressed('Hand (pan)')).toBe('true'), { timeout: 5000 })
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.test.tsx
@@ -1021,3 +1021,34 @@ describe('?new=canvas launch shortcut', () => {
     window.history.replaceState(null, '', '/')
   })
 })
+
+describe('BrowserLocalCanvasPage — initial tool follows the canvas shape', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('an empty canvas opens in Select — the user came to place, not to pan', async () => {
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    expect(
+      (await screen.findByRole('button', { name: 'Select' })).getAttribute('aria-pressed'),
+    ).toBe('true')
+  })
+
+  it("this tab's last choice outranks the canvas-shape guess", async () => {
+    sessionStorage.setItem('wb.lastTool', 'hand')
+    const store = new MemoryStore()
+    await store.setDefaultCanvasId('c1')
+    await store.save(snap)
+    await act(async () => {
+      render(<BrowserLocalCanvasPage store={store} loro={new FakeLoroStore()} />)
+    })
+    expect(
+      (await screen.findByRole('button', { name: 'Hand (pan)' })).getAttribute('aria-pressed'),
+    ).toBe('true')
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -42,6 +42,7 @@ import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { BROWSER_LOCAL_FILE_ADAPTER } from '../lib/canvas-embed-content.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { browserLocalFaviconStatus, type FaviconStyle, resolveRectColor } from '../lib/favicon.js'
+import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -291,6 +292,7 @@ export function BrowserLocalCanvasPage({
   // represented as null instead of a throwaway placeholder canvas id.
   const {
     canvas,
+    loaded: canvasLoaded,
     onChange,
     externalVersion,
     exportScene,
@@ -701,6 +703,17 @@ export function BrowserLocalCanvasPage({
                   branch keys for the same reason.) */}
               <SpatialEditor
                 key={canvasId ?? 'no-canvas'}
+                // Decided from the canvas's own shape, but only once its
+                // document has loaded — at mount every canvas still looks
+                // empty.
+                initialTool={
+                  canvasLoaded
+                    ? resolveInitialTool({
+                        isEmpty: canvas.nodes.length === 0,
+                        lastTool: readLastTool(),
+                      })
+                    : undefined
+                }
                 canvas={canvas}
                 onChange={onChange}
                 externalVersion={externalVersion}

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -28,6 +28,7 @@ import { createDaemonFetch } from '../lib/daemon-api-client.js'
 import { createDaemonFileAdapter } from '../lib/daemon-file-adapter.js'
 import { deriveNewCanvasSlug } from '../lib/derive-new-canvas-slug.js'
 import { daemonFaviconStatus, type FaviconStyle, resolveRectColor } from '../lib/favicon.js'
+import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { setShellDaemonAuthError } from '../lib/shell-status-store.js'
@@ -200,6 +201,7 @@ export function DaemonCanvasPage({
 
   const {
     canvas: canvasValue,
+    loaded: canvasLoaded,
     onChange,
     externalVersion,
     clearLocalUndo,
@@ -619,6 +621,17 @@ export function DaemonCanvasPage({
                 previous canvas's viewport. */}
             <SpatialEditor
               key={canvas ? `${canvas.workspaceId}/${canvas.slug}` : 'no-canvas'}
+              // Decided from the canvas's own shape, but only once its
+              // document has loaded — at mount every canvas still looks
+              // empty.
+              initialTool={
+                canvasLoaded
+                  ? resolveInitialTool({
+                      isEmpty: canvasValue.nodes.length === 0,
+                      lastTool: readLastTool(),
+                    })
+                  : undefined
+              }
               ref={spatialEditorRef}
               canvas={canvasValue}
               onChange={onChange}


### PR DESCRIPTION
## What

Per the user's spec: **an empty canvas opens in Select**, **a canvas that already holds nodes opens in Hand**, and **whatever tool you last picked in this tab wins over both** (sessionStorage — a second tab opened for a different task starts from the canvas's own guess rather than inheriting the first tab's mode).

The rationale is intent: an empty canvas is one you came to *fill*, so it opens ready to place and edit; a canvas with content is one you came to *read*, so a plain drag pans instead of dragging someone's work out of place. `connect` is never restored — a transient drawing mode is not a resting state.

This closes the **HIGH** first-run finding from the journey analysis: the hand-tool default made double-click-to-edit silently no-op on a brand-new canvas, which is where a first-time user always starts.

## The part that only a real browser could tell me

My first implementation resolved the tool at mount, and the jsdom test passed — but a real-browser probe showed **the canvas document arrives *after* the editor mounts**, so every canvas still looks empty at that moment. The jsdom test passed only because its canvas was empty either way; the "canvas with content" case would never have fired in the shipped app.

Fix: `useCanvasSync` now reports a `loaded` flag (its first publish), pages resolve the opening tool from that, and `SpatialEditor` applies it **exactly once** and **never over a tool the user already picked** — an opening preference must not reach in and change the mode someone is working in.

## Verification

- New real-browser test: empty canvas → Select; add one note through the real editor (real IndexedDB); remount → Hand. This is the pin that the mount-timing bug would break.
- Unit tests for the pure resolver + session storage (8 cases incl. connect-never-restored, junk values, throwing storage)
- apps/web jsdom **166 files / 2011 green**; web-browser **95 files / 508 green**; typecheck / knip / bundle gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc