### PR TITLE
docs(dev-flow): say which browser CI actually runs, and guard the claim

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -14,7 +14,7 @@ pnpm install
 pnpm exec playwright install --with-deps chromium
 ```
 
-CI and the release workflow assume Playwright-managed Chromium. Set `WHITEBOARD_CHROME_PATH` only when you specifically want to drive a system Chrome.
+This installs Playwright's own Chromium, which is what a local browser-mode run uses. **CI does not**: every browser job in `.github/workflows/ci.yml` sets `WHITEBOARD_CHROME_PATH=/usr/bin/google-chrome-stable`, so CI drives the runner's system Chrome. Local and CI therefore execute browser tests in *different* browser builds — worth remembering when a browser test disagrees between them, since the browser itself is one of the variables. Set `WHITEBOARD_CHROME_PATH` locally to match CI when you are chasing exactly that kind of divergence.
 
 ## Bundled skills install
 

--- a/packages/mcp-server/src/server/release/ci-verify-coverage.test.ts
+++ b/packages/mcp-server/src/server/release/ci-verify-coverage.test.ts
@@ -64,4 +64,17 @@ describe('ci.yml verify coverage of removed publish-gate correctness projects', 
       expect.arrayContaining(['check', 'test-unit', 'test-jsdom', 'test-browser']),
     )
   })
+
+  // Which browser CI runs is not a detail: local runs use Playwright's Chromium
+  // and CI pins the runner's system Chrome, so the browser is a variable
+  // whenever a browser test passes in one place and fails in the other. The
+  // setup doc claimed the opposite for a while, which is the worst version of
+  // this — a contributor matching their machine to the doc diverges from CI.
+  it('the setup doc names the system-Chrome pin CI actually uses', () => {
+    const chromePin = text.match(/WHITEBOARD_CHROME_PATH:\s*(\S+)/)
+    expect(chromePin, 'ci.yml must pin a browser for the browser jobs').not.toBeNull()
+    const doc = readFileSync(join(ROOT, 'docs/contributing/development.md'), 'utf-8')
+    expect(doc).toContain(chromePin![1])
+    expect(doc).not.toContain('CI and the release workflow assume Playwright-managed Chromium')
+  })
 })


### PR DESCRIPTION
## What

`docs/contributing/development.md` said *"CI and the release workflow assume Playwright-managed Chromium. Set `WHITEBOARD_CHROME_PATH` only when you specifically want to drive a system Chrome."*

That is backwards. All three browser jobs in `.github/workflows/ci.yml` set `WHITEBOARD_CHROME_PATH: /usr/bin/google-chrome-stable`, so **CI drives the runner's system Chrome** while a local run uses the Playwright Chromium the setup steps just installed.

This is not trivia. When a browser test passes locally and fails in CI (or the reverse), the browser build is one of the variables — and a contributor who matched their machine to the doc had matched it to the wrong thing. Earlier today a "deterministic local failure vs green CI" investigation in this repo spent real effort on exactly that class of divergence. The text now states the split plainly and names it as a debugging lever.

## Guard

`ci-verify-coverage.test.ts` already reads `ci.yml`, so the assertion lands there: the doc must name the path CI actually pins, and must not contain the old claim. Mutation-checked both ways — restoring the old sentence turns it red (1 failed / 5 passed), the fix turns it green (6 passed).

Docs + one test assertion; no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw