### PR TITLE
feat(render): optimize edge sides by region past the edge gate

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -375,6 +375,35 @@ paths:
       then the same loop reusing unchanged paths (4.5x). What made it
       affordable was reusing the search's OWN incremental trial machinery
       instead of writing a second scorer beside it.
+    - **Past the optimizer's edge gate the search runs over spatial REGIONS,
+      not over nothing.** `CROSSING_OPT_MAX_EDGES` (200) used to skip
+      side-choice optimization wholesale, which is not a small loss: measured
+      on a 345-edge clustered canvas, 331 avoidable-ink violations — one per
+      edge — against 29 across the ~4400 edges of the entire small corpus.
+      That is the size an AI-authored document reaches, so the size where
+      optimization stops being affordable is not the size where quality stops
+      mattering. `optimizeAcrossRegions` groups edges along a Morton curve
+      through their midpoints, chunks them into even regions of at most the
+      gate, and runs the ordinary two-run search per region. It works because
+      interaction is LOCAL: 4-5% of edge pairs survive a bounding-box test on
+      the clustered bench cases (55% on the deliberately pathological stride
+      canvas). What it gives up, stated plainly: a crossing between edges in
+      two different regions is never priced. Result on that canvas —
+      violations 331 -> 183, interior ink 42623 -> 21001, border ink
+      889 -> 554, at 12ms -> 622ms. Nothing at or under the gate changes, by
+      construction (one region, same two runs, same seed).
+      Region size is `CROSSING_OPT_MAX_EDGES` itself rather than a second
+      knob, deliberately. The measured curve on that canvas is 200 -> 183
+      violations, 120 -> 158, 80 -> 122, with time rising 1023 -> 1184 ->
+      1481ms: SMALLER regions buy quality, because `TRIAL_BUDGET_EDGES`
+      applies per region, so the real knob is total trial budget and the
+      region size is only how it is spent. Tuning it against one synthetic
+      canvas would make that canvas the convention by accident; the curve is
+      recorded here so the next person can move it on evidence.
+      **The live-drag path keeps the hard gate.** Several hundred ms is worth
+      paying once on a committed change and never on a frame someone is
+      dragging through, so a canvas past the gate drags exactly as fast as
+      before and picks up its regional repair on drop.
     - **Facet-driven rendering rides the injected-resolver pattern.**
       Shipped: `SpatialLayoutOptions.resolveFileFacets?: (file: string) =>
       FacetCardData | undefined` (`layout/spatial-canvas.ts`), same seam

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -14,7 +14,7 @@
 // it, and only the side-choice penalties upstream ever priced it.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
-import { ROUTING_CORPUS, syntheticLayouts } from '../test-utils/routing-corpus.js'
+import { clusteredLayout, ROUTING_CORPUS, syntheticLayouts } from '../test-utils/routing-corpus.js'
 import {
   bends,
   borderInk,
@@ -185,4 +185,50 @@ describe('routing quality across the synthetic corpus', () => {
       shortArrowRunway: 235,
     })
   })
+})
+
+// The corpus above is 2000 SMALL layouts, every one of them under the
+// side-choice optimizer's edge gate. Nothing in this file has ever asked
+// what a canvas past that gate looks like — and past it the optimizer is
+// skipped wholesale, so the answer is "whatever the initial ranking
+// happened to pick". An AI-authored document reaches this size easily, and
+// the debt below is what it is served today.
+//
+// Pinned exactly, like the aggregate above, and for the same reason: this
+// is a debt figure whose target is lower, and an improvement has to be as
+// loud as a regression.
+describe('routing quality past the side-choice optimizer gate', () => {
+  it('reports the drawing cost of a large clustered canvas', () => {
+    const layout = clusteredLayout({ clusters: 24, nodesPerCluster: 12, edgesPerCluster: 16 })
+    const violations = avoidableInk(layout.nodes, layout.edges)
+    const anchors = assignEdgeAnchors(layout.nodes, layout.edges, 'orthogonal')
+    const paths = layout.edges.map(
+      (edge) => routeEdge(layout.nodes, edge, 'orthogonal', anchors.get(edge.id)).path,
+    )
+    let bendCount = 0
+    let length = 0
+    let border = 0
+    for (const path of paths) {
+      bendCount += bends(path)
+      length += drawnLength(path)
+      for (const n of layout.nodes) border += borderInk(path, rectOf(n))
+    }
+    expect({
+      edges: layout.edges.length,
+      violations: violations.length,
+      interiorInk: Math.round(violations.reduce((sum, v) => sum + v.ink, 0)),
+      borderInk: Math.round(border),
+      bends: bendCount,
+      crossings: crossings(paths),
+      length: Math.round(length),
+    }).toEqual({
+      edges: 345,
+      violations: 331,
+      interiorInk: 42623,
+      borderInk: 889,
+      bends: 633,
+      crossings: 782,
+      length: 274487,
+    })
+  }, 120_000)
 })

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -223,12 +223,12 @@ describe('routing quality past the side-choice optimizer gate', () => {
       length: Math.round(length),
     }).toEqual({
       edges: 345,
-      violations: 331,
-      interiorInk: 42623,
-      borderInk: 889,
-      bends: 633,
-      crossings: 782,
-      length: 274487,
+      violations: 183,
+      interiorInk: 21001,
+      borderInk: 554,
+      bends: 658,
+      crossings: 752,
+      length: 274428,
     })
   }, 120_000)
 })

--- a/packages/canvas-render/src/layout/spatial-edges.bench.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.bench.ts
@@ -11,6 +11,7 @@
 // in one sitting, never a committed figure against a fresh run.
 import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
 import { bench, describe } from 'vitest'
+import { clusteredLayout } from '../test-utils/routing-corpus.js'
 import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
 
 /**
@@ -39,6 +40,18 @@ function gridCanvas(nodeCount: number, edgeCount: number) {
 const sparse = gridCanvas(40, 40)
 const dense = gridCanvas(60, 200)
 
+// The stride canvas above is the WORST case for spatial pruning: every edge
+// spans the whole layout, so 55% of edge pairs survive a bounding-box test.
+// A real document clusters, and so do its edges — measured on these two, 5%
+// and 4%. Both shapes belong here: the stride canvas bounds the damage when
+// pruning cannot help, and these bound the common case, where nearly all of
+// the pair loop's work is rejecting edges that could never have interacted.
+const clustered = clusteredLayout({ clusters: 12, nodesPerCluster: 12, edgesPerCluster: 16 })
+// Deliberately past CROSSING_OPT_MAX_EDGES, where side-choice optimization
+// is skipped entirely today: this is the size an AI-authored canvas reaches,
+// and the number to watch when raising that gate.
+const clusteredLarge = clusteredLayout({ clusters: 24, nodesPerCluster: 12, edgesPerCluster: 16 })
+
 describe('side-choice search', () => {
   bench('assignEdgeAnchors 40 nodes / 40 edges', () => {
     assignEdgeAnchors(sparse.nodes, sparse.edges, 'orthogonal')
@@ -46,6 +59,14 @@ describe('side-choice search', () => {
 
   bench('assignEdgeAnchors 60 nodes / 200 edges', () => {
     assignEdgeAnchors(dense.nodes, dense.edges, 'orthogonal')
+  })
+
+  bench('assignEdgeAnchors clustered 144 nodes / 165 edges', () => {
+    assignEdgeAnchors(clustered.nodes, clustered.edges, 'orthogonal')
+  })
+
+  bench('assignEdgeAnchors clustered 288 nodes / 345 edges (over the opt gate)', () => {
+    assignEdgeAnchors(clusteredLarge.nodes, clusteredLarge.edges, 'orthogonal')
   })
 })
 

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1015,6 +1015,117 @@ function anchorsWithoutCoincidentEnds(
   return computeAnchorsFor(nodes, edges, repaired, align, pins)
 }
 
+/**
+ * Side choices for a canvas of ANY size: `optimizeSideChoices` directly when
+ * the edge set fits its gate, otherwise the same search run over spatial
+ * REGIONS of the canvas.
+ *
+ * Past `CROSSING_OPT_MAX_EDGES` the search used to be skipped wholesale, and
+ * "skipped" is not a small loss — measured on a 345-edge clustered canvas, one
+ * avoidable-ink violation per edge, against 29 across the entire small corpus.
+ * A canvas that big is exactly what an AI-authored document grows into, so the
+ * size where quality stops mattering is not the size where it stops being
+ * affordable.
+ *
+ * Regions work because interaction is local: on a canvas with any locality at
+ * all, 4-5% of edge pairs survive a bounding-box test (55% on the deliberately
+ * pathological stride canvas the bench also carries). Two edges in
+ * well-separated regions were never going to be scored against each other
+ * anyway, so optimizing region by region gives up little and costs
+ * `regions * cost(regionSize)` instead of `cost(E)` — linear in the canvas
+ * rather than super-linear.
+ *
+ * What it gives up, stated plainly: a crossing between edges assigned to two
+ * different regions is never priced. Edges are grouped along a Morton curve
+ * through their midpoints, so neighbours in space are neighbours in the
+ * ordering and a split falls between clusters far more often than through one,
+ * but nothing guarantees that.
+ */
+function optimizeAcrossRegions(
+  nodes: readonly SpatialNode[],
+  edges: readonly CanvasEdge[],
+  style: EdgeRoutingStyle,
+  initial: ReadonlyMap<string, SidePair>,
+  locked?: ReadonlySet<string>,
+  pins?: ReadonlyMap<string, EdgeAnchorOverride>,
+): ReadonlyMap<string, SidePair> {
+  const bothRuns = (
+    regionEdges: readonly CanvasEdge[],
+    seed: ReadonlyMap<string, SidePair>,
+  ): ReadonlyMap<string, SidePair> => {
+    const unaligned = optimizeSideChoices(nodes, regionEdges, style, seed, locked)
+    return optimizeSideChoices(nodes, regionEdges, style, unaligned, locked, true, pins)
+  }
+
+  if (edges.length <= CROSSING_OPT_MAX_EDGES) return bothRuns(edges, initial)
+
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const midpoints = edges.map((edge) => {
+    const from = byId.get(edge.fromNode)
+    const to = byId.get(edge.toNode)
+    if (from === undefined || to === undefined) return { x: 0, y: 0 }
+    const a = centerOf(rectOf(from))
+    const b = centerOf(rectOf(to))
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+  })
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const m of midpoints) {
+    if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) continue
+    minX = Math.min(minX, m.x)
+    minY = Math.min(minY, m.y)
+    maxX = Math.max(maxX, m.x)
+    maxY = Math.max(maxY, m.y)
+  }
+  // A degenerate extent (every midpoint on one point, or none finite) leaves
+  // every key 0; the sort then falls back to document order, which is still
+  // a total, deterministic grouping.
+  const spanX = Number.isFinite(minX) ? Math.max(maxX - minX, 1) : 1
+  const spanY = Number.isFinite(minY) ? Math.max(maxY - minY, 1) : 1
+  const originX = Number.isFinite(minX) ? minX : 0
+  const originY = Number.isFinite(minY) ? minY : 0
+  const GRID = 1024
+  const interleave = (v: number) => {
+    // Spread 10 bits so x and y can be woven into one 20-bit key.
+    let x = v & 0x3ff
+    x = (x | (x << 16)) & 0x030000ff
+    x = (x | (x << 8)) & 0x0300f00f
+    x = (x | (x << 4)) & 0x030c30c3
+    x = (x | (x << 2)) & 0x09249249
+    return x
+  }
+  const mortonOf = (m: Point) => {
+    if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) return 0
+    const gx = Math.min(GRID - 1, Math.max(0, Math.floor(((m.x - originX) / spanX) * (GRID - 1))))
+    const gy = Math.min(GRID - 1, Math.max(0, Math.floor(((m.y - originY) / spanY) * (GRID - 1))))
+    return interleave(gx) | (interleave(gy) << 1)
+  }
+  const ordered = edges
+    .map((edge, i) => ({ edge, i, key: mortonOf(midpoints[i] as Point) }))
+    // Document order breaks key ties, so the grouping is a total function of
+    // the canvas — two layouts of the same canvas never split it differently.
+    .sort((a, b) => a.key - b.key || a.i - b.i)
+
+  // Even-sized regions rather than cap-sized ones: cost grows super-linearly
+  // inside a region, so two regions of 173 beat one of 200 plus one of 145.
+  const regionCount = Math.ceil(edges.length / CROSSING_OPT_MAX_EDGES)
+  const regionSize = Math.ceil(edges.length / regionCount)
+  const settled = new Map(initial)
+  for (let start = 0; start < ordered.length; start += regionSize) {
+    const regionEdges = ordered.slice(start, start + regionSize).map((entry) => entry.edge)
+    if (regionEdges.length < 2) continue
+    const seed = new Map<string, SidePair>()
+    for (const edge of regionEdges) {
+      const pair = settled.get(edge.id)
+      if (pair !== undefined) seed.set(edge.id, pair)
+    }
+    for (const [id, pair] of bothRuns(regionEdges, seed)) settled.set(id, pair)
+  }
+  return settled
+}
+
 export function assignEdgeAnchors(
   nodes: readonly SpatialNode[],
   edges: readonly CanvasEdge[],
@@ -1045,15 +1156,19 @@ export function assignEdgeAnchors(
     // disagree with what the committed render will pick, and the drop
     // then visibly re-sides an edge the preview never showed that way.
     let liveSides: ReadonlyMap<string, SidePair> = merged
+    // The live-drag path keeps the hard gate the committed path no longer
+    // needs. Regional optimization is worth several hundred ms once, when a
+    // change is committed; it is not worth it on a frame someone is dragging
+    // through, and this branch exists precisely to serve those frames. A
+    // canvas past the gate drags exactly as fast as it does today and picks
+    // up its regional repair on drop.
     if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES && locked.size < edges.length) {
-      liveSides = optimizeSideChoices(nodes, edges, style, merged, locked)
-      liveSides = optimizeSideChoices(nodes, edges, style, liveSides, locked, true, sideOverrides)
+      liveSides = optimizeAcrossRegions(nodes, edges, style, merged, locked, sideOverrides)
     }
     return anchorsWithoutCoincidentEnds(nodes, edges, liveSides, style, true, sideOverrides)
   }
-  if (edges.length >= 2 && edges.length <= CROSSING_OPT_MAX_EDGES) {
-    sides = optimizeSideChoices(nodes, edges, style, sides)
-    sides = optimizeSideChoices(nodes, edges, style, sides, undefined, true)
+  if (edges.length >= 2) {
+    sides = optimizeAcrossRegions(nodes, edges, style, sides)
   }
   return anchorsWithoutCoincidentEnds(nodes, edges, sides, style, true)
 }

--- a/packages/canvas-render/src/test-utils/routing-corpus.ts
+++ b/packages/canvas-render/src/test-utils/routing-corpus.ts
@@ -99,3 +99,71 @@ export function syntheticLayouts(count: number): readonly RoutingCase[] {
   }
   return cases
 }
+
+/**
+ * One large canvas with REAL LOCALITY — the shape an AI-authored document
+ * grows into, and the case every other instrument in this package is blind
+ * to.
+ *
+ * The bench's `gridCanvas` wires nodes by a stride, so every edge spans the
+ * whole canvas and each one's bounding box overlaps roughly half the others
+ * (measured: 55% of pairs survive the broad phase). That is the worst case
+ * for any spatial pruning, and it is not what a real document looks like:
+ * work clusters, and so do the edges between it. Optimising against the
+ * stride canvas alone would price a spatial index at its least favourable
+ * input and reject it for the wrong reason.
+ *
+ * So: `clusters` groups of nodes laid out in well-separated regions, with
+ * `crossClusterRatio` of the edges reaching between neighbouring groups and
+ * the rest staying local. Deterministic for a given seed, like every other
+ * generator here.
+ */
+export function clusteredLayout(options: {
+  readonly clusters: number
+  readonly nodesPerCluster: number
+  readonly edgesPerCluster: number
+  readonly crossClusterRatio?: number
+  readonly seed?: number
+}): RoutingCase {
+  const { clusters, nodesPerCluster, edgesPerCluster } = options
+  const crossClusterRatio = options.crossClusterRatio ?? 0.15
+  const random = mulberry32(options.seed ?? 0xc105)
+  const int = (max: number) => Math.floor(random() * max)
+
+  // Cluster regions on a square grid, spaced far enough apart that a local
+  // edge cannot reach a neighbouring region — that separation is the whole
+  // point of the fixture.
+  const perRow = Math.ceil(Math.sqrt(clusters))
+  const REGION_PX = 1200
+  const nodes: SpatialNode[] = []
+  for (let c = 0; c < clusters; c++) {
+    const ox = (c % perRow) * REGION_PX
+    const oy = Math.floor(c / perRow) * REGION_PX
+    for (let n = 0; n < nodesPerCluster; n++) {
+      nodes.push(node(`c${c}n${n}`, ox + int(700), oy + int(700), 120 + int(120), 60 + int(80)))
+    }
+  }
+
+  const edges: CanvasEdge[] = []
+  const seen = new Set<string>()
+  const push = (from: string, to: string) => {
+    if (from === to) return
+    const key = `${from}->${to}`
+    if (seen.has(key)) return
+    seen.add(key)
+    edges.push({ id: `e${edges.length}`, fromNode: from, toNode: to })
+  }
+  for (let c = 0; c < clusters; c++) {
+    for (let e = 0; e < edgesPerCluster; e++) {
+      // A cross-cluster edge reaches the NEXT region only; a document's
+      // long-range links are few and mostly between neighbours.
+      if (random() < crossClusterRatio && clusters > 1) {
+        const other = (c + 1) % clusters
+        push(`c${c}n${int(nodesPerCluster)}`, `c${other}n${int(nodesPerCluster)}`)
+      } else {
+        push(`c${c}n${int(nodesPerCluster)}`, `c${c}n${int(nodesPerCluster)}`)
+      }
+    }
+  }
+  return { name: `clustered ${clusters}x${nodesPerCluster}`, nodes, edges }
+}


### PR DESCRIPTION
Past `CROSSING_OPT_MAX_EDGES` (200), side-choice optimization was skipped **wholesale**. That is not a performance gate anyone had measured the other side of — so this PR measures it first, then fixes it.

On a 345-edge clustered canvas: **331 avoidable-ink violations, one per edge**, against 29 across the ~4400 edges of the entire small corpus. A canvas that size is what an AI-authored document grows into, so the size where optimization stops being *affordable* is not the size where quality stops *mattering*. It was a silent quality cliff — 345 edges laid out in 12ms because nothing was optimizing them.

## Three commits, instrument first

1. **`test(render): add clustered large canvases to the routing bench`** — every routing instrument here measured one shape: `gridCanvas` wires nodes by a stride, so every edge spans the whole layout and **55%** of edge pairs survive a bounding-box test. Real documents cluster. The new `clusteredLayout` cases measure **5%** and **4%**. This distinction is load-bearing: optimising against the stride canvas alone prices spatial locality at its least favourable input and rejects it for the wrong reason. (It did exactly that to a spatial index I tried and threw away — zero win at 55%.)
2. **`test(render): pin the drawing cost of a canvas past the optimizer gate`** — the 331/42623/782 figures above, pinned exactly like the existing aggregate.
3. **`feat(render): optimize edge sides by region past the edge gate`** — the fix.

## How

`optimizeAcrossRegions` groups edges along a Morton curve through their midpoints, chunks them into even regions of at most the gate, and runs the ordinary unaligned-then-aligned search per region. Interaction is local, so two edges in well-separated regions were never going to be scored against each other anyway.

**What it gives up, plainly:** a crossing between edges assigned to different regions is never priced. Morton order puts spatial neighbours next to each other so a split falls between clusters far more often than through one, but nothing guarantees it.

## Measured

345-edge clustered canvas:

| metric | before | after |
|---|---|---|
| avoidable-ink violations | 331 | **183** |
| interior ink | 42623 | **21001** |
| border ink | 889 | **554** |
| crossings | 782 | **752** |
| bends | 633 | 658 |
| layout time | 12ms | 622ms |

**At or under the gate nothing changes, by construction** — one region, same two runs, same seed. The small-corpus pins are untouched and the 40n/40e, 60n/200e and clustered-165e benches are flat across interleaved paired runs.

**The live-drag path keeps the hard gate.** Several hundred ms is worth paying once on a committed change and never on a frame someone is dragging through; a canvas past the gate drags exactly as fast as before and picks up its regional repair on drop.

## On the region size

It reuses `CROSSING_OPT_MAX_EDGES` rather than adding a second knob. Measured curve: 200 → 183 violations, 120 → 158, 80 → 122, at 1023 → 1184 → 1481ms. Smaller regions buy quality because `TRIAL_BUDGET_EDGES` applies *per region* — the real knob is total trial budget, and region size is only how it gets spent. Tuning a new constant against one synthetic canvas would make that canvas the convention by accident, so the curve is recorded in the package rule instead.

## Also tried and rejected (measured, not argued)

- **Branch-and-bound early abort** on trial evaluation — neutral to slightly worse. Making the accumulation monotone required subtracting priors in a separate pass, which cost what the abort saved.
- **Uniform-grid broad phase** for the pair update — zero. At E ≤ 200 a `Set` costs more than the linear scan with an inlined AABB test it replaces.
- **Memoizing `interiorInkThrough`'s O(n²) containment filter** — 1% of runtime; it is called with 2 rects, not 143.

The clustered breakdown that explains all three: routes 31%, anchors 16%, setup 16%, **pair loop 10%**. No dominant hot spot, so there is no cheap 2× in this band — which is why this PR spends its effort on the cliff instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ