### PR TITLE
fix(mcp-server): stop getCanvasKind inventing a kind that then gets stored

### DIFF
--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -381,9 +381,14 @@ describe('getCanvasKind', () => {
     expect(await getCanvasKind('session1', 'note')).toBe('markdown')
   })
 
-  it('defaults to spatial when saveCanvas was called without a kind option', async () => {
+  it('reports an unrecorded kind as unknown rather than guessing spatial', async () => {
+    // Its only callers stamp the answer onto a restored canvas's row, so a
+    // guess here is not a display default — it is written down, and a
+    // markdown document that predates kinds becomes permanently spatial,
+    // opened by the wrong editor. Both callers already omit a null kind,
+    // which copies the source's real state, unknown included.
     await saveCanvas('session1', 'canvas-a', new LoroDoc())
-    expect(await getCanvasKind('session1', 'canvas-a')).toBe('spatial')
+    expect(await getCanvasKind('session1', 'canvas-a')).toBeNull()
   })
 })
 

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -296,9 +296,16 @@ export async function deleteCanvas(workspaceId: string, slug: string): Promise<b
   })
 }
 
-// Returns null when the canvas does not exist, so callers can distinguish
-// "no such canvas" from a stored-but-unset kind (which the null-column
-// back-compat default in listCanvases resolves to 'spatial').
+// Null for both "no such canvas" and "the canvas records no kind" — its
+// callers want the same thing from either, which is to stamp nothing.
+//
+// This deliberately does NOT resolve an unset kind to 'spatial' the way
+// listCanvases does. The difference is what the answer is used for: a list
+// renders a badge, while this feeds a WRITE onto a restored canvas's row.
+// A guess that gets stored outlives the guess — a markdown document that
+// predates kinds would become permanently spatial and open in the wrong
+// editor, which is the exact failure the callers' comments say they are
+// copying the source's kind to avoid.
 export async function getCanvasKind(workspaceId: string, slug: string): Promise<CanvasKind | null> {
   validateWorkspaceId(workspaceId)
   validateSlug(slug)
@@ -309,8 +316,7 @@ export async function getCanvasKind(workspaceId: string, slug: string): Promise<
     .where('workspaceId', '=', workspaceId)
     .where('slug', '=', slug)
     .executeTakeFirst()
-  if (!row) return null
-  return row.kind ?? 'spatial'
+  return row?.kind ?? null
 }
 
 export interface CompactResult {


### PR DESCRIPTION
`getCanvasKind`'s contract comment says callers can tell "no such canvas" from a stored-but-unset kind. They could not — the function resolved an unset kind to `'spatial'` before returning, so the distinction it promised never reached a caller:

```ts
// … so callers can distinguish "no such canvas" from a stored-but-unset kind
if (!row) return null
return row.kind ?? 'spatial'   // <- the distinction, collapsed
```

## Why the same default is right in one place and wrong here

`listCanvases` applies the identical `?? 'spatial'`, and there it is fine: a list renders a **badge**. Both of `getCanvasKind`'s callers (`routes/canvas/restore.ts`) stamp its answer onto a restored canvas's **row**. A guess that gets written down outlives the guess.

The consequence is precisely what those call sites say they exist to prevent:

> the target's stored kind must follow it or a kind-aware consumer (editor routing) opens the overwritten canvas with the wrong editor

Restore a pre-kind **markdown** document and the invented `'spatial'` is stamped onto the target permanently — the note now opens in the spatial editor. The invention defeats the code consuming it.

## The change

One line. Both callers already spread the kind conditionally (`sourceKind !== null ? { kind } : {}`), so returning the truth makes restore copy the source's real state — *unknown* included — and **no call site changes**.

Null now means both "no such canvas" and "records no kind", which is honest: the callers want the same thing from either, which is to stamp nothing.

## Notes for the reviewer

- The existing test pinned the old default (`defaults to spatial when saveCanvas was called without a kind option`), so it is **replaced, not deleted** — it asserted exactly the behaviour being removed. Red first: it failed `expected 'spatial' to be null` before the fix.
- `listCanvases`' own `?? 'spatial'` is deliberately left alone. Making the list honest changes its output shape and the UI badge — a separate slice.
- **Gap I am not closing here**: `restore.test.ts` has 3 tests and none touch `kind`, so the propagation behaviour those long source comments describe is unpinned at the route layer. The store is the nearest layer to this root cause; the route-level coverage is worth its own increment.

`mcp-node`: 268 files / 3320 tests pass. `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw