### PR TITLE
test(canvas-codec): pin the backslash round-trip defect instead of tripping over it by seed

### DIFF
--- a/packages/canvas-codec/src/markdown/markdown-backslash-round-trip.test.ts
+++ b/packages/canvas-codec/src/markdown/markdown-backslash-round-trip.test.ts
@@ -1,0 +1,37 @@
+// A CHARACTERIZATION test: it pins behaviour that is WRONG, so the defect is
+// visible in the suite instead of only in a property that trips over it on
+// one seed in a hundred. When `mdast-util-to-markdown` fixes it this test
+// goes red — that is the point, and the fix is to assert the round trip and
+// drop `hasNoBackslashText` from round-trip.property.test.ts.
+//
+// `safe()` makes a character safe one of two ways: ASCII punctuation gets a
+// backslash escape, anything else gets a character reference. On the
+// reference branch it flushes the preceding text with a HARDCODED `after` of
+// `'\\'` rather than the `&` that actually follows, so a backslash needing
+// no escape of its own is left able to escape the reference's ampersand.
+import { expect, it } from 'vitest'
+import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
+
+const body = (children: unknown[]) =>
+  ({ type: 'root', children: [{ type: 'paragraph', children }] }) as never
+
+const firstTextValue = (root: unknown) =>
+  (root as { children: { children: { value?: string }[] }[] }).children[0]?.children?.[0]?.value
+
+it('round-trips a trailing backslash when nothing forces a character reference', () => {
+  for (const value of ['\\A', 'a\\A', '\\!', '\\<', '\\&', '\\\\']) {
+    const round = parseMarkdownBody(stringifyMarkdownBody(body([{ type: 'text', value }])))
+    expect({ value, round: firstTextValue(round) }).toEqual({ value, round: value })
+  }
+})
+
+it('CORRUPTS a backslash when the next character is emitted as a reference', () => {
+  const input = body([
+    { type: 'text', value: '\\A' },
+    { type: 'emphasis', children: [{ type: 'inlineMath', value: '!' }] },
+  ])
+  const markdown = stringifyMarkdownBody(input)
+  // The backslash is left bare in front of the reference it now escapes.
+  expect(markdown).toBe('\\&#x41;*$!$*')
+  expect(firstTextValue(parseMarkdownBody(markdown))).toBe('&#x41;')
+})

--- a/packages/canvas-codec/src/markdown/round-trip.property.test.ts
+++ b/packages/canvas-codec/src/markdown/round-trip.property.test.ts
@@ -112,11 +112,43 @@ function hasNoExcludedDescendant(node: any): boolean {
   return true
 }
 
+/**
+ * A literal backslash in text is excluded, and this one is an upstream
+ * DEFECT rather than an encoding ambiguity like the exclusions above.
+ *
+ * `mdast-util-to-markdown`'s `safe()` makes a character safe one of two
+ * ways: ASCII punctuation gets a backslash escape, anything else gets a
+ * character reference. On the reference branch it flushes the text before
+ * the position with `escapeBackslashes(value.slice(start, position), '\\')`
+ * — a HARDCODED `after`, which is not what actually follows. What follows
+ * is the reference it is about to push, whose first character is `&`. A
+ * backslash before `&` is an escape, so a trailing backslash that needed no
+ * escaping of its own silently becomes one:
+ *
+ *     text '\\A' next to emphasis-wrapped math
+ *       -> serialized  \&#x41;
+ *       -> re-parsed   text '&#x41;'
+ *
+ * `markdown-backslash-round-trip.test.ts` pins that exact behaviour, so
+ * this exclusion disappears the moment upstream stops doing it. Excluded
+ * here rather than in canvas-model's shared arbitrary because the totality
+ * property has no problem with the same input.
+ */
+function hasNoBackslashText(node: { type?: string; value?: unknown; children?: unknown }): boolean {
+  if (node?.type === 'text' && typeof node.value === 'string' && node.value.includes('\\')) {
+    return false
+  }
+  return Array.isArray(node?.children)
+    ? node.children.every((child) => hasNoBackslashText(child as { type?: string }))
+    : true
+}
+
 function nonListFlowArbitrary(maxDepth: number) {
   return mdastFlowContentArbitrary(maxDepth)
     .filter((node) => !EXCLUDED_ROUND_TRIP_TYPES.has(node.type))
     .filter(hasNoEmptyContainer)
     .filter(hasNoExcludedDescendant)
+    .filter(hasNoBackslashText)
 }
 
 const rootArbitrary = fc


### PR DESCRIPTION
The round-trip property failed CI on seed 803073354 and blocked #720, which touched a different package entirely. **It is not a flake.** Shrunk 13 times, it names a real content-corruption bug.

## The defect

```
text '\A' followed by emphasis-wrapped inline math
  -> serialized   \&#x41;*$!$*
  -> re-parsed    text '&#x41;'
```

A user typing `\A` in a document body has it silently rewritten across one save/load cycle.

Narrowed by hand — it takes emphasis **wrapping** math:

| input | serialized | |
|---|---|---|
| `text("\A")` + `emphasis(inlineMath)` | `\&#x41;*$!$*` | **corrupted** |
| `text("\A")` + `emphasis(text)` | `\A*x*` | fine |
| `text("\A")` + `inlineMath` | `\A$!$` | fine |
| `text("\A")` alone | `\A` | fine |

## Root cause, upstream

In `mdast-util-to-markdown`'s `safe()`. A character is made safe one of two ways — ASCII punctuation gets a backslash escape, anything else gets a character reference — and on the reference branch it flushes the preceding text with:

```js
result.push(escapeBackslashes(value.slice(start, position), '\\'))
```

a **hardcoded `after`** that is not what follows. What follows is the reference it is about to push, whose first character is `&`. A backslash before `&` is an escape, so a trailing backslash that needed no escaping of its own silently becomes one.

There is no clean fix from this side: the decision, the flush, and the `after` it should have used are all inside that function.

## So this PR does not pretend to fix it

It makes the defect **visible** and stops it blocking unrelated work.

- **`markdown-backslash-round-trip.test.ts`** — a characterization test pinning the wrong behaviour exactly, alongside the six backslash inputs that *do* round-trip. When upstream fixes this, the pin goes red. **That is the point**: the follow-up is to assert the round trip and delete the filter below.
- **`hasNoBackslashText`** — excludes literal backslashes in text from the round-trip generator, next to the encoding-ambiguity exclusions already in that file and documented to the same standard. Local to this property, not in canvas-model's shared arbitrary, because the totality property handles the same input fine.

## Verification

- **The seed is not pinned** (per the repo's PBT rule). Verified the originally-failing 803073354 plus four other seeds now pass.
- **Mutation-checked**: removing the filter turns 803073354 red again with the identical counterexample.
- canvas-codec + canvas-model: 243 assertions green. `typecheck`, `lint`, `knip` clean.

Tracked as task #34 for the upstream report and the eventual real fix.