### PR TITLE
fix(canvas-render): stop routing edge ink through its own endpoint node's body

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -301,27 +301,39 @@ paths:
       existing function. `layout/edge-rules.ts` implements the PREFERENCE
       half: `SIDE_PREFERENCE_RULES` names zero-bend-facing-first,
       dominant-axis-first, l-pair-crowding-tie-break, u-hook-when-degenerate,
-      gap-valid-opposing-before-invalid, and incumbent-wins-ties;
-      `composeSidePairs` is the composition `rankedSidePairs`
-      (`layout/spatial-edges.ts`) wraps, and `shouldAdoptCandidate` is the
-      incumbent-wins-ties predicate `optimizeSideChoices` consults. The
-      PENALTY half is `PENALTY_RULES`: overlap-and-intrusion (tier 0,
-      collinear overlap plus self-retrace/body-intrusion), illegibility
-      (tier 1), crossings (tier 2), border-tracing (tier 3, self-only — a
-      routed segment collinear with AND overlapping a node's own border,
-      `nodeBorders` including the path's own endpoint rects unlike
-      `foreignBodies`), and realized-bends (tier 4, self-only and
-      deliberately last). border-tracing sits BELOW crossings rather than
-      adjacent to overlap-and-intrusion: it is evaluated against the
-      optimizer's unaligned TRIAL paths (`computeAnchorsFor`'s pre-
-      `slideAlongSide` representation, used only for candidate ranking),
-      whose unaligned anchor placement can coincidentally trace a
-      bystander's extended border for a real stretch — a false signal a
-      genuine crossing never produces (verified against
-      `edge-lane-rank.test.ts`'s sweep-rank pin: tier 1 placement adopted a
-      route with a real crossing over a crossing-free one). `pairScore`/
-      `selfPenalty` (`spatial-edges.ts`) compose over the list, and every
-      cost-tuple helper (`ConfigCost` shape, `addCost`, `lessCost`,
+      gap-valid-opposing-before-invalid, u-hook-span-exposed-first, and
+      incumbent-wins-ties; `composeSidePairs` is the composition
+      `rankedSidePairs` (`layout/spatial-edges.ts`) wraps, and
+      `shouldAdoptCandidate` is the incumbent-wins-ties predicate
+      `optimizeSideChoices` consults. `u-hook-span-exposed-first` demotes a
+      same-side U-hook candidate whose DEPARTURE side border runs through
+      the target's strict interior (group frames excluded via
+      `fullyContains`) behind one that does not — this is what makes the
+      optimizer's ALREADY-CORRECT scoring of a clean same-side route
+      reachable in one improving hop instead of several: the defect was in
+      candidate ORDER, not the search budget, so `CROSSING_OPT_MAX_PASSES`
+      stays 2. The PENALTY half is `PENALTY_RULES`: overlap-and-intrusion
+      (tier 0, collinear overlap plus self-retrace/body-intrusion),
+      illegibility (tier 1), crossings (tier 2), border-tracing (tier 3,
+      self-only — a routed segment collinear with AND overlapping a node's
+      own border, `nodeBorders` including the path's own endpoint rects
+      unlike `foreignBodies`), endpoint-body-ink (tier 4, self-only — a
+      routed segment STRICTLY BETWEEN a rect's two borders, the interior
+      complement of border-tracing, priced against the edge's OWN endpoint
+      rects since `foreignBodies` deliberately excludes them for the tunnel
+      check), and realized-bends (tier 5, self-only and deliberately last).
+      border-tracing sits BELOW crossings rather than adjacent to
+      overlap-and-intrusion: it is evaluated against the optimizer's
+      unaligned TRIAL paths (`computeAnchorsFor`'s pre-`slideAlongSide`
+      representation, used only for candidate ranking), whose unaligned
+      anchor placement can coincidentally trace a bystander's extended
+      border for a real stretch — a false signal a genuine crossing never
+      produces (verified against `edge-lane-rank.test.ts`'s sweep-rank pin:
+      tier 1 placement adopted a route with a real crossing over a
+      crossing-free one). endpoint-body-ink sits below border-tracing for
+      the same trial-path-artifact reason. `pairScore`/`selfPenalty`
+      (`spatial-edges.ts`) compose over the list, and every cost-tuple
+      helper (`ConfigCost` shape, `addCost`, `lessCost`,
       `hasRepairableProblem`) derives from the declared tiers, so a new
       penalty rule is one list entry, never a new slot threaded by hand.
     - **Facet-driven rendering rides the injected-resolver pattern**

--- a/packages/canvas-render/src/layout/edge-endpoint-body-ink.test.ts
+++ b/packages/canvas-render/src/layout/edge-endpoint-body-ink.test.ts
@@ -1,0 +1,63 @@
+// A routed segment must never run STRICTLY INSIDE a node's body: ink drawn
+// across a node's interior reads as though the edge connects that node.
+// border-tracing (edge-border-trace.test.ts) pins the complementary
+// outline-riding invariant on this same canvas; this file pins interior
+// ink, which border-tracing's collinear-ON-the-border check cannot see.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+/** Independent oracle (never calls production code): total length of every
+ * path segment that runs STRICTLY inside a rect's interior — a border-riding
+ * or perpendicular-departure segment contributes 0, only a true interior
+ * chord counts. */
+function strictInteriorLength(
+  path: readonly { x: number; y: number }[],
+  rects: readonly { x: number; y: number; w: number; h: number }[],
+): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    for (const r of rects) {
+      if (a.y === b.y && a.y > r.y && a.y < r.y + r.h) {
+        const lo = Math.max(Math.min(a.x, b.x), r.x)
+        const hi = Math.min(Math.max(a.x, b.x), r.x + r.w)
+        if (hi > lo) total += hi - lo
+      } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w) {
+        const lo = Math.max(Math.min(a.y, b.y), r.y)
+        const hi = Math.min(Math.max(a.y, b.y), r.y + r.h)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total
+}
+
+it('never routes a segment of A->B strictly inside any node body, on the exact user canvas', () => {
+  const nodes = [
+    box('A', 100, 570, 200, 100),
+    box('B', 220, 520, 200, 100),
+    box('T', 80, 360, 200, 110),
+  ]
+  const edges: CanvasEdge[] = [
+    { id: 'ab', fromNode: 'A', toNode: 'B' },
+    { id: 'ta', fromNode: 'T', toNode: 'A', label: 'hoge' },
+    { id: 'tb', fromNode: 'T', toNode: 'B' },
+  ]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const ab = edges[0] as CanvasEdge
+  const { path } = routeEdge(nodes, ab, 'orthogonal', anchors.get('ab'))
+  const rects = nodes.map((n) => ({ x: n.x, y: n.y, w: n.width, h: n.height }))
+  expect(strictInteriorLength(path, rects)).toBe(0)
+})

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -159,7 +159,7 @@ describe('PENALTY_RULES: each rule writes only its declared tier slot', () => {
     (path, foreignBodies, nodeBorders) => {
       const cost = selfPenalty(path, foreignBodies, nodeBorders)
       for (const rule of PENALTY_RULES) {
-        expect(cost[rule.tier]).toBe(rule.selfTerm(path, foreignBodies, nodeBorders))
+        expect(cost[rule.tier]).toBe(rule.selfTerm(path, foreignBodies, nodeBorders, []))
       }
     },
   )
@@ -300,6 +300,178 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
     'agrees with an independently-computed collinear overlap length',
     ({ path, nodeBorders }) => {
       expect(selfPenalty(path, [], nodeBorders)[3]).toBe(referenceBorderTrace(path, nodeBorders))
+    },
+  )
+})
+
+// endpoint-body-ink-specific properties: analogous to the border-tracing
+// block above, but the dense domain snaps generated points to the
+// STRICT INTERIOR of a rect (rather than its border) so the property has a
+// real chance of finding a positive interior chord instead of passing
+// vacuously.
+const interiorPointArb = (rect: Rect): fc.Arbitrary<Point> =>
+  fc.oneof(
+    // y strictly between the rect's top and bottom (when the rect is tall
+    // enough for one to exist), x ranging generously so the clipping
+    // branch is exercised too.
+    fc.record({
+      x: fc.integer({ min: rect.x - 50, max: rect.x + rect.w + 50 }),
+      y:
+        rect.h >= 2
+          ? fc.integer({ min: rect.y + 1, max: rect.y + rect.h - 1 })
+          : fc.constant(rect.y),
+    }),
+    // x strictly between the rect's left and right.
+    fc.record({
+      x:
+        rect.w >= 2
+          ? fc.integer({ min: rect.x + 1, max: rect.x + rect.w - 1 })
+          : fc.constant(rect.x),
+      y: fc.integer({ min: rect.y - 50, max: rect.y + rect.h + 50 }),
+    }),
+    pointArb,
+  )
+
+const endpointRectArb: fc.Arbitrary<Rect> = borderRectArb
+
+// The rect a chord was BUILT from is folded into endpointRects (alongside
+// independently generated extras, and a chance of a CONTAINER rect around
+// it) so the oracle-equality property below always has a real chance of
+// exercising both the interior-chord branch and the containment exclusion.
+const endpointBodyInkScenarioArb: fc.Arbitrary<{
+  path: readonly Point[]
+  endpointRects: readonly Rect[]
+}> = fc.tuple(endpointRectArb, foreignBodiesArb, fc.boolean()).chain(([rect, extras, wrapped]) =>
+  fc.array(interiorPointArb(rect), { minLength: 0, maxLength: 6 }).map((path) => ({
+    path,
+    endpointRects: wrapped
+      ? [{ x: rect.x - 10, y: rect.y - 10, w: rect.w + 20, h: rect.h + 20 }, rect, ...extras]
+      : [rect, ...extras],
+  })),
+)
+
+/** Independent oracle (never calls production code): total STRICTLY
+ * interior chord length, container rects excluded. All generator
+ * coordinates are integers, so multiplying by COST_QUANTUM at the end is
+ * exact — no quantization drift from the production rule's `q()`. */
+function referenceEndpointBodyInk(path: readonly Point[], rects: readonly Rect[]): number {
+  const containsRect = (outer: Rect, inner: Rect): boolean =>
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.w <= outer.x + outer.w &&
+    inner.y + inner.h <= outer.y + outer.h
+  const priced = rects.filter((r) => !rects.some((other) => other !== r && containsRect(r, other)))
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    for (const r of priced) {
+      if (a.y === b.y && a.y > r.y && a.y < r.y + r.h) {
+        const lo = Math.max(Math.min(a.x, b.x), r.x)
+        const hi = Math.min(Math.max(a.x, b.x), r.x + r.w)
+        if (hi > lo) total += hi - lo
+      } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w) {
+        const lo = Math.max(Math.min(a.y, b.y), r.y)
+        const hi = Math.min(Math.max(a.y, b.y), r.y + r.h)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total * COST_QUANTUM
+}
+
+describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => {
+  fcTest.prop([endpointBodyInkScenarioArb], withDefaults())(
+    'the endpoint-body-ink term is a finite, non-negative, integral, deterministic total',
+    ({ path, endpointRects }) => {
+      const cost1 = selfPenalty(path, [], [], endpointRects)
+      const cost2 = selfPenalty(path, [], [], endpointRects)
+      expect(cost1[4]).toBe(cost2[4])
+      expect(Number.isInteger(cost1[4])).toBe(true)
+      expect(cost1[4]).toBeGreaterThanOrEqual(0)
+    },
+  )
+
+  fcTest.prop([endpointBodyInkScenarioArb], withDefaults())(
+    'is invariant under permutation of the endpoint-rect array (a sum must not depend on order)',
+    ({ path, endpointRects }) => {
+      const shuffled = [...endpointRects].reverse()
+      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
+        selfPenalty(path, [], [], shuffled)[4],
+      )
+    },
+  )
+
+  // The property that actually catches a "returns 0" or otherwise-wrong
+  // mutation: totality/purity/order-invariance above all hold trivially for
+  // a stub that always returns 0, so this is the one that must go red under
+  // mutation (verified: reverting endpointBodyInk.selfTerm to `() => 0`
+  // fails this test, confirming the dense generator reaches real interior
+  // chords — including through the containment-exclusion branch).
+  fcTest.prop([endpointBodyInkScenarioArb], withDefaults())(
+    'agrees with an independently-computed strictly-interior chord length',
+    ({ path, endpointRects }) => {
+      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
+        referenceEndpointBodyInk(path, endpointRects),
+      )
+    },
+  )
+})
+
+// No-double-charge: the SAME segment/rect pair must never be priced by both
+// border-tracing (collinear ON the border) and endpoint-body-ink (STRICTLY
+// between the two borders) — the two conditions are exact complements in
+// quantized space. Generated segments mix on-border, strictly-interior, and
+// exterior coordinates so the property has a real chance of making EITHER
+// term positive.
+const axisSegmentArb = (rect: Rect): fc.Arbitrary<{ a: Point; b: Point }> => {
+  const yCandidates = fc.oneof(
+    fc.constantFrom(rect.y, rect.y + rect.h),
+    rect.h >= 2 ? fc.integer({ min: rect.y + 1, max: rect.y + rect.h - 1 }) : fc.constant(rect.y),
+    fc.integer({ min: rect.y - 50, max: rect.y + rect.h + 50 }),
+  )
+  const xCandidates = fc.oneof(
+    fc.constantFrom(rect.x, rect.x + rect.w),
+    rect.w >= 2 ? fc.integer({ min: rect.x + 1, max: rect.x + rect.w - 1 }) : fc.constant(rect.x),
+    fc.integer({ min: rect.x - 50, max: rect.x + rect.w + 50 }),
+  )
+  return fc.oneof(
+    fc
+      .record({
+        y: yCandidates,
+        x1: fc.integer({ min: rect.x - 50, max: rect.x + rect.w + 50 }),
+        x2: fc.integer({ min: rect.x - 50, max: rect.x + rect.w + 50 }),
+      })
+      .map(({ y, x1, x2 }) => ({ a: { x: x1, y }, b: { x: x2, y } })),
+    fc
+      .record({
+        x: xCandidates,
+        y1: fc.integer({ min: rect.y - 50, max: rect.y + rect.h + 50 }),
+        y2: fc.integer({ min: rect.y - 50, max: rect.y + rect.h + 50 }),
+      })
+      .map(({ x, y1, y2 }) => ({ a: { x, y: y1 }, b: { x, y: y2 } })),
+  )
+}
+
+const complementarityArb: fc.Arbitrary<{ rect: Rect; a: Point; b: Point }> = borderRectArb.chain(
+  (rect) => axisSegmentArb(rect).map(({ a, b }) => ({ rect, a, b })),
+)
+
+function penaltyRule(name: string): (typeof PENALTY_RULES)[number] {
+  const rule = PENALTY_RULES.find((r) => r.name === name)
+  if (rule === undefined) throw new Error(`no such rule: ${name}`)
+  return rule
+}
+const borderTracingRule = penaltyRule('border-tracing')
+const endpointBodyInkRule = penaltyRule('endpoint-body-ink')
+
+describe('border-tracing / endpoint-body-ink: no double-charge', () => {
+  fcTest.prop([complementarityArb], withDefaults())(
+    'never charges the same single-segment/single-rect pair on both tiers',
+    ({ rect, a, b }) => {
+      const border = borderTracingRule.selfTerm([a, b], [], [rect], [])
+      const endpointInk = endpointBodyInkRule.selfTerm([a, b], [], [], [rect])
+      expect(Math.min(border, endpointInk)).toBe(0)
     },
   )
 })

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -341,14 +341,23 @@ const endpointRectArb: fc.Arbitrary<Rect> = borderRectArb
 const endpointBodyInkScenarioArb: fc.Arbitrary<{
   path: readonly Point[]
   endpointRects: readonly Rect[]
-}> = fc.tuple(endpointRectArb, foreignBodiesArb, fc.boolean()).chain(([rect, extras, wrapped]) =>
-  fc.array(interiorPointArb(rect), { minLength: 0, maxLength: 6 }).map((path) => ({
-    path,
-    endpointRects: wrapped
-      ? [{ x: rect.x - 10, y: rect.y - 10, w: rect.w + 20, h: rect.h + 20 }, rect, ...extras]
-      : [rect, ...extras],
-  })),
-)
+}> = fc
+  .tuple(endpointRectArb, foreignBodiesArb, fc.boolean(), fc.boolean())
+  .chain(([rect, extras, wrapped, duplicated]) =>
+    fc.array(interiorPointArb(rect), { minLength: 0, maxLength: 6 }).map((path) => ({
+      path,
+      // `duplicated` reaches the equal-rect case deterministically instead of
+      // waiting for the generator to collide: two identical endpoint rects
+      // contain each other, which the PROPER-containment exclusion keeps
+      // priced and a plain-containment one would silently drop.
+      endpointRects: [
+        ...(wrapped ? [{ x: rect.x - 10, y: rect.y - 10, w: rect.w + 20, h: rect.h + 20 }] : []),
+        rect,
+        ...(duplicated ? [{ ...rect }] : []),
+        ...extras,
+      ],
+    })),
+  )
 
 /** Independent oracle (never calls production code): total STRICTLY
  * interior chord length, container rects excluded. All generator
@@ -360,7 +369,11 @@ function referenceEndpointBodyInk(path: readonly Point[], rects: readonly Rect[]
     inner.y >= outer.y &&
     inner.x + inner.w <= outer.x + outer.w &&
     inner.y + inner.h <= outer.y + outer.h
-  const priced = rects.filter((r) => !rects.some((other) => other !== r && containsRect(r, other)))
+  // PROPER containment only: two identical rects each contain the other, and
+  // neither is a group frame around the other, so both stay priced.
+  const priced = rects.filter(
+    (r) => !rects.some((other) => other !== r && containsRect(r, other) && !containsRect(other, r)),
+  )
   let total = 0
   for (let i = 1; i < path.length; i++) {
     const a = path[i - 1] as Point

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -486,6 +486,27 @@ describe('endpoint-body-ink', () => {
     expect(selfPenalty(path, [], [], [a, b])[4]).toBe(60 * COST_QUANTUM)
   })
 
+  it('self term: two DISTINCT but numerically-equal endpoint rects (e.g. a self-loop, or two fully-overlapping same-size nodes) are NOT mutually excluded — this is the exact worst-case overlap the rule prices', () => {
+    // Two separate rect objects with identical values — not the same
+    // reference — so the `other !== r` identity check does not itself
+    // prevent the pair from being compared, exactly as `endpointRectsFor`
+    // (spatial-edges.ts) builds two independent rect objects for a
+    // self-loop edge (edge.fromNode === edge.toNode) or two same-size
+    // fully-overlapping nodes.
+    const rectA: Rect = { x: 0, y: 0, w: 50, h: 50 }
+    const rectB: Rect = { x: 0, y: 0, w: 50, h: 50 }
+    const path = [
+      { x: -10, y: 25 },
+      { x: 60, y: 25 },
+    ]
+    // fullyContains(rectA, rectB) is true in both directions under its
+    // inclusive comparisons, so a naive symmetric exclusion filter would
+    // drop BOTH rects and price 0. Neither PROPERLY contains the other, so
+    // both stay in the ink-priced set (chord clipped to [0,50], summed once
+    // per rect since inkAlongRects iterates the rect list).
+    expect(selfPenalty(path, [], [], [rectA, rectB])[4]).toBe(2 * 50 * COST_QUANTUM)
+  })
+
   it('self term: zero-width and zero-height endpoint rects contribute 0 (unsatisfiable strict-interior test)', () => {
     const flatH: Rect = { x: 0, y: 0, w: 100, h: 0 }
     const flatW: Rect = { x: 0, y: 0, w: 0, h: 100 }

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -177,14 +177,66 @@ describe('incumbent-wins-ties', () => {
 })
 
 describe('SIDE_PREFERENCE_RULES', () => {
-  it('declares exactly the six named rules from decision #10, in order', () => {
+  it('declares exactly the seven named rules from decision #10, in order', () => {
     expect(SIDE_PREFERENCE_RULES.map((r) => r.name)).toEqual([
       'zero-bend-facing-first',
       'dominant-axis-first',
       'l-pair-crowding-tie-break',
       'u-hook-when-degenerate',
       'gap-valid-opposing-before-invalid',
+      'u-hook-span-exposed-first',
       'incumbent-wins-ties',
+    ])
+  })
+})
+
+describe('u-hook-span-exposed-first', () => {
+  const rule = candidateRule('u-hook-span-exposed-first')
+
+  it('is total: always offers all four same-side hooks, only reordered', () => {
+    const fromRect = rectAt(0, 0)
+    const toRect = rectAt(200, 200)
+    const pairs = rule.generate({ dx: 200, dy: 200, fromRect, toRect, crowd: () => 0 })
+    expect(pairs).toHaveLength(4)
+    expect(new Set(pairs.map((p) => p.fromSide))).toEqual(
+      new Set(['top', 'right', 'bottom', 'left']),
+    )
+  })
+
+  it('demotes a departure side whose border runs through the target body, on the reported canvas', () => {
+    // A(100,570,200,100) -> B(220,520,200,100): A's top border (y=570,
+    // x[100,300]) runs strictly through B's interior for x in (220,300);
+    // A's bottom border (y=670) misses B's y-range [520,620] entirely.
+    const fromRect: Rect = { x: 100, y: 570, w: 200, h: 100 }
+    const toRect: Rect = { x: 220, y: 520, w: 200, h: 100 }
+    const pairs = rule.generate({ dx: 120, dy: -50, fromRect, toRect, crowd: () => 0 })
+    const bottomIndex = pairs.findIndex((p) => p.fromSide === 'bottom')
+    const topIndex = pairs.findIndex((p) => p.fromSide === 'top')
+    expect(bottomIndex).toBeLessThan(topIndex)
+  })
+
+  it('never demotes any side when the other endpoint fully contains this one (group-frame exclusion)', () => {
+    const fromRect: Rect = { x: 10, y: 10, w: 20, h: 20 }
+    const toRect: Rect = { x: 0, y: 0, w: 200, h: 200 }
+    const pairs = rule.generate({ dx: 0, dy: 0, fromRect, toRect, crowd: () => 0 })
+    expect(pairs).toEqual([
+      { fromSide: 'top', toSide: 'top' },
+      { fromSide: 'right', toSide: 'right' },
+      { fromSide: 'bottom', toSide: 'bottom' },
+      { fromSide: 'left', toSide: 'left' },
+    ])
+  })
+
+  it('keeps compass order stable among sides that share the same taint status', () => {
+    // Neither endpoint's border runs through the other: nothing is
+    // demoted, so the fixed compass order survives unchanged.
+    const fromRect = rectAt(0, 0)
+    const toRect = rectAt(400, 400)
+    expect(rule.generate({ dx: 400, dy: 400, fromRect, toRect, crowd: () => 0 })).toEqual([
+      { fromSide: 'top', toSide: 'top' },
+      { fromSide: 'right', toSide: 'right' },
+      { fromSide: 'bottom', toSide: 'bottom' },
+      { fromSide: 'left', toSide: 'left' },
     ])
   })
 })

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -190,12 +190,13 @@ describe('SIDE_PREFERENCE_RULES', () => {
 })
 
 describe('PENALTY_RULES', () => {
-  it('declares the five named tiers in tier order, realized-bends last', () => {
+  it('declares the six named tiers in tier order, realized-bends last', () => {
     expect(PENALTY_RULES.map((r) => r.name)).toEqual([
       'overlap-and-intrusion',
       'illegibility',
       'crossings',
       'border-tracing',
+      'endpoint-body-ink',
       'realized-bends',
     ])
     PENALTY_RULES.forEach((rule, i) => {
@@ -213,7 +214,7 @@ describe('overlap-and-intrusion', () => {
       { x: 10, y: 0 },
       { x: 30, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0, 0, 0])
   })
 
   it('self term: a path retracing its own ink contributes the quantized retrace length to tier 0', () => {
@@ -224,7 +225,7 @@ describe('overlap-and-intrusion', () => {
       { x: 20, y: 0 },
       { x: 5, y: 0 },
     ]
-    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 1])
+    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 0, 1])
   })
 
   it('self term: a segment through a foreign rect interior contributes the quantized chord length to tier 0', () => {
@@ -233,7 +234,7 @@ describe('overlap-and-intrusion', () => {
       { x: 110, y: 50 },
     ]
     const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
-    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0, 0])
+    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0, 0, 0])
   })
 
   it('self term: a segment riding exactly on the rect boundary contributes 0 (grazing exclusion)', () => {
@@ -255,7 +256,7 @@ describe('illegibility', () => {
       { x: 1, y: 9 },
       { x: 9, y: 1 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0, 0, 0])
   })
 
   it('pair term: a transversal crossing far from every end contributes 0 to tier 1', () => {
@@ -265,7 +266,7 @@ describe('illegibility', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0])
   })
 })
 
@@ -277,7 +278,7 @@ describe('crossings', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0])
   })
 
   it('collinear overlap short-circuits the crossing count for that segment pair', () => {
@@ -300,7 +301,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0])
   })
 
   it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to tier 3', () => {
@@ -308,7 +309,7 @@ describe('border-tracing', () => {
       { x: 100, y: 0 },
       { x: 100, y: 40 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0, 0])
   })
 
   it('self term: a perpendicular segment touching the border at a single point contributes 0', () => {
@@ -360,13 +361,95 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0])
+    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0])
   })
 
   it('defaults nodeBorders to [] when omitted, contributing 0 (no border ink declared)', () => {
     const path = [
       { x: 0, y: 0 },
       { x: 100, y: 0 },
+    ]
+    expect(selfPenalty(path, [])).toEqual(zeroPenalty())
+  })
+})
+
+describe('endpoint-body-ink', () => {
+  const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
+
+  it('self term: a horizontal segment strictly between the rect top and bottom contributes the quantized clipped chord length to tier 4', () => {
+    const path = [
+      { x: -10, y: 20 },
+      { x: 110, y: 20 },
+    ]
+    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 100 * COST_QUANTUM, 0])
+  })
+
+  it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to tier 4', () => {
+    const path = [
+      { x: 50, y: -10 },
+      { x: 50, y: 50 },
+    ]
+    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 40 * COST_QUANTUM, 0])
+  })
+
+  it('self term: a segment riding exactly on the border contributes 0 to this tier (border-tracing prices it instead, no double-charge)', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    const cost = selfPenalty(path, [], [rect], [rect])
+    expect(cost[4]).toBe(0)
+    expect(cost[3]).toBe(100 * COST_QUANTUM)
+  })
+
+  it('self term: a perpendicular segment departing from a point on its own node border contributes 0', () => {
+    const path = [
+      { x: 50, y: -20 },
+      { x: 50, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [], [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: an endpoint rect fully containing the OTHER endpoint rect is excluded (group-frame exclusion)', () => {
+    const inner: Rect = { x: 10, y: 10, w: 20, h: 10 }
+    const outer: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    const path = [
+      { x: -10, y: 15 },
+      { x: 110, y: 15 },
+    ]
+    // outer fully contains inner: outer is excluded, so only inner (strictly
+    // crossed at y=15, clipped to inner's x-range [10,30]) is priced.
+    expect(selfPenalty(path, [], [], [outer, inner])[4]).toBe(20 * COST_QUANTUM)
+  })
+
+  it('self term: the same geometry WITHOUT containment prices both rects', () => {
+    const a: Rect = { x: 0, y: 0, w: 30, h: 20 }
+    const b: Rect = { x: 20, y: 0, w: 30, h: 20 }
+    const path = [
+      { x: -10, y: 10 },
+      { x: 60, y: 10 },
+    ]
+    // Neither fully contains the other: a clips to [0,30] (30px), b clips to
+    // [20,50] (30px), summed.
+    expect(selfPenalty(path, [], [], [a, b])[4]).toBe(60 * COST_QUANTUM)
+  })
+
+  it('self term: zero-width and zero-height endpoint rects contribute 0 (unsatisfiable strict-interior test)', () => {
+    const flatH: Rect = { x: 0, y: 0, w: 100, h: 0 }
+    const flatW: Rect = { x: 0, y: 0, w: 0, h: 100 }
+    const path = [
+      { x: -10, y: 0 },
+      { x: 110, y: 0 },
+    ]
+    expect(selfPenalty(path, [], [], [flatH, flatW])[4]).toBe(0)
+  })
+
+  it('defaults endpointRects to [] when omitted, contributing 0 (no endpoint ink declared)', () => {
+    // y=20 sits strictly inside `rect` (top 0, bottom 40) — priced only if
+    // this rect is passed as endpointRects, which is omitted here.
+    const path = [
+      { x: -10, y: 20 },
+      { x: 110, y: 20 },
     ]
     expect(selfPenalty(path, [])).toEqual(zeroPenalty())
   })
@@ -412,24 +495,25 @@ describe('realized-bends', () => {
       ],
       0,
     ],
-  ] as const)('%s path contributes %i to tier 4', (_label, path, expected) => {
+  ] as const)('%s path contributes %i to tier 5', (_label, path, expected) => {
     const cost = selfPenalty(path, [])
-    expect(cost[4]).toBe(expected)
+    expect(cost[5]).toBe(expected)
     expect(cost.every((n) => Number.isFinite(n) && n >= 0)).toBe(true)
   })
 })
 
 describe('hasRepairableProblem', () => {
   it('is false when the only nonzero tier is the last (realized-bends) tier', () => {
-    expect(hasRepairableProblem([0, 0, 0, 0, 5])).toBe(false)
+    expect(hasRepairableProblem([0, 0, 0, 0, 0, 5])).toBe(false)
   })
 
   it.each([
-    [[1, 0, 0, 0, 0]],
-    [[0, 1, 0, 0, 0]],
-    [[0, 0, 1, 0, 0]],
-    [[0, 0, 0, 1, 0]],
-    [[1, 1, 1, 1, 5]],
+    [[1, 0, 0, 0, 0, 0]],
+    [[0, 1, 0, 0, 0, 0]],
+    [[0, 0, 1, 0, 0, 0]],
+    [[0, 0, 0, 1, 0, 0]],
+    [[0, 0, 0, 0, 1, 0]],
+    [[1, 1, 1, 1, 1, 5]],
   ] as const)('is true when a non-final tier is nonzero: %j', (cost) => {
     expect(hasRepairableProblem(cost)).toBe(true)
   })
@@ -439,7 +523,11 @@ describe('hasRepairableProblem', () => {
   })
 
   it('is true when the only nonzero tier is border-tracing (repairable, unlike realized-bends)', () => {
-    expect(hasRepairableProblem([0, 0, 0, 7, 0])).toBe(true)
+    expect(hasRepairableProblem([0, 0, 0, 7, 0, 0])).toBe(true)
+  })
+
+  it('is true when the only nonzero tier is endpoint-body-ink (repairable, unlike realized-bends)', () => {
+    expect(hasRepairableProblem([0, 0, 0, 0, 7, 0])).toBe(true)
   })
 
   it('is false when rules is empty (guards Math.max(...[]) === -Infinity)', () => {
@@ -449,11 +537,15 @@ describe('hasRepairableProblem', () => {
 
 describe('addCost', () => {
   it('sums two cost arrays tier-by-tier with sign=1', () => {
-    expect(addCost([1, 2, 3, 4, 5], [10, 20, 30, 40, 50], 1)).toEqual([11, 22, 33, 44, 55])
+    expect(addCost([1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60], 1)).toEqual([
+      11, 22, 33, 44, 55, 66,
+    ])
   })
 
   it('subtracts b from a tier-by-tier with sign=-1', () => {
-    expect(addCost([10, 20, 30, 40, 50], [1, 2, 3, 4, 5], -1)).toEqual([9, 18, 27, 36, 45])
+    expect(addCost([10, 20, 30, 40, 50, 60], [1, 2, 3, 4, 5, 6], -1)).toEqual([
+      9, 18, 27, 36, 45, 54,
+    ])
   })
 
   it('defaults a missing index in either operand to 0', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -618,7 +618,14 @@ const borderTracing: PenaltyRule = {
  * group frame around its member) is skipped — every route out of the
  * contained node crosses the container, so pricing it would make the edge
  * permanently 'repairable' with no better option, and the optimizer would
- * churn on it every layout.
+ * churn on it every layout. The exclusion test is deliberately ASYMMETRIC
+ * (`fullyContains(r, other) && !fullyContains(other, r)`), not a bare
+ * `fullyContains(r, other)`: two numerically-equal rects (a self-loop, or
+ * two same-size fully-overlapping nodes — the exact worst-case overlap this
+ * rule exists to price) satisfy `fullyContains` in BOTH directions under its
+ * inclusive `<=`/`>=` comparisons, so the symmetric test excluded BOTH rects
+ * and silently zeroed the penalty for that case. Same asymmetric idiom as
+ * `tidy.ts`'s `isRoot` group-containment tie-break.
  *
  * Tier 4, BELOW border-tracing, for the same trial-path-artifact reason
  * border-tracing itself was demoted off tier 1 (see its own comment). Ranked
@@ -636,7 +643,10 @@ const endpointBodyInk: PenaltyRule = {
     inkAlongRects(
       path,
       endpointRects.filter(
-        (r) => !endpointRects.some((other) => other !== r && fullyContains(r, other)),
+        (r) =>
+          !endpointRects.some(
+            (other) => other !== r && fullyContains(r, other) && !fullyContains(other, r),
+          ),
       ),
       (fixed, near, far) => near < fixed && fixed < far,
     ),

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -365,6 +365,43 @@ export function fullyContains(outer: Rect, inner: Rect): boolean {
 }
 
 /**
+ * Quantized length of an axis-aligned path's ink lying along `rects`, in the
+ * COST_QUANTUM-quantized integer space every ink-length term is measured in
+ * (so the term is integral by construction). `qualifies` is the ONE thing
+ * ink-length rules differ by: given a segment's fixed coordinate and the
+ * rect's two borders on that axis, whether the segment counts —
+ * border-tracing passes "on either border", endpoint-body-ink "strictly
+ * between them". Both take the single per-axis condition rather than two
+ * independent checks, which is what stops a zero-extent rect (near === far)
+ * from being charged twice for the same segment.
+ */
+function inkAlongRects(
+  path: readonly Point[],
+  rects: readonly Rect[],
+  qualifies: (fixed: number, near: number, far: number) => boolean,
+): number {
+  const q = (n: number) => Math.round(n * COST_QUANTUM)
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    const horizontal = a.y === b.y
+    if (!horizontal && a.x !== b.x) continue
+    for (const r of rects) {
+      const near = horizontal ? r.y : r.x
+      const far = horizontal ? r.y + r.h : r.x + r.w
+      if (!qualifies(q(horizontal ? a.y : a.x), q(near), q(far))) continue
+      const p1 = horizontal ? a.x : a.y
+      const p2 = horizontal ? b.x : b.y
+      const lo = Math.max(q(Math.min(p1, p2)), q(horizontal ? r.x : r.y))
+      const hi = Math.min(q(Math.max(p1, p2)), q(horizontal ? r.x + r.w : r.y + r.h))
+      if (hi > lo) total += hi - lo
+    }
+  }
+  return total
+}
+
+/**
  * overlap-and-intrusion: collinear axis-aligned overlap (a parallel overlap
  * has no crossing point, so a line jump cannot express it) plus, from a
  * single path's own geometry, retracing its own ink (the doubled-line
@@ -449,11 +486,7 @@ const crossings: PenaltyRule = {
  * tunnel check) — the defect this rule exists to price is a segment riding
  * the SOURCE node's own border. A perpendicular departure/arrival only
  * touches its border at a point (zero-length overlap, costs 0); only
- * positive overlap length is priced, in COST_QUANTUM-quantized integer
- * space so the term is integral by construction. The single per-axis OR
- * condition (segment y equals the rect's top OR bottom, not two
- * independent checks) is what stops a zero-height rect (top === bottom)
- * from being charged twice for the same segment.
+ * positive overlap length is priced.
  *
  * Tier 3, BELOW crossings, because this rule is evaluated against the
  * optimizer's unaligned TRIAL paths (the pre-`slideAlongSide`
@@ -466,39 +499,15 @@ const crossings: PenaltyRule = {
  * sweep-rank scenario). Below crossings it still repairs the border-riding
  * defect, whose lower tiers are all-zero for every side-pair option, so the
  * lexicographic comparison falls through to this tier as the decisive one.
- *
- * A tier-3 placement (directly below crossings, ranking THIS rule ahead of
- * endpoint-body-ink) was tried and rejected: on the reported canvas it let
- * the optimizer accept eliminating a few px of border ink at the cost of
- * driving a route through ~120px of a bystander node's interior instead —
- * trading this rule's own defect for endpoint-body-ink's, not fixing either
- * for good, and it flipped this rule's own pin on that same canvas
- * (edge-border-trace.test.ts) from 0 to 120. This rule keeps tier 3.
+ * It must also stay ABOVE endpoint-body-ink: ranked below it, the optimizer
+ * trades this rule's defect for that one (see endpoint-body-ink's comment).
  */
 const borderTracing: PenaltyRule = {
   name: 'border-tracing',
   tier: 3,
   pairTerm: () => 0,
-  selfTerm: (path, _foreignBodies, nodeBorders) => {
-    const q = (n: number) => Math.round(n * COST_QUANTUM)
-    let overlap = 0
-    for (let i = 1; i < path.length; i++) {
-      const a = path[i - 1] as Point
-      const b = path[i] as Point
-      for (const r of nodeBorders) {
-        if (a.y === b.y && (q(a.y) === q(r.y) || q(a.y) === q(r.y + r.h))) {
-          const lo = Math.max(q(Math.min(a.x, b.x)), q(r.x))
-          const hi = Math.min(q(Math.max(a.x, b.x)), q(r.x + r.w))
-          if (hi > lo) overlap += hi - lo
-        } else if (a.x === b.x && (q(a.x) === q(r.x) || q(a.x) === q(r.x + r.w))) {
-          const lo = Math.max(q(Math.min(a.y, b.y)), q(r.y))
-          const hi = Math.min(q(Math.max(a.y, b.y)), q(r.y + r.h))
-          if (hi > lo) overlap += hi - lo
-        }
-      }
-    }
-    return overlap
-  },
+  selfTerm: (path, _foreignBodies, nodeBorders) =>
+    inkAlongRects(path, nodeBorders, (fixed, near, far) => fixed === near || fixed === far),
 }
 
 /**
@@ -506,12 +515,11 @@ const borderTracing: PenaltyRule = {
  * node's body — the departure/arrival stub cutting through the near or far
  * endpoint's interior, which overlapping nodes provoke (a stub leaving one
  * node's border can land inside a neighbour's overlapping body). Self-only,
- * and the exact interior complement of border-tracing: border-tracing prices
- * a segment collinear WITH AND overlapping a border (`q(a.y) === q(r.y)`),
- * this rule prices a segment STRICTLY BETWEEN a rect's two borders
- * (`q(r.y) < q(a.y) < q(r.y + r.h)`) — the two conditions are mutually
- * exclusive in quantized space, so the same segment is never charged by
- * both (see the per-(segment,rect) complementarity property).
+ * and the exact interior complement of border-tracing: that rule prices a
+ * segment ON a border, this one a segment STRICTLY BETWEEN a rect's two
+ * borders — mutually exclusive in quantized space, so the same segment is
+ * never charged by both (pinned by the per-(segment,rect) complementarity
+ * property).
  *
  * `foreignBodies`/`overlap-and-intrusion` already price a tunnel through a
  * FOREIGN node's body; this rule exists only because that check deliberately
@@ -526,44 +534,25 @@ const borderTracing: PenaltyRule = {
  * churn on it every layout.
  *
  * Tier 4, BELOW border-tracing, for the same trial-path-artifact reason
- * border-tracing itself was demoted off tier 1 (see its own comment): this
- * rule too is evaluated against the optimizer's unaligned TRIAL paths,
- * where an artifact can outrank a genuine improvement. A tier-3 placement
- * (ranked AHEAD of border-tracing) was tried and rejected — it flipped
- * border-tracing's own established pin on the reported canvas from 0 to
- * 120 (see border-tracing's comment); a rule fixing one visible-ink defect
- * must not reintroduce the other it sits beside. Kept at tier 4, this rule
- * needs one more optimizer PASS than border-tracing alone did to fully
- * settle the reported canvas — see CROSSING_OPT_MAX_PASSES in
- * spatial-edges.ts for why the bound moved from 2 to 3 alongside this rule.
+ * border-tracing itself was demoted off tier 1 (see its own comment). Ranked
+ * ABOVE border-tracing instead, the optimizer buys a few px of border ink
+ * back with ~120px of interior ink — trading one visible-ink defect for the
+ * other rather than clearing both. At tier 4 clearing both takes one more
+ * optimizer PASS than border-tracing alone needed: see
+ * CROSSING_OPT_MAX_PASSES in spatial-edges.ts.
  */
 const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',
   tier: 4,
   pairTerm: () => 0,
-  selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) => {
-    const q = (n: number) => Math.round(n * COST_QUANTUM)
-    const priced = endpointRects.filter(
-      (r) => !endpointRects.some((other) => other !== r && fullyContains(r, other)),
-    )
-    let interior = 0
-    for (let i = 1; i < path.length; i++) {
-      const a = path[i - 1] as Point
-      const b = path[i] as Point
-      for (const r of priced) {
-        if (a.y === b.y && q(r.y) < q(a.y) && q(a.y) < q(r.y + r.h)) {
-          const lo = Math.max(q(Math.min(a.x, b.x)), q(r.x))
-          const hi = Math.min(q(Math.max(a.x, b.x)), q(r.x + r.w))
-          if (hi > lo) interior += hi - lo
-        } else if (a.x === b.x && q(r.x) < q(a.x) && q(a.x) < q(r.x + r.w)) {
-          const lo = Math.max(q(Math.min(a.y, b.y)), q(r.y))
-          const hi = Math.min(q(Math.max(a.y, b.y)), q(r.y + r.h))
-          if (hi > lo) interior += hi - lo
-        }
-      }
-    }
-    return interior
-  },
+  selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) =>
+    inkAlongRects(
+      path,
+      endpointRects.filter(
+        (r) => !endpointRects.some((other) => other !== r && fullyContains(r, other)),
+      ),
+      (fixed, near, far) => near < fixed && fixed < far,
+    ),
 }
 
 /** realized-bends: direction changes along ONE routed path. Self-only, and

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -238,8 +238,7 @@ const gapValidOpposingBeforeInvalid = {
 const dominantAxisFirst = { kind: 'tiebreak' as const, name: 'dominant-axis-first' }
 const incumbentWinsTies = { kind: 'tiebreak' as const, name: 'incumbent-wins-ties' }
 
-/** The four points bounding rect's border on `side`, as a 2-point segment
- * `inkAlongRects` (declared below, a hoisted function declaration) can walk. */
+/** `rect`'s border on `side`, as a 2-point segment `inkAlongRects` can walk. */
 function sideSegment(rect: Rect, side: Side): readonly [Point, Point] {
   switch (side) {
     case 'top':
@@ -267,14 +266,12 @@ function sideSegment(rect: Rect, side: Side): readonly [Point, Point] {
 
 /**
  * Whether `rect`'s WHOLE `side` border passes through `other`'s STRICT
- * interior for some positive-length stretch — the SPAN version of "this
- * anchor sits inside the other endpoint", needed because a same-side U-hook
- * anchor is placed by `computeAnchorsFor`'s fan-out (not the side midpoint),
- * so only the full span, not one point, reliably sees the occlusion. Reuses
+ * interior for some positive-length stretch. The SPAN, not the side
+ * midpoint: a same-side U-hook anchor is placed by `computeAnchorsFor`'s
+ * fan-out, so a single point can miss an occlusion the span sees. Runs
  * `inkAlongRects`'s ink-length loop (the same "strictly between the two
- * borders" predicate `endpoint-body-ink` prices) against one synthetic
- * segment tracing the side, rather than a second span-overlap
- * implementation — one producer for "is this stretch inside that rect".
+ * borders" predicate `endpoint-body-ink` prices) over one synthetic segment
+ * rather than adding a second span-overlap implementation.
  */
 function sideSpanEntersRect(rect: Rect, side: Side, other: Rect): boolean {
   return (
@@ -291,20 +288,16 @@ function sideSpanEntersRect(rect: Rect, side: Side, other: Rect): boolean {
  * departure and arrival on the SAME compass side of each rect — the
  * fallback that hooks OVER everything when the ranked vocabulary above
  * offers nothing usable, or loses on cost to some other candidate), demote
- * one whose DEPARTURE side border runs through the target's strict
- * interior behind one that does not. This is departure-only, not symmetric
- * with the arrival end: the actual routed geometry approaches an arrival
- * anchor from OUTSIDE the target (an arc around it, never along its own
- * border through a bystander), so an arrival side's border passing through
- * the source's interior is not evidence of real interior ink — verified
- * against the reported canvas, where the CLEAN route's arrival-side border
- * (`toRect`'s bottom) geometrically overlaps the source's body exactly as
- * much as the dirty route's does, yet only the dirty route draws through
- * it. A DEPARTURE stub, by contrast, draws in a straight line off that
- * exact border, so a departure side whose span runs through the target's
- * body is real evidence the stub cuts through it (this is the exact defect
- * endpoint-body-ink prices: "the departure/arrival stub cutting through
- * the near or far endpoint's interior").
+ * one whose DEPARTURE side border runs through the target's strict interior
+ * behind one that does not.
+ *
+ * Departure-only, NOT symmetric with the arrival end: a departure stub
+ * draws in a straight line off its own border, so a departure span through
+ * the target's body is real evidence of the ink `endpoint-body-ink` prices;
+ * the routed geometry reaches an arrival anchor from OUTSIDE the target,
+ * so an arrival side's border overlapping the source proves nothing. A
+ * symmetric version also flips edge-side-occlusion.test.ts's "far endpoint
+ * overlapping the anchor is not an occluder" pin.
  *
  * MANDATORY EXCLUSION, same predicate as endpoint-body-ink and
  * deriveDefaultSides's occlusion filter: a rect that `fullyContains` the
@@ -322,13 +315,12 @@ const uHookSpanExposedFirst = {
   kind: 'candidates' as const,
   name: 'u-hook-span-exposed-first',
   generate: (ctx: PreferenceRuleContext): readonly SidePair[] => {
-    const taints = (side: Side): boolean =>
-      !fullyContains(ctx.toRect, ctx.fromRect) && sideSpanEntersRect(ctx.fromRect, side, ctx.toRect)
-    const hooks = (['top', 'right', 'bottom', 'left'] as const).map((side) => ({
-      fromSide: side as Side,
-      toSide: side as Side,
-    }))
-    return [...hooks.filter((p) => !taints(p.fromSide)), ...hooks.filter((p) => taints(p.fromSide))]
+    const hooks: readonly SidePair[] = (['top', 'right', 'bottom', 'left'] as const).map(
+      (side) => ({ fromSide: side, toSide: side }),
+    )
+    if (fullyContains(ctx.toRect, ctx.fromRect)) return hooks
+    const taints = (p: SidePair) => sideSpanEntersRect(ctx.fromRect, p.fromSide, ctx.toRect)
+    return [...hooks.filter((p) => !taints(p)), ...hooks.filter(taints)]
   },
 }
 
@@ -632,9 +624,9 @@ const borderTracing: PenaltyRule = {
  * border-tracing itself was demoted off tier 1 (see its own comment). Ranked
  * ABOVE border-tracing instead, the optimizer buys a few px of border ink
  * back with ~120px of interior ink — trading one visible-ink defect for the
- * other rather than clearing both. At tier 4 clearing both takes one more
- * optimizer PASS than border-tracing alone needed: see
- * CROSSING_OPT_MAX_PASSES in spatial-edges.ts.
+ * other rather than clearing both. Clearing both inside the optimizer's
+ * pass budget is a matter of candidate ORDER, not more passes: see
+ * `u-hook-span-exposed-first` above.
  */
 const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -330,6 +330,10 @@ export function bendCount(path: readonly Point[]): number {
  * parameter is every node's border rect (INCLUDING the path's own endpoints
  * — unlike `foreignBodies`, which deliberately excludes them), for rules
  * that price ink drawn on a node's OUTLINE rather than through its interior.
+ * The fourth parameter is the edge's OWN endpoint rects (`from`/`to` node
+ * borders only), for rules that price ink through an endpoint's own
+ * interior — the complementary case `foreignBodies` cannot see, since it
+ * deliberately excludes the edge's own endpoints for the tunnel check.
  */
 export type PenaltyRule = {
   readonly name: string
@@ -339,7 +343,25 @@ export type PenaltyRule = {
     path: readonly Point[],
     foreignBodies: readonly Rect[],
     nodeBorders: readonly Rect[],
+    endpointRects: readonly Rect[],
   ) => number
+}
+
+/**
+ * Whether `outer` fully contains `inner` (inclusive borders). A rect that
+ * FULLY CONTAINS an edge's endpoint node (a group frame around its member)
+ * can never be treated as an obstacle to route around — every route out of
+ * the contained node still has to cross it — so both `deriveDefaultSides`'s
+ * occlusion filter (spatial-edges.ts) and `endpoint-body-ink`'s exclusion
+ * below reuse this SAME predicate rather than each inventing their own.
+ */
+export function fullyContains(outer: Rect, inner: Rect): boolean {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.w <= outer.x + outer.w &&
+    inner.y + inner.h <= outer.y + outer.h
+  )
 }
 
 /**
@@ -444,6 +466,14 @@ const crossings: PenaltyRule = {
  * sweep-rank scenario). Below crossings it still repairs the border-riding
  * defect, whose lower tiers are all-zero for every side-pair option, so the
  * lexicographic comparison falls through to this tier as the decisive one.
+ *
+ * A tier-3 placement (directly below crossings, ranking THIS rule ahead of
+ * endpoint-body-ink) was tried and rejected: on the reported canvas it let
+ * the optimizer accept eliminating a few px of border ink at the cost of
+ * driving a route through ~120px of a bystander node's interior instead —
+ * trading this rule's own defect for endpoint-body-ink's, not fixing either
+ * for good, and it flipped this rule's own pin on that same canvas
+ * (edge-border-trace.test.ts) from 0 to 120. This rule keeps tier 3.
  */
 const borderTracing: PenaltyRule = {
   name: 'border-tracing',
@@ -471,6 +501,71 @@ const borderTracing: PenaltyRule = {
   },
 }
 
+/**
+ * endpoint-body-ink: ink drawn STRICTLY INSIDE an edge's OWN endpoint
+ * node's body — the departure/arrival stub cutting through the near or far
+ * endpoint's interior, which overlapping nodes provoke (a stub leaving one
+ * node's border can land inside a neighbour's overlapping body). Self-only,
+ * and the exact interior complement of border-tracing: border-tracing prices
+ * a segment collinear WITH AND overlapping a border (`q(a.y) === q(r.y)`),
+ * this rule prices a segment STRICTLY BETWEEN a rect's two borders
+ * (`q(r.y) < q(a.y) < q(r.y + r.h)`) — the two conditions are mutually
+ * exclusive in quantized space, so the same segment is never charged by
+ * both (see the per-(segment,rect) complementarity property).
+ *
+ * `foreignBodies`/`overlap-and-intrusion` already price a tunnel through a
+ * FOREIGN node's body; this rule exists only because that check deliberately
+ * excludes an edge's own endpoints (a rect containing an endpoint can never
+ * be routed around) — but that reasoning only rules out routing AROUND the
+ * endpoint's rect, not ink running through it beyond the anchor point.
+ *
+ * MANDATORY EXCLUSION: a rect that `fullyContains` another endpoint rect (a
+ * group frame around its member) is skipped — every route out of the
+ * contained node crosses the container, so pricing it would make the edge
+ * permanently 'repairable' with no better option, and the optimizer would
+ * churn on it every layout.
+ *
+ * Tier 4, BELOW border-tracing, for the same trial-path-artifact reason
+ * border-tracing itself was demoted off tier 1 (see its own comment): this
+ * rule too is evaluated against the optimizer's unaligned TRIAL paths,
+ * where an artifact can outrank a genuine improvement. A tier-3 placement
+ * (ranked AHEAD of border-tracing) was tried and rejected — it flipped
+ * border-tracing's own established pin on the reported canvas from 0 to
+ * 120 (see border-tracing's comment); a rule fixing one visible-ink defect
+ * must not reintroduce the other it sits beside. Kept at tier 4, this rule
+ * needs one more optimizer PASS than border-tracing alone did to fully
+ * settle the reported canvas — see CROSSING_OPT_MAX_PASSES in
+ * spatial-edges.ts for why the bound moved from 2 to 3 alongside this rule.
+ */
+const endpointBodyInk: PenaltyRule = {
+  name: 'endpoint-body-ink',
+  tier: 4,
+  pairTerm: () => 0,
+  selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) => {
+    const q = (n: number) => Math.round(n * COST_QUANTUM)
+    const priced = endpointRects.filter(
+      (r) => !endpointRects.some((other) => other !== r && fullyContains(r, other)),
+    )
+    let interior = 0
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as Point
+      const b = path[i] as Point
+      for (const r of priced) {
+        if (a.y === b.y && q(r.y) < q(a.y) && q(a.y) < q(r.y + r.h)) {
+          const lo = Math.max(q(Math.min(a.x, b.x)), q(r.x))
+          const hi = Math.min(q(Math.max(a.x, b.x)), q(r.x + r.w))
+          if (hi > lo) interior += hi - lo
+        } else if (a.x === b.x && q(r.x) < q(a.x) && q(a.x) < q(r.x + r.w)) {
+          const lo = Math.max(q(Math.min(a.y, b.y)), q(r.y))
+          const hi = Math.min(q(Math.max(a.y, b.y)), q(r.y + r.h))
+          if (hi > lo) interior += hi - lo
+        }
+      }
+    }
+    return interior
+  },
+}
+
 /** realized-bends: direction changes along ONE routed path. Self-only, and
  * deliberately the last tier — the optimizer's short-circuit
  * (`hasRepairableProblem`) and worst-offender filter both ignore it, since
@@ -478,7 +573,7 @@ const borderTracing: PenaltyRule = {
  * and reshuffling it purely to shave bends is churn, not repair. */
 const realizedBends: PenaltyRule = {
   name: 'realized-bends',
-  tier: 4,
+  tier: 5,
   pairTerm: () => 0,
   selfTerm: (path) => bendCount(path),
 }
@@ -494,6 +589,7 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   illegibility,
   crossings,
   borderTracing,
+  endpointBodyInk,
   realizedBends,
 ]
 
@@ -520,19 +616,23 @@ export function pairPenalty(
 /**
  * The self half of the composition (`optimizeSideChoices`, spatial-edges.ts):
  * map one routed path's self-geometry into a full cost array, one rule per
- * declared tier. `nodeBorders` defaults to `[]` ("no border ink declared")
- * rather than falling back to `foreignBodies` — a caller that passes no
- * border rects gets 0 from `border-tracing`, exactly as if the rule did not
+ * declared tier. `nodeBorders` and `endpointRects` each default to `[]`
+ * ("no border/endpoint ink declared") rather than falling back to
+ * `foreignBodies` or to each other — a caller that passes none gets 0 from
+ * `border-tracing`/`endpoint-body-ink`, exactly as if the rule did not
  * exist.
  */
 export function selfPenalty(
   path: readonly Point[],
   foreignBodies: readonly Rect[],
   nodeBorders: readonly Rect[] = [],
+  endpointRects: readonly Rect[] = [],
   rules: readonly PenaltyRule[] = PENALTY_RULES,
 ): number[] {
   const cost = zeroPenalty(rules)
-  for (const rule of rules) cost[rule.tier] = rule.selfTerm(path, foreignBodies, nodeBorders)
+  for (const rule of rules) {
+    cost[rule.tier] = rule.selfTerm(path, foreignBodies, nodeBorders, endpointRects)
+  }
   return cost
 }
 

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -238,6 +238,100 @@ const gapValidOpposingBeforeInvalid = {
 const dominantAxisFirst = { kind: 'tiebreak' as const, name: 'dominant-axis-first' }
 const incumbentWinsTies = { kind: 'tiebreak' as const, name: 'incumbent-wins-ties' }
 
+/** The four points bounding rect's border on `side`, as a 2-point segment
+ * `inkAlongRects` (declared below, a hoisted function declaration) can walk. */
+function sideSegment(rect: Rect, side: Side): readonly [Point, Point] {
+  switch (side) {
+    case 'top':
+      return [
+        { x: rect.x, y: rect.y },
+        { x: rect.x + rect.w, y: rect.y },
+      ]
+    case 'bottom':
+      return [
+        { x: rect.x, y: rect.y + rect.h },
+        { x: rect.x + rect.w, y: rect.y + rect.h },
+      ]
+    case 'left':
+      return [
+        { x: rect.x, y: rect.y },
+        { x: rect.x, y: rect.y + rect.h },
+      ]
+    case 'right':
+      return [
+        { x: rect.x + rect.w, y: rect.y },
+        { x: rect.x + rect.w, y: rect.y + rect.h },
+      ]
+  }
+}
+
+/**
+ * Whether `rect`'s WHOLE `side` border passes through `other`'s STRICT
+ * interior for some positive-length stretch — the SPAN version of "this
+ * anchor sits inside the other endpoint", needed because a same-side U-hook
+ * anchor is placed by `computeAnchorsFor`'s fan-out (not the side midpoint),
+ * so only the full span, not one point, reliably sees the occlusion. Reuses
+ * `inkAlongRects`'s ink-length loop (the same "strictly between the two
+ * borders" predicate `endpoint-body-ink` prices) against one synthetic
+ * segment tracing the side, rather than a second span-overlap
+ * implementation — one producer for "is this stretch inside that rect".
+ */
+function sideSpanEntersRect(rect: Rect, side: Side, other: Rect): boolean {
+  return (
+    inkAlongRects(
+      sideSegment(rect, side),
+      [other],
+      (fixed, near, far) => near < fixed && fixed < far,
+    ) > 0
+  )
+}
+
+/**
+ * u-hook-span-exposed-first: among the four same-side U-hook candidates (a
+ * departure and arrival on the SAME compass side of each rect — the
+ * fallback that hooks OVER everything when the ranked vocabulary above
+ * offers nothing usable, or loses on cost to some other candidate), demote
+ * one whose DEPARTURE side border runs through the target's strict
+ * interior behind one that does not. This is departure-only, not symmetric
+ * with the arrival end: the actual routed geometry approaches an arrival
+ * anchor from OUTSIDE the target (an arc around it, never along its own
+ * border through a bystander), so an arrival side's border passing through
+ * the source's interior is not evidence of real interior ink — verified
+ * against the reported canvas, where the CLEAN route's arrival-side border
+ * (`toRect`'s bottom) geometrically overlaps the source's body exactly as
+ * much as the dirty route's does, yet only the dirty route draws through
+ * it. A DEPARTURE stub, by contrast, draws in a straight line off that
+ * exact border, so a departure side whose span runs through the target's
+ * body is real evidence the stub cuts through it (this is the exact defect
+ * endpoint-body-ink prices: "the departure/arrival stub cutting through
+ * the near or far endpoint's interior").
+ *
+ * MANDATORY EXCLUSION, same predicate as endpoint-body-ink and
+ * deriveDefaultSides's occlusion filter: a rect that `fullyContains` the
+ * other endpoint (a group frame around its member) never taints a side —
+ * every hook out of the contained node runs through the container equally,
+ * which says nothing about which side to prefer.
+ *
+ * Always total (returns all four, only reordered) and placed LAST among
+ * the 'candidates' rules: `gap-valid-opposing-before-invalid` above it
+ * already guarantees a non-empty ranking, so this rule can never become
+ * `pairs[0]` — it only refines the tail `candidatesFor` (spatial-edges.ts)
+ * tries once every ranked-vocabulary pair has been exhausted.
+ */
+const uHookSpanExposedFirst = {
+  kind: 'candidates' as const,
+  name: 'u-hook-span-exposed-first',
+  generate: (ctx: PreferenceRuleContext): readonly SidePair[] => {
+    const taints = (side: Side): boolean =>
+      !fullyContains(ctx.toRect, ctx.fromRect) && sideSpanEntersRect(ctx.fromRect, side, ctx.toRect)
+    const hooks = (['top', 'right', 'bottom', 'left'] as const).map((side) => ({
+      fromSide: side as Side,
+      toSide: side as Side,
+    }))
+    return [...hooks.filter((p) => !taints(p.fromSide)), ...hooks.filter((p) => taints(p.fromSide))]
+  },
+}
+
 /**
  * The declared, ordered PREFERENCE-rule catalog (decision #10). Candidate
  * generation (`composeSidePairs`) composes only the 'candidates'-kind
@@ -251,6 +345,7 @@ export const SIDE_PREFERENCE_RULES: readonly PreferenceRule[] = [
   lPairCrowdingTieBreak,
   uHookWhenDegenerate,
   gapValidOpposingBeforeInvalid,
+  uHookSpanExposedFirst,
   incumbentWinsTies,
 ]
 

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -552,16 +552,11 @@ const CROSSING_OPT_MAX_EDGES = 200
  * Each pass gives every edge at most one improving re-side; a chain of N
  * DISTINCT improving candidates for the same edge needs N passes to fully
  * settle (greedy first-strict-improvement adoption, no backtracking).
- * Raised 2 -> 3 alongside endpoint-body-ink (edge-rules.ts): on an
- * overlapping-nodes canvas already needing 2 hops to clear border-tracing
- * (right-facing -> an L-pair -> the zero-border U-hook), endpoint-body-ink
- * legitimately needs a 3rd hop to move off that U-hook's endpoint-interior
- * ink onto the one candidate clear of BOTH problems — verified this is the
- * exact bound needed (2 passes settles on the border-clean-but-interior-
- * dirty route every time; 3 reaches the fully clean one) via
- * edge-endpoint-body-ink.test.ts's canvas. Still bounded (no complexity
- * blow-up: one more full edge-set sweep, same TRIAL_BUDGET_EDGES cap above
- * FULL_OPT_MAX_EDGES).
+ * 3 is the bound clearing border-tracing AND endpoint-body-ink together on
+ * an overlapping-nodes canvas (right-facing -> an L-pair -> the zero-border
+ * U-hook -> the route clear of both); at 2 it settles every time on the
+ * border-clean-but-interior-dirty U-hook, pinned by
+ * edge-endpoint-body-ink.test.ts.
  */
 const CROSSING_OPT_MAX_PASSES = 3
 /** At or under this many edges, every edge tries candidates (the exact

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -696,11 +696,9 @@ function optimizeSideChoices(
     const toRect = rectOf(toNode)
     const fromCenter = centerOf(fromRect)
     const toCenter = centerOf(toRect)
-    // rankedSidePairs already ends with the same-side U-hook candidates
-    // (u-hook-span-exposed-first, edge-rules.ts) — the fallback that hooks
-    // OVER everything when every ranked-vocabulary pair crosses, overlaps,
-    // or retraces. One producer for that list, so it is not re-generated
-    // here in a separate fixed compass order.
+    // The same-side U-hook fallback (for when every ranked-vocabulary pair
+    // crosses, overlaps, or retraces) comes from rankedSidePairs' last rule,
+    // `u-hook-span-exposed-first` — one producer, not a second list here.
     const pairs = rankedSidePairs(
       toCenter.x - fromCenter.x,
       toCenter.y - fromCenter.y,

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -6,6 +6,7 @@ import {
   bendCount,
   composeSidePairs,
   facingLaneWindow,
+  fullyContains,
   hasRepairableProblem,
   lessCost,
   oppositeSide,
@@ -55,15 +56,6 @@ function sidePoint(rect: Rect, side: Side): Point {
 function strictlyInside(rect: Rect, point: Point): boolean {
   return (
     point.x > rect.x && point.x < rect.x + rect.w && point.y > rect.y && point.y < rect.y + rect.h
-  )
-}
-
-function fullyContains(outer: Rect, inner: Rect): boolean {
-  return (
-    inner.x >= outer.x &&
-    inner.y >= outer.y &&
-    inner.x + inner.w <= outer.x + outer.w &&
-    inner.y + inner.h <= outer.y + outer.h
   )
 }
 
@@ -556,7 +548,22 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
  * raising further.
  */
 const CROSSING_OPT_MAX_EDGES = 200
-const CROSSING_OPT_MAX_PASSES = 2
+/**
+ * Each pass gives every edge at most one improving re-side; a chain of N
+ * DISTINCT improving candidates for the same edge needs N passes to fully
+ * settle (greedy first-strict-improvement adoption, no backtracking).
+ * Raised 2 -> 3 alongside endpoint-body-ink (edge-rules.ts): on an
+ * overlapping-nodes canvas already needing 2 hops to clear border-tracing
+ * (right-facing -> an L-pair -> the zero-border U-hook), endpoint-body-ink
+ * legitimately needs a 3rd hop to move off that U-hook's endpoint-interior
+ * ink onto the one candidate clear of BOTH problems — verified this is the
+ * exact bound needed (2 passes settles on the border-clean-but-interior-
+ * dirty route every time; 3 reaches the fully clean one) via
+ * edge-endpoint-body-ink.test.ts's canvas. Still bounded (no complexity
+ * blow-up: one more full edge-set sweep, same TRIAL_BUDGET_EDGES cap above
+ * FULL_OPT_MAX_EDGES).
+ */
+const CROSSING_OPT_MAX_PASSES = 3
 /** At or under this many edges, every edge tries candidates (the exact
  * pre-sweep behavior); above it, only the worst offenders do. */
 const FULL_OPT_MAX_EDGES = 40
@@ -614,8 +621,16 @@ function optimizeSideChoices(
   // prices ink on a node's own outline, unlike foreignBodiesFor's tunnel
   // check which must exclude the edge's endpoints.
   const nodeBorders = nodes.map(rectOf)
+  // Each edge's OWN endpoint rects (from, to) only — endpoint-body-ink's
+  // interior check, unlike border-tracing's outline check above, needs to
+  // know which two of nodeBorders belong to THIS edge.
+  const endpointRectsFor = edges.map((e) =>
+    [byId.get(e.fromNode), byId.get(e.toNode)]
+      .filter((n): n is SpatialNode => n !== undefined)
+      .map(rectOf),
+  )
   const selfCosts: ConfigCost[] = paths.map((path, i) =>
-    selfPenalty(path, foreignBodiesFor[i]!, nodeBorders),
+    selfPenalty(path, foreignBodiesFor[i]!, nodeBorders, endpointRectsFor[i]),
   )
   let currentCost: ConfigCost = zeroPenalty()
   for (const self of selfCosts) currentCost = addCost(currentCost, self, 1)
@@ -658,7 +673,12 @@ function optimizeSideChoices(
     const updates = new Map<number, ConfigCost>()
     const selfUpdates = new Map<number, ConfigCost>()
     for (const i of touched) {
-      const next = selfPenalty(trialPaths[i]!, foreignBodiesFor[i]!, nodeBorders)
+      const next = selfPenalty(
+        trialPaths[i]!,
+        foreignBodiesFor[i]!,
+        nodeBorders,
+        endpointRectsFor[i],
+      )
       cost = addCost(cost, selfCosts[i] ?? zeroPenalty(), -1)
       cost = addCost(cost, next, 1)
       selfUpdates.set(i, next)

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -548,17 +548,7 @@ function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
  * raising further.
  */
 const CROSSING_OPT_MAX_EDGES = 200
-/**
- * Each pass gives every edge at most one improving re-side; a chain of N
- * DISTINCT improving candidates for the same edge needs N passes to fully
- * settle (greedy first-strict-improvement adoption, no backtracking).
- * 3 is the bound clearing border-tracing AND endpoint-body-ink together on
- * an overlapping-nodes canvas (right-facing -> an L-pair -> the zero-border
- * U-hook -> the route clear of both); at 2 it settles every time on the
- * border-clean-but-interior-dirty U-hook, pinned by
- * edge-endpoint-body-ink.test.ts.
- */
-const CROSSING_OPT_MAX_PASSES = 3
+const CROSSING_OPT_MAX_PASSES = 2
 /** At or under this many edges, every edge tries candidates (the exact
  * pre-sweep behavior); above it, only the worst offenders do. */
 const FULL_OPT_MAX_EDGES = 40
@@ -706,6 +696,11 @@ function optimizeSideChoices(
     const toRect = rectOf(toNode)
     const fromCenter = centerOf(fromRect)
     const toCenter = centerOf(toRect)
+    // rankedSidePairs already ends with the same-side U-hook candidates
+    // (u-hook-span-exposed-first, edge-rules.ts) — the fallback that hooks
+    // OVER everything when every ranked-vocabulary pair crosses, overlaps,
+    // or retraces. One producer for that list, so it is not re-generated
+    // here in a separate fixed compass order.
     const pairs = rankedSidePairs(
       toCenter.x - fromCenter.x,
       toCenter.y - fromCenter.y,
@@ -713,18 +708,8 @@ function optimizeSideChoices(
       toRect,
       () => 0,
     )
-    // U-pairs (both ends on the SAME compass side) are outside the ranked
-    // vocabulary — the initial heuristic never wants them — but they are
-    // exactly what hooks OVER everything when every ranked pair crosses,
-    // overlaps, or retraces, and what a pair of overlapping nodes needs to
-    // arrive without doubling back. Offered last: the optimizer only
-    // adopts one on a strict cost decrease.
-    const uPairs = (['top', 'right', 'bottom', 'left'] as const).map((side) => ({
-      fromSide: side as Side,
-      toSide: side as Side,
-    }))
     const seen = new Set<string>()
-    return [...pairs, ...uPairs]
+    return pairs
       .map((pair) => ({
         fromSide: edge.fromSide ?? pair.fromSide,
         toSide: edge.toSide ?? pair.toSide,


### PR DESCRIPTION
The second half of the reported overlapping-nodes defect. #705 removed the segment that rode the source node's outline; the departure stub still ran **50px straight through the target node's body**, so the line was drawn across the box it points at.

## Two changes, one per layer

**A new PENALTY rule — `endpoint-body-ink` (tier 4).** `overlap-and-intrusion`'s body-intrusion half only ever scored FOREIGN rects: `foreignBodiesFor` excludes the edge's own endpoints, on the reasoning that a rect containing an endpoint cannot be routed around. Sound for a rect that *contains* the endpoint, too broad in general — an anchor sits ON its node's border, so a well-formed route's interior length inside its own endpoints should be zero, and nothing observed when it wasn't. The new rule prices strictly-interior ink only, making it provably complementary to `border-tracing` (collinear-ON-a-border) — a property asserts the two never charge the same ink. A rect that `fullyContains` an endpoint is excluded: every route out of a contained node crosses its group frame, and pricing that would mark the edge permanently repairable and spin the optimizer forever.

**A new PREFERENCE rule — `u-hook-span-exposed-first`.** With the penalty alone the clean route was reachable only in a 3rd improving hop, one more than `CROSSING_OPT_MAX_PASSES` allows. The first attempt raised that budget to 3 and flagged it for sign-off; measured, it cost **+74% / +67%** of layout time (40 nodes/40 edges 58.6→101.8ms, 60/200 165.1→275.1ms) — giving back most of the sweepline work's gain to reach one better route. Declined.

The real defect was candidate ORDER, not search budget: the clean route scores zero on every tier but was ranked behind a dirty same-side hook. The new preference rule demotes a same-side U-hook whose departure side span runs through the target's strict interior, behind one that doesn't. Departure-only, not symmetric — a symmetric check flips `edge-side-occlusion.test.ts`'s "the far endpoint overlapping the anchor is not an occluder" pin, which encodes genuinely different and correct semantics (tried first, per the plan, and rejected on that evidence). It lives in `SIDE_PREFERENCE_RULES` rather than in `deriveDefaultSides`'s local filter because that filter only seeds the initial configuration, while the optimizer builds its own candidate list from the same `composeSidePairs` composition — a local filter would reach half the concept and duplicate the predicate.

`CROSSING_OPT_MAX_PASSES` is back at 2, byte-identical to main. Timing re-measured on the same probe: **60.2ms / 173.8ms** (+3% / +5% of baseline, inside the ±10% bar set for this change).

## Verification

Settled route for the reported edge: `bottom → bottom`, `(200,670)(200,690)(320,690)(320,640)(320,620)` — border tracing 0, interior ink 0, one of the two configurations that are clean on both metrics.

Confirmed in the running app on the same canvas, read from the rendered SVG: `216,686 216,706 336,706 336,656 336,636` (the same route modulo the paste offset).

- Red-first example pin asserting the invariant (no A→B segment strictly inside any node body), plus per-rule unit tests, and properties for totality, determinism, permutation-invariance, independent-oracle equality, and no-double-charge with `border-tracing`.
- Mutation-checked both ways: removing the penalty rule turns the pin and its properties red; removing the preference rule (passes still 2) turns the pin red again — proving the ranking fix, not the pass budget, is what resolves it.
- Whole canvas-render-node suite green (516) with every pin unweakened, `edge-side-occlusion.test.ts` untouched. SVG determinism goldens byte-identical. typecheck, knip, build clean.
- Docs: decision #10 now lists all six penalty tiers and the seventh preference rule.

## Visual repro

Before (post-#705 — border clean, but the line crosses the target's body):

![before-endpoint-body-ink.png](https://github.com/user-attachments/assets/fbe14961-a74c-474b-979d-9050518766d0)

After (clean on both):

![after-endpoint-body-ink.jpg](https://github.com/user-attachments/assets/5382d857-ac48-4e93-8017-6dd12466cc4b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved orthogonal edge routing by prioritizing paths that avoid crossing node interiors.
  * Added smarter ordering for same-side U-hook routes.
  * Enhanced route scoring to account for endpoint interior crossings.

* **Bug Fixes**
  * Improved handling of contained, overlapping, border-touching, and degenerate node shapes.
  * Reduced unnecessary bends and improved route repairability.

* **Tests**
  * Added comprehensive regression and property-based coverage for the updated routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->