### PR TITLE
refactor(mcp-server): drop the fourth copy of the tool-name list

### DIFF
--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -6,13 +6,22 @@
  * It is defined independently of the four category arrays below so that the
  * meta-property test can verify category completeness without self-reference.
  *
- * When adding or removing a tool:
- *   1. Update ALL_REGISTERED_TOOLS.
- *   2. Add the tool to exactly one of the four category arrays.
- *   3. The property test (tool-structured-content.property.test.ts) will fail
- *      if the categories do not cover ALL_REGISTERED_TOOLS exactly.
- *   4. The smoke (mcp-e2e-checkpoint.mjs / smoke-impl.ts) will fail if tools/list no longer
- *      matches ALL_REGISTERED_TOOLS.
+ * Adding or removing a tool touches four places, and each is checked against
+ * the one below it rather than against a copy of itself:
+ *   1. ALL_REGISTERED_TOOLS here — compared to a REAL server's tools/list by
+ *      the mcp-smoke checkpoint (mcp-e2e-checkpoint.smoke-impl.ts), so this
+ *      is the list that is held to reality rather than to another list.
+ *   2. Exactly one of the category arrays below — the property test
+ *      (tool-structured-content.property.test.ts) fails if the categories do
+ *      not partition ALL_REGISTERED_TOOLS exactly.
+ *   3. TOOL_PROFILES (tool-profiles.ts) — tool-naming.test.ts fails if it
+ *      does not cover ALL_REGISTERED_TOOLS exactly. A registered tool with
+ *      no profile silently downgrades to MUTATING with its name as its title.
+ *   4. EXPECTED_TOOLS in scripts/smoke/mcp-e2e-smoke.mjs. Deliberately a
+ *      separate copy: that smoke drives the server as a subprocess, so
+ *      importing this list would make it agree with itself instead of
+ *      catching packaging drift. It is a plain .mjs script and cannot import
+ *      this module anyway.
  *
  * Category meanings:
  *   COVERED_TOOLS       — exercised end-to-end in the smoke (success path).

--- a/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.test.ts
@@ -1,38 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { TOOL_PROFILES } from './tool-profiles.js'
 
-// Tools actually registered by registerOpenCanvasTools (opencanvas-tools.ts).
-// Every removed Excalidraw-era tool name (canvas_list, export_svg,
-// create_frame, etc.) must have no entry here — a stale entry gives a
-// client a misleading approval-policy hint for a tool that no longer exists.
-const ACTIVE_TOOL_NAMES = [
-  'wb_facet_set',
-  'wb_edge_add',
-  'wb_node_add',
-  'wb_node_lock',
-  'wb_node_patch',
-  'wb_edge_lock',
-  'wb_edge_patch',
-  'wb_canvas_tidy',
-  'wb_body_patch',
-  'wb_scene_render',
-  'wb_scene_digest',
-  'wb_document_set',
-  'wb_document_create',
-  'wb_document_get',
-  'wb_document_list',
-  'wb_document_resolve',
-  'wb_document_delete',
-  'wb_version_save',
-  'wb_version_restore',
-  'wb_version_list',
-]
-
+// Coverage of TOOL_PROFILES against the registered tool set is asserted in
+// tool-naming.test.ts, against ALL_REGISTERED_TOOLS — which the mcp-smoke
+// checkpoint compares to a real server's tools/list. A restatement here
+// would only be a fourth list to forget to update.
 describe('TOOL_PROFILES', () => {
-  it('contains exactly the active OpenCanvas tool set (no dead Excalidraw entries)', () => {
-    expect(Object.keys(TOOL_PROFILES).sort()).toEqual([...ACTIVE_TOOL_NAMES].sort())
-  })
-
   it('declares wb_document_set as mutating, not read-only or destructive', () => {
     const profile = TOOL_PROFILES.wb_document_set.profile
     expect(profile.readOnlyHint).not.toBe(true)


### PR DESCRIPTION
## The finding

Adding a tool meant editing **five** lists. Investigating which of them actually earn their place turned up a cleaner answer than the "derive them all from one source" I set out to write: four are already checked against each other in a chain that ends at a **real server**, and only one was redundant.

```
EXPECTED_TOOLS (smoke .mjs) ─┐
                             ├─→ a live tools/list
ALL_REGISTERED_TOOLS ────────┘
  ├─→ the category arrays partition it
  └─→ TOOL_PROFILES covers it exactly
```

`ACTIVE_TOOL_NAMES` in `tool-profiles.test.ts` was the fifth, and it was only ever compared to `TOOL_PROFILES` — which `tool-naming.test.ts` already compares to `ALL_REGISTERED_TOOLS`, the list the `mcp-smoke` checkpoint holds against a real server's `tools/list`. So it restated a **weaker** form of an assertion that already existed, and its only failure mode was forgetting to update it. Adding `wb_node_add` (#731) and `wb_edge_add` (#734) went red on exactly that, twice, with nothing else wrong.

Note what this does *not* do: no new test, and no in-process tool-listing harness. The reality check the redundant list was pretending to be already exists.

## Mutation-checked before deleting

A guard is only safe to remove once the survivor is shown to cover it. Injecting a `create_frame` entry into `TOOL_PROFILES`:

```
× TOOL_PROFILES covers exactly the registered tools
  AssertionError: expected [ 'create_frame', …(20) ] to deeply equal [ 'wb_body_patch', …(19) ]
```

That is the stale-Excalidraw-entry case the deleted test named in its own comment, still caught.

## The checklist that was missing

`mcp-smoke-coverage.ts`'s header now lists all four places a new tool has to be added and **what checks each**, so the next person reads a checklist instead of discovering it one red test at a time. It also records why the smoke's copy is deliberately separate: that smoke drives the server as a subprocess, so importing the list would make it agree with itself instead of catching packaging drift — and it is a plain `.mjs` script that cannot import the module anyway.

## Verification

271 test files green (`mcp-node` + `mcp-smoke`), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB