### PR TITLE
fix(server-core): delete a document's stored bytes, not just its tree node

### DIFF
--- a/packages/canvas-ports/src/canvas-doc-store.ts
+++ b/packages/canvas-ports/src/canvas-doc-store.ts
@@ -80,6 +80,9 @@ export type ReadFrontierInput = z.infer<typeof readFrontierInputSchema>
 export const readFrontierResultSchema = z.object({ frontier: frontierSchema }).strict().nullable()
 export type ReadFrontierResult = z.infer<typeof readFrontierResultSchema>
 
+export const deleteDocInputSchema = z.object({ docRef: docRefSchema }).strict()
+export type DeleteDocInput = z.infer<typeof deleteDocInputSchema>
+
 /**
  * Persistence for a single Loro-backed document (a canvas or the
  * workspace-tree). `docRef` carries the scope for every method; there is
@@ -92,4 +95,11 @@ export interface CanvasDocStore {
   appendDeltas(input: AppendDeltasInput): Promise<AppendDeltasResult>
   loadDeltas(input: LoadDeltasInput): Promise<LoadDeltasResult>
   readFrontier(input: ReadFrontierInput): Promise<ReadFrontierResult>
+  /**
+   * Remove everything stored for the document: snapshot, chunks, frontier
+   * and deltas. Deleting an absent document succeeds — the caller wants the
+   * document gone, and reporting that it already was gone would only make
+   * every call site write the same catch.
+   */
+  deleteDoc(input: DeleteDocInput): Promise<void>
 }

--- a/packages/mcp-server/src/server/store/inmemory/in-memory-canvas-doc-store.ts
+++ b/packages/mcp-server/src/server/store/inmemory/in-memory-canvas-doc-store.ts
@@ -2,6 +2,7 @@ import type {
   AppendDeltasInput,
   AppendDeltasResult,
   CanvasDocStore,
+  DeleteDocInput,
   Frontier,
   LoadDeltasInput,
   LoadDeltasResult,
@@ -111,5 +112,9 @@ export class InMemoryCanvasDocStore implements CanvasDocStore {
       return null
     }
     return { frontier: cloneBytes(record.frontier) }
+  }
+
+  async deleteDoc(input: DeleteDocInput): Promise<void> {
+    this.docs.delete(docRefKey(input.docRef))
   }
 }

--- a/packages/mcp-server/src/server/store/libsql/libsql-canvas-doc-store.parity.test.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-canvas-doc-store.parity.test.ts
@@ -40,7 +40,12 @@ type AppendDeltasOp = {
   newFrontier: Uint8Array
 }
 
-type Op = SaveSnapshotOp | AppendDeltasOp
+type DeleteDocOp = {
+  type: 'deleteDoc'
+  docRefIndex: number
+}
+
+type Op = SaveSnapshotOp | AppendDeltasOp | DeleteDocOp
 
 function buildSnapshotArgs(chunkByteArrays: Uint8Array[]): {
   manifest: SnapshotManifest
@@ -62,9 +67,11 @@ async function applyOp(store: CanvasDocStore, op: Op): Promise<void> {
   if (op.type === 'saveSnapshot') {
     const { manifest, chunks } = buildSnapshotArgs(op.chunkByteArrays)
     await store.saveSnapshot({ docRef, manifest, chunks, frontier: op.frontier })
-  } else {
+  } else if (op.type === 'appendDeltas') {
     const deltaBatch: DeltaBatch = { updates: op.updates, newFrontier: op.newFrontier }
     await store.appendDeltas({ docRef, deltaBatch })
+  } else {
+    await store.deleteDoc({ docRef })
   }
 }
 
@@ -98,6 +105,14 @@ const opArbitrary: fc.Arbitrary<Op> = fc.oneof(
     docRefIndex: fc.integer({ min: 0, max: DOC_REFS.length - 1 }),
     updates: fc.array(fc.uint8Array({ maxLength: 5 }), { minLength: 1, maxLength: 3 }),
     newFrontier: fc.uint8Array({ maxLength: 5 }),
+  }),
+  // Deleting is generated alongside the writes rather than only after them:
+  // what a partial delete leaves behind (an orphan frontier, a delta run with
+  // no snapshot) is only observable when a later op reads or rewrites the
+  // same docKey.
+  fc.record({
+    type: fc.constant('deleteDoc' as const),
+    docRefIndex: fc.integer({ min: 0, max: DOC_REFS.length - 1 }),
   }),
 )
 

--- a/packages/mcp-server/src/server/store/libsql/libsql-canvas-doc-store.ts
+++ b/packages/mcp-server/src/server/store/libsql/libsql-canvas-doc-store.ts
@@ -2,6 +2,7 @@ import type {
   AppendDeltasInput,
   AppendDeltasResult,
   CanvasDocStore,
+  DeleteDocInput,
   Frontier,
   LoadDeltasInput,
   LoadDeltasResult,
@@ -159,6 +160,20 @@ export class LibsqlCanvasDocStore implements CanvasDocStore {
     })
 
     log.debug({ docKey, chunkCount: manifest.chunkCount }, 'saved snapshot')
+  }
+
+  async deleteDoc({ docRef }: DeleteDocInput): Promise<void> {
+    const docKey = docRefKey(docRef)
+    // All four tables in one transaction. A partial delete would leave a
+    // frontier or a delta run addressing a snapshot that is gone, which
+    // loadSnapshot cannot distinguish from a document mid-write.
+    await this.db.transaction().execute(async (trx) => {
+      await trx.deleteFrom('canvasDocSnapshotChunks').where('docKey', '=', docKey).execute()
+      await trx.deleteFrom('canvasDocSnapshots').where('docKey', '=', docKey).execute()
+      await trx.deleteFrom('canvasDocDeltas').where('docKey', '=', docKey).execute()
+      await trx.deleteFrom('canvasDocFrontiers').where('docKey', '=', docKey).execute()
+    })
+    log.debug({ docKey }, 'deleted doc')
   }
 
   async appendDeltas({ docRef, deltaBatch }: AppendDeltasInput): Promise<AppendDeltasResult> {

--- a/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
+++ b/packages/server-core/src/test-utils/fake-canvas-doc-store.ts
@@ -3,6 +3,7 @@ import type {
   AppendDeltasInput,
   AppendDeltasResult,
   CanvasDocStore,
+  DeleteDocInput,
   DocRef,
   LoadDeltasInput,
   LoadDeltasResult,
@@ -54,6 +55,10 @@ export class FakeCanvasDocStore implements CanvasDocStore {
 
   async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
     throw new Error('not implemented')
+  }
+
+  async deleteDoc(input: DeleteDocInput): Promise<void> {
+    this.saved.delete(docRefKey(input.docRef))
   }
 }
 

--- a/packages/server-core/src/test-utils/in-memory-canvas-doc-store.ts
+++ b/packages/server-core/src/test-utils/in-memory-canvas-doc-store.ts
@@ -2,6 +2,7 @@ import type {
   AppendDeltasInput,
   AppendDeltasResult,
   CanvasDocStore,
+  DeleteDocInput,
   DocRef,
   LoadDeltasInput,
   LoadDeltasResult,
@@ -47,6 +48,9 @@ export function createInMemoryCanvasDocStore(): CanvasDocStore {
       const stored = snapshots.get(docRefKey(_input.docRef))
       if (!stored) return null
       return { frontier: structuredClone(stored.frontier) } as ReadFrontierResult
+    },
+    async deleteDoc(input: DeleteDocInput): Promise<void> {
+      snapshots.delete(docRefKey(input.docRef))
     },
   }
 }

--- a/packages/server-core/src/tools/canvas-crud.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.test.ts
@@ -238,6 +238,27 @@ describe('wbCanvasDelete', () => {
     ).rejects.toThrow(CanvasNotFoundError)
   })
 
+  it('deletes the stored document, not only its place in the tree', async () => {
+    // Removing the tree node makes the document unreachable, which reads as
+    // deleted and leaves its snapshot behind for good. Nothing else ever
+    // refers to that id again, so the bytes are unreferenced rather than
+    // merely orphaned — and deletion is how a resolved item is closed, so
+    // the store grows once per completed piece of work.
+    const deps = makeDeps()
+    const created = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc-a',
+      kind: 'spatial',
+      createWorkspace: true,
+    })
+    const docRef = { kind: 'canvas', canvasId: created.canvasId } as const
+    expect(await deps.canvasDocStore.loadSnapshot({ docRef })).not.toBeNull()
+
+    await wbCanvasDelete(deps, { workspaceId: 'ws-1', canvasId: created.canvasId })
+
+    expect(await deps.canvasDocStore.loadSnapshot({ docRef })).toBeNull()
+  })
+
   it('throws CanvasNotFoundError when deleting a non-existent canvasId', async () => {
     const deps = makeDeps()
     await expect(

--- a/packages/server-core/src/tools/canvas-crud.ts
+++ b/packages/server-core/src/tools/canvas-crud.ts
@@ -115,5 +115,8 @@ export async function wbCanvasDelete(
   const node = findNodeOrThrow(tree, input.workspaceId, input.canvasId)
   tree.delete(node.id)
   await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
+  // The tree removal alone makes the document unreachable; its stored bytes
+  // would stay behind with nothing left that could ever name them again.
+  await deps.canvasDocStore.deleteDoc({ docRef: { kind: 'canvas', canvasId: node.canvasId } })
   return { deleted: true }
 }


### PR DESCRIPTION
First of the two steps recommended after the persistence investigation — independent of the convergence design, and it grows every day it is left.

## The leak

`wb_document_delete` removed the workspace-tree node and stopped. The document became unreachable — which reads as deleted — while its snapshot, chunks, frontier and deltas stayed behind with **nothing left that could ever name them again**.

```ts
tree.delete(node.id)
await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
return { deleted: true }        // <- the bytes are still there
```

Measured in this checkout's dev data: `canvasDocSnapshots` holds **8** canvas documents while the workspace tree holds **4**. And under this repo's ticketing workflow *deletion is how a resolved item is closed*, so the store gained a document per completed piece of work.

## The fix

`CanvasDocStore` gains `deleteDoc`. Deleting an absent document succeeds — the caller wants it gone, and reporting that it already was would only make every call site write the same catch.

The libsql implementation clears all four tables **in one transaction**: a partial delete leaves a frontier or a delta run addressing a snapshot that is gone, and `loadSnapshot` cannot tell that from a document mid-write.

## Testing the implementation, not just the interface

The `server-core` test runs against a fake store, so on its own it would prove the call is made and nothing about the store that actually leaks. The real coverage is the existing **libsql ↔ in-memory parity property**, which now generates `deleteDoc` alongside the writes rather than only after them — a partial delete is only observable when a later op reads or rewrites the same `docKey`.

Mutation-checked, and it is not vacuous:

| mutation | result |
|---|---|
| drop the `canvasDocFrontiers` delete | fails at `[saveSnapshot, deleteDoc]` |
| drop the `canvasDocDeltas` delete | fails |

Both minimal two-op counterexamples.

## Scope

`mcp-node` 3322 pass, `server-core-node` 244 pass, `pnpm -r typecheck` clean, `pnpm knip` clean. Four `CanvasDocStore` implementations updated (libsql, mcp-server in-memory, and the two server-core test doubles); typecheck across every package confirms none was missed.

**Not included:** the 4 already-orphaned snapshots in the local dev data. This stops new ones; clearing the existing bytes is the owner's call, not something to do to someone's data unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw