### PR TITLE
chore: stop .gitignore swallowing example env files, and fix a dead doc anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,14 @@ web_modules/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variable files
+# dotenv environment variable files. The negation covers EVERY example file,
+# not just `.env.example`: `.env.*` otherwise swallows `.env.server.example`
+# and any future `.env.<target>.example`, which are meant to be committed and
+# would be silently untrackable (git reports nothing when `git add` skips an
+# ignored path).
 .env
 .env.*
-!.env.example
+!.env*.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -343,7 +343,7 @@ Which gate enforces each hosted-app security property (entry points for `securit
 
 ## Quality Gates
 
-Common commands are also summarized in [CONTRIBUTING.md](../../CONTRIBUTING.md#quality-gates). This section is the canonical gate matrix.
+Common commands are also summarized in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-checklist). This section is the canonical gate matrix.
 
 ```bash
 pnpm lint           # Biome — must be green before review


### PR DESCRIPTION
Two independent one-line hygiene fixes from the audit backlog, each verified against the repo rather than taken on the audit's word.

**`.gitignore` swallows example env files.** `.env.*` matches `.env.server.example`; the `!.env.example` negation rescues exactly that one filename. The committed `.env.server.example` survives only because it predates the rule — a contributor adding `.env.web.example` today would find `git add` skipping it **silently**, since git says nothing when it declines an ignored path. The negation now covers `.env*.example`. Verified behaviourally, not by reading the pattern: a fresh `.env.web.example` adds cleanly, and a real `.env.local` is still refused. (`git check-ignore` alone is misleading here — it skips tracked paths unless `--no-index`, so the committed example looked un-ignored while the rule was in fact matching it.)

**Dead doc anchor.** `testing.md` linked `CONTRIBUTING.md#quality-gates`; that file has no such heading (nearest is "Pull request checklist"). GitHub silently resolves an unknown anchor to the top of the page, so the link looked healthy and landed nowhere useful. Now points at a heading that exists.

No code, no tests — `.gitignore` and one markdown link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw
