### PR TITLE
fix(web): Escape discards the note it was creating, not just its text

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -1959,7 +1959,7 @@ describe('node placement and affordances', () => {
     })
   })
 
-  it('pressing Escape still discards typed text (the one documented discard path)', async () => {
+  it('pressing Escape discards the typed text AND the note it was creating', async () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
@@ -1978,9 +1978,10 @@ describe('node placement and affordances', () => {
       .element()
       .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 
+    // The note existed only to hold this edit, so cancelling takes it too —
+    // an empty box the user has to clean up is debris, not a discarded edit.
     const canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
-    const node = canvas.nodes.find((n) => n.id === 'note-2')
-    expect(node?.type === 'text' ? node.text : undefined).toBe('')
+    expect(canvas.nodes.find((n) => n.id === 'note-2')).toBeUndefined()
   })
 
   it('the Add note button has real, visible button affordance (icon + accessible name)', async () => {

--- a/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
@@ -1,0 +1,72 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+// Real browser: the Add-note path opens a focused textarea and Escape is a
+// real key event through the editor's own handlers — the exact sequence a
+// first-time user hits when they change their mind about a note.
+function Host({ onCanvas }: { onCanvas: (c: SpatialCanvas) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>({ nodes: [], edges: [] })
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        canvas={canvas}
+        defaultTool="select"
+        onChange={(next) => {
+          setCanvas(next)
+          onCanvas(next)
+        }}
+      />
+    </div>
+  )
+}
+
+// No vitest `globals`, so testing-library's auto-cleanup never registers:
+// a surviving editor from the previous test would double every query.
+afterEach(() => {
+  cleanup()
+})
+
+describe('Escape while typing a brand-new note (real browser)', () => {
+  it('takes the note with the discarded text instead of leaving an empty box', async () => {
+    let latest: SpatialCanvas = { nodes: [], edges: [] }
+    render(<Host onCanvas={(c) => (latest = c)} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    const editor = await screen.findByRole('textbox')
+    await waitFor(() => expect(latest.nodes).toHaveLength(1))
+
+    await userEvent.type(editor, 'changed my mind')
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() => expect(latest.nodes).toHaveLength(0))
+  })
+
+  it('keeps an existing note and its stored text when the edit is cancelled', async () => {
+    let latest: SpatialCanvas = { nodes: [], edges: [] }
+    render(<Host onCanvas={(c) => (latest = c)} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    const editor = await screen.findByRole('textbox')
+    await userEvent.type(editor, 'kept')
+    // Commit, then reopen the SAME node and cancel: the node survives.
+    await userEvent.keyboard('{Control>}{Enter}{/Control}')
+    await waitFor(() => {
+      const node = latest.nodes[0]
+      expect(node?.type === 'text' ? node.text : undefined).toBe('kept')
+    })
+
+    const box = await screen.findByText('kept')
+    await userEvent.dblClick(box)
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() => expect(latest.nodes).toHaveLength(1))
+    const kept = latest.nodes[0]
+    expect(kept?.type === 'text' ? kept.text : undefined).toBe('kept')
+  })
+})

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -485,6 +485,8 @@ describe('dblclick-empty (create-node)', () => {
       kind: 'editing-text',
       nodeId: 'new-node',
       pendingText: '',
+      // The node exists only for this edit — cancelling takes it with it.
+      createdForEdit: true,
     })
   })
 
@@ -513,6 +515,8 @@ describe('dblclick-empty (create-node)', () => {
       kind: 'editing-text',
       nodeId: 'new-node',
       pendingText: '',
+      // The node exists only for this edit — cancelling takes it with it.
+      createdForEdit: true,
     })
   })
 })
@@ -609,5 +613,59 @@ describe('multi-selection resize', () => {
 
   it('emits nothing when the drag ended where it began', () => {
     expect(dragSouthEastBy(0, 0).commands).toEqual([])
+  })
+})
+
+describe('cancel-text-edit removes a node that only existed for the cancelled edit', () => {
+  const empty = (): SpatialCanvas => ({ nodes: [], edges: [] })
+
+  it('deletes the just-created node — nothing was typed, so nothing should remain', () => {
+    const created = reduceGesture(
+      createIdleState(),
+      empty(),
+      { type: 'dblclick-empty', point: { x: 40, y: 40 } },
+      { createId: () => 'n-new' },
+    )
+    expect(created.commands).toEqual([expect.objectContaining({ kind: 'create-node' })])
+
+    const withNode: SpatialCanvas = {
+      nodes: [{ id: 'n-new', type: 'text', x: 0, y: 0, width: 160, height: 90, text: '' }],
+      edges: [],
+    }
+    const cancelled = reduceGesture(created.state, withNode, { type: 'cancel-text-edit' })
+    expect(cancelled.state).toEqual({ kind: 'idle' })
+    expect(cancelled.commands).toEqual([{ kind: 'delete-node', id: 'n-new' }])
+    expect(cancelled.selectedId).toBeNull()
+  })
+
+  it('keeps an existing node — cancel reverts the edit, it does not delete', () => {
+    const c = canvas()
+    const editing = reduceGesture(createIdleState(), c, {
+      type: 'start-text-edit',
+      nodeId: 'a',
+      text: 'hi',
+    })
+    const cancelled = reduceGesture(editing.state, c, { type: 'cancel-text-edit' })
+    expect(cancelled.commands).toEqual([])
+    const node = c.nodes[0]
+    expect(node?.type === 'text' ? node.text : undefined).toBe('hi')
+  })
+
+  it('keeps a created node whose text was committed', () => {
+    const created = reduceGesture(
+      createIdleState(),
+      { nodes: [], edges: [] },
+      { type: 'dblclick-empty', point: { x: 10, y: 10 } },
+      { createId: () => 'n-typed' },
+    )
+    const typed = reduceGesture(
+      created.state,
+      { nodes: [], edges: [] },
+      {
+        type: 'commit-text-edit',
+        text: 'hello',
+      },
+    )
+    expect(typed.commands).toEqual([{ kind: 'set-text', id: 'n-typed', text: 'hello' }])
   })
 })

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -25,7 +25,8 @@
  * requested gesture, matching every text editor's click-away-commits
  * behavior (and this component's own blur-commits convention in
  * `TextNodeEditor`). Escape (`cancel-text-edit`) remains the only explicit
- * discard.
+ * discard, and it discards the whole node when the node existed only to
+ * hold that edit.
  */
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type { EditorCommand } from './commands.js'
@@ -72,6 +73,13 @@ interface EditTextSnapshot {
   readonly kind: 'editing-text'
   readonly nodeId: string
   readonly pendingText: string
+  /**
+   * The node came into existence to hold this edit (double-click on empty
+   * canvas, the + menu). Cancelling such an edit has nothing to revert TO,
+   * so the node goes with it — an empty box the user has to clean up is
+   * debris, not a discarded edit.
+   */
+  readonly createdForEdit?: boolean
 }
 
 interface IdleSnapshot {
@@ -347,7 +355,7 @@ function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureRe
     text: '',
   }
   return {
-    state: { kind: 'editing-text', nodeId: id, pendingText: '' },
+    state: { kind: 'editing-text', nodeId: id, pendingText: '', createdForEdit: true },
     commands: [{ kind: 'create-node', node }],
     selectedId: id,
   }
@@ -376,6 +384,13 @@ export function reduceGesture(
       return reduceCanvasReplaced(state, event.canvas, event.origin ?? 'local')
     case 'pointercancel':
     case 'cancel-text-edit':
+      if (state.kind === 'editing-text' && state.createdForEdit === true) {
+        return {
+          state: { kind: 'idle' },
+          commands: [{ kind: 'delete-node', id: state.nodeId }],
+          selectedId: null,
+        }
+      }
       return idle
     case 'pointerdown-empty':
       return withPendingTextCommit(state, {


### PR DESCRIPTION
## What

Escape already discarded a text edit — that part was intended and stays. What it left behind was the problem: a note created **for** that edit survived as an empty box the user had to find and delete. The journey analysis caught a first-time user typing a label, changing their mind, and being left with debris.

The `editing-text` gesture now remembers that its node came into existence to hold this edit (double-click on empty canvas and the palette's **Add note** share that reducer path), and cancelling such an edit deletes the node. Cancelling an edit on an **existing** note is unchanged — the note and its stored text stay, which is what "revert" means there.

## Verification

- New real-browser test covering both directions: Add note → type → Escape leaves **zero** nodes; commit → reopen → Escape keeps the note **and** its text
- Reducer tests for the same two cases plus "created node whose text was committed survives"
- The existing SpatialEditor browser test that pinned the old outcome (node kept, text empty) now pins the new one — restated, not weakened
- apps/web jsdom **2019 green**; web-browser **96 files / 510 green**; typecheck / knip / bundle gate clean

## Related decisions from this round (not code)

- **Pen tool: not being added** — JSON Canvas compatibility is the constraint we keep
- **Rectangle tool: plausible, but blocked on toolbar IA** — it collides with the + (Add) group, so it needs a display-area design first
- **Zoom/viewport toolbar visibility** — it appears in hand mode; making it permanent is a layout question, still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc