### PR TITLE
test(canvas-render): measure routing quality instead of pinning one canvas at a time

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -412,6 +412,25 @@ paths:
   coordinate-sign geometry: jump hops, rounded-edge corners, arrowheads,
   rect corner radius) — fixtures and the deliberate `--update`-then-eyeball
   regeneration flow live in `src/test-utils/pixel-golden-scenes.ts`.
+- `layout/edge-routing-quality.test.ts` is the routing SCOREBOARD, and the
+  answer to "did that rule change help overall". Four reported defects were
+  each pinned by the one canvas that exposed it, which could never say
+  whether a fix moved the failure somewhere nobody had looked. It holds one
+  invariant — no routed line runs strictly inside a node body it could have
+  gone around — strictly over the named corpus, and COUNTS violations over
+  2000 deterministic synthetic layouts, split by which search should have
+  stopped each: `own-endpoint` (invisible to `bestCandidate`, since
+  `routeEdge` drops both endpoint nodes from its obstacle list),
+  `foreign` (`bestCandidate`'s last fallback returning the shortest BLOCKED
+  candidate when none of its six is clear), `degenerate` (coincident
+  anchors). The exemption is `routeEdge`'s own: a rect STRICTLY containing
+  an anchor cannot be routed around; a rect merely touched on its border
+  can. The counts are pinned EXACTLY, not as a ceiling, so an improvement is
+  as loud as a regression — they are a debt figure whose target is three
+  zeroes, at which point the aggregate becomes the strict property. Metrics
+  live in `src/test-utils/routing-metrics.ts` and never call `edge-rules.ts`
+  (the `reversal-count.ts` independent-oracle contract); layouts live in
+  `src/test-utils/routing-corpus.ts`.
 
 ## Common mistakes (append as review finds them)
 

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -314,14 +314,15 @@ paths:
       candidate ORDER, not the search budget, so `CROSSING_OPT_MAX_PASSES`
       stays 2. The PENALTY half is `PENALTY_RULES`: overlap-and-intrusion
       (tier 0, collinear overlap plus self-retrace/body-intrusion),
-      illegibility (tier 1), crossings (tier 2), border-tracing (tier 3,
-      self-only — a routed segment collinear with AND overlapping a node's
-      own border, `nodeBorders` including the path's own endpoint rects
-      unlike `foreignBodies`), endpoint-body-ink (tier 4, self-only — a
-      routed segment STRICTLY BETWEEN a rect's two borders, the interior
-      complement of border-tracing, priced against the edge's OWN endpoint
-      rects since `foreignBodies` deliberately excludes them for the tunnel
-      check), and realized-bends (tier 5, self-only and deliberately last).
+      illegibility (tier 1), crossings (tier 2), endpoint-body-ink (tier 3,
+      self-only — a routed segment STRICTLY BETWEEN a rect's two borders,
+      priced against the edge's OWN endpoint rects since `foreignBodies`
+      deliberately excludes them for the tunnel check), border-tracing
+      (tier 4, self-only — the border complement: a segment collinear with
+      AND overlapping a node's own border, `nodeBorders` including the
+      path's own endpoint rects unlike `foreignBodies`), path-reversal
+      (tier 5) and realized-bends (tier 6, self-only and deliberately
+      last).
       border-tracing sits BELOW crossings rather than adjacent to
       overlap-and-intrusion: it is evaluated against the optimizer's
       unaligned TRIAL paths (`computeAnchorsFor`'s pre-`slideAlongSide`

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -1,0 +1,97 @@
+// The one invariant every reported routing defect violated: a line drawn
+// through the inside of a box. Four of them (#705, #706, #711, #713) reached
+// a human before they reached the suite, because each was pinned by the
+// single canvas that exposed it and nothing asked the question generally.
+//
+// The exemption is the one `routeEdge` already applies when it picks
+// obstacles: a rect that STRICTLY contains an anchor can never be routed
+// around, since every detour still has to reach the point inside it — that is
+// what lets an edge between two members of a group run inside the group's
+// frame. A rect merely touched by an anchor on its border, INCLUDING the
+// edge's own two endpoints, is not exempt. That distinction is the whole
+// point: `routeEdge` drops both endpoint nodes from its obstacle list, so a
+// route through its own target's body is invisible to the search that picks
+// it, and only the side-choice penalties upstream ever priced it.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { ROUTING_CORPUS, syntheticLayouts } from '../test-utils/routing-corpus.js'
+import { interiorInk, type MetricRect } from '../test-utils/routing-metrics.js'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+type Violation = { edge: string; node: string; ink: number; kind: ViolationKind }
+
+/**
+ * Which search was supposed to prevent it. `own-endpoint` and `degenerate`
+ * are invisible to `bestCandidate` by construction; `foreign` is a path
+ * `pathIsClear` rejected but `bestCandidate` returned anyway, because its
+ * last fallback takes the shortest BLOCKED candidate when none of its six
+ * is clear.
+ */
+type ViolationKind = 'own-endpoint' | 'foreign' | 'degenerate'
+
+const rectOf = (n: SpatialNode): MetricRect => ({ x: n.x, y: n.y, w: n.width, h: n.height })
+
+const strictlyInside = (r: MetricRect, p: { x: number; y: number }) =>
+  p.x > r.x && p.x < r.x + r.w && p.y > r.y && p.y < r.y + r.h
+
+/** Every node body an edge put ink inside that it could have gone around. */
+function avoidableInk(nodes: readonly SpatialNode[], edges: readonly CanvasEdge[]): Violation[] {
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const found: Violation[] = []
+  for (const edge of edges) {
+    const { path } = routeEdge(nodes, edge, 'orthogonal', anchors.get(edge.id))
+    const start = path[0]
+    const end = path[path.length - 1]
+    if (start === undefined || end === undefined) continue
+    const coincident = start.x === end.x && start.y === end.y
+    for (const n of nodes) {
+      const rect = rectOf(n)
+      if (strictlyInside(rect, start) || strictlyInside(rect, end)) continue
+      const ink = interiorInk(path, rect)
+      if (ink <= 0) continue
+      const own = n.id === edge.fromNode || n.id === edge.toNode
+      found.push({
+        edge: edge.id,
+        node: n.id,
+        ink,
+        kind: coincident ? 'degenerate' : own ? 'own-endpoint' : 'foreign',
+      })
+    }
+  }
+  return found
+}
+
+describe('routing quality', () => {
+  it.each(
+    ROUTING_CORPUS.map((c) => [c.name, c] as const),
+  )('draws no line through a node body — %s', (_name, testCase) => {
+    expect(avoidableInk(testCase.nodes, testCase.edges)).toEqual([])
+  })
+})
+
+/**
+ * The aggregate the individual pins could never give: how often the router
+ * does this across many layouts, split by which search failed to stop it.
+ *
+ * The counts are pinned EXACTLY, not as a ceiling, so an improvement is as
+ * loud as a regression — the point of a scoreboard is that the number moves
+ * and someone has to say why. They are a debt figure, not a target: the goal
+ * is three zeroes, and reaching it turns this into the strict property the
+ * corpus above already holds to.
+ *
+ * `own-endpoint` dominating by an order of magnitude is the measurement that
+ * says where to start: it is exactly the class `bestCandidate` cannot see.
+ */
+describe('routing quality across the synthetic corpus', () => {
+  it('reports the current violation count per class', () => {
+    const tally: Record<ViolationKind, number> = {
+      'own-endpoint': 0,
+      foreign: 0,
+      degenerate: 0,
+    }
+    for (const testCase of syntheticLayouts(2000)) {
+      for (const v of avoidableInk(testCase.nodes, testCase.edges)) tally[v.kind]++
+    }
+    expect(tally).toEqual({ 'own-endpoint': 160, foreign: 24, degenerate: 2 })
+  })
+})

--- a/packages/canvas-render/src/layout/edge-rules.properties.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.properties.test.ts
@@ -24,6 +24,13 @@ import {
   selfPenalty,
 } from './edge-rules.js'
 
+/** The declared slot for a rule, so a deliberate tier reorder never edits a test. */
+const tierOf = (name: string): number => {
+  const rule = PENALTY_RULES.find((r) => r.name === name)
+  if (rule === undefined) throw new Error(`no penalty rule named ${name}`)
+  return rule.tier
+}
+
 const rectArb: fc.Arbitrary<Rect> = fc.record({
   x: fc.integer({ min: -100, max: 100 }),
   y: fc.integer({ min: -100, max: 100 }),
@@ -279,9 +286,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
     ({ path, nodeBorders }) => {
       const cost1 = selfPenalty(path, [], nodeBorders)
       const cost2 = selfPenalty(path, [], nodeBorders)
-      expect(cost1[3]).toBe(cost2[3])
-      expect(Number.isInteger(cost1[3])).toBe(true)
-      expect(cost1[3]).toBeGreaterThanOrEqual(0)
+      expect(cost1[tierOf('border-tracing')]).toBe(cost2[tierOf('border-tracing')])
+      expect(Number.isInteger(cost1[tierOf('border-tracing')])).toBe(true)
+      expect(cost1[tierOf('border-tracing')]).toBeGreaterThanOrEqual(0)
     },
   )
 
@@ -289,7 +296,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
     'is invariant under permutation of the node-border array (a sum must not depend on order)',
     ({ path, nodeBorders }) => {
       const shuffled = [...nodeBorders].reverse()
-      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(selfPenalty(path, [], shuffled)[3])
+      expect(selfPenalty(path, [], nodeBorders)[tierOf('border-tracing')]).toBe(
+        selfPenalty(path, [], shuffled)[tierOf('border-tracing')],
+      )
     },
   )
 
@@ -301,7 +310,9 @@ describe('border-tracing: dense-on-borders property (mutation-checked)', () => {
   fcTest.prop([tracingScenarioArb], withDefaults())(
     'agrees with an independently-computed collinear overlap length',
     ({ path, nodeBorders }) => {
-      expect(selfPenalty(path, [], nodeBorders)[3]).toBe(referenceBorderTrace(path, nodeBorders))
+      expect(selfPenalty(path, [], nodeBorders)[tierOf('border-tracing')]).toBe(
+        referenceBorderTrace(path, nodeBorders),
+      )
     },
   )
 })
@@ -401,9 +412,9 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
     ({ path, endpointRects }) => {
       const cost1 = selfPenalty(path, [], [], endpointRects)
       const cost2 = selfPenalty(path, [], [], endpointRects)
-      expect(cost1[4]).toBe(cost2[4])
-      expect(Number.isInteger(cost1[4])).toBe(true)
-      expect(cost1[4]).toBeGreaterThanOrEqual(0)
+      expect(cost1[tierOf('endpoint-body-ink')]).toBe(cost2[tierOf('endpoint-body-ink')])
+      expect(Number.isInteger(cost1[tierOf('endpoint-body-ink')])).toBe(true)
+      expect(cost1[tierOf('endpoint-body-ink')]).toBeGreaterThanOrEqual(0)
     },
   )
 
@@ -411,8 +422,8 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
     'is invariant under permutation of the endpoint-rect array (a sum must not depend on order)',
     ({ path, endpointRects }) => {
       const shuffled = [...endpointRects].reverse()
-      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
-        selfPenalty(path, [], [], shuffled)[4],
+      expect(selfPenalty(path, [], [], endpointRects)[tierOf('endpoint-body-ink')]).toBe(
+        selfPenalty(path, [], [], shuffled)[tierOf('endpoint-body-ink')],
       )
     },
   )
@@ -426,7 +437,7 @@ describe('endpoint-body-ink: dense-interior property (mutation-checked)', () => 
   fcTest.prop([endpointBodyInkScenarioArb], withDefaults())(
     'agrees with an independently-computed strictly-interior chord length',
     ({ path, endpointRects }) => {
-      expect(selfPenalty(path, [], [], endpointRects)[4]).toBe(
+      expect(selfPenalty(path, [], [], endpointRects)[tierOf('endpoint-body-ink')]).toBe(
         referenceEndpointBodyInk(path, endpointRects),
       )
     },

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -18,6 +18,21 @@ import {
   zeroPenalty,
 } from './edge-rules.js'
 
+/** A zero cost tuple with one rule's slot set, built from the DECLARED tier so
+ * a deliberate reorder never rewrites an expectation. */
+const costAt = (name: string, value: number): number[] => {
+  const cost = zeroPenalty()
+  cost[tierOf(name)] = value
+  return cost
+}
+
+/** The declared slot for a rule, so a deliberate tier reorder never edits a test. */
+const tierOf = (name: string): number => {
+  const rule = PENALTY_RULES.find((r) => r.name === name)
+  if (rule === undefined) throw new Error(`no penalty rule named ${name}`)
+  return rule.tier
+}
+
 function candidateRule(name: string): Extract<PreferenceRule, { kind: 'candidates' }> {
   const rule = SIDE_PREFERENCE_RULES.find((r) => r.name === name)
   if (rule === undefined || rule.kind !== 'candidates') {
@@ -247,8 +262,8 @@ describe('PENALTY_RULES', () => {
       'overlap-and-intrusion',
       'illegibility',
       'crossings',
-      'border-tracing',
       'endpoint-body-ink',
+      'border-tracing',
       'path-reversal',
       'realized-bends',
     ])
@@ -351,20 +366,20 @@ describe('crossings', () => {
 describe('border-tracing', () => {
   const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
 
-  it('self term: a horizontal segment lying along the rect top contributes the quantized clipped overlap length to tier 3', () => {
+  it('self term: a horizontal segment lying along the rect top contributes the quantized clipped overlap length to the border-tracing tier', () => {
     const path = [
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual(costAt('border-tracing', 100 * COST_QUANTUM))
   })
 
-  it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to tier 3', () => {
+  it('self term: a vertical segment lying along the rect right side contributes the quantized overlap length to the border-tracing tier', () => {
     const path = [
       { x: 100, y: 0 },
       { x: 100, y: 40 },
     ]
-    expect(selfPenalty(path, [], [rect])).toEqual([0, 0, 0, 40 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [], [rect])).toEqual(costAt('border-tracing', 40 * COST_QUANTUM))
   })
 
   it('self term: a perpendicular segment touching the border at a single point contributes 0', () => {
@@ -396,7 +411,7 @@ describe('border-tracing', () => {
       { x: -50, y: 0 },
       { x: 200, y: 0 },
     ]
-    expect(selfPenalty(path, [], [rect])[3]).toBe(100 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [rect])[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: a zero-height rect is charged once, not twice, for a segment lying on it', () => {
@@ -405,7 +420,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [], [flat])[3]).toBe(100 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [flat])[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: fires against the path’s OWN endpoint node, unlike foreignBodies which excludes it', () => {
@@ -416,7 +431,7 @@ describe('border-tracing', () => {
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ]
-    expect(selfPenalty(path, [rect], [rect])).toEqual([0, 0, 0, 100 * COST_QUANTUM, 0, 0, 0])
+    expect(selfPenalty(path, [rect], [rect])).toEqual(costAt('border-tracing', 100 * COST_QUANTUM))
   })
 
   it('defaults nodeBorders to [] when omitted, contributing 0 (no border ink declared)', () => {
@@ -431,20 +446,24 @@ describe('border-tracing', () => {
 describe('endpoint-body-ink', () => {
   const rect: Rect = { x: 0, y: 0, w: 100, h: 40 }
 
-  it('self term: a horizontal segment strictly between the rect top and bottom contributes the quantized clipped chord length to tier 4', () => {
+  it('self term: a horizontal segment strictly between the rect top and bottom contributes the quantized clipped chord length to the endpoint-body-ink tier', () => {
     const path = [
       { x: -10, y: 20 },
       { x: 110, y: 20 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 100 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual(
+      costAt('endpoint-body-ink', 100 * COST_QUANTUM),
+    )
   })
 
-  it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to tier 4', () => {
+  it('self term: a vertical segment strictly between the rect left and right contributes the quantized clipped chord length to the endpoint-body-ink tier', () => {
     const path = [
       { x: 50, y: -10 },
       { x: 50, y: 50 },
     ]
-    expect(selfPenalty(path, [], [], [rect])).toEqual([0, 0, 0, 0, 40 * COST_QUANTUM, 0, 0])
+    expect(selfPenalty(path, [], [], [rect])).toEqual(
+      costAt('endpoint-body-ink', 40 * COST_QUANTUM),
+    )
   })
 
   it('self term: a segment riding exactly on the border contributes 0 to this tier (border-tracing prices it instead, no double-charge)', () => {
@@ -453,8 +472,8 @@ describe('endpoint-body-ink', () => {
       { x: 100, y: 0 },
     ]
     const cost = selfPenalty(path, [], [rect], [rect])
-    expect(cost[4]).toBe(0)
-    expect(cost[3]).toBe(100 * COST_QUANTUM)
+    expect(cost[tierOf('endpoint-body-ink')]).toBe(0)
+    expect(cost[tierOf('border-tracing')]).toBe(100 * COST_QUANTUM)
   })
 
   it('self term: a perpendicular segment departing from a point on its own node border contributes 0', () => {
@@ -474,7 +493,9 @@ describe('endpoint-body-ink', () => {
     ]
     // outer fully contains inner: outer is excluded, so only inner (strictly
     // crossed at y=15, clipped to inner's x-range [10,30]) is priced.
-    expect(selfPenalty(path, [], [], [outer, inner])[4]).toBe(20 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [outer, inner])[tierOf('endpoint-body-ink')]).toBe(
+      20 * COST_QUANTUM,
+    )
   })
 
   it('self term: the same geometry WITHOUT containment prices both rects', () => {
@@ -486,7 +507,7 @@ describe('endpoint-body-ink', () => {
     ]
     // Neither fully contains the other: a clips to [0,30] (30px), b clips to
     // [20,50] (30px), summed.
-    expect(selfPenalty(path, [], [], [a, b])[4]).toBe(60 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [a, b])[tierOf('endpoint-body-ink')]).toBe(60 * COST_QUANTUM)
   })
 
   it('self term: two DISTINCT but numerically-equal endpoint rects (e.g. a self-loop, or two fully-overlapping same-size nodes) are NOT mutually excluded — this is the exact worst-case overlap the rule prices', () => {
@@ -507,7 +528,9 @@ describe('endpoint-body-ink', () => {
     // drop BOTH rects and price 0. Neither PROPERLY contains the other, so
     // both stay in the ink-priced set (chord clipped to [0,50], summed once
     // per rect since inkAlongRects iterates the rect list).
-    expect(selfPenalty(path, [], [], [rectA, rectB])[4]).toBe(2 * 50 * COST_QUANTUM)
+    expect(selfPenalty(path, [], [], [rectA, rectB])[tierOf('endpoint-body-ink')]).toBe(
+      2 * 50 * COST_QUANTUM,
+    )
   })
 
   it('self term: zero-width and zero-height endpoint rects contribute 0 (unsatisfiable strict-interior test)', () => {
@@ -517,7 +540,7 @@ describe('endpoint-body-ink', () => {
       { x: -10, y: 0 },
       { x: 110, y: 0 },
     ]
-    expect(selfPenalty(path, [], [], [flatH, flatW])[4]).toBe(0)
+    expect(selfPenalty(path, [], [], [flatH, flatW])[tierOf('endpoint-body-ink')]).toBe(0)
   })
 
   it('defaults endpointRects to [] when omitted, contributing 0 (no endpoint ink declared)', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -591,7 +591,7 @@ const crossings: PenaltyRule = {
  */
 const borderTracing: PenaltyRule = {
   name: 'border-tracing',
-  tier: 3,
+  tier: 4,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, nodeBorders) =>
     inkAlongRects(path, nodeBorders, (fixed, near, far) => fixed === near || fixed === far),
@@ -637,7 +637,7 @@ const borderTracing: PenaltyRule = {
  */
 const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',
-  tier: 4,
+  tier: 3,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) =>
     inkAlongRects(
@@ -749,8 +749,8 @@ export const PENALTY_RULES: readonly PenaltyRule[] = [
   overlapAndIntrusion,
   illegibility,
   crossings,
-  borderTracing,
   endpointBodyInk,
+  borderTracing,
   pathReversal,
   realizedBends,
 ]

--- a/packages/canvas-render/src/layout/edge-tier-order.test.ts
+++ b/packages/canvas-render/src/layout/edge-tier-order.test.ts
@@ -1,0 +1,72 @@
+// Ink through a node's BODY is worse than ink along its border: the body is
+// content the line now crosses, the border is a stroke it merely doubles.
+// The two rules were both demoted below crossings for the same trial-path
+// reason, and their order relative to each other was never argued — with
+// border-tracing above, the lexicographic compare bought 0px of border
+// tracing with 170px of tunnelling straight through the target.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { PENALTY_RULES } from './edge-rules.js'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const node = (id: string, x: number, y: number, width: number, height: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width,
+  height,
+  text: '',
+})
+
+/** Length of path running strictly inside a node body — the harm being ranked. */
+function interiorInk(
+  path: readonly { x: number; y: number }[],
+  rects: readonly SpatialNode[],
+): number {
+  let total = 0
+  for (const n of rects) {
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1] as { x: number; y: number }
+      const b = path[i] as { x: number; y: number }
+      if (a.y === b.y && a.y > n.y && a.y < n.y + n.height) {
+        const lo = Math.max(Math.min(a.x, b.x), n.x)
+        const hi = Math.min(Math.max(a.x, b.x), n.x + n.width)
+        if (hi > lo) total += hi - lo
+      }
+      if (a.x === b.x && a.x > n.x && a.x < n.x + n.width) {
+        const lo = Math.max(Math.min(a.y, b.y), n.y)
+        const hi = Math.min(Math.max(a.y, b.y), n.y + n.height)
+        if (hi > lo) total += hi - lo
+      }
+    }
+  }
+  return total
+}
+
+it('ranks interior ink above border tracing', () => {
+  const tier = (name: string) => PENALTY_RULES.find((r) => r.name === name)?.tier
+  expect(tier('endpoint-body-ink')).toBeLessThan(tier('border-tracing') as number)
+})
+
+it('never routes through a node body when a border-tracing route would avoid it', () => {
+  const nodes = [
+    node('A', 100, 570, 200, 100),
+    node('B', 280, 520, 200, 100),
+    node('T', 80, 360, 200, 110),
+  ]
+  const edges: CanvasEdge[] = [
+    { id: 'e_AB', fromNode: 'A', toNode: 'B' },
+    { id: 'e_TA', fromNode: 'T', toNode: 'A', label: 'hoge' },
+    { id: 'e_TB', fromNode: 'T', toNode: 'B' },
+  ]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+
+  for (const edge of edges) {
+    const { path } = routeEdge(nodes, edge, 'orthogonal', anchors.get(edge.id))
+    expect({ id: edge.id, interior: interiorInk(path, nodes) }).toEqual({
+      id: edge.id,
+      interior: 0,
+    })
+  }
+})

--- a/packages/canvas-render/src/test-utils/routing-corpus.ts
+++ b/packages/canvas-render/src/test-utils/routing-corpus.ts
@@ -1,0 +1,101 @@
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+
+/**
+ * The canvases that reached a human before they reached the suite. Each one
+ * is a routing defect someone had to notice and report; keeping them together
+ * makes "did this change help overall" a question with an answer, instead of
+ * one pin per fix judged on its own.
+ *
+ * Every case is the same shape — two overlapping boxes plus a third above —
+ * because that is the arrangement the router kept getting wrong, and the
+ * horizontal offset between the two is what separates them.
+ */
+export type RoutingCase = {
+  readonly name: string
+  readonly nodes: readonly SpatialNode[]
+  readonly edges: readonly CanvasEdge[]
+}
+
+const node = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+const overlappingPair = (name: string, bx: number, by: number): RoutingCase => ({
+  name,
+  nodes: [node('A', 100, 570, 200, 100), node('B', bx, by, 200, 100), node('T', 80, 360, 200, 110)],
+  edges: [
+    { id: 'e_AB', fromNode: 'A', toNode: 'B' },
+    { id: 'e_TA', fromNode: 'T', toNode: 'A', label: 'hoge' },
+    { id: 'e_TB', fromNode: 'T', toNode: 'B' },
+  ],
+})
+
+export const ROUTING_CORPUS: readonly RoutingCase[] = [
+  // The edge ran along the source's own border, indistinguishable from it.
+  overlappingPair('reported: edge traced the source border', 220, 520),
+  // The route hooked past its anchor and doubled back, reading as a loop.
+  overlappingPair('reported: edge looped at the arrival', 246, 510),
+  // The route cut 170px straight through the target's body.
+  overlappingPair('reported: edge tunnelled through the target', 280, 520),
+  {
+    name: 'nested: an edge between two members of a frame',
+    nodes: [
+      node('frame', 0, 0, 400, 300),
+      node('inner1', 40, 40, 100, 60),
+      node('inner2', 240, 180, 100, 60),
+    ],
+    edges: [{ id: 'e_inner', fromNode: 'inner1', toNode: 'inner2' }],
+  },
+  {
+    name: 'corridor: a third node sits between the endpoints',
+    nodes: [node('L', 0, 100, 120, 80), node('M', 200, 60, 100, 160), node('R', 380, 100, 120, 80)],
+    edges: [{ id: 'e_LR', fromNode: 'L', toNode: 'R' }],
+  },
+]
+
+/**
+ * A fixed synthetic corpus for the aggregate count. Deliberately NOT a
+ * fast-check property: the routing defects are widespread enough that the
+ * honest assertion today is a pinned total, and a total is only meaningful
+ * if the layouts behind it never change. `mulberry32` makes the whole corpus
+ * a pure function of its index.
+ *
+ * Boxes are large relative to the coordinate range on purpose — the defects
+ * only appear when nodes crowd each other, so a generator that spread them
+ * out would report a clean score while drawing the same broken pictures.
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export function syntheticLayouts(count: number): readonly RoutingCase[] {
+  const random = mulberry32(0x5eed)
+  const int = (max: number) => Math.floor(random() * max)
+  const cases: RoutingCase[] = []
+  for (let i = 0; cases.length < count; i++) {
+    const size = 2 + int(4)
+    const nodes = Array.from({ length: size }, (_, n) =>
+      node(`n${n}`, int(401), int(401), 60 + int(141), 40 + int(121)),
+    )
+    const edges: CanvasEdge[] = []
+    for (let a = 0; a < size; a++) {
+      for (let b = a + 1; b < size; b++) {
+        if (int(2) === 1) edges.push({ id: `e${a}_${b}`, fromNode: `n${a}`, toNode: `n${b}` })
+      }
+    }
+    if (edges.length > 0) cases.push({ name: `synthetic ${i}`, nodes, edges })
+  }
+  return cases
+}

--- a/packages/canvas-render/src/test-utils/routing-metrics.test.ts
+++ b/packages/canvas-render/src/test-utils/routing-metrics.test.ts
@@ -1,0 +1,238 @@
+// The oracle needs its own check: an aggregate report is only worth reading
+// if the numbers under it are right, and every value here is hand-computed
+// against a picture rather than recorded from a run.
+import { describe, expect, it } from 'vitest'
+import { bends, borderInk, crossings, interiorInk, pathLength } from './routing-metrics.js'
+
+const box = { x: 100, y: 100, w: 200, h: 100 } // x 100..300, y 100..200
+
+describe('interiorInk', () => {
+  it('measures the part of a crossing segment that is inside', () => {
+    expect(
+      interiorInk(
+        [
+          { x: 0, y: 150 },
+          { x: 400, y: 150 },
+        ],
+        box,
+      ),
+    ).toBe(200)
+  })
+
+  it('measures a partial entry up to the far border', () => {
+    expect(
+      interiorInk(
+        [
+          { x: 200, y: 150 },
+          { x: 500, y: 150 },
+        ],
+        box,
+      ),
+    ).toBe(100)
+  })
+
+  it('counts nothing for a segment lying exactly along a border', () => {
+    expect(
+      interiorInk(
+        [
+          { x: 0, y: 100 },
+          { x: 400, y: 100 },
+        ],
+        box,
+      ),
+    ).toBe(0)
+    expect(
+      interiorInk(
+        [
+          { x: 300, y: 0 },
+          { x: 300, y: 400 },
+        ],
+        box,
+      ),
+    ).toBe(0)
+  })
+
+  it('counts nothing for a segment that misses the box', () => {
+    expect(
+      interiorInk(
+        [
+          { x: 0, y: 50 },
+          { x: 400, y: 50 },
+        ],
+        box,
+      ),
+    ).toBe(0)
+  })
+
+  it('measures a diagonal by its own length, not its projection', () => {
+    // Enters at (100,100), leaves at (200,200) — a 45° chord of the corner.
+    expect(
+      interiorInk(
+        [
+          { x: 0, y: 0 },
+          { x: 200, y: 200 },
+        ],
+        box,
+      ),
+    ).toBeCloseTo(Math.hypot(100, 100), 9)
+  })
+
+  it('sums across the segments of a polyline', () => {
+    const path = [
+      { x: 0, y: 150 },
+      { x: 200, y: 150 },
+      { x: 200, y: 400 },
+    ]
+    expect(interiorInk(path, box)).toBe(100 + 50)
+  })
+})
+
+describe('borderInk', () => {
+  it('measures the overlap of a segment lying along a border', () => {
+    expect(
+      borderInk(
+        [
+          { x: 0, y: 100 },
+          { x: 400, y: 100 },
+        ],
+        box,
+      ),
+    ).toBe(200)
+    expect(
+      borderInk(
+        [
+          { x: 150, y: 200 },
+          { x: 400, y: 200 },
+        ],
+        box,
+      ),
+    ).toBe(150)
+  })
+
+  it('counts nothing for an interior or an outside segment', () => {
+    expect(
+      borderInk(
+        [
+          { x: 0, y: 150 },
+          { x: 400, y: 150 },
+        ],
+        box,
+      ),
+    ).toBe(0)
+    expect(
+      borderInk(
+        [
+          { x: 0, y: 99 },
+          { x: 400, y: 99 },
+        ],
+        box,
+      ),
+    ).toBe(0)
+  })
+
+  it('is the complement of interiorInk — no length is counted by both', () => {
+    for (const path of [
+      [
+        { x: 0, y: 100 },
+        { x: 400, y: 100 },
+      ],
+      [
+        { x: 0, y: 150 },
+        { x: 400, y: 150 },
+      ],
+      [
+        { x: 100, y: 0 },
+        { x: 100, y: 400 },
+      ],
+    ]) {
+      expect(Math.min(interiorInk(path, box), borderInk(path, box))).toBe(0)
+    }
+  })
+})
+
+describe('bends and pathLength', () => {
+  it('counts a corner per direction change', () => {
+    expect(
+      bends([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+    ).toBe(0)
+    expect(
+      bends([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 0 },
+      ]),
+    ).toBe(0)
+    expect(
+      bends([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    ).toBe(1)
+    expect(
+      bends([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 20, y: 10 },
+      ]),
+    ).toBe(2)
+  })
+
+  it('sums segment lengths', () => {
+    expect(
+      pathLength([
+        { x: 0, y: 0 },
+        { x: 3, y: 4 },
+        { x: 3, y: 14 },
+      ]),
+    ).toBe(15)
+  })
+})
+
+describe('crossings', () => {
+  it('counts a clean cross once', () => {
+    expect(
+      crossings([
+        [
+          { x: 0, y: 5 },
+          { x: 10, y: 5 },
+        ],
+        [
+          { x: 5, y: 0 },
+          { x: 5, y: 10 },
+        ],
+      ]),
+    ).toBe(1)
+  })
+
+  it('ignores a touch at an endpoint and a shared corner', () => {
+    expect(
+      crossings([
+        [
+          { x: 0, y: 5 },
+          { x: 10, y: 5 },
+        ],
+        [
+          { x: 5, y: 5 },
+          { x: 5, y: 10 },
+        ],
+      ]),
+    ).toBe(0)
+  })
+
+  it('ignores segments of the same path meeting each other', () => {
+    expect(
+      crossings([
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: 10 },
+        ],
+      ]),
+    ).toBe(0)
+  })
+})

--- a/packages/canvas-render/src/test-utils/routing-metrics.ts
+++ b/packages/canvas-render/src/test-utils/routing-metrics.ts
@@ -1,0 +1,155 @@
+/**
+ * Independent geometric oracle for routing quality. Deliberately never calls
+ * `edge-rules.ts` or any other production scorer, so a test asserting against
+ * it cannot be satisfied by a broken rule agreeing with itself — the same
+ * contract `reversal-count.ts` holds for the `path-reversal` rule.
+ *
+ * Where the penalty rules answer "which candidate wins", these answer "how
+ * good is the drawing", in units a reader can check against a picture:
+ * pixels of ink in the wrong place, and counts of the shapes that make a
+ * diagram hard to read.
+ */
+
+export type MetricRect = { x: number; y: number; w: number; h: number }
+export type MetricPoint = { x: number; y: number }
+
+/** Clip parameters of the part of `a`→`b` strictly inside `rect`, if any. */
+function clipOpen(a: MetricPoint, b: MetricPoint, rect: MetricRect): [number, number] | undefined {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  let t0 = 0
+  let t1 = 1
+  const slabs: readonly [number, number][] = [
+    [-dx, a.x - rect.x],
+    [dx, rect.x + rect.w - a.x],
+    [-dy, a.y - rect.y],
+    [dy, rect.y + rect.h - a.y],
+  ]
+  for (const [p, q] of slabs) {
+    if (p === 0) {
+      // Parallel to this slab. `q > 0` is strictly within it; `q === 0` puts
+      // the whole segment ON the boundary, which is border ink, not interior.
+      if (q <= 0) return undefined
+      continue
+    }
+    const t = q / p
+    if (p < 0) {
+      if (t > t1) return undefined
+      if (t > t0) t0 = t
+    } else {
+      if (t < t0) return undefined
+      if (t < t1) t1 = t
+    }
+  }
+  return t1 > t0 ? [t0, t1] : undefined
+}
+
+const segmentLength = (a: MetricPoint, b: MetricPoint) => Math.hypot(b.x - a.x, b.y - a.y)
+
+/**
+ * Length of `path` running strictly INSIDE `rect` — the harm of a line that
+ * crosses a node's content instead of going around it. A segment lying
+ * exactly along a border contributes nothing here; that is `borderInk`.
+ */
+export function interiorInk(path: readonly MetricPoint[], rect: MetricRect): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as MetricPoint
+    const b = path[i] as MetricPoint
+    const clip = clipOpen(a, b, rect)
+    if (clip !== undefined) total += (clip[1] - clip[0]) * segmentLength(a, b)
+  }
+  return total
+}
+
+/**
+ * Length of `path` lying ON one of `rect`'s four borders — a stroke drawn
+ * over a stroke. Milder than `interiorInk` (it hides an existing line rather
+ * than crossing content), and the two are complements: no length is counted
+ * by both.
+ */
+export function borderInk(path: readonly MetricPoint[], rect: MetricRect): number {
+  const right = rect.x + rect.w
+  const bottom = rect.y + rect.h
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as MetricPoint
+    const b = path[i] as MetricPoint
+    if (a.y === b.y && (a.y === rect.y || a.y === bottom)) {
+      const lo = Math.max(Math.min(a.x, b.x), rect.x)
+      const hi = Math.min(Math.max(a.x, b.x), right)
+      if (hi > lo) total += hi - lo
+    }
+    if (a.x === b.x && (a.x === rect.x || a.x === right)) {
+      const lo = Math.max(Math.min(a.y, b.y), rect.y)
+      const hi = Math.min(Math.max(a.y, b.y), bottom)
+      if (hi > lo) total += hi - lo
+    }
+  }
+  return total
+}
+
+/** Corners: direction changes along the polyline. */
+export function bends(path: readonly MetricPoint[]): number {
+  let count = 0
+  for (let i = 2; i < path.length; i++) {
+    const a = path[i - 2] as MetricPoint
+    const b = path[i - 1] as MetricPoint
+    const c = path[i] as MetricPoint
+    const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x)
+    if (cross !== 0) count++
+  }
+  return count
+}
+
+export function pathLength(path: readonly MetricPoint[]): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    total += segmentLength(path[i - 1] as MetricPoint, path[i] as MetricPoint)
+  }
+  return total
+}
+
+/** True when `a`→`b` and `c`→`d` meet at a point interior to both. */
+function segmentsProperlyCross(
+  a: MetricPoint,
+  b: MetricPoint,
+  c: MetricPoint,
+  d: MetricPoint,
+): boolean {
+  const orient = (p: MetricPoint, q: MetricPoint, r: MetricPoint) =>
+    Math.sign((q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x))
+  const d1 = orient(a, b, c)
+  const d2 = orient(a, b, d)
+  const d3 = orient(c, d, a)
+  const d4 = orient(c, d, b)
+  // All four strict: a touch at an endpoint or a shared corner is not a
+  // crossing, and collinear overlap is a different defect (border tracing).
+  return d1 !== 0 && d2 !== 0 && d3 !== 0 && d4 !== 0 && d1 !== d2 && d3 !== d4
+}
+
+/** Places two different paths visibly cross each other. */
+export function crossings(paths: readonly (readonly MetricPoint[])[]): number {
+  let count = 0
+  for (let i = 0; i < paths.length; i++) {
+    for (let j = i + 1; j < paths.length; j++) {
+      const p = paths[i] as readonly MetricPoint[]
+      const q = paths[j] as readonly MetricPoint[]
+      for (let a = 1; a < p.length; a++) {
+        for (let b = 1; b < q.length; b++) {
+          if (
+            segmentsProperlyCross(
+              p[a - 1] as MetricPoint,
+              p[a] as MetricPoint,
+              q[b - 1] as MetricPoint,
+              q[b] as MetricPoint,
+            )
+          ) {
+            count++
+          }
+        }
+      }
+    }
+  }
+  return count
+}


### PR DESCRIPTION
Stacked on #713. **Instrument, not a fix** — no production code changes.

## Why

Four routing defects in a row (#705, #706, #711, #713) were reported by a human. Each was fixed and pinned by the single canvas that exposed it, so nothing ever asked the question generally, and nothing could say whether a rule change improved routing overall or only moved the failure somewhere nobody had looked.

## What

- **`routing-metrics.ts`** — interior ink, border ink, bends, length, crossings, computed geometrically and deliberately never calling `edge-rules.ts`. Same independent-oracle contract `reversal-count.ts` holds for `path-reversal`: a test asserting against it cannot be satisfied by a broken rule agreeing with itself. Every expected value in its own test is hand-computed against a picture.
- **`routing-corpus.ts`** — the four reported canvases plus a group-frame and a corridor case, and a deterministic synthetic corpus. Boxes are large relative to the coordinate range on purpose: the defects only appear when nodes crowd each other, so a generator that spread them out would report a clean score while drawing the same broken pictures.
- **`edge-routing-quality.test.ts`** — the invariant all four violated (no routed line runs strictly inside a node body it could have gone around), held strictly over the named corpus and counted over 2000 synthetic layouts.

The exemption is the one `routeEdge` already applies when choosing obstacles: a rect that **strictly** contains an anchor can never be routed around. A rect merely touched by an anchor on its border is not exempt — and that includes the edge's own two endpoints. That distinction *is* the measurement.

## What it measured

Counts are pinned **exactly**, not as a ceiling, so an improvement is as loud as a regression. They are a debt figure, not a target — three zeroes is the goal, at which point the aggregate becomes the strict property the named corpus already holds to.

| class | count | which search should have stopped it |
|---|---:|---|
| `own-endpoint` | 160 | none — `routeEdge` drops both endpoint nodes from its obstacle list, so `bestCandidate` cannot see it |
| `foreign` | 24 | `pathIsClear` rejected the path; `bestCandidate`'s last fallback returned it anyway (shortest BLOCKED candidate when none of its six is clear) |
| `degenerate` | 2 | two touching boxes whose anchors coincide, leaving a 20px spike through both |

**The split is the finding.** `own-endpoint` at 86% is exactly the class the inner search is structurally blind to, which says where to start — and it is the first evidence for that diagnosis that is a number rather than an argument.

## Verification

- 575 canvas-render tests pass; `typecheck`, `lint`, `knip` clean.
- Mutation-checked: reverting #713's tier swap turns the tunnelling corpus case red and moves the aggregate 160 → 163. Both halves of the instrument detect it.
- Aggregate runtime 1.5s.