### PR TITLE
fix(web): validate the stashed pairing transaction with a schema

### DIFF
--- a/apps/web/src/lib/pairing-grant.test.ts
+++ b/apps/web/src/lib/pairing-grant.test.ts
@@ -193,6 +193,58 @@ describe('consumeGrantFragment', () => {
     expect(JSON.parse(String(init.body)).nonce).toMatch(/^[A-Za-z0-9_-]{20,}$/)
   })
 
+  // The stash holds a PKCE verifier and decides where the code is redeemed, so
+  // a daemonBaseUrl that is not a bare origin must never reach fetch(): the
+  // exchange POSTs the verifier and the single-use code to whatever that value
+  // names. sessionStorage is same-origin-writable and is cloned into windows
+  // this page opens, so "nobody can put a bad value there" is not an argument
+  // this code gets to make.
+  it.each([
+    ['a URL carrying a path', 'https://evil.example/collect'],
+    ['a URL carrying a query', 'https://evil.example?x=1'],
+    ['credentials in the authority', 'https://user:pw@evil.example'],
+    ['not a URL at all', 'not-a-url'],
+    ['an empty string', ''],
+  ])('refuses to exchange when daemonBaseUrl is %s', async (_label, daemonBaseUrl) => {
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st-1',
+        codeVerifier: 'verifier',
+        daemonBaseUrl,
+      }),
+    })
+    const fetchFn = vi.fn(async () => Response.json({ token: 'tok' }))
+
+    const result = await consumeGrantFragment({
+      hash: '#wb-grant=the-code&state=st-1',
+      sessionStorage: storage,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    expect(result).toEqual({ status: 'error', detail: 'corrupt pairing transaction' })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('refuses to exchange when the stashed codeVerifier is empty', async () => {
+    const { storage } = makeStorage({
+      'whiteboard:pairing-transaction': JSON.stringify({
+        state: 'st-1',
+        codeVerifier: '',
+        daemonBaseUrl: DAEMON,
+      }),
+    })
+    const fetchFn = vi.fn(async () => Response.json({ token: 'tok' }))
+
+    const result = await consumeGrantFragment({
+      hash: '#wb-grant=the-code&state=st-1',
+      sessionStorage: storage,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    expect(result).toEqual({ status: 'error', detail: 'corrupt pairing transaction' })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
   it('rejects a state mismatch without exchanging anything', async () => {
     const { storage } = makeStorage({
       'whiteboard:pairing-transaction': JSON.stringify({

--- a/apps/web/src/lib/pairing-grant.ts
+++ b/apps/web/src/lib/pairing-grant.ts
@@ -18,6 +18,8 @@
  */
 
 import { pairingTokenResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { z } from 'zod'
+import { bareOriginSchema } from '../runtime-config.js'
 import {
   createChallengeNonce,
   getPinnedIdentity,
@@ -28,6 +30,18 @@ import {
 
 const TRANSACTION_KEY = 'whiteboard:pairing-transaction'
 const GRANT_FRAGMENT_PREFIX = '#wb-grant='
+
+// The stash survives a top-level navigation and is same-origin writable, so it
+// re-enters this module as untrusted input however it left. `daemonBaseUrl` is
+// the load-bearing field: the exchange POSTs the PKCE verifier and the
+// single-use code to it, so it reuses runtime-config's bareOriginSchema rather
+// than a looser string check — a value with a path, query or credentials is not
+// an origin this app ever wrote, and must not be one it redeems against.
+const pairingTransactionSchema = z.object({
+  state: z.string().min(1),
+  codeVerifier: z.string().min(1),
+  daemonBaseUrl: bareOriginSchema,
+})
 
 interface StorageLike {
   getItem(key: string): string | null
@@ -125,19 +139,17 @@ export async function consumeGrantFragment({
   if (rawTransaction === null) {
     return { status: 'error', detail: 'no pairing transaction in progress' }
   }
-  let transaction: { state?: unknown; codeVerifier?: unknown; daemonBaseUrl?: unknown }
+  let parsedTransaction: unknown
   try {
-    transaction = JSON.parse(rawTransaction)
+    parsedTransaction = JSON.parse(rawTransaction)
   } catch {
     return { status: 'error', detail: 'corrupt pairing transaction' }
   }
-  if (
-    typeof transaction.state !== 'string' ||
-    typeof transaction.codeVerifier !== 'string' ||
-    typeof transaction.daemonBaseUrl !== 'string'
-  ) {
+  const validated = pairingTransactionSchema.safeParse(parsedTransaction)
+  if (!validated.success) {
     return { status: 'error', detail: 'corrupt pairing transaction' }
   }
+  const transaction = validated.data
   if (fragment.state !== transaction.state) {
     return { status: 'error', detail: 'pairing state mismatch' }
   }


### PR DESCRIPTION
## What

`consumeGrantFragment` read the pairing transaction back out of `sessionStorage` with `JSON.parse` plus three `typeof x === 'string'` checks. That accepted **any** string for `daemonBaseUrl` — one with a path, a query, or embedded credentials — and the next thing the function does is POST the PKCE verifier and the single-use grant code to it. Empty strings passed the same way.

The stash is same-origin writable and, as the file's own header notes, is cloned into windows this page opens, so it re-enters as untrusted input however it left. It now hydrates through a Zod schema reusing `runtime-config`'s `bareOriginSchema` — the same origin rule the other cross-boundary contracts use, and exactly the persisted-JSON half of the repo's schema discipline ("declare a schema next to the parser, hydrate through it instead of casting").

## Tests

Six red-first cases pinned the hole before the fix — path, query, credentials-in-authority, non-URL, empty origin, empty verifier — each now stopping at `corrupt pairing transaction` with `fetch` never called. All six failed against the old code; 28/28 green after.

apps/web suite 166 files / 2036 tests green; typecheck and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw
