### PR TITLE
fix(mcp): make wb_canvas_tidy's "spatial documents only" true

### DIFF
--- a/packages/server-core/src/tools/tidy-canvas.test.ts
+++ b/packages/server-core/src/tools/tidy-canvas.test.ts
@@ -1,13 +1,19 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { chunkSnapshot } from '@kamiazya/whiteboard-canvas-ports'
-import { setNodeLock, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
+import {
+  setNodeLock,
+  writeDocumentKind,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
+  seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
+import { DocumentKindMismatchError } from './errors.js'
 import { createTidyCanvasTool } from './tidy-canvas.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -138,5 +144,43 @@ describe('wb_canvas_tidy tool', () => {
     const tool = createTidyCanvasTool(makeDeps(canvasDocStore))
 
     await expect(tool.execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })).rejects.toThrow()
+  })
+})
+
+describe('wb_canvas_tidy on a markdown document', () => {
+  test('refuses it, rather than repositioning the node holding its OKF body', async () => {
+    // The description has always said "spatial documents only", and the
+    // spatial-schema parse it credited for that never enforced it: a
+    // markdown document's stored content IS a valid spatial canvas, so it
+    // parsed and tidy went ahead.
+    //
+    // Two nodes, because that is the case where it is not merely untidy but
+    // wrong: tidy returns no moves for a lone node, so a document written by
+    // wb_document_set (exactly one body node) was a silent no-op. A markdown
+    // document predating the format guards, or one the web editor gave a
+    // second node, is the one that got repositioned.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeDocumentKind(doc, 'markdown')
+      writeSpatialCanvas(doc, {
+        nodes: [
+          { id: 'okf-body', type: 'text', x: 3, y: 7, width: 200, height: 100, text: 'body' },
+          { id: 'stray', type: 'text', x: 211, y: 9, width: 200, height: 100, text: 'stray' },
+        ],
+        edges: [],
+      })
+    })
+    const deps = { canvasDocStore: store, blobStore: {} as never }
+
+    await expect(
+      createTidyCanvasTool(deps).execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),
+    ).rejects.toThrow(DocumentKindMismatchError)
+
+    const { canvas } = await loadCanvasDoc(deps, CANVAS_ID)
+    expect(canvas.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y }))).toEqual([
+      { id: 'okf-body', x: 3, y: 7 },
+      { id: 'stray', x: 211, y: 9 },
+    ])
   })
 })

--- a/packages/server-core/src/tools/tidy-canvas.ts
+++ b/packages/server-core/src/tools/tidy-canvas.ts
@@ -5,11 +5,11 @@ import {
   workspaceIdSchema,
 } from '@kamiazya/whiteboard-canvas-model'
 import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
-import { readNodeLocks } from '@kamiazya/whiteboard-canvas-workspace'
+import { readDocumentKind, readNodeLocks } from '@kamiazya/whiteboard-canvas-workspace'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
-import { PatchValidationError } from './errors.js'
+import { DocumentKindMismatchError, PatchValidationError } from './errors.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 export const tidyCanvasInputSchema = z
@@ -37,12 +37,25 @@ export function createTidyCanvasTool(deps: ServerDeps) {
   return {
     name: 'wb_canvas_tidy' as const,
     description:
-      'Re-lay-out the spatial canvas. Spatial documents only — it parses through the spatial schema and rejects anything else.',
+      'Re-lay-out the spatial canvas. Spatial documents only — a markdown document is refused rather than having the node holding its body repositioned.',
     inputSchema: tidyCanvasInputSchema,
     outputSchema: tidyCanvasOutputSchema,
     execute: async (input: TidyCanvasInput): Promise<TidyCanvasOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const { doc, canvas } = await loadCanvasDoc(deps, input.canvasId)
+
+      // A markdown document stores its OKF body in a text node, so its
+      // content parses as a perfectly valid spatial canvas and the schema
+      // gate below cannot tell the two apart. Unlike wb_node_add this does
+      // not declare a kind for a document that has none: repositioning what
+      // is already there is no evidence of what the document is.
+      if (readDocumentKind(doc) === 'markdown') {
+        throw new DocumentKindMismatchError(
+          input.canvasId,
+          'markdown',
+          'This re-lays-out a spatial canvas, and its only node holds its OKF body. Edit its body through wb_body_patch.',
+        )
+      }
 
       // Locks bind agents exactly as they bind the editor: a locked node is
       // a fixed obstacle tidy routes around, never a participant it moves.


### PR DESCRIPTION
## The finding

`wb_canvas_tidy`'s description said:

> Spatial documents only — it parses through the spatial schema and rejects anything else.

**That parse never did that.** A markdown document's stored content IS a valid spatial canvas — its OKF body lives in a text node — so it passed the gate and tidy went ahead. The schema rejects *invalid content*, not *markdown documents*.

Found by sweeping the MCP surface for claims that had stopped being true, which is the recurring defect shape in this batch (`wb_node_patch`'s "Create or update", the ex-exporters' tool names, docs naming removed tools, `wb_edge_lock`'s "no MCP tool creates an edge").

## Measured, because the two cases differ

| document | `tidyNodes` result |
|---|---|
| one node — what `wb_document_set` writes | `[]` — silent no-op |
| two nodes | `okf-body` 3,7 → **0,8**, `stray` 211,9 → **224,8** |

So the document this tool is normally pointed at was harmless, and the one that actually got its **body node repositioned** is a markdown document predating the format guards, or one the web editor gave a second node.

**The regression test uses two nodes for exactly that reason** — with one node it would pass with or without the guard, which is the kind of test that looks like coverage and is not.

## The fix

Refuses markdown, matching the rule `wb_document_set` / `wb_node_add` / `wb_edge_add` already follow (#732, #734).

It deliberately does **not** declare a kind for a document that has none, unlike those three: moving what is already there is no evidence of what the document is.

Correcting the description instead was the smaller change. The guard won because the claim is the one a caller acts on, and the codebase now has a stated rule for exactly this case.

## Verification

305 test files green, `pnpm smoke:e2e` ALL OK, typecheck and knip clean. No caller outside MCP — tidy has no HTTP route and `apps/web` does not call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB