### PR TITLE
feat(canvas-render): add the resolveFileFacets seam and a generic core-facet card

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -336,12 +336,31 @@ paths:
       helper (`ConfigCost` shape, `addCost`, `lessCost`,
       `hasRepairableProblem`) derives from the declared tiers, so a new
       penalty rule is one list entry, never a new slot threaded by hand.
-    - **Facet-driven rendering rides the injected-resolver pattern**
-      (a future `resolveFileFacets`, same seam class as
-      `resolveFileCanvas`/`resolveFileImage`), and export stays a pure
-      function of the canvas snapshot by default — resolving another
-      document's live facet state into exported bytes is opt-in, exactly
-      parallel to the style opt-in above.
+    - **Facet-driven rendering rides the injected-resolver pattern.**
+      Shipped: `SpatialLayoutOptions.resolveFileFacets?: (file: string) =>
+      FacetCardData | undefined` (`layout/spatial-canvas.ts`), same seam
+      class as `resolveFileCanvas`/`resolveFileImage` — synchronous,
+      optional, caller-supplied, total (a throw or `undefined` degrades to
+      the plain chrome+label rendering rather than aborting layout).
+      `FacetCardData` (`{ title?: string; rows: ReadonlyArray<{ label:
+      string; value: string }> }`) is plain TS, not Zod — it never crosses a
+      process boundary; the caller maps its own facet data
+      (`coreFacetsSchema` and friends) into it in-process, and this package
+      learns nothing about what a facet MEANS. `composeFileFacets` is
+      checked LAST in the file-node pre-pass — after `composeFileImage` and
+      `composeFileEmbed` — so a resolved image or canvas embed always
+      outranks a facet card, and the card in turn always outranks the plain
+      label it replaces. Card text goes through `layoutMdastBlocks`
+      (`heading`+`paragraph` blocks only, never `list`/`table`, to stay out
+      of the `subtreeOffsetX` transform-boundary class); content that
+      overflows the node's padded box is truncated at whole-block
+      granularity with no "more" affordance (ponytail: that needs a
+      focusable DOM-overlay/keyboard treatment this pure-geometry package
+      cannot own — upgrade path is an editor-side overlay in a later
+      slice). No consumer passes the seam yet — export stays a pure
+      function of the canvas snapshot by default, exactly parallel to the
+      style opt-in above; wiring `apps/web` to paint a card on a real screen
+      is a separate, later increment.
 
 ## Conventions
 

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -11,7 +11,11 @@ export type {
   SpatialAppearanceResolver,
   SpatialNodeAppearance,
 } from './layout/spatial-appearance.js'
-export type { SpatialLayoutDegradation, SpatialLayoutOptions } from './layout/spatial-canvas.js'
+export type {
+  FacetCardData,
+  SpatialLayoutDegradation,
+  SpatialLayoutOptions,
+} from './layout/spatial-canvas.js'
 export { layoutSpatialCanvas, layoutSpatialEdges } from './layout/spatial-canvas.js'
 export {
   assignEdgeAnchors,

--- a/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
@@ -5,7 +5,7 @@ import { renderSceneToSvg } from '../svg/backend.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
-import { layoutSpatialCanvas, layoutSpatialEdges } from './spatial-canvas.js'
+import { type FacetCardData, layoutSpatialCanvas, layoutSpatialEdges } from './spatial-canvas.js'
 
 const measure = createFakeMeasure()
 
@@ -131,6 +131,63 @@ describe('layoutSpatialCanvas properties (PBT)', () => {
       const svgA = renderSceneToSvg(layoutSpatialCanvas(canvas, options), { padding: 4 })
       const svgB = renderSceneToSvg(layoutSpatialCanvas(canvas, options), { padding: 4 })
       expect(svgA).toBe(svgB)
+    },
+  )
+})
+
+/**
+ * A fixed (not fc-generated) resolver keyed off `spatialNodeArb`'s file
+ * pool: deterministic per file, so the property below exercises every
+ * `composeFileFacets` path (usable card, degrades-to-nothing, no match)
+ * across generated canvases without needing its own arbitrary.
+ */
+function fakeResolveFileFacets(file: string): FacetCardData | undefined {
+  if (file === 'a.md') {
+    return {
+      title: 'Card',
+      rows: [
+        { label: 'type', value: 'note' },
+        { label: 'tags', value: 'x, y' },
+      ],
+    }
+  }
+  if (file === 'notes/b.md') {
+    // No usable content: degrades to the plain chrome+label rendering.
+    return { rows: [] }
+  }
+  return undefined
+}
+
+describe('layoutSpatialCanvas facet-card properties (PBT)', () => {
+  const optionsWithFacets = {
+    measure,
+    parseBody: fakeParseBody,
+    appearance,
+    resolveFileFacets: fakeResolveFileFacets,
+  }
+
+  fcTest.prop([spatialCanvasArb], withDefaults())(
+    'a resolving facet resolver never throws and renders identically twice (determinism)',
+    (canvas) => {
+      const svgA = renderSceneToSvg(layoutSpatialCanvas(canvas, optionsWithFacets), { padding: 8 })
+      const svgB = renderSceneToSvg(layoutSpatialCanvas(canvas, optionsWithFacets), { padding: 8 })
+      expect(svgA).toBe(svgB)
+    },
+  )
+
+  fcTest.prop([spatialCanvasArb], withDefaults())(
+    'an installed-but-silent resolver changes nothing (additivity)',
+    (canvas) => {
+      const withNoOpSeam = layoutSpatialCanvas(canvas, {
+        ...optionsWithFacets,
+        resolveFileFacets: () => undefined,
+      })
+      const withoutSeam = layoutSpatialCanvas(canvas, {
+        measure,
+        parseBody: fakeParseBody,
+        appearance,
+      })
+      expect(withNoOpSeam).toEqual(withoutSeam)
     },
   )
 })

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -421,8 +421,7 @@ function composeFileFacets(
   }
   if (card === undefined) return undefined
 
-  const title =
-    typeof card.title === 'string' && card.title.trim().length > 0 ? card.title : undefined
+  const title = card.title?.trim() ? card.title : undefined
   const rows = card.rows.filter((row) => row.label.trim().length > 0 || row.value.trim().length > 0)
   if (title === undefined && rows.length === 0) return undefined
 
@@ -462,11 +461,10 @@ function composeFileFacets(
   // "more" affordance needs a focusable DOM-overlay/keyboard treatment this
   // pure-geometry package cannot own. Upgrade path is an editor-side
   // overlay in a later slice, not a scene node here.
-  // `layoutMdastBlocks` never emits a `ResolvedEdgeNode` (the one SceneNode
-  // variant with no `bbox`); the guard is for the type checker, not runtime.
+  // `layoutMdastBlocks` never emits an edge (the one SceneNode variant with
+  // no `bbox`); that guard is for the type checker, not runtime.
   const fitted = body.nodes.filter(
-    (entry): entry is Exclude<SceneNode, ResolvedEdgeNode> =>
-      entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= innerH,
+    (entry) => entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= innerH,
   )
   if (fitted.length === 0) return undefined
 

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -25,7 +25,7 @@
 // a total function of a deterministic canvas, so the same canvas renders
 // the same SVG twice regardless.
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
+import type { MdastFlowContent, MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import type { MeasureText } from '../measure.js'
 import { sceneBounds } from '../scene-bounds.js'
 import type {
@@ -67,6 +67,21 @@ export type SpatialLayoutDegradation =
       readonly nodeId: string
       readonly style: 'repeat'
     }
+
+/**
+ * Presentation-shaped card content for a file node, mapped by the caller
+ * from its own facet data (canvas-model's `coreFacetsSchema` and friends).
+ * Deliberately NOT domain-shaped: this package renders "one bare heading
+ * line, then labelled rows" and learns nothing about what a facet MEANS —
+ * the semantic mapping (`title = facets.title ?? facets.type`, one row per
+ * core facet) is the caller's job. Plain TS, not Zod, per
+ * zod-schema-discipline: it is constructed and consumed entirely
+ * in-process and never crosses a process boundary.
+ */
+export interface FacetCardData {
+  readonly title?: string
+  readonly rows: readonly { readonly label: string; readonly value: string }[]
+}
 
 export interface SpatialLayoutOptions {
   readonly measure: MeasureText
@@ -123,6 +138,15 @@ export interface SpatialLayoutOptions {
   readonly resolveFileImage?: (
     file: string,
   ) => { readonly href: string; readonly alt?: string } | undefined
+  /**
+   * Resolves a file node's reference to card content built from its facet
+   * data. Checked LAST among the file-node content resolvers — after the
+   * image and canvas-embed seams — so it never outranks either; `undefined`,
+   * a throw, or card data with no usable title/rows (the common case for a
+   * document that carries no facets this caller maps) all keep the plain
+   * chrome+label rendering.
+   */
+  readonly resolveFileFacets?: (file: string) => FacetCardData | undefined
 }
 
 /** Internal: options with geometry resolved exactly once per layout call. */
@@ -368,6 +392,88 @@ function composeFileImage(
 }
 
 /**
+ * The facet-card rendering of a file node: a bare heading line (the card's
+ * `title`) followed by one paragraph per row (`label: value`), laid out
+ * through `layoutMdastBlocks` — the same producer `composeTextNode` uses —
+ * rather than a second text-layout producer (package-canvas-render.md's
+ * "one producer per geometry" rule). Deliberately only `heading`/
+ * `paragraph` blocks: `list`/`table` are the only two block renderers that
+ * emit their own SVG `transform` (the `subtreeOffsetX` class), and this
+ * card has no reason to enter that tripwire.
+ *
+ * Returns `undefined` — keeping the plain chrome+label rendering — for
+ * every "no usable content" path: no resolver, an `undefined` or thrown
+ * result, a title that is empty/whitespace-only with no usable row, or a
+ * degenerate (non-positive) content box. This is the expected common case,
+ * not an error: the model guarantees payloads this layer cannot validate,
+ * so canvas-render never reports it via `onDegrade`.
+ */
+function composeFileFacets(
+  node: Extract<SpatialNode, { type: 'file' }>,
+  options: ResolvedLayoutOptions,
+): readonly SceneNode[] | undefined {
+  if (options.resolveFileFacets === undefined) return undefined
+  let card: FacetCardData | undefined
+  try {
+    card = options.resolveFileFacets(node.file)
+  } catch {
+    card = undefined
+  }
+  if (card === undefined) return undefined
+
+  const title =
+    typeof card.title === 'string' && card.title.trim().length > 0 ? card.title : undefined
+  const rows = card.rows.filter((row) => row.label.trim().length > 0 || row.value.trim().length > 0)
+  if (title === undefined && rows.length === 0) return undefined
+
+  const padding = options.geometry.paddingPx
+  const innerW = node.width - 2 * padding
+  const innerH = node.height - 2 * padding
+  if (!(innerW > 0) || !(innerH > 0)) return undefined
+
+  const blocks: MdastFlowContent[] = []
+  if (title !== undefined) {
+    blocks.push({ type: 'heading', depth: 3, children: [{ type: 'text', value: title }] })
+  }
+  for (const row of rows) {
+    blocks.push({
+      type: 'paragraph',
+      children: [
+        { type: 'strong', children: [{ type: 'text', value: row.label }] },
+        { type: 'text', value: `: ${row.value}` },
+      ],
+    })
+  }
+
+  const body = layoutMdastBlocks(
+    { type: 'root', children: blocks },
+    {
+      measure: options.measure,
+      maxWidth: contentWidth(node.width, options),
+      fontFamily: options.appearance.resolveLabel().fontFamily ?? 'sans-serif',
+    },
+  )
+
+  // Truncate at whole-block granularity: layoutMdastBlocks lays top-level
+  // blocks out with strictly increasing bottoms, so the blocks whose bottom
+  // fits the padded content box are exactly a contiguous top prefix.
+  //
+  // ponytail: silently dropping the rest is the ceiling for this slice — a
+  // "more" affordance needs a focusable DOM-overlay/keyboard treatment this
+  // pure-geometry package cannot own. Upgrade path is an editor-side
+  // overlay in a later slice, not a scene node here.
+  // `layoutMdastBlocks` never emits a `ResolvedEdgeNode` (the one SceneNode
+  // variant with no `bbox`); the guard is for the type checker, not runtime.
+  const fitted = body.nodes.filter(
+    (entry): entry is Exclude<SceneNode, ResolvedEdgeNode> =>
+      entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= innerH,
+  )
+  if (fitted.length === 0) return undefined
+
+  return [chromeShape(node, options), ...placeInNode(node, { nodes: fitted }, options)]
+}
+
+/**
  * JSON Canvas group background: a full-frame image behind the members.
  * `backgroundStyle` maps 'ratio' -> contain and 'cover'/absent -> cover
  * (the spec's visual default); 'repeat' degrades to cover, reported via
@@ -416,6 +522,8 @@ function composeNode(node: SpatialNode, options: ResolvedLayoutOptions): readonl
           ? [chrome, embed]
           : [chrome, ...placeAboveNode(node, { nodes: [labelRun(label, options)] }), embed]
       }
+      const facets = composeFileFacets(node, options)
+      if (facets !== undefined) return facets
       break
     }
     default:

--- a/packages/canvas-render/src/layout/spatial-embed.test.ts
+++ b/packages/canvas-render/src/layout/spatial-embed.test.ts
@@ -4,9 +4,19 @@
 // package's embed contract already promises.
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
-import type { EmbedResolvedNode, ShapeSceneNode } from '../scene-graph.js'
+import type {
+  EmbedResolvedNode,
+  HeadingBlockNode,
+  ParagraphBlockNode,
+  ShapeSceneNode,
+} from '../scene-graph.js'
+import { renderSceneToSvg } from '../svg/backend.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
-import { layoutSpatialCanvas, type SpatialLayoutOptions } from './spatial-canvas.js'
+import {
+  type FacetCardData,
+  layoutSpatialCanvas,
+  type SpatialLayoutOptions,
+} from './spatial-canvas.js'
 
 const APPEARANCE = {
   resolveNode: () => ({}),
@@ -103,6 +113,19 @@ describe('file-node inline embeds', () => {
       baseOptions({ resolveFileCanvas: () => undefined, expandFileNode: () => true }),
     )
     expect(embedOf(unresolvable)).toBeUndefined()
+  })
+
+  it('a resolved canvas embed wins over a resolved facet card', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileCanvas: (file) => (file === 'child' ? childCanvas : undefined),
+        expandFileNode: () => true,
+        resolveFileFacets: () => ({ title: 'Card', rows: [{ label: 'type', value: 'note' }] }),
+      }),
+    )
+    expect(embedOf(scene)).toBeDefined()
+    expect(scene.nodes.some((n) => n.kind === 'heading')).toBe(false)
   })
 
   it("keeps a line-jump child's hop points inside the frame (jumps transform with the path)", () => {
@@ -226,5 +249,152 @@ describe('file-node images', () => {
     expect(throwing.nodes.some((n) => n.kind === 'image')).toBe(false)
     // The card label still renders.
     expect(throwing.nodes.some((n) => n.kind === 'textRun')).toBe(true)
+  })
+
+  it('image resolution wins over a resolved facet card', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileImage: () => ({ href: 'data:image/png;base64,AAA' }),
+        resolveFileFacets: () => ({ title: 'Card', rows: [{ label: 'type', value: 'note' }] }),
+      }),
+    )
+    expect(scene.nodes.some((n) => n.kind === 'image')).toBe(true)
+    expect(scene.nodes.some((n) => n.kind === 'heading')).toBe(false)
+  })
+})
+
+describe('file-node facet cards', () => {
+  const card: FacetCardData = {
+    title: 'Ship it',
+    rows: [
+      { label: 'type', value: 'issue' },
+      { label: 'tags', value: 'a, b' },
+    ],
+  }
+
+  it("renders the card's title and rows, replacing the plain label", () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({ resolveFileFacets: (file) => (file === 'child' ? card : undefined) }),
+    )
+    const heading = scene.nodes.find((n): n is HeadingBlockNode => n.kind === 'heading')
+    expect(heading?.runs.map((run) => run.text).join('')).toBe('Ship it')
+
+    const paragraphs = scene.nodes.filter((n): n is ParagraphBlockNode => n.kind === 'paragraph')
+    expect(paragraphs).toHaveLength(2)
+    expect(paragraphs[0]?.runs.map((run) => run.text).join('')).toBe('type: issue')
+    expect(paragraphs[1]?.runs.map((run) => run.text).join('')).toBe('tags: a, b')
+
+    // The raw file label is a plain top-level textRun — the card replaces it.
+    expect(scene.nodes.some((n) => n.kind === 'textRun')).toBe(false)
+
+    // Card content is drawn strictly inside the node's own padded box.
+    for (const entry of [heading, ...paragraphs]) {
+      expect(entry).toBeDefined()
+      expect(entry!.bbox.x).toBeGreaterThanOrEqual(100)
+      expect(entry!.bbox.y).toBeGreaterThanOrEqual(100)
+      expect(entry!.bbox.x + entry!.bbox.w).toBeLessThanOrEqual(320)
+      expect(entry!.bbox.y + entry!.bbox.h).toBeLessThanOrEqual(280)
+    }
+  })
+
+  it('wins over the plain label when both resolvers resolve', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode()], edges: [] },
+      baseOptions({
+        resolveFileLabel: () => 'A human title',
+        resolveFileFacets: () => card,
+      }),
+    )
+    expect(scene.nodes.some((n) => n.kind === 'textRun')).toBe(false)
+    expect(scene.nodes.some((n) => n.kind === 'heading')).toBe(true)
+  })
+
+  it('degrades to the plain chrome+label rendering when there is no usable card data', () => {
+    const canvas: SpatialCanvas = { nodes: [fileNode()], edges: [] }
+    const baseline = layoutSpatialCanvas(canvas, baseOptions())
+    const baselineSvg = renderSceneToSvg(baseline)
+
+    const noResolverScene = layoutSpatialCanvas(canvas, baseOptions())
+    expect(noResolverScene).toEqual(baseline)
+    expect(renderSceneToSvg(noResolverScene)).toBe(baselineSvg)
+
+    const resolvers: Array<() => FacetCardData | undefined> = [
+      () => undefined,
+      () => {
+        throw new Error('boom')
+      },
+      () => ({ rows: [] }),
+      () => ({ title: '   ', rows: [{ label: '', value: '' }] }),
+    ]
+    for (const resolveFileFacets of resolvers) {
+      const scene = layoutSpatialCanvas(canvas, baseOptions({ resolveFileFacets }))
+      expect(scene).toEqual(baseline)
+      expect(renderSceneToSvg(scene)).toBe(baselineSvg)
+    }
+  })
+
+  it('truncates content that overflows the node box at whole-block granularity', () => {
+    const shortNode = fileNode({ height: 100 })
+    const manyRows: FacetCardData = {
+      title: 'Overflowing',
+      rows: Array.from({ length: 40 }, (_, i) => ({ label: `k${i}`, value: `v${i}` })),
+    }
+    const scene = layoutSpatialCanvas(
+      { nodes: [shortNode], edges: [] },
+      baseOptions({ resolveFileFacets: () => manyRows }),
+    )
+    const blocks = scene.nodes.filter((n) => n.kind === 'heading' || n.kind === 'paragraph')
+    expect(blocks.length).toBeGreaterThan(0)
+    expect(blocks.length).toBeLessThan(41)
+    for (const block of blocks) {
+      expect(block.bbox.y + block.bbox.h).toBeLessThanOrEqual(shortNode.y + shortNode.height - 8)
+    }
+  })
+
+  it('keeps the chrome-only rendering for a degenerate (zero-size) node rather than throwing', () => {
+    const zeroNode = fileNode({ width: 0, height: 0 })
+    expect(() =>
+      layoutSpatialCanvas(
+        { nodes: [zeroNode], edges: [] },
+        baseOptions({ resolveFileFacets: () => card }),
+      ),
+    ).not.toThrow()
+    const scene = layoutSpatialCanvas(
+      { nodes: [zeroNode], edges: [] },
+      baseOptions({ resolveFileFacets: () => card }),
+    )
+    expect(scene.nodes.some((n) => n.kind === 'heading' || n.kind === 'paragraph')).toBe(false)
+  })
+
+  it('renders byte-identical SVG for the same canvas laid out twice (determinism)', () => {
+    const canvas: SpatialCanvas = { nodes: [fileNode()], edges: [] }
+    const options = baseOptions({ resolveFileFacets: () => card })
+    const svgA = renderSceneToSvg(layoutSpatialCanvas(canvas, options))
+    const svgB = renderSceneToSvg(layoutSpatialCanvas(canvas, options))
+    expect(svgA).toBe(svgB)
+  })
+
+  it('emits the card within its own node slot, in document order ahead of a later node', () => {
+    const textNode: SpatialNode = {
+      id: 't1',
+      type: 'text',
+      x: 400,
+      y: 100,
+      width: 100,
+      height: 100,
+      text: '',
+    }
+    const scene = layoutSpatialCanvas(
+      { nodes: [fileNode(), textNode], edges: [] },
+      baseOptions({ resolveFileFacets: () => card }),
+    )
+    const headingIndex = scene.nodes.findIndex((n) => n.kind === 'heading')
+    const textChromeIndex = scene.nodes.findIndex(
+      (n) => n.kind === 'shape' && n.bbox.x === 400 && n.bbox.y === 100,
+    )
+    expect(headingIndex).toBeGreaterThanOrEqual(0)
+    expect(textChromeIndex).toBeGreaterThan(headingIndex)
   })
 })


### PR DESCRIPTION
Slice A of facet-driven node rendering. **Foundation-only by design**: nothing consumes the seam yet, so every existing output is byte-identical. apps/web wiring is slice B.

## What lands

- `resolveFileFacets?: (file: string) => FacetCardData | undefined` on `SpatialLayoutOptions`, mirroring `resolveFileImage`'s contract exactly — synchronous, optional, caller-supplied, total.
- `FacetCardData` is a plain TS type, `{ title?, rows: {label, value}[] }` — deliberately **presentation-shaped, not domain-shaped**. The caller maps facets to a card; canvas-render never learns what a facet *means*. No Zod: it never crosses a process boundary (decision #1).
- `composeFileFacets` is the third and last step of the file-node pre-pass, per the agreed precedence: **image > canvas embed > facet card > plain label**.

The `kicker` field from the sketch was dropped with a reason: the theme has exactly one label text scale, so a kicker would render indistinguishably from a row. Add it when a second scale exists, not before.

## Why it does not grow the package's surface

- Card text goes through the existing `layoutMdastBlocks` producer (heading + paragraph blocks only, never `list`/`table`), so no second text-layout producer appears and `translateScene`'s listItem/tableCell transform-boundary tripwire (decision #5) stays untouched.
- No new geometry constant: width from `contentWidth`/`options.geometry`, gaps and sizes from `mdast-blocks.ts`.
- No color literal — family comes from the injected `appearance.resolveLabel()`, so light/dark still flows only from the resolver (decision #6/#8).
- No new `SpatialLayoutDegradation` kind: server-core consumes that union through an exhaustive record, and "no card data" is the common case, not an error worth reporting.

## Degradation is the primary path, and it is pinned

Absent resolver, `undefined` return, a throw, and a card whose title and rows are all empty/whitespace each `return undefined` and fall through to the **pre-existing** `case 'file'` branch — the same code, not a copy that could drift. Verified deep-equal *and* byte-equal through `renderSceneToSvg` against the no-seam baseline.

Overflowing content is truncated at whole-block granularity, with a `ponytail:` marker naming the ceiling: a "more" affordance needs a focusable overlay and keyboard treatment that a pure-geometry package cannot own.

## Verification

- Red-first: four failing tests referencing the not-yet-existing seam, then green.
- Precedence, degradation matrix, and determinism pinned in `spatial-embed.test.ts` — placed there because that file already owns the file-node pre-pass suites including the existing image-beats-embed test, so the third rung sits beside the two it is ranked against.
- Two new fast-check properties (totality + determinism with a resolving resolver; additivity against a no-op resolver), mutation-checked by making the card path depend on an ambient counter and confirming red.
- SVG determinism goldens (node + browser) and the pixel goldens unchanged — confirmed by running them, not by reasoning.
- `pnpm test` (703 files), `pnpm -r typecheck`, `pnpm knip` all clean.

Docs: decision #10's forward-looking "a future `resolveFileFacets`" is replaced with the shipped seam, its precedence position and its degradation contract.

No visual evidence applicable — by construction nothing renders this yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ