### PR TITLE
docs(render): record the measured verdict on batch side-choice evaluation

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -404,6 +404,35 @@ paths:
       paying once on a committed change and never on a frame someone is
       dragging through, so a canvas past the gate drags exactly as fast as
       before and picks up its regional repair on drop.
+    - **Batch (Jacobi) side-choice evaluation is MEASURED AND DEFERRED, not
+      untried.** The search adopts one improvement at a time and re-bases
+      before the next edge (Gauss-Seidel), which is inherently sequential —
+      the reason a GPU cannot help it, and the real prerequisite behind any
+      WebGPU/SIMD plan. (Float determinism is NOT that blocker: integer or
+      fixed-point arithmetic is bit-exact on a GPU, and this package's cost
+      model is already integer-quantized by `COST_QUANTUM`.) The batch form
+      scores every trial edge against ONE base configuration, so a round is
+      order-independent and parallelisable, then adopts the non-conflicting
+      subset. Sound multi-adoption needs more than disjoint touched sets: a
+      pair spanning two proposals changes score and neither proposal costed
+      it, so their BOUNDING BOXES must be disjoint too — then every such pair
+      scores zero on both sides and the batch equals sequential adoption
+      exactly.
+      Measured over the corpus: batch needs 6 rounds to converge (12 is
+      identical), and at 6 it MATCHES sequential on avoidable-ink violations
+      (29) while beating it on crossings (473 vs 500) and ink (2169 vs 2192).
+      At the same 2-round budget it is far worse (47 violations, 611
+      crossings) — the extra rounds are how it pays for re-basing less often.
+      The cost is +36% layout time single-threaded (4471ms vs 3287ms over the
+      corpus). That is the whole finding: batch is quality-competitive and
+      strictly more work on one thread, and its extra work is exactly the
+      work a parallel executor could absorb.
+      Deferred rather than shipped because `canvas-render` is a shared-layer
+      package with no worker, no SIMD path, and no `navigator.gpu` (a DOM
+      global this layer forbids) — so today it would buy a 36% regression for
+      a few percent of crossings. Revisit when a composition root can supply a
+      parallel executor through a seam, which is a larger design than the
+      search itself.
     - **Facet-driven rendering rides the injected-resolver pattern.**
       Shipped: `SpatialLayoutOptions.resolveFileFacets?: (file: string) =>
       FacetCardData | undefined` (`layout/spatial-canvas.ts`), same seam


### PR DESCRIPTION
Documentation only — the spike this describes is reverted, and no production code changes.

## The question

The side-choice search adopts one improvement at a time and re-bases before the next edge (Gauss-Seidel), which is inherently sequential. That, **not float determinism**, is what stops a GPU from helping it — integer/fixed-point arithmetic is bit-exact on a GPU, and this package's cost model is already integer-quantized by `COST_QUANTUM`. So the real prerequisite behind any WebGPU/SIMD plan is reformulating the search, and the open question was whether the batch form is even competitive.

## The spike

Every trial edge scored against **one** base configuration — making a round order-independent and parallelisable — then the non-conflicting subset adopted.

Sound multi-adoption needs more than disjoint touched sets: a pair spanning two proposals changes score and neither proposal costed it. Requiring their **bounding boxes** to be disjoint makes every such pair score zero on both sides, so the batch equals sequential adoption exactly.

## Measured over the corpus

| variant | violations | ink | crossings | time |
|---|---|---|---|---|
| sequential, 2 rounds (shipped) | 29 | 2192 | 500 | 3287ms |
| batch, 2 rounds | 47 | 3106 | 611 | 3196ms |
| batch, **6 rounds** | **29** | **2169** | **473** | **4471ms** |
| batch, 12 rounds | 29 | 2169 | 473 | 4554ms |

Batch converges at 6 rounds (12 is identical), **matches** sequential on avoidable-ink violations, **beats** it on crossings and ink, and costs **+36% single-threaded**. At the same 2-round budget it is far worse — the extra rounds are how it pays for re-basing less often.

That is the whole finding: batch is quality-competitive and strictly more work on one thread, and its extra work is exactly the work a parallel executor could absorb. Sequential's cannot be parallelised at all.

## Why it is deferred rather than shipped

`canvas-render` is a shared-layer package with no worker, no SIMD path, and no `navigator.gpu` (a DOM global this layer forbids). Today the change would buy a 36% layout regression for a few percent of crossings — on top of the 2× already paid for the aligned re-score in #751. Revisit when a composition root can supply a parallel executor through a seam, which is a larger design than the search itself.

Recording it so the question does not have to be re-opened from scratch, and so the next person does not spend the spike again to learn the same number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ