### PR TITLE
fix(canvas-render): price edge segments that trace a node's border

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -320,7 +320,7 @@ paths:
       genuine crossing never produces (verified against
       `edge-lane-rank.test.ts`'s sweep-rank pin: tier 1 placement adopted a
       route with a real crossing over a crossing-free one). `pairScore`/
-      `selfScore` (`spatial-edges.ts`) compose over the list, and every
+      `selfPenalty` (`spatial-edges.ts`) compose over the list, and every
       cost-tuple helper (`ConfigCost` shape, `addCost`, `lessCost`,
       `hasRepairableProblem`) derives from the declared tiers, so a new
       penalty rule is one list entry, never a new slot threaded by hand.

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -307,12 +307,23 @@ paths:
       incumbent-wins-ties predicate `optimizeSideChoices` consults. The
       PENALTY half is `PENALTY_RULES`: overlap-and-intrusion (tier 0,
       collinear overlap plus self-retrace/body-intrusion), illegibility
-      (tier 1), crossings (tier 2), and realized-bends (tier 3, self-only
-      and deliberately last). `pairScore`/`selfScore` (`spatial-edges.ts`)
-      compose over the list, and every cost-tuple helper (`ConfigCost`
-      shape, `addCost`, `lessCost`, `hasRepairableProblem`) derives from
-      the declared tiers, so a new penalty rule is one list entry, never
-      a new slot threaded by hand.
+      (tier 1), crossings (tier 2), border-tracing (tier 3, self-only — a
+      routed segment collinear with AND overlapping a node's own border,
+      `nodeBorders` including the path's own endpoint rects unlike
+      `foreignBodies`), and realized-bends (tier 4, self-only and
+      deliberately last). border-tracing sits BELOW crossings rather than
+      adjacent to overlap-and-intrusion: it is evaluated against the
+      optimizer's unaligned TRIAL paths (`computeAnchorsFor`'s pre-
+      `slideAlongSide` representation, used only for candidate ranking),
+      whose unaligned anchor placement can coincidentally trace a
+      bystander's extended border for a real stretch — a false signal a
+      genuine crossing never produces (verified against
+      `edge-lane-rank.test.ts`'s sweep-rank pin: tier 1 placement adopted a
+      route with a real crossing over a crossing-free one). `pairScore`/
+      `selfScore` (`spatial-edges.ts`) compose over the list, and every
+      cost-tuple helper (`ConfigCost` shape, `addCost`, `lessCost`,
+      `hasRepairableProblem`) derives from the declared tiers, so a new
+      penalty rule is one list entry, never a new slot threaded by hand.
     - **Facet-driven rendering rides the injected-resolver pattern**
       (a future `resolveFileFacets`, same seam class as
       `resolveFileCanvas`/`resolveFileImage`), and export stays a pure

--- a/packages/canvas-render/src/layout/edge-border-trace.test.ts
+++ b/packages/canvas-render/src/layout/edge-border-trace.test.ts
@@ -1,0 +1,63 @@
+// User-reported defect: a routed segment can trace exactly along a node's
+// own border (e.g. the source node's top edge), reading on screen as though
+// the line merges into the box outline. The exact user canvas below picked
+// fromSide 'top' / toSide 'left' for A->B, whose last segment
+// (200,570)->(220,570) rides A's own top border (A.y === 570, x in
+// [100,300]) before the border-tracing penalty existed.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+/** Collinear-and-overlapping length between a path segment and a rect
+ * border, quantized the same way the production rule must be: a point
+ * touch (perpendicular departure/arrival) is zero, not positive. */
+function borderTraceLength(
+  path: readonly { x: number; y: number }[],
+  rects: readonly { x: number; y: number; w: number; h: number }[],
+): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    for (const r of rects) {
+      if (a.y === b.y && (a.y === r.y || a.y === r.y + r.h)) {
+        const lo = Math.max(Math.min(a.x, b.x), r.x)
+        const hi = Math.min(Math.max(a.x, b.x), r.x + r.w)
+        if (hi > lo) total += hi - lo
+      } else if (a.x === b.x && (a.x === r.x || a.x === r.x + r.w)) {
+        const lo = Math.max(Math.min(a.y, b.y), r.y)
+        const hi = Math.min(Math.max(a.y, b.y), r.y + r.h)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total
+}
+
+it('never routes a segment of A->B on top of a node border, on the exact user canvas', () => {
+  const nodes = [
+    box('A', 100, 570, 200, 100),
+    box('B', 220, 520, 200, 100),
+    box('T', 80, 360, 200, 110),
+  ]
+  const edges: CanvasEdge[] = [
+    { id: 'ab', fromNode: 'A', toNode: 'B' },
+    { id: 'ta', fromNode: 'T', toNode: 'A', label: 'hoge' },
+    { id: 'tb', fromNode: 'T', toNode: 'B' },
+  ]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const ab = edges[0] as CanvasEdge
+  const { path } = routeEdge(nodes, ab, 'orthogonal', anchors.get('ab'))
+  const rects = nodes.map((n) => ({ x: n.x, y: n.y, w: n.width, h: n.height }))
+  expect(borderTraceLength(path, rects)).toBe(0)
+})

--- a/packages/canvas-render/src/layout/edge-border-trace.test.ts
+++ b/packages/canvas-render/src/layout/edge-border-trace.test.ts
@@ -1,9 +1,7 @@
-// User-reported defect: a routed segment can trace exactly along a node's
-// own border (e.g. the source node's top edge), reading on screen as though
-// the line merges into the box outline. The exact user canvas below picked
-// fromSide 'top' / toSide 'left' for A->B, whose last segment
-// (200,570)->(220,570) rides A's own top border (A.y === 570, x in
-// [100,300]) before the border-tracing penalty existed.
+// A routed segment must never run along a node's own border: ink on an
+// outline reads as though the edge merges into the box. Overlapping nodes
+// are the arrangement that provokes it, because a side's anchor can sit
+// inside the other node and the route has to come back around.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { expect, it } from 'vitest'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import {
+  COST_QUANTUM,
   composeSidePairs,
   hasRepairableProblem,
   PENALTY_RULES,
@@ -134,6 +135,14 @@ const foreignBodiesArb: fc.Arbitrary<readonly Rect[]> = fc.array(foreignRectArb,
   maxLength: 4,
 })
 
+// Node-border domain for the border-tracing rule: mutually overlapping and
+// zero-size rects included (canvas-model keeps zero sizes legal), same
+// bound as foreignBodiesArb.
+const nodeBordersArb: fc.Arbitrary<readonly Rect[]> = fc.array(foreignRectArb, {
+  minLength: 0,
+  maxLength: 4,
+})
+
 const tripleArb: fc.Arbitrary<readonly [number, number, number]> = fc.tuple(
   fc.integer({ min: 0, max: 1000 }),
   fc.integer({ min: 0, max: 1000 }),
@@ -149,12 +158,12 @@ describe('PENALTY_RULES: each rule writes only its declared tier slot', () => {
     },
   )
 
-  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
-    'selfPenalty places every rule contribution at rule.tier, for any path/foreign-body pair',
-    (path, foreignBodies) => {
-      const cost = selfPenalty(path, foreignBodies)
+  fcTest.prop([pathArb, foreignBodiesArb, nodeBordersArb], withDefaults())(
+    'selfPenalty places every rule contribution at rule.tier, for any path/foreign-body/node-border triple',
+    (path, foreignBodies, nodeBorders) => {
+      const cost = selfPenalty(path, foreignBodies, nodeBorders)
       for (const rule of PENALTY_RULES) {
-        expect(cost[rule.tier]).toBe(rule.selfTerm(path, foreignBodies))
+        expect(cost[rule.tier]).toBe(rule.selfTerm(path, foreignBodies, nodeBorders))
       }
     },
   )
@@ -165,10 +174,12 @@ describe('PENALTY_RULES: scorers are deterministic', () => {
     expect(pairPenalty(triple)).toEqual(pairPenalty(triple))
   })
 
-  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
+  fcTest.prop([pathArb, foreignBodiesArb, nodeBordersArb], withDefaults())(
     'selfPenalty is pure',
-    (path, foreignBodies) => {
-      expect(selfPenalty(path, foreignBodies)).toEqual(selfPenalty(path, foreignBodies))
+    (path, foreignBodies, nodeBorders) => {
+      expect(selfPenalty(path, foreignBodies, nodeBorders)).toEqual(
+        selfPenalty(path, foreignBodies, nodeBorders),
+      )
     },
   )
 })
@@ -184,13 +195,115 @@ describe('PENALTY_RULES: totals are finite non-negative integers', () => {
     },
   )
 
-  fcTest.prop([pathArb, foreignBodiesArb], withDefaults())(
+  fcTest.prop([pathArb, foreignBodiesArb, nodeBordersArb], withDefaults())(
     'selfPenalty totality, incl. zero-size rects, empty/single-point/zero-length paths',
-    (path, foreignBodies) => {
-      for (const n of selfPenalty(path, foreignBodies)) {
+    (path, foreignBodies, nodeBorders) => {
+      for (const n of selfPenalty(path, foreignBodies, nodeBorders)) {
         expect(Number.isInteger(n)).toBe(true)
         expect(n).toBeGreaterThanOrEqual(0)
       }
+    },
+  )
+})
+
+// border-tracing-specific properties: pathArb/nodeBordersArb sampled
+// independently would rarely land a segment exactly on a border (passing
+// vacuously — see AGENTS.md's PBT discipline), so this domain builds a path
+// FROM the border rects by snapping coordinates onto a rect's sides,
+// mixed with the generic pathArb via fc.oneof for coverage of the
+// non-tracing branches too.
+const tracingPointArb = (rect: Rect): fc.Arbitrary<Point> =>
+  fc.oneof(
+    // On the top/bottom border, x anywhere within a generous span (may
+    // overhang the rect — exercises the clipping branch).
+    fc.record({
+      x: fc.integer({ min: rect.x - 50, max: rect.x + rect.w + 50 }),
+      y: fc.constantFrom(rect.y, rect.y + rect.h),
+    }),
+    // On the left/right border.
+    fc.record({
+      x: fc.constantFrom(rect.x, rect.x + rect.w),
+      y: fc.integer({ min: rect.y - 50, max: rect.y + rect.h + 50 }),
+    }),
+    pointArb,
+  )
+
+const borderRectArb: fc.Arbitrary<Rect> = fc.record({
+  x: fc.integer({ min: -100, max: 100 }),
+  y: fc.integer({ min: -100, max: 100 }),
+  w: fc.integer({ min: 0, max: 150 }),
+  h: fc.integer({ min: 0, max: 150 }),
+})
+
+// The rect a tracing path was BUILT from is folded into nodeBorders
+// (alongside independently generated extras) so the equality property
+// below always has a real chance of finding a positive-overlap segment —
+// generating path and nodeBorders fully independently would only rarely
+// line a segment up with a border by chance.
+const tracingScenarioArb: fc.Arbitrary<{
+  path: readonly Point[]
+  nodeBorders: readonly Rect[]
+}> = fc.tuple(borderRectArb, nodeBordersArb).chain(([rect, extras]) =>
+  fc.array(tracingPointArb(rect), { minLength: 0, maxLength: 6 }).map((path) => ({
+    path,
+    nodeBorders: [rect, ...extras],
+  })),
+)
+
+/** Independent oracle (never calls production code): the same collinear-
+ * overlap-length definition, computed directly against the reference
+ * rects. All generator coordinates are integers, so multiplying by
+ * COST_QUANTUM at the end is exact — no quantization drift from the
+ * production rule's per-coordinate `q()` rounding. */
+function referenceBorderTrace(path: readonly Point[], rects: readonly Rect[]): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    for (const r of rects) {
+      if (a.y === b.y && (a.y === r.y || a.y === r.y + r.h)) {
+        const lo = Math.max(Math.min(a.x, b.x), r.x)
+        const hi = Math.min(Math.max(a.x, b.x), r.x + r.w)
+        if (hi > lo) total += hi - lo
+      } else if (a.x === b.x && (a.x === r.x || a.x === r.x + r.w)) {
+        const lo = Math.max(Math.min(a.y, b.y), r.y)
+        const hi = Math.min(Math.max(a.y, b.y), r.y + r.h)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total * COST_QUANTUM
+}
+
+describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
+  fcTest.prop([tracingScenarioArb], withDefaults())(
+    'the border-tracing term is a finite, non-negative, integral, deterministic total',
+    ({ path, nodeBorders }) => {
+      const cost1 = selfPenalty(path, [], nodeBorders)
+      const cost2 = selfPenalty(path, [], nodeBorders)
+      expect(cost1[3]).toBe(cost2[3])
+      expect(Number.isInteger(cost1[3])).toBe(true)
+      expect(cost1[3]).toBeGreaterThanOrEqual(0)
+    },
+  )
+
+  fcTest.prop([tracingScenarioArb], withDefaults())(
+    'is invariant under permutation of the node-border array (a sum must not depend on order)',
+    ({ path, nodeBorders }) => {
+      const shuffled = [...nodeBorders].reverse()
+      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(selfPenalty(path, [], shuffled)[3])
+    },
+  )
+
+  // The property that actually catches a "returns 0" or otherwise-wrong
+  // mutation: totality/purity/order-invariance above all hold trivially for
+  // a stub that always returns 0, so this is the one that must go red under
+  // mutation (verified: reverting borderTracing.selfTerm to `() => 0` fails
+  // this test, confirming the dense generator reaches real overlap).
+  fcTest.prop([tracingScenarioArb], withDefaults())(
+    'agrees with an independently-computed collinear overlap length',
+    ({ path, nodeBorders }) => {
+      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(referenceBorderTrace(path, nodeBorders))
     },
   )
 })

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -135,13 +135,9 @@ const foreignBodiesArb: fc.Arbitrary<readonly Rect[]> = fc.array(foreignRectArb,
   maxLength: 4,
 })
 
-// Node-border domain for the border-tracing rule: mutually overlapping and
-// zero-size rects included (canvas-model keeps zero sizes legal), same
-// bound as foreignBodiesArb.
-const nodeBordersArb: fc.Arbitrary<readonly Rect[]> = fc.array(foreignRectArb, {
-  minLength: 0,
-  maxLength: 4,
-})
+// Node-border domain for the border-tracing rule: same shape as the
+// foreign-body domain (mutually overlapping and zero-size rects included).
+const nodeBordersArb = foreignBodiesArb
 
 const tripleArb: fc.Arbitrary<readonly [number, number, number]> = fc.tuple(
   fc.integer({ min: 0, max: 1000 }),

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -190,11 +190,12 @@ describe('SIDE_PREFERENCE_RULES', () => {
 })
 
 describe('PENALTY_RULES', () => {
-  it('declares the four named tiers in tier order, realized-bends last', () => {
+  it('declares the five named tiers in tier order, realized-bends last', () => {
     expect(PENALTY_RULES.map((r) => r.name)).toEqual([
       'overlap-and-intrusion',
       'illegibility',
       'crossings',
+      'border-tracing',
       'realized-bends',
     ])
     PENALTY_RULES.forEach((rule, i) => {
@@ -212,7 +213,7 @@ describe('overlap-and-intrusion', () => {
       { x: 10, y: 0 },
       { x: 30, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0, 0])
   })
 
   it('self term: a path retracing its own ink contributes the quantized retrace length to tier 0', () => {
@@ -223,7 +224,7 @@ describe('overlap-and-intrusion', () => {
       { x: 20, y: 0 },
       { x: 5, y: 0 },
     ]
-    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 1])
+    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 1])
   })
 
   it('self term: a segment through a foreign rect interior contributes the quantized chord length to tier 0', () => {
@@ -232,7 +233,7 @@ describe('overlap-and-intrusion', () => {
       { x: 110, y: 50 },
     ]
     const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
-    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0, 0])
   })
 
   it('self term: a segment riding exactly on the rect boundary contributes 0 (grazing exclusion)', () => {
@@ -254,7 +255,7 @@ describe('illegibility', () => {
       { x: 1, y: 9 },
       { x: 9, y: 1 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0])
+    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0, 0])
   })
 
   it('pair term: a transversal crossing far from every end contributes 0 to tier 1', () => {
@@ -264,7 +265,7 @@ describe('illegibility', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0])
   })
 })
 
@@ -276,7 +277,7 @@ describe('crossings', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0])
   })
 
   it('collinear overlap short-circuits the crossing count for that segment pair', () => {
@@ -288,6 +289,86 @@ describe('crossings', () => {
     )
     expect(triple[0]).toBeGreaterThan(0)
     expect(pairPenalty(triple)[2]).toBe(0)
+  })
+})
+
+describe('border-tracing', () => {
+  const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
+
+  it('self term: a horizontal segment lying along the rect top contributes the quantized clipped overlap length to tier 3', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0])
+  })
+
+  it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to tier 3', () => {
+    const path = [
+      { x: 100, y: 0 },
+      { x: 100, y: 40 },
+    ]
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0])
+  })
+
+  it('self term: a perpendicular segment touching the border at a single point contributes 0', () => {
+    const path = [
+      { x: 50, y: -20 },
+      { x: 50, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: a segment parallel to a side but offset by 1px contributes 0', () => {
+    const path = [
+      { x: 0, y: 1 },
+      { x: 100, y: 1 },
+    ]
+    expect(selfPenalty(path, [], [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: a segment collinear with a side but disjoint along the axis contributes 0', () => {
+    const path = [
+      { x: 150, y: 0 },
+      { x: 200, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: overlap is clipped to the side length when the segment overhangs both corners', () => {
+    const path = [
+      { x: -50, y: 0 },
+      { x: 200, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [rect])[3]).toBe(100 * COST_QUANTUM)
+  })
+
+  it('self term: a zero-height rect is charged once, not twice, for a segment lying on it', () => {
+    const flat: Rect = { x: 0, y: 0, w: 100, h: 0 }
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [flat])[3]).toBe(100 * COST_QUANTUM)
+  })
+
+  it('self term: fires against the path’s OWN endpoint node, unlike foreignBodies which excludes it', () => {
+    // foreignBodies deliberately excludes an edge's own endpoints (tunnel
+    // check); nodeBorders deliberately does NOT — the whole point is
+    // pricing a segment riding the SOURCE node's own border.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0])
+  })
+
+  it('defaults nodeBorders to [] when omitted, contributing 0 (no border ink declared)', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(selfPenalty(path, [])).toEqual(zeroPenalty())
   })
 })
 
@@ -331,29 +412,34 @@ describe('realized-bends', () => {
       ],
       0,
     ],
-  ] as const)('%s path contributes %i to tier 3', (_label, path, expected) => {
+  ] as const)('%s path contributes %i to tier 4', (_label, path, expected) => {
     const cost = selfPenalty(path, [])
-    expect(cost[3]).toBe(expected)
+    expect(cost[4]).toBe(expected)
     expect(cost.every((n) => Number.isFinite(n) && n >= 0)).toBe(true)
   })
 })
 
 describe('hasRepairableProblem', () => {
   it('is false when the only nonzero tier is the last (realized-bends) tier', () => {
-    expect(hasRepairableProblem([0, 0, 0, 5])).toBe(false)
+    expect(hasRepairableProblem([0, 0, 0, 0, 5])).toBe(false)
   })
 
   it.each([
-    [[1, 0, 0, 0]],
-    [[0, 1, 0, 0]],
-    [[0, 0, 1, 0]],
-    [[1, 1, 1, 5]],
+    [[1, 0, 0, 0, 0]],
+    [[0, 1, 0, 0, 0]],
+    [[0, 0, 1, 0, 0]],
+    [[0, 0, 0, 1, 0]],
+    [[1, 1, 1, 1, 5]],
   ] as const)('is true when a non-final tier is nonzero: %j', (cost) => {
     expect(hasRepairableProblem(cost)).toBe(true)
   })
 
   it('is false for the zero cost', () => {
     expect(hasRepairableProblem(zeroPenalty())).toBe(false)
+  })
+
+  it('is true when the only nonzero tier is border-tracing (repairable, unlike realized-bends)', () => {
+    expect(hasRepairableProblem([0, 0, 0, 7, 0])).toBe(true)
   })
 
   it('is false when rules is empty (guards Math.max(...[]) === -Infinity)', () => {
@@ -363,11 +449,11 @@ describe('hasRepairableProblem', () => {
 
 describe('addCost', () => {
   it('sums two cost arrays tier-by-tier with sign=1', () => {
-    expect(addCost([1, 2, 3, 4], [10, 20, 30, 40], 1)).toEqual([11, 22, 33, 44])
+    expect(addCost([1, 2, 3, 4, 5], [10, 20, 30, 40, 50], 1)).toEqual([11, 22, 33, 44, 55])
   })
 
   it('subtracts b from a tier-by-tier with sign=-1', () => {
-    expect(addCost([10, 20, 30, 40], [1, 2, 3, 4], -1)).toEqual([9, 18, 27, 36])
+    expect(addCost([10, 20, 30, 40, 50], [1, 2, 3, 4, 5], -1)).toEqual([9, 18, 27, 36, 45])
   })
 
   it('defaults a missing index in either operand to 0', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -326,13 +326,22 @@ export function bendCount(path: readonly Point[]): number {
  * bystander rects it might tunnel through; a rule with no self contribution
  * returns 0 without walking the path. Every rule's `tier` is also its slot
  * index into the composed cost array — enforced by the `PENALTY_RULES`
- * tier-order pin in edge-rules.test.ts, not by this type.
+ * tier-order pin in edge-rules.test.ts, not by this type. `selfTerm`'s third
+ * parameter is every node's border rect (INCLUDING the path's own endpoints
+ * — unlike `foreignBodies`, which deliberately excludes them), for rules
+ * that price ink drawn on a node's OUTLINE rather than through its interior;
+ * a rule with no such contribution ignores the parameter (fewer params is
+ * legal in TS).
  */
 export type PenaltyRule = {
   readonly name: string
   readonly tier: number
   readonly pairTerm: (triple: readonly [number, number, number]) => number
-  readonly selfTerm: (path: readonly Point[], foreignBodies: readonly Rect[]) => number
+  readonly selfTerm: (
+    path: readonly Point[],
+    foreignBodies: readonly Rect[],
+    nodeBorders: readonly Rect[],
+  ) => number
 }
 
 /**
@@ -412,6 +421,72 @@ const crossings: PenaltyRule = {
   selfTerm: () => 0,
 }
 
+/**
+ * border-tracing: a routed segment running collinear with AND overlapping a
+ * node's border — ink drawn on top of an outline reads as though the edge
+ * merges into that box. Tier 3, BELOW crossings rather than adjacent to
+ * overlap-and-intrusion: this rule is evaluated against the optimizer's
+ * unaligned TRIAL paths (the pre-`slideAlongSide` representation used only
+ * for ranking candidates — see `computeAnchorsFor`'s `align` parameter),
+ * whose unaligned anchor placement can coincidentally run a detour segment
+ * exactly along a bystander node's extended border for a real stretch, a
+ * false signal an actual jump-arc-defeating CROSSING never produces. Tier 1
+ * was tried first and reverted: on a real canvas (edge-lane-rank.test.ts's
+ * sweep-rank pin — red{0,100,300,120}/yellow{450,290,260,130}/
+ * cyan{630,610,280,160}, e-orange fromNode yellow toNode red toSide
+ * 'right', e-red fromNode red toNode cyan fromSide 'right') it out-ranked a
+ * real crossing: the initial, genuinely crossing-free pick (e-red toSide
+ * 'left', final path (300,180)(320,180)(320,690)(610,690)(630,690)) scored
+ * a spurious 480 on its UNALIGNED trial path (which detours through
+ * (300,444)-(630,444), tracing 40px of red's own right border then 80px of
+ * cyan's left border) against toSide 'top''s trial cost of 0 — so the
+ * optimizer adopted 'top', whose actual final path,
+ * (300,180)(320,180)(770,180)(770,590)(770,610), crosses e-orange's path at
+ * (332,180). That is a strictly worse rendered result for a rule that fired
+ * on geometry the renderer never draws. Below crossings, a genuine crossing
+ * always outranks a trial-path border artifact while the rule still
+ * repairs the reported defect: A/B/T's overlap-and-intrusion/illegibility/
+ * crossings tiers are already all-zero for every side-pair option (the
+ * report's own 16-way enumeration), so lexicographic comparison still
+ * falls through to this tier as the decisive one. Self-only; `nodeBorders`
+ * includes the path's own endpoint rects (unlike `foreignBodies`, which
+ * excludes them for the tunnel check) — the defect this rule exists to
+ * price is a segment riding the SOURCE node's own border. A perpendicular
+ * departure/arrival still only touches its border at a point (zero-length
+ * overlap, costs 0); only positive overlap length is priced. All
+ * arithmetic runs in COST_QUANTUM-quantized integer space (matching
+ * overlap-and-intrusion's self-retrace half) so the term is integral by
+ * construction. The single per-axis OR condition (segment y equals the
+ * rect's top OR bottom, not two independent checks) is what stops a
+ * zero-height rect (top === bottom) from being charged twice for the same
+ * segment.
+ */
+const borderTracing: PenaltyRule = {
+  name: 'border-tracing',
+  tier: 3,
+  pairTerm: () => 0,
+  selfTerm: (path, _foreignBodies, nodeBorders) => {
+    const q = (n: number) => Math.round(n * COST_QUANTUM)
+    let overlap = 0
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as Point
+      const b = path[i] as Point
+      for (const r of nodeBorders ?? []) {
+        if (a.y === b.y && (q(a.y) === q(r.y) || q(a.y) === q(r.y + r.h))) {
+          const lo = Math.max(q(Math.min(a.x, b.x)), q(r.x))
+          const hi = Math.min(q(Math.max(a.x, b.x)), q(r.x + r.w))
+          if (hi > lo) overlap += hi - lo
+        } else if (a.x === b.x && (q(a.x) === q(r.x) || q(a.x) === q(r.x + r.w))) {
+          const lo = Math.max(q(Math.min(a.y, b.y)), q(r.y))
+          const hi = Math.min(q(Math.max(a.y, b.y)), q(r.y + r.h))
+          if (hi > lo) overlap += hi - lo
+        }
+      }
+    }
+    return overlap
+  },
+}
+
 /** realized-bends: direction changes along ONE routed path. Self-only, and
  * deliberately the last tier — the optimizer's short-circuit
  * (`hasRepairableProblem`) and worst-offender filter both ignore it, since
@@ -419,7 +494,7 @@ const crossings: PenaltyRule = {
  * and reshuffling it purely to shave bends is churn, not repair. */
 const realizedBends: PenaltyRule = {
   name: 'realized-bends',
-  tier: 3,
+  tier: 4,
   pairTerm: () => 0,
   selfTerm: (path) => bendCount(path),
 }
@@ -434,6 +509,7 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   overlapAndIntrusion,
   illegibility,
   crossings,
+  borderTracing,
   realizedBends,
 ]
 
@@ -461,14 +537,20 @@ export function pairPenalty(
 /**
  * `selfScore`'s composition step (spatial-edges.ts): map one routed path's
  * self-geometry into a full cost array, one rule per declared tier.
+ * `nodeBorders` defaults to `[]` ("no border ink declared") rather than
+ * falling back to `foreignBodies` — that default is what keeps every
+ * existing 2-arg call site (and the pre-existing grazing-exclusion pin)
+ * behaviorally unchanged: a caller that never passes border rects gets 0
+ * from `border-tracing`, exactly as if the rule did not exist.
  */
 export function selfPenalty(
   path: readonly Point[],
   foreignBodies: readonly Rect[],
+  nodeBorders: readonly Rect[] = [],
   rules: readonly PenaltyRule[] = PENALTY_RULES,
 ): number[] {
   const cost = zeroPenalty(rules)
-  for (const rule of rules) cost[rule.tier] = rule.selfTerm(path, foreignBodies)
+  for (const rule of rules) cost[rule.tier] = rule.selfTerm(path, foreignBodies, nodeBorders)
   return cost
 }
 

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -10,8 +10,8 @@
  * `rankedSidePairs` (spatial-edges.ts, a thin wrapper over `composeSidePairs`
  * below) plus the solver's adoption predicate (`shouldAdoptCandidate`, the
  * "incumbent-wins-ties" rule) are the PREFERENCE half; `PENALTY_RULES` below
- * is the PENALTY half — `pairScore`/`selfScore` (spatial-edges.ts) compose
- * over it to build the cost tuple `optimizeSideChoices` compares.
+ * is the PENALTY half — `pairScore` (spatial-edges.ts) and `selfPenalty`
+ * compose over it to build the cost tuple `optimizeSideChoices` compares.
  */
 
 export type Side = 'top' | 'right' | 'bottom' | 'left'
@@ -329,9 +329,7 @@ export function bendCount(path: readonly Point[]): number {
  * tier-order pin in edge-rules.test.ts, not by this type. `selfTerm`'s third
  * parameter is every node's border rect (INCLUDING the path's own endpoints
  * — unlike `foreignBodies`, which deliberately excludes them), for rules
- * that price ink drawn on a node's OUTLINE rather than through its interior;
- * a rule with no such contribution ignores the parameter (fewer params is
- * legal in TS).
+ * that price ink drawn on a node's OUTLINE rather than through its interior.
  */
 export type PenaltyRule = {
   readonly name: string
@@ -424,42 +422,28 @@ const crossings: PenaltyRule = {
 /**
  * border-tracing: a routed segment running collinear with AND overlapping a
  * node's border — ink drawn on top of an outline reads as though the edge
- * merges into that box. Tier 3, BELOW crossings rather than adjacent to
- * overlap-and-intrusion: this rule is evaluated against the optimizer's
- * unaligned TRIAL paths (the pre-`slideAlongSide` representation used only
- * for ranking candidates — see `computeAnchorsFor`'s `align` parameter),
- * whose unaligned anchor placement can coincidentally run a detour segment
- * exactly along a bystander node's extended border for a real stretch, a
- * false signal an actual jump-arc-defeating CROSSING never produces. Tier 1
- * was tried first and reverted: on a real canvas (edge-lane-rank.test.ts's
- * sweep-rank pin — red{0,100,300,120}/yellow{450,290,260,130}/
- * cyan{630,610,280,160}, e-orange fromNode yellow toNode red toSide
- * 'right', e-red fromNode red toNode cyan fromSide 'right') it out-ranked a
- * real crossing: the initial, genuinely crossing-free pick (e-red toSide
- * 'left', final path (300,180)(320,180)(320,690)(610,690)(630,690)) scored
- * a spurious 480 on its UNALIGNED trial path (which detours through
- * (300,444)-(630,444), tracing 40px of red's own right border then 80px of
- * cyan's left border) against toSide 'top''s trial cost of 0 — so the
- * optimizer adopted 'top', whose actual final path,
- * (300,180)(320,180)(770,180)(770,590)(770,610), crosses e-orange's path at
- * (332,180). That is a strictly worse rendered result for a rule that fired
- * on geometry the renderer never draws. Below crossings, a genuine crossing
- * always outranks a trial-path border artifact while the rule still
- * repairs the reported defect: A/B/T's overlap-and-intrusion/illegibility/
- * crossings tiers are already all-zero for every side-pair option (the
- * report's own 16-way enumeration), so lexicographic comparison still
- * falls through to this tier as the decisive one. Self-only; `nodeBorders`
- * includes the path's own endpoint rects (unlike `foreignBodies`, which
- * excludes them for the tunnel check) — the defect this rule exists to
- * price is a segment riding the SOURCE node's own border. A perpendicular
- * departure/arrival still only touches its border at a point (zero-length
- * overlap, costs 0); only positive overlap length is priced. All
- * arithmetic runs in COST_QUANTUM-quantized integer space (matching
- * overlap-and-intrusion's self-retrace half) so the term is integral by
- * construction. The single per-axis OR condition (segment y equals the
- * rect's top OR bottom, not two independent checks) is what stops a
- * zero-height rect (top === bottom) from being charged twice for the same
- * segment.
+ * merges into that box. Self-only; `nodeBorders` includes the path's own
+ * endpoint rects (unlike `foreignBodies`, which excludes them for the
+ * tunnel check) — the defect this rule exists to price is a segment riding
+ * the SOURCE node's own border. A perpendicular departure/arrival only
+ * touches its border at a point (zero-length overlap, costs 0); only
+ * positive overlap length is priced, in COST_QUANTUM-quantized integer
+ * space so the term is integral by construction. The single per-axis OR
+ * condition (segment y equals the rect's top OR bottom, not two
+ * independent checks) is what stops a zero-height rect (top === bottom)
+ * from being charged twice for the same segment.
+ *
+ * Tier 3, BELOW crossings, because this rule is evaluated against the
+ * optimizer's unaligned TRIAL paths (the pre-`slideAlongSide`
+ * representation used only for ranking candidates — see
+ * `computeAnchorsFor`'s `align` parameter), whose anchor placement can
+ * coincidentally run a detour segment along a bystander's border for a
+ * real stretch: a false signal a genuine CROSSING never produces. At tier 1
+ * that artifact out-ranked a real crossing and the optimizer adopted a
+ * strictly worse rendered route (pinned by edge-lane-rank.test.ts's
+ * sweep-rank scenario). Below crossings it still repairs the border-riding
+ * defect, whose lower tiers are all-zero for every side-pair option, so the
+ * lexicographic comparison falls through to this tier as the decisive one.
  */
 const borderTracing: PenaltyRule = {
   name: 'border-tracing',
@@ -471,7 +455,7 @@ const borderTracing: PenaltyRule = {
     for (let i = 1; i < path.length; i++) {
       const a = path[i - 1] as Point
       const b = path[i] as Point
-      for (const r of nodeBorders ?? []) {
+      for (const r of nodeBorders) {
         if (a.y === b.y && (q(a.y) === q(r.y) || q(a.y) === q(r.y + r.h))) {
           const lo = Math.max(q(Math.min(a.x, b.x)), q(r.x))
           const hi = Math.min(q(Math.max(a.x, b.x)), q(r.x + r.w))
@@ -535,13 +519,12 @@ export function pairPenalty(
 }
 
 /**
- * `selfScore`'s composition step (spatial-edges.ts): map one routed path's
- * self-geometry into a full cost array, one rule per declared tier.
- * `nodeBorders` defaults to `[]` ("no border ink declared") rather than
- * falling back to `foreignBodies` — that default is what keeps every
- * existing 2-arg call site (and the pre-existing grazing-exclusion pin)
- * behaviorally unchanged: a caller that never passes border rects gets 0
- * from `border-tracing`, exactly as if the rule did not exist.
+ * The self half of the composition (`optimizeSideChoices`, spatial-edges.ts):
+ * map one routed path's self-geometry into a full cost array, one rule per
+ * declared tier. `nodeBorders` defaults to `[]` ("no border ink declared")
+ * rather than falling back to `foreignBodies` — a caller that passes no
+ * border rects gets 0 from `border-tracing`, exactly as if the rule did not
+ * exist.
  */
 export function selfPenalty(
   path: readonly Point[],

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -497,9 +497,8 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   realizedBends,
 ]
 
-/** The all-zero cost, sized to `rules` — the composition path's only
- * length-4 literal is this `.map`, derived from the declared list rather
- * than hardcoded. */
+/** The all-zero cost, sized to `rules` — derived from the declared list
+ * (`rules.map`), never a hardcoded array length. */
 export function zeroPenalty(rules: readonly PenaltyRule[] = PENALTY_RULES): number[] {
   return rules.map(() => 0)
 }

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -508,7 +508,7 @@ function computeAnchorsFor(
  * slot per PENALTY_RULES tier (edge-rules.ts): total collinear axis-aligned
  * overlap length (a parallel overlap has no crossing point, so a line jump
  * cannot express it — heaviest; an edge RETRACING its own ink counts here
- * too, via `selfScore`), crossings too close to a segment end to render
+ * too, via `selfPenalty`), crossings too close to a segment end to render
  * their jump arc, total crossings, then total REALIZED bends. Bends sit
  * last and the optimizer's short-circuit ignores them (`hasRepairableProblem`):
  * they only break ties between configurations that already tie on every
@@ -541,22 +541,6 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
     }
   }
   return pairPenalty([overlap, illegible, crossings])
-}
-
-/**
- * `selfScore`'s composition over PENALTY_RULES: per-edge quality of ONE
- * routed path — collinear overlap with itself, tunnelling through a
- * bystander node's raw body, tracing a node's own border (including the
- * path's own endpoint nodes — the whole point of the border-tracing rule
- * is pricing ink drawn on the SOURCE node's own outline), and realized
- * bend count, each contributed by its own named rule.
- */
-function selfScore(
-  path: readonly Point[],
-  foreignBodies: readonly Rect[],
-  nodeBorders: readonly Rect[],
-): ConfigCost {
-  return selfPenalty(path, foreignBodies, nodeBorders)
 }
 
 /**
@@ -631,7 +615,7 @@ function optimizeSideChoices(
   // check which must exclude the edge's endpoints.
   const nodeBorders = nodes.map(rectOf)
   const selfCosts: ConfigCost[] = paths.map((path, i) =>
-    selfScore(path, foreignBodiesFor[i]!, nodeBorders),
+    selfPenalty(path, foreignBodiesFor[i]!, nodeBorders),
   )
   let currentCost: ConfigCost = zeroPenalty()
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
@@ -674,7 +658,7 @@ function optimizeSideChoices(
     const updates = new Map<number, ConfigCost>()
     const selfUpdates = new Map<number, ConfigCost>()
     for (const i of touched) {
-      const next = selfScore(trialPaths[i]!, foreignBodiesFor[i]!, nodeBorders)
+      const next = selfPenalty(trialPaths[i]!, foreignBodiesFor[i]!, nodeBorders)
       cost = addCost(cost, selfCosts[i] ?? zeroPenalty(), -1)
       cost = addCost(cost, next, 1)
       selfUpdates.set(i, next)

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -546,11 +546,17 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
 /**
  * `selfScore`'s composition over PENALTY_RULES: per-edge quality of ONE
  * routed path — collinear overlap with itself, tunnelling through a
- * bystander node's raw body, and realized bend count, each contributed by
- * its own named rule.
+ * bystander node's raw body, tracing a node's own border (including the
+ * path's own endpoint nodes — the whole point of the border-tracing rule
+ * is pricing ink drawn on the SOURCE node's own outline), and realized
+ * bend count, each contributed by its own named rule.
  */
-function selfScore(path: readonly Point[], foreignBodies: readonly Rect[]): ConfigCost {
-  return selfPenalty(path, foreignBodies)
+function selfScore(
+  path: readonly Point[],
+  foreignBodies: readonly Rect[],
+  nodeBorders: readonly Rect[],
+): ConfigCost {
+  return selfPenalty(path, foreignBodies, nodeBorders)
 }
 
 /**
@@ -620,7 +626,13 @@ function optimizeSideChoices(
   const foreignBodiesFor = edges.map((e) =>
     nodes.filter((n) => n.id !== e.fromNode && n.id !== e.toNode).map(rectOf),
   )
-  const selfCosts: ConfigCost[] = paths.map((path, i) => selfScore(path, foreignBodiesFor[i]!))
+  // Every node's border, INCLUDING an edge's own endpoints — border-tracing
+  // prices ink on a node's own outline, unlike foreignBodiesFor's tunnel
+  // check which must exclude the edge's endpoints.
+  const nodeBorders = nodes.map(rectOf)
+  const selfCosts: ConfigCost[] = paths.map((path, i) =>
+    selfScore(path, foreignBodiesFor[i]!, nodeBorders),
+  )
   let currentCost: ConfigCost = zeroPenalty()
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
   // Sweep-and-prune instead of the O(E^2) double loop: identical scores
@@ -662,7 +674,7 @@ function optimizeSideChoices(
     const updates = new Map<number, ConfigCost>()
     const selfUpdates = new Map<number, ConfigCost>()
     for (const i of touched) {
-      const next = selfScore(trialPaths[i]!, foreignBodiesFor[i]!)
+      const next = selfScore(trialPaths[i]!, foreignBodiesFor[i]!, nodeBorders)
       cost = addCost(cost, selfCosts[i] ?? zeroPenalty(), -1)
       cost = addCost(cost, next, 1)
       selfUpdates.set(i, next)


### PR DESCRIPTION
## The defect

Reported from the app: with two overlapping nodes, the edge between them is drawn **on top of the source node's own outline** and reads as merging into the box.

Reproduced exactly. `assignEdgeAnchors` picked `top → left` and routed:

```
(233.33,570) (233.33,550) (200,550) (200,570) (220,570)
                                    └──────────────────┘  ← lies exactly on node A's top border (A.y = 570)
```

## Why nothing caught it

- `overlap-and-intrusion` (tier 0) prices edge-vs-**edge** collinear overlap and body **interior** chords. A segment riding exactly **on** a rect boundary is deliberately excluded (the documented grazing exclusion). Tracing a border therefore cost **0**.
- Nothing priced ink drawn on a node's **outline** at all. The edge's whole cost tuple was zero — which also made it **ineligible for repair**: `hasRepairableProblem` was false, so the optimizer's worst-offender filter never trialled it.

Enumerating all 16 side pairs showed **seven zero-trace configurations already inside the optimizer's search space**, so this is a missing objective term, not a router problem.

## The change

One new named PENALTY rule, per decision #10 ("new routing feedback = one named rule + its own test, never a new branch in `spatial-edges.ts`"):

- **`border-tracing`** — a routed segment collinear with **and overlapping** a node's border, priced by overlap length in `COST_QUANTUM`-quantized integer space. Self-only; `edge-crossing-sweep.ts` (the single narrow-phase producer) is untouched.
- Its `nodeBorders` input **includes the path's own endpoint rects** — unlike `foreignBodies`, which excludes them for the tunnel check. That is the whole point: the border being traced is the source node's own.
- A perpendicular departure/arrival touches its border at a point (zero-length overlap) and stays free.

**Tier 3, below crossings — placed by evidence, not assertion.** At tier 1 it flipped a pre-existing pin (`edge-lane-rank.test.ts`): the rule is evaluated against the optimizer's *unaligned trial* paths (the pre-`slideAlongSide` ranking representation), whose detours can coincidentally run along a bystander's border for a real stretch — a false signal a genuine crossing never produces. The optimizer then adopted a route whose *rendered* path crosses another edge. Below crossings, a real crossing always outranks a trial-path artifact, and the reported defect is still repaired (its lower tiers are all zero, so the comparison falls through to this tier). It stays strictly above the last tier, so `hasRepairableProblem` still sees it.

## Verification

Final route for the reported edge: `top → top`, `(233.33,570) (233.33,550) (233.33,488) (353.33,488) (353.33,520)` — **trace 0**.

Confirmed in the running app (vite dev, the exact canvas pasted, edge routing set to orthogonal): the rendered polyline is `249.333,586 249.333,566 249.333,504 369.333,504 369.333,536` — the same route modulo the paste offset, with no segment on any border.

- Red-first example pin on the exact reported canvas, asserting the **invariant** (no segment has positive collinear overlap with any node border), not a hardcoded path.
- 9 focused unit tests for the rule + an oracle-equality fast-check property with a dense border-snapping generator.
- Mutation-checked: reverting the rule to `() => 0` turns both the pin and the property red.
- All pre-existing routing/side-choice/parity pins unweakened; SVG determinism goldens byte-identical.

## Visual evidence

![after](tmp/screenshots/after-border-tracing-fix.png)

The border-riding hook is gone. **Known residual, not introduced here:** the departure stub still crosses the target node's body, because no rule prices ink over an endpoint node's own body (the old route did this too, for 20px). A follow-up rule is planned; `bottom → bottom` is the fully clean option the optimizer cannot yet see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added penalties for routed edges that trace along node borders.
  * Expanded routing evaluation to account for endpoint border overlap.
  * Updated penalty scoring to use five tiers, with realized bends evaluated after border tracing.

* **Bug Fixes**
  * Improved route optimization to discourage paths overlapping node borders.

* **Tests**
  * Added coverage for border tracing, clipping, endpoint handling, determinism, and cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->