### PR TITLE
fix(render): give same-side routes the arrow runway perpendicular ones get

### DIFF
--- a/packages/canvas-render/src/layout/edge-arrow-runway.test.ts
+++ b/packages/canvas-render/src/layout/edge-arrow-runway.test.ts
@@ -1,0 +1,83 @@
+// An arrowhead is ARROW_LENGTH (10px) long and is drawn ON the final segment,
+// so a shorter approach paints an arrow with no line behind it — it reads as a
+// marker stuck to the box rather than an edge arriving at it.
+//
+// `routeOrthogonal` already rescues PERPENDICULAR pairs by sliding the
+// departure anchor along its own side. Same-side pairs had no equivalent and
+// were the larger source of the defect: measured over the routing corpus, 99
+// short approaches came from same-side pairs against 11 from perpendicular
+// ones. A same-side route runs a shared corridor at the departure stub's depth
+// and comes back up into the arrival anchor, so when the ARRIVAL box extends
+// further out than the departure box, the corridor clears it by less than the
+// stub depth — by nothing at all once the difference exceeds it.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { finalSegmentLength } from '../test-utils/routing-metrics.js'
+import { assignEdgeAnchors, routeEdge } from './spatial-edges.js'
+
+const ARROW_LENGTH_PX = 10
+
+const route = (nodes: readonly SpatialNode[], edge: CanvasEdge) => {
+  const anchors = assignEdgeAnchors(nodes, [edge], 'orthogonal')
+  return routeEdge(nodes, edge, 'orthogonal', anchors.get(edge.id))
+}
+
+describe('a same-side route leaves its arrowhead a runway', () => {
+  it('deepens the shared corridor when the arrival box extends further out', () => {
+    // B's bottom sits 15px below A's, so a corridor 20px under A clears B's
+    // anchor by 5 — half an arrowhead.
+    const nodes: SpatialNode[] = [
+      { id: 'A', type: 'text', x: 0, y: 0, width: 100, height: 100, text: 'A' },
+      { id: 'B', type: 'text', x: 200, y: 0, width: 100, height: 115, text: 'B' },
+    ]
+    const routed = route(nodes, {
+      id: 'e',
+      fromNode: 'A',
+      toNode: 'B',
+      fromSide: 'bottom',
+      toSide: 'bottom',
+    })
+    expect(finalSegmentLength(routed.path)).toBeGreaterThanOrEqual(ARROW_LENGTH_PX)
+    // The corridor moved; the route did not gain a bend to get there.
+    expect(routed.path).toHaveLength(4)
+  })
+
+  it('holds when the arrival box extends further out than the stub is deep', () => {
+    // 40px deeper than A — past the 20px stub, so the naive corridor would
+    // arrive from INSIDE the box and the approach would reverse.
+    const nodes: SpatialNode[] = [
+      { id: 'A', type: 'text', x: 0, y: 0, width: 100, height: 100, text: 'A' },
+      { id: 'B', type: 'text', x: 200, y: 0, width: 100, height: 140, text: 'B' },
+    ]
+    const routed = route(nodes, {
+      id: 'e',
+      fromNode: 'A',
+      toNode: 'B',
+      fromSide: 'bottom',
+      toSide: 'bottom',
+    })
+    expect(finalSegmentLength(routed.path)).toBeGreaterThanOrEqual(ARROW_LENGTH_PX)
+  })
+
+  it('leaves a route whose arrival box is the shallower one alone', () => {
+    // A is the deeper box here, so the corridor already clears B generously
+    // and nothing should be deepened.
+    const nodes: SpatialNode[] = [
+      { id: 'A', type: 'text', x: 0, y: 0, width: 100, height: 140, text: 'A' },
+      { id: 'B', type: 'text', x: 200, y: 0, width: 100, height: 100, text: 'B' },
+    ]
+    const routed = route(nodes, {
+      id: 'e',
+      fromNode: 'A',
+      toNode: 'B',
+      fromSide: 'bottom',
+      toSide: 'bottom',
+    })
+    expect(routed.path.map((p) => `${p.x},${p.y}`)).toEqual([
+      '50,140',
+      '50,160',
+      '250,160',
+      '250,100',
+    ])
+  })
+})

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -176,13 +176,13 @@ describe('routing quality across the synthetic corpus', () => {
       length: Math.round(length),
       shortArrowRunway: shortRunway,
     }).toEqual({
-      violations: { 'own-endpoint': 14, foreign: 15, degenerate: 0 },
-      interiorInk: 2192,
-      borderInk: 1054,
-      bends: 8160,
-      crossings: 500,
-      length: 1337098,
-      shortArrowRunway: 235,
+      violations: { 'own-endpoint': 14, foreign: 16, degenerate: 0 },
+      interiorInk: 2203,
+      borderInk: 824,
+      bends: 8150,
+      crossings: 498,
+      length: 1340155,
+      shortArrowRunway: 137,
     })
   })
 })
@@ -228,7 +228,7 @@ describe('routing quality past the side-choice optimizer gate', () => {
       borderInk: 554,
       bends: 658,
       crossings: 752,
-      length: 274428,
+      length: 274440,
     })
   }, 120_000)
 })

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1567,6 +1567,28 @@ function routeOrthogonal(
       if (slid !== undefined) start = slid
     }
   }
+  // Same-side pairs get their approach from the depth of the SHARED corridor,
+  // which is measured from the departure anchor — so an arrival box that
+  // reaches further out than the departure box eats into it, and one that
+  // reaches further than the stub is deep leaves the corridor arriving from
+  // inside. Deepening the corridor to clear the arrival anchor by a full
+  // approach is the same-side analogue of the departure slide above: it buys
+  // the runway without adding a bend, because the corridor is a segment the
+  // route already draws.
+  if (fromSide === toSide) {
+    const arrivalOvershoot = toNormal.x * (end.x - start.x) + toNormal.y * (end.y - start.y)
+    const approach = fromDepth - arrivalOvershoot
+    // Only the band where the corridor clears the arrival anchor but by less
+    // than an approach. Deeper than that (`approach <= 0`) the corridor
+    // arrives from inside, the arrival stub is kept below, and that stub IS
+    // the runway — deepening those turns a sound route into a long detour
+    // around the outside of a box that reaches far further out than its
+    // partner. Inside the band the correction is bounded by MIN_APPROACH_PX,
+    // so the corridor never moves more than one approach.
+    if (approach > 0 && approach < MIN_APPROACH_PX) {
+      fromDepth = arrivalOvershoot + MIN_APPROACH_PX
+    }
+  }
   const exit = stubFrom(start, fromSide, fromDepth)
   const entry = stubFrom(end, toSide, toDepth)
   // The arrival stub exists so the last segment reaches the anchor from


### PR DESCRIPTION
An arrowhead is 10px long and is drawn **on** the final segment, so a shorter approach paints an arrow with no line behind it — a marker stuck to the box rather than an edge arriving at it. `routeOrthogonal` already rescued **perpendicular** pairs by sliding the departure anchor along its own side; same-side pairs had no equivalent.

## Counting first moved the blame

The task said "same-side pairs". Classifying all 235 short approaches over the corpus says something more useful:

| shape | count | fixable? |
|---|---|---|
| opposing, boxes < 10px apart | **111** | **no** — no routing produces a 10px approach in a 5px gap |
| **same-side** | **99** | yes |
| opposing, gap ≥ 20px | 13 | yes |
| perpendicular | 11 | mostly the existing rescue working |

So same-side is the whole of the reachable debt, **and this metric has a geometric floor around 111** — it cannot go to zero, which is worth knowing before anyone chases it.

## The fix, and the narrow band it applies to

A same-side route runs a shared corridor at the departure stub's depth and comes back up into the arrival anchor, so an arrival box reaching further out than its partner eats into the approach.

The broken band is narrow. Past the stub depth the corridor arrives from *inside*, the arrival stub is kept, and **that stub is the runway** — those routes were already sound. Only `0 < fromDepth - overshoot < MIN_APPROACH_PX` is defective, and there the correction is bounded by one approach, so the corridor never moves more than 20px.

**Deepening unconditionally was measured first and rejected:** it turned sound long-overshoot routes into detours around boxes reaching far further out than their partners — interior ink 2192 → **3699**, own-endpoint violations 14 → **27**. Bounding it to the band keeps ink flat.

## Measured

| metric | before | after |
|---|---|---|
| **shortArrowRunway** | 235 | **137** |
| border ink | 1054 | **824** |
| bends | 8160 | **8150** |
| crossings | 500 | **498** |
| interior ink | 2192 | 2203 |
| length | 1337098 | 1340155 (+0.2%) |
| foreign violations | 15 | 16 |

**On the `foreign` +1**, since that is an invariant metric whose target is zero: the new violation is on a `left->bottom` route — a **perpendicular** pair, which the same-side corridor change cannot have produced. It is a downstream side-choice shift after costs moved elsewhere, not a route ploughing through a box. Verified by diffing the per-case violation list before and after.

Large-canvas block moves by 12px of length and nothing else. `pnpm bench` flat across interleaved paired runs at every size — the change is a few arithmetic ops inside one branch.

## Tests

`edge-arrow-runway.test.ts` pins the repaired case, the past-the-stub case that must be left alone, and a control where the arrival box is the shallower one (exact path pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ