### PR TITLE
fix(server-core): keep pre-kind markdown documents writable

### DIFF
--- a/packages/server-core/src/tools/document-set.test.ts
+++ b/packages/server-core/src/tools/document-set.test.ts
@@ -186,6 +186,36 @@ describe('wb_document_set tool', () => {
     expect(readDocumentKind(await loadDoc(store, CANVAS_ID))).toBe('markdown')
   })
 
+  test('a document predating kinds that holds only an OKF body is still healed', async () => {
+    // A markdown document's stored content is a valid spatial canvas: its
+    // body lives in one text node. So "holds nodes" alone would refuse the
+    // pre-kind markdown documents the OKF import path produced, and send
+    // them to wb_node_add, which would declare them spatial — the wrong
+    // kind, and the "no way back" the healing exists to prevent.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [
+          { id: 'okf-body', type: 'text', x: 0, y: 0, width: 600, height: 400, text: 'Old body.' },
+        ],
+        edges: [],
+      })
+    })
+    const tool = createDocumentSetTool(makeDeps(store))
+
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nNew body.',
+    })
+
+    const doc = await loadDoc(store, CANVAS_ID)
+    expect(readDocumentKind(doc)).toBe('markdown')
+    const node = readSpatialCanvas(doc).nodes[0]
+    expect(node?.type === 'text' ? node.text : undefined).toBe('New body.')
+  })
+
   test('a document predating kinds that holds nodes is refused, not flattened', async () => {
     // The healing above is safe because an empty document has nothing to
     // lose. A pre-kind document that holds a diagram does: this write

--- a/packages/server-core/src/tools/document-set.ts
+++ b/packages/server-core/src/tools/document-set.ts
@@ -80,9 +80,10 @@ export function createDocumentSetTool(deps: ServerDeps) {
       // document it is a destruction rather than an edit. A document with no
       // kind predates them: the write is the only thing that can give it one,
       // and refusing would leave it with no way back (ADR-0009 decision 4) —
-      // but only an empty document has nothing to lose by being declared
-      // markdown. One that already holds a canvas gets its way back from the
-      // spatial side, which declares a kind without discarding anything.
+      // but only a document already in markdown's own shape has nothing to
+      // lose by being declared markdown. One holding a canvas gets its way
+      // back from the spatial side, which declares a kind without discarding
+      // anything.
       const kind = readDocumentKind(doc)
       if (kind === undefined) {
         const existing = readSpatialCanvas(doc)

--- a/packages/server-core/src/tools/document-set.ts
+++ b/packages/server-core/src/tools/document-set.ts
@@ -16,6 +16,21 @@ import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 const TEXT_NODE_ID = 'okf-body'
 
+/**
+ * Whether a canvas is one this tool could itself have written, and so holds
+ * nothing a markdown write would destroy. A markdown document's stored
+ * content IS a valid spatial canvas — the body lives in one text node — so
+ * "has any node" cannot tell the two apart, and the documents that predate
+ * kinds include both shapes. Matching the exact shape written below keeps
+ * the pre-kind markdown ones editable without letting a diagram through.
+ */
+function isMarkdownShaped(canvas: { nodes: readonly { id: string }[]; edges: readonly unknown[] }) {
+  if (canvas.edges.length > 0) return false
+  return (
+    canvas.nodes.length === 0 || (canvas.nodes.length === 1 && canvas.nodes[0]?.id === TEXT_NODE_ID)
+  )
+}
+
 export const documentSetInputSchema = z
   .object({
     workspaceId: workspaceIdSchema,
@@ -71,7 +86,7 @@ export function createDocumentSetTool(deps: ServerDeps) {
       const kind = readDocumentKind(doc)
       if (kind === undefined) {
         const existing = readSpatialCanvas(doc)
-        if (existing.nodes.length > 0 || existing.edges.length > 0) {
+        if (!isMarkdownShaped(existing)) {
           throw new DocumentContentLossError(
             input.canvasId,
             `It holds ${existing.nodes.length} node(s) and ${existing.edges.length} edge(s), which this write would replace with a single text node. ` +


### PR DESCRIPTION
Follow-up to #746, fixing a regression it introduced.

#746 refused to declare an undeclared document `markdown` when it held **any** node, to stop a diagram being flattened. But — as #745 established for `wb_canvas_tidy` — **a markdown document's stored content IS a valid spatial canvas**: its body lives in one text node. So "holds a node" also caught the pre-kind *markdown* documents the old OKF import path produced, and pointed them at `wb_node_add`, which would declare them **spatial**. Wrong kind, and the same "no way back" the healing branch exists to prevent — just moved to the other kind of document.

Reproduced before fixing:

```
× a document predating kinds that holds only an OKF body is still healed
  DocumentContentLossError: … It holds 1 node(s) and 0 edge(s) …
```

## The fix

The guard now matches the exact shape **this tool itself writes**: no edges, and either no nodes or the single `okf-body` text node. A document in that shape holds nothing a markdown write would destroy, because a markdown write is what produced it. That is a structural signature, not the content-based format inference ADR-0009 rejects — it does not decide *what kind a document is*, only *whether this write would discard something*.

Both pre-kind shapes now have a non-destructive way back: a canvas via `wb_node_add` (spatial), a body via `wb_document_set` (markdown).

**Residual, deliberate**: a spatial document whose only node happens to be named `okf-body` is treated as markdown-shaped. The two kinds' content genuinely overlaps, and a one-node canvas is the smallest thing that could be lost.

## Why the gate missed it

Nothing covered re-writing a pre-kind markdown document — 241 tests passed over the regression. The new test is that coverage.

- `server-core-node`: 34 files / 243 tests pass. `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw