### PR TITLE
feat(canvas-render): search for a real path when no enumerated route is clean

### DIFF
--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -137,12 +137,12 @@ describe('routing quality across the synthetic corpus', () => {
       crossings: crossingCount,
       length: Math.round(length),
     }).toEqual({
-      violations: { 'own-endpoint': 84, foreign: 24, degenerate: 2 },
-      interiorInk: 9029,
-      borderInk: 1106,
-      bends: 7975,
-      crossings: 598,
-      length: 1313806,
+      violations: { 'own-endpoint': 69, foreign: 21, degenerate: 2 },
+      interiorInk: 6866,
+      borderInk: 1343,
+      bends: 8317,
+      crossings: 593,
+      length: 1345035,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -137,12 +137,12 @@ describe('routing quality across the synthetic corpus', () => {
       crossings: crossingCount,
       length: Math.round(length),
     }).toEqual({
-      violations: { 'own-endpoint': 69, foreign: 21, degenerate: 2 },
-      interiorInk: 6866,
-      borderInk: 1343,
-      bends: 8317,
-      crossings: 593,
-      length: 1345035,
+      violations: { 'own-endpoint': 39, foreign: 19, degenerate: 2 },
+      interiorInk: 4052,
+      borderInk: 1147,
+      bends: 8493,
+      crossings: 644,
+      length: 1360632,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -641,21 +641,36 @@ const borderTracing: PenaltyRule = {
  * it is choosing between paths, so the inter-edge terms do not apply and
  * the foreign-body ones are already the clearance tiers it sorts within.
  */
+/**
+ * Length of `path` running STRICTLY between a rect's two borders — ink laid
+ * over content rather than over an existing stroke. A rect that fully
+ * contains another in the same list is dropped: a group frame is drawn
+ * around its members, and a route legitimately inside it is not tunnelling
+ * through anything a reader would notice.
+ *
+ * Exported because `spatial-edges.ts` asks the same question of a candidate
+ * path directly, rather than through the whole cost tuple: inside a single
+ * side pair it is choosing between paths, so the inter-edge terms do not
+ * apply. Two producers of "how much ink is inside a box" is exactly the
+ * drift this package has a one-producer-per-geometry rule about.
+ */
+export function interiorInkThrough(path: readonly Point[], rects: readonly Rect[]): number {
+  return inkAlongRects(
+    path,
+    rects.filter(
+      (r) =>
+        !rects.some((other) => other !== r && fullyContains(r, other) && !fullyContains(other, r)),
+    ),
+    (fixed, near, far) => near < fixed && fixed < far,
+  )
+}
+
 export const endpointBodyInk: PenaltyRule = {
   name: 'endpoint-body-ink',
   tier: 3,
   pairTerm: () => 0,
   selfTerm: (path, _foreignBodies, _nodeBorders, endpointRects) =>
-    inkAlongRects(
-      path,
-      endpointRects.filter(
-        (r) =>
-          !endpointRects.some(
-            (other) => other !== r && fullyContains(r, other) && !fullyContains(other, r),
-          ),
-      ),
-      (fixed, near, far) => near < fixed && fixed < far,
-    ),
+    interiorInkThrough(path, endpointRects),
 }
 
 /** Quantized per-axis direction sign, in the same COST_QUANTUM space every

--- a/packages/canvas-render/src/layout/grid-route.test.ts
+++ b/packages/canvas-render/src/layout/grid-route.test.ts
@@ -1,0 +1,64 @@
+// The fallback search only runs where the enumerated candidates already
+// failed, so nothing else in the suite exercises it. These are its own
+// checks: the shapes it must produce, and the two ways it is allowed to
+// give up.
+import { describe, expect, it } from 'vitest'
+import { routeOnGrid } from './grid-route.js'
+
+const rect = (x: number, y: number, w: number, h: number) => ({ x, y, w, h })
+
+describe('routeOnGrid', () => {
+  it('runs straight when nothing is in the way', () => {
+    expect(routeOnGrid({ x: 0, y: 0 }, { x: 100, y: 0 }, [], 16)).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it('steps around a box that blocks the straight run', () => {
+    const path = routeOnGrid({ x: 0, y: 50 }, { x: 200, y: 50 }, [rect(80, 0, 40, 100)], 16)
+    expect(path?.[0]).toEqual({ x: 0, y: 50 })
+    expect(path?.[path.length - 1]).toEqual({ x: 200, y: 50 })
+    // Nothing may run through the box's strict interior.
+    for (let i = 1; i < (path?.length ?? 0); i++) {
+      const a = path?.[i - 1] as { x: number; y: number }
+      const b = path?.[i] as { x: number; y: number }
+      const horizontal = a.y === b.y
+      const crosses = horizontal
+        ? a.y > 0 && a.y < 100 && Math.min(a.x, b.x) < 120 && Math.max(a.x, b.x) > 80
+        : a.x > 80 && a.x < 120 && Math.min(a.y, b.y) < 100 && Math.max(a.y, b.y) > 0
+      expect(crosses).toBe(false)
+    }
+  })
+
+  it('keeps the requested clearance from the obstacle it passes', () => {
+    const path = routeOnGrid({ x: 0, y: 50 }, { x: 200, y: 50 }, [rect(80, 0, 40, 100)], 16)
+    // The only ways past are the channels 16px above and below the box.
+    expect(path?.some((p) => p.y === -16 || p.y === 116)).toBe(true)
+  })
+
+  it('collapses collinear points', () => {
+    const path = routeOnGrid({ x: 0, y: 0 }, { x: 300, y: 0 }, [rect(500, 500, 10, 10)], 16)
+    expect(path).toEqual([
+      { x: 0, y: 0 },
+      { x: 300, y: 0 },
+    ])
+  })
+
+  it('gives up rather than search a dense canvas', () => {
+    // 40 obstacles put the grid past MAX_GRID_CELLS; the caller keeps its
+    // enumerated candidate instead of paying for this.
+    const many = Array.from({ length: 40 }, (_, i) => rect(i * 50, i * 30, 20, 20))
+    expect(routeOnGrid({ x: -100, y: -100 }, { x: 3000, y: 2000 }, many, 16)).toBeUndefined()
+  })
+
+  it('returns undefined when the target is walled in', () => {
+    const walls = [
+      rect(90, 40, 20, 120),
+      rect(190, 40, 20, 120),
+      rect(90, 40, 120, 20),
+      rect(90, 140, 120, 20),
+    ]
+    expect(routeOnGrid({ x: 0, y: 100 }, { x: 150, y: 100 }, walls, 16)).toBeUndefined()
+  })
+})

--- a/packages/canvas-render/src/layout/grid-route.ts
+++ b/packages/canvas-render/src/layout/grid-route.ts
@@ -1,0 +1,241 @@
+import type { Point, Rect } from './edge-rules.js'
+
+/**
+ * A rectilinear shortest path around rectangles, used ONLY as a fallback
+ * when the enumerated candidates in `spatial-edges.ts` all fail.
+ *
+ * The enumerated family — two elbows plus four ways around one bounding box —
+ * handles the arrangements that actually occur, cheaply, and is what runs for
+ * almost every edge. What it cannot do is thread BETWEEN obstacles: measured
+ * across 2000 generated layouts, 67 of the 68 routes that still cut through a
+ * node body had a clean rectilinear path available that no candidate in that
+ * family expressed. This finds those.
+ *
+ * The search space is the Hanan grid — every obstacle border offset outward by
+ * `clearance`, plus the two endpoints' own coordinates. A rectilinear shortest
+ * path among rectangles always exists on that grid if it exists at all, so
+ * nothing is lost by not searching the continuous plane. Cost is Manhattan
+ * length plus a per-corner charge, which is what makes it prefer the straight
+ * route over an equally-long staircase.
+ *
+ * Deliberately NOT the default path: it is O(n^2) grid nodes for n obstacles
+ * and runs a priority search over them, against a handful of array operations
+ * for the enumerated candidates. `MAX_GRID_CELLS` abandons the search rather
+ * than spend an unbounded amount of time on a dense canvas — the caller keeps
+ * its best enumerated candidate, exactly as before this existed.
+ */
+
+/** Charge per corner, in px. Two routes of equal length differ only in how
+ * many times they turn, and a reader prefers the one that turns less. Sized
+ * against a typical node so a detour is worth taking to remove a pair of
+ * corners, but never worth a large excursion. */
+const BEND_COST_PX = 80
+
+/** Above this the grid is abandoned rather than searched. A 12x12 obstacle
+ * neighbourhood is already past what the enumerated candidates fail on. */
+const MAX_GRID_CELLS = 4096
+
+type Axis = 0 | 1
+
+const enteredHorizontally = (axis: Axis) => axis === 0
+
+/**
+ * True when the open segment `a`-`b` passes through the strict interior of
+ * `rect`. Touching a border is allowed: obstacles are already offset outward
+ * by the caller's clearance, so a route riding that offset line is at the
+ * intended distance, not grazing the node.
+ */
+function segmentEntersRect(a: Point, b: Point, rect: Rect): boolean {
+  const right = rect.x + rect.w
+  const bottom = rect.y + rect.h
+  if (a.y === b.y) {
+    if (!(a.y > rect.y && a.y < bottom)) return false
+    return Math.min(a.x, b.x) < right && Math.max(a.x, b.x) > rect.x
+  }
+  if (!(a.x > rect.x && a.x < right)) return false
+  return Math.min(a.y, b.y) < bottom && Math.max(a.y, b.y) > rect.y
+}
+
+/**
+ * Length of `a`-`b` lying ON one of `rect`'s borders. Charged rather than
+ * forbidden: the anchors themselves sit on a border, so the first and last
+ * step of every route trace one by construction and a hard rule would make
+ * the target unreachable.
+ */
+function borderOverlap(a: Point, b: Point, rect: Rect): number {
+  const right = rect.x + rect.w
+  const bottom = rect.y + rect.h
+  if (a.y === b.y && (a.y === rect.y || a.y === bottom)) {
+    const lo = Math.max(Math.min(a.x, b.x), rect.x)
+    const hi = Math.min(Math.max(a.x, b.x), right)
+    return hi > lo ? hi - lo : 0
+  }
+  if (a.x === b.x && (a.x === rect.x || a.x === right)) {
+    const lo = Math.max(Math.min(a.y, b.y), rect.y)
+    const hi = Math.min(Math.max(a.y, b.y), bottom)
+    return hi > lo ? hi - lo : 0
+  }
+  return 0
+}
+
+const uniqueSorted = (values: readonly number[]) => [...new Set(values)].sort((a, b) => a - b)
+
+/**
+ * The cheapest rectilinear path from `start` to `end` whose interior avoids
+ * every rect in `obstacles`, or undefined when there is none (or the grid is
+ * too large to search). The returned path always begins at `start` and ends
+ * at `end`, with collinear intermediate points removed.
+ */
+export function routeOnGrid(
+  start: Point,
+  end: Point,
+  obstacles: readonly Rect[],
+  clearance: number,
+): Point[] | undefined {
+  const xs = uniqueSorted([
+    start.x,
+    end.x,
+    ...obstacles.flatMap((r) => [r.x - clearance, r.x + r.w + clearance]),
+  ])
+  const ys = uniqueSorted([
+    start.y,
+    end.y,
+    ...obstacles.flatMap((r) => [r.y - clearance, r.y + r.h + clearance]),
+  ])
+  if (xs.length * ys.length > MAX_GRID_CELLS) return undefined
+
+  const si = xs.indexOf(start.x)
+  const sj = ys.indexOf(start.y)
+  const ei = xs.indexOf(end.x)
+  const ej = ys.indexOf(end.y)
+  if (si < 0 || sj < 0 || ei < 0 || ej < 0) return undefined
+
+  const width = xs.length
+  // Two states per cell — arrived horizontally or vertically — so a turn can
+  // be charged. Collapsing them would make the first arrival win regardless
+  // of how many corners it took to get there.
+  const stateOf = (i: number, j: number, axis: Axis) => (j * width + i) * 2 + axis
+  const best = new Map<number, number>()
+  const cameFrom = new Map<number, number>()
+  // A small binary heap: the grid is bounded but still large enough that a
+  // linear scan per pop dominates the search.
+  const heap: { cost: number; state: number }[] = []
+  const push = (cost: number, state: number) => {
+    heap.push({ cost, state })
+    let child = heap.length - 1
+    while (child > 0) {
+      const parent = (child - 1) >> 1
+      if ((heap[parent] as { cost: number }).cost <= (heap[child] as { cost: number }).cost) break
+      const swap = heap[parent] as { cost: number; state: number }
+      heap[parent] = heap[child] as { cost: number; state: number }
+      heap[child] = swap
+      child = parent
+    }
+  }
+  const pop = () => {
+    const top = heap[0] as { cost: number; state: number }
+    const last = heap.pop() as { cost: number; state: number }
+    if (heap.length > 0) {
+      heap[0] = last
+      let parent = 0
+      for (;;) {
+        const left = parent * 2 + 1
+        const right = left + 1
+        let smallest = parent
+        if (
+          left < heap.length &&
+          (heap[left] as { cost: number }).cost < (heap[smallest] as { cost: number }).cost
+        )
+          smallest = left
+        if (
+          right < heap.length &&
+          (heap[right] as { cost: number }).cost < (heap[smallest] as { cost: number }).cost
+        )
+          smallest = right
+        if (smallest === parent) break
+        const swap = heap[parent] as { cost: number; state: number }
+        heap[parent] = heap[smallest] as { cost: number; state: number }
+        heap[smallest] = swap
+        parent = smallest
+      }
+    }
+    return top
+  }
+
+  for (const axis of [0, 1] as const) {
+    best.set(stateOf(si, sj, axis), 0)
+    push(0, stateOf(si, sj, axis))
+  }
+
+  const steps: readonly (readonly [number, number, Axis])[] = [
+    [1, 0, 0],
+    [-1, 0, 0],
+    [0, 1, 1],
+    [0, -1, 1],
+  ]
+
+  let goal: number | undefined
+  while (heap.length > 0) {
+    const { cost, state } = pop()
+    if ((best.get(state) ?? Number.POSITIVE_INFINITY) < cost) continue
+    const axis = (state % 2) as Axis
+    const cell = (state - axis) / 2
+    const i = cell % width
+    const j = (cell - i) / width
+    if (i === ei && j === ej) {
+      goal = state
+      break
+    }
+    for (const [di, dj, nextAxis] of steps) {
+      const ni = i + di
+      const nj = j + dj
+      if (ni < 0 || nj < 0 || ni >= xs.length || nj >= ys.length) continue
+      const a = { x: xs[i] as number, y: ys[j] as number }
+      const b = { x: xs[ni] as number, y: ys[nj] as number }
+      if (obstacles.some((rect) => segmentEntersRect(a, b, rect))) continue
+      const turn = enteredHorizontally(axis) === enteredHorizontally(nextAxis) ? 0 : BEND_COST_PX
+      // A traced border costs its own length again: a line hidden on top of
+      // a box's edge is the defect this router would otherwise reintroduce
+      // while avoiding the one it exists to fix. Doubling makes going around
+      // clearly cheaper without making a border-hugging step impossible.
+      const traced = obstacles.reduce((sum, rect) => sum + borderOverlap(a, b, rect), 0)
+      const next = cost + Math.abs(b.x - a.x) + Math.abs(b.y - a.y) + turn + traced
+      const nextState = stateOf(ni, nj, nextAxis)
+      if (next >= (best.get(nextState) ?? Number.POSITIVE_INFINITY)) continue
+      best.set(nextState, next)
+      cameFrom.set(nextState, state)
+      push(next, nextState)
+    }
+  }
+  if (goal === undefined) return undefined
+
+  const reversed: Point[] = []
+  for (let state: number | undefined = goal; state !== undefined; state = cameFrom.get(state)) {
+    const axis = state % 2
+    const cell = (state - axis) / 2
+    const i = cell % width
+    const j = (cell - i) / width
+    const point = { x: xs[i] as number, y: ys[j] as number }
+    const last = reversed[reversed.length - 1]
+    if (last === undefined || last.x !== point.x || last.y !== point.y) reversed.push(point)
+  }
+  reversed.reverse()
+
+  // Both start states seed the search, so the walk back can end on either;
+  // collinear runs collapse to their endpoints.
+  const path: Point[] = []
+  for (const point of reversed) {
+    const a = path[path.length - 2]
+    const b = path[path.length - 1]
+    if (
+      a !== undefined &&
+      b !== undefined &&
+      ((a.x === b.x && b.x === point.x) || (a.y === b.y && b.y === point.y))
+    ) {
+      path[path.length - 1] = point
+      continue
+    }
+    path.push(point)
+  }
+  return path.length >= 2 ? path : undefined
+}

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -5,10 +5,10 @@ import {
   addCost,
   bendCount,
   composeSidePairs,
-  endpointBodyInk,
   facingLaneWindow,
   fullyContains,
   hasRepairableProblem,
+  interiorInkThrough,
   lessCost,
   oppositeSide,
   type Point,
@@ -932,7 +932,7 @@ function bestCandidate(
   // several times.
   const scored = candidates.map((path) => ({
     path,
-    ink: endpointBodyInk.selfTerm(path, [], [], endpointRects),
+    ink: interiorInkThrough(path, endpointRects),
     length: pathLength(path),
     bends: bendCount(path),
   }))
@@ -1219,22 +1219,38 @@ function routeOrthogonal(
     return withoutRepeats([start, exit, ...middles, ...approach, end])
   }
 
+  const endpointRects = [fromRect, toRect]
   const elbows = [between([{ x: entry.x, y: exit.y }]), between([{ x: exit.x, y: entry.y }])]
-  if (elbows.some((path) => pathIsClear(path, inflated))) {
-    return bestCandidate(elbows, inflated, raw, [fromRect, toRect])
+  // An elbow is good enough to stop here only if it is clear of the FOREIGN
+  // obstacles AND puts no ink inside its own endpoints. Testing foreign
+  // clearance alone returned an elbow that tunnelled straight through the
+  // target's body without ever generating a detour — the endpoint rects are
+  // not obstacles, so nothing reported the route as blocked.
+  if (
+    elbows.some(
+      (path) => pathIsClear(path, inflated) && interiorInkThrough(path, endpointRects) === 0,
+    )
+  ) {
+    return bestCandidate(elbows, inflated, raw, endpointRects)
   }
 
   // Detours are needed when the paths this style actually travels are
   // blocked — which the direct diagonal cannot answer, since an orthogonal
   // edge never travels it. Two obstacles can sit on the two elbows while
   // leaving that diagonal clear.
-  const region = unionRect(
-    inflated.filter((rect) =>
-      elbows.some((path) =>
-        path.some((point, i) => i > 0 && segmentCrossesRect(path[i - 1] as Point, point, rect)),
-      ),
-    ),
-  )
+  //
+  // An endpoint body the elbows cut through joins the region for the same
+  // reason a foreign body does: it is what the route has to get around. It
+  // can never be an obstacle for the CLEARANCE test — every route has to
+  // reach a point on it — but it is a perfectly good thing to steer past.
+  const crossedBy = (rect: Rect) =>
+    elbows.some((path) =>
+      path.some((point, i) => i > 0 && segmentCrossesRect(path[i - 1] as Point, point, rect)),
+    )
+  const region = unionRect([
+    ...inflated.filter(crossedBy),
+    ...endpointRects.filter((rect) => elbows.some((path) => interiorInkThrough(path, [rect]) > 0)),
+  ])
   const candidates =
     region === undefined
       ? elbows
@@ -1242,7 +1258,7 @@ function routeOrthogonal(
           ...elbows,
           ...detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1))),
         ]
-  return bestCandidate(candidates, inflated, raw, [fromRect, toRect])
+  return bestCandidate(candidates, inflated, raw, endpointRects)
 }
 
 /**

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -20,6 +20,7 @@ import {
   shouldAdoptCandidate,
   zeroPenalty,
 } from './edge-rules.js'
+import { routeOnGrid } from './grid-route.js'
 
 function rectOf(node: SpatialNode): Rect {
   return { x: node.x, y: node.y, w: node.width, h: node.height }
@@ -1258,7 +1259,18 @@ function routeOrthogonal(
           ...elbows,
           ...detourCandidates(exit, entry, region).map((path) => between(path.slice(1, -1))),
         ]
-  return bestCandidate(candidates, inflated, raw, endpointRects)
+  const enumerated = bestCandidate(candidates, inflated, raw, endpointRects)
+  if (interiorInkThrough(enumerated, endpointRects) === 0 && pathIsClear(enumerated, raw)) {
+    return enumerated
+  }
+  // Nothing enumerated works, so pay for a real search. It runs between the
+  // STUBS, not the anchors, so the perpendicular departure and arrival the
+  // rest of this function guarantees survive it — the grid only decides what
+  // happens in between.
+  const searched = routeOnGrid(exit, entry, [...raw, ...endpointRects], OBSTACLE_CLEARANCE_PX)
+  return searched === undefined
+    ? enumerated
+    : bestCandidate([enumerated, between(searched.slice(1, -1))], inflated, raw, endpointRects)
 }
 
 /**


### PR DESCRIPTION
## The measurement that decided this

Before writing anything, I asked whether the remaining debt was even fixable: for each route still cutting through a node body, does a clean rectilinear path exist at all? A Hanan-grid BFS answered it.

**67 of 68 had one.** Only a single case is geometrically impossible.

So the remaining debt was never a cost-model problem — you cannot rank a path you never generate. The enumerated candidate family (two elbows plus four ways around one bounding box) simply cannot express those routes, which is exactly why #715 (ranking) and #716 (widening that family) hit diminishing returns.

## What this adds

`routeOnGrid` — a rectilinear shortest path over the Hanan grid (every obstacle border offset by the clearance, plus the endpoints' own coordinates). Cost is Manhattan length + a per-corner charge + a charge for riding a node's border. A rectilinear shortest path among rectangles always exists on that grid if it exists at all, so nothing is lost by not searching the plane.

**It is a fallback, not the new default.** The enumerated candidates run first and answer almost every edge in a handful of array operations; the search runs only when the winner still tunnels or still crosses a bystander, and `MAX_GRID_CELLS` abandons it rather than spend unbounded time on a dense canvas. It runs between the **stubs**, so the perpendicular departure and arrival the rest of `routeOrthogonal` guarantees survive it — the grid only decides what happens in between.

## Visual repro

`synthetic 326` from the scoreboard corpus, edge `n0 → n2`. Before, the route stabs up through n2 and hooks back down to its bottom border. After, it goes around and arrives from below.

![grid-fallback.png](https://github.com/user-attachments/assets/5fae7e77-a9bd-42ae-929e-f4d651026a67)

## Measured (2000 layouts)

| metric | before | after | |
|---|---:|---:|---|
| `own-endpoint` | 69 | **39** | **−43%** |
| `foreign` | 21 | **19** | −10% |
| `interiorInk` | 6866 | **4052** | **−41%** |
| `borderInk` | 1343 | **1147** | −15% |
| `bends` | 8317 | 8493 | +2% |
| `length` | 1345035 | 1360632 | +1.2% |
| `crossings` | 593 | 644 | **+9%** |

**Crossings are the one regression, and a deliberate one** (human decision). Every routing defect reported against this package has been a line through a box or a line looping back on itself — never a crossing — and the package already renders jump arcs for crossings while nothing at all mitigates a tunnel.

The rise is also not inherent to the search: `optimizeSideChoices` scores trial paths from `computeAnchorsFor`, never the routed path, so the crossing-aware pass is blind to what the fallback actually draws. Closing that mismatch is tracked separately.

## The border-ink charge exists because the first version regressed a user-reported pin

`edge-border-trace.test.ts` went red — a grid path is free to ride a node's edge, and did, reintroducing the exact defect that pin exists to prevent while fixing a different one. Charging a traced border its own length again restored the pin **and** lowered border ink below where this increment started.

That is the pin doing its job, and worth saying out loud: a fallback that only optimises for the metric you are currently chasing will happily undo an older fix.

## Verification

- All **582** package assertions and both browser suites (99 files / 521 tests) hold; only the scoreboard's pinned numbers moved.
- `grid-route.test.ts` covers the search directly — the shapes it must produce, the clearance it must keep, and both ways it is allowed to give up.
- Layout time: **+0.3%** at 40n/40e (64.1 → 64.3ms), **+7.5%** at 60n/200e (255.2 → 274.4ms). The dense case is where the enumerated candidates fail most often, so that is where the fallback is paid for.
- `typecheck`, `lint`, `knip` clean.

## Where the debt stands

`own-endpoint` **160 → 84 → 69 → 39** (−76% across four increments). `interiorInk` **18234 → 4052** (−78%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved orthogonal edge routing around obstacles with a grid-based fallback.
  * Supports safer paths when standard detour options cannot meet clearance requirements.
  * Handles dense or unreachable layouts gracefully without disrupting existing routing.

* **Tests**
  * Added coverage for straight paths, obstacle avoidance, clearance, fallback behavior, and unreachable targets.
  * Updated routing quality expectations to reflect improved path results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->