### PR TITLE
feat(mcp): add wb_node_add so MCP can put a node on a spatial canvas

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -128,6 +128,7 @@ const EXPECTED_TOOLS = [
   'wb_edge_lock',
   'wb_edge_patch',
   'wb_facet_set',
+  'wb_node_add',
   'wb_node_lock',
   'wb_node_patch',
   'wb_canvas_tidy',
@@ -200,34 +201,47 @@ async function main() {
   }
   console.log('[e2e] wb_facet_set → seeded canvas state')
 
-  // wb_node_lock: the sidecar lock round-trip. wb_document_set is the only
-  // MCP path that creates a spatial node, and it always writes one text
-  // node with this id.
-  await callTool('wb_document_set', {
+  // wb_node_add: the only MCP path that puts a node on a spatial canvas,
+  // and what the lock round-trip below needs to have something to lock.
+  const added = await callTool('wb_node_add', {
     workspaceId: WORKSPACE_ID,
     canvasId,
-    markdown: '---\ntype: canvas\ntitle: e2e-lock\n---\n\nlockable body\n',
+    node: { id: 'lockable', type: 'text', x: 0, y: 0, width: 200, height: 100, text: 'lockable' },
   })
+  if (added.canvasId !== canvasId || added.node?.id !== 'lockable') {
+    throw new Error(`wb_node_add returned unexpected shape: ${JSON.stringify(added)}`)
+  }
+  console.log('[e2e] wb_node_add → lockable')
+
+  await expectToolError(
+    'wb_node_add',
+    {
+      workspaceId: WORKSPACE_ID,
+      canvasId,
+      node: { id: 'lockable', type: 'text', x: 1, y: 1, width: 10, height: 10, text: 'clobber' },
+    },
+    'on an id that is already taken',
+  )
 
   const nodeLocked = await callTool('wb_node_lock', {
     workspaceId: WORKSPACE_ID,
     canvasId,
-    nodeId: 'okf-body',
+    nodeId: 'lockable',
     locked: true,
   })
   if (
     nodeLocked.canvasId !== canvasId ||
-    nodeLocked.nodeId !== 'okf-body' ||
+    nodeLocked.nodeId !== 'lockable' ||
     nodeLocked.locked !== true
   ) {
     throw new Error(`wb_node_lock returned unexpected shape: ${JSON.stringify(nodeLocked)}`)
   }
-  console.log('[e2e] wb_node_lock → okf-body locked')
+  console.log('[e2e] wb_node_lock → lockable locked')
 
   // The lock binds agents, not just the pointer.
   await expectToolError(
     'wb_node_patch',
-    { workspaceId: WORKSPACE_ID, canvasId, nodeId: 'okf-body', patch: { x: 999 } },
+    { workspaceId: WORKSPACE_ID, canvasId, nodeId: 'lockable', patch: { x: 999 } },
     'on a locked node',
   )
 
@@ -249,7 +263,7 @@ async function main() {
   await callTool('wb_node_lock', {
     workspaceId: WORKSPACE_ID,
     canvasId,
-    nodeId: 'okf-body',
+    nodeId: 'lockable',
     locked: false,
   })
 
@@ -272,7 +286,7 @@ async function main() {
   // The names have to be the ones the OTHER tools take. A digest that reads
   // back positionally still satisfies the schema and still looks right in a
   // unit test, while telling a reader to patch a node that does not exist.
-  if (!digest.nodes.some((node) => node.id === 'okf-body')) {
+  if (!digest.nodes.some((node) => node.id === 'lockable')) {
     throw new Error(
       `wb_scene_digest did not name the seeded node by its document id: ${JSON.stringify(digest.nodes)}`,
     )

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -33,6 +33,7 @@ export const ALL_REGISTERED_TOOLS = [
   'wb_edge_lock',
   'wb_edge_patch',
   'wb_facet_set',
+  'wb_node_add',
   'wb_node_lock',
   'wb_node_patch',
   'wb_canvas_tidy',
@@ -48,6 +49,7 @@ export const ALL_REGISTERED_TOOLS = [
 
 export const COVERED_TOOLS = [
   'wb_document_set',
+  'wb_node_add',
   'wb_node_lock',
   'wb_canvas_tidy',
   'wb_facet_set',

--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
@@ -85,6 +85,23 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
 
   registerToolWithAnnotations(
     server,
+    tools.nodeAdd.name,
+    {
+      description: tools.nodeAdd.description,
+      inputSchema: tools.nodeAdd.inputSchema.shape,
+      outputSchema: tools.nodeAdd.outputSchema,
+    },
+    async (args) => {
+      const parsed = tools.nodeAdd.inputSchema.parse(args)
+      const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
+        tools.nodeAdd.execute(parsed),
+      )
+      return structuredJsonResult(result)
+    },
+  )
+
+  registerToolWithAnnotations(
+    server,
     tools.nodePatch.name,
     {
       description: tools.nodePatch.description,

--- a/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
@@ -7,6 +7,7 @@ import { TOOL_PROFILES } from './tool-profiles.js'
 // client a misleading approval-policy hint for a tool that no longer exists.
 const ACTIVE_TOOL_NAMES = [
   'wb_facet_set',
+  'wb_node_add',
   'wb_node_lock',
   'wb_node_patch',
   'wb_edge_lock',

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -22,6 +22,7 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
     profile: MUTATING_IDEMPOTENT,
     title: 'Set the OKF frontmatter facets of a document',
   },
+  wb_node_add: { profile: MUTATING, title: 'Add a node to the spatial canvas' },
   wb_node_patch: { profile: MUTATING_IDEMPOTENT, title: 'Patch a node on the spatial canvas' },
   wb_edge_patch: { profile: MUTATING_IDEMPOTENT, title: 'Patch an edge on the spatial canvas' },
   wb_node_lock: {

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -25,6 +25,7 @@ import { createEdgeLockTool } from './tools/edge-lock.js'
 import { createEdgePatchTool } from './tools/edge-patch.js'
 import { CanvasDocNotFoundError } from './tools/errors.js'
 import { createFacetSetTool } from './tools/facet-set.js'
+import { createNodeAddTool } from './tools/node-add.js'
 import { createNodeLockTool } from './tools/node-lock.js'
 import { createNodePatchTool } from './tools/node-patch.js'
 import { createTidyCanvasTool } from './tools/tidy-canvas.js'
@@ -129,6 +130,7 @@ export function createServer(deps: ServerDeps) {
     facetSet: createFacetSetTool(deps),
     nodeLock: createNodeLockTool(deps),
     edgeLock: createEdgeLockTool(deps),
+    nodeAdd: createNodeAddTool(deps),
     nodePatch: createNodePatchTool(deps),
     edgePatch: createEdgePatchTool(deps),
     tidyCanvas: createTidyCanvasTool(deps),

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -85,6 +85,8 @@ export {
 export type { FacetSetInput, FacetSetOutput } from './tools/facet-set.js'
 export { createFacetSetTool, facetSetInputSchema, facetSetOutputSchema } from './tools/facet-set.js'
 export { generateCanvasId } from './tools/generate-canvas-id.js'
+export type { NodeAddInput, NodeAddOutput } from './tools/node-add.js'
+export { createNodeAddTool, nodeAddInputSchema, nodeAddOutputSchema } from './tools/node-add.js'
 export type { NodeLockInput, NodeLockOutput } from './tools/node-lock.js'
 export {
   createNodeLockTool,

--- a/packages/server-core/src/tools/node-add.test.ts
+++ b/packages/server-core/src/tools/node-add.test.ts
@@ -1,0 +1,97 @@
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import { describe, expect, test } from 'vitest'
+import {
+  FakeCanvasDocStore,
+  registerCanvasInWorkspace,
+  seedDoc,
+} from '../test-utils/fake-canvas-doc-store.js'
+import { loadCanvasDoc } from './canvas-doc-io.js'
+import { createNodeAddTool, NodeAlreadyExistsError } from './node-add.js'
+
+const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const WORKSPACE_ID = 'ws-1'
+
+function makeDeps(canvasDocStore: FakeCanvasDocStore) {
+  return { canvasDocStore, blobStore: {} as never }
+}
+
+const RECT = {
+  id: 'n1',
+  type: 'text',
+  x: 10,
+  y: 20,
+  width: 200,
+  height: 100,
+  text: 'hello',
+} as const
+
+describe('wb_node_add', () => {
+  test('adds a node to an empty spatial canvas', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, { nodes: [], edges: [] })
+    })
+    const tool = createNodeAddTool(makeDeps(store))
+
+    const result = await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      node: RECT,
+    })
+
+    expect(result.node.id).toBe('n1')
+    const canvas = (await loadCanvasDoc(makeDeps(store), CANVAS_ID)).canvas
+    expect(canvas.nodes).toHaveLength(1)
+  })
+
+  test('keeps the nodes already on the canvas', async () => {
+    // The gap this closes is that the only previous way to get a node in was
+    // wb_document_set, which replaced the whole canvas. Adding must add.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, { nodes: [RECT], edges: [] })
+    })
+    const tool = createNodeAddTool(makeDeps(store))
+
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      node: { ...RECT, id: 'n2', text: 'second' },
+    })
+
+    const canvas = (await loadCanvasDoc(makeDeps(store), CANVAS_ID)).canvas
+    expect(canvas.nodes.map((n) => n.id).sort()).toEqual(['n1', 'n2'])
+  })
+
+  test('refuses an id that is already taken rather than overwriting it', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, { nodes: [RECT], edges: [] })
+    })
+    const tool = createNodeAddTool(makeDeps(store))
+
+    await expect(
+      tool.execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        node: { ...RECT, text: 'clobber' },
+      }),
+    ).rejects.toThrow(NodeAlreadyExistsError)
+
+    const canvas = (await loadCanvasDoc(makeDeps(store), CANVAS_ID)).canvas
+    expect(canvas.nodes).toHaveLength(1)
+    if (canvas.nodes[0].type === 'text') expect(canvas.nodes[0].text).toBe('hello')
+  })
+
+  test('rejects when the canvas is not in the workspace', async () => {
+    const store = new FakeCanvasDocStore()
+    const tool = createNodeAddTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, node: RECT }),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/server-core/src/tools/node-add.ts
+++ b/packages/server-core/src/tools/node-add.ts
@@ -1,0 +1,77 @@
+import {
+  canvasIdSchema,
+  spatialCanvasSchema,
+  spatialNodeSchema,
+  workspaceIdSchema,
+} from '@kamiazya/whiteboard-canvas-model'
+import { z } from 'zod'
+import type { ServerDeps } from '../server-deps.js'
+import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
+import { PatchValidationError } from './errors.js'
+import { assertCanvasInWorkspace } from './workspace-tree-io.js'
+
+export const nodeAddInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    canvasId: canvasIdSchema,
+    node: spatialNodeSchema.describe(
+      'The whole node, including the id you want it to have. Ids are yours to choose so an edge can refer to one before the other end exists.',
+    ),
+  })
+  .strict()
+export type NodeAddInput = z.infer<typeof nodeAddInputSchema>
+
+export const nodeAddOutputSchema = z
+  .object({
+    canvasId: canvasIdSchema,
+    node: spatialNodeSchema,
+  })
+  .strict()
+export type NodeAddOutput = z.infer<typeof nodeAddOutputSchema>
+
+export class NodeAlreadyExistsError extends Error {
+  constructor(
+    public readonly canvasId: string,
+    public readonly nodeId: string,
+  ) {
+    super(
+      `Node ${nodeId} already exists on canvas ${canvasId}. ` +
+        'Use wb_node_patch to change it, or add it under a different id.',
+    )
+    this.name = 'NodeAlreadyExistsError'
+  }
+}
+
+/**
+ * The one MCP path that puts a node on a spatial canvas. wb_node_patch only
+ * updates a node that is already there, so without this the sole way to
+ * create one was the OKF write's side effect — a single text node with a
+ * fixed id, replacing everything else on the canvas.
+ */
+export function createNodeAddTool(deps: ServerDeps) {
+  return {
+    name: 'wb_node_add' as const,
+    description:
+      'Add a node to a spatial canvas, keeping the nodes already on it. Fails if the id is taken — this never overwrites an existing node.',
+    inputSchema: nodeAddInputSchema,
+    outputSchema: nodeAddOutputSchema,
+    execute: async (input: NodeAddInput): Promise<NodeAddOutput> => {
+      await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
+      const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      if (canvas.nodes.some((existing) => existing.id === input.node.id)) {
+        throw new NodeAlreadyExistsError(input.canvasId, input.node.id)
+      }
+
+      const parsed = spatialCanvasSchema.safeParse({
+        nodes: [...canvas.nodes, input.node],
+        edges: canvas.edges,
+      })
+      if (!parsed.success) throw new PatchValidationError(parsed.error.issues)
+
+      await saveCanvasDoc(deps, input.canvasId, doc, parsed.data)
+
+      return { canvasId: input.canvasId, node: input.node }
+    },
+  }
+}

--- a/packages/server-core/src/tools/node-patch.ts
+++ b/packages/server-core/src/tools/node-patch.ts
@@ -56,7 +56,8 @@ export type NodePatchOutput = z.infer<typeof nodePatchOutputSchema>
 export function createNodePatchTool(deps: ServerDeps) {
   return {
     name: 'wb_node_patch' as const,
-    description: 'Create or update a node on the spatial canvas.',
+    description:
+      'Update the geometry or style of a node already on the spatial canvas. Fails if the node does not exist — use wb_node_add to create one.',
     inputSchema: nodePatchInputSchema,
     outputSchema: nodePatchOutputSchema,
     execute: async (input: NodePatchInput): Promise<NodePatchOutput> => {


### PR DESCRIPTION
## What

`wb_node_patch` only updates a node that is already there — it throws `NodeNotFoundError` otherwise, despite a description promising "Create or update". So the only way MCP ever got a node onto a spatial canvas was a **side effect of `wb_document_set`**: writing OKF Markdown replaces the whole canvas with one text node under the fixed id `okf-body`.

That is not authoring. It is a flattening bug that happens to leave a node behind, and the e2e smoke had to reach for an OKF write just to have something to lock.

## The tool

`wb_node_add` takes a whole node validated by `spatialNodeSchema` and adds it to what is already on the canvas.

- The id is the **caller's**, so an edge can name one end before the other exists.
- A taken id is **refused** (`NodeAlreadyExistsError`), never silently overwritten.
- Registered through the same `withCanvasDocWriteLock` path as the other mutations.

## Verification

- `packages/server-core/src/tools/node-add.test.ts` — red first; covers add-to-empty, add-preserving-existing, duplicate-id refusal leaving the original intact, and the workspace-ownership guard.
- `pnpm smoke:e2e` — **ALL OK, 19 tools**. The smoke now creates its lockable node with `wb_node_add` (covering the new tool end to end through the real MCP SDK's `structuredContent` validation) and its lock round-trip no longer depends on an OKF write.
- `pnpm -r typecheck`, `pnpm knip`, `pnpm build` clean.

## Follow-up

This is the missing half of a guard coming next: `wb_document_set` does not check the document kind, so writing OKF into a spatial document destroys the diagram. That guard removes the OKF-write creation path, which is only safe once this exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB