### PR TITLE
refactor(server-core): render MCP scenes through layoutSpatialCanvas

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -254,6 +254,24 @@ async function main() {
     locked: false,
   })
 
+  // wb_scene_render / wb_scene_digest: the only two tools whose
+  // structuredContent is built through server-core's layoutSpatialCanvas
+  // delegate (compose-canvas-scene.ts) rather than read back from stored
+  // content — this is the runtime guard that the laid-out scene still
+  // validates against canvasRenderSvgOutputSchema / sceneDigestSchema
+  // through the real MCP SDK, which a type-level check cannot see.
+  const rendered = await callTool('wb_scene_render', { workspaceId: WORKSPACE_ID, canvasId })
+  if (typeof rendered.svg !== 'string' || !rendered.svg.includes('<rect')) {
+    throw new Error(`wb_scene_render returned unexpected shape: ${JSON.stringify(rendered)}`)
+  }
+  console.log('[e2e] wb_scene_render → svg with chrome for the seeded text node')
+
+  const digest = await callTool('wb_scene_digest', { workspaceId: WORKSPACE_ID, canvasId })
+  if (!Array.isArray(digest.nodes) || digest.nodes.length === 0) {
+    throw new Error(`wb_scene_digest returned unexpected shape: ${JSON.stringify(digest)}`)
+  }
+  console.log('[e2e] wb_scene_digest → digest over the seeded text node')
+
   // wb_canvas_tidy: the canvas holds a single node here, so the contract answer
   // is "nothing to tidy" — the call still runs the full pipeline (input
   // parse → doc load → tidy → structuredContent vs outputSchema), which is

--- a/packages/server-core/src/render/compose-canvas-scene.test.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.test.ts
@@ -1,69 +1,115 @@
+import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { routeEdge } from '@kamiazya/whiteboard-canvas-render'
-import { describe, expect, test } from 'vitest'
 import {
-  composeCanvasScene,
-  computeCanvasDimensions,
-  translateNode,
-} from './compose-canvas-scene.js'
+  assignEdgeAnchors,
+  createSpatialTheme,
+  layoutSpatialCanvas,
+  routeEdge,
+} from '@kamiazya/whiteboard-canvas-render'
+import { afterEach, describe, expect, test } from 'vitest'
+import { setLogSink } from '../log.js'
+import { composeCanvasScene, computeCanvasDimensions } from './compose-canvas-scene.js'
 import { fallbackMeasureText } from './fallback-measure.js'
 
-describe('translateNode', () => {
-  test('translates a shape node bbox like other leaf scene nodes', () => {
-    const translated = translateNode(
-      { kind: 'shape', bbox: { x: 5, y: 6, w: 40, h: 30 }, radius: 4 },
-      10,
-      20,
-    )
-
-    expect(translated).toEqual({ kind: 'shape', bbox: { x: 15, y: 26, w: 40, h: 30 }, radius: 4 })
-  })
+afterEach(() => {
+  // `sink` is module-level state in log.ts, shared across every test file
+  // that imports it in the same worker — restore the no-op default so a
+  // sink installed here never leaks into another file's assertions.
+  setLogSink(() => {})
 })
 
 describe('composeCanvasScene', () => {
-  test('translates a text node body by its own (x, y)', () => {
+  test('a file node produces a visible chrome shape, and edges route through the shared anchor-assignment pass', () => {
     const canvas: SpatialCanvas = {
       nodes: [
-        { id: 'n1', type: 'text', x: 10, y: 20, width: 100, height: 50, text: 'hello world' },
+        { id: 'a', type: 'file', x: 0, y: 0, width: 100, height: 60, file: 'notes/a.md' },
+        { id: 'b', type: 'group', x: 300, y: 0, width: 100, height: 60 },
+        { id: 'c', type: 'group', x: 300, y: 300, width: 100, height: 60 },
       ],
-      edges: [],
+      edges: [
+        { id: 'e1', fromNode: 'a', toNode: 'b' },
+        { id: 'e2', fromNode: 'a', toNode: 'c' },
+      ],
     }
 
     const scene = composeCanvasScene(canvas, fallbackMeasureText)
 
-    expect(scene.nodes).toHaveLength(1)
-    const [paragraph] = scene.nodes
-    if (!('bbox' in paragraph)) throw new Error('expected a bbox-carrying scene node')
-    expect(paragraph.kind).toBe('paragraph')
-    expect(paragraph.bbox.x).toBe(10)
-    expect(paragraph.bbox.y).toBe(20)
+    // (a) the file node emits a `kind: 'shape'` scene node at its own bbox.
+    const fileChrome = scene.nodes.find(
+      (n) =>
+        n.kind === 'shape' &&
+        n.bbox.x === 0 &&
+        n.bbox.y === 0 &&
+        n.bbox.w === 100 &&
+        n.bbox.h === 60,
+    )
+    expect(fileChrome).toBeDefined()
+
+    // (b) each routed edge matches routeEdge + assignEdgeAnchors run together
+    // over the whole edge set — the anchor fan-out/side-optimization pass
+    // that a per-edge `routeEdge` call (with no anchors) never runs. The
+    // theme's edge appearance is merged on top, matching what
+    // layoutSpatialCanvas's own composeEdge does.
+    const style = canvas['x-whiteboard']?.edgeRouting?.style
+    const anchors = assignEdgeAnchors(canvas.nodes, canvas.edges, style)
+    const theme = createSpatialTheme({ mode: 'light' })
+    const edgeNodes = scene.nodes.filter((n) => n.kind === 'edge')
+    expect(edgeNodes).toHaveLength(2)
+    for (const edge of canvas.edges) {
+      const routed = routeEdge(canvas.nodes, edge, style, anchors.get(edge.id))
+      const appearance = theme.resolveEdge(edge)
+      const expected = appearance === undefined ? routed : { ...routed, appearance }
+      const actual = edgeNodes.find((n) => n.kind === 'edge' && n.id === edge.id)
+      expect(actual).toEqual(expected)
+    }
   })
 
-  test('degrades a file/link/group node to a placeholder box at its own bbox', () => {
+  test('is a pure delegate to layoutSpatialCanvas with the pinned MCP injection set (parity)', () => {
     const canvas: SpatialCanvas = {
       nodes: [
-        { id: 'n1', type: 'file', x: 5, y: 6, width: 40, height: 30, file: 'a.png' },
-        { id: 'n2', type: 'link', x: 1, y: 2, width: 10, height: 10, url: 'https://example.com' },
-        { id: 'n3', type: 'group', x: 0, y: 0, width: 200, height: 200 },
+        { id: 'text', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello **world**' },
+        { id: 'file', type: 'file', x: 200, y: 0, width: 100, height: 60, file: 'a.png' },
+        {
+          id: 'link',
+          type: 'link',
+          x: 0,
+          y: 200,
+          width: 80,
+          height: 40,
+          url: 'https://example.com',
+        },
+        {
+          id: 'group',
+          type: 'group',
+          x: 400,
+          y: 400,
+          width: 200,
+          height: 200,
+          label: 'a group',
+        },
       ],
-      edges: [],
+      edges: [
+        { id: 'e1', fromNode: 'text', toNode: 'file', label: 'goes to' },
+        { id: 'e2', fromNode: 'file', toNode: 'group' },
+      ],
     }
 
-    const scene = composeCanvasScene(canvas, fallbackMeasureText)
+    const actual = composeCanvasScene(canvas, fallbackMeasureText)
+    const expected = layoutSpatialCanvas(canvas, {
+      measure: fallbackMeasureText,
+      parseBody: parseMarkdownBody,
+      appearance: createSpatialTheme({ mode: 'light' }),
+    })
 
-    expect(scene.nodes).toHaveLength(3)
-    for (const [index, node] of canvas.nodes.entries()) {
-      const sceneNode = scene.nodes[index]
-      if (!('bbox' in sceneNode)) throw new Error('expected a bbox-carrying scene node')
-      expect(sceneNode.kind).toBe('group')
-      expect(sceneNode.bbox).toEqual({ x: node.x, y: node.y, w: node.width, h: node.height })
-    }
+    expect(actual).toEqual(expected)
   })
 
-  test('a malformed text body degrades to a placeholder instead of throwing', () => {
-    // An unbalanced/invalid fence-like construct that the closed mdast
-    // subset's schema rejects after remark parses it into a shape
-    // mdastRootSchema does not accept.
+  test('HTML embedded in a text body renders as a literal rawHtml run instead of throwing', () => {
+    // canvas-model's mdast subset accepts a raw `html` node verbatim (see
+    // package-canvas-model.md) — parseMarkdownBody is total over any string
+    // a real editor can produce, so this is not the failure path (that one
+    // needs an actually-unrecognized node kind, exercised below via a node
+    // with a type outside the closed union).
     const canvas: SpatialCanvas = {
       nodes: [
         {
@@ -79,23 +125,54 @@ describe('composeCanvasScene', () => {
       edges: [],
     }
 
-    expect(() => composeCanvasScene(canvas, fallbackMeasureText)).not.toThrow()
+    const scene = composeCanvasScene(canvas, fallbackMeasureText)
+
+    const literalRun = scene.nodes.find(
+      (n) => n.kind === 'rawHtml' && n.value === '<div><span></div>',
+    )
+    expect(literalRun).toBeDefined()
   })
 
-  test('edge scene nodes are not translated a second time on top of routeEdge', () => {
+  test('reports a degradation through getLogger, without changing the returned scene', () => {
+    // A node `type` outside the closed union — unreachable through the
+    // schema-validated store path, but canvas-render's own defensive branch
+    // (spatial-canvas.ts) still degrades it to chrome-only and reports it,
+    // which is what this pins.
+    const canvas = {
+      nodes: [{ id: 'n1', type: 'bogus', x: 0, y: 0, width: 100, height: 50 }],
+      edges: [],
+    } as unknown as SpatialCanvas
+
+    const sceneWithoutSink = composeCanvasScene(canvas, fallbackMeasureText)
+
+    const records: unknown[] = []
+    setLogSink((record) => records.push(record))
+    const sceneWithSink = composeCanvasScene(canvas, fallbackMeasureText)
+
+    expect(records).toEqual([
+      {
+        scope: 'compose-canvas-scene',
+        level: 'warning',
+        msg: 'unrecognized spatial node kind; emitting chrome only',
+        data: { nodeId: 'n1', type: 'bogus' },
+      },
+    ])
+    // Being told is observability-only — the callback must never change
+    // what was rendered.
+    expect(sceneWithSink).toEqual(sceneWithoutSink)
+  })
+
+  test('is deterministic across repeated calls', () => {
     const canvas: SpatialCanvas = {
       nodes: [
-        { id: 'a', type: 'group', x: 0, y: 0, width: 50, height: 50 },
-        { id: 'b', type: 'group', x: 200, y: 200, width: 50, height: 50 },
+        { id: 'n1', type: 'text', x: 10, y: 20, width: 100, height: 50, text: 'hello world' },
       ],
-      edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+      edges: [],
     }
 
-    const scene = composeCanvasScene(canvas, fallbackMeasureText)
-    const edgeNode = scene.nodes.find((n) => n.kind === 'edge')
-    const expected = routeEdge(canvas.nodes, canvas.edges[0])
-
-    expect(edgeNode).toEqual(expected)
+    expect(composeCanvasScene(canvas, fallbackMeasureText)).toEqual(
+      composeCanvasScene(canvas, fallbackMeasureText),
+    )
   })
 })
 

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -1,134 +1,60 @@
 import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import type {
-  ListItemNode,
   MeasureText,
   Scene,
-  SceneNode,
+  SpatialLayoutDegradation,
 } from '@kamiazya/whiteboard-canvas-render'
-import {
-  layoutMdastBlocks,
-  routeEdge,
-  SPATIAL_THEME_FONT_FAMILY,
-} from '@kamiazya/whiteboard-canvas-render'
+import { createSpatialTheme, layoutSpatialCanvas } from '@kamiazya/whiteboard-canvas-render'
+import { getLogger } from '../log.js'
 
-/**
- * Recursively translates every bbox in a scene node subtree by (dx, dy).
- * `layoutMdastBlocks` always starts a document at (0, 0); a spatial
- * canvas's text node lives at its own (x, y), so its laid-out scene must be
- * shifted into place before joining the rest of the canvas's scene graph.
- */
-export function translateNode(node: SceneNode, dx: number, dy: number): SceneNode {
-  if (node.kind === 'edge') {
-    // Edges are already resolved in absolute canvas coordinates by
-    // routeEdge — translating them here would double-shift them.
-    return node
-  }
+// MCP render/digest are deliberately pinned to light (package-canvas-render.md
+// decision #8): a user's ambient UI theme must never change what wb_scene_render
+// or wb_scene_digest emit. Built once — the resolver is stateless.
+const MCP_SCENE_APPEARANCE = createSpatialTheme({ mode: 'light' })
 
-  const bbox = { x: node.bbox.x + dx, y: node.bbox.y + dy, w: node.bbox.w, h: node.bbox.h }
+const log = getLogger('compose-canvas-scene')
 
-  switch (node.kind) {
-    case 'textRun':
-    case 'thematicBreak':
-    case 'codeBlock':
-    case 'rawHtml':
-    case 'unresolvedReference':
-    case 'svgFragment':
-    case 'embedPlaceholder':
-    case 'shape':
-    case 'image':
-      return { ...node, bbox }
-    case 'heading':
-    case 'paragraph':
-      return {
-        ...node,
-        bbox,
-        runs: node.runs.map((run) => translateNode(run, dx, dy) as typeof run),
-      }
-    case 'list':
-      return {
-        ...node,
-        bbox,
-        items: node.items.map((item) => translateListItem(item, dx, dy)),
-      }
-    case 'blockquote':
-    case 'group':
-    case 'embedResolved':
-      return { ...node, bbox, children: node.children.map((child) => translateNode(child, dx, dy)) }
-    case 'table':
-      return {
-        ...node,
-        bbox,
-        rows: node.rows.map((row) => ({
-          ...row,
-          bbox: { x: row.bbox.x + dx, y: row.bbox.y + dy, w: row.bbox.w, h: row.bbox.h },
-          cells: row.cells.map((cell) => ({
-            ...cell,
-            bbox: { x: cell.bbox.x + dx, y: cell.bbox.y + dy, w: cell.bbox.w, h: cell.bbox.h },
-            runs: cell.runs.map((run) => translateNode(run, dx, dy) as typeof run),
-          })),
-        })),
-      }
-  }
-}
-
-/** `ListItemNode` is not itself a `SceneNode` variant, so it needs its own translator. */
-function translateListItem(item: ListItemNode, dx: number, dy: number): ListItemNode {
-  return {
-    ...item,
-    bbox: { x: item.bbox.x + dx, y: item.bbox.y + dy, w: item.bbox.w, h: item.bbox.h },
-    children: item.children.map((child) => translateNode(child, dx, dy)),
+/** Reports a layout degradation via `getLogger`, since canvas-render itself cannot log. */
+function onDegrade(event: SpatialLayoutDegradation): void {
+  switch (event.kind) {
+    case 'body-parse-failed':
+      log.warning('text node body failed to parse as markdown; falling back to literal text', {
+        nodeId: event.nodeId,
+        err: event.err,
+      })
+      return
+    case 'unsupported-background-style':
+      log.warning('group backgroundStyle not supported; rendering as cover', {
+        nodeId: event.nodeId,
+        style: event.style,
+      })
+      return
+    case 'unknown-node-kind':
+      log.warning('unrecognized spatial node kind; emitting chrome only', {
+        nodeId: event.nodeId,
+        type: event.type,
+      })
+      return
   }
 }
 
 /**
- * `file`/`link`/`group` spatial nodes have no markdown body to lay out.
- * Multi-doc embed recursion (`resolveEmbeds`/`ResolvedDocBundle`) is out of
- * scope for this tool set — these nodes degrade to a placeholder box at
- * their own bbox, matching canvas-render's own "degrade rather than throw"
- * convention (`EmbedPlaceholderNode`).
- */
-function placeholderFor(node: SpatialNode): SceneNode {
-  return {
-    kind: 'group',
-    bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
-    children: [],
-  }
-}
-
-function layoutTextNode(node: SpatialNode & { type: 'text' }, measure: MeasureText): SceneNode[] {
-  let laidOut: Scene
-  try {
-    const mdastRoot = parseMarkdownBody(node.text)
-    laidOut = layoutMdastBlocks(mdastRoot, {
-      measure,
-      maxWidth: node.width,
-      fontFamily: SPATIAL_THEME_FONT_FAMILY,
-    })
-  } catch {
-    // parseMarkdownBody throws when a body's remark-parsed tree falls
-    // outside the closed mdast subset (mdastRootSchema rejects it) — a
-    // real, reachable case, not a bug in this composer. Degrade instead of
-    // aborting the whole canvas's render for one bad node.
-    return [placeholderFor(node)]
-  }
-  return laidOut.nodes.map((sceneNode) => translateNode(sceneNode, node.x, node.y))
-}
-
-/**
- * Composes a full-canvas scene from a `SpatialCanvas`'s independently
- * positioned nodes and edges. Assembling one scene from many per-node
- * layouts is tool-specific composition (not a generic layout function), so
- * it lives here rather than in canvas-render's library surface.
+ * Composes a full-canvas scene from a `SpatialCanvas`. Delegates to
+ * canvas-render's `layoutSpatialCanvas` — the single SpatialCanvas -> Scene
+ * builder shared by every consumer (package-canvas-render.md decision #7).
+ * No `resolveFileCanvas`/`resolveFileImage`/`resolveFileLabel`/`expandFileNode`
+ * are passed, which keeps the MCP surface a pure function of the canvas
+ * snapshot (decision #10's opt-in rule) — a file node renders as chrome +
+ * label regardless of whether the reference resolves to anything.
  */
 export function composeCanvasScene(canvas: SpatialCanvas, measure: MeasureText): Scene {
-  const blockNodes = canvas.nodes.flatMap((node) =>
-    node.type === 'text' ? layoutTextNode(node, measure) : [placeholderFor(node)],
-  )
-  const edgeNodes = canvas.edges.map((edge) =>
-    routeEdge(canvas.nodes, edge, canvas['x-whiteboard']?.edgeRouting?.style),
-  )
-  return { nodes: [...blockNodes, ...edgeNodes] }
+  return layoutSpatialCanvas(canvas, {
+    measure,
+    parseBody: parseMarkdownBody,
+    appearance: MCP_SCENE_APPEARANCE,
+    onDegrade,
+  })
 }
 
 /**

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -15,28 +15,18 @@ const MCP_SCENE_APPEARANCE = createSpatialTheme({ mode: 'light' })
 
 const log = getLogger('compose-canvas-scene')
 
+// Keyed by every `SpatialLayoutDegradation['kind']`, so a kind added in
+// canvas-render is a compile error here rather than a silently unreported
+// degradation.
+const DEGRADATION_MESSAGE: Record<SpatialLayoutDegradation['kind'], string> = {
+  'body-parse-failed': 'text node body failed to parse as markdown; falling back to literal text',
+  'unsupported-background-style': 'group backgroundStyle not supported; rendering as cover',
+  'unknown-node-kind': 'unrecognized spatial node kind; emitting chrome only',
+}
+
 /** Reports a layout degradation via `getLogger`, since canvas-render itself cannot log. */
-function onDegrade(event: SpatialLayoutDegradation): void {
-  switch (event.kind) {
-    case 'body-parse-failed':
-      log.warning('text node body failed to parse as markdown; falling back to literal text', {
-        nodeId: event.nodeId,
-        err: event.err,
-      })
-      return
-    case 'unsupported-background-style':
-      log.warning('group backgroundStyle not supported; rendering as cover', {
-        nodeId: event.nodeId,
-        style: event.style,
-      })
-      return
-    case 'unknown-node-kind':
-      log.warning('unrecognized spatial node kind; emitting chrome only', {
-        nodeId: event.nodeId,
-        type: event.type,
-      })
-      return
-  }
+function onDegrade({ kind, ...data }: SpatialLayoutDegradation): void {
+  log.warning(DEGRADATION_MESSAGE[kind], data)
 }
 
 /**

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -1,8 +1,6 @@
-import { sceneDigest, sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
+import { sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { describe, expect, test } from 'vitest'
-import { composeCanvasScene } from '../render/compose-canvas-scene.js'
-import { fallbackMeasureText } from '../render/fallback-measure.js'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasDigestTool } from './canvas-digest.js'
@@ -15,7 +13,7 @@ function makeDeps(canvasDocStore: FakeCanvasDocStore) {
 }
 
 describe('wb_scene_digest tool', () => {
-  test('matches sceneDigest computed directly over an overlapping two-node canvas', async () => {
+  test('digests an overlapping two-node canvas to a pinned literal', async () => {
     const store = new FakeCanvasDocStore()
     const canvas = {
       nodes: [
@@ -30,9 +28,29 @@ describe('wb_scene_digest tool', () => {
     const tool = createCanvasDigestTool(makeDeps(store))
 
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
-    const expected = sceneDigest(composeCanvasScene(canvas, fallbackMeasureText))
 
-    expect(result).toEqual(expected)
+    // Pinned explicitly (not computed by calling composeCanvasScene again)
+    // so a real scene regression actually turns this test red — an
+    // expectation computed via the tool's own producer can never fail when
+    // that producer changes. Unlabelled groups emit a single chrome shape
+    // at their own bbox (no label run), so ids/bboxes match the digest an
+    // agent saw before this migration.
+    expect(result).toEqual({
+      nodes: [
+        { id: 'n0', bbox: { x: 0, y: 0, w: 100, h: 100 }, z: 0 },
+        { id: 'n1', bbox: { x: 50, y: 50, w: 100, h: 100 }, z: 1 },
+      ],
+      overlaps: [['n0', 'n1']],
+      containment: [],
+      clusters: [['n0', 'n1']],
+      freeRegions: [
+        { x: 100, y: 0, w: 60, h: 20 },
+        { x: 100, y: 20, w: 60, h: 20 },
+        { x: 0, y: 100, w: 40, h: 20 },
+        { x: 0, y: 120, w: 40, h: 20 },
+        { x: 0, y: 140, w: 40, h: 20 },
+      ],
+    })
     expect(result.overlaps.length).toBeGreaterThan(0)
     expect(() => sceneDigestSchema.parse(result)).not.toThrow()
   })

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -26,6 +26,10 @@ describe('wb_scene_render tool', () => {
 
     expect(result.svg).toContain('<svg xmlns="http://www.w3.org/2000/svg">')
     expect(result.svg).toContain('hi')
+    // The node's chrome — absent from every MCP-rendered SVG before this
+    // migration, since the old builder degraded every node to an empty
+    // `<g>` with no visible shape.
+    expect(result.svg).toContain('<rect')
     expect(result.width).toBe(100)
     expect(result.height).toBe(50)
   })


### PR DESCRIPTION
`packages/server-core/src/render/compose-canvas-scene.ts` was a **second** `SpatialCanvas → Scene` builder, contradicting decision #7 ("layoutSpatialCanvas is the single builder shared by every consumer"). It backed both MCP tools that draw a canvas — `wb_scene_render` and `wb_scene_digest`.

What that meant in practice:

- Every **non-text node** (file / group / link) rendered as `{kind:'group', bbox, children: []}` — no chrome rect, no label. Invisible except for its box.
- Text nodes got their mdast blocks but **no chrome either**.
- Edges called `routeEdge` per edge **without `assignEdgeAnchors`**, so side optimization, anchor fan-out, facing alignment and the entire routing rule catalog (six PENALTY tiers, seven SIDE_PREFERENCE rules) never ran. Every routing improvement landed recently was invisible to MCP consumers.

`composeCanvasScene` is now a delegate to `layoutSpatialCanvas` with the same injection set `headless-renderer.ts` already uses: the caller's `fallbackMeasureText` (unchanged — the measurer is a separate concern), `parseMarkdownBody`, a module-level `createSpatialTheme({ mode: 'light' })` (decision #8 pins that UI theme never changes served bytes), no `geometry` override, and **no `resolveFile*`** — which is what keeps the MCP surface a pure function of the canvas snapshot per decision #10's opt-in rule. `translateNode` / `placeholderFor` / `layoutTextNode` are deleted; `computeCanvasDimensions` is untouched.

`onDegrade` is now wired to `getLogger('compose-canvas-scene')`. The task spec claimed server-core had no logger; that was wrong — it owns an injectable-sink logger that mcp-server already binds via `setLogSink`, so degradations now reach the real daemon log instead of being dropped.

## Two gate gaps this surfaced

- **`canvas-digest.test.ts` computed its own expectation** by calling `composeCanvasScene`, so it could never go red on a scene regression. Replaced with an explicit pinned digest literal, mutation-checked against the old builder.
- **`pnpm smoke:e2e` never actually invoked `wb_scene_render` or `wb_scene_digest`** — both names appeared only in the `EXPECTED_TOOLS` list check, never in a `tools/call`. Real invocations added, and the new chrome assertion mutation-checked (restore the placeholder builder → red).

## Digest delta, measured not assumed

On a representative canvas (text + file + labelled group + 2 edges): node count 3→6, containment 0→2. The added entries are chrome-to-own-content pairs; a second canvas with real group/member nesting confirms the genuine containment relation still appears as its own entry and stays legible. Within the ceiling agreed up front, so no stop condition triggered — but see the follow-up note below.

## Verification

- Red-first test pinning both defects (file node emits a `kind:'shape'`; each edge deep-equals `routeEdge(..., assignEdgeAnchors(...).get(edge.id))`), failing before the migration.
- Parity test pinning `composeCanvasScene ≡ layoutSpatialCanvas` with the exact injection set — mutation-checked by flipping the theme mode.
- `pnpm smoke:e2e` green through a real MCP client, including the new tool calls.
- Live daemon check on this branch: `wb_scene_render` now returns chrome (`<rect …/>`) where it previously returned nothing for the same node.
- `pnpm test` green except a known local flake (`purity-guard.test.ts` times out under a saturated worker pool, passes in isolation in ~190ms — filed separately), plus `pnpm -r typecheck` and `pnpm knip` clean.

## Follow-up, not in this PR

`computeCanvasDimensions` unions node boxes and so does not bound a group's outside label or an edge routed past the node union; `sceneBounds` would be the correct producer, but switching it changes emitted SVG dimensions and deserves its own increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved canvas rendering with consistent layout, edge routing, light appearance, and visible node backgrounds.
  * Added graceful handling and logging for unsupported content or rendering issues.
  * Enhanced end-to-end smoke checks for SVG rendering and scene digests.

* **Bug Fixes**
  * Improved rendering of text content and repeated renders for consistent results.
  * Corrected shared edge anchors and spatial canvas layout behavior.

* **Tests**
  * Expanded coverage for rendering, digests, node handling, edge routing, and scene structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->