### PR TITLE
refactor(server-core): name the wb_document_set module after its tool

### DIFF
--- a/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
+++ b/packages/mcp-server/src/server/mcp/opencanvas-tools.ts
@@ -314,16 +314,16 @@ export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): vo
 
   registerToolWithAnnotations(
     server,
-    tools.canvasImportOkf.name,
+    tools.documentSet.name,
     {
-      description: tools.canvasImportOkf.description,
-      inputSchema: tools.canvasImportOkf.inputSchema.shape,
-      outputSchema: tools.canvasImportOkf.outputSchema,
+      description: tools.documentSet.description,
+      inputSchema: tools.documentSet.inputSchema.shape,
+      outputSchema: tools.documentSet.outputSchema,
     },
     async (args) => {
-      const parsed = tools.canvasImportOkf.inputSchema.parse(args)
+      const parsed = tools.documentSet.inputSchema.parse(args)
       const result = await withCanvasDocWriteLock(parsed.canvasId, () =>
-        tools.canvasImportOkf.execute(parsed),
+        tools.documentSet.execute(parsed),
       )
       return structuredJsonResult(result)
     },

--- a/packages/server-core/src/canvas-routes.test.ts
+++ b/packages/server-core/src/canvas-routes.test.ts
@@ -143,7 +143,7 @@ describe('canvas OKF read route', () => {
       body: JSON.stringify({ segment: 'doc-a', kind: 'markdown', createWorkspace: true }),
     })
     const created = createCanvasOutputSchema.parse(await createRes.json())
-    await tools.canvasImportOkf.execute({
+    await tools.documentSet.execute({
       workspaceId: 'ws-1',
       canvasId: created.canvasId,
       markdown: '---\ntype: note\ntitle: Doc A\n---\n\nHello tree',

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -18,9 +18,9 @@ import {
 } from './tools/canvas-crud.schemas.js'
 import { createCanvasDigestTool } from './tools/canvas-digest.js'
 import { canvasExportOkfInputSchema, createCanvasExportOkfTool } from './tools/canvas-export-okf.js'
-import { createCanvasImportOkfTool } from './tools/canvas-import-okf.js'
 import { createCanvasRenderSvgTool } from './tools/canvas-render-svg.js'
 import { createDocumentGetTool } from './tools/document-get.js'
+import { createDocumentSetTool } from './tools/document-set.js'
 import { createEdgeAddTool } from './tools/edge-add.js'
 import { createEdgeLockTool } from './tools/edge-lock.js'
 import { createEdgePatchTool } from './tools/edge-patch.js'
@@ -140,7 +140,7 @@ export function createServer(deps: ServerDeps) {
     canvasRenderSvg: createCanvasRenderSvgTool(deps),
     canvasDigest: createCanvasDigestTool(deps),
     documentGet: createDocumentGetTool(deps),
-    canvasImportOkf: createCanvasImportOkfTool(deps),
+    documentSet: createDocumentSetTool(deps),
     versionSave: createVersionSaveTool(deps),
     versionList: createVersionListTool(deps),
     versionRestore: createVersionRestoreTool(deps),

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -47,19 +47,19 @@ export {
   canvasExportOkfOutputSchema,
   createCanvasExportOkfTool,
 } from './tools/canvas-export-okf.js'
-export type { CanvasImportOkfInput, CanvasImportOkfOutput } from './tools/canvas-import-okf.js'
-export {
-  canvasImportOkfInputSchema,
-  canvasImportOkfOutputSchema,
-  createCanvasImportOkfTool,
-  OkfParseError,
-} from './tools/canvas-import-okf.js'
 export type { CanvasRenderSvgInput, CanvasRenderSvgOutput } from './tools/canvas-render-svg.js'
 export {
   canvasRenderSvgInputSchema,
   canvasRenderSvgOutputSchema,
   createCanvasRenderSvgTool,
 } from './tools/canvas-render-svg.js'
+export type { DocumentSetInput, DocumentSetOutput } from './tools/document-set.js'
+export {
+  createDocumentSetTool,
+  documentSetInputSchema,
+  documentSetOutputSchema,
+  OkfParseError,
+} from './tools/document-set.js'
 export type { EdgeAddInput, EdgeAddOutput } from './tools/edge-add.js'
 export { createEdgeAddTool, edgeAddInputSchema, edgeAddOutputSchema } from './tools/edge-add.js'
 export type { EdgeLockInput, EdgeLockOutput } from './tools/edge-lock.js'

--- a/packages/server-core/src/tools/document-set.test.ts
+++ b/packages/server-core/src/tools/document-set.test.ts
@@ -13,7 +13,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
-import { createCanvasImportOkfTool } from './canvas-import-okf.js'
+import { createDocumentSetTool } from './document-set.js'
 import { DocumentKindMismatchError } from './errors.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -35,7 +35,7 @@ describe('wb_document_set tool', () => {
   test('imports markdown with facets and body into a new LoroDoc', async () => {
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     const markdown = [
       '---',
@@ -70,7 +70,7 @@ describe('wb_document_set tool', () => {
   test('imports markdown with empty body (facets only)', async () => {
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     const markdown = '---\ntype: note\n---\n'
 
@@ -86,7 +86,7 @@ describe('wb_document_set tool', () => {
   test('overwrites existing doc on re-import', async () => {
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     const v1 = '---\ntype: issue\nfacets:\n  example/1:\n    status: open\n---\nFirst body.'
     await tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown: v1 })
@@ -108,7 +108,7 @@ describe('wb_document_set tool', () => {
   test('rejects invalid OKF markdown', async () => {
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     await expect(
       tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown: 'no frontmatter' }),
@@ -117,7 +117,7 @@ describe('wb_document_set tool', () => {
 
   test('rejects when canvas is not in workspace', async () => {
     const store = new FakeCanvasDocStore()
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     const markdown = '---\ntype: note\n---\nBody.'
 
@@ -139,7 +139,7 @@ describe('wb_document_set tool', () => {
         edges: [],
       })
     })
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     await expect(
       tool.execute({
@@ -158,7 +158,7 @@ describe('wb_document_set tool', () => {
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
     await seedDoc(store, CANVAS_ID, (doc) => writeDocumentKind(doc, 'markdown'))
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     await tool.execute({
       workspaceId: WORKSPACE_ID,
@@ -175,7 +175,7 @@ describe('wb_document_set tool', () => {
     // unwritable through this tool, with no path out.
     const store = new FakeCanvasDocStore()
     await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-    const tool = createCanvasImportOkfTool(makeDeps(store))
+    const tool = createDocumentSetTool(makeDeps(store))
 
     await tool.execute({
       workspaceId: WORKSPACE_ID,

--- a/packages/server-core/src/tools/document-set.ts
+++ b/packages/server-core/src/tools/document-set.ts
@@ -15,22 +15,22 @@ import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 const TEXT_NODE_ID = 'okf-body'
 
-export const canvasImportOkfInputSchema = z
+export const documentSetInputSchema = z
   .object({
     workspaceId: workspaceIdSchema,
     canvasId: canvasIdSchema,
     markdown: z.string(),
   })
   .strict()
-export type CanvasImportOkfInput = z.infer<typeof canvasImportOkfInputSchema>
+export type DocumentSetInput = z.infer<typeof documentSetInputSchema>
 
-export const canvasImportOkfOutputSchema = z
+export const documentSetOutputSchema = z
   .object({
     canvasId: canvasIdSchema,
     imported: z.literal(true),
   })
   .strict()
-export type CanvasImportOkfOutput = z.infer<typeof canvasImportOkfOutputSchema>
+export type DocumentSetOutput = z.infer<typeof documentSetOutputSchema>
 
 export class OkfParseError extends Error {
   constructor(
@@ -42,14 +42,14 @@ export class OkfParseError extends Error {
   }
 }
 
-export function createCanvasImportOkfTool(deps: ServerDeps) {
+export function createDocumentSetTool(deps: ServerDeps) {
   return {
     name: 'wb_document_set' as const,
     description:
       'Replace the entire content of an existing document from an OKF Markdown string. The document must already exist; core facets, extension facets and the body are all overwritten rather than merged.',
-    inputSchema: canvasImportOkfInputSchema,
-    outputSchema: canvasImportOkfOutputSchema,
-    execute: async (input: CanvasImportOkfInput): Promise<CanvasImportOkfOutput> => {
+    inputSchema: documentSetInputSchema,
+    outputSchema: documentSetOutputSchema,
+    execute: async (input: DocumentSetInput): Promise<DocumentSetOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
 
       const parsed = parseOkf(input.markdown)

--- a/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../test-utils/fake-canvas-doc-store.js'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import { createCanvasExportOkfTool } from './canvas-export-okf.js'
-import { createCanvasImportOkfTool } from './canvas-import-okf.js'
+import { createDocumentSetTool } from './document-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
@@ -78,19 +78,19 @@ async function setupTools() {
   await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
   const deps = { canvasDocStore: store, blobStore: {} as never }
   return {
-    importOkf: createCanvasImportOkfTool(deps),
+    documentSet: createDocumentSetTool(deps),
     exportOkf: createCanvasExportOkfTool(deps),
   }
 }
 
-describe('wb_document_set -> canvas_export_okf round-trip property', () => {
+describe('wb_document_set -> the OKF exporter round-trip property', () => {
   fcTest.prop([okfDocumentArbitrary], withDefaults({ numRuns: 50 }))(
     'export(import(x)).frontmatter equals x.frontmatter up to canonical facet-key ordering, body verbatim',
     async (doc) => {
-      const { importOkf, exportOkf } = await setupTools()
+      const { documentSet, exportOkf } = await setupTools()
       const markdown = serializeOkf(doc)
 
-      await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+      await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
       const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
       expect(result.frontmatter.type).toBe(doc.frontmatter.type)

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../test-utils/fake-canvas-doc-store.js'
 import { createCanvasExportJsonCanvasTool } from './canvas-export-json-canvas.js'
 import { createCanvasExportOkfTool } from './canvas-export-okf.js'
-import { createCanvasImportOkfTool, OkfParseError } from './canvas-import-okf.js'
+import { createDocumentSetTool, OkfParseError } from './document-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
@@ -33,18 +33,18 @@ async function setupTools() {
   const deps = makeDeps(store)
   return {
     store,
-    importOkf: createCanvasImportOkfTool(deps),
+    documentSet: createDocumentSetTool(deps),
     exportOkf: createCanvasExportOkfTool(deps),
     exportJson: createCanvasExportJsonCanvasTool(deps),
   }
 }
 
-describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
+describe('wb_document_set -> OKF export composed round-trip', () => {
   test('preserves body text through the LoroDoc persistence layer', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
     const markdown = '---\ntype: note\n---\n# Title\n\nBody text.'
-    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
     const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -52,7 +52,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
   })
 
   test('preserves core facets (type/title/tags/view) through the LoroDoc persistence layer', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
     const markdown = [
       '---',
@@ -68,7 +68,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
       '---',
       'Body text.',
     ].join('\n')
-    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
     const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -82,7 +82,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
   })
 
   test('preserves facets with arbitrary domain keys through the LoroDoc persistence layer', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
     const markdown = [
       '---',
@@ -94,7 +94,7 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
       '---',
       'Body.',
     ].join('\n')
-    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
     const result = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
@@ -102,9 +102,9 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
   })
 
   test('an empty (facets-only) body round-trips to an empty body', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\n',
@@ -116,13 +116,13 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
   })
 
   test('re-import after export is idempotent: the second import produces the same LoroDoc state', async () => {
-    const { store, importOkf, exportOkf } = await setupTools()
+    const { store, documentSet, exportOkf } = await setupTools()
 
     const markdown = '---\ntype: note\nfacets:\n  kanban/1:\n    status: todo\n---\nOriginal body.'
-    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
     const exported = await exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: exported.markdown,
@@ -138,11 +138,11 @@ describe('wb_document_set -> canvas_export_okf composed round-trip', () => {
   })
 })
 
-describe('wb_document_set -> canvas_export_json_canvas composed round-trip', () => {
+describe('wb_document_set -> the JSON Canvas exporter composed round-trip', () => {
   test('the imported body appears as a text node in the exported (extended) JSON Canvas', async () => {
-    const { importOkf, exportJson } = await setupTools()
+    const { documentSet, exportJson } = await setupTools()
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nHello from OKF.',
@@ -156,9 +156,9 @@ describe('wb_document_set -> canvas_export_json_canvas composed round-trip', () 
   })
 
   test('the exported (strict) JSON Canvas has no x-whiteboard extensions', async () => {
-    const { importOkf, exportJson } = await setupTools()
+    const { documentSet, exportJson } = await setupTools()
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nHello.',
@@ -175,11 +175,11 @@ describe('wb_document_set -> canvas_export_json_canvas composed round-trip', () 
   })
 })
 
-describe('canvas_export_json_canvas output re-parses as valid JSON Canvas', () => {
+describe('the JSON Canvas exporter output re-parses as valid JSON Canvas', () => {
   test('parseSpatial succeeds on the exported (extended) JSON', async () => {
-    const { importOkf, exportJson } = await setupTools()
+    const { documentSet, exportJson } = await setupTools()
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nRe-parse me.',
@@ -190,9 +190,9 @@ describe('canvas_export_json_canvas output re-parses as valid JSON Canvas', () =
   })
 
   test('parseSpatial succeeds on the exported (strict) JSON', async () => {
-    const { importOkf, exportJson } = await setupTools()
+    const { documentSet, exportJson } = await setupTools()
 
-    await importOkf.execute({
+    await documentSet.execute({
       workspaceId: WORKSPACE_ID,
       canvasId: CANVAS_ID,
       markdown: '---\ntype: note\n---\nRe-parse me too.',
@@ -209,10 +209,10 @@ describe('canvas_export_json_canvas output re-parses as valid JSON Canvas', () =
 
 describe('error paths do not silently produce corrupt output', () => {
   test('import_okf with no frontmatter rejects before any export is attempted', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
     await expect(
-      importOkf.execute({
+      documentSet.execute({
         workspaceId: WORKSPACE_ID,
         canvasId: CANVAS_ID,
         markdown: 'no frontmatter here',
@@ -227,7 +227,7 @@ describe('error paths do not silently produce corrupt output', () => {
   })
 
   test('a non-yaml-safe facet value (YAML .nan) imports but rejects on export, never silently exported', async () => {
-    const { importOkf, exportOkf } = await setupTools()
+    const { documentSet, exportOkf } = await setupTools()
 
     // parseOkf's frontmatter schema only validates facet KEYS, not values
     // (extensionFacetsSchema stores values as z.unknown()) — the yaml-safe
@@ -236,7 +236,7 @@ describe('error paths do not silently produce corrupt output', () => {
     // successfully but must fail the composed export rather than silently
     // emitting corrupt YAML.
     const markdown = '---\ntype: note\nfacets:\n  bad/1:\n    value: .nan\n---\nBody.'
-    await importOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
+    await documentSet.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID, markdown })
 
     await expect(
       exportOkf.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),


### PR DESCRIPTION
## What

`canvas-import-okf.ts` was named for the tool it used to be. Both halves of the old name are wrong:

- **"import"** was implementation-time framing for what is a content write.
- **OKF** is the format the tool happens to accept, not what the module is for.

[ADR-0009](https://github.com/kamiazya/whiteboard/blob/main/docs/contributing/adr/0009-mcp-tool-naming.md) settled both. Two recent commits (#732, #734) deferred this rename only because an in-flight PR owned `opencanvas-tools.ts`; it has merged.

The file, its test, and every symbol now follow the tool: `documentSetInputSchema` / `documentSetOutputSchema`, `createDocumentSetTool`, `DocumentSetInput` / `DocumentSetOutput`, and the `tools.documentSet` key.

Two round-trip test files also named `canvas_export_okf` and `canvas_export_json_canvas` in their `describe` titles. Those stopped being tool names when the exporters collapsed into `wb_document_get` (#699), so the titles say what they actually exercise.

## Left alone deliberately

The `imported: true` field in the output schema carries the same import-era vocabulary, but it crosses the MCP boundary, and `.claude/rules/vocabulary.md` keeps published surfaces to their own increment.

## Verification

Pure rename — no behaviour change, and the compiler enumerated the call sites rather than a substring sweep (the sweep is how `wb_wb_facet_set` once got into 19 files).

305 test files green (server-core-node + mcp-node + mcp-smoke), `pnpm -r typecheck` clean, `pnpm knip` clean, `pnpm smoke:e2e` ALL OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB