### PR TITLE
fix(canvas-render): stop routed paths doubling back, and meet perpendicular sides at one corner

### DIFF
--- a/apps/web/src/components/spatial-editor/edge-curved-hit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-curved-hit.browser.test.tsx
@@ -10,7 +10,7 @@ import { SpatialEditor } from './SpatialEditor.js'
 afterEach(cleanup)
 
 // a → b routes as a one-bend L with its corner at (480,130); the drawn
-// curve's apex for that corner is (450,151.25), well off the waypoint
+// curve's apex for that corner is (450,153.75), well off the waypoint
 // polyline.
 const canvas: SpatialCanvas = {
   nodes: [
@@ -35,8 +35,8 @@ it('selects a curved edge by clicking the drawn curve, and highlights along it',
   await vi.waitFor(() => expect(container.querySelector('svg path[d*="Q"]')).not.toBeNull())
 
   // The curve's apex — on the ink, 20px away from the waypoint polyline.
-  fireEvent.pointerDown(root, { pointerId: 1, clientX: 450, clientY: 151.25, buttons: 1 })
-  fireEvent.pointerUp(root, { pointerId: 1, clientX: 450, clientY: 151.25 })
+  fireEvent.pointerDown(root, { pointerId: 1, clientX: 450, clientY: 153.75, buttons: 1 })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: 450, clientY: 153.75 })
 
   await vi.waitFor(() =>
     expect(container.querySelector('[data-testid="edge-selection-highlight"]')).not.toBeNull(),
@@ -51,6 +51,6 @@ it('selects a curved edge by clicking the drawn curve, and highlights along it',
     const [x, y] = pair.split(',').map(Number)
     return { x: x as number, y: y as number }
   })
-  expect(points.some((p) => Math.hypot(p.x - 450, p.y - 151.25) < 2)).toBe(true)
+  expect(points.some((p) => Math.hypot(p.x - 450, p.y - 153.75) < 2)).toBe(true)
   expect(points.some((p) => p.x === 480 && p.y === 130)).toBe(false)
 })

--- a/packages/canvas-render/src/layout/edge-one-bend.test.ts
+++ b/packages/canvas-render/src/layout/edge-one-bend.test.ts
@@ -1,0 +1,77 @@
+// The arrival stub is what makes a perpendicular pair read as two corners
+// instead of one: the route reaches the elbow, continues 20px PAST the
+// arrival anchor, then comes back to it. The departure stub stays — its
+// depth is what separates edges that share a side into distinct
+// corridors — so a one-corner route still carries a collinear stub point.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const node = (id: string, x: number, y: number, width: number, height: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width,
+  height,
+  text: '',
+})
+
+const edge = (id: string, fromNode: string, toNode: string, rest: Partial<CanvasEdge> = {}) =>
+  ({ id, fromNode, toNode, ...rest }) as CanvasEdge
+
+/** Direction changes between horizontal and vertical travel. */
+function bendCount(path: readonly { x: number; y: number }[]): number {
+  let bends = 0
+  let axis: 'h' | 'v' | undefined
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    if (a.x === b.x && a.y === b.y) continue
+    const next = a.x === b.x ? 'v' : 'h'
+    if (axis !== undefined && next !== axis) bends++
+    axis = next
+  }
+  return bends
+}
+
+it('meets perpendicular sides at one corner instead of stubbing out of both', () => {
+  const nodes = [node('A', 100, 570, 200, 100), node('B', 246, 510, 200, 100)]
+  const edges = [edge('e', 'A', 'B')]
+  const anchors = assignEdgeAnchors(
+    nodes,
+    edges,
+    'orthogonal',
+    new Map([['e', { fromSide: 'right' as const, toSide: 'bottom' as const }]]),
+  )
+
+  const { path } = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
+
+  // A's right anchor already sits below B's bottom border, so the arrival
+  // needs no excursion under it: right (through the departure stub, which
+  // is collinear and so draws as one straight run), then up.
+  expect(path).toEqual([
+    { x: 300, y: 620 },
+    { x: 320, y: 620 },
+    { x: 346, y: 620 },
+    { x: 346, y: 610 },
+  ])
+  expect(bendCount(path)).toBe(1)
+})
+
+it('keeps stubbing out when the corner would sit inside the arrival side', () => {
+  // B is ABOVE A's right anchor here, so travelling right-then-up would
+  // reach B's bottom from inside it. The stub-and-elbow path is correct.
+  const nodes = [node('A', 100, 570, 200, 100), node('B', 400, 300, 200, 100)]
+  const edges = [edge('e', 'A', 'B')]
+  const anchors = assignEdgeAnchors(
+    nodes,
+    edges,
+    'orthogonal',
+    new Map([['e', { fromSide: 'right' as const, toSide: 'top' as const }]]),
+  )
+
+  const { path } = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
+
+  expect(path.length).toBeGreaterThan(3)
+})

--- a/packages/canvas-render/src/layout/edge-one-bend.test.ts
+++ b/packages/canvas-render/src/layout/edge-one-bend.test.ts
@@ -1,8 +1,11 @@
-// The arrival stub is what makes a perpendicular pair read as two corners
-// instead of one: the route reaches the elbow, continues 20px PAST the
-// arrival anchor, then comes back to it. The departure stub stays — its
-// depth is what separates edges that share a side into distinct
-// corridors — so a one-corner route still carries a collinear stub point.
+// Two things make a perpendicular pair read badly. The arrival stub sends
+// the route 20px PAST the anchor and back, which is a hook rather than a
+// corner. And the corner's distance from the arrival side is whatever the
+// departure anchor happened to be, which can leave the final segment
+// shorter than the arrowhead drawn on it — a marker stuck to the box with
+// no line behind it. The departure stub itself stays: its depth is what
+// separates edges sharing a side into distinct corridors, so a one-corner
+// route still carries a collinear stub point.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { expect, it } from 'vitest'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
@@ -47,16 +50,19 @@ it('meets perpendicular sides at one corner instead of stubbing out of both', ()
 
   const { path } = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
 
-  // A's right anchor already sits below B's bottom border, so the arrival
-  // needs no excursion under it: right (through the departure stub, which
-  // is collinear and so draws as one straight run), then up.
+  // Right (through the collinear departure stub, so it draws as one
+  // straight run), then up. The departure slid from y=620 to y=630 so the
+  // final segment is 20px — the arrowhead's own length plus as much again
+  // of plain line.
   expect(path).toEqual([
-    { x: 300, y: 620 },
-    { x: 320, y: 620 },
-    { x: 346, y: 620 },
+    { x: 300, y: 630 },
+    { x: 320, y: 630 },
+    { x: 346, y: 630 },
     { x: 346, y: 610 },
   ])
   expect(bendCount(path)).toBe(1)
+  const approach = Math.abs((path[3] as { y: number }).y - (path[2] as { y: number }).y)
+  expect(approach).toBeGreaterThanOrEqual(20)
 })
 
 it('keeps stubbing out when the corner would sit inside the arrival side', () => {

--- a/packages/canvas-render/src/layout/edge-path-reversal.test.ts
+++ b/packages/canvas-render/src/layout/edge-path-reversal.test.ts
@@ -5,11 +5,11 @@
 // apart, never collinear, so nothing catches it before path-reversal.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { expect, it } from 'vitest'
-import { COST_QUANTUM } from './edge-rules.js'
 import {
   assertQuantumSeparated,
   referenceReversalCount as reversalCount,
 } from '../test-utils/reversal-count.js'
+import { COST_QUANTUM } from './edge-rules.js'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
 
 const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({

--- a/packages/canvas-render/src/layout/edge-path-reversal.test.ts
+++ b/packages/canvas-render/src/layout/edge-path-reversal.test.ts
@@ -5,7 +5,11 @@
 // apart, never collinear, so nothing catches it before path-reversal.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { expect, it } from 'vitest'
-import { referenceReversalCount as reversalCount } from '../test-utils/reversal-count.js'
+import { COST_QUANTUM } from './edge-rules.js'
+import {
+  assertQuantumSeparated,
+  referenceReversalCount as reversalCount,
+} from '../test-utils/reversal-count.js'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
 
 const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
@@ -35,6 +39,9 @@ it('never settles A->B on a route that reverses on both axes, on the exact user 
   const { path } = routeEdge(userCanvasNodes, ab, 'orthogonal', anchors.get('ab'))
   // A route may legitimately carry ONE reversal (a deliberate U-hook, see
   // the reachability pin below) — but never a double-axis knot.
+  // Routed anchors are fractional, so state the oracle's domain before
+  // trusting it — see reversal-count.ts.
+  assertQuantumSeparated(path, 1 / COST_QUANTUM)
   expect(reversalCount(path)).toBeLessThanOrEqual(1)
 })
 
@@ -43,6 +50,7 @@ it('keeps T->A and T->B reversal-free on the same canvas (the fix must not buy t
   for (const id of ['ta', 'tb']) {
     const edge = userCanvasEdges.find((e) => e.id === id) as CanvasEdge
     const { path } = routeEdge(userCanvasNodes, edge, 'orthogonal', anchors.get(id))
+    assertQuantumSeparated(path, 1 / COST_QUANTUM)
     expect(reversalCount(path)).toBe(0)
   }
 })
@@ -59,5 +67,6 @@ it('keeps a deliberate U-hook reachable for an interpenetrating pair with no val
   // (top/top) — every candidate here reverses once, so they tie on the new
   // tier and incumbent-wins-ties + the existing preference order decide.
   expect(anchors.get('ab2')).toMatchObject({ fromSide: 'top', toSide: 'top' })
+  assertQuantumSeparated(path, 1 / COST_QUANTUM)
   expect(reversalCount(path)).toBe(1)
 })

--- a/packages/canvas-render/src/layout/edge-path-reversal.test.ts
+++ b/packages/canvas-render/src/layout/edge-path-reversal.test.ts
@@ -1,0 +1,86 @@
+// A routed path must never double back on itself: moving up then down, or
+// left then right, on the SAME axis reads as a small knot/loop hanging off
+// the node even though no other tier (overlap, border-tracing,
+// endpoint-body-ink) prices it — the two retrograde segments are a few px
+// apart, never collinear, so nothing catches it before path-reversal.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+/** Independent oracle (never calls production code): direction reversals
+ * per axis along a polyline — a segment whose sign on an axis is opposite
+ * to the last non-zero sign on that same axis. */
+function reversalCount(path: readonly { x: number; y: number }[]): number {
+  let reversals = 0
+  let lastSignX: number | undefined
+  let lastSignY: number | undefined
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    const sx = Math.sign(b.x - a.x)
+    const sy = Math.sign(b.y - a.y)
+    if (sx !== 0) {
+      if (lastSignX !== undefined && sx === -lastSignX) reversals++
+      lastSignX = sx
+    }
+    if (sy !== 0) {
+      if (lastSignY !== undefined && sy === -lastSignY) reversals++
+      lastSignY = sy
+    }
+  }
+  return reversals
+}
+
+const userCanvasNodes = [
+  box('A', 100, 570, 200, 100),
+  box('B', 246, 510, 200, 100),
+  box('T', 80, 360, 200, 110),
+]
+const userCanvasEdges: CanvasEdge[] = [
+  { id: 'ab', fromNode: 'A', toNode: 'B' },
+  { id: 'ta', fromNode: 'T', toNode: 'A', label: 'hoge' },
+  { id: 'tb', fromNode: 'T', toNode: 'B' },
+]
+
+it('never settles A->B on a route that reverses on both axes, on the exact user canvas', () => {
+  const anchors = assignEdgeAnchors(userCanvasNodes, userCanvasEdges, 'orthogonal')
+  const ab = userCanvasEdges[0] as CanvasEdge
+  const { path } = routeEdge(userCanvasNodes, ab, 'orthogonal', anchors.get('ab'))
+  // A route may legitimately carry ONE reversal (a deliberate U-hook, see
+  // the reachability pin below) — but never a double-axis knot.
+  expect(reversalCount(path)).toBeLessThanOrEqual(1)
+})
+
+it('keeps T->A and T->B reversal-free on the same canvas (the fix must not buy the knot back on a neighbour)', () => {
+  const anchors = assignEdgeAnchors(userCanvasNodes, userCanvasEdges, 'orthogonal')
+  for (const id of ['ta', 'tb']) {
+    const edge = userCanvasEdges.find((e) => e.id === id) as CanvasEdge
+    const { path } = routeEdge(userCanvasNodes, edge, 'orthogonal', anchors.get(id))
+    expect(reversalCount(path)).toBe(0)
+  }
+})
+
+it('keeps a deliberate U-hook reachable for an interpenetrating pair with no valid alternative', () => {
+  // Same-axis interpenetrating boxes: no zero-bend facing pair, no L-pair,
+  // no gap-valid opposing pair — u-hook-when-degenerate's exact geometry.
+  const nodes = [box('A2', 0, 0, 100, 100), box('B2', 50, 0, 100, 100)]
+  const edges: CanvasEdge[] = [{ id: 'ab2', fromNode: 'A2', toNode: 'B2' }]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const ab2 = edges[0] as CanvasEdge
+  const { path } = routeEdge(nodes, ab2, 'orthogonal', anchors.get('ab2'))
+  // Settled pair stays the same-side hook it settled on before the rule
+  // (top/top) — every candidate here reverses once, so they tie on the new
+  // tier and incumbent-wins-ties + the existing preference order decide.
+  expect(anchors.get('ab2')).toMatchObject({ fromSide: 'top', toSide: 'top' })
+  expect(reversalCount(path)).toBe(1)
+})

--- a/packages/canvas-render/src/layout/edge-path-reversal.test.ts
+++ b/packages/canvas-render/src/layout/edge-path-reversal.test.ts
@@ -5,6 +5,7 @@
 // apart, never collinear, so nothing catches it before path-reversal.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { expect, it } from 'vitest'
+import { referenceReversalCount as reversalCount } from '../test-utils/reversal-count.js'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
 
 const box = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
@@ -16,30 +17,6 @@ const box = (id: string, x: number, y: number, w: number, h: number): SpatialNod
   height: h,
   text: id,
 })
-
-/** Independent oracle (never calls production code): direction reversals
- * per axis along a polyline — a segment whose sign on an axis is opposite
- * to the last non-zero sign on that same axis. */
-function reversalCount(path: readonly { x: number; y: number }[]): number {
-  let reversals = 0
-  let lastSignX: number | undefined
-  let lastSignY: number | undefined
-  for (let i = 1; i < path.length; i++) {
-    const a = path[i - 1] as { x: number; y: number }
-    const b = path[i] as { x: number; y: number }
-    const sx = Math.sign(b.x - a.x)
-    const sy = Math.sign(b.y - a.y)
-    if (sx !== 0) {
-      if (lastSignX !== undefined && sx === -lastSignX) reversals++
-      lastSignX = sx
-    }
-    if (sy !== 0) {
-      if (lastSignY !== undefined && sy === -lastSignY) reversals++
-      lastSignY = sy
-    }
-  }
-  return reversals
-}
 
 const userCanvasNodes = [
   box('A', 100, 570, 200, 100),

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -8,6 +8,7 @@
 // of them.
 import { describe, expect, it } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { referenceReversalCount } from '../test-utils/reversal-count.js'
 import {
   bendCount,
   COST_QUANTUM,
@@ -514,31 +515,9 @@ const orthogonalPathArb: fc.Arbitrary<readonly Point[]> = fc
     return path
   })
 
-/** Independent oracle (never calls production code): direction reversals
- * per axis. All generator coordinates are integers, so COST_QUANTUM
- * rounding in the production rule never changes a sign here — no
- * quantization drift to account for, unlike the ink-length oracles above. */
-function referenceReversalCount(path: readonly Point[]): number {
-  let reversals = 0
-  let lastSignX: number | undefined
-  let lastSignY: number | undefined
-  for (let i = 1; i < path.length; i++) {
-    const a = path[i - 1] as Point
-    const b = path[i] as Point
-    const sx = Math.sign(b.x - a.x)
-    const sy = Math.sign(b.y - a.y)
-    if (sx !== 0) {
-      if (lastSignX !== undefined && sx === -lastSignX) reversals++
-      lastSignX = sx
-    }
-    if (sy !== 0) {
-      if (lastSignY !== undefined && sy === -lastSignY) reversals++
-      lastSignY = sy
-    }
-  }
-  return reversals
-}
-
+// All generator coordinates here are integers, so COST_QUANTUM rounding in
+// the production rule never changes a sign — no quantization drift to
+// account for against the oracle, unlike the ink-length oracles above.
 const pathReversalRule = penaltyRule('path-reversal')
 
 describe('path-reversal: dense-orthogonal-walk property (mutation-checked)', () => {

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -6,9 +6,10 @@
 // why the other candidate-contributing rules are presence-gated, not
 // order-only) plus a weaker monotonic-removal property that holds for all
 // of them.
-import { describe, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import {
+  bendCount,
   COST_QUANTUM,
   composeSidePairs,
   hasRepairableProblem,
@@ -485,6 +486,117 @@ describe('border-tracing / endpoint-body-ink: no double-charge', () => {
       const border = borderTracingRule.selfTerm([a, b], [], [rect], [])
       const endpointInk = endpointBodyInkRule.selfTerm([a, b], [], [], [rect])
       expect(Math.min(border, endpointInk)).toBe(0)
+    },
+  )
+})
+
+// path-reversal-specific properties: pathArb's four-point-max, +-200-range
+// generic domain rarely lands two consecutive same-axis moves with opposite
+// signs (passes vacuously — see AGENTS.md's PBT discipline), so this domain
+// builds a path as an explicit walk of alternating-or-not axis moves, dense
+// enough that a same-axis sign flip (a reversal) is common rather than rare.
+const axisMoveArb = fc.record({
+  axis: fc.constantFrom<'h' | 'v'>('h', 'v'),
+  delta: fc.integer({ min: -20, max: 20 }),
+})
+
+const orthogonalPathArb: fc.Arbitrary<readonly Point[]> = fc
+  .array(axisMoveArb, { minLength: 0, maxLength: 10 })
+  .map((moves) => {
+    let x = 0
+    let y = 0
+    const path: Point[] = [{ x, y }]
+    for (const move of moves) {
+      if (move.axis === 'h') x += move.delta
+      else y += move.delta
+      path.push({ x, y })
+    }
+    return path
+  })
+
+/** Independent oracle (never calls production code): direction reversals
+ * per axis. All generator coordinates are integers, so COST_QUANTUM
+ * rounding in the production rule never changes a sign here — no
+ * quantization drift to account for, unlike the ink-length oracles above. */
+function referenceReversalCount(path: readonly Point[]): number {
+  let reversals = 0
+  let lastSignX: number | undefined
+  let lastSignY: number | undefined
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    const sx = Math.sign(b.x - a.x)
+    const sy = Math.sign(b.y - a.y)
+    if (sx !== 0) {
+      if (lastSignX !== undefined && sx === -lastSignX) reversals++
+      lastSignX = sx
+    }
+    if (sy !== 0) {
+      if (lastSignY !== undefined && sy === -lastSignY) reversals++
+      lastSignY = sy
+    }
+  }
+  return reversals
+}
+
+const pathReversalRule = penaltyRule('path-reversal')
+
+describe('path-reversal: dense-orthogonal-walk property (mutation-checked)', () => {
+  it('the generator actually produces reversing paths (not vacuous)', () => {
+    const samples = fc.sample(orthogonalPathArb, 200)
+    expect(samples.some((path) => referenceReversalCount(path) > 0)).toBe(true)
+  })
+
+  fcTest.prop([orthogonalPathArb], withDefaults())(
+    'the path-reversal term is a finite, non-negative, integral, deterministic total',
+    (path) => {
+      const term1 = pathReversalRule.selfTerm(path, [], [], [])
+      const term2 = pathReversalRule.selfTerm(path, [], [], [])
+      expect(term1).toBe(term2)
+      expect(Number.isInteger(term1)).toBe(true)
+      expect(term1).toBeGreaterThanOrEqual(0)
+    },
+  )
+
+  // The property that actually catches a "returns 0" or otherwise-wrong
+  // mutation: totality/determinism above hold trivially for a stub that
+  // always returns 0, so this is the one that must go red under mutation
+  // (verified: reverting pathReversal.selfTerm to `() => 0` fails this
+  // test, confirming the dense generator reaches real reversals).
+  fcTest.prop([orthogonalPathArb], withDefaults())(
+    'agrees with an independently-computed per-axis reversal count',
+    (path) => {
+      expect(pathReversalRule.selfTerm(path, [], [], [])).toBe(referenceReversalCount(path))
+    },
+  )
+
+  fcTest.prop(
+    [orthogonalPathArb, fc.integer({ min: -500, max: 500 }), fc.integer({ min: -500, max: 500 })],
+    withDefaults(),
+  )('is invariant under translating the whole path by any offset', (path, dx, dy) => {
+    const translated = path.map((p) => ({ x: p.x + dx, y: p.y + dy }))
+    expect(pathReversalRule.selfTerm(translated, [], [], [])).toBe(
+      pathReversalRule.selfTerm(path, [], [], []),
+    )
+  })
+
+  fcTest.prop([orthogonalPathArb], withDefaults())(
+    'is invariant under reversing the point order',
+    (path) => {
+      const reversed = [...path].reverse()
+      expect(pathReversalRule.selfTerm(reversed, [], [], [])).toBe(
+        pathReversalRule.selfTerm(path, [], [], []),
+      )
+    },
+  )
+
+  // Cross-rule: a reversal is always a direction change, so this tier can
+  // never exceed its realized-bends sibling — ties the two rules together
+  // instead of letting them drift independently.
+  fcTest.prop([orthogonalPathArb], withDefaults())(
+    'reversalCount never exceeds bendCount, for any generated path',
+    (path) => {
+      expect(pathReversalRule.selfTerm(path, [], [], [])).toBeLessThanOrEqual(bendCount(path))
     },
   )
 })

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -242,13 +242,14 @@ describe('u-hook-span-exposed-first', () => {
 })
 
 describe('PENALTY_RULES', () => {
-  it('declares the six named tiers in tier order, realized-bends last', () => {
+  it('declares the seven named tiers in tier order, realized-bends last', () => {
     expect(PENALTY_RULES.map((r) => r.name)).toEqual([
       'overlap-and-intrusion',
       'illegibility',
       'crossings',
       'border-tracing',
       'endpoint-body-ink',
+      'path-reversal',
       'realized-bends',
     ])
     PENALTY_RULES.forEach((rule, i) => {
@@ -266,18 +267,20 @@ describe('overlap-and-intrusion', () => {
       { x: 10, y: 0 },
       { x: 30, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([10 * COST_QUANTUM, 0, 0, 0, 0, 0, 0])
   })
 
   it('self term: a path retracing its own ink contributes the quantized retrace length to tier 0', () => {
     // Out to (20,0), back to (5,0): the [20,0]-[5,0] segment retraces
-    // [0,0]-[20,0] over x in [5,20], a 15px overlap.
+    // [0,0]-[20,0] over x in [5,20], a 15px overlap. The doubling-back on x
+    // also reverses once (tier 5), and the direction change is one bend
+    // (tier 6).
     const path = [
       { x: 0, y: 0 },
       { x: 20, y: 0 },
       { x: 5, y: 0 },
     ]
-    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 0, 1])
+    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 0, 1, 1])
   })
 
   it('self term: a segment through a foreign rect interior contributes the quantized chord length to tier 0', () => {
@@ -286,7 +289,7 @@ describe('overlap-and-intrusion', () => {
       { x: 110, y: 50 },
     ]
     const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
-    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0, 0, 0])
+    expect(selfPenalty(path, [rect])).toEqual([100 * COST_QUANTUM, 0, 0, 0, 0, 0, 0])
   })
 
   it('self term: a segment riding exactly on the rect boundary contributes 0 (grazing exclusion)', () => {
@@ -308,7 +311,7 @@ describe('illegibility', () => {
       { x: 1, y: 9 },
       { x: 9, y: 1 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 1, 1, 0, 0, 0, 0])
   })
 
   it('pair term: a transversal crossing far from every end contributes 0 to tier 1', () => {
@@ -318,7 +321,7 @@ describe('illegibility', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0, 0])
   })
 })
 
@@ -330,7 +333,7 @@ describe('crossings', () => {
       { x: 0, y: 100 },
       { x: 100, y: 0 },
     )
-    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0])
+    expect(pairPenalty(triple)).toEqual([0, 0, 1, 0, 0, 0, 0])
   })
 
   it('collinear overlap short-circuits the crossing count for that segment pair', () => {
@@ -353,7 +356,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
   })
 
   it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to tier 3', () => {
@@ -361,7 +364,7 @@ describe('border-tracing', () => {
       { x: 100, y: 0 },
       { x: 100, y: 40 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0, 0, 0])
   })
 
   it('self term: a perpendicular segment touching the border at a single point contributes 0', () => {
@@ -413,7 +416,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
   })
 
   it('defaults nodeBorders to [] when omitted, contributing 0 (no border ink declared)', () => {
@@ -433,7 +436,7 @@ describe('endpoint-body-ink', () => {
       { x: -10, y: 20 },
       { x: 110, y: 20 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 100 * COST_QUANTUM, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 100 * COST_QUANTUM, 0, 0])
   })
 
   it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to tier 4', () => {
@@ -441,7 +444,7 @@ describe('endpoint-body-ink', () => {
       { x: 50, y: -10 },
       { x: 50, y: 50 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 40 * COST_QUANTUM, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 40 * COST_QUANTUM, 0, 0])
   })
 
   it('self term: a segment riding exactly on the border contributes 0 to this tier (border-tracing prices it instead, no double-charge)', () => {
@@ -528,6 +531,94 @@ describe('endpoint-body-ink', () => {
   })
 })
 
+describe('path-reversal', () => {
+  const tier = (PENALTY_RULES.find((r) => r.name === 'path-reversal') as PenaltyRule).tier
+
+  it.each([
+    [
+      'straight',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      0,
+    ],
+    [
+      'clean L',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      0,
+    ],
+    [
+      'Z (right, down, right — never undoes a direction)',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 20, y: 10 },
+      ],
+      0,
+    ],
+    [
+      'U-hook (right, down, left)',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ],
+      1,
+    ],
+    [
+      'the reported knot: up, left, down, right — reverses on BOTH axes',
+      [
+        { x: 233.33333333333331, y: 570 },
+        { x: 233.33333333333331, y: 550 },
+        { x: 226, y: 550 },
+        { x: 226, y: 560 },
+        { x: 246, y: 560 },
+      ],
+      2,
+    ],
+    ['empty', [], 0],
+    ['single point', [{ x: 0, y: 0 }], 0],
+    [
+      'repeated identical points',
+      [
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+      ],
+      0,
+    ],
+    [
+      'a path of only zero-length segments',
+      [
+        { x: 5, y: 5 },
+        { x: 5, y: 5 },
+      ],
+      0,
+    ],
+  ] as const)('%s path contributes %i to its declared tier', (_label, path, expected) => {
+    const cost = selfPenalty(path, [])
+    expect(cost[tier]).toBe(expected)
+    expect(cost.every((n) => Number.isFinite(n) && n >= 0)).toBe(true)
+  })
+
+  it('pair term is always 0 (self-only rule)', () => {
+    const triple = scoreSegmentPair(
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+      { x: 100, y: 0 },
+    )
+    expect(pairPenalty(triple)[tier]).toBe(0)
+  })
+})
+
 describe('realized-bends', () => {
   it.each([
     [
@@ -568,25 +659,26 @@ describe('realized-bends', () => {
       ],
       0,
     ],
-  ] as const)('%s path contributes %i to tier 5', (_label, path, expected) => {
+  ] as const)('%s path contributes %i to tier 6', (_label, path, expected) => {
     const cost = selfPenalty(path, [])
-    expect(cost[5]).toBe(expected)
+    expect(cost[6]).toBe(expected)
     expect(cost.every((n) => Number.isFinite(n) && n >= 0)).toBe(true)
   })
 })
 
 describe('hasRepairableProblem', () => {
   it('is false when the only nonzero tier is the last (realized-bends) tier', () => {
-    expect(hasRepairableProblem([0, 0, 0, 0, 0, 5])).toBe(false)
+    expect(hasRepairableProblem([0, 0, 0, 0, 0, 0, 5])).toBe(false)
   })
 
   it.each([
-    [[1, 0, 0, 0, 0, 0]],
-    [[0, 1, 0, 0, 0, 0]],
-    [[0, 0, 1, 0, 0, 0]],
-    [[0, 0, 0, 1, 0, 0]],
-    [[0, 0, 0, 0, 1, 0]],
-    [[1, 1, 1, 1, 1, 5]],
+    [[1, 0, 0, 0, 0, 0, 0]],
+    [[0, 1, 0, 0, 0, 0, 0]],
+    [[0, 0, 1, 0, 0, 0, 0]],
+    [[0, 0, 0, 1, 0, 0, 0]],
+    [[0, 0, 0, 0, 1, 0, 0]],
+    [[0, 0, 0, 0, 0, 1, 0]],
+    [[1, 1, 1, 1, 1, 1, 5]],
   ] as const)('is true when a non-final tier is nonzero: %j', (cost) => {
     expect(hasRepairableProblem(cost)).toBe(true)
   })
@@ -596,11 +688,15 @@ describe('hasRepairableProblem', () => {
   })
 
   it('is true when the only nonzero tier is border-tracing (repairable, unlike realized-bends)', () => {
-    expect(hasRepairableProblem([0, 0, 0, 7, 0, 0])).toBe(true)
+    expect(hasRepairableProblem([0, 0, 0, 7, 0, 0, 0])).toBe(true)
   })
 
   it('is true when the only nonzero tier is endpoint-body-ink (repairable, unlike realized-bends)', () => {
-    expect(hasRepairableProblem([0, 0, 0, 0, 7, 0])).toBe(true)
+    expect(hasRepairableProblem([0, 0, 0, 0, 7, 0, 0])).toBe(true)
+  })
+
+  it('is true when the only nonzero tier is path-reversal (repairable, unlike realized-bends)', () => {
+    expect(hasRepairableProblem([0, 0, 0, 0, 0, 7, 0])).toBe(true)
   })
 
   it('is false when rules is empty (guards Math.max(...[]) === -Infinity)', () => {
@@ -610,14 +706,14 @@ describe('hasRepairableProblem', () => {
 
 describe('addCost', () => {
   it('sums two cost arrays tier-by-tier with sign=1', () => {
-    expect(addCost([1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60], 1)).toEqual([
-      11, 22, 33, 44, 55, 66,
+    expect(addCost([1, 2, 3, 4, 5, 6, 7], [10, 20, 30, 40, 50, 60, 70], 1)).toEqual([
+      11, 22, 33, 44, 55, 66, 77,
     ])
   })
 
   it('subtracts b from a tier-by-tier with sign=-1', () => {
-    expect(addCost([10, 20, 30, 40, 50, 60], [1, 2, 3, 4, 5, 6], -1)).toEqual([
-      9, 18, 27, 36, 45, 54,
+    expect(addCost([10, 20, 30, 40, 50, 60, 70], [1, 2, 3, 4, 5, 6, 7], -1)).toEqual([
+      9, 18, 27, 36, 45, 54, 63,
     ])
   })
 

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -652,14 +652,89 @@ const endpointBodyInk: PenaltyRule = {
     ),
 }
 
+/** Quantized per-axis direction sign, in the same COST_QUANTUM space every
+ * other ink-length term is measured in — anchors are fractional (a slid
+ * anchor can land at e.g. 233.333...px), so a raw `Math.sign` would read a
+ * sub-quarter-pixel rounding wobble as a reversal. */
+function quantizedSign(a: number, b: number): number {
+  return Math.sign(Math.round(b * COST_QUANTUM) - Math.round(a * COST_QUANTUM))
+}
+
+/** Direction reversals per axis along a polyline: a segment whose sign on
+ * an axis is opposite to the last NON-ZERO sign this walk saw on that same
+ * axis. Axes are tracked independently (unlike `bendCount`, which combines
+ * both axes into one direction pair) — a Z zig-zags through two different
+ * combined directions without ever undoing either axis alone, so it must
+ * read 0 here while still reading 2 bends. */
+function reversalCount(path: readonly Point[]): number {
+  let reversals = 0
+  let lastSignX: number | undefined
+  let lastSignY: number | undefined
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    const sx = quantizedSign(a.x, b.x)
+    const sy = quantizedSign(a.y, b.y)
+    if (sx !== 0) {
+      if (lastSignX !== undefined && sx === -lastSignX) reversals++
+      lastSignX = sx
+    }
+    if (sy !== 0) {
+      if (lastSignY !== undefined && sy === -lastSignY) reversals++
+      lastSignY = sy
+    }
+  }
+  return reversals
+}
+
+/**
+ * path-reversal: a routed path that doubles back on itself — moving up
+ * then down, or left then right, on the SAME axis. This is invisible to
+ * every tier above it: the two retrograde segments of the defect this rule
+ * was written for sit a few px apart (never collinear), so
+ * overlap-and-intrusion's self-retrace check never fires, and there is no
+ * foreign-body ink and no crossing either. A route like this reads on
+ * screen as a small knot hanging off the node, independent of and often
+ * shorter than a clean alternative — a length-based term would keep
+ * choosing it, so this rule counts reversals, not length.
+ *
+ * Self-only, and REPAIRABLE (unlike its `realized-bends` neighbour): a
+ * deliberate same-side U-hook over an interpenetrating pair (see
+ * `u-hook-when-degenerate`) also reverses once by construction, so this
+ * tier alone cannot forbid a reversal outright — it can only rank a
+ * reversal-free route ahead of a reversing one when both are otherwise
+ * candidates, which is exactly what makes the knot repairable while a
+ * genuinely unavoidable hook still settles.
+ *
+ * Tier placement is evidence-driven, same discipline as border-tracing and
+ * endpoint-body-ink above: on the canvas this rule exists to fix, every
+ * tier below `endpoint-body-ink` is zero for the settled configuration
+ * (`hasRepairableProblem` was false, so the optimizer never evaluated a
+ * single candidate), so the rule has to sit BELOW the last declared tier to
+ * change the outcome at all. It sits directly above `realized-bends` —
+ * the lowest repairable slot — rather than higher: this file's own history
+ * (border-tracing tier 1 -> 3, endpoint-body-ink placed below it) is a
+ * rule scored against the optimizer's UNALIGNED TRIAL paths, where a
+ * higher tier risks an artifact outranking a real signal; the lowest
+ * repairable slot is the least aggressive placement that still fixes the
+ * defect.
+ */
+const pathReversal: PenaltyRule = {
+  name: 'path-reversal',
+  tier: 5,
+  pairTerm: () => 0,
+  selfTerm: (path) => reversalCount(path),
+}
+
 /** realized-bends: direction changes along ONE routed path. Self-only, and
- * deliberately the last tier — the optimizer's short-circuit
+ * deliberately the LAST tier — the optimizer's short-circuit
  * (`hasRepairableProblem`) and worst-offender filter both ignore it, since
- * a configuration with no overlap/illegibility/crossings is already healthy
- * and reshuffling it purely to shave bends is churn, not repair. */
+ * a configuration with no overlap/illegibility/crossings/reversal is
+ * already healthy and reshuffling it purely to shave bends is churn, not
+ * repair. */
 const realizedBends: PenaltyRule = {
   name: 'realized-bends',
-  tier: 5,
+  tier: 6,
   pairTerm: () => 0,
   selfTerm: (path) => bendCount(path),
 }
@@ -676,6 +751,7 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   crossings,
   borderTracing,
   endpointBodyInk,
+  pathReversal,
   realizedBends,
 ]
 

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1107,7 +1107,7 @@ function withoutRepeats(path: readonly Point[]): Point[] {
  * edge around a region that is not there.
  */
 function routeOrthogonal(
-  start: Point,
+  startAnchor: Point,
   end: Point,
   fromSide: Side,
   toSide: Side,
@@ -1118,6 +1118,7 @@ function routeOrthogonal(
   inflated: readonly Rect[],
   raw: readonly Rect[],
 ): Point[] {
+  let start = startAnchor
   // Zero-bend shortcut: two ends on OPPOSING, mutually facing sides can
   // often share one tangent coordinate — anchors are renderer-chosen
   // defaults, so sliding one end along its side buys a single straight
@@ -1165,9 +1166,31 @@ function routeOrthogonal(
       }
     }
   }
+  const toNormal = outwardNormal(toSide)
+  // An arrowhead is ARROW_LENGTH long and is drawn ON the final segment, so
+  // an approach shorter than this leaves the arrow with no line behind it —
+  // it reads as a marker stuck to the box rather than an edge arriving at
+  // it. Two arrow-lengths gives the head its own run plus the same again of
+  // plain line.
+  const MIN_APPROACH_PX = 20
+  // Perpendicular pairs take their corner from the DEPARTURE anchor's
+  // tangent coordinate, so the approach is only as long as that anchor is
+  // far from the arrival side. Sliding the departure along its own side
+  // lengthens it without adding a corner; a side with no room to slide
+  // keeps the anchor and falls through to the stub-and-elbow path.
+  if (fromSide !== toSide && fromSide !== oppositeSide(toSide)) {
+    const approach = toNormal.x * (start.x - end.x) + toNormal.y * (start.y - end.y)
+    if (approach > 0 && approach < MIN_APPROACH_PX) {
+      const shortfall = MIN_APPROACH_PX - approach
+      const slid = slideAlongSide(start, fromRect, fromSide, {
+        x: start.x + toNormal.x * shortfall,
+        y: start.y + toNormal.y * shortfall,
+      })
+      if (slid !== undefined) start = slid
+    }
+  }
   const exit = stubFrom(start, fromSide, fromDepth)
   const entry = stubFrom(end, toSide, toDepth)
-  const toNormal = outwardNormal(toSide)
   // The arrival stub exists so the last segment reaches the anchor from
   // OUTSIDE its side. When the elbow already sits outside, on the arrival
   // axis, the stub only buys a detour past the anchor and back — a 20px

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1167,8 +1167,21 @@ function routeOrthogonal(
   }
   const exit = stubFrom(start, fromSide, fromDepth)
   const entry = stubFrom(end, toSide, toDepth)
-  const between = (middles: readonly Point[]) =>
-    withoutRepeats([start, exit, ...middles, entry, end])
+  const toNormal = outwardNormal(toSide)
+  // The arrival stub exists so the last segment reaches the anchor from
+  // OUTSIDE its side. When the elbow already sits outside, on the arrival
+  // axis, the stub only buys a detour past the anchor and back — a 20px
+  // excursion that reads as a hook and reverses direction on that axis.
+  // The DEPARTURE stub is never dropped the same way: its depth is what
+  // separates edges sharing one side into distinct corridors.
+  const arrivesFromOutside = (point: Point) =>
+    toNormal.x * (point.x - end.x) + toNormal.y * (point.y - end.y) > 0 &&
+    (toNormal.x === 0 ? point.x === end.x : point.y === end.y)
+  const between = (middles: readonly Point[]) => {
+    const last = middles[middles.length - 1]
+    const approach = last !== undefined && arrivesFromOutside(last) ? [] : [entry]
+    return withoutRepeats([start, exit, ...middles, ...approach, end])
+  }
 
   const elbows = [between([{ x: entry.x, y: exit.y }]), between([{ x: exit.x, y: entry.y }])]
   if (elbows.some((path) => pathIsClear(path, inflated))) {

--- a/packages/canvas-render/src/test-utils/reversal-count.ts
+++ b/packages/canvas-render/src/test-utils/reversal-count.ts
@@ -1,0 +1,27 @@
+/**
+ * Independent oracle for the `path-reversal` penalty rule: direction
+ * reversals per axis along a polyline — a segment whose sign on an axis is
+ * opposite to the last non-zero sign on that same axis. Deliberately never
+ * calls production code, so a test asserting against it cannot be satisfied
+ * by a broken rule agreeing with itself.
+ */
+export function referenceReversalCount(path: readonly { x: number; y: number }[]): number {
+  let reversals = 0
+  let lastSignX: number | undefined
+  let lastSignY: number | undefined
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    const sx = Math.sign(b.x - a.x)
+    const sy = Math.sign(b.y - a.y)
+    if (sx !== 0) {
+      if (lastSignX !== undefined && sx === -lastSignX) reversals++
+      lastSignX = sx
+    }
+    if (sy !== 0) {
+      if (lastSignY !== undefined && sy === -lastSignY) reversals++
+      lastSignY = sy
+    }
+  }
+  return reversals
+}

--- a/packages/canvas-render/src/test-utils/reversal-count.ts
+++ b/packages/canvas-render/src/test-utils/reversal-count.ts
@@ -4,6 +4,12 @@
  * opposite to the last non-zero sign on that same axis. Deliberately never
  * calls production code, so a test asserting against it cannot be satisfied
  * by a broken rule agreeing with itself.
+ *
+ * Compares RAW coordinates, where the rule compares them quantized by
+ * COST_QUANTUM. The two agree only while every per-axis step is either zero
+ * or at least one quantum, so callers supply integer or quantum-separated
+ * geometry — `assertQuantumSeparated` states that contract for a caller
+ * feeding it real routed paths, whose anchors are fractional.
  */
 export function referenceReversalCount(path: readonly { x: number; y: number }[]): number {
   let reversals = 0
@@ -24,4 +30,27 @@ export function referenceReversalCount(path: readonly { x: number; y: number }[]
     }
   }
   return reversals
+}
+
+/**
+ * Guards the oracle's stated domain for a caller that feeds it real routed
+ * geometry. Without it, a future route carrying a sub-quantum wobble would
+ * fail the comparison as if the RULE were wrong, which is the most expensive
+ * kind of red: a correct implementation accused by its own oracle.
+ */
+export function assertQuantumSeparated(
+  path: readonly { x: number; y: number }[],
+  quantum: number,
+): void {
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    for (const step of [Math.abs(b.x - a.x), Math.abs(b.y - a.y)]) {
+      if (step !== 0 && step < quantum) {
+        throw new Error(
+          `path step ${step} is below one quantum (${quantum}); the raw-coordinate oracle does not model this path`,
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Three routing defects reported from the app on the same overlapping-nodes canvas, each surfacing once the one before it was fixed: the edge drew a **small knot**; then it connected with **two corners where one would do**; then the final leg was **exactly as long as the arrowhead**, leaving the arrow no line behind it.

A `{100,570,200,100}`, B `{246,510,200,100}` (overlapping), T `{80,360,200,110}`; edges A→B, T→A, T→B; orthogonal.

```
reported   (233,570)(233,550)(226,550)(226,560)(246,560)   knot: up, left 7, down 10, right 20
after #1   (200,670)(200,690)(346,690)(346,610)            no knot, but the long way round
after #2   (300,620)(320,620)(346,620)(346,610)            one corner, 10px approach
after #3   (300,630)(320,630)(346,630)(346,610)            one corner, 20px approach
```

Neither is a regression: the same probe at `42114d78^`, before any of this session's routing work, reproduces the original knot exactly.

## 1. `path-reversal` — a new PENALTY tier

Every existing tier scored the knot **zero**: not ink-on-ink, not ink-through-a-body, just a path that doubles back on itself. `overlap-and-intrusion`'s self-retrace half only counts *collinear* self-overlap, and those two vertical segments are 7px apart.

Enumerating all 16 side pairs showed the discriminator is **reversals, not length** — the defective route was the *shortest of all sixteen*, so any length term would have kept choosing it. The new rule counts per-axis direction reversals, quantized in the same `COST_QUANTUM` space as its siblings.

Tier placement was forced by a measurement rather than chosen: on this canvas the whole-config cost is all-zero, so `hasRepairableProblem` is false and the optimizer returns without evaluating a candidate. The rule had to sit strictly below the last tier — tier 5, the lowest repairable slot, with `realized-bends` renumbering to 6 and staying last (its churn-avoidance exclusion is load-bearing).

## 2. Dropping the arrival stub

The stub-and-elbow construction always leaves *both* anchors along their outward normals. When the elbow already sits outside the arrival side, on the arrival axis, the arrival stub only buys a detour 20px past the anchor and back — the hook that made a perpendicular pair read as two corners.

**The departure stub is deliberately untouched.** Its depth is what separates edges sharing one side into distinct corridors. A first attempt at a symmetric one-bend shortcut broke exactly that: `edge-routing.properties`' "every member of a shared side exits through a distinct corridor" property plus both lane-depth pins. Scoped to the arrival, all three stay green.

The two changes compose: with the excursion gone, `right→bottom` loses its reversal, which makes the configuration repairable, so the optimizer settles there instead of the long way round.

## 3. A minimum approach length

A perpendicular pair takes its corner from the departure anchor's tangent coordinate, so the final segment is only as long as that anchor happened to be from the arrival side — 10px here, exactly `ARROW_LENGTH`. The departure now slides along its own side until the approach reaches 20px: the head's own length plus as much again of plain line. Sliding costs no corner, and `slideAlongSide` already refuses to leave the side's usable span, so a side with no room keeps its anchor and falls through unchanged.

## Verification

![arrow-runway-after.jpg](https://github.com/user-attachments/assets/b4360a7e-7f3c-4a68-8981-41e289e05f4e)

Confirmed in the running app on the reported canvas, read from the rendered SVG: `316,646 336,646 362,646 362,626` — the same route modulo the paste offset, drawing as one straight run, a single turn, and a visible line under the arrowhead.

- Red-first pins for both defects, each failing before its fix.
- A **U-hook reachability pin**: an interpenetrating pair whose candidates all reverse still settles where it did before — measured, not assumed.
- Unit cases (straight/L/Z = 0, U-hook = 1, the knot = 2, degenerate inputs = 0) read through the rule's *declared* tier, never a hardcoded slot.
- Properties: totality, determinism, independent-oracle equality, translation invariance, point-order invariance, `reversals ≤ bends`, with an explicit density assertion that the generator actually produces reversing paths.
- Mutation-checked both ways: neutralising the rule reddens the pin and every property; moving it to the last tier reddens the catalog pin, proving the repairable-slot placement is load-bearing.
- The oracle's raw-coordinate domain is documented and guarded (`assertQuantumSeparated`), so a future route that leaves it says so instead of accusing a correct rule — a CodeRabbit finding, verified and fixed.

**One expectation moved, and it is geometry, not a weakening**: `edge-curved-hit.browser.test.tsx` pins the drawn curve's apex, which shifts 2.5px because the redundant collinear waypoint no longer caps the corner's rounding allowance. Mutation-checked that the updated pin still reddens when hit-testing stops following the drawn curve.

Full repo suite green (705 files, no flake), typecheck and knip clean, SVG determinism goldens byte-identical. No pin moved for changes 2 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ
