### PR TITLE
fix(canvas-viewer): name the rendered canvas for assistive technology

### DIFF
--- a/.claude/rules/package-canvas-viewer.md
+++ b/.claude/rules/package-canvas-viewer.md
@@ -65,6 +65,17 @@ paths:
   injected string and escapes `&`/`<`/`>` in text and `"`/`'` in attribute
   values (`packages/canvas-render/src/svg/format.ts`). No sanitizer
   dependency is added because of this.
+- The injected SVG is wrapped in a **named `<figure>` element** (the
+  element, not `role="figure"` on a div — biome's `useSemanticElements`
+  enforces that, and its UA margin is cleared since this is a layout
+  container the host sizes), never `role="img"`.
+  The SVG's `<text>` runs are real content and, until canvas-render grows
+  the a11y projection it defers, the only way a screen reader reaches any
+  of it; `img` would supply a name while marking every child
+  presentational, buying the label at the cost of the content. The name
+  itself comes from the host (`label`, defaulting to "Canvas") because a
+  document's name lives in the workspace, never in canvas content
+  (vocabulary.md).
 - `VIEWER_FONT_FAMILY` and mcp-server's `EXPORT_FONT_FAMILY` name the same
   font family ("Roboto") in two packages that cannot import each other —
   a deliberate, documented duplication (see `font.ts`'s comment). A font

--- a/packages/canvas-viewer/src/CanvasViewer.a11y.test.tsx
+++ b/packages/canvas-viewer/src/CanvasViewer.a11y.test.tsx
@@ -1,0 +1,48 @@
+// The injected SVG had no role and no name: to a screen reader the viewer was
+// an unlabelled generic box whose only content was a stream of disconnected
+// text runs. It needs a NAME without losing that content — `role="img"` would
+// have supplied the name while marking every child presentational, trading the
+// one access path there is for a label. `figure` names the region and keeps
+// its children reachable, which is the honest interim until canvas-render
+// grows the a11y projection its README defers.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CanvasViewer } from './CanvasViewer.js'
+
+const fakeMeasure: MeasureText = (text) => ({
+  advanceWidth: text.length * 8,
+  ascent: 12,
+  descent: 4,
+  lineGap: 0,
+})
+
+afterEach(cleanup)
+
+const canvas: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 120, height: 60, text: 'Hello' }],
+  edges: [],
+}
+
+describe('CanvasViewer accessibility', () => {
+  it('names the rendered canvas', () => {
+    render(<CanvasViewer canvas={canvas} measure={fakeMeasure} label="Sprint board" />)
+    expect(screen.getByRole('figure', { name: 'Sprint board' })).toBeTruthy()
+  })
+
+  it('falls back to a generic name when the host supplies none', () => {
+    // The viewer cannot know the document's name — that lives in the
+    // workspace, never in canvas content — so the caller owns the label and
+    // this is only the floor.
+    render(<CanvasViewer canvas={canvas} measure={fakeMeasure} />)
+    expect(screen.getByRole('figure', { name: 'Canvas' })).toBeTruthy()
+  })
+
+  it('keeps the rendered text reachable rather than marking it presentational', () => {
+    const { container } = render(<CanvasViewer canvas={canvas} measure={fakeMeasure} />)
+    const figure = screen.getByRole('figure')
+    expect(figure.getAttribute('aria-hidden')).toBeNull()
+    expect(container.querySelector('svg text')?.textContent).toContain('Hello')
+  })
+})

--- a/packages/canvas-viewer/src/CanvasViewer.tsx
+++ b/packages/canvas-viewer/src/CanvasViewer.tsx
@@ -26,9 +26,17 @@ export interface CanvasViewerProps {
   /** Injection seam for tests; defaults to the real Canvas 2D measurer. */
   measure?: MeasureText
   testId?: string
+  /**
+   * Accessible name for the rendered canvas. The viewer cannot derive one:
+   * a document's name lives in the workspace, never in canvas content (see
+   * vocabulary.md), so the host supplies it and `DEFAULT_LABEL` is only the
+   * floor.
+   */
+  label?: string
 }
 
 const DEFAULT_TEST_ID = 'canvas-viewer'
+const DEFAULT_LABEL = 'Canvas'
 
 export function CanvasViewer({
   canvas,
@@ -38,6 +46,7 @@ export function CanvasViewer({
   background,
   measure,
   testId = DEFAULT_TEST_ID,
+  label = DEFAULT_LABEL,
 }: CanvasViewerProps) {
   // Stable across re-renders of the same component instance so layoutSpatialCanvas
   // doesn't recreate the (lazily-created) Canvas 2D context on every render.
@@ -74,10 +83,26 @@ export function CanvasViewer({
   // path here, and this is not a generic sanitizer-needed sink. Do not add a
   // sanitizer dependency; if this ever stops being canvas-render's own output,
   // this reasoning no longer holds and must be revisited.
+  // `figure`, not `img`: the injected SVG's `<text>` runs are real content
+  // and today the ONLY way a screen reader reaches any of it, and `img`
+  // marks every child presentational — that would buy a name at the cost of
+  // the content. A figure names the region and leaves its children
+  // reachable. Reading it is still choppy (one run per wrapped line, in
+  // document order), which is what the deferred a11y projection is for; a
+  // name and reachable text is the honest floor until then.
   return (
-    <div
+    <figure
       data-testid={testId}
-      style={{ width: width ?? '100%', height: height ?? '100%', overflow: 'hidden' }}
+      aria-label={label}
+      // A real <figure>, not role="figure" on a div: same semantics, and the
+      // element carries them without ARIA. Its UA margin is cleared because
+      // this is a layout container the host sizes, not prose.
+      style={{
+        width: width ?? '100%',
+        height: height ?? '100%',
+        overflow: 'hidden',
+        margin: 0,
+      }}
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   )

--- a/packages/canvas-viewer/src/mount.ts
+++ b/packages/canvas-viewer/src/mount.ts
@@ -12,6 +12,8 @@ export interface MountCanvasViewerOptions {
   width?: number
   height?: number
   testId?: string
+  /** Accessible name for the rendered canvas; see CanvasViewerProps.label. */
+  label?: string
   // Hand-off seam for embedding hosts (e.g. an MCP Apps widget iframe) to
   // receive postMessage traffic without this package owning any bridge
   // protocol. Registered on `window`, unbound by dispose(). Receives the
@@ -80,6 +82,7 @@ export function mountCanvasViewer(
         width: opts.width,
         height: opts.height,
         testId: opts.testId,
+        label: opts.label,
       }),
     )
   })


### PR DESCRIPTION
The injected SVG sat in an unlabelled generic `div`. A screen reader announced nothing about the region and reached its content only as a stream of disconnected text runs.

## Why `<figure>` and not `role="img"`

`role="img"` is the reflex for a complex graphic, and it would have supplied the name in one attribute — but it also marks **every child presentational**. Those `<text>` runs are real content, and until canvas-render grows the a11y projection its package rule explicitly defers, they are the only way any of the canvas is reachable at all. Buying a label at the cost of the content is a net loss, so this names the region and leaves its children reachable.

Reading it is still choppy — one run per wrapped line, in document order — which is exactly what the deferred projection is for. A name plus reachable text is the honest floor until then.

It is the `<figure>` **element**, not `role="figure"` on a div: same semantics without ARIA, which is what biome's `useSemanticElements` caught when the first attempt used the role (its UA margin is cleared, since this is a layout container the host sizes).

## Where the name comes from

The host supplies it (`label`, threaded through `mountCanvasViewer`, defaulting to `"Canvas"`). The viewer cannot derive one: a document's name lives in the workspace, never in canvas content (vocabulary.md), so a viewer that invented a name would be inventing it from the wrong place.

## Verification

- Three jsdom pins: the supplied name is exposed, the fallback is used when the host gives none, and the SVG text stays reachable (not `aria-hidden`, not presentational) — that last one is what stops a future "just use role=img" from silently undoing this.
- Built the widget and read its accessibility tree in a real browser: `figure "Canvas"` where it previously reported an unnamed container.
- `smoke:widget` still passes (zero network requests, svg rendered, fonts loaded, JP text present).
- Full repo suite green apart from one unrelated known browser-flow flake that passes in isolation; typecheck, lint and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible labeling for canvas viewers, with support for custom labels and a default “Canvas” label.
  * Preserved readable SVG text content for assistive technologies.
  * Added label support when mounting a canvas viewer.

* **Tests**
  * Added accessibility coverage for custom labels, default labeling, and SVG text reachability.

* **Documentation**
  * Documented the viewer’s accessibility structure and labeling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->