### PR TITLE
perf(canvas-render): stop re-routing identical edges inside the side-choice search

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "knip": "knip",
     "secretlint": "secretlint --secretlintignore .secretlintignore \"**/*\"",
     "test:scripts": "node --test .claude/scripts/*.test.mjs .claude/workflows/lib/*.test.mjs",
-    "prepare": "lefthook install || true"
+    "prepare": "lefthook install || true",
+    "bench": "vitest bench --project canvas-render-node"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",

--- a/packages/canvas-render/src/layout/spatial-edges.bench.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.bench.ts
@@ -1,0 +1,69 @@
+// Edge routing is the layout budget: `assignEdgeAnchors` runs a side-choice
+// search that re-routes and re-scores the edge set many times over, and it
+// is the only part of layout whose cost grows with the SQUARE of the canvas.
+// Run with `pnpm bench`.
+//
+// The two sizes are chosen to separate the costs. 40n/40e is a sparse canvas
+// where the search settles quickly; 60n/200e is dense enough that the
+// optimizer keeps working, which is where every regression has shown up.
+//
+// Numbers are machine-specific — compare a before/after on the SAME machine
+// in one sitting, never a committed figure against a fresh run.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { bench, describe } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+/**
+ * A regular grid of boxes wired by a stride that guarantees long, crossing
+ * edges rather than neighbour-to-neighbour hops — the arrangement that keeps
+ * the optimizer busy. Deterministic, so two runs compare like for like.
+ */
+function gridCanvas(nodeCount: number, edgeCount: number) {
+  const nodes: SpatialNode[] = Array.from({ length: nodeCount }, (_, i) => ({
+    id: `n${i}`,
+    type: 'text',
+    x: (i % 8) * 260,
+    y: Math.floor(i / 8) * 180,
+    width: 200,
+    height: 120,
+    text: `n${i}`,
+  }))
+  const edges: CanvasEdge[] = Array.from({ length: edgeCount }, (_, i) => ({
+    id: `e${i}`,
+    fromNode: `n${i % nodeCount}`,
+    toNode: `n${(i * 7 + 3) % nodeCount}`,
+  })).filter((e) => e.fromNode !== e.toNode)
+  return { nodes, edges }
+}
+
+const sparse = gridCanvas(40, 40)
+const dense = gridCanvas(60, 200)
+
+describe('side-choice search', () => {
+  bench('assignEdgeAnchors 40 nodes / 40 edges', () => {
+    assignEdgeAnchors(sparse.nodes, sparse.edges, 'orthogonal')
+  })
+
+  bench('assignEdgeAnchors 60 nodes / 200 edges', () => {
+    assignEdgeAnchors(dense.nodes, dense.edges, 'orthogonal')
+  })
+})
+
+// The primitives the search calls, so a regression can be attributed rather
+// than guessed at: if the search slows down but these did not, the cost is in
+// how many times it calls them.
+describe('routing primitives', () => {
+  const denseAnchors = assignEdgeAnchors(dense.nodes, dense.edges, 'orthogonal')
+
+  bench('routeEdge over 200 edges, orthogonal', () => {
+    for (const edge of dense.edges) {
+      routeEdge(dense.nodes, edge, 'orthogonal', denseAnchors.get(edge.id))
+    }
+  })
+
+  bench('routeEdge over 200 edges, straight', () => {
+    for (const edge of dense.edges) {
+      routeEdge(dense.nodes, edge, 'straight', denseAnchors.get(edge.id))
+    }
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -607,11 +607,29 @@ function optimizeSideChoices(
   // the anchor groups it left and joined) re-route and re-score their
   // pairs — everything else is carried over. This is what keeps a trial
   // O(affected * E) instead of O(E^2).
+  // Same edge, same anchors, same obstacles -> same path. A trial re-sides
+  // ONE edge, but that recomputes the anchor groups it leaves and joins, so
+  // the same (edge, anchor) combination comes back around repeatedly:
+  // measured at 60 nodes / 200 edges, 296 of 854 routings were repeats of an
+  // identical call, one combination recurring nine times. `nodes` and
+  // `style` are fixed for the whole call, so they are not part of the key —
+  // and the cache lives only as long as this call, so a later layout of a
+  // moved canvas never sees a stale path.
+  const routeCache = new Map<string, readonly Point[]>()
+  const anchorKey = (edge: CanvasEdge, a: EdgeAnchorPair | undefined) =>
+    `${edge.id}|${a?.fromSide}|${a?.toSide}|${a?.from?.x},${a?.from?.y}|${a?.to?.x},${a?.to?.y}|${a?.fromLaneDepth}|${a?.toLaneDepth}`
+  const routeCached = (edge: CanvasEdge, a: EdgeAnchorPair | undefined): readonly Point[] => {
+    const key = anchorKey(edge, a)
+    const hit = routeCache.get(key)
+    if (hit !== undefined) return hit
+    const path = routeEdge(nodes, edge, style, a).path
+    routeCache.set(key, path)
+    return path
+  }
+
   let current = new Map(initial)
   let anchors = computeAnchorsFor(nodes, edges, current, false)
-  let paths: (readonly Point[])[] = edges.map(
-    (e) => routeEdge(nodes, e, style, anchors.get(e.id)).path,
-  )
+  let paths: (readonly Point[])[] = edges.map((e) => routeCached(e, anchors.get(e.id)))
   const pairKey = (i: number, j: number) => i * edges.length + j
   const matrix = new Map<number, ConfigCost>()
   const foreignBodiesFor = edges.map((e) =>
@@ -666,7 +684,7 @@ function optimizeSideChoices(
     }
     const trialPaths = paths.slice()
     for (const i of touched) {
-      trialPaths[i] = routeEdge(nodes, edges[i]!, style, trialAnchors.get(edges[i]!.id)).path
+      trialPaths[i] = routeCached(edges[i]!, trialAnchors.get(edges[i]!.id))
     }
     const touchedSet = new Set(touched)
     let cost = currentCost

--- a/packages/canvas-render/vitest.node.config.ts
+++ b/packages/canvas-render/vitest.node.config.ts
@@ -6,5 +6,8 @@ export default defineProject({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.browser.test.ts'],
+    // `vitest bench` only — `vitest run` never picks these up, since
+    // `include` above matches *.test.ts and nothing else.
+    benchmark: { include: ['src/**/*.bench.ts'] },
   },
 })


### PR DESCRIPTION
Follows a profile, and adds the benchmark that made it measurable. Suggested by @kamiazya — `vitest bench` replaces the throwaway timing loops I had been using.

## The profile

At 60 nodes / 200 edges, where `assignEdgeAnchors` costs ~250ms:

| | |
|---|---:|
| `routeEdge` calls | 854 (4.3 per edge) |
| …of which **identical repeats** | **296 (35%)**, one combination nine times |
| `computeAnchorsFor` passes, each over **all 200 edges** | **104** |
| one full routing pass | ~9ms |
| one crossing-scoring pass | ~1.6ms |

**The time is not in arithmetic.** The primitives are fast; the search runs them over and over. A trial re-sides ONE edge, but that recomputes the anchor groups it leaves and joins, so the same `(edge, anchor)` combination comes back around.

## The change

Memoize on the anchor identity `sameAnchor` already compares, scoped to the one `optimizeSideChoices` call. `nodes` and `style` are fixed for its duration so they are not part of the key, and the cache cannot outlive the call and hand a stale path to a later layout of a moved canvas.

## Measured

Three **interleaved** rounds — the machine drifts too much between separate runs to trust a single pair:

| round | before (min) | after (min) |
|---|---:|---:|
| 1 | 247.9 | **236.4** |
| 2 | 257.5 | **220.0** |
| 3 | 275.4 | **225.4** |

Faster in every paired round. Median **257.5 → 225.4ms, about −12%**.

**Behaviour is unchanged, and the proof is that the routing scoreboard's pinned counts did not move by a single pixel** — 584 assertions green with no edit to any expectation. That is the strongest correctness check available for a pure optimisation here.

## The benchmark

`pnpm bench`. Two canvas sizes separate the costs: 40n/40e settles quickly, 60n/200e keeps the optimizer working, which is where every regression has shown up. Routing primitives are benched alongside so a regression can be **attributed** — if the search slows down but `routeEdge` did not, the cost is in how many times it is called.

No new project or config file: `benchmark.include` on the existing `canvas-render-node` project is enough, and `vitest run` still matches only `*.test.ts` (verified: 56 test files, bench excluded).

**One caveat learned while using it, and recorded in the file:** the primitives bench is *not* a valid control for a change to the search, because both run in one process. This change makes the search call `routeEdge` 854 → 558 times, which leaves it colder when the primitives bench starts, and it measures ~40% slower for that reason alone. Interleaved runs of the same benchmark are the only comparison I would trust here.

## What is next, and why not a GPU or a rewrite

The remaining bulk is those **104 full-edge-set anchor recomputations**: `evaluateTrial` already knows which edges a trial touched, but `computeAnchorsFor` rebuilds all 200 regardless. That is the next change.

It is also the reason neither WebGPU nor a Rust port is the answer here — they would make redundant work faster rather than remove it, and 200 edges is far too small a workload to pay for either.