### PR TITLE
fix(server-core): measure the rendered scene, not the canvas's nodes

### DIFF
--- a/packages/server-core/src/render/compose-canvas-scene.test.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@kamiazya/whiteboard-canvas-render'
 import { afterEach, describe, expect, test } from 'vitest'
 import { setLogSink } from '../log.js'
-import { composeCanvasScene, computeCanvasDimensions } from './compose-canvas-scene.js'
+import { composeCanvasScene } from './compose-canvas-scene.js'
 import { fallbackMeasureText } from './fallback-measure.js'
 
 afterEach(() => {
@@ -173,19 +173,5 @@ describe('composeCanvasScene', () => {
     expect(composeCanvasScene(canvas, fallbackMeasureText)).toEqual(
       composeCanvasScene(canvas, fallbackMeasureText),
     )
-  })
-})
-
-describe('computeCanvasDimensions', () => {
-  test('returns a zero-sized default for an empty canvas', () => {
-    expect(computeCanvasDimensions([])).toEqual({ width: 0, height: 0 })
-  })
-
-  test('returns the union bounding box over multiple nodes', () => {
-    const dims = computeCanvasDimensions([
-      { id: 'a', type: 'group', x: 0, y: 0, width: 50, height: 50 },
-      { id: 'b', type: 'group', x: 100, y: 100, width: 50, height: 50 },
-    ])
-    expect(dims).toEqual({ width: 150, height: 150 })
   })
 })

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -1,11 +1,15 @@
 import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
-import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import type {
   MeasureText,
   Scene,
   SpatialLayoutDegradation,
 } from '@kamiazya/whiteboard-canvas-render'
-import { createSpatialTheme, layoutSpatialCanvas } from '@kamiazya/whiteboard-canvas-render'
+import {
+  createSpatialTheme,
+  layoutSpatialCanvas,
+  sceneBounds,
+} from '@kamiazya/whiteboard-canvas-render'
 import { getLogger } from '../log.js'
 
 // MCP render/digest are deliberately pinned to light (package-canvas-render.md
@@ -48,22 +52,23 @@ export function composeCanvasScene(canvas: SpatialCanvas, measure: MeasureText):
 }
 
 /**
- * Union bounding box over every top-level node's own geometry — the `<svg>`
- * root's width/height for `wb_scene_render`. An empty canvas has no
- * geometry to union, so it defaults to a zero-sized box rather than an
- * arbitrary sentinel.
+ * How far the drawing extends from the origin — the size a consumer needs to
+ * show all of `wb_scene_render`'s SVG.
+ *
+ * Measured from the SCENE, not the canvas's nodes. The two agree only while
+ * nothing is drawn outside a node's own box, and the router deliberately
+ * breaks that: an edge steps AROUND a node it would otherwise cut through,
+ * and that step lands beyond every node's geometry. Measuring the nodes
+ * reported a size that clipped the very detours the routing work added.
+ *
+ * Right/bottom extent rather than `sceneBounds`' width/height, because the
+ * SVG this describes is the bodyless-root form with no `viewBox`: its user
+ * space starts at the origin whatever the content does, so a consumer needs
+ * the far edge, not the span. An empty scene has no geometry to measure and
+ * reports zero rather than `sceneBounds`' non-degenerate 1x1 fallback.
  */
-export function computeCanvasDimensions(nodes: readonly SpatialNode[]): {
-  width: number
-  height: number
-} {
-  if (nodes.length === 0) return { width: 0, height: 0 }
-
-  let maxX = Number.NEGATIVE_INFINITY
-  let maxY = Number.NEGATIVE_INFINITY
-  for (const node of nodes) {
-    maxX = Math.max(maxX, node.x + node.width)
-    maxY = Math.max(maxY, node.y + node.height)
-  }
-  return { width: maxX, height: maxY }
+export function computeSceneDimensions(scene: Scene): { width: number; height: number } {
+  if (scene.nodes.length === 0) return { width: 0, height: 0 }
+  const bounds = sceneBounds(scene)
+  return { width: bounds.x + bounds.w, height: bounds.y + bounds.h }
 }

--- a/packages/server-core/src/render/scene-dimensions.test.ts
+++ b/packages/server-core/src/render/scene-dimensions.test.ts
@@ -1,0 +1,61 @@
+// `wb_scene_render` reports the size of what it drew. It was measuring the
+// canvas's NODES, so anything drawn outside a node's own box — an edge
+// routed around one, which the router now does deliberately — fell outside
+// the reported size, and a consumer sizing a viewport by it clipped the
+// drawing.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { composeCanvasScene, computeSceneDimensions } from './compose-canvas-scene.js'
+import { fallbackMeasureText } from './fallback-measure.js'
+
+const canvas = (nodes: unknown[], edges: unknown[] = []): SpatialCanvas =>
+  ({ nodes, edges }) as unknown as SpatialCanvas
+
+const node = (id: string, x: number, y: number, w = 100, h = 60) => ({
+  id,
+  type: 'text' as const,
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+const dimensionsOf = (c: SpatialCanvas) =>
+  computeSceneDimensions(composeCanvasScene(c, fallbackMeasureText))
+
+describe('computeSceneDimensions', () => {
+  it('an empty canvas has no size', () => {
+    expect(dimensionsOf(canvas([]))).toEqual({ width: 0, height: 0 })
+  })
+
+  it('measures to the far edge of the nodes', () => {
+    expect(dimensionsOf(canvas([node('a', 0, 0), node('b', 200, 140)]))).toEqual({
+      width: 300,
+      height: 200,
+    })
+  })
+
+  it('includes an edge routed outside every node box', () => {
+    // b sits directly below a, so the route between them cannot run straight:
+    // it steps around, and the step is drawn beyond both boxes.
+    const withEdge = canvas(
+      [node('a', 0, 0, 200, 100), node('b', 40, 140, 200, 100)],
+      [{ id: 'e', fromNode: 'a', toNode: 'b' }],
+    )
+    const nodesOnly = canvas([node('a', 0, 0, 200, 100), node('b', 40, 140, 200, 100)])
+    const withEdgeSize = dimensionsOf(withEdge)
+    const nodesOnlySize = dimensionsOf(nodesOnly)
+    // Whatever the route is, the reported size must cover it.
+    expect(withEdgeSize.width).toBeGreaterThanOrEqual(nodesOnlySize.width)
+    expect(withEdgeSize.height).toBeGreaterThanOrEqual(nodesOnlySize.height)
+    const scene = composeCanvasScene(withEdge, fallbackMeasureText)
+    for (const sceneNode of scene.nodes) {
+      if (sceneNode.kind !== 'edge') continue
+      for (const point of sceneNode.path) {
+        expect(point.x).toBeLessThanOrEqual(withEdgeSize.width)
+        expect(point.y).toBeLessThanOrEqual(withEdgeSize.height)
+      }
+    }
+  })
+})

--- a/packages/server-core/src/tools/canvas-render-svg.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.ts
@@ -1,7 +1,7 @@
 import { canvasIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-canvas-model'
 import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
 import { z } from 'zod'
-import { composeCanvasScene, computeCanvasDimensions } from '../render/compose-canvas-scene.js'
+import { composeCanvasScene, computeSceneDimensions } from '../render/compose-canvas-scene.js'
 import { fallbackMeasureText } from '../render/fallback-measure.js'
 import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import type { ServerDeps } from '../server-deps.js'
@@ -32,7 +32,7 @@ export function createCanvasRenderSvgTool(deps: ServerDeps) {
     async execute(input: CanvasRenderSvgInput): Promise<CanvasRenderSvgOutput> {
       const { canvas } = await loadSpatialCanvas(deps, input.canvasId)
       const scene = composeCanvasScene(canvas, fallbackMeasureText)
-      const { width, height } = computeCanvasDimensions(canvas.nodes)
+      const { width, height } = computeSceneDimensions(scene)
       return { svg: renderSceneToSvg(scene), width, height }
     },
   }


### PR DESCRIPTION
`wb_scene_render` reports the size of what it drew, and it was measuring the canvas's **nodes**.

The two agree only while nothing is drawn outside a node's own box — and the router deliberately breaks that. An edge steps *around* a node it would otherwise cut through, and that step lands beyond every node's geometry. #715–#718 made those detours common, so the reported size clipped the very drawing it describes.

## The change

`computeSceneDimensions` replaces `computeCanvasDimensions`: it takes the laid-out scene and defers to canvas-render's `sceneBounds`, which already walks the whole tree including edge polylines and nested content.

That also removes the second producer of "how big is this drawing" the codebase had grown — the package has a **one-producer-per-geometry** rule precisely because that drift has shipped real defects before.

## One deliberate difference from `sceneBounds`

It reports the **right/bottom extent**, not `sceneBounds`' width/height. The SVG it describes is the bodyless-root form with no `viewBox`, so its user space starts at the origin whatever the content does — a consumer needs the far edge, not the span. An empty scene reports zero rather than `sceneBounds`' non-degenerate 1×1 fallback, keeping the empty-canvas answer the tool always gave.

## Verification

- `scene-dimensions.test.ts` pins all three cases: empty, nodes-only, and an edge whose route is asserted **point by point** to fall inside the reported size.
- The old `computeCanvasDimensions` and its tests are deleted; nothing else referenced it.
- server-core + mcp-node: 3538 assertions green. `typecheck`, `lint`, `knip`, `build`, `smoke:e2e` clean.

Closes task #25.