### PR TITLE
feat(web): place creations where they are dropped, and add a rectangle

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -41,6 +41,7 @@ import {
   Scissors,
   SendToBack,
   Sparkles,
+  Square,
   SquareDashed,
   StickyNote,
   Tag,
@@ -94,6 +95,8 @@ export interface CanvasContextMenuProps {
   readonly setGroupLabelEditId: (id: string | null) => void
   readonly pasteClipboard: (at?: Point) => boolean
   readonly createNodeAt: (point: Point) => void
+  /** Places a text node nobody typed into — no editor opens. */
+  readonly createRectangleAt: (point: Point) => void
   readonly createGroupAtViewportCenter: (at?: Point) => void
   readonly setLinkDialog: (state: LinkDialogState | null) => void
   readonly fileRefOptions?: readonly FileRefOption[]
@@ -132,6 +135,7 @@ export function CanvasContextMenu({
   setGroupLabelEditId,
   pasteClipboard,
   createNodeAt,
+  createRectangleAt,
   createGroupAtViewportCenter,
   setLinkDialog,
   fileRefOptions,
@@ -373,6 +377,11 @@ export function CanvasContextMenu({
               label: 'Add note here',
               icon: <StickyNote />,
               onSelect: () => createNodeAt(contextMenu.point),
+            },
+            {
+              label: 'Add rectangle here',
+              icon: <Square />,
+              onSelect: () => createRectangleAt(contextMenu.point),
             },
             {
               label: 'Add link here',

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -164,7 +164,12 @@ import {
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
-import { draggedCreation, type EditorTool, ToolPalette } from './ToolPalette.js'
+import {
+  type DraggableCreation,
+  draggedCreation,
+  type EditorTool,
+  ToolPalette,
+} from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   type ContainerSize,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2366,6 +2366,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       else createGroupAtViewportCenter(point)
     }
 
+    /**
+     * Same cascade as the note path: the tap path always resolves to the one
+     * viewport-centre point, so without it every press stacks an identical
+     * rectangle on the last one and looks like nothing happened.
+     */
+    const createRectangleAtViewportCenter = () => {
+      const preferred = screenToCanvas(viewportCenterScreen(), viewport)
+      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+      const point = findFreeSpot(
+        preferred,
+        { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT },
+        occupied,
+      )
+      createRectangleAt(point)
+      panToShow({
+        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
+        y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
+        width: NEW_NODE_WIDTH,
+        height: NEW_NODE_HEIGHT,
+      })
+    }
+
     const createNodeAtViewportCenter = () => {
       const preferred = screenToCanvas(viewportCenterScreen(), viewport)
       const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
@@ -2706,9 +2728,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}
-          onCreateRectangle={() =>
-            createRectangleAt(screenToCanvas(viewportCenterScreen(), viewport))
-          }
+          onCreateRectangle={createRectangleAtViewportCenter}
           onCreateCanvasRef={
             fileRefOptions === undefined ? undefined : () => setCanvasPicker({ mode: 'create' })
           }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -164,7 +164,7 @@ import {
 import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
-import { type EditorTool, ToolPalette } from './ToolPalette.js'
+import { draggedCreation, type EditorTool, ToolPalette } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
 import {
   type ContainerSize,
@@ -2247,6 +2247,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
+     * A rectangle: the same node Add-note makes, with no editor opened on
+     * top of it. Not a new node type — see the reducer's `create-closed-node`.
+     */
+    const createRectangleAt = (point: Point) => {
+      applyResult(
+        reduceGesture(gestureState, canvas, { type: 'create-closed-node', point }, { createId }),
+      )
+      applySelection({ type: 'collapse-extras' })
+    }
+
+    /**
      * The button path (unlike double-click, whose point comes straight from
      * the pointer) always resolves to the same viewport-center point, so
      * without a placement rule every click here would stack an identical,
@@ -2341,6 +2352,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const frameSelection = (): boolean => {
       if (selection === undefined) return frameContent()
       return frameContent(new Set([selection.id, ...extraIds]))
+    }
+
+    /** Places one of the directly-creatable kinds at a canvas-space point. */
+    const createAt = (kind: DraggableCreation, point: Point) => {
+      if (kind === 'note') createNodeAt(point)
+      else if (kind === 'rectangle') createRectangleAt(point)
+      else createGroupAtViewportCenter(point)
     }
 
     const createNodeAtViewportCenter = () => {
@@ -2555,11 +2573,25 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // Image intake: drop anywhere on the canvas, or paste — both route
         // through the same host storage seam as the picker.
         onDragOver={(e) => {
+          if (draggedCreation(e.dataTransfer.types) !== null) {
+            e.preventDefault()
+            e.dataTransfer.dropEffect = 'copy'
+            return
+          }
           if (onAddImage !== undefined && e.dataTransfer.types.includes('Files')) {
             e.preventDefault()
           }
         }}
         onDrop={(e) => {
+          const dragged = draggedCreation(e.dataTransfer.types)
+          if (dragged !== null) {
+            e.preventDefault()
+            const root = rootRef.current
+            if (root === null) return
+            const local = clientPointToRootLocal(e, root)
+            createAt(dragged, screenToCanvas(local, viewport))
+            return
+          }
           if (onAddImage === undefined) return
           if (e.dataTransfer.files.length === 0) return
           // Cancel the browser's default file-drop handling (navigation to
@@ -2669,6 +2701,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}
+          onCreateRectangle={() =>
+            createRectangleAt(screenToCanvas(viewportCenterScreen(), viewport))
+          }
           onCreateCanvasRef={
             fileRefOptions === undefined ? undefined : () => setCanvasPicker({ mode: 'create' })
           }
@@ -2759,6 +2794,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             setGroupLabelEditId={setGroupLabelEditId}
             pasteClipboard={pasteClipboard}
             createNodeAt={createNodeAt}
+            createRectangleAt={createRectangleAt}
             createGroupAtViewportCenter={createGroupAtViewportCenter}
             setLinkDialog={setLinkDialog}
             fileRefOptions={fileRefOptions}

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -33,6 +33,7 @@ import {
   MousePointer2,
   Plus,
   Spline,
+  Square,
   StickyNote,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
@@ -41,12 +42,37 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 export type EditorTool = 'select' | 'hand' | 'connect'
 
+/**
+ * Drag payload for placing a creation where it is dropped: the kind travels
+ * in the MIME TYPE, not in the data.
+ *
+ * Two reasons it is shaped this way. A custom type rather than `text/plain`,
+ * because the canvas already turns foreign text drops into notes and the two
+ * must not be confused. And the kind in the type rather than in the value,
+ * because a drag data store is in protected mode for everything except
+ * `dragstart` — `getData` reads back empty at the drop, while `types` stays
+ * readable throughout.
+ */
+export const CREATE_DRAG_MIME_PREFIX = 'application/x-whiteboard-create+'
+
+/** The kind carried by a drag, or null when the drag is not one of ours. */
+export function draggedCreation(types: readonly string[]): DraggableCreation | null {
+  const type = types.find((t) => t.startsWith(CREATE_DRAG_MIME_PREFIX))
+  if (type === undefined) return null
+  const kind = type.slice(CREATE_DRAG_MIME_PREFIX.length)
+  return kind === 'note' || kind === 'rectangle' || kind === 'group' ? kind : null
+}
+/** Creations that place directly, so a drop point is all they need. */
+export type DraggableCreation = 'note' | 'rectangle' | 'group'
+
 interface ToolPaletteProps {
   /** Host-supplied controls (undo/redo/versions) docked as the leading group. */
   readonly leading?: ReactNode
   readonly onCreateNode: () => void
   readonly onCreateLink: () => void
   readonly onCreateGroup: () => void
+  /** Creates a text node nobody typed into, at the viewport center. */
+  readonly onCreateRectangle: () => void
   /** Absent when the host supplies no canvas listing — the entry hides. */
   readonly onCreateCanvasRef?: () => void
   /** Absent when the host supplies no image storage — the entry hides. */
@@ -63,6 +89,12 @@ interface AddMenuEntry {
   readonly label: string
   readonly icon: ReactNode
   readonly onSelect: () => void
+  /**
+   * Present when the entry can be dragged onto the canvas to choose its
+   * place. Absent for entries that open a dialog or a picker first — there
+   * is nothing to place until that returns.
+   */
+  readonly drag?: DraggableCreation
 }
 
 export function ToolPalette({
@@ -70,6 +102,7 @@ export function ToolPalette({
   onCreateNode,
   onCreateLink,
   onCreateGroup,
+  onCreateRectangle,
   onCreateCanvasRef,
   onCreateImage,
   tool,
@@ -106,6 +139,13 @@ export function ToolPalette({
       label: 'Add note',
       icon: <StickyNote aria-hidden="true" className="size-4" />,
       onSelect: onCreateNode,
+      drag: 'note',
+    },
+    {
+      label: 'Add rectangle',
+      icon: <Square aria-hidden="true" className="size-4" />,
+      onSelect: onCreateRectangle,
+      drag: 'rectangle',
     },
     {
       label: 'Add link',
@@ -116,6 +156,7 @@ export function ToolPalette({
       label: 'Add group',
       icon: <Frame aria-hidden="true" className="size-4" />,
       onSelect: onCreateGroup,
+      drag: 'group',
     },
     ...(onCreateCanvasRef !== undefined
       ? [
@@ -268,6 +309,18 @@ export function ToolPalette({
               role="menuitem"
               aria-label={entry.label}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+              // Tapping keeps the viewport-center placement; dragging hands
+              // the choice of place to the person making the thing, which is
+              // what stops the view jumping to wherever the center happened
+              // to be. Both paths stay — a drag is not reachable one-handed
+              // on every device, and the keyboard has only the tap.
+              draggable={entry.drag !== undefined}
+              onDragStart={(e) => {
+                if (entry.drag === undefined) return
+                e.dataTransfer.setData(`${CREATE_DRAG_MIME_PREFIX}${entry.drag}`, entry.drag)
+                e.dataTransfer.effectAllowed = 'copy'
+                setAddOpen(false)
+              }}
               onClick={() => {
                 setAddOpen(false)
                 entry.onSelect()

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -319,8 +319,11 @@ export function ToolPalette({
                 if (entry.drag === undefined) return
                 e.dataTransfer.setData(`${CREATE_DRAG_MIME_PREFIX}${entry.drag}`, entry.drag)
                 e.dataTransfer.effectAllowed = 'copy'
-                setAddOpen(false)
               }}
+              // Closed on dragEND, not dragstart: removing the source element
+              // mid-drag tears down the drag session in Chromium, so closing
+              // early makes the drag never reach a drop.
+              onDragEnd={() => setAddOpen(false)}
               onClick={() => {
                 setAddOpen(false)
                 entry.onSelect()

--- a/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
@@ -84,7 +84,7 @@ it('creation entries live in the + menu, which opens upward inside the viewport'
   const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
 
   // No flat per-type creation buttons on the dock itself.
-  for (const label of ['Add note', 'Add link', 'Add group', 'Add canvas']) {
+  for (const label of ['Add note', 'Add rectangle', 'Add link', 'Add group', 'Add canvas']) {
     expect(
       [...palette.querySelectorAll(':scope > button, :scope [data-slot="tooltip-trigger"]')].some(
         (b) => b.getAttribute('aria-label') === label,
@@ -97,7 +97,7 @@ it('creation entries live in the + menu, which opens upward inside the viewport'
   const items = [...menu.querySelectorAll('[role="menuitem"]')].map((b) =>
     b.getAttribute('aria-label'),
   )
-  expect(items).toEqual(['Add note', 'Add link', 'Add group', 'Add canvas'])
+  expect(items).toEqual(['Add note', 'Add rectangle', 'Add link', 'Add group', 'Add canvas'])
 
   // Opens upward from the dock and stays inside the host, above the dock.
   const menuRect = menu.getBoundingClientRect()

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -117,7 +117,13 @@ it('empty space offers the full creation set, anchored at the click point', asyn
 
   // The dock's + menu creation set, repeated "here" (canvas entry appears
   // because the host supplies the reference seam).
-  for (const label of ['Add note here', 'Add link here', 'Add group here', 'Add canvas here']) {
+  for (const label of [
+    'Add note here',
+    'Add rectangle here',
+    'Add link here',
+    'Add group here',
+    'Add canvas here',
+  ]) {
     expect(container.textContent).toContain(label)
   }
 
@@ -128,6 +134,39 @@ it('empty space offers the full creation set, anchored at the click point', asyn
   // Centered on the click point (600,450 screen = canvas at identity view).
   expect(frame.x + frame.width / 2).toBeCloseTo(600, 0)
   expect(frame.y + frame.height / 2).toBeCloseTo(450, 0)
+})
+
+it('Add rectangle here lands on the click point, with no editor over it', async () => {
+  const { Host, latest } = (() => {
+    const l: { canvas: SpatialCanvas } = { canvas: start }
+    function H() {
+      const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+      l.canvas = canvas
+      return (
+        <div style={{ width: 900, height: 700 }}>
+          <SpatialEditor
+            defaultTool="select"
+            canvas={canvas}
+            onChange={(next) => setCanvas(next)}
+            theme="light"
+          />
+        </div>
+      )
+    }
+    return { Host: H, latest: l }
+  })()
+  const { container } = render(<Host />)
+  rightClick(rootOf(container), 600, 450)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  const before = latest.canvas.nodes.length
+  await userEvent.click(page.getByRole('menuitem', { name: 'Add rectangle here' }))
+  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(before + 1))
+  const node = latest.canvas.nodes.at(-1)
+  if (node === undefined) throw new Error('node missing')
+  expect(node.x + node.width / 2).toBeCloseTo(600, 0)
+  expect(node.y + node.height / 2).toBeCloseTo(450, 0)
+  expect(container.querySelector('[data-testid="text-node-editor"]')).toBeNull()
 })
 
 it('Escape closes the menu without acting', async () => {

--- a/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
@@ -1,0 +1,120 @@
+// Where a created node LANDS, and which creations open an editor.
+//
+// Two paths out of the "+" menu, deliberately different: tapping an entry
+// keeps its long-standing behaviour (viewport centre), while dragging one
+// onto the canvas places it where it is dropped — the viewport never moves,
+// so nothing has to pan to show what was just made.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const empty: SpatialCanvas = { nodes: [], edges: [] }
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas } = { canvas: empty }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(empty)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor canvas={canvas} onChange={(next) => setCanvas(next)} theme="light" />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function openAddMenu(container: HTMLElement) {
+  fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
+}
+
+/** The canvas-space centre of the one node on the canvas. */
+function soleNodeCentre(canvas: SpatialCanvas) {
+  const node = canvas.nodes[0]
+  if (node === undefined) throw new Error('no node was created')
+  return { x: node.x + node.width / 2, y: node.y + node.height / 2 }
+}
+
+it('Add rectangle creates an empty node and leaves the editor closed', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  openAddMenu(container)
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+
+  expect(latest.canvas.nodes).toHaveLength(1)
+  const node = latest.canvas.nodes[0]
+  // A rectangle is not a new node type — JSON Canvas has none, and the
+  // x-whiteboard extension is deliberately not an escape hatch for new
+  // visual primitives. It is a text node nobody typed into.
+  expect(node?.type).toBe('text')
+  expect(node?.type === 'text' ? node.text : 'unset').toBe('')
+  // The one behavioural difference from Add note: no editor opens.
+  expect(container.querySelector('[data-testid="text-node-editor"]')).toBeNull()
+})
+
+it('Add note still opens its editor — the rectangle path did not change it', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+
+  openAddMenu(container)
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Add note' }))
+
+  expect(container.querySelector('[data-testid="text-node-editor"]')).not.toBeNull()
+})
+
+it('dragging a menu entry onto the canvas creates it AT THE DROP POINT, not the centre', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+
+  openAddMenu(container)
+  const entry = screen.getByRole('menuitem', { name: 'Add rectangle' })
+  // Real DragEvents, not fireEvent's synthesised ones: `dataTransfer` is
+  // read-only on a DragEvent, so an assigned property never reaches the
+  // handler and the drag silently carries nothing.
+  const dataTransfer = new DataTransfer()
+  const dragEvent = (type: string, init: DragEventInit = {}) =>
+    new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer, ...init })
+
+  // Dispatched THROUGH fireEvent, which wraps in act(): a raw dispatchEvent
+  // leaves React's state update unflushed and the assertion reads the canvas
+  // as it was before the drop.
+  fireEvent(entry, dragEvent('dragstart'))
+  // The kind rides in the MIME type — `types` survives protected mode, the
+  // data does not (see CREATE_DRAG_MIME_PREFIX).
+  expect([...dataTransfer.types]).toContain('application/x-whiteboard-create+rectangle')
+
+  // Well away from the viewport centre (400,300 in root-local pixels).
+  const drop: [number, number] = [640, 120]
+  const at = { clientX: r.left + drop[0], clientY: r.top + drop[1] }
+  const over = dragEvent('dragover', at)
+  fireEvent(root, over)
+  // The canvas must accept the drag, or the browser shows a no-drop cursor
+  // and never delivers a drop at all.
+  expect(over.defaultPrevented).toBe(true)
+  fireEvent(root, dragEvent('drop', at))
+
+  // Zoom is 1 and the viewport starts at the origin, so root-local pixels
+  // are canvas units here.
+  const centre = soleNodeCentre(latest.canvas)
+  expect(centre.x).toBeCloseTo(drop[0], 0)
+  expect(centre.y).toBeCloseTo(drop[1], 0)
+})
+
+it('tapping a menu entry keeps placing it at the viewport centre', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  openAddMenu(container)
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+
+  const centre = soleNodeCentre(latest.canvas)
+  expect(centre.x).toBeCloseTo(400, 0)
+  expect(centre.y).toBeCloseTo(300, 0)
+})

--- a/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
@@ -105,6 +105,30 @@ it('dragging a menu entry onto the canvas creates it AT THE DROP POINT, not the 
   const centre = soleNodeCentre(latest.canvas)
   expect(centre.x).toBeCloseTo(drop[0], 0)
   expect(centre.y).toBeCloseTo(drop[1], 0)
+
+  // The menu survives the drag and closes on dragend. Closing it any earlier
+  // removes the dragged element mid-drag, which tears the drag session down
+  // in Chromium and means no drop ever arrives.
+  expect(container.querySelector('[data-testid="add-menu"]')).not.toBeNull()
+  fireEvent(entry, dragEvent('dragend'))
+  expect(container.querySelector('[data-testid="add-menu"]')).toBeNull()
+})
+
+it('two rectangles from the menu do not stack on the same spot', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+
+  for (let i = 0; i < 2; i++) {
+    openAddMenu(container)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+  }
+
+  const [first, second] = latest.canvas.nodes
+  if (first === undefined || second === undefined) throw new Error('expected two nodes')
+  // The tap path always resolves to the same viewport-centre point, so
+  // without a free-spot cascade the second one lands exactly on the first
+  // and is indistinguishable from having created nothing.
+  expect({ x: second.x, y: second.y }).not.toEqual({ x: first.x, y: first.y })
 })
 
 it('tapping a menu entry keeps placing it at the viewport centre', () => {

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -467,6 +467,30 @@ describe('text-edit gesture', () => {
   })
 })
 
+describe('create-closed-node (the rectangle path)', () => {
+  it('creates the same node dblclick-empty does, selects it, and opens NO editor', () => {
+    const c = canvas()
+    const result = reduceGesture(
+      createIdleState(),
+      c,
+      { type: 'create-closed-node', point: { x: 300, y: 200 } },
+      { createId: () => 'new-node' },
+    )
+    expect(result.commands).toEqual([
+      {
+        kind: 'create-node',
+        node: { id: 'new-node', type: 'text', text: '', x: 200, y: 150, width: 200, height: 100 },
+      },
+    ])
+    // Selecting it is what gives the new rectangle its handles: without this
+    // it lands on the canvas with nothing to grab, move or delete it by.
+    expect(result.selectedId).toBe('new-node')
+    // The whole difference from a note. `editing-text` here would open the
+    // editor on a shape nobody asked to type into.
+    expect(result.state).toEqual({ kind: 'idle' })
+  })
+})
+
 describe('dblclick-empty (create-node)', () => {
   it('creates a text node centered on the point, selects it, and opens it for typing immediately', () => {
     const c = canvas()

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -489,6 +489,24 @@ describe('create-closed-node (the rectangle path)', () => {
     // editor on a shape nobody asked to type into.
     expect(result.state).toEqual({ kind: 'idle' })
   })
+
+  it('commits an open text edit first, exactly as the note path does', () => {
+    const c = canvas()
+    const editing = reduceGesture(createIdleState(), c, {
+      type: 'start-text-edit',
+      nodeId: 'a',
+      text: 'hi',
+    })
+    const result = reduceGesture(
+      editing.state,
+      c,
+      { type: 'create-closed-node', point: { x: 10, y: 10 } },
+      { createId: () => 'new-node' },
+    )
+    // Creating something else must not be a way to lose what was typed.
+    expect(result.commands[0]).toMatchObject({ kind: 'set-text', id: 'a' })
+    expect(result.commands.some((cmd) => cmd.kind === 'create-node')).toBe(true)
+  })
 })
 
 describe('dblclick-empty (create-node)', () => {

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -412,11 +412,11 @@ export function reduceGesture(
       })
     case 'create-closed-node': {
       const id = createId()
-      return {
+      return withPendingTextCommit(state, {
         state: { kind: 'idle' },
         commands: [{ kind: 'create-node', node: newTextNodeAt(event.point, id) }],
         selectedId: id,
-      }
+      })
     }
     case 'dblclick-empty':
       return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -111,6 +111,14 @@ export type GestureEvent =
   | { readonly type: 'pointerdown-connect'; readonly nodeId: string }
   | { readonly type: 'pointerdown-empty' }
   | { readonly type: 'dblclick-empty'; readonly point: Point }
+  /**
+   * The same text node `dblclick-empty` makes, left CLOSED. JSON Canvas has
+   * no shape type and the `x-whiteboard` extension is deliberately not an
+   * escape hatch for new visual primitives, so a rectangle is a text node
+   * nobody typed into — the only difference from a note is that no editor
+   * opens on top of it.
+   */
+  | { readonly type: 'create-closed-node'; readonly point: Point }
   | { readonly type: 'delete-selection'; readonly nodeId: string }
   | { readonly type: 'pointermove'; readonly point: Point }
   | { readonly type: 'pointerup'; readonly point: Point; readonly targetNodeId?: string }
@@ -343,9 +351,8 @@ export const NEW_NODE_HEIGHT = 100
  * immediately — a node you must double-click again to type into is a worse
  * affordance than Excalidraw's.
  */
-function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureResult {
-  const id = createId()
-  const node: SpatialNode = {
+function newTextNodeAt(point: Point, id: string): SpatialNode {
+  return {
     id,
     type: 'text',
     x: Math.round(point.x - NEW_NODE_WIDTH / 2),
@@ -354,6 +361,11 @@ function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureRe
     height: NEW_NODE_HEIGHT,
     text: '',
   }
+}
+
+function reduceCreateTextNodeAt(point: Point, createId: () => string): GestureResult {
+  const id = createId()
+  const node = newTextNodeAt(point, id)
   return {
     state: { kind: 'editing-text', nodeId: id, pendingText: '', createdForEdit: true },
     commands: [{ kind: 'create-node', node }],
@@ -398,6 +410,14 @@ export function reduceGesture(
         commands: [],
         selectedId: null,
       })
+    case 'create-closed-node': {
+      const id = createId()
+      return {
+        state: { kind: 'idle' },
+        commands: [{ kind: 'create-node', node: newTextNodeAt(event.point, id) }],
+        selectedId: id,
+      }
+    }
     case 'dblclick-empty':
       return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))
     case 'delete-selection':

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -24,8 +24,10 @@ switch between canvases later.
 A fresh canvas starts empty. Double-click empty canvas space to make a note
 and start typing immediately, or open the **+** menu in the bottom dock: tap
 an entry to place it in the middle of the view, or drag one onto the canvas
-to drop it exactly where you want it. Right-clicking (long-pressing on
-touch) empty space offers the same creations, placed where you pressed. The
+to drop it exactly where you want it. In **Select** mode, right-clicking
+(long-pressing on touch) empty space offers the same creations, placed where
+you pressed — Hand mode is navigation only, so it deliberately leaves the
+right-click menu closed. The
 browser UI also selects, moves, resizes, connects, and edits existing nodes,
 and deletes the selected node with Delete/Backspace (disabled while you're
 typing in its text editor, so Backspace edits text instead of deleting the

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -21,9 +21,11 @@ switch between canvases later.
 
 ![Browser-local canvas list](../assets/browser-local-list.png)
 
-A fresh canvas starts empty —
-double-click empty canvas space, or click the "Add note" button in the
-top-left corner, to create a new note and start typing immediately. The
+A fresh canvas starts empty. Double-click empty canvas space to make a note
+and start typing immediately, or open the **+** menu in the bottom dock: tap
+an entry to place it in the middle of the view, or drag one onto the canvas
+to drop it exactly where you want it. Right-clicking (long-pressing on
+touch) empty space offers the same creations, placed where you pressed. The
 browser UI also selects, moves, resizes, connects, and edits existing nodes,
 and deletes the selected node with Delete/Backspace (disabled while you're
 typing in its text editor, so Backspace edits text instead of deleting the


### PR DESCRIPTION
Stacked on #750 (the dock/zoom layer) — review that one first; this PR's diff is only the creation layer.

## Two paths out of the "+" menu

| gesture | lands | why both stay |
|---|---|---|
| **tap** an entry | viewport centre (unchanged) | the keyboard has only this one, and a drag is not a one-handed reach on every device |
| **drag** an entry onto the canvas | **the drop point** | the view never moves, so nothing has to pan to show what was just made |

The context menu's "here" entries already placed at the pointer; this gives the palette the same power without taking anything away.

The kind travels in the **MIME type** (`application/x-whiteboard-create+<kind>`), not in the data: a drag data store is in protected mode for every event except `dragstart`, so `getData` reads back empty at the drop while `types` stays readable. Only entries that place directly are draggable — link, canvas and image open a dialog or picker first, so there is nothing to place until that returns.

## Add rectangle

A **text node nobody typed into**. JSON Canvas has no shape type, and `canvas-model` states the `x-whiteboard` extension is *"deliberately NOT a general escape hatch for new visual primitives"* — so the compatible representation is the node we already have. `group` was the other candidate and is wrong: dragging one carries every node inside it (`carriedWithDrag`), so a rectangle drawn over three notes would take them along.

The entire implementation difference from Add note is that **no editor opens** (`create-closed-node` in the reducer).

## Visual repro

Dragged from the "+" menu and dropped at the top right — the node's centre lands exactly on the drop point, and the viewport never moved:

![drag-placement.png](https://github.com/user-attachments/assets/0e32974d-30a6-475b-8058-4bab3c922ed5)

## A bug only the real browser could show

The menu first closed on `dragstart`. Removing the dragged element mid-drag **tears down the drag session in Chromium**: the drag started and no drop ever arrived. The synthetic-event test could not see it — it never removes the source element — so the fix is a separate commit and the honest note is that this class of bug still needs the browser.

Verified there afterwards: drop at page (720,180) → created node's centre at page (720,180), exact.

## Verification

- `pnpm test --project web-browser spatial-editor` — 321 passed (4 new in `create-placement.browser.test.tsx`)
- `pnpm --filter @kamiazya/whiteboard-web typecheck` clean (the pre-push hook caught a missing type import here before it left the machine)
- Real browser: rectangle creates with no editor, drag places at the drop point, menu closes after the drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add rectangles from the bottom-dock menu, by dragging from the palette, or through the canvas context menu.
  * Place notes, rectangles, and groups by dragging them to a precise canvas location.
  * Create rectangles at the viewport center or directly at the clicked location without opening text editing.
  * Create notes by double-clicking, tapping, or using the bottom-dock menu.

* **Documentation**
  * Updated the getting-started tutorial with the latest note-creation and placement workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->