### PR TITLE
fix(web): tell first-run users what happened, in words they use

### DIFF
--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -51,6 +51,12 @@ describe('AppShell', () => {
     expect((router.state.location.state as { from?: string }).from).toBe('/local/c1')
   })
 
+  it('names what the dot is about, so it reads as a task and not a warning', () => {
+    renderShell(false)
+    expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /settings.*(step|setup)/i })).toBeTruthy()
+  })
+
   it('carries the nudge dot while a setup todo remains (no daemon)', () => {
     renderShell(false)
     expect(screen.getByTestId('settings-nudge')).toBeTruthy()

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -60,7 +60,11 @@ export function AppShell({ daemon }: { daemon: boolean }) {
       <span className="min-w-0 flex-1" />
       <button
         type="button"
-        aria-label="Settings"
+        // The dot is the only thing on the shell that can read as an alarm.
+        // Naming its cause turns it from "did I break something?" into a
+        // task the user can choose to do.
+        aria-label={nudge ? 'Settings — a setup step is waiting' : 'Settings'}
+        title={nudge ? 'Settings — a setup step is waiting' : 'Settings'}
         data-testid="shell-settings"
         onClick={() =>
           navigate(settingsPath(), {

--- a/apps/web/src/components/canvas-list/CanvasListView.test.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.test.tsx
@@ -190,3 +190,12 @@ describe('CanvasListView — branded empty state', () => {
     expect(screen.getByText('No canvases yet')).toBeTruthy()
   })
 })
+
+describe('CanvasListView empty state — says what this is', () => {
+  it('names the product and what a canvas is for, not just its own emptiness', () => {
+    renderList({ rows: [] })
+    // Someone who arrived from a link has no other page to learn from.
+    expect(screen.getByText(/notes.*connect|connect.*notes/i)).toBeTruthy()
+    expect(screen.getByText(/stays in this browser|on your (device|machine)/i)).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/canvas-list/CanvasListView.tsx
+++ b/apps/web/src/components/canvas-list/CanvasListView.tsx
@@ -84,7 +84,13 @@ export function CanvasListView({
             blank board, not an error — the mark stays quiet (BRAND.md). */}
         <EmptyMark className="text-muted-foreground/30" />
         <p className="text-sm font-medium">No canvases yet</p>
-        <p className="text-sm text-muted-foreground">Create a canvas and it opens ready to draw.</p>
+        {/* Arrivals from a shared link have no other page to learn from, so
+            the empty board is where the product introduces itself: what a
+            canvas holds, and where the work lives. */}
+        <p className="max-w-sm text-sm text-muted-foreground">
+          A canvas is a space for notes you place and connect. Everything stays in this browser — no
+          account, no upload.
+        </p>
         <button
           type="button"
           disabled={createDisabled}

--- a/apps/web/src/components/settings/SetupJourney.tsx
+++ b/apps/web/src/components/settings/SetupJourney.tsx
@@ -8,6 +8,13 @@ export type PersistStepState = 'unknown' | 'granted' | 'browser-managed' | 'todo
 
 export interface SetupJourneyProps {
   persist: PersistStepState
+  /**
+   * True after a Protect request came back without a grant. Chromium
+   * decides silently on engagement heuristics, so "nothing happened" is a
+   * real outcome the user must be told about — otherwise the button reads
+   * as broken.
+   */
+  protectDeclined?: boolean
   /** A Protect request is in flight. */
   protecting: boolean
   onProtect: () => void
@@ -39,6 +46,7 @@ const ACTION_CLASS =
  */
 export function SetupJourney({
   persist,
+  protectDeclined = false,
   protecting,
   onProtect,
   install,
@@ -65,7 +73,7 @@ export function SetupJourney({
           kind: 'action',
           title: 'Protect your data',
           state: persist === 'unknown' ? '…' : 'not granted yet',
-          desc: 'Ask the browser to protect canvases from storage-pressure eviction.',
+          desc: 'Ask the browser to keep your canvases even when it is running low on space — without this it may delete them to free up room.',
           action:
             persist === 'todo' ? (
               <button
@@ -77,6 +85,9 @@ export function SetupJourney({
                 {protecting ? 'Protecting…' : 'Protect'}
               </button>
             ) : undefined,
+          hint: protectDeclined
+            ? 'Your browser turned this down for now — it usually grants it once you have used the app a few times. Your canvases still work; keep an export of anything you cannot lose.'
+            : undefined,
         },
     install === 'installed'
       ? { key: 'install', kind: 'done', title: 'Install the app', state: 'installed' }
@@ -101,13 +112,13 @@ export function SetupJourney({
             hint: 'Your browser’s menu may offer Install or Add to Home Screen.',
           },
     daemonConnected
-      ? { key: 'daemon', kind: 'done', title: 'Connect a local daemon', state: 'connected' }
+      ? { key: 'daemon', kind: 'done', title: 'Connect the companion app', state: 'connected' }
       : {
           key: 'daemon',
           kind: 'action',
-          title: 'Connect a local daemon',
+          title: 'Connect the companion app',
           state: 'not connected',
-          desc: 'Durable storage and your AI agent live in the local daemon.',
+          desc: 'Run the companion app to keep canvases in real files on your computer, with version history.',
           action: (
             <Link to={settingsPath('connections')} className={ACTION_CLASS}>
               How to connect

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -189,6 +189,35 @@ describe('SettingsPage — Data & app setup journey', () => {
     expect(await within(mobile).findByText('managed by the browser')).toBeTruthy()
   })
 
+  it('a browser that declines Protect says so, instead of leaving the row unchanged', async () => {
+    // Chromium grants silently on engagement; a fresh profile is simply
+    // refused. The refusal is the case that used to look like a dead button.
+    stubStorage({ persisted: false, persistResult: false })
+    renderAt('/settings/data')
+    const mobile = screen.getByTestId('settings-mobile')
+    fireEvent.click(await within(mobile).findByRole('button', { name: 'Protect' }))
+    expect(
+      await within(mobile).findByText(/browser turned this down|not granted it yet/i),
+    ).toBeTruthy()
+  })
+
+  it('explains persistence without storage jargon', async () => {
+    stubStorage({ persisted: false })
+    renderAt('/settings/data')
+    const mobile = screen.getByTestId('settings-mobile')
+    await within(mobile).findByRole('button', { name: 'Protect' })
+    expect(within(mobile).queryByText(/eviction/i)).toBeNull()
+    expect(within(mobile).getByText(/delete.*(free up|space)|running low/i)).toBeTruthy()
+  })
+
+  it('describes the daemon step without developer vocabulary', async () => {
+    stubStorage({ persisted: true })
+    renderAt('/settings/data')
+    const mobile = screen.getByTestId('settings-mobile')
+    await within(mobile).findByText('granted')
+    expect(within(mobile).queryByText(/daemon|AI agent/i)).toBeNull()
+  })
+
   it('Protect asks for persistence and celebrates the live grant exactly once', async () => {
     stubStorage({ persisted: false, persistResult: true })
     renderAt('/settings/data')

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -216,6 +216,7 @@ function sectionContent(
     onWebMcpToggle: () => void
     persistStep: PersistStepState
     protecting: boolean
+    protectDeclined: boolean
     onProtect: () => void
     installStatus: 'installed' | 'installable' | 'not-captured'
     daemon?: { baseUrl: string; token: string | null }
@@ -239,6 +240,7 @@ function sectionContent(
           <SetupJourney
             persist={props.persistStep}
             protecting={props.protecting}
+            protectDeclined={props.protectDeclined}
             onProtect={props.onProtect}
             install={props.installStatus}
             onInstall={() => void promptInstall()}
@@ -319,11 +321,18 @@ export function SettingsPage({ daemon }: SettingsPageProps) {
   }, [])
 
   const [protecting, setProtecting] = useState(false)
+  const [protectDeclined, setProtectDeclined] = useState(false)
   const handleProtect = useCallback(() => {
     setProtecting(true)
+    setProtectDeclined(false)
     void ensurePersistentStorage()
-      .then(() => queryPersistentStorage())
-      .then((state) => setPersisted(state))
+      .then(async (granted) => {
+        const state = await queryPersistentStorage()
+        setPersisted(state)
+        // A silent refusal is the common Chromium answer on a fresh
+        // profile; without saying so the button looks broken.
+        setProtectDeclined(granted !== true && state !== true)
+      })
       .finally(() => setProtecting(false))
   }, [])
 
@@ -375,6 +384,7 @@ export function SettingsPage({ daemon }: SettingsPageProps) {
     onWebMcpToggle: handleWebMcpToggle,
     persistStep,
     protecting,
+    protectDeclined,
     onProtect: handleProtect,
     installStatus: installState.status,
     daemon,


### PR DESCRIPTION
## What

Four findings from the first-run journey analysis (3 personas, real browser), all cases where the product knew something and did not say it.

- **Protect looked like a dead button.** Chromium decides persistence silently on engagement heuristics, so a fresh profile is simply refused — the row stayed "not granted yet" with no dialog, no toast, no way to tell a refusal from a bug. The refusal is now stated, with what it means for their data and what usually changes it.
- **Jargon in the ladder.** "storage-pressure eviction" → *"keep your canvases even when it is running low on space — without this it may delete them to free up room"*. The step below it named a "local daemon" and an "AI agent" while a non-technical user was mid-task → **"Connect the companion app"** / *"keep canvases in real files on your computer, with version history"*.
- **The empty board never said what the product is.** Someone arriving from a shared link has no other page to learn from → it now introduces the canvas (*"a space for notes you place and connect"*) and where the work lives (*"stays in this browser — no account, no upload"*).
- **The gear's attention dot read as an alarm** ("is something wrong? did I break it?" — the persona's words). Its accessible name now says a setup step is waiting, turning anxiety into a task.

## Verification

- Live dev-server pass: intro copy visible on the empty board, gear label reads *"Settings — a setup step is waiting"*, zero "eviction"/"daemon" strings left in the ladder, and Protect on a fresh profile now renders the refusal text (screenshot below)
- Red-first tests for each: the declined-Protect message, both jargon assertions (a regression that reintroduces the words fails), the empty-state copy, and the gear's explanatory name
- apps/web jsdom **166 files / 2016 green**; typecheck / knip / bundle gate clean

## Visual repro

Protect refused — the outcome is now visible, and the ladder speaks plainly:

![firstrun-protect.png](https://github.com/user-attachments/assets/129abd89-991e-439f-a47e-03e72282a78d)

Empty board introduces the product:

![firstrun-empty.png](https://github.com/user-attachments/assets/26b7a012-31c3-4e1d-8141-c39c7c2ff658)

## Not in this PR

Deliberately separate lanes from the same analysis: viewport re-centering on create, Escape discarding inline text, the new-note cascade sliding under the toolbar, and the missing shape/pen tool (an expectation-vs-product question, not a copy fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified the empty canvas experience, including what canvases contain and how content is stored locally.
  * Improved setup guidance with clearer explanations for data protection and the companion app.
  * Settings prompts now indicate when setup steps require attention.
  * Added a warning when data protection is declined, with improved retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->