### PR TITLE
test(web): give the CodeMirror focus waits the budget their neighbours have

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -101,9 +101,17 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // exact identity is what real keyboard-event delivery depends on, and a
     // looser containment check can pass while focus still sits on some other
     // in-flight descendant (e.g. mid-mount) and races the first keystrokes.
-    await waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    // Same 10s budget every other wait in this file carries: this one waits on
+    // mount PLUS autofocus against a real browser and real IndexedDB, and the
+    // testing-library default is 1s. Under CI load that expires with focus
+    // still on <body>, which reads as "autofocus is broken" when it only means
+    // "autofocus had not happened yet".
+    await waitFor(
+      () => {
+        expect(document.activeElement).toBe(editable)
+      },
+      { timeout: 10_000 },
+    )
     await userEvent.keyboard('# Persisted note')
     await waitFor(() => {
       expect(document.querySelector('.cm-content')?.textContent).toBe('# Persisted note')
@@ -218,9 +226,12 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // test 1 above already pins (see its focus-wait comment for why exact
     // contentDOM identity is required).
     await userEvent.click(editable)
-    await waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await waitFor(
+      () => {
+        expect(document.activeElement).toBe(editable)
+      },
+      { timeout: 10_000 },
+    )
     await userEvent.keyboard('body first')
     await waitFor(() => {
       expect(document.querySelector('.cm-content')?.textContent).toBe('body first')

--- a/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
@@ -78,9 +78,15 @@ describe('browser-local list landing (browser — real IndexedDB)', () => {
     // contentDOM identity — not .cm-editor containment — is what real
     // keyboard-event delivery depends on; containment can pass while focus
     // still sits on another in-flight descendant and race the first keys.
-    await waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    // 10s, like the neighbouring waits: this one covers navigation, mount and
+    // autofocus against a real browser, and testing-library's 1s default
+    // expires under CI load with focus still on <body>.
+    await waitFor(
+      () => {
+        expect(document.activeElement).toBe(editable)
+      },
+      { timeout: 10_000 },
+    )
     await userEvent.keyboard('# From the list')
     await waitFor(() => {
       expect(document.querySelector('.cm-content')?.textContent).toBe('# From the list')


### PR DESCRIPTION
The exact-contentDOM focus check I added in #676 was left on testing-library's **1s default** while every other wait in these files carries 10–15s — they drive a real browser against real IndexedDB.

Under CI load that 1s expires with focus still on `<body>`, reported as `expected <body> to be <div spellcheck="false">`. It reads as a broken autofocus when it only means autofocus had not happened yet. Same test failed on #652 (before the strictness) and again on #739 (after), so this is the second CI occurrence of the class — root-caused rather than rerun again.

The condition is unchanged and still strict: `activeElement` must **be** the contentDOM, not merely be inside `.cm-editor`. Only the time allowed for mount-plus-autofocus changes, in all three places #676 touched (two in the markdown page suite, one in the index-page flow).

Both files green locally: 2 files / 8 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw