### PR TITLE
feat(canvas-render): name digest entries by document node id, and report only addressable nodes

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -35,7 +35,16 @@ paths:
 - The SVG backend (`svg/backend.ts` + `svg/format.ts`): scene -> SVG string,
   one implementation shared by Node/browser/Workers.
 - `sceneDigest` (`scene-digest.ts`): the AI-facing spatial digest, the one
-  Zod-schematized output of this package.
+  Zod-schematized output of this package. It reports one entry per
+  ADDRESSABLE node — the chrome shapes carrying a document `id` — because
+  the reader's only way to act on what it sees is a tool that takes a node
+  id. Content laid out inside a node (its text runs, a facet card's rows)
+  carries a bbox too but is deliberately excluded: reporting it made a
+  three-node canvas answer with six entries, each "contained in" another,
+  and none of the extra three could be acted on. A scene with no identified
+  shape at all (hand-built, a fragment) keeps the older behaviour of taking
+  every bbox-carrying node named by position — there is nothing better to
+  name them by, and the alternative is answering with nothing.
 
 ## What does NOT belong here
 

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -193,6 +193,7 @@ function chromeShape(node: SpatialNode, options: ResolvedLayoutOptions): ShapeSc
   const resolved = options.appearance.resolveNode(node)
   return {
     kind: 'shape',
+    id: node.id,
     bbox: { x: node.x, y: node.y, w: node.width, h: node.height },
     ...(resolved.radius !== undefined ? { radius: resolved.radius } : {}),
     ...(resolved.appearance !== undefined ? { appearance: resolved.appearance } : {}),

--- a/packages/canvas-render/src/scene-digest-ids.test.ts
+++ b/packages/canvas-render/src/scene-digest-ids.test.ts
@@ -1,0 +1,84 @@
+// The digest is what an AI reads to decide what to change, and the only way
+// it can act on what it read is `wb_node_patch` against a node id. Numbering
+// the entries by array position gave it names that mean nothing outside the
+// digest and that shift whenever a node is added or removed — the reader
+// could see "these two overlap" and had no way to say which two.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
+import { expect, it } from 'vitest'
+import type { SpatialAppearanceResolver } from './layout/spatial-appearance.js'
+import { layoutSpatialCanvas } from './layout/spatial-canvas.js'
+import { sceneDigest } from './scene-digest.js'
+import { createFakeMeasure } from './test-utils/fake-measure.js'
+
+const appearance: SpatialAppearanceResolver = {
+  resolveNode: () => ({}),
+  resolveEdge: () => ({}),
+  resolveLabel: () => ({ fill: '#000', fontFamily: 'sans-serif' }),
+}
+const parseBody = (text: string): MdastRoot => ({
+  type: 'root',
+  children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }],
+})
+
+/** Fixed coordinates per id, so removing a node moves nothing that remains. */
+const PLACES: Record<string, { x: number; y: number }> = {
+  alpha: { x: 0, y: 0 },
+  beta: { x: 40, y: 0 },
+  gamma: { x: 300, y: 0 },
+}
+
+const canvasWith = (ids: readonly string[]): SpatialCanvas =>
+  ({
+    nodes: ids.map((id) => ({
+      id,
+      type: 'text',
+      x: PLACES[id]?.x ?? 0,
+      y: PLACES[id]?.y ?? 0,
+      width: 100,
+      height: 60,
+      text: id,
+    })),
+    edges: [],
+  }) as unknown as SpatialCanvas
+
+const digestOf = (canvas: SpatialCanvas) =>
+  sceneDigest(
+    layoutSpatialCanvas(canvas, {
+      measure: createFakeMeasure(),
+      parseBody,
+      appearance,
+      geometry: { paddingPx: 8, labelFontSizePx: 12, minContentWidthPx: 1 },
+    }),
+  )
+
+it('names each entry by its document node id', () => {
+  const digest = digestOf(canvasWith(['alpha', 'beta', 'gamma']))
+  expect(digest.nodes.map((n) => n.id)).toEqual(['alpha', 'beta', 'gamma'])
+})
+
+it('keeps a node its name when an earlier node is removed', () => {
+  // Positional ids renamed gamma from n2 to n1 here, silently pointing any
+  // instruction written against the first digest at a different node.
+  const before = digestOf(canvasWith(['alpha', 'beta', 'gamma']))
+  const after = digestOf(canvasWith(['beta', 'gamma']))
+  expect(before.nodes.map((n) => n.id)).toEqual(['alpha', 'beta', 'gamma'])
+  expect(after.nodes.map((n) => n.id)).toEqual(['beta', 'gamma'])
+  expect(after.nodes.find((n) => n.id === 'gamma')?.bbox).toEqual(
+    before.nodes.find((n) => n.id === 'gamma')?.bbox,
+  )
+})
+
+it('reports one entry per canvas node, not one per laid-out box', () => {
+  // Each node also lays out its text, which carries a bbox of its own. Those
+  // are content inside a node, not nodes: reporting them made a three-node
+  // canvas answer with six entries, each "contained in" another.
+  expect(digestOf(canvasWith(['alpha', 'beta', 'gamma'])).nodes).toHaveLength(3)
+  expect(digestOf(canvasWith(['alpha', 'beta', 'gamma'])).containment).toEqual([])
+})
+
+it('names overlap pairs by document id too', () => {
+  // Two 100-wide boxes 40 apart overlap.
+  const digest = digestOf(canvasWith(['alpha', 'beta']))
+  expect(digest.overlaps).toEqual([['alpha', 'beta']])
+})

--- a/packages/canvas-render/src/scene-digest.ts
+++ b/packages/canvas-render/src/scene-digest.ts
@@ -210,12 +210,26 @@ function computeFreeRegions(entries: readonly DigestEntry[]): BoundingBox[] {
 }
 
 /**
- * Only nodes that carry a `bbox` participate in the digest — a resolved
- * edge is a path, not an area, so it has no bounding box to contribute to
- * overlap/containment/cluster/free-region derivation.
+ * What the digest reports as a "node".
+ *
+ * When the scene came from a spatial canvas, that is exactly the chrome
+ * shapes — the boxes a reader can address by id. Everything else with a
+ * bbox is CONTENT laid out inside one of them (a node's text runs, a card's
+ * rows), and reporting those alongside was actively misleading: a
+ * three-node canvas answered with six entries, every one of which was
+ * "contained in" another, and none of the extra three could be acted on.
+ *
+ * A scene with no identified shape at all is not a canvas projection — a
+ * hand-built scene, a fragment — and keeps the previous behaviour of taking
+ * every bbox-carrying node, named by position. There is nothing better to
+ * name them by, and the alternative is answering with nothing.
  */
-function collectTopLevelBoxes(scene: Scene): BoundingBox[] {
-  return scene.nodes.flatMap((node) => (node.kind === 'edge' ? [] : [node.bbox]))
+function collectEntries(scene: Scene): { readonly id?: string; readonly bbox: BoundingBox }[] {
+  const identified = scene.nodes.flatMap((node) =>
+    node.kind === 'shape' && node.id !== undefined ? [{ id: node.id, bbox: node.bbox }] : [],
+  )
+  if (identified.length > 0) return identified
+  return scene.nodes.flatMap((node) => (node.kind === 'edge' ? [] : [{ bbox: node.bbox }]))
 }
 
 /**
@@ -225,10 +239,9 @@ function collectTopLevelBoxes(scene: Scene): BoundingBox[] {
  * in the same canonical order.
  */
 export function sceneDigest(scene: Scene): SceneDigest {
-  const boxes = collectTopLevelBoxes(scene)
-  const entries: DigestEntry[] = boxes.map((bbox, index) => ({
-    id: `n${index}`,
-    bbox,
+  const entries: DigestEntry[] = collectEntries(scene).map((entry, index) => ({
+    id: entry.id ?? `n${index}`,
+    bbox: entry.bbox,
     z: index,
   }))
 

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -83,6 +83,16 @@ export interface TextRunNode {
  */
 export interface ShapeSceneNode {
   readonly kind: 'shape'
+  /**
+   * The DOCUMENT node this chrome belongs to, when the scene was built from
+   * one. Semantic provenance in the same sense as a heading's `level` — the
+   * SVG backend never emits it, but `sceneDigest` needs it to name what it
+   * reports something the reader can actually address (`wb_node_patch`
+   * takes a node id, not a position in a list). Optional because a scene
+   * can be built by hand, and a chrome rect drawn for something that is not
+   * a document node has no id to give.
+   */
+  readonly id?: string
   readonly bbox: BoundingBox
   /** Uniform corner radius. Non-finite or <= 0 omits `rx` entirely. */
   readonly radius?: number

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -270,7 +270,15 @@ async function main() {
   if (!Array.isArray(digest.nodes) || digest.nodes.length === 0) {
     throw new Error(`wb_scene_digest returned unexpected shape: ${JSON.stringify(digest)}`)
   }
-  console.log('[e2e] wb_scene_digest → digest over the seeded text node')
+  // The names have to be the ones the OTHER tools take. A digest that reads
+  // back positionally still satisfies the schema and still looks right in a
+  // unit test, while telling a reader to patch a node that does not exist.
+  if (!digest.nodes.some((node) => node.id === 'okf-body')) {
+    throw new Error(
+      `wb_scene_digest did not name the seeded node by its document id: ${JSON.stringify(digest.nodes)}`,
+    )
+  }
+  console.log('[e2e] wb_scene_digest → digest naming the seeded node by document id')
 
   // wb_canvas_tidy: the canvas holds a single node here, so the contract answer
   // is "nothing to tidy" — the call still runs the full pipeline (input

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -33,16 +33,18 @@ describe('wb_scene_digest tool', () => {
     // so a real scene regression actually turns this test red — an
     // expectation computed via the tool's own producer can never fail when
     // that producer changes. Unlabelled groups emit a single chrome shape
-    // at their own bbox (no label run), so ids/bboxes match the digest an
-    // agent saw before this migration.
+    // at their own bbox and no label run, so the entry count here is the
+    // same one an agent saw before the digest started naming entries by
+    // document node id; only the names changed, from positional `n0`/`n1`
+    // to the canvas's own `n1`/`n2`.
     expect(result).toEqual({
       nodes: [
-        { id: 'n0', bbox: { x: 0, y: 0, w: 100, h: 100 }, z: 0 },
-        { id: 'n1', bbox: { x: 50, y: 50, w: 100, h: 100 }, z: 1 },
+        { id: 'n1', bbox: { x: 0, y: 0, w: 100, h: 100 }, z: 0 },
+        { id: 'n2', bbox: { x: 50, y: 50, w: 100, h: 100 }, z: 1 },
       ],
-      overlaps: [['n0', 'n1']],
+      overlaps: [['n1', 'n2']],
       containment: [],
-      clusters: [['n0', 'n1']],
+      clusters: [['n1', 'n2']],
       freeRegions: [
         { x: 100, y: 0, w: 60, h: 20 },
         { x: 100, y: 20, w: 60, h: 20 },


### PR DESCRIPTION
`sceneDigest` is what an AI reads to decide what to change, and its only way to act on what it read is a tool that takes a node id.

It was numbering entries `n0`, `n1`, … **by array position**. Names that mean nothing outside the digest, and that shift whenever a node is added or removed — so a reader could see "these two overlap" with no way to say *which two*, and an instruction written against one digest silently pointed at a different node in the next.

The scene graph had no id to give: `ShapeSceneNode` carried a bbox and paint and nothing identifying. It does now, as **semantic provenance** in the same sense as a heading's `level` — the SVG backend never emits it, and a hand-built scene may omit it.

## A second defect fell out of writing the test

Every bbox-carrying node was reported, so a three-node canvas answered with **six entries**: each node's chrome plus the text laid out *inside* it, every one of the extra three "contained in" another, and none of them addressable.

The digest now reports the identified shapes — exactly the boxes a reader can act on. A scene with no identified shape at all (hand-built, a fragment) keeps the old behaviour of taking every bbox-carrying node named by position; there is nothing better to name them by, and the alternative is answering with nothing.

## Not a schema change

`sceneDigestSchema` is untouched — `id` was already `z.string()`. **It is the values that were unusable**, which is exactly why nothing caught this: every wrong answer here validates.

## Verification

- Three new tests in `scene-digest-ids.test.ts`, red before the change: names by document id, keeps a name when an earlier node is removed, and one entry per canvas node with no self-containment.
- **The smoke now asserts the digest names the seeded node `okf-body`**, not merely that it returned a well-shaped array. Mutation-checked — dropping the id in the layout makes `pnpm smoke:e2e` fail loudly:

  ```
  [e2e] FAIL: wb_scene_digest did not name the seeded node by its document id:
    [{"id":"n0",...,"w":600,"h":400},{"id":"n1",...,"w":584,"h":16}]
  ```

  which also shows the extra text-run entry the second half of this change removes.
- server-core's pinned digest literal moves from `n0`/`n1` to the canvas's own `n1`/`n2` — same entries, real names.
- canvas-render + server-core: 808 assertions green. `typecheck`, `lint`, `knip`, `build`, `smoke:e2e` clean.

Closes task #24.