### PR TITLE
fix(web): stop the canvas sliding every time something is created

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -165,6 +165,7 @@ import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import {
+  DOCK_OCCLUSION_PX,
   type DraggableCreation,
   draggedCreation,
   type EditorTool,
@@ -2378,6 +2379,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       createRectangleAt(point)
       panToShow({
@@ -2395,6 +2397,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       createNodeAt(point)
       panToShow({
@@ -2416,6 +2419,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       const id =
         createId?.() ??
@@ -2446,6 +2450,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       const id = newId()
       const node = fileNodeDefaults(id, point, file)
@@ -2477,6 +2482,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       const id = newId()
       const node = imageNodeDefaults(id, point, file)
@@ -2515,10 +2521,29 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * When the created box does not fully fit on screen, pan (keeping the
      * zoom) so it sits centered — creation is always visible feedback.
      */
+    /**
+     * The canvas-space rectangle a person can actually see: the root, minus
+     * the strip the dock paints over. Creation places inside this before it
+     * places anywhere else, which is what keeps the view still.
+     */
+    const visibleCanvasRect = (): Box | undefined => {
+      const containerSize = containerSizeOf(rootRef.current)
+      if (containerSize === null) return undefined
+      const topLeft = screenToCanvas({ x: 0, y: 0 }, viewport)
+      return {
+        x: topLeft.x,
+        y: topLeft.y,
+        width: containerSize.width / viewport.zoom,
+        height: (containerSize.height - DOCK_OCCLUSION_PX) / viewport.zoom,
+      }
+    }
+
     const panToShow = (box: Box) => {
       const containerSize = containerSizeOf(rootRef.current)
       if (containerSize === null) return
-      setViewport((vp) => panToShowTarget(box, vp, containerSize) ?? vp)
+      setViewport(
+        (vp) => panToShowTarget(box, vp, containerSize, { bottom: DOCK_OCCLUSION_PX }) ?? vp,
+      )
     }
 
     const newId = () =>
@@ -2538,6 +2563,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         preferred,
         { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT },
         occupied,
+        visibleCanvasRect(),
       )
       const id = newId()
       const node = groupNodeDefaults(id, point)

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -83,6 +83,16 @@ interface ToolPaletteProps {
   readonly onZoomToFit: () => void
 }
 
+/**
+ * Vertical strip of the canvas this dock covers: its own height plus the
+ * `bottom-3` offset, doubled so a revealed node clears it rather than
+ * touching it. The viewport subtracts this from the visible area — see
+ * ViewportOcclusion. Pinned against the real rendered height by
+ * bottom-dock.browser.test.tsx, which is what stops it drifting when the
+ * dock's classes change.
+ */
+export const DOCK_OCCLUSION_PX = 70
+
 export const TOOL_BUTTON_CLASS = `${DOCK_BUTTON_CLASS} aria-pressed:bg-accent aria-pressed:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground`
 
 interface AddMenuEntry {

--- a/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, expect, it, vi } from 'vitest'
 import '../../index.css'
 import { HistoryCluster } from '../history-cluster/HistoryCluster.js'
 import { SpatialEditor } from './SpatialEditor.js'
+import { DOCK_OCCLUSION_PX } from './ToolPalette.js'
 
 afterEach(cleanup)
 
@@ -77,6 +78,20 @@ it('the dock is the same in every mode, and still fits a phone width in one row'
     [...palette.querySelectorAll('button')].map((b) => Math.round(b.getBoundingClientRect().top)),
   )
   expect(tops.size).toBe(1)
+})
+
+it('DOCK_OCCLUSION_PX still covers what the dock actually paints over', () => {
+  const { container } = renderAt(375)
+  const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+  const host = container.firstElementChild as HTMLElement
+
+  // The viewport subtracts this constant instead of measuring, so this is
+  // the only thing standing between a class change on the dock and nodes
+  // quietly parking underneath it again.
+  const covered = host.getBoundingClientRect().bottom - palette.getBoundingClientRect().top
+  expect(covered).toBeLessThanOrEqual(DOCK_OCCLUSION_PX)
+  // And not wildly generous: a too-large inset wastes canvas on every pan.
+  expect(covered).toBeGreaterThan(DOCK_OCCLUSION_PX - 24)
 })
 
 it('creation entries live in the + menu, which opens upward inside the viewport', () => {

--- a/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
@@ -177,7 +177,6 @@ it('nothing is ever parked under the dock', () => {
   const dockTop = dock.getBoundingClientRect().top - rootRect.top
   const zoom = Number(/scale\(([\d.]+)\)/.exec(transformOfRoot(container))?.[1] ?? 1)
   const offset = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(transformOfRoot(container))
-  const panX = Number(offset?.[1] ?? 0)
   const panY = Number(offset?.[2] ?? 0)
   for (const node of latest.canvas.nodes) {
     const screenBottom = (node.y + node.height) * zoom + panY
@@ -185,10 +184,8 @@ it('nothing is ever parked under the dock', () => {
     // A node whose whole body is above the dock strip, or scrolled off the
     // top, is fine — the failure being pinned is a node sitting IN the strip.
     if (screenTop > rootRect.height) continue
-    expect({ id: node.id, screenBottom }).toEqual({ id: node.id, screenBottom: screenBottom })
     expect(screenBottom).toBeLessThanOrEqual(dockTop)
   }
-  expect(panX).toBeDefined()
 })
 
 function transformOfRoot(container: HTMLElement): string {

--- a/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
@@ -142,3 +142,56 @@ it('tapping a menu entry keeps placing it at the viewport centre', () => {
   expect(centre.x).toBeCloseTo(400, 0)
   expect(centre.y).toBeCloseTo(300, 0)
 })
+
+it('creating repeatedly does not move the viewport while the screen has room', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const transform = () =>
+    (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style.transform
+  const before = transform()
+
+  // Four is well within what an 800x600 view holds at 200x100 per node —
+  // enough to prove the point without making this the suite's heaviest file.
+  for (let i = 0; i < 4; i++) {
+    openAddMenu(container)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+  }
+
+  // Making something is not a request to go somewhere: the canvas under the
+  // hand must stay put while there is still room in view to place into.
+  expect(transform()).toBe(before)
+})
+
+it('nothing is ever parked under the dock', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const dock = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
+
+  for (let i = 0; i < 5; i++) {
+    openAddMenu(container)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+  }
+
+  const rootRect = root.getBoundingClientRect()
+  const dockTop = dock.getBoundingClientRect().top - rootRect.top
+  const zoom = Number(/scale\(([\d.]+)\)/.exec(transformOfRoot(container))?.[1] ?? 1)
+  const offset = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(transformOfRoot(container))
+  const panX = Number(offset?.[1] ?? 0)
+  const panY = Number(offset?.[2] ?? 0)
+  for (const node of latest.canvas.nodes) {
+    const screenBottom = (node.y + node.height) * zoom + panY
+    const screenTop = node.y * zoom + panY
+    // A node whose whole body is above the dock strip, or scrolled off the
+    // top, is fine — the failure being pinned is a node sitting IN the strip.
+    if (screenTop > rootRect.height) continue
+    expect({ id: node.id, screenBottom }).toEqual({ id: node.id, screenBottom: screenBottom })
+    expect(screenBottom).toBeLessThanOrEqual(dockTop)
+  }
+  expect(panX).toBeDefined()
+})
+
+function transformOfRoot(container: HTMLElement): string {
+  return (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style
+    .transform
+}

--- a/apps/web/src/components/spatial-editor/geometry.test.ts
+++ b/apps/web/src/components/spatial-editor/geometry.test.ts
@@ -164,4 +164,43 @@ describe('findFreeSpot', () => {
     expect(Number.isFinite(spot.x)).toBe(true)
     expect(Number.isFinite(spot.y)).toBe(true)
   })
+  it('stays inside the visible area while it has room, so creating never pans the canvas', () => {
+    const size = { width: 200, height: 100 }
+    // A column of notes filling the cascade's diagonal path.
+    const occupied = Array.from({ length: 13 }, (_, i) => ({
+      x: 400 + i * 24 - 100,
+      y: 300 + i * 24 - 50,
+      width: 200,
+      height: 100,
+    }))
+    const visible = { x: 0, y: 0, width: 800, height: 600 }
+    const spot = findFreeSpot({ x: 400, y: 300 }, size, occupied, visible)
+    // The unbounded cascade would have walked to (712,612) — its box runs
+    // past the visible bottom, so the viewport would have to chase it.
+    expect(spot.x - size.width / 2).toBeGreaterThanOrEqual(visible.x)
+    expect(spot.y - size.height / 2).toBeGreaterThanOrEqual(visible.y)
+    expect(spot.x + size.width / 2).toBeLessThanOrEqual(visible.x + visible.width)
+    expect(spot.y + size.height / 2).toBeLessThanOrEqual(visible.y + visible.height)
+  })
+
+  it('uses a straight column when the visible area is too narrow for the diagonal', () => {
+    const size = { width: 200, height: 100 }
+    // Phone-shaped: one note wide, many notes tall.
+    const visible = { x: 0, y: 0, width: 240, height: 700 }
+    const occupied = [{ x: 20, y: 300, width: 200, height: 100 }]
+    const spot = findFreeSpot({ x: 120, y: 350 }, size, occupied, visible)
+    expect(spot.x - size.width / 2).toBeGreaterThanOrEqual(visible.x)
+    expect(spot.x + size.width / 2).toBeLessThanOrEqual(visible.x + visible.width)
+    expect(spot.y + size.height / 2).toBeLessThanOrEqual(visible.y + visible.height)
+  })
+
+  it('falls back to the plain cascade once the visible area is genuinely full', () => {
+    const size = { width: 200, height: 100 }
+    // Wall-to-wall: nothing inside `visible` can hold another box.
+    const occupied = [{ x: -1000, y: -1000, width: 4000, height: 4000 }]
+    const visible = { x: 0, y: 0, width: 800, height: 600 }
+    const withVisible = findFreeSpot({ x: 400, y: 300 }, size, occupied, visible)
+    const without = findFreeSpot({ x: 400, y: 300 }, size, occupied)
+    expect(withVisible).toEqual(without)
+  })
 })

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -120,6 +120,7 @@ export function findFreeSpot(
   preferred: Point,
   size: { readonly width: number; readonly height: number },
   occupied: readonly Box[],
+  visible?: Box,
 ): Point {
   const candidateAt = (step: number): Point => ({
     x: preferred.x + step * CASCADE_STEP_PX,
@@ -131,10 +132,51 @@ export function findFreeSpot(
     width: size.width,
     height: size.height,
   })
+  const isFree = (box: Box) => !occupied.some((other) => boxesIntersect(box, other))
+  const insideVisible = (box: Box) =>
+    visible === undefined ||
+    (box.x >= visible.x &&
+      box.y >= visible.y &&
+      box.x + box.width <= visible.x + visible.width &&
+      box.y + box.height <= visible.y + visible.height)
+
+  // First pass: a spot that is both free AND already on screen. Walking the
+  // cascade off the edge is what makes creation pan the canvas — the node
+  // has to be chased to a place nobody asked to go.
+  //
+  // Down-right first (the familiar cascade), then the other three diagonals,
+  // because one direction runs out of screen quickly on a phone: at 390px a
+  // 200px-wide note leaves the viewport after two steps, and every creation
+  // after that would pan.
+  // Diagonals first (the familiar cascade look), then the orthogonals: a
+  // phone is far taller than it is wide, so once the diagonals hit the side
+  // edge a straight column down is the only shape left that still fits.
+  const DIRECTIONS = [
+    { x: 1, y: 1 },
+    { x: -1, y: 1 },
+    { x: -1, y: -1 },
+    { x: 1, y: -1 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 },
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+  ] as const
+  for (const dir of DIRECTIONS) {
+    for (let step = 0; step < MAX_CASCADE_STEPS; step += 1) {
+      const candidate = {
+        x: preferred.x + dir.x * step * CASCADE_STEP_PX,
+        y: preferred.y + dir.y * step * CASCADE_STEP_PX,
+      }
+      const box = boxAt(candidate)
+      if (isFree(box) && insideVisible(box)) return candidate
+    }
+  }
+  // The visible area is genuinely full: fall back to the unbounded cascade,
+  // which will land off-screen and be panned to — the correct outcome once
+  // there is nowhere left to put it.
   for (let step = 0; step < MAX_CASCADE_STEPS; step += 1) {
     const candidate = candidateAt(step)
-    const box = boxAt(candidate)
-    if (!occupied.some((other) => boxesIntersect(box, other))) return candidate
+    if (isFree(boxAt(candidate))) return candidate
   }
   return candidateAt(MAX_CASCADE_STEPS)
 }

--- a/apps/web/src/components/spatial-editor/node-factories.ts
+++ b/apps/web/src/components/spatial-editor/node-factories.ts
@@ -120,8 +120,9 @@ export function resolveSpawnPoint(
   preferred: Point,
   size: Size,
   occupied: readonly Box[],
+  visible?: Box,
 ): Point {
-  return anchor ?? findFreeSpot(preferred, size, occupied)
+  return anchor ?? findFreeSpot(preferred, size, occupied, visible)
 }
 
 export interface GroupEnclosure {

--- a/apps/web/src/components/spatial-editor/viewport.test.ts
+++ b/apps/web/src/components/spatial-editor/viewport.test.ts
@@ -199,6 +199,22 @@ describe('panToShowTarget', () => {
     expect(next.y).toBeCloseTo(540 + 40 + PAN_MARGIN_PX - (containerSize.height - 80), 0)
   })
 
+  it('reveals a box whose size is within a margin of the visible extent — both edges, not one', () => {
+    // The band the one-edge-at-a-time shift used to miss: tall enough that
+    // honouring the top margin pushes the bottom back under the dock, but
+    // still small enough to fit. A node landing 2px under the strip is the
+    // exact thing the pan exists to prevent.
+    const vp = { x: 0, y: 0, zoom: 1 }
+    const container = { width: 800, height: 280 }
+    const box = { x: 100, y: -100, width: 100, height: 200 }
+    const next = panToShowTarget(box, vp, container, { bottom: 70 })
+    if (next === undefined) throw new Error('expected a pan')
+    const top = canvasToScreen({ x: box.x, y: box.y }, next)
+    const bottom = canvasToScreen({ x: box.x + box.width, y: box.y + box.height }, next)
+    expect(top.y).toBeGreaterThanOrEqual(0)
+    expect(bottom.y).toBeLessThanOrEqual(container.height - 70)
+  })
+
   it('centers on an axis the box cannot fit on, since no pan can reveal all of it', () => {
     const vp = { x: 0, y: 0, zoom: 1 }
     const box = { x: 0, y: 0, width: 100, height: 2000 }

--- a/apps/web/src/components/spatial-editor/viewport.test.ts
+++ b/apps/web/src/components/spatial-editor/viewport.test.ts
@@ -8,6 +8,7 @@ import {
   IDENTITY_VIEWPORT,
   MAX_ZOOM,
   MIN_ZOOM,
+  PAN_MARGIN_PX,
   panBy,
   panToShowTarget,
   screenToCanvas,
@@ -173,14 +174,47 @@ describe('panToShowTarget', () => {
     )
   })
 
-  it('pans to center the box, keeping the current zoom, when it does not fit', () => {
-    const vp = { x: 0, y: 0, zoom: 2 }
-    const box = { x: 5000, y: 5000, width: 100, height: 100 }
+  it('pans the MINIMUM distance, not to the center: making something must not slide the canvas', () => {
+    const vp = { x: 0, y: 0, zoom: 1 }
+    // 40px below the bottom edge. Centering would move the canvas by ~340px
+    // and take every other node with it — the whole board lurches under the
+    // hand of someone who only added one note.
+    const box = { x: 100, y: 580, width: 100, height: 60 }
     const next = panToShowTarget(box, vp, containerSize)
-    expect(next?.zoom).toBe(2)
-    const centerScreen = canvasToScreen({ x: 5050, y: 5050 }, next as typeof vp)
-    expect(centerScreen.x).toBeCloseTo(containerSize.width / 2)
-    expect(centerScreen.y).toBeCloseTo(containerSize.height / 2)
+    if (next === undefined) throw new Error('expected a pan')
+    expect(next.zoom).toBe(1)
+    // Horizontally already visible: untouched.
+    expect(next.x).toBe(0)
+    // Just far enough that the box's bottom clears the edge, plus the margin.
+    expect(next.y).toBeCloseTo(580 + 60 + PAN_MARGIN_PX - containerSize.height, 0)
+  })
+
+  it('treats the bottom dock as not-visible: a box under it is panned clear', () => {
+    const vp = { x: 0, y: 0, zoom: 1 }
+    // Fully inside the container, but underneath the dock's strip.
+    const box = { x: 100, y: 540, width: 100, height: 40 }
+    expect(panToShowTarget(box, vp, containerSize)).toBe(undefined)
+    const next = panToShowTarget(box, vp, containerSize, { bottom: 80 })
+    if (next === undefined) throw new Error('expected a pan out from under the dock')
+    expect(next.y).toBeCloseTo(540 + 40 + PAN_MARGIN_PX - (containerSize.height - 80), 0)
+  })
+
+  it('centers on an axis the box cannot fit on, since no pan can reveal all of it', () => {
+    const vp = { x: 0, y: 0, zoom: 1 }
+    const box = { x: 0, y: 0, width: 100, height: 2000 }
+    const next = panToShowTarget(box, vp, containerSize)
+    if (next === undefined) throw new Error('expected a pan')
+    const center = canvasToScreen({ x: 50, y: 1000 }, next)
+    expect(center.y).toBeCloseTo(containerSize.height / 2, 0)
+  })
+
+  it('scales the pan by zoom — the distance is in screen pixels, the viewport is in canvas units', () => {
+    const vp = { x: 0, y: 0, zoom: 2 }
+    const box = { x: 100, y: 320, width: 50, height: 50 }
+    const next = panToShowTarget(box, vp, containerSize)
+    if (next === undefined) throw new Error('expected a pan')
+    // Box bottom sits at 740 screen px; it must end at 600 - PAN_MARGIN_PX.
+    expect(next.y).toBeCloseTo((740 + PAN_MARGIN_PX - containerSize.height) / 2, 0)
   })
 
   it('returns undefined when containerSize is null (root not yet measured)', () => {

--- a/apps/web/src/components/spatial-editor/viewport.ts
+++ b/apps/web/src/components/spatial-editor/viewport.ts
@@ -182,25 +182,56 @@ export function frameViewport(
  * "already visible" (nothing to pan) or `containerSize: null` (root not yet
  * measured, nothing to pan against).
  */
+/** Breathing room left between a revealed box and the edge that hid it. */
+export const PAN_MARGIN_PX = 12
+
+/**
+ * Chrome painted OVER the canvas, which the viewport must not treat as
+ * visible space. Today that is the bottom dock; a node parked underneath it
+ * is as invisible as one past the edge, and the creation cascade walks
+ * straight into that strip.
+ */
+export interface ViewportOcclusion {
+  readonly bottom: number
+}
+
+/** How far one axis must move so [start,end] lands inside [min,max]. */
+function shiftToReveal(start: number, end: number, min: number, max: number): number {
+  // Too big to reveal whole — center it, because every pan leaves some of it
+  // off-screen and the middle is the least arbitrary choice.
+  if (end - start > max - min) return (start + end) / 2 - (min + max) / 2
+  if (start < min + PAN_MARGIN_PX) return start - (min + PAN_MARGIN_PX)
+  if (end > max - PAN_MARGIN_PX) return end - (max - PAN_MARGIN_PX)
+  return 0
+}
+
+/**
+ * Moves the viewport the LEAST it can to reveal `box`, or leaves it alone.
+ *
+ * Not a re-center: creating something is not a request to go somewhere. A
+ * center-on-create slides the whole board by hundreds of pixels every time a
+ * note is added, so the thing just made appears in the middle while
+ * everything already on the canvas walks off under the hand of the person
+ * who only added one node.
+ */
 export function panToShowTarget(
   box: BBoxLike,
   viewport: Viewport,
   containerSize: ContainerSize | null,
+  occlusion?: ViewportOcclusion,
 ): Viewport | undefined {
   if (containerSize === null) return undefined
   const topLeft = canvasToScreen({ x: box.x, y: box.y }, viewport)
   const bottomRight = canvasToScreen({ x: box.x + box.width, y: box.y + box.height }, viewport)
+  const visibleBottom = containerSize.height - (occlusion?.bottom ?? 0)
   const fits =
     topLeft.x >= 0 &&
     topLeft.y >= 0 &&
     bottomRight.x <= containerSize.width &&
-    bottomRight.y <= containerSize.height
+    bottomRight.y <= visibleBottom
   if (fits) return undefined
-  const centerX = box.x + box.width / 2
-  const centerY = box.y + box.height / 2
-  return {
-    ...viewport,
-    x: centerX - containerSize.width / 2 / viewport.zoom,
-    y: centerY - containerSize.height / 2 / viewport.zoom,
-  }
+  const dx = shiftToReveal(topLeft.x, bottomRight.x, 0, containerSize.width)
+  const dy = shiftToReveal(topLeft.y, bottomRight.y, 0, visibleBottom)
+  // The shifts are screen pixels; the viewport origin is canvas units.
+  return { ...viewport, x: viewport.x + dx / viewport.zoom, y: viewport.y + dy / viewport.zoom }
 }

--- a/apps/web/src/components/spatial-editor/viewport.ts
+++ b/apps/web/src/components/spatial-editor/viewport.ts
@@ -197,9 +197,12 @@ export interface ViewportOcclusion {
 
 /** How far one axis must move so [start,end] lands inside [min,max]. */
 function shiftToReveal(start: number, end: number, min: number, max: number): number {
-  // Too big to reveal whole — center it, because every pan leaves some of it
-  // off-screen and the middle is the least arbitrary choice.
-  if (end - start > max - min) return (start + end) / 2 - (min + max) / 2
+  // Centre whenever both margins cannot be honoured at once. Only ONE edge
+  // is corrected below, so a box within a margin of the full extent would
+  // otherwise be pushed clear of one edge and left hanging past the other —
+  // still under the dock, by up to PAN_MARGIN_PX. Centring reveals any box
+  // that fits at all, so no clamp is needed after it.
+  if (end - start > max - min - 2 * PAN_MARGIN_PX) return (start + end) / 2 - (min + max) / 2
   if (start < min + PAN_MARGIN_PX) return start - (min + PAN_MARGIN_PX)
   if (end > max - PAN_MARGIN_PX) return end - (max - PAN_MARGIN_PX)
   return 0


### PR DESCRIPTION
Two dogfooding reports from a phone, one cause each, and they turned out to be two ends of the same bug: **the view moves when you make something**, and **new notes walk under the toolbar**.

## Measured first

On the real app at 390px, creating six rectangles:

| | viewport moved | nodes visible |
|---|---|---|
| before | **5 of 5** times after the first (120px each) | 4 |
| after | **1 of 5** (only when the screen genuinely filled) | 7 |

Every creation re-centred the board. The reason nothing ever appeared under the dock was that the view kept *chasing* the new node — so fixing the sliding would have created the second report.

## Before / after (390px, six creations)

![before-creation.png](https://github.com/user-attachments/assets/03279619-c29c-47e5-becd-ecb590f77113)
![after-creation.png](https://github.com/user-attachments/assets/4ef83392-0bdb-4f7c-a064-f5a57f5c8f14)

## What changed

**`panToShowTarget` re-centred** whenever the new node was not fully visible. Centring is the largest possible move; "show me what I just made" asks for the smallest one. It now shifts by the minimum per axis, and only centres on an axis whose content cannot fit at all.

**`findFreeSpot` cascaded down-right without bound**, so the spot itself walked off-screen and the pan chased it. It now prefers a free spot **inside the visible rectangle** — the familiar down-right diagonal first, then the other diagonals, then the orthogonals, because a phone is far taller than it is wide and once the diagonals hit the side edge a straight column down is the only shape that still fits. It falls back to the old unbounded cascade when the screen is genuinely full, where panning *is* the right outcome.

**The visible rectangle excludes the bottom dock.** That closes the second report in the same breath: the cascade used to walk into the strip the dock paints over, where a node is as invisible as one past the edge, and nothing in the viewport maths knew the dock existed.

`DOCK_OCCLUSION_PX` is a constant rather than a measurement, so a browser test pins it against the dock's **real rendered height** — that test is the only thing standing between a class change on the dock and nodes quietly parking underneath again.

## Verification

- `pnpm test --project web-browser` — 522 passed, run twice for stability
- apps/web jsdom — 2042 passed; `pnpm -r typecheck` clean
- New: 4 unit tests on the pan maths (minimal pan, occlusion, zoom scaling, unfittable axis), 2 on placement (stays in view; narrow-viewport column), 2 browser tests (viewport does not move while there is room; nothing under the dock)
- One honest note: my first version of these browser tests created 8 nodes per test and destabilised the suite — a different test failed on each full run. They now create 4–5, which pins the same behaviour without making this the heaviest file in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Newly created rectangles, notes, links, images, file references, and groups now avoid being hidden beneath the bottom tool dock.
  - The editor keeps newly created content visible with minimal panning instead of unnecessarily recentering the canvas.
  - Content larger than the available viewport is positioned and revealed more reliably.

- **Tests**
  - Added coverage for dock overlap, repeated creation, visible placement, narrow viewports, and viewport panning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->