### PR TITLE
fix(canvas-render): re-pair the arrival when occlusion moves the departure

### DIFF
--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -137,12 +137,12 @@ describe('routing quality across the synthetic corpus', () => {
       crossings: crossingCount,
       length: Math.round(length),
     }).toEqual({
-      violations: { 'own-endpoint': 39, foreign: 19, degenerate: 2 },
-      interiorInk: 4052,
+      violations: { 'own-endpoint': 35, foreign: 17, degenerate: 2 },
+      interiorInk: 3625,
       borderInk: 1147,
-      bends: 8493,
-      crossings: 644,
-      length: 1360632,
+      bends: 8484,
+      crossings: 647,
+      length: 1362720,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-side-repair.test.ts
+++ b/packages/canvas-render/src/layout/edge-side-repair.test.ts
@@ -1,0 +1,40 @@
+// An arrival is chosen as the partner of a particular departure. When
+// occlusion moves the departure, keeping that arrival describes a pair the
+// ranking never proposed, and the edge reaches its target the long way
+// round: the reported canvas arrived at n2's BOTTOM from below, four
+// corners, when n2's right side was one corner away.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const node = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+it('re-pairs the arrival onto the axis the moved departure did not take', () => {
+  // n1 buries n0's left anchor, so the departure moves left -> top. The
+  // arrival must follow onto the horizontal axis (n2's right), not keep the
+  // `bottom` that only existed as `left`'s partner.
+  const nodes = [
+    node('n0', 328, 383, 140, 137),
+    node('n1', 273, 344, 104, 121),
+    node('n2', 7, 216, 64, 133),
+  ]
+  const edges: CanvasEdge[] = [{ id: 'e', fromNode: 'n0', toNode: 'n2' }]
+  const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+  const routed = routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
+  expect({ from: routed.fromSide, to: routed.toSide }).toEqual({ from: 'top', to: 'right' })
+  // One corner between the departure stub and the arrival.
+  expect(routed.path.map((p) => `${p.x},${p.y}`)).toEqual([
+    '398,383',
+    '398,363',
+    '398,282.5',
+    '71,282.5',
+  ])
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -130,9 +130,8 @@ function deriveDefaultSides(
     const occluders = foreign.filter((r) => !fullyContains(r, rect))
     return !occluders.some((r) => strictlyInside(r, sidePoint(rect, side)))
   }
-  // Ranking is geometric only; occlusion then adjusts each end
-  // independently from the chosen pair (an occluded end moves to its next
-  // exposed side alone, rather than dragging the other end with it).
+  // Ranking is geometric only; occlusion then moves an end that is buried
+  // under a neighbour to its next exposed side.
   const best = pairs[0]!
   const pick = (rect: Rect, primary: Side, mirror: readonly [Side, Side, Side, Side]): Side => {
     const candidates = [primary, ...mirror.filter((sd) => sd !== primary)]
@@ -140,10 +139,24 @@ function deriveDefaultSides(
   }
   const fromMirror = facingSides(dx, dy)
   const toMirror = fromMirror.map(oppositeSide) as unknown as readonly [Side, Side, Side, Side]
-  return {
-    fromSide: pick(fromRect, best.fromSide, fromMirror),
-    toSide: pick(toRect, best.toSide, toMirror),
+  const fromSide = pick(fromRect, best.fromSide, fromMirror)
+  // partner-follows-moved-end: an arrival is chosen as the partner of a
+  // particular departure, so when occlusion moves the departure the arrival
+  // is left describing a pair that no longer exists — `left->bottom` with
+  // the departure pushed to `top` becomes `top->bottom`, a combination the
+  // ranking never proposed and which reaches the target's far side the long
+  // way round. The coherent partner is the one on the axis the departure did
+  // NOT take: leaving horizontally arrives on the vertical facing side, and
+  // leaving vertically arrives on the horizontal one. Only the orphaned half
+  // is replaced — an arrival occlusion never touched keeps its own choice.
+  const horizontal = (side: Side) => side === 'left' || side === 'right'
+  const { h, v } = {
+    h: dx >= 0 ? ('right' as Side) : ('left' as Side),
+    v: dy >= 0 ? ('bottom' as Side) : ('top' as Side),
   }
+  const partnerSide =
+    fromSide === best.fromSide ? best.toSide : oppositeSide(horizontal(fromSide) ? v : h)
+  return { fromSide, toSide: pick(toRect, partnerSide, toMirror) }
 }
 
 /** Distance the self-edge loop bulges out along the selected side's outward normal, in px. */


### PR DESCRIPTION
Reported: on the previous increment's "after" figure, the edge should ideally reach the left node's **right side with one corner**. It does now.

![arrival](https://github.com/user-attachments/assets/1f46adc7-fdc6-4ff6-a7e2-21c912e6b591)

## The bug

An arrival side is chosen as the **partner** of a particular departure. When occlusion then moves the departure, the arrival is left describing a pair that no longer exists.

On this canvas the ranking's best pair was `left→bottom`. A neighbour buries the source's left anchor, so the departure moves to `top` — and the `bottom` that had only ever been `left`'s partner stays. `top→bottom` is a combination **the ranking never proposed**: it reaches the target by going down past it, along underneath, and back up into its bottom edge. Four corners, when the target's right side was one corner away.

`top→right` was sitting at position 1 in the ranked list the whole time. Nothing consulted it once the departure moved:

```
0: left->bottom     <- best; departure occluded, moves to 'top'
1: top->right       <- the coherent pair for that departure
2: left->right
3: top->bottom      <- what we drew
```

## The rule

`partner-follows-moved-end`: the coherent partner is the one on **the axis the departure did not take** — leaving horizontally arrives on the vertical facing side, leaving vertically arrives on the horizontal one. Only the orphaned half is replaced; an arrival occlusion never touched keeps its own choice.

**A first attempt asked the ranked list for any pair starting from the new departure side.** That broke `edge-side-occlusion.test.ts`'s group-frame pin: for a purely horizontal arrangement the L-pair rule generates nothing (`dx === 0 || dy === 0` returns early), so the lookup fell through to a same-side U-hook and picked the target's far edge. The axis rule is what the L-pairs encode anyway, and it holds whether or not the ranking bothered to emit them — that pin caught a real overreach.

## Measured (2000 layouts)

**Every metric improved.** Rare enough to note — this one was not a trade.

| metric | before | after |
|---|---:|---:|
| `own-endpoint` | 39 | **35** |
| `foreign` | 19 | **17** |
| `interiorInk` | 4052 | **3625** (−11%) |
| `bends` | 8493 | **8484** |
| `borderInk` | 1147 | 1147 |
| `crossings` | 644 | 647 |
| `length` | 1360632 | 1362720 |

## Verification

- Mutation-checked: reverting the rule turns the new pin red with exactly the reported symptom (`top→bottom` instead of `top→right`).
- All **583** package assertions and both browser suites (99 files / 521 tests) hold.
- `typecheck`, `lint`, `knip` clean.