### PR TITLE
feat(web): render a referenced document's core facets on its file node

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -66,6 +66,7 @@ import type {
 } from '@kamiazya/whiteboard-canvas-model'
 import type {
   EdgeSides,
+  FacetCardData,
   MeasureText,
   SpatialPresetKey,
   TextMetrics,
@@ -306,6 +307,7 @@ export interface SpatialEditorProps {
    * returns undefined and the card renders. Absent → embeds never expand.
    */
   readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
+  readonly resolveFileFacets?: (file: string) => FacetCardData | undefined
   /** Image content for media file nodes (data:/blob: href). Sync, cached by the host. */
   readonly resolveFileImage?: (
     file: string,
@@ -416,6 +418,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       onOpenFileRef,
       paletteLeading,
       resolveFileCanvas,
+      resolveFileFacets,
       resolveFileImage,
       onAddImage,
       isImageFileRef,
@@ -627,25 +630,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const byFile = new Map(fileRefOptions.map((option) => [option.file, option.label]))
       return (file: string) => byFile.get(file)
     }, [fileRefOptions])
+    // ONE object for every render path below (committed scene, drag ghost,
+    // drag-static backdrop, resize preview). Four hand-listed copies is how a
+    // seam ends up wired into the committed render and missing from the drag
+    // overlay, which reads as content vanishing mid-gesture.
+    const fileSeamOptions = useMemo(
+      () => ({
+        resolveFileLabel,
+        resolveFileCanvas,
+        expandFileNode,
+        resolveFileImage,
+        resolveFileFacets,
+      }),
+      [resolveFileLabel, resolveFileCanvas, expandFileNode, resolveFileImage, resolveFileFacets],
+    )
     const { svg, bounds, scene } = useMemo(
       () =>
         renderCanvasToSvg(canvas, {
           measure: resolvedMeasure,
           theme,
-          resolveFileLabel,
-          resolveFileCanvas,
-          expandFileNode,
-          resolveFileImage,
+          ...fileSeamOptions,
         }),
-      [
-        canvas,
-        resolvedMeasure,
-        theme,
-        resolveFileLabel,
-        resolveFileCanvas,
-        expandFileNode,
-        resolveFileImage,
-      ],
+      [canvas, resolvedMeasure, theme, fileSeamOptions],
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
@@ -743,10 +749,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         {
           measure: resolvedMeasure,
           theme,
-          resolveFileLabel,
-          resolveFileCanvas,
-          expandFileNode,
-          resolveFileImage,
+          ...fileSeamOptions,
         },
       )
       return {
@@ -763,10 +766,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       lockedNodeIds,
       resolvedMeasure,
       theme,
-      resolveFileLabel,
-      resolveFileCanvas,
-      expandFileNode,
-      resolveFileImage,
+      fileSeamOptions,
     ])
 
     /**
@@ -803,10 +803,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       const rendered = renderCanvasToSvg(base, {
         measure: resolvedMeasure,
         theme,
-        resolveFileLabel,
-        resolveFileCanvas,
-        expandFileNode,
-        resolveFileImage,
+        ...fileSeamOptions,
       })
       const metricsCache = new Map<string, TextMetrics>()
       const measure: MeasureText = (text, font) => {
@@ -835,10 +832,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       lockedNodeIds,
       resolvedMeasure,
       theme,
-      resolveFileLabel,
-      resolveFileCanvas,
-      expandFileNode,
-      resolveFileImage,
+      fileSeamOptions,
     ])
 
     useImperativeHandle(
@@ -1037,24 +1031,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         {
           measure: dragStatic.measure,
           theme,
-          resolveFileLabel,
-          resolveFileCanvas,
-          expandFileNode,
-          resolveFileImage,
+          ...fileSeamOptions,
         },
       )
       return { svg: rendered.svg, bounds: rendered.bounds }
-    }, [
-      gestureState,
-      dragPreview,
-      dragStatic,
-      canvas,
-      theme,
-      resolveFileLabel,
-      resolveFileCanvas,
-      expandFileNode,
-      resolveFileImage,
-    ])
+    }, [gestureState, dragPreview, dragStatic, canvas, theme, fileSeamOptions])
 
     /**
      * How far a snap guide extends, in canvas space: across all content plus

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -67,6 +67,23 @@ describe('theme resolver purity (no ambient DOM read)', () => {
   })
 })
 
+describe('file seams reach every render path', () => {
+  it('SpatialEditor builds its file-seam options once and spreads them everywhere', () => {
+    // Four render paths draw the same nodes — committed scene, drag ghost,
+    // drag-static backdrop, resize preview. When each listed the seams by
+    // hand, adding one meant remembering four places, and the failure mode
+    // is silent: content that renders committed and vanishes mid-gesture.
+    const source = modules['./SpatialEditor.tsx'] as string
+    expect(source.match(/const fileSeamOptions = useMemo\(/g) ?? []).toHaveLength(1)
+    const renderCalls = (source.match(/renderCanvasToSvg\(/g) ?? []).length
+    const spreads = (source.match(/\.\.\.fileSeamOptions/g) ?? []).length
+    expect(spreads).toBe(renderCalls)
+    // A seam named at a call site instead of inside the shared object is the
+    // regression this pins.
+    expect(source).not.toMatch(/renderCanvasToSvg\([\s\S]{0,400}?resolveFileCanvas,/)
+  })
+})
+
 describe('single content path (S10 guardrail)', () => {
   it('raw HTML injection exists ONLY at the two documented scene-svg sinks', async () => {
     // String-level TRIPWIRE, not a syntax-aware proof: it catches the ways

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -6,7 +6,12 @@
  */
 import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
-import type { BoundingBox, MeasureText, Scene } from '@kamiazya/whiteboard-canvas-render'
+import type {
+  BoundingBox,
+  FacetCardData,
+  MeasureText,
+  Scene,
+} from '@kamiazya/whiteboard-canvas-render'
 import {
   layoutSpatialCanvas,
   renderSceneToSvg,
@@ -30,6 +35,8 @@ export interface RenderCanvasOptions {
   readonly resolveFileImage?: (
     file: string,
   ) => { readonly href: string; readonly alt?: string } | undefined
+  /** Passed through to layout: the referenced document's facets as card content. */
+  readonly resolveFileFacets?: (file: string) => FacetCardData | undefined
 }
 
 export interface RenderedCanvas {
@@ -71,6 +78,7 @@ export function renderCanvasToSvg(
     resolveFileCanvas: options.resolveFileCanvas,
     expandFileNode: options.expandFileNode,
     resolveFileImage: options.resolveFileImage,
+    resolveFileFacets: options.resolveFileFacets,
   })
   const bounds = sceneBounds(scene)
   const svg = renderSceneToSvg(scene, {

--- a/apps/web/src/hooks/use-canvas-file-seams.test.tsx
+++ b/apps/web/src/hooks/use-canvas-file-seams.test.tsx
@@ -5,10 +5,10 @@
  * same-instance guard, URL revocation) are subtle enough that a second
  * hand-written copy is exactly what should not happen.
  */
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { CoreFacets, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { type CanvasFileAdapter, useCanvasFileSeams } from './use-canvas-file-seams.js'
+import { type CanvasFileAdapter, toFacetCard, useCanvasFileSeams } from './use-canvas-file-seams.js'
 
 const canvasWith = (...files: string[]): SpatialCanvas => ({
   nodes: files.map((file, i) => ({
@@ -31,7 +31,7 @@ const embedded = (text: string): SpatialCanvas => ({
 function makeAdapter(overrides: Partial<CanvasFileAdapter> = {}) {
   const adapter: CanvasFileAdapter = {
     isImageRef: (file) => file.startsWith('asset:'),
-    loadCanvas: vi.fn(async (ref: string) => embedded(ref)),
+    loadDocument: vi.fn(async (ref: string) => ({ canvas: embedded(ref) })),
     loadImageUrl: vi.fn(async (ref: string) => `blob:${ref}`),
     storeImage: vi.fn(async () => 'asset:new'),
     ...overrides,
@@ -69,8 +69,8 @@ describe('useCanvasFileSeams', () => {
 
     await waitFor(() => expect(result.current.resolveFileImage('asset:pic')).toBeDefined())
     expect(result.current.resolveFileImage('asset:pic')).toEqual({ href: 'blob:asset:pic' })
-    expect(adapter.loadCanvas).toHaveBeenCalledWith('sibling')
-    expect(adapter.loadCanvas).not.toHaveBeenCalledWith('asset:pic')
+    expect(adapter.loadDocument).toHaveBeenCalledWith('sibling')
+    expect(adapter.loadDocument).not.toHaveBeenCalledWith('asset:pic')
     expect(adapter.loadImageUrl).not.toHaveBeenCalledWith('sibling')
   })
 
@@ -83,15 +83,15 @@ describe('useCanvasFileSeams', () => {
       { initialProps: { stampOf: new Map([['other', 'v1']]) as ReadonlyMap<string, string> } },
     )
     await waitFor(() => expect(result.current.resolveFileCanvas('other')).toBeDefined())
-    expect(adapter.loadCanvas).toHaveBeenCalledTimes(1)
+    expect(adapter.loadDocument).toHaveBeenCalledTimes(1)
 
     // Same stamp, new map identity: a re-render must not re-fetch.
     rerender({ stampOf: new Map([['other', 'v1']]) })
-    expect(adapter.loadCanvas).toHaveBeenCalledTimes(1)
+    expect(adapter.loadDocument).toHaveBeenCalledTimes(1)
 
     // Moved stamp: the referenced canvas was edited elsewhere.
     rerender({ stampOf: new Map([['other', 'v2']]) })
-    await waitFor(() => expect(adapter.loadCanvas).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(adapter.loadDocument).toHaveBeenCalledTimes(2))
   })
 
   it('does not spin when every image load fails', async () => {
@@ -145,5 +145,123 @@ describe('useCanvasFileSeams', () => {
 
     expect(result.current.isImageFileRef('asset:pic')).toBe(true)
     expect(result.current.isImageFileRef('sibling')).toBe(false)
+  })
+})
+
+describe('toFacetCard', () => {
+  it('maps a type-only facet set to a titled card with one row', () => {
+    expect(toFacetCard({ type: 'note' })).toEqual({
+      title: 'note',
+      rows: [{ label: 'type', value: 'note' }],
+    })
+  })
+
+  it('prefers the facet title over the type for the heading', () => {
+    expect(toFacetCard({ type: 'note', title: 'Spec' })).toEqual({
+      title: 'Spec',
+      rows: [{ label: 'type', value: 'note' }],
+    })
+  })
+
+  it('joins tags into one row and omits the row when there are none', () => {
+    expect(toFacetCard({ type: 'note', tags: ['a', 'b'] })?.rows).toEqual([
+      { label: 'type', value: 'note' },
+      { label: 'tags', value: 'a, b' },
+    ])
+    expect(toFacetCard({ type: 'note', tags: [] })?.rows).toEqual([
+      { label: 'type', value: 'note' },
+    ])
+  })
+
+  it('renders no row for facets the card deliberately does not show', () => {
+    // `view` selects a template; it is not content. Unknown root keys are
+    // preserved by the model but have no agreed presentation.
+    // `readCoreFacets` returns core facets PLUS `facetsRaw`, so the extra key
+    // really does arrive at runtime even though the parameter narrows it away.
+    const facets = { type: 'note', view: 'kanban/1', facetsRaw: { owner: 'x' } } as CoreFacets
+    const card = toFacetCard(facets)
+    expect(card?.rows).toEqual([{ label: 'type', value: 'note' }])
+  })
+
+  it('has no card for a document with no readable facets', () => {
+    expect(toFacetCard(undefined)).toBeUndefined()
+  })
+})
+
+describe('useCanvasFileSeams facets', () => {
+  it('resolves core facets once the document has been pre-fetched', async () => {
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async (ref: string) => ({
+        canvas: embedded(ref),
+        facets: { type: 'note', title: 'Spec', tags: ['x'] },
+      })),
+    })
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('other'), adapter, stampOf: new Map() }),
+    )
+
+    expect(result.current.resolveFileFacets('other')).toBeUndefined()
+    await waitFor(() => expect(result.current.resolveFileFacets('other')).toBeDefined())
+    expect(result.current.resolveFileFacets('other')?.title).toBe('Spec')
+  })
+
+  it('keeps a facet-only document cached even though it has no canvas', async () => {
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async () => ({ facets: { type: 'note' } })),
+    })
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('doc'), adapter, stampOf: new Map() }),
+    )
+
+    await waitFor(() => expect(result.current.resolveFileFacets('doc')).toBeDefined())
+    expect(result.current.resolveFileCanvas('doc')).toBeUndefined()
+  })
+
+  it('has no card for a document that loads without facets', async () => {
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async (ref: string) => ({ canvas: embedded(ref) })),
+    })
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('other'), adapter, stampOf: new Map() }),
+    )
+
+    await waitFor(() => expect(result.current.resolveFileCanvas('other')).toBeDefined())
+    expect(result.current.resolveFileFacets('other')).toBeUndefined()
+  })
+
+  it('settles at one load for a reference that has no staleness stamp', async () => {
+    // The write normalises a missing stamp to '' while the compare read the
+    // raw `undefined`, so a dangling reference never matched its own recorded
+    // stamp and reloaded on every render.
+    const adapter = makeAdapter()
+    const canvas = canvasWith('dangling')
+    const { rerender } = renderHook(() =>
+      useCanvasFileSeams({ canvas, adapter, stampOf: new Map() }),
+    )
+
+    await waitFor(() => expect(adapter.loadDocument).toHaveBeenCalledTimes(1))
+    rerender()
+    rerender()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(adapter.loadDocument).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useCanvasFileSeams empty canvases', () => {
+  it('has nothing to embed for a document whose canvas has no nodes', async () => {
+    // A markdown document reads back this way; an empty miniature outranks
+    // the facet card and shows less than it would.
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async () => ({
+        canvas: { nodes: [], edges: [] },
+        facets: { type: 'note' },
+      })),
+    })
+    const { result } = renderHook(() =>
+      useCanvasFileSeams({ canvas: canvasWith('note'), adapter, stampOf: new Map() }),
+    )
+
+    await waitFor(() => expect(result.current.resolveFileFacets('note')).toBeDefined())
+    expect(result.current.resolveFileCanvas('note')).toBeUndefined()
   })
 })

--- a/apps/web/src/hooks/use-canvas-file-seams.ts
+++ b/apps/web/src/hooks/use-canvas-file-seams.ts
@@ -13,16 +13,31 @@
  * Totality mirrors the layout seam: any load failure resolves to `undefined`
  * and the editor keeps the card — a broken reference never takes down a page.
  */
-import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { CoreFacets, SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { FacetCardData } from '@kamiazya/whiteboard-canvas-render'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { collectFileRefs } from '../lib/canvas-embed-content.js'
+
+/**
+ * What one reference resolves to. Both halves are optional and independent:
+ * a markdown document has facets and no spatial content, and a canvas
+ * written before facets existed has content and none.
+ */
+export interface LoadedFileDocument {
+  readonly canvas?: SpatialCanvas
+  readonly facets?: CoreFacets
+}
 
 /** What a backend must supply for the seams to work against it. */
 export interface CanvasFileAdapter {
   /** Distinguishes a stored image asset from a reference to another canvas. */
   isImageRef(file: string): boolean
-  /** Resolves a canvas reference to its spatial content, or undefined. */
-  loadCanvas(ref: string): Promise<SpatialCanvas | undefined>
+  /**
+   * Resolves a reference to the document behind it. Facets ride along on the
+   * load the embed seam already performs — a second fetch just to read four
+   * frontmatter fields would double every referenced document's cost.
+   */
+  loadDocument(ref: string): Promise<LoadedFileDocument | undefined>
   /** Resolves an image reference to a displayable URL, or undefined. */
   loadImageUrl(ref: string): Promise<string | undefined>
   /** Stores a picked/dropped/pasted image, returning its new reference. */
@@ -42,6 +57,7 @@ export interface UseCanvasFileSeamsOptions {
 
 export interface CanvasFileSeams {
   resolveFileCanvas: (file: string) => SpatialCanvas | undefined
+  resolveFileFacets: (file: string) => FacetCardData | undefined
   resolveFileImage: (file: string) => { href: string } | undefined
   onAddImage: (file: File) => Promise<string | undefined>
   isImageFileRef: (file: string) => boolean
@@ -52,7 +68,9 @@ export function useCanvasFileSeams({
   adapter,
   stampOf,
 }: UseCanvasFileSeamsOptions): CanvasFileSeams {
-  const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, SpatialCanvas>>(new Map())
+  const [embedContent, setEmbedContent] = useState<ReadonlyMap<string, LoadedFileDocument>>(
+    new Map(),
+  )
   const embedStampsRef = useRef<Map<string, string>>(new Map())
   // Image assets are immutable once stored, so object URLs cache for the
   // lifetime of the page and are revoked together on unmount.
@@ -76,19 +94,26 @@ export function useCanvasFileSeams({
   useEffect(() => {
     const refs = collectFileRefs(canvas).filter((ref) => !adapterRef.current.isImageRef(ref))
     if (refs.length === 0) return
+    // Normalised on BOTH sides: the write below stores `?? ''`, so comparing
+    // against a raw `undefined` left a reference with no stamp entry (a
+    // dangling one, or a document absent from the page's list) permanently
+    // stale, reloading it on every render.
     const stale = refs.filter(
-      (ref) => !embedContent.has(ref) || embedStampsRef.current.get(ref) !== stampOf.get(ref),
+      (ref) =>
+        !embedContent.has(ref) || embedStampsRef.current.get(ref) !== (stampOf.get(ref) ?? ''),
     )
     if (stale.length === 0) return
     let cancelled = false
     void Promise.all(
-      stale.map(async (ref) => [ref, await adapterRef.current.loadCanvas(ref)] as const),
+      stale.map(async (ref) => [ref, await adapterRef.current.loadDocument(ref)] as const),
     ).then((loaded) => {
       if (cancelled) return
       setEmbedContent((prev) => {
         const next = new Map(prev)
-        for (const [ref, content] of loaded) {
-          if (content !== undefined) next.set(ref, content)
+        for (const [ref, document] of loaded) {
+          // A document with facets but no canvas is still a cache HIT — it is
+          // what renders the facet card.
+          if (document !== undefined) next.set(ref, document)
           else next.delete(ref)
           embedStampsRef.current.set(ref, stampOf.get(ref) ?? '')
         }
@@ -130,7 +155,20 @@ export function useCanvasFileSeams({
     }
   }, [canvas, imageUrls])
 
-  const resolveFileCanvas = useCallback((file: string) => embedContent.get(file), [embedContent])
+  const resolveFileCanvas = useCallback(
+    (file: string) => {
+      // A markdown document reads back as a canvas with no nodes. Embedding
+      // one draws an empty frame that outranks the facet card and shows
+      // strictly less, so "nothing to embed" is the honest answer.
+      const canvas = embedContent.get(file)?.canvas
+      return canvas === undefined || canvas.nodes.length === 0 ? undefined : canvas
+    },
+    [embedContent],
+  )
+  const resolveFileFacets = useCallback(
+    (file: string) => toFacetCard(embedContent.get(file)?.facets),
+    [embedContent],
+  )
   const resolveFileImage = useCallback(
     (file: string) => {
       const href = imageUrls.get(file)
@@ -141,5 +179,25 @@ export function useCanvasFileSeams({
   const onAddImage = useCallback((file: File) => adapterRef.current.storeImage(file), [])
   const isImageFileRef = useCallback((file: string) => adapterRef.current.isImageRef(file), [])
 
-  return { resolveFileCanvas, resolveFileImage, onAddImage, isImageFileRef }
+  return { resolveFileCanvas, resolveFileFacets, resolveFileImage, onAddImage, isImageFileRef }
+}
+
+/**
+ * The one place core facets become card content. canvas-render is told WHAT
+ * to draw and never what a facet means, so every semantic choice — which
+ * field is the heading, which become rows, what a tag list reads like — is
+ * made here.
+ *
+ * `view` selects a template rather than carrying content, and `facetsRaw`
+ * holds keys with no agreed presentation, so neither renders.
+ */
+export function toFacetCard(facets: CoreFacets | undefined): FacetCardData | undefined {
+  if (facets === undefined) return undefined
+  const rows = [{ label: 'type', value: facets.type }]
+  if (facets.tags !== undefined && facets.tags.length > 0) {
+    rows.push({ label: 'tags', value: facets.tags.join(', ') })
+  }
+  // `type` is required by the schema, so a parsed facet set always yields a
+  // heading and at least one row — an empty card is unrepresentable here.
+  return { title: facets.title ?? facets.type, rows }
 }

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -10,9 +10,9 @@
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'
-import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { readCoreFacets, readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
-import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
+import type { CanvasFileAdapter, LoadedFileDocument } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
 import { CanvasFileStore } from './canvas-file-store.js'
 import { LoroStore } from './loro-store.js'
@@ -20,16 +20,18 @@ import { LoroStore } from './loro-store.js'
 const log = getAppLogger('canvas-embed-content')
 
 /** Loads one referenced canvas's spatial content from IndexedDB. */
-async function loadEmbeddedSpatialCanvas(canvasId: string): Promise<SpatialCanvas | undefined> {
+async function loadEmbeddedDocument(canvasId: string): Promise<LoadedFileDocument | undefined> {
   try {
     const result = await new LoroStore().load(canvasId)
     if (result.kind !== 'ok') return undefined
     const doc = new Loro()
     doc.import(result.snapshot)
     for (const delta of result.deltas ?? []) doc.import(delta)
-    return readSpatialCanvas(doc)
+    // One load, both reads — the doc used to be discarded after the canvas
+    // read, which is why facets need no second store round-trip.
+    return { canvas: readSpatialCanvas(doc), facets: readCoreFacets(doc) }
   } catch (err) {
-    log.warn('embedded canvas load failed', { canvasId, err })
+    log.warn('embedded document load failed', { canvasId, err })
     return undefined
   }
 }
@@ -73,7 +75,7 @@ async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
  */
 export const BROWSER_LOCAL_FILE_ADAPTER: CanvasFileAdapter = {
   isImageRef,
-  loadCanvas: loadEmbeddedSpatialCanvas,
+  loadDocument: loadEmbeddedDocument,
   loadImageUrl: loadImageAssetUrl,
   storeImage: storeImageAsset,
 }

--- a/apps/web/src/lib/daemon-file-adapter.test.ts
+++ b/apps/web/src/lib/daemon-file-adapter.test.ts
@@ -129,10 +129,10 @@ describe('createDaemonFileAdapter', () => {
       slug: SLUG,
     })
 
-    const loaded = await adapter.loadCanvas('sibling')
+    const loaded = await adapter.loadDocument('sibling')
 
     expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/sibling/snapshot`)
-    expect(loaded?.nodes[0]).toMatchObject({ id: 'n1', text: 'hello' })
+    expect(loaded?.canvas?.nodes[0]).toMatchObject({ id: 'n1', text: 'hello' })
   })
 
   it('resolves an unreachable referenced canvas to undefined', async () => {
@@ -146,7 +146,7 @@ describe('createDaemonFileAdapter', () => {
       slug: SLUG,
     })
 
-    await expect(adapter.loadCanvas('sibling')).resolves.toBeUndefined()
+    await expect(adapter.loadDocument('sibling')).resolves.toBeUndefined()
   })
 
   it('percent-encodes a slug on its way into the path', async () => {
@@ -158,7 +158,7 @@ describe('createDaemonFileAdapter', () => {
       slug: SLUG,
     })
 
-    await adapter.loadCanvas('a b')
+    await adapter.loadDocument('a b')
 
     expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/a%20b/snapshot`)
   })

--- a/apps/web/src/lib/daemon-file-adapter.ts
+++ b/apps/web/src/lib/daemon-file-adapter.ts
@@ -10,7 +10,7 @@
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { imageRefId, isImageRef, newImageRef } from '@kamiazya/whiteboard-canvas-model'
-import { readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { readCoreFacets, readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { Loro } from 'loro-crdt'
 import type { CanvasFileAdapter } from '../hooks/use-canvas-file-seams.js'
 import { getAppLogger } from './app-logger.js'
@@ -36,15 +36,17 @@ export function createDaemonFileAdapter({
   return {
     isImageRef,
 
-    async loadCanvas(ref) {
+    async loadDocument(ref) {
       try {
         const res = await daemonFetch(`${canvasPath(ref)}/snapshot`)
         if (!res.ok) return undefined
         const doc = new Loro()
         doc.import(new Uint8Array(await res.arrayBuffer()))
-        return readSpatialCanvas(doc) as SpatialCanvas
+        // One snapshot, both reads: the doc used to be discarded after the
+        // canvas read, which is why facets needed no second request.
+        return { canvas: readSpatialCanvas(doc) as SpatialCanvas, facets: readCoreFacets(doc) }
       } catch (err) {
-        log.warn('referenced canvas load failed', { ref, err })
+        log.warn('referenced document load failed', { ref, err })
         return undefined
       }
     },


### PR DESCRIPTION
Slice B of facet-driven node rendering, and the increment that makes it visible: the seam canvas-render shipped in #708 now has a producer, so a file node pointing at a document with facets shows its title, type and tags instead of a bare reference label.

## Visual repro

![facet-card-after.jpg](https://github.com/user-attachments/assets/e574f5d3-bf5c-46f8-93e8-ce7e8b0fdbfe)

Left: a file node referencing a markdown document with `type: note`, `title: Rendering spec`, `tags: [render, facets]`. Right: a dangling reference, still rendering today's plain card — the degradation path, unchanged.

## How facets are sourced

They ride along on the load the embed seam already performs. Both adapters built a `LoroDoc`, read the canvas out of it and **discarded the doc**, so `readCoreFacets` needs no second fetch and no second cache: `loadCanvas` becomes `loadDocument` returning both halves, and a document with facets but no canvas is a cache **hit** rather than a miss.

`toFacetCard` is the one place facets become card content — canvas-render is told what to draw and never what a facet *means*. `view` selects a template rather than carrying content and `facetsRaw` has no agreed presentation, so neither renders. `type` is required by the schema, so a parsed facet set always yields a heading and at least one row: an empty card is unrepresentable rather than guarded against.

## Three defects found while wiring it

- **A reference with no staleness stamp reloaded on every render.** The write normalised a missing stamp to `''` while the compare read the raw `undefined`, so a dangling reference never matched its own recorded stamp. Pinned by a test that a stamp-less ref settles at exactly one load.
- **A node-less canvas embedded as an empty frame.** That is what a markdown document reads back as, and the embed outranks the facet card, so the card could never appear for the main use case while the frame showed strictly less. `resolveFileCanvas` now answers "nothing to embed".
- **Four render paths listed the seams by hand** (committed scene, drag ghost, drag-static backdrop, resize preview). They share one memoized object now, so a new seam cannot reach the committed render and miss the drag overlay — the defect class that reads as content vanishing mid-gesture. A source guard asserts the object is built once and spread at every `renderCanvasToSvg` call; mutation-checked by dropping one spread.

## Verification

Driven in the running app against a seeded markdown document, reading the rendered SVG: the card emits `Rendering spec` / `type: note` / `tags: render, facets`, the dangling reference beside it keeps its plain label, and the card content survives a drag.

17 hook/mapping tests (table-driven mapping incl. the `view`/`facetsRaw` exclusions, the facet-only cache entry, the no-facets case, the stamp-reload regression, the node-less-canvas case), both adapters updated with their tests, `pnpm test` green except a known load-flake in `sse-shared-worker` that passes in isolation, `pnpm -r typecheck` and `pnpm knip` clean.

## Noted, not fixed here

"New canvas" on the browser-local index page is a silent no-op once a canvas already exists — no new row, no error. It blocked this verification (I seeded the document instead) and is unrelated to this change; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ