### PR TITLE
fix(canvas-render): look for a detour when an elbow tunnels through its own endpoint

### DIFF
--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -137,12 +137,12 @@ describe('routing quality across the synthetic corpus', () => {
       crossings: crossingCount,
       length: Math.round(length),
     }).toEqual({
-      violations: { 'own-endpoint': 84, foreign: 24, degenerate: 2 },
-      interiorInk: 9029,
-      borderInk: 1106,
-      bends: 7975,
-      crossings: 598,
-      length: 1313806,
+      violations: { 'own-endpoint': 69, foreign: 21, degenerate: 2 },
+      interiorInk: 6866,
+      borderInk: 1343,
+      bends: 8317,
+      crossings: 593,
+      length: 1345035,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -641,21 +641,36 @@ const borderTracing: PenaltyRule = {
  * it is choosing between paths, so the inter-edge terms do not apply and
  * the foreign-body ones are already the clearance tiers it sorts within.
  */
+/**
+ * Length of `path` running STRICTLY between a rect's two borders — ink laid
+ * over content rather than over an existing stroke. A rect that fully
+ * contains another in the same list is dropped: a group frame is drawn
+ * around its members, and a route legitimately inside it is not tunnelling
+ * through anything a reader would notice.
+ *
+ * Exported because `spatial-edges.ts` asks the same question of a candidate
+ * path directly, rather than through the whole cost tuple: inside a single
+ * side pair it is choosing between paths, so the inter-edge terms do not
+ * apply. Two producers of "how much ink is inside a box" is exactly the
+ * drift this package has a one-producer-per-geometry rule about.
+ */
+export function interiorInkThrough(path: readonly Point[], rects: readonly Rect[]): number {
+  return inkAlongRects(
+    path,
+    rects.filter(
+      (r) =>
+        !rects.some((other) => other !== r && fullyContains(r, other) && !fullyContains(other, r)),
+    ),
+    (fixed, near, far) => near < fixed && fixed < far,
+  )
+}
+
 export const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',
   tier: 3,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) =>
-    inkAlongRects(
-      path,
-      endpointRects.filter(
-        (r) =>
-          !endpointRects.some(
-            (other) => other !== r && fullyContains(r, other) && !fullyContains(other, r),
-          ),
-      ),
-      (fixed, near, far) => near < fixed && fixed < far,
-    ),
+    interiorInkThrough(path, endpointRects),
 }
 
 /** Quantized per-axis direction sign, in the same COST_QUANTUM space every

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -5,10 +5,10 @@ import {
   addCost,
   bendCount,
   composeSidePairs,
-  endpointBodyInk,
   facingLaneWindow,
   fullyContains,
   hasRepairableProblem,
+  interiorInkThrough,
   lessCost,
   oppositeSide,
   type Point,
@@ -932,7 +932,7 @@ function bestCandidate(
   // several times.
   const scored = candidates.map((path) => ({
     path,
-    ink: endpointBodyInk.selfTerm(path, [], [], endpointRects),
+    ink: interiorInkThrough(path, endpointRects),
     length: pathLength(path),
     bends: bendCount(path),
   }))
@@ -1219,22 +1219,38 @@ function routeOrthogonal(
     return withoutRepeats([start, exit, ...middles, ...approach, end])
   }
 
+  const endpointRects = [fromRect, toRect]
   const elbows = [between([{ x: entry.x, y: exit.y }]), between([{ x: exit.x, y: entry.y }])]
-  if (elbows.some((path) => pathIsClear(path, inflated))) {
-    return bestCandidate(elbows, inflated, raw, [fromRect, toRect])
+  // An elbow is good enough to stop here only if it is clear of the FOREIGN
+  // obstacles AND puts no ink inside its own endpoints. Testing foreign
+  // clearance alone returned an elbow that tunnelled straight through the
+  // target's body without ever generating a detour — the endpoint rects are
+  // not obstacles, so nothing reported the route as blocked.
+  if (
+    elbows.some(
+      (path) => pathIsClear(path, inflated) && interiorInkThrough(path, endpointRects) === 0,
+    )
+  ) {
+    return bestCandidate(elbows, inflated, raw, endpointRects)
   }
 
   // Detours are needed when the paths this style actually travels are
   // blocked — which the direct diagonal cannot answer, since an orthogonal
   // edge never travels it. Two obstacles can sit on the two elbows while
   // leaving that diagonal clear.
-  const region = unionRect(
-    inflated.filter((rect) =>
-      elbows.some((path) =>
-        path.some((point, i) => i > 0 && segmentCrossesRect(path[i - 1] as Point, point, rect)),
-      ),
-    ),
-  )
+  //
+  // An endpoint body the elbows cut through joins the region for the same
+  // reason a foreign body does: it is what the route has to get around. It
+  // can never be an obstacle for the CLEARANCE test — every route has to
+  // reach a point on it — but it is a perfectly good thing to steer past.
+  const crossedBy = (rect: Rect) =>
+    elbows.some((path) =>
+      path.some((point, i) => i > 0 && segmentCrossesRect(path[i - 1] as Point, point, rect)),
+    )
+  const region = unionRect([
+    ...inflated.filter(crossedBy),
+    ...endpointRects.filter((rect) => elbows.some((path) => interiorInkThrough(path, [rect]) > 0)),
+  ])
   const candidates =
     region === undefined
       ? elbows
@@ -1242,7 +1258,7 @@ function routeOrthogonal(
           ...elbows,
           ...detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1))),
         ]
-  return bestCandidate(candidates, inflated, raw, [fromRect, toRect])
+  return bestCandidate(candidates, inflated, raw, endpointRects)
 }
 
 /**


### PR DESCRIPTION
Base is `main` this time, not a stack — #713/#714/#715 all landed, and this stands on its own.

## The bug

`routeOrthogonal` returned early as soon as either elbow was clear of the **foreign** obstacles:

```ts
if (elbows.some((path) => pathIsClear(path, inflated))) return ...
```

An endpoint node is never in that obstacle list — every route has to reach a point on it. So an elbow cutting straight through the target's body reported as clear, took the early return, and **the detour candidates were never generated at all**.

#715 taught the ranking to see that ink. This is the case where ranking cannot help, because the good path was never a candidate.

The early return now also requires zero ink inside the edge's own endpoints, and an endpoint body the elbows cut through joins the region the detours steer around — for the same reason a foreign body does. It can never be an obstacle for the *clearance* test, but it is a perfectly good thing to go past.

## Measured (2000 layouts)

| metric | before | after | |
|---|---:|---:|---|
| `own-endpoint` | 84 | **69** | −18% |
| `foreign` | 24 | **21** | −13% |
| `interiorInk` | 9029 | **6866** | −24% |
| `crossings` | 598 | 593 | −1% |
| `bends` | 7975 | 8317 | +4% (price) |
| `borderInk` | 1106 | 1343 | +21% (price) |
| `length` | 1313806 | 1345035 | +2.4% (price) |

`foreign` improving was not the aim; an edge that stops cutting through its own target stops arriving from a direction that needed a bystander crossed.

## Two other widenings were tried and rejected on measurement

This is what the scoreboard is for. Neither is in this diff.

- **Detours around each blocker separately as well as their union.** Bought `own-endpoint` 69 → 59 and −918 interior ink, with *shorter* paths — but pushed `crossings` 593 → 609 and `borderInk` 1343 → 2064. Crossings are **tier 2** and endpoint-body-ink is **tier 3**: buying tier-3 debt with tier-2 debt is a bad trade by the ordering this package already decided.
- **A last-resort fallback picking the least-intruding candidate rather than the shortest.** Lowered total interior ink but **raised the violation count** (69 → 71 `own-endpoint`, 21 → 24 `foreign`) — it spreads shallow intrusions where the shortest-path fallback concentrated deep ones. A reader sees "this edge is wrong", not how many pixels of it are.

## Also

`interiorInkThrough` is extracted from `endpointBodyInk`'s `selfTerm` and exported, so the router and the rule share one producer of "how much ink is inside a box" rather than growing a second — this package's one-producer-per-geometry rule.

## Verification

- All 575 package assertions and both browser suites (99 files / 521 tests) hold unchanged; only the scoreboard's pinned numbers moved.
- Layout time **+3.3%** at 40n/40e (74.9 → 77.4ms), **unchanged** at 60n/200e (256.4 → 256.0ms) — the widened candidate set only builds when the elbows fail.
- `typecheck`, `lint`, `knip` clean.

## Where the debt stands

`own-endpoint` 160 → 84 (#715) → **69**. `interiorInk` 18234 → **6866**, a 62% reduction across the three merged increments.