### PR TITLE
fix(canvas-render): route around the side with room, and pin that an edge is never invisible

### DIFF
--- a/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
+++ b/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
@@ -1,0 +1,65 @@
+// Two boxes that touch exactly can put both of an edge's anchors on the same
+// point — flush-stacked nodes wired bottom-to-top land on the shared corner
+// of their fan-out spans. `routeOrthogonal` assumes a direction to leave and
+// arrive along; with none it built a stub each way and drew a spike 20px
+// into one box and 40px back up through both.
+//
+// Found by the routing scoreboard's property, not by a report: it is exactly
+// the arrangement `wb_canvas_tidy` produces when it snaps nodes into a
+// column, so it is reachable without anyone placing boxes by hand.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const node = (id: string, x: number, y: number, w: number, h: number): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: w,
+  height: h,
+  text: id,
+})
+
+/** Length of `path` running strictly inside a node's box. */
+function interiorInk(path: readonly { x: number; y: number }[], n: SpatialNode): number {
+  let total = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as { x: number; y: number }
+    const b = path[i] as { x: number; y: number }
+    if (a.x === b.x && a.x > n.x && a.x < n.x + n.width) {
+      const lo = Math.max(Math.min(a.y, b.y), n.y)
+      const hi = Math.min(Math.max(a.y, b.y), n.y + n.height)
+      if (hi > lo) total += hi - lo
+    }
+    if (a.y === b.y && a.y > n.y && a.y < n.y + n.height) {
+      const lo = Math.max(Math.min(a.x, b.x), n.x)
+      const hi = Math.min(Math.max(a.x, b.x), n.x + n.width)
+      if (hi > lo) total += hi - lo
+    }
+  }
+  return total
+}
+
+describe('coincident anchors', () => {
+  // n1 sits directly under n0, sharing the y = 40 boundary.
+  const nodes = [node('n0', 17, 0, 60, 40), node('n1', 0, 40, 60, 40)]
+  const edges: CanvasEdge[] = [{ id: 'e', fromNode: 'n0', toNode: 'n1' }]
+
+  const routed = () => {
+    const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
+    return routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
+  }
+
+  it('draws nothing rather than a spike through both boxes', () => {
+    const { path } = routed()
+    expect(path.map((p) => `${p.x},${p.y}`)).toEqual(['38.5,40', '38.5,40'])
+  })
+
+  it('leaves no ink inside either box', () => {
+    const { path } = routed()
+    for (const n of nodes) {
+      expect({ node: n.id, ink: interiorInk(path, n) }).toEqual({ node: n.id, ink: 0 })
+    }
+  })
+})

--- a/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
+++ b/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
@@ -57,8 +57,12 @@ describe('coincident anchors', () => {
     // drew must not disappear because the pair the ranking preferred happens
     // to be degenerate.
     const routed = routeWith({ id: 'e', fromNode: 'n0', toNode: 'n1' })
-    expect({ from: routed.fromSide, to: routed.toSide }).toEqual({ from: 'left', to: 'left' })
-    expect(routed.path.map((p) => `${p.x},${p.y}`)).toEqual(['17,20', '-3,20', '-3,60', '0,60'])
+    expect({ from: routed.fromSide, to: routed.toSide }).toEqual({ from: 'right', to: 'right' })
+    expect(routed.path.map((p) => `${p.x},${p.y}`)).toEqual(['77,20', '97,20', '97,60', '60,60'])
+    // The arrowhead is 10px and is drawn ON the final segment; the left-side
+    // route this replaced arrived with 3px of line under a 10px arrow.
+    const [beforeTail, tail] = routed.path.slice(-2)
+    expect(Math.hypot(tail!.x - beforeTail!.x, tail!.y - beforeTail!.y)).toBeGreaterThanOrEqual(10)
   })
 
   it('leaves no ink inside either box', () => {

--- a/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
+++ b/packages/canvas-render/src/layout/edge-degenerate-anchors.test.ts
@@ -42,22 +42,45 @@ function interiorInk(path: readonly { x: number; y: number }[], n: SpatialNode):
 }
 
 describe('coincident anchors', () => {
-  // n1 sits directly under n0, sharing the y = 40 boundary.
+  // n1 sits directly under n0, sharing the y = 40 boundary. Their fan-out
+  // spans meet at one point, so bottom-to-top has no distance to travel.
   const nodes = [node('n0', 17, 0, 60, 40), node('n1', 0, 40, 60, 40)]
-  const edges: CanvasEdge[] = [{ id: 'e', fromNode: 'n0', toNode: 'n1' }]
 
-  const routed = () => {
+  const routeWith = (edge: CanvasEdge) => {
+    const edges = [edge]
     const anchors = assignEdgeAnchors(nodes, edges, 'orthogonal')
-    return routeEdge(nodes, edges[0] as CanvasEdge, 'orthogonal', anchors.get('e'))
+    return routeEdge(nodes, edge, 'orthogonal', anchors.get(edge.id))
   }
 
-  it('draws nothing rather than a spike through both boxes', () => {
-    const { path } = routed()
-    expect(path.map((p) => `${p.x},${p.y}`)).toEqual(['38.5,40', '38.5,40'])
+  it('routes around the side that has room instead of vanishing', () => {
+    // The boxes are flush on ONE axis; the other has space. An edge someone
+    // drew must not disappear because the pair the ranking preferred happens
+    // to be degenerate.
+    const routed = routeWith({ id: 'e', fromNode: 'n0', toNode: 'n1' })
+    expect({ from: routed.fromSide, to: routed.toSide }).toEqual({ from: 'left', to: 'left' })
+    expect(routed.path.map((p) => `${p.x},${p.y}`)).toEqual(['17,20', '-3,20', '-3,60', '0,60'])
   })
 
   it('leaves no ink inside either box', () => {
-    const { path } = routed()
+    const { path } = routeWith({ id: 'e', fromNode: 'n0', toNode: 'n1' })
+    for (const n of nodes) {
+      expect({ node: n.id, ink: interiorInk(path, n) }).toEqual({ node: n.id, ink: 0 })
+    }
+  })
+
+  it('draws the shared point, not a spike, when authored sides force the collision', () => {
+    // Naming both sides is a request for that geometry. The re-siding above
+    // deliberately leaves it alone, so the router still has to handle a pair
+    // with no distance in it — and its answer is nothing, not 20px into one
+    // box and 40px back through both.
+    const { path } = routeWith({
+      id: 'e',
+      fromNode: 'n0',
+      toNode: 'n1',
+      fromSide: 'bottom',
+      toSide: 'top',
+    })
+    expect(path.map((p) => `${p.x},${p.y}`)).toEqual(['38.5,40', '38.5,40'])
     for (const n of nodes) {
       expect({ node: n.id, ink: interiorInk(path, n) }).toEqual({ node: n.id, ink: 0 })
     }

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -19,6 +19,8 @@ import {
   bends,
   borderInk,
   crossings,
+  drawnLength,
+  finalSegmentLength,
   interiorInk,
   type MetricRect,
   pathLength,
@@ -68,6 +70,39 @@ function avoidableInk(nodes: readonly SpatialNode[], edges: readonly CanvasEdge[
   return found
 }
 
+/**
+ * The arrowhead's own length. An edge whose final segment is shorter paints
+ * an arrow with no line under it.
+ */
+const ARROW_LENGTH_PX = 10
+
+describe('an edge is always visible', () => {
+  // The strictest thing the corpus can say, and it is true today, so it is a
+  // hard invariant rather than a counted debt: an edge someone drew must
+  // never render as nothing. A zero-length path paints no line AND cannot
+  // orient an arrowhead, so a reader cannot tell the edge exists — which is
+  // indistinguishable from the canvas having lost it.
+  //
+  // This exists because a fix for a degenerate case very nearly shipped that
+  // way: two boxes touching exactly put both anchors on one point, and
+  // collapsing the route to that point removed the wrong drawing by removing
+  // the drawing.
+  // A deliberate sweep over the whole corpus, like the aggregate below: it
+  // routes every edge of 2005 layouts, so it needs a budget that reflects
+  // the work rather than the 5s default a unit test gets.
+  it('draws something for every edge in every layout', { timeout: 60_000 }, () => {
+    const invisible: { layout: string; edge: string }[] = []
+    for (const testCase of [...ROUTING_CORPUS, ...syntheticLayouts(2000)]) {
+      const anchors = assignEdgeAnchors(testCase.nodes, testCase.edges, 'orthogonal')
+      for (const edge of testCase.edges) {
+        const { path } = routeEdge(testCase.nodes, edge, 'orthogonal', anchors.get(edge.id))
+        if (drawnLength(path) === 0) invisible.push({ layout: testCase.name, edge: edge.id })
+      }
+    }
+    expect(invisible).toEqual([])
+  })
+})
+
 describe('routing quality', () => {
   it.each(
     ROUTING_CORPUS.map((c) => [c.name, c] as const),
@@ -113,6 +148,8 @@ describe('routing quality across the synthetic corpus', () => {
     let bendCount = 0
     let crossingCount = 0
     let length = 0
+    // Arrowheads drawn on a segment shorter than the arrow itself.
+    let shortRunway = 0
     for (const testCase of syntheticLayouts(2000)) {
       for (const v of avoidableInk(testCase.nodes, testCase.edges)) {
         violations[v.kind]++
@@ -126,6 +163,7 @@ describe('routing quality across the synthetic corpus', () => {
       for (const path of paths) {
         bendCount += bends(path)
         length += pathLength(path)
+        if (finalSegmentLength(path) < ARROW_LENGTH_PX) shortRunway++
         for (const n of testCase.nodes) border += borderInk(path, rectOf(n))
       }
     }
@@ -136,6 +174,7 @@ describe('routing quality across the synthetic corpus', () => {
       bends: bendCount,
       crossings: crossingCount,
       length: Math.round(length),
+      shortArrowRunway: shortRunway,
     }).toEqual({
       violations: { 'own-endpoint': 35, foreign: 17, degenerate: 0 },
       interiorInk: 3545,
@@ -143,6 +182,7 @@ describe('routing quality across the synthetic corpus', () => {
       bends: 8486,
       crossings: 647,
       length: 1362776,
+      shortArrowRunway: 209,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -140,9 +140,9 @@ describe('routing quality across the synthetic corpus', () => {
       violations: { 'own-endpoint': 35, foreign: 17, degenerate: 0 },
       interiorInk: 3545,
       borderInk: 1147,
-      bends: 8484,
+      bends: 8486,
       crossings: 647,
-      length: 1362640,
+      length: 1362776,
     })
   })
 })

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -137,12 +137,12 @@ describe('routing quality across the synthetic corpus', () => {
       crossings: crossingCount,
       length: Math.round(length),
     }).toEqual({
-      violations: { 'own-endpoint': 35, foreign: 17, degenerate: 2 },
-      interiorInk: 3625,
+      violations: { 'own-endpoint': 35, foreign: 17, degenerate: 0 },
+      interiorInk: 3545,
       borderInk: 1147,
       bends: 8484,
       crossings: 647,
-      length: 1362720,
+      length: 1362640,
     })
   })
 })

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -931,7 +931,12 @@ function anchorsWithoutCoincidentEnds(
     // target, and "first clean one" alone accepted a four-bend loop around
     // both boxes when a short hop up the shared side was available. Clean is
     // the requirement; shortest-and-straightest picks among the clean.
-    let best: { pair: SidePair; bends: number; length: number } | undefined
+    // Three tiers, because they are not equally important and treating them
+    // as one filter made an edge vanish: a candidate that is clean AND has
+    // runway is best, a clean one without runway still beats an ugly one, and
+    // ANY visible route beats the collided pair. Visibility is the
+    // requirement; the rest is preference.
+    let best: { pair: SidePair; tier: number; bends: number; length: number } | undefined
     for (const pair of candidates) {
       const sided: SidePair = {
         fromSide: edge.fromSide ?? pair.fromSide,
@@ -942,12 +947,28 @@ function anchorsWithoutCoincidentEnds(
       const trialAnchors = computeAnchorsFor(nodes, edges, trial, align, pins)
       if (coincides(trialAnchors, edge.id)) continue
       const { path } = routeEdge(nodes, edge, style, trialAnchors.get(edge.id))
-      if (interiorInkThrough(path, [fromRect, toRect]) > 0) continue
-      const scored = { pair: sided, bends: bendCount(path), length: pathLength(path) }
+      // The arrowhead is drawn ON the final segment; a shorter one paints an
+      // arrow with no line under it. Re-siding is choosing this route from
+      // scratch, so it can decline the ones that arrive with no runway.
+      const tail = path[path.length - 1]
+      const beforeTail = path[path.length - 2]
+      const runway =
+        tail === undefined || beforeTail === undefined
+          ? 0
+          : Math.hypot(tail.x - beforeTail.x, tail.y - beforeTail.y)
+      const clean = interiorInkThrough(path, [fromRect, toRect]) === 0
+      const scored = {
+        pair: sided,
+        tier: clean && runway >= ARROW_RUNWAY_PX ? 0 : clean ? 1 : 2,
+        bends: bendCount(path),
+        length: pathLength(path),
+      }
       if (
         best === undefined ||
-        scored.bends < best.bends ||
-        (scored.bends === best.bends && scored.length < best.length)
+        scored.tier < best.tier ||
+        (scored.tier === best.tier &&
+          (scored.bends < best.bends ||
+            (scored.bends === best.bends && scored.length < best.length)))
       ) {
         best = scored
       }
@@ -1000,6 +1021,10 @@ export function assignEdgeAnchors(
   }
   return anchorsWithoutCoincidentEnds(nodes, edges, sides, style, true)
 }
+
+/** An arrowhead's own length: a final segment shorter than this paints an
+ * arrow with no line under it (see edge-arrows.ts's ARROW_LENGTH). */
+const ARROW_RUNWAY_PX = 10
 
 /** How close a route may pass to a foreign node's border, in px. */
 const ROUTE_MARGIN_PX = 8

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1219,6 +1219,18 @@ function routeOrthogonal(
   raw: readonly Rect[],
 ): Point[] {
   let start = startAnchor
+  // Boxes that touch exactly can put both anchors on the same point — two
+  // flush-stacked nodes wired bottom-to-top land on the shared corner of
+  // their fan-out spans. There is no distance to route: the connection IS
+  // that point. Everything below assumes a direction to leave and arrive
+  // along, and with none it built a stub each way, drawing a spike 20px
+  // into one box and 40px back through both.
+  //
+  // ponytail: this draws nothing rather than the wrong thing. A VISIBLE
+  // connector between flush boxes would have to leave from a face with room
+  // beside it, which is a side-choice decision (`rankedSidePairs`), not
+  // something this function can invent after the sides are fixed.
+  if (start.x === end.x && start.y === end.y) return [start, end]
   // Zero-bend shortcut: two ends on OPPOSING, mutually facing sides can
   // often share one tangent coordinate — anchors are renderer-chosen
   // defaults, so sliding one end along its side buys a single straight

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -870,6 +870,96 @@ function optimizeSideChoices(
   return current
 }
 
+/**
+ * Anchors for `sides`, with any edge whose two ends landed on the SAME point
+ * re-sided onto a face that has room.
+ *
+ * Boxes that touch exactly produce that collision: flush-stacked nodes wired
+ * bottom-to-top share the corner their fan-out spans meet at. The pair is
+ * geometrically fine — the sides do face each other — and there is simply no
+ * distance between them, so the route degenerates and the edge disappears.
+ * An edge someone drew deliberately must not vanish, and the boxes are only
+ * flush on ONE axis: the other one has space to route through, which is a
+ * side CHOICE, not something the router can invent once the sides are fixed.
+ *
+ * Only the collided edges are re-sided, and an edge whose sides were
+ * authored is left exactly as authored — a user who names both sides has
+ * asked for that geometry, degenerate or not (routeOrthogonal still declines
+ * to draw a spike for it).
+ */
+function anchorsWithoutCoincidentEnds(
+  nodes: readonly SpatialNode[],
+  edges: readonly CanvasEdge[],
+  sides: ReadonlyMap<string, SidePair>,
+  style: EdgeRoutingStyle,
+  align: boolean,
+  pins?: ReadonlyMap<string, EdgeAnchorOverride>,
+): ReadonlyMap<string, EdgeAnchorPair> {
+  const coincides = (anchors: ReadonlyMap<string, EdgeAnchorPair>, id: string): boolean => {
+    const a = anchors.get(id)
+    return a?.from !== undefined && a.to !== undefined && a.from.x === a.to.x && a.from.y === a.to.y
+  }
+  const anchors = computeAnchorsFor(nodes, edges, sides, align, pins)
+  const collided = edges.filter(
+    (edge) =>
+      edge.fromNode !== edge.toNode &&
+      (edge.fromSide === undefined || edge.toSide === undefined) &&
+      coincides(anchors, edge.id),
+  )
+  if (collided.length === 0) return anchors
+
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const repaired = new Map(sides)
+  for (const edge of collided) {
+    const fromNode = byId.get(edge.fromNode)
+    const toNode = byId.get(edge.toNode)
+    if (fromNode === undefined || toNode === undefined) continue
+    const fromRect = rectOf(fromNode)
+    const toRect = rectOf(toNode)
+    const fromCenter = centerOf(fromRect)
+    const toCenter = centerOf(toRect)
+    const candidates = rankedSidePairs(
+      toCenter.x - fromCenter.x,
+      toCenter.y - fromCenter.y,
+      fromRect,
+      toRect,
+      () => 0,
+    )
+    // Every candidate is scored, not just the first that qualifies. Two
+    // predicates are needed and neither alone is enough: "not coincident"
+    // alone accepted a pair that reached the far side straight THROUGH the
+    // target, and "first clean one" alone accepted a four-bend loop around
+    // both boxes when a short hop up the shared side was available. Clean is
+    // the requirement; shortest-and-straightest picks among the clean.
+    let best: { pair: SidePair; bends: number; length: number } | undefined
+    for (const pair of candidates) {
+      const sided: SidePair = {
+        fromSide: edge.fromSide ?? pair.fromSide,
+        toSide: edge.toSide ?? pair.toSide,
+      }
+      const trial = new Map(repaired)
+      trial.set(edge.id, sided)
+      const trialAnchors = computeAnchorsFor(nodes, edges, trial, align, pins)
+      if (coincides(trialAnchors, edge.id)) continue
+      const { path } = routeEdge(nodes, edge, style, trialAnchors.get(edge.id))
+      if (interiorInkThrough(path, [fromRect, toRect]) > 0) continue
+      const scored = { pair: sided, bends: bendCount(path), length: pathLength(path) }
+      if (
+        best === undefined ||
+        scored.bends < best.bends ||
+        (scored.bends === best.bends && scored.length < best.length)
+      ) {
+        best = scored
+      }
+    }
+    if (best !== undefined) repaired.set(edge.id, best.pair)
+    // No candidate reaches it cleanly: keep the collided pair. routeOrthogonal
+    // draws the shared point rather than a spike, so the worst case is an
+    // invisible edge, never a wrong one.
+  }
+  return computeAnchorsFor(nodes, edges, repaired, align, pins)
+}
+
 export function assignEdgeAnchors(
   nodes: readonly SpatialNode[],
   edges: readonly CanvasEdge[],
@@ -903,12 +993,12 @@ export function assignEdgeAnchors(
     if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES && locked.size < edges.length) {
       liveSides = optimizeSideChoices(nodes, edges, style, merged, locked)
     }
-    return computeAnchorsFor(nodes, edges, liveSides, true, sideOverrides)
+    return anchorsWithoutCoincidentEnds(nodes, edges, liveSides, style, true, sideOverrides)
   }
   if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES) {
     sides = optimizeSideChoices(nodes, edges, style, sides)
   }
-  return computeAnchorsFor(nodes, edges, sides)
+  return anchorsWithoutCoincidentEnds(nodes, edges, sides, style, true)
 }
 
 /** How close a route may pass to a foreign node's border, in px. */

--- a/packages/canvas-render/src/test-utils/routing-metrics.ts
+++ b/packages/canvas-render/src/test-utils/routing-metrics.ts
@@ -153,3 +153,21 @@ export function crossings(paths: readonly (readonly MetricPoint[])[]): number {
   }
   return count
 }
+
+/**
+ * The arrowhead is drawn ON the final segment and is `ARROW_LENGTH` long, so
+ * a shorter final segment paints an arrow with no line under it — it reads as
+ * a marker stuck to the box rather than an edge arriving at it. Reported as a
+ * length so a caller can decide its own floor.
+ */
+export function finalSegmentLength(path: readonly MetricPoint[]): number {
+  const end = path[path.length - 1]
+  const before = path[path.length - 2]
+  return end === undefined || before === undefined ? 0 : segmentLength(before, end)
+}
+
+/** Total drawn length. Zero means the edge is INVISIBLE — nothing is painted
+ * and no arrowhead can be oriented, so a reader cannot tell the edge exists. */
+export function drawnLength(path: readonly MetricPoint[]): number {
+  return pathLength(path)
+}


### PR DESCRIPTION
Two nodes that touch exactly put both of an edge's anchors on the **same point** — flush-stacked boxes wired bottom-to-top share the corner their fan-out spans meet at. With no direction to leave or arrive along, the router built a stub each way: 20px down into the lower box, 40px back up through both, and an arrowhead pointing into the **source**.

![degenerate.png](https://github.com/user-attachments/assets/6db2d9d8-7fd2-4503-8100-4038cbe51f53)

## Three attempts, each corrected by looking at the picture

All three predicates are now in the code, because each was learned by watching the previous one fail:

1. **Degenerate to the shared point.** Stopped the wrong drawing by stopping the drawing — an edge someone drew deliberately vanished.
2. **Re-side to any pair whose anchors differ.** The first such pair reached the far side straight *through* the target: 33px of interior ink.
3. **Re-side to the first clean pair.** A four-bend loop around both boxes when a two-bend hop was available — arriving with **3px of line under a 10px arrowhead**.

`anchorsWithoutCoincidentEnds` now scores every candidate and ranks them in three tiers — clean **and** with arrow runway, then clean, then merely visible — picking fewest bends and shortest within a tier. **Visibility is the requirement; the rest is preference**, which is what stops tier 0's runway rule from reintroducing an invisible edge when nothing satisfies it.

The reported canvas routes `right→right`, `(77,20) (97,20) (97,60) (60,60)`: two bends, no ink in either box, **37px of runway**.

## Two new guarantees — measuring decided which could be strict

| | |
|---|---|
| **An edge is never invisible** | A hard invariant over the whole corpus. True today, and it is exactly what catches attempt 1. A zero-length path paints no line and cannot orient an arrowhead, so a reader cannot distinguish it from the canvas having lost the edge. |
| **`shortArrowRunway`: 209** | Edges whose final segment is shorter than the 10px arrowhead drawn on it. **Not introduced here** — 209 of 6137 routes across the corpus already do this, so it lands on the scoreboard as debt rather than as a rule that fails on arrival. |

That second number is worth stating plainly: #711 established the 20px minimum approach for **perpendicular** pairs only. Same-side pairs never had it, and nothing was watching. Now something is.

## Scoreboard

| metric | before | after |
|---|---:|---:|
| `degenerate` | 2 | **0** |
| `interiorInk` | 3625 | **3545** |
| `bends` | 8484 | 8486 |
| `length` | 1362720 | 1362776 |
| `own-endpoint` / `foreign` / `borderInk` / `crossings` | | **unchanged** |

Two bends and 136px, for two edges that go from wrong to visible-and-clean.

## Also

An edge whose sides were **authored** is left exactly as authored — naming both sides is a request for that geometry — so the router still answers a degenerate pair, and its answer is the shared point rather than a spike. Pinned.

The visibility sweep gets an explicit 60s budget for the same reason the aggregate has one: it routes every edge of 2005 layouts, and the 5s default made it fail under the parallel suite rather than on merit. That is the flake shape recorded in `integrator-flow.md` yesterday — recognised from its message this time.

## Verification

Mutation-checked. 592 package assertions, both browser suites, `typecheck`, `lint`, `knip` clean.