### PR TITLE
fix(canvas-render): rank ink through a node's body above ink on its border

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -314,14 +314,15 @@ paths:
       candidate ORDER, not the search budget, so `CROSSING_OPT_MAX_PASSES`
       stays 2. The PENALTY half is `PENALTY_RULES`: overlap-and-intrusion
       (tier 0, collinear overlap plus self-retrace/body-intrusion),
-      illegibility (tier 1), crossings (tier 2), border-tracing (tier 3,
-      self-only — a routed segment collinear with AND overlapping a node's
-      own border, `nodeBorders` including the path's own endpoint rects
-      unlike `foreignBodies`), endpoint-body-ink (tier 4, self-only — a
-      routed segment STRICTLY BETWEEN a rect's two borders, the interior
-      complement of border-tracing, priced against the edge's OWN endpoint
-      rects since `foreignBodies` deliberately excludes them for the tunnel
-      check), and realized-bends (tier 5, self-only and deliberately last).
+      illegibility (tier 1), crossings (tier 2), endpoint-body-ink (tier 3,
+      self-only — a routed segment STRICTLY BETWEEN a rect's two borders,
+      priced against the edge's OWN endpoint rects since `foreignBodies`
+      deliberately excludes them for the tunnel check), border-tracing
+      (tier 4, self-only — the border complement: a segment collinear with
+      AND overlapping a node's own border, `nodeBorders` including the
+      path's own endpoint rects unlike `foreignBodies`), path-reversal
+      (tier 5) and realized-bends (tier 6, self-only and deliberately
+      last).
       border-tracing sits BELOW crossings rather than adjacent to
       overlap-and-intrusion: it is evaluated against the optimizer's
       unaligned TRIAL paths (`computeAnchorsFor`'s pre-`slideAlongSide`

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -24,6 +24,13 @@ import {
   selfPenalty,
 } from './edge-rules.js'
 
+/** The declared slot for a rule, so a deliberate tier reorder never edits a test. */
+const tierOf = (name: string): number => {
+  const rule = PENALTY_RULES.find((r) => r.name === name)
+  if (rule === undefined) throw new Error(`no penalty rule named ${name}`)
+  return rule.tier
+}
+
 const rectArb: fc.Arbitrary<Rect> = fc.record({
   x: fc.integer({ min: -100, max: 100 }),
   y: fc.integer({ min: -100, max: 100 }),
@@ -279,9 +286,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
     ({ path, nodeBorders }) => {
       const cost1 = selfPenalty(path, [], nodeBorders)
       const cost2 = selfPenalty(path, [], nodeBorders)
-      expect(cost1[3]).toBe(cost2[3])
-      expect(Number.isInteger(cost1[3])).toBe(true)
-      expect(cost1[3]).toBeGreaterThanOrEqual(0)
+      expect(cost1[tierOf('border-tracing')]).toBe(cost2[tierOf('border-tracing')])
+      expect(Number.isInteger(cost1[tierOf('border-tracing')])).toBe(true)
+      expect(cost1[tierOf('border-tracing')]).toBeGreaterThanOrEqual(0)
     },
   )
 
@@ -289,7 +296,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
     'is invariant under permutation of the node-border array (a sum must not depend on order)',
     ({ path, nodeBorders }) => {
       const shuffled = [...nodeBorders].reverse()
-      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(selfPenalty(path, [], shuffled)[3])
+      expect(selfPenalty(path, [], nodeBorders)[tierOf('border-tracing')]).toBe(
+        selfPenalty(path, [], shuffled)[tierOf('border-tracing')],
+      )
     },
   )
 
@@ -301,7 +310,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
   fcTest.prop([tracingScenarioArb], withDefaults())(
     'agrees with an independently-computed collinear overlap length',
     ({ path, nodeBorders }) => {
-      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(referenceBorderTrace(path, nodeBorders))
+      expect(selfPenalty(path, [], nodeBorders)[tierOf('border-tracing')]).toBe(
+        referenceBorderTrace(path, nodeBorders),
+      )
     },
   )
 })
@@ -401,9 +412,9 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
     ({ path, endpointRects }) => {
       const cost1 = selfPenalty(path, [], [], endpointRects)
       const cost2 = selfPenalty(path, [], [], endpointRects)
-      expect(cost1[4]).toBe(cost2[4])
-      expect(Number.isInteger(cost1[4])).toBe(true)
-      expect(cost1[4]).toBeGreaterThanOrEqual(0)
+      expect(cost1[tierOf('endpoint-body-ink')]).toBe(cost2[tierOf('endpoint-body-ink')])
+      expect(Number.isInteger(cost1[tierOf('endpoint-body-ink')])).toBe(true)
+      expect(cost1[tierOf('endpoint-body-ink')]).toBeGreaterThanOrEqual(0)
     },
   )
 
@@ -411,8 +422,8 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
     'is invariant under permutation of the endpoint-rect array (a sum must not depend on order)',
     ({ path, endpointRects }) => {
       const shuffled = [...endpointRects].reverse()
-      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
-        selfPenalty(path, [], [], shuffled)[4],
+      expect(selfPenalty(path, [], [], endpointRects)[tierOf('endpoint-body-ink')]).toBe(
+        selfPenalty(path, [], [], shuffled)[tierOf('endpoint-body-ink')],
       )
     },
   )
@@ -426,7 +437,7 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
   fcTest.prop([endpointBodyInkScenarioArb], withDefaults())(
     'agrees with an independently-computed strictly-interior chord length',
     ({ path, endpointRects }) => {
-      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
+      expect(selfPenalty(path, [], [], endpointRects)[tierOf('endpoint-body-ink')]).toBe(
         referenceEndpointBodyInk(path, endpointRects),
       )
     },

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -18,6 +18,21 @@ import {
   zeroPenalty,
 } from './edge-rules.js'
 
+/** A zero cost tuple with one rule's slot set, built from the DECLARED tier so
+ * a deliberate reorder never rewrites an expectation. */
+const costAt = (name: string, value: number): number[] => {
+  const cost = zeroPenalty()
+  cost[tierOf(name)] = value
+  return cost
+}
+
+/** The declared slot for a rule, so a deliberate tier reorder never edits a test. */
+const tierOf = (name: string): number => {
+  const rule = PENALTY_RULES.find((r) => r.name === name)
+  if (rule === undefined) throw new Error(`no penalty rule named ${name}`)
+  return rule.tier
+}
+
 function candidateRule(name: string): Extract<PreferenceRule, { kind: 'candidates' }> {
   const rule = SIDE_PREFERENCE_RULES.find((r) => r.name === name)
   if (rule === undefined || rule.kind !== 'candidates') {
@@ -247,8 +262,8 @@ describe('PENALTY_RULES', () => {
       'overlap-and-intrusion',
       'illegibility',
       'crossings',
-      'border-tracing',
       'endpoint-body-ink',
+      'border-tracing',
       'path-reversal',
       'realized-bends',
     ])
@@ -351,20 +366,20 @@ describe('crossings', () => {
 describe('border-tracing', () => {
   const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
 
-  it('self term: a horizontal segment lying along the rect top contributes the quantized clipped overlap length to tier 3', () => {
+  it('self term: a horizontal segment lying along the rect top contributes the quantized clipped overlap length to the border-tracing tier', () => {
     const path = [
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual(costAt('border-tracing', 100 * COST_QUANTUM))
   })
 
-  it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to tier 3', () => {
+  it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to the border-tracing tier', () => {
     const path = [
       { x: 100, y: 0 },
       { x: 100, y: 40 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual(costAt('border-tracing', 40 * COST_QUANTUM))
   })
 
   it('self term: a perpendicular segment touching the border at a single point contributes 0', () => {
@@ -396,7 +411,7 @@ describe('border-tracing', () => {
       { x: -50, y: 0 },
       { x: 200, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])[3]).toBe(100 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [rect])[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: a zero-height rect is charged once, not twice, for a segment lying on it', () => {
@@ -405,7 +420,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [flat])[3]).toBe(100 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [flat])[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: fires against the path’s OWN endpoint node, unlike foreignBodies which excludes it', () => {
@@ -416,7 +431,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [rect], [rect])).toEqual(costAt('border-tracing', 100 * COST_QUANTUM))
   })
 
   it('defaults nodeBorders to [] when omitted, contributing 0 (no border ink declared)', () => {
@@ -431,20 +446,24 @@ describe('border-tracing', () => {
 describe('endpoint-body-ink', () => {
   const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
 
-  it('self term: a horizontal segment strictly between the rect top and bottom contributes the quantized clipped chord length to tier 4', () => {
+  it('self term: a horizontal segment strictly between the rect top and bottom contributes the quantized clipped chord length to the endpoint-body-ink tier', () => {
     const path = [
       { x: -10, y: 20 },
       { x: 110, y: 20 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 100 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual(
+      costAt('endpoint-body-ink', 100 * COST_QUANTUM),
+    )
   })
 
-  it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to tier 4', () => {
+  it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to the endpoint-body-ink tier', () => {
     const path = [
       { x: 50, y: -10 },
       { x: 50, y: 50 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 40 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual(
+      costAt('endpoint-body-ink', 40 * COST_QUANTUM),
+    )
   })
 
   it('self term: a segment riding exactly on the border contributes 0 to this tier (border-tracing prices it instead, no double-charge)', () => {
@@ -453,8 +472,8 @@ describe('endpoint-body-ink', () => {
       { x: 100, y: 0 },
     ]
     const cost = selfPenalty(path, [], [rect], [rect])
-    expect(cost[4]).toBe(0)
-    expect(cost[3]).toBe(100 * COST_QUANTUM)
+    expect(cost[tierOf('endpoint-body-ink')]).toBe(0)
+    expect(cost[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: a perpendicular segment departing from a point on its own node border contributes 0', () => {
@@ -474,7 +493,9 @@ describe('endpoint-body-ink', () => {
     ]
     // outer fully contains inner: outer is excluded, so only inner (strictly
     // crossed at y=15, clipped to inner's x-range [10,30]) is priced.
-    expect(selfPenalty(path, [], [], [outer, inner])[4]).toBe(20 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [outer, inner])[tierOf('endpoint-body-ink')]).toBe(
+      20 * COST_QUANTUM,
+    )
   })
 
   it('self term: the same geometry WITHOUT containment prices both rects', () => {
@@ -486,7 +507,7 @@ describe('endpoint-body-ink', () => {
     ]
     // Neither fully contains the other: a clips to [0,30] (30px), b clips to
     // [20,50] (30px), summed.
-    expect(selfPenalty(path, [], [], [a, b])[4]).toBe(60 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [a, b])[tierOf('endpoint-body-ink')]).toBe(60 * COST_QUANTUM)
   })
 
   it('self term: two DISTINCT but numerically-equal endpoint rects (e.g. a self-loop, or two fully-overlapping same-size nodes) are NOT mutually excluded — this is the exact worst-case overlap the rule prices', () => {
@@ -507,7 +528,9 @@ describe('endpoint-body-ink', () => {
     // drop BOTH rects and price 0. Neither PROPERLY contains the other, so
     // both stay in the ink-priced set (chord clipped to [0,50], summed once
     // per rect since inkAlongRects iterates the rect list).
-    expect(selfPenalty(path, [], [], [rectA, rectB])[4]).toBe(2 * 50 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [rectA, rectB])[tierOf('endpoint-body-ink')]).toBe(
+      2 * 50 * COST_QUANTUM,
+    )
   })
 
   it('self term: zero-width and zero-height endpoint rects contribute 0 (unsatisfiable strict-interior test)', () => {
@@ -517,7 +540,7 @@ describe('endpoint-body-ink', () => {
       { x: -10, y: 0 },
       { x: 110, y: 0 },
     ]
-    expect(selfPenalty(path, [], [], [flatH, flatW])[4]).toBe(0)
+    expect(selfPenalty(path, [], [], [flatH, flatW])[tierOf('endpoint-body-ink')]).toBe(0)
   })
 
   it('defaults endpointRects to [] when omitted, contributing 0 (no endpoint ink declared)', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -591,7 +591,7 @@ const crossings: PenaltyRule = {
  */
 const borderTracing: PenaltyRule = {
   name: 'border-tracing',
-  tier: 3,
+  tier: 4,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, nodeBorders) =>
     inkAlongRects(path, nodeBorders, (fixed, near, far) => fixed === near || fixed === far),
@@ -637,7 +637,7 @@ const borderTracing: PenaltyRule = {
  */
 const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',
-  tier: 4,
+  tier: 3,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) =>
     inkAlongRects(
@@ -749,8 +749,8 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   overlapAndIntrusion,
   illegibility,
   crossings,
-  borderTracing,
   endpointBodyInk,
+  borderTracing,
   pathReversal,
   realizedBends,
 ]

--- a/packages/canvas-render/src/layout/edge-tier-order.test.ts
+++ b/packages/canvas-render/src/layout/edge-tier-order.test.ts
@@ -1,0 +1,72 @@
+// Ink through a node's BODY is worse than ink along its border: the body is
+// content the line now crosses, the border is a stroke it merely doubles.
+// The two rules were both demoted below crossings for the same trial-path
+// reason, and their order relative to each other was never argued — with
+// border-tracing above, the lexicographic compare bought 0px of border
+// tracing with 170px of tunnelling straight through the target.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { PENALTY_RULES } from './edge-rules.js'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const node = (id: string, x: number, y: number, width: number, height: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width,
+  height,
+  text: '',
+})
+
+/** Length of path running strictly inside a node body — the harm being ranked. */
+function interiorInk(
+  path: readonly { x: number; y: number }[],
+  rects: readonly SpatialNode[],
+): number {
+  let total = 0
+  for (const n of rects) {
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as { x: number; y: number }
+      const b = path[i] as { x: number; y: number }
+      if (a.y === b.y && a.y > n.y && a.y < n.y + n.height) {
+        const lo = Math.max(Math.min(a.x, b.x), n.x)
+        const hi = Math.min(Math.max(a.x, b.x), n.x + n.width)
+        if (hi > lo) total += hi - lo
+      }
+      if (a.x === b.x && a.x > n.x && a.x < n.x + n.width) {
+        const lo = Math.max(Math.min(a.y, b.y), n.y)
+        const hi = Math.min(Math.max(a.y, b.y), n.y + n.height)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total
+}
+
+it('ranks interior ink above border tracing', () => {
+  const tier = (name: string) => PENALTY_RULES.find((r) => r.name === name)?.tier
+  expect(tier('endpoint-body-ink')).toBeLessThan(tier('border-tracing') as number)
+})
+
+it('never routes through a node body when a border-tracing route would avoid it', () => {
+  const nodes = [
+    node('A', 100, 570, 200, 100),
+    node('B', 280, 520, 200, 100),
+    node('T', 80, 360, 200, 110),
+  ]
+  const edges: CanvasEdge[] = [
+    { id: 'e_AB', fromNode: 'A', toNode: 'B' },
+    { id: 'e_TA', fromNode: 'T', toNode: 'A', label: 'hoge' },
+    { id: 'e_TB', fromNode: 'T', toNode: 'B' },
+  ]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+
+  for (const edge of edges) {
+    const { path } = routeEdge(nodes, edge, 'orthogonal', anchors.get(edge.id))
+    expect({ id: edge.id, interior: interiorInk(path, nodes) }).toEqual({
+      id: edge.id,
+      interior: 0,
+    })
+  }
+})


### PR DESCRIPTION
## What

A reported canvas routed straight through the target node: 170px of line across B's body, arriving at its bottom edge from *inside*.

The cost model already ranked the alternatives correctly — the clean route scored zero on every tier — but the settled route won the lexicographic compare anyway:

| candidate | cost tuple | reading |
|---|---|---|
| `right→bottom` | `[80,0,0,320,0,1,2]` | 80px of border tracing, no tunnel |
| `top→bottom` | `[80,0,0,0,680,2,3]` | no border tracing, **170px tunnel** ← chosen |

`border-tracing` sat above `endpoint-body-ink`, so the compare happily bought 0px of border tracing with 170px of tunnelling. Both rules had been demoted below `crossings` for the same trial-path-artifact reason (#705, #706), and their order relative to *each other* was never argued — this canvas is what exposed it.

Ink through a body is content the line crosses; ink on a border is a stroke it doubles. The body wins.

The fix is two declared `tier` fields and their catalog positions. No rule geometry changed, no routing pin moved.

Settled route for the reported canvas becomes `bottom→bottom` — interior ink 0, border trace 0.

## Also

The rule tests read hardcoded slots (`cost[3]`, `[0,0,0,400,0,0,0]`) where the unit tests written alongside `path-reversal` read `PENALTY_RULES`'s declared tier. That is exactly the fragility the data-driven catalog (#700) was meant to remove. They now all derive the slot, so the next deliberate reorder edits no test.

## Verification

- New `edge-tier-order.test.ts`: pins the tier relation, and pins `interiorInk === 0` for every edge on the reported canvas.
- Mutation-checked — swapping the two tiers back turns both new pins red.
- `canvas-render-node` 553 passed.

## Visual repro

Both panels are the reported canvas rendered through `layoutSpatialCanvas` + `renderSceneToSvg`, the tier order being the only difference.

![tier-order.png](https://github.com/user-attachments/assets/6703f396-0531-4806-8c12-3e41262b7d46)

- **before**: `A→B` enters B's left border, runs 170px through B's body and doubles back up to arrive at B's bottom from inside.
- **after**: `A→B` leaves A's bottom and routes below both nodes — `(200,670) (200,690) (380,690) (380,620)`, interior ink 0, border trace 0.

The other two edges are unchanged apart from a 10px lane shift on `T→A`.
