### PR TITLE
test(mcp-server): stop the relative --data-dir test planting dirs in the repo root

### DIFF
--- a/packages/mcp-server/src/cli/daemon-run.test.ts
+++ b/packages/mcp-server/src/cli/daemon-run.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { captureLogsForTests } from '../server/log.js'
 import { getDataDir, resetDataDirForTests } from '../shared/data-dir-secure.js'
@@ -194,7 +194,16 @@ describe('runDaemonRun --data-dir storage redirection', () => {
   })
 
   it('hands the registry the resolved-absolute dir even when --data-dir is relative', async () => {
-    const rel = `./tmp-daemon-run-rel-${Date.now()}`
+    // A relative --data-dir resolves against cwd, and runDaemonRun creates it.
+    // Pointing at `./something` would therefore plant a directory in whatever
+    // cwd the suite runs from — the repo root — and because the daemon never
+    // writes into it, the empty dir is invisible to `git status` and just
+    // accumulates. Aim the relative path at a temp dir instead: still
+    // relative, so it still exercises the resolve(), but nothing lands here.
+    const absolute = join(tmpdir(), `daemon-run-rel-${Date.now()}`)
+    const rel = relative(process.cwd(), absolute)
+    expect(isAbsolute(rel)).toBe(false)
+    expect(resolve(rel).startsWith(process.cwd())).toBe(false)
     const outcome = await runDaemonRun({
       host: '127.0.0.1',
       port: 3099,


### PR DESCRIPTION
## What

Audit item: `daemon-run.test.ts` used `./tmp-daemon-run-rel-<timestamp>` as a relative `--data-dir`. A relative data dir resolves against cwd and `runDaemonRun` creates it, so every run planted a directory in the repo root.

Why nobody noticed: the daemon never writes into that dir, and **git does not track empty directories** — so `git status` stays clean while they pile up. Ten had accumulated in this checkout. CI is unaffected (fresh container per run), which is exactly why no gate caught it; this only degrades local checkouts.

The relative path now points into `os.tmpdir()` via `path.relative`, so it is still relative — the test still exercises the `resolve()` it exists to pin — but the directory lands where temp directories belong. Two assertions encode the rule instead of leaving it to a comment: the path stays relative, and it must not resolve inside cwd.

**Mutation-checked**: restoring `./tmp-...` turns the test red (1 failed / 22 passed), the fix turns it green (23 passed). Verified after the fix that a run creates zero repo-root entries and one dir under `/tmp`.

The ten stale directories were removed from the local checkout; nothing to clean in the repo itself since git never saw them.

## Gates

`pnpm test --project mcp-node`: 267 files / 3319 tests green. Format/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for relative data-directory paths.
  * Ensured relative paths remain relative and resolve correctly outside the repository’s working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->