### PR TITLE
docs: describe the MCP tool surface that actually ships

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -205,7 +205,7 @@ Default regression triple after a change:
 ```bash
 pnpm test        # full suite (see root vitest.config.ts): mcp-node, mcp-smoke, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node/browser, canvas-viewer node/jsdom/browser, apps/web node/jsdom/browser (Playwright projects are slower)
 pnpm typecheck   # tsc --noEmit (~10s)
-pnpm smoke:e2e   # stdio MCP subprocess: wb_document_create -> wb_facet_set -> version save/list/restore -> wb_document_set -> canvas_export_okf
+pnpm smoke:e2e   # stdio MCP subprocess: wb_document_create -> wb_node_add -> wb_edge_add -> version save/list/restore -> wb_document_set -> wb_document_get
 ```
 
 For a fast, narrow pass while iterating on `packages/mcp-server` (selects only the `mcp-node` project out of the sixteen configured in root `vitest.config.ts`, so it also skips `mcp-smoke`, canvas-model node, canvas-ports node, canvas-codec node, canvas-workspace node, server-core node, arch-lint-node, canvas-render node, canvas-viewer node/jsdom, apps/web node/jsdom, and all three browser projects (canvas-render-browser, canvas-viewer-browser, web-browser)):

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -237,7 +237,7 @@ Runs alongside `mcp-node` during normal `pnpm test`. No build prerequisite. Test
 | Script | What it covers |
 |---|---|
 | `pnpm smoke` | Startup-only: MCP server starts without fatal errors and stays alive for 3 s |
-| `pnpm smoke:e2e` | Full stdio MCP round-trip: `wb_document_create` → `wb_facet_set` → version save/list/restore → `wb_document_set` → `canvas_export_okf` |
+| `pnpm smoke:e2e` | Full stdio MCP round-trip: `wb_document_create` → `wb_facet_set` → `wb_node_add` → `wb_edge_add` → lock/patch refusals → `wb_scene_render` / `wb_scene_digest` → `wb_canvas_tidy` → version save/list/restore → `wb_document_set` → `wb_document_get` |
 
 Run all mcp-smoke tests together:
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -60,15 +60,26 @@ The MCP server exposes a small, opinionated set of tools that match the canvas l
 
 | Tool | Purpose |
 |---|---|
-| `wb_document_create` / `wb_document_list` / `wb_document_resolve` / `wb_document_delete` | Canvas lifecycle (CRUD). |
-| `wb_node_patch` / `wb_edge_patch` / `wb_body_patch` | Patch a canvas's spatial nodes, edges, or a node's Markdown body. |
+| `wb_document_create` / `wb_document_list` / `wb_document_resolve` / `wb_document_delete` | Document lifecycle (CRUD). |
+| `wb_node_add` / `wb_edge_add` | Add a node to a spatial document, or connect two of its nodes. Both refuse an id already in use rather than overwriting, and `wb_edge_add` refuses an endpoint the canvas does not have. |
+| `wb_node_patch` / `wb_edge_patch` / `wb_body_patch` | Update a node, an edge, or a node's Markdown body. These update only — an element that is not there is an error, not a create. |
+| `wb_node_lock` / `wb_edge_lock` | Lock an element against edits. The lock binds agents exactly as it binds the pointer, and is editor state that never appears in an export. |
 | `wb_canvas_tidy` | Normalize a canvas's spatial layout: snap near-aligned nodes into rows/columns on the grid and separate overlaps, optionally restricted to a `scope` of node ids. Locked nodes never move. Idempotent — a second call reports no moves. |
 | `wb_facet_set` | Set structured facet metadata on a canvas (used for the private ticketing backlog, among other uses). |
 | `wb_scene_render` | Render the current canvas to an SVG string from its persisted document — no browser connection required. The reported `width`/`height` cover everything drawn, edges included, not just the nodes' own boxes. |
 | `wb_scene_digest` | Return the AI-facing spatial digest (overlap/containment/cluster/free-region summary) of a canvas. Entries are named by the canvas's own node ids, so anything the digest reports can be acted on directly with `wb_node_patch`; content laid out inside a node is not reported as a node of its own. |
-| `canvas_export_okf` / `wb_document_set` | Export/import a canvas as an OKF Markdown document (YAML frontmatter + Markdown body). |
-| `canvas_export_json_canvas` | Export a canvas as JSON Canvas 1.0 (with the `x-whiteboard` extension). |
+| `wb_document_get` / `wb_document_set` | Read and replace a document's content. `wb_document_get` answers in the document's own format — OKF Markdown for a markdown document, JSON Canvas 1.0 (with the `x-whiteboard` extension) for a spatial one — and the format is not a parameter. `wb_document_set` writes OKF Markdown. |
 | `wb_version_save` / `wb_version_restore` / `wb_version_list` | Save and restore labeled canvas versions. `wb_version_restore` accepts an optional `targetSlug` to fork the past state into a new canvas instead of reconciling in place. |
+
+**A content write has to match the document's format.** The two formats share
+one stored structure — a markdown document keeps its OKF body in a spatial
+text node — so an unguarded cross-format write would not fail, it would
+destroy: OKF into a diagram replaces its nodes and edges, a node into a
+markdown document lands beside the one holding its body. The first content
+write declares the document's format and every later write must match it, so
+`wb_document_set` on a spatial document and `wb_node_add` / `wb_edge_add` on a
+markdown one are errors. A document created before formats were recorded takes
+its format from the first write.
 
 Every tool above operates on the persisted document and never requires a
 connected browser tab — canvas rendering and export are headless. `wb_document_create`

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -112,9 +112,9 @@ token exchange. Until that lands, discovery is convenience, not proof.
 ## Browser-dependent operations
 
 No current MCP tool requires a connected browser client — canvas patching
-(`wb_node_patch` / `wb_edge_patch` / `wb_body_patch` / `wb_facet_set`), rendering
-(`wb_scene_render`), export/import (`canvas_export_okf` /
-`canvas_export_json_canvas` / `wb_document_set`), and versioning
+(`wb_node_add` / `wb_node_patch` / `wb_edge_add` / `wb_edge_patch` /
+`wb_body_patch` / `wb_facet_set`), rendering (`wb_scene_render`), reading and
+writing content (`wb_document_get` / `wb_document_set`), and versioning
 (`wb_version_save` / `wb_version_restore` / `wb_version_list`) all operate on the
 persisted document headlessly.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -8,7 +8,7 @@ Reference pages:
 
 - **[configuration](configuration.md)** — runtime environment variables and storage layout.
 - **[keyboard shortcuts](keyboard-shortcuts.md)** — every canvas-editor binding and its pointer equivalent.
-- **[export formats](export-formats.md)** — SVG / OKF Markdown / JSON Canvas via `wb_scene_render` / `canvas_export_okf` / `canvas_export_json_canvas`.
+- **[export formats](export-formats.md)** — OKF Markdown / JSON Canvas via `wb_document_get`, SVG via `wb_scene_render`.
 - **MCP tools** — the tools the MCP server exposes (entry point to the live `tools/list`) _(planned)_.
 
 ← Back to [documentation home](../)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -153,7 +153,7 @@ Inside the Codex sandbox, two issues are common:
 Each workspace lives at `${WHITEBOARD_DATA_DIR}/{workspaceId}/` and contains:
 
 - `*.loro` — Loro CRDT snapshots (one per canvas)
-- `*.svg`, `*.md` (OKF), `*.canvas` (JSON Canvas) — exports (via `wb_scene_render` / `canvas_export_okf` / `canvas_export_json_canvas`)
+- `*.svg`, `*.md` (OKF), `*.canvas` (JSON Canvas) — exports (via `wb_scene_render` / `wb_document_get`)
 - `palette.json`, `manifestJson`, library metadata, and other persisted JSON
 
 See [architecture](../explanation/architecture.md) for how each layer reads and writes this tree.

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -1,13 +1,22 @@
 # Export formats
 
-The MCP server exposes three export-shaped tools, each rendered headlessly from
-the canvas's persisted document — none of them require a connected browser client.
+The MCP server exposes two export-shaped tools, each rendered headlessly from
+the document's persisted content — neither requires a connected browser client.
 
 | Tool | Output | Notes |
 | --- | --- | --- |
-| `wb_scene_render` | Vector image (`.svg`) | Rendered from the canvas's spatial layout (canvas-render's scene graph + SVG backend) — shapes, laid-out Markdown text, and routed edges. |
-| `canvas_export_okf` | OKF Markdown document (YAML frontmatter + Markdown body) | Lossless round-trip with `wb_document_set`. |
-| `canvas_export_json_canvas` | JSON Canvas 1.0 (with the `x-whiteboard` extension) | Round-trips with other JSON Canvas-compatible tools; the `x-whiteboard` extension carries whiteboard-specific fields that a strict JSON Canvas reader can safely drop. |
+| `wb_document_get` | The document's own format | A markdown document comes back as OKF Markdown (YAML frontmatter + Markdown body), lossless round-trip with `wb_document_set`. A spatial document comes back as JSON Canvas 1.0 with the `x-whiteboard` extension, round-tripping with other JSON Canvas-compatible tools. |
+| `wb_scene_render` | Vector image (`.svg`) | Rendered from the document's spatial layout (canvas-render's scene graph + SVG backend) — shapes, laid-out Markdown text, and routed edges. |
+
+**The format is not a parameter.** `wb_document_get` answers in whatever
+format the document is in, and says which in its `kind` field; there is no
+"read this diagram as Markdown". SVG is the one cross-format output, and it is
+an explicitly lossy projection rather than a way to read the stored content
+(see [ADR-0009](../contributing/adr/0009-mcp-tool-naming.md)).
+
+A document created before formats were recorded has no answer here and is
+refused rather than guessed at; writing its content through `wb_document_set`
+gives it one.
 
 A `file` node renders as a labeled box when exported to SVG; its referenced image
 is not embedded in the output.
@@ -25,7 +34,7 @@ extension key, `x-whiteboard`, allowed at two sites:
 
 No other non-standard field is ever emitted, at any level. Foreign keys on an
 imported document (another tool's vendor fields) are stripped on parse and
-never re-emitted. Strict-mode output (`canvas_export_json_canvas` with
+never re-emitted. Strict-mode output (`wb_document_get` with
 `options.strict: true`) drops the `x-whiteboard` key entirely and is plain
 JSON Canvas 1.0.
 


### PR DESCRIPTION
## What was wrong

The two exporters became one `wb_document_get` (#699) and node/edge creation tools were added (#731, #734), but **five user-facing docs still named `canvas_export_okf` and `canvas_export_json_canvas`** — tools a reader would call and find missing. The reference, configuration, security-model, architecture and contributing docs now name what is registered.

Beyond the renames, three things were **absent** rather than stale:

- `wb_node_add` / `wb_edge_add` and `wb_node_lock` / `wb_edge_lock` had no row in the architecture tool table at all.
- The patch tools were described as "patch", which reads as create-or-update. They update only — an element that is not there is an error.
- Nothing documented that **a content write has to match the document's format** (#732), which is the one place a caller now gets a hard error where the write used to succeed and destroy.

ADR-0009's own mentions of the old names are left alone: an ADR records the decision at its date, and those lines describe the before-state.

## Verified against a real MCP client, not just read

The docs now claim MCP can author a spatial document. That claim was checked by driving the real server over stdio — `wb_document_create(spatial)` → `wb_node_add` ×3 → `wb_edge_add` ×2 → `wb_scene_render`:

![mcp-authored-diagram.png](https://github.com/user-attachments/assets/bec68b09-f4e5-4350-8a5e-dedda5623ef3)

540×360, rendered by `wb_scene_render` from the persisted document. Before #731/#734 this sequence was not expressible through MCP at all.

The same run checked the two refusals the docs now describe:

```
dangling edge (toNode: 'ghost')  → refused
cross-format write               → "Document … is a spatial document. This writes OKF
                                    Markdown, which would replace its nodes and edges
                                    with a single text node."
after the refusal                → kind=spatial, 3 nodes, 2 edges still there
```

That last line is the point of the guard: the refusal leaves the document intact.

## Vocabulary

The lifecycle row said "Canvas lifecycle" for what the same table calls documents (`.claude/rules/vocabulary.md`'s standing rule — fix violations in what you touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB