### PR TITLE
feat(web): redesign the OKF markdown editor surface

### DIFF
--- a/apps/web/src/components/markdown-editor/DocumentHeader.tsx
+++ b/apps/web/src/components/markdown-editor/DocumentHeader.tsx
@@ -1,0 +1,39 @@
+import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
+
+export interface DocumentHeaderProps {
+  readonly meta: CanvasCoreMeta
+}
+
+/**
+ * The rendered projection of the OKF core facets, shown above the document
+ * body in Read mode. Display-only by design: facet EDITING stays in
+ * `CanvasProperties` (the header row), which owns the whole-`CanvasCoreMeta`
+ * emit contract — a second editor here would race it. The title rendered
+ * here is the workspace display name's projection, exactly what `title:`
+ * frontmatter serialises to.
+ */
+export function DocumentHeader({ meta }: DocumentHeaderProps) {
+  const tags = meta.tags ?? []
+  return (
+    <header
+      data-testid="markdown-document-header"
+      className="border-border mb-8 flex flex-col gap-3 border-b pb-6"
+    >
+      {meta.title !== undefined && meta.title !== '' && (
+        <h2 className="text-foreground text-3xl font-semibold tracking-tight text-balance">
+          {meta.title}
+        </h2>
+      )}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <span className="border-border text-muted-foreground rounded-md border px-2 py-0.5 text-xs font-medium">
+          {meta.type}
+        </span>
+        {tags.map((tag) => (
+          <span key={tag} className="text-muted-foreground text-xs">
+            #{tag}
+          </span>
+        ))}
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/components/markdown-editor/EditorToolbar.tsx
+++ b/apps/web/src/components/markdown-editor/EditorToolbar.tsx
@@ -1,0 +1,125 @@
+import { Bold, BookOpen, Code, Columns2, Italic, PenLine } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '../../lib/utils.js'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
+
+export type MarkdownViewMode = 'write' | 'split' | 'read'
+
+export interface EditorToolbarProps {
+  readonly mode: MarkdownViewMode
+  readonly onModeChange: (mode: MarkdownViewMode) => void
+  /** Split needs room for two columns; narrow containers drop the option. */
+  readonly splitAvailable: boolean
+  readonly wordCount: number
+  /** Wraps the current source selection (same commands as Mod-b / Mod-i). */
+  readonly onFormat: (delimiter: string) => void
+  /** Formatting targets the source pane, so Read mode disables it. */
+  readonly formattingEnabled: boolean
+}
+
+interface ModeOption {
+  readonly mode: MarkdownViewMode
+  readonly label: string
+  readonly icon: LucideIcon
+}
+
+const MODE_OPTIONS: readonly ModeOption[] = [
+  { mode: 'write', label: 'Write', icon: PenLine },
+  { mode: 'split', label: 'Split', icon: Columns2 },
+  { mode: 'read', label: 'Read', icon: BookOpen },
+]
+
+interface FormatAction {
+  readonly label: string
+  readonly delimiter: string
+  readonly icon: LucideIcon
+  readonly shortcut: string
+}
+
+const FORMAT_ACTIONS: readonly FormatAction[] = [
+  { label: 'Bold', delimiter: '**', icon: Bold, shortcut: '⌘B' },
+  { label: 'Italic', delimiter: '*', icon: Italic, shortcut: '⌘I' },
+  { label: 'Code', delimiter: '`', icon: Code, shortcut: '' },
+]
+
+/**
+ * The markdown editor's one chrome strip: formatting on the left, word
+ * count + view mode on the right. Deliberately shallow — no heading/list
+ * menus, no insert gallery — because the source pane is the real editing
+ * surface and this row must recede next to it (quiet-tool rule).
+ */
+export function EditorToolbar({
+  mode,
+  onModeChange,
+  splitAvailable,
+  wordCount,
+  onFormat,
+  formattingEnabled,
+}: EditorToolbarProps) {
+  return (
+    <div className="border-border bg-background flex h-10 shrink-0 items-center gap-1 border-b px-2">
+      <div className="flex items-center gap-0.5" role="group" aria-label="Formatting">
+        {FORMAT_ACTIONS.map(({ label, delimiter, icon: Icon, shortcut }) => (
+          <Tooltip key={label}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={label}
+                disabled={!formattingEnabled}
+                // Keep focus (and therefore the selection) in the source
+                // pane: a focused toolbar button would collapse the very
+                // selection the command is about to wrap.
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => onFormat(delimiter)}
+                className="text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring inline-flex size-7 items-center justify-center rounded-md transition-colors duration-(--motion-duration-fast) focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40"
+              >
+                <Icon aria-hidden className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{shortcut === '' ? label : `${label} ${shortcut}`}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-3">
+        <span
+          data-testid="markdown-word-count"
+          className="text-muted-foreground hidden text-xs tabular-nums sm:block"
+        >
+          {wordCount === 1 ? '1 word' : `${wordCount} words`}
+        </span>
+        <div
+          className="bg-muted flex items-center gap-0.5 rounded-lg p-0.5"
+          role="group"
+          aria-label="View mode"
+        >
+          {MODE_OPTIONS.map(({ mode: option, label, icon: Icon }) => {
+            if (option === 'split' && !splitAvailable) return null
+            const active = option === mode
+            return (
+              <Tooltip key={option}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={label}
+                    aria-pressed={active}
+                    onClick={() => onModeChange(option)}
+                    className={cn(
+                      'focus-visible:ring-ring inline-flex h-6 items-center justify-center rounded-md px-2 transition-colors duration-(--motion-duration-fast) focus-visible:ring-2 focus-visible:outline-none',
+                      active
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <Icon aria-hidden className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{label}</TooltipContent>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/markdown-editor/EditorToolbar.tsx
+++ b/apps/web/src/components/markdown-editor/EditorToolbar.tsx
@@ -1,5 +1,5 @@
-import { Bold, BookOpen, Code, Columns2, Italic, PenLine } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import { Bold, BookOpen, Code, Columns2, Italic, PenLine } from 'lucide-react'
 import { cn } from '../../lib/utils.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 
@@ -58,7 +58,7 @@ export function EditorToolbar({
 }: EditorToolbarProps) {
   return (
     <div className="border-border bg-background flex h-10 shrink-0 items-center gap-1 border-b px-2">
-      <div className="flex items-center gap-0.5" role="group" aria-label="Formatting">
+      <fieldset className="flex items-center gap-0.5" aria-label="Formatting">
         {FORMAT_ACTIONS.map(({ label, delimiter, icon: Icon, shortcut }) => (
           <Tooltip key={label}>
             <TooltipTrigger asChild>
@@ -79,7 +79,7 @@ export function EditorToolbar({
             <TooltipContent>{shortcut === '' ? label : `${label} ${shortcut}`}</TooltipContent>
           </Tooltip>
         ))}
-      </div>
+      </fieldset>
 
       <div className="ml-auto flex items-center gap-3">
         <span
@@ -88,9 +88,8 @@ export function EditorToolbar({
         >
           {wordCount === 1 ? '1 word' : `${wordCount} words`}
         </span>
-        <div
+        <fieldset
           className="bg-muted flex items-center gap-0.5 rounded-lg p-0.5"
-          role="group"
           aria-label="View mode"
         >
           {MODE_OPTIONS.map(({ mode: option, label, icon: Icon }) => {
@@ -118,7 +117,7 @@ export function EditorToolbar({
               </Tooltip>
             )
           })}
-        </div>
+        </fieldset>
       </div>
     </div>
   )

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
@@ -1,10 +1,11 @@
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
   cleanup()
   vi.useRealTimers()
+  window.localStorage.clear()
 })
 
 describe('MarkdownEditor', () => {
@@ -31,5 +32,70 @@ describe('MarkdownEditor', () => {
     })
     expect(getByTestId('markdown-preview-pane').textContent).toContain('Changed')
     expect(original).toBe('# Original')
+  })
+
+  it('Read mode hides the source pane without unmounting it; Write mode drops the preview', () => {
+    const { getByTestId, getByRole, queryByTestId } = render(
+      <MarkdownEditor value="# Hi" onChange={() => {}} />,
+    )
+    // Default: split — both panes and the divider.
+    expect(getByTestId('markdown-split-divider')).toBeTruthy()
+
+    fireEvent.click(getByRole('button', { name: 'Read' }))
+    // Still mounted (CodeMirror keeps its undo history), only hidden.
+    const sourceWrap = getByTestId('markdown-source-wrap')
+    expect(sourceWrap.style.display).toBe('none')
+    expect(getByTestId('markdown-preview-pane')).toBeTruthy()
+    expect(queryByTestId('markdown-split-divider')).toBeNull()
+
+    fireEvent.click(getByRole('button', { name: 'Write' }))
+    expect(sourceWrap.style.display).not.toBe('none')
+    expect(queryByTestId('markdown-preview-pane')).toBeNull()
+    expect(queryByTestId('markdown-split-divider')).toBeNull()
+  })
+
+  it('persists the chosen view mode and restores it on the next mount', () => {
+    const first = render(<MarkdownEditor value="# Hi" onChange={() => {}} />)
+    fireEvent.click(first.getByRole('button', { name: 'Read' }))
+    first.unmount()
+
+    const second = render(<MarkdownEditor value="# Hi" onChange={() => {}} />)
+    expect(second.getByTestId('markdown-source-wrap').style.display).toBe('none')
+    expect(second.getByRole('button', { name: 'Read' }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('shows a word count that follows the debounced value', async () => {
+    vi.useFakeTimers()
+    const { getByTestId, rerender } = render(
+      <MarkdownEditor value="# Hi there" onChange={() => {}} previewDebounceMs={150} />,
+    )
+    await act(async () => {
+      vi.advanceTimersByTime(150)
+    })
+    // "#" is markup, not a word.
+    expect(getByTestId('markdown-word-count').textContent).toContain('2')
+    rerender(
+      <MarkdownEditor value="# Hi there again" onChange={() => {}} previewDebounceMs={150} />,
+    )
+    await act(async () => {
+      vi.advanceTimersByTime(150)
+    })
+    expect(getByTestId('markdown-word-count').textContent).toContain('3')
+  })
+
+  it('renders the core facets as a document header in Read mode', () => {
+    const { getByRole, getByTestId } = render(
+      <MarkdownEditor
+        value="body"
+        onChange={() => {}}
+        meta={{ type: 'issue', title: 'Release plan', tags: ['q3', 'infra'] }}
+      />,
+    )
+    fireEvent.click(getByRole('button', { name: 'Read' }))
+    const header = getByTestId('markdown-document-header')
+    expect(header.textContent).toContain('Release plan')
+    expect(header.textContent).toContain('issue')
+    expect(header.textContent).toContain('q3')
+    expect(header.textContent).toContain('infra')
   })
 })

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
@@ -83,6 +83,54 @@ describe('MarkdownEditor', () => {
     expect(getByTestId('markdown-word-count').textContent).toContain('3')
   })
 
+  it('disables the formatting buttons in Read mode and re-enables them in Write', () => {
+    const { getByRole } = render(<MarkdownEditor value="# Hi" onChange={() => {}} />)
+    const bold = getByRole('button', { name: 'Bold' }) as HTMLButtonElement
+    expect(bold.disabled).toBe(false)
+
+    fireEvent.click(getByRole('button', { name: 'Read' }))
+    expect(bold.disabled).toBe(true)
+
+    fireEvent.click(getByRole('button', { name: 'Write' }))
+    expect(bold.disabled).toBe(false)
+  })
+
+  it('falls back from Split to Write in a narrow container, reflecting it in the toolbar without overwriting the stored preference', () => {
+    // jsdom has no ResizeObserver; stub one that reports a narrow container.
+    class NarrowResizeObserver {
+      private readonly callback: ResizeObserverCallback
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+      observe() {
+        this.callback(
+          [{ contentRect: { width: 480 } } as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        )
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', NarrowResizeObserver)
+    try {
+      window.localStorage.setItem('whiteboard.markdown-view-mode', 'split')
+      const { getByRole, queryByTestId, queryByRole, getByTestId } = render(
+        <MarkdownEditor value="# Hi" onChange={() => {}} />,
+      )
+      // Write layout is in effect: source only, no divider, no preview.
+      expect(getByTestId('markdown-source-wrap').style.display).not.toBe('none')
+      expect(queryByTestId('markdown-split-divider')).toBeNull()
+      expect(queryByTestId('markdown-preview-pane')).toBeNull()
+      // The toolbar reflects the EFFECTIVE mode (Split is not offered at all).
+      expect(queryByRole('button', { name: 'Split' })).toBeNull()
+      expect(getByRole('button', { name: 'Write' }).getAttribute('aria-pressed')).toBe('true')
+      // The stored preference survives the fallback.
+      expect(window.localStorage.getItem('whiteboard.markdown-view-mode')).toBe('split')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('renders the core facets as a document header in Read mode', () => {
     const { getByRole, getByTestId } = render(
       <MarkdownEditor

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -14,7 +14,7 @@ import { cn } from '../../lib/utils.js'
 import { DocumentHeader } from './DocumentHeader.js'
 import { EditorToolbar, type MarkdownViewMode } from './EditorToolbar.js'
 import { PreviewPane } from './PreviewPane.js'
-import { type SourcePaneApi, SourcePane } from './SourcePane.js'
+import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { useDebouncedValue } from './use-debounced-value.js'
 
 export interface MarkdownEditorProps {

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -219,7 +219,10 @@ export function MarkdownEditor({
   return (
     <div ref={rootRef} className={cn('flex h-full w-full min-w-0 flex-col', className)}>
       <EditorToolbar
-        mode={mode}
+        // The EFFECTIVE mode, not the stored preference: on a narrow
+        // container a stored 'split' renders as Write, and the toolbar's
+        // active state (and aria-pressed) must describe what is on screen.
+        mode={effectiveMode}
         onModeChange={changeMode}
         splitAvailable={splitAvailable}
         wordCount={wordCount}

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
@@ -9,15 +10,18 @@ import {
   useState,
 } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { cn } from '../../lib/utils.js'
+import { DocumentHeader } from './DocumentHeader.js'
+import { EditorToolbar, type MarkdownViewMode } from './EditorToolbar.js'
 import { PreviewPane } from './PreviewPane.js'
-import { SourcePane } from './SourcePane.js'
+import { type SourcePaneApi, SourcePane } from './SourcePane.js'
 import { useDebouncedValue } from './use-debounced-value.js'
 
 export interface MarkdownEditorProps {
   value: string
   onChange: (next: string) => void
   className?: string
-  /** Preview layout width in px. Defaults to a reasonable single-pane width. */
+  /** Upper bound for the preview's layout width in px. */
   maxWidth?: number
   /** Trailing-edge debounce delay for preview recomputation. Default 150ms. */
   previewDebounceMs?: number
@@ -27,17 +31,29 @@ export interface MarkdownEditorProps {
   autoFocus?: boolean
   /** Resolved app theme; drives the preview's inherited text fill. */
   theme?: ResolvedTheme
+  /**
+   * Core OKF facets, rendered as the document header in Read mode —
+   * display-only; facet editing stays in `CanvasProperties`.
+   */
+  meta?: CanvasCoreMeta
 }
 
-const DEFAULT_MAX_WIDTH = 480
+const DEFAULT_MAX_WIDTH = 720
 const DEFAULT_PREVIEW_DEBOUNCE_MS = 150
+const MIN_PREVIEW_WIDTH = 320
 
 /**
  * A controlled markdown editor: one source-of-truth `value` string, edited
- * through a CodeMirror 6 source pane on the left and previewed on the right
- * through `renderMarkdownPreviewSvg` — the same parse -> layout -> SVG path
- * the spatial canvas's text node and export use, so there is no second
+ * through a CodeMirror 6 source pane and previewed through
+ * `renderMarkdownPreviewSvg` — the same parse -> layout -> SVG path the
+ * spatial canvas's text node and export use, so there is no second
  * markdown-to-HTML renderer to drift from it.
+ *
+ * Three view modes (Write / Split / Read), persisted per browser. Read
+ * HIDES the source pane instead of unmounting it, so the CodeMirror undo
+ * history survives a Read -> Write round trip. Split needs room for two
+ * columns; a container narrower than `SPLIT_MIN_WIDTH` falls back to Write
+ * without overwriting the stored preference.
  *
  * Deliberately out of scope, each for a specific reason:
  * - CRDT binding (`loro-codemirror`) belongs to the sync slice: binding a
@@ -59,6 +75,25 @@ const DEFAULT_PREVIEW_DEBOUNCE_MS = 150
 const MIN_SPLIT_RATIO = 0.2
 const MAX_SPLIT_RATIO = 0.8
 const KEYBOARD_SPLIT_STEP = 0.05
+const SPLIT_MIN_WIDTH = 640
+const VIEW_MODE_STORAGE_KEY = 'whiteboard.markdown-view-mode'
+
+function isViewMode(value: unknown): value is MarkdownViewMode {
+  return value === 'write' || value === 'split' || value === 'read'
+}
+
+function readStoredViewMode(): MarkdownViewMode {
+  try {
+    const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
+    return isViewMode(stored) ? stored : 'split'
+  } catch {
+    return 'split'
+  }
+}
+
+function countWords(value: string): number {
+  return (value.match(/[\p{L}\p{N}]+/gu) ?? []).length
+}
 
 export function MarkdownEditor({
   value,
@@ -69,15 +104,46 @@ export function MarkdownEditor({
   measure,
   autoFocus = false,
   theme = 'light',
+  meta,
 }: MarkdownEditorProps) {
   const resolvedMeasure = useMemo(() => measure ?? createBrowserMeasureText(), [measure])
   const debouncedValue = useDebouncedValue(value, previewDebounceMs)
+
+  const [mode, setMode] = useState<MarkdownViewMode>(readStoredViewMode)
+  const changeMode = (next: MarkdownViewMode) => {
+    setMode(next)
+    try {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, next)
+    } catch {
+      // Preference persistence is best-effort; the session state still works.
+    }
+  }
 
   // Source-pane share of the split, clamped so neither pane can vanish.
   const [splitRatio, setSplitRatio] = useState(0.5)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const sourceWrapRef = useRef<HTMLDivElement | null>(null)
   const previewScrollRef = useRef<HTMLDivElement | null>(null)
+  const sourceApiRef = useRef<SourcePaneApi | null>(null)
+
+  // Container width drives the split fallback and the preview's adaptive
+  // layout width. `null` (pre-observation, or jsdom without ResizeObserver)
+  // is treated as wide, matching the split-by-default contract the existing
+  // tests pin.
+  const [containerWidth, setContainerWidth] = useState<number | null>(null)
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width
+      if (width !== undefined && width > 0) setContainerWidth(width)
+    })
+    observer.observe(root)
+    return () => observer.disconnect()
+  }, [])
+
+  const splitAvailable = containerWidth === null || containerWidth >= SPLIT_MIN_WIDTH
+  const effectiveMode: MarkdownViewMode = mode === 'split' && !splitAvailable ? 'write' : mode
 
   const clampRatio = (ratio: number) => Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio))
 
@@ -85,9 +151,9 @@ export function MarkdownEditor({
   const onDividerPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return
     draggingRef.current = true
-    // Capture keeps the drag alive when the pointer outruns the 4px
-    // divider; a synthetic test event has no active pointer to capture,
-    // so a capture failure must not abort the drag itself.
+    // Capture keeps the drag alive when the pointer outruns the divider;
+    // a synthetic test event has no active pointer to capture, so a
+    // capture failure must not abort the drag itself.
     try {
       event.currentTarget.setPointerCapture(event.pointerId)
     } catch {
@@ -131,50 +197,93 @@ export function MarkdownEditor({
     return () => scroller.removeEventListener('scroll', onScroll)
   }, [])
 
+  // Layout width the preview typesets at: what the pane can actually offer
+  // (minus the document column's padding), clamped to a readable measure.
+  const horizontalPadding = 48
+  const paneWidth =
+    containerWidth === null
+      ? maxWidth
+      : effectiveMode === 'split'
+        ? containerWidth * (1 - splitRatio)
+        : containerWidth
+  // Quantized so a divider drag re-typesets the whole document at 64px
+  // steps instead of on every pointermove.
+  const previewWidth = Math.max(
+    MIN_PREVIEW_WIDTH,
+    Math.min(maxWidth, Math.round((paneWidth - horizontalPadding) / 64) * 64),
+  )
+
+  const wordCount = useMemo(() => countWords(debouncedValue), [debouncedValue])
+  const previewEmpty = debouncedValue.trim() === ''
+
   return (
-    <div
-      ref={rootRef}
-      className={className}
-      style={{ display: 'flex', width: '100%', height: '100%', minWidth: 0 }}
-    >
-      <div
-        ref={sourceWrapRef}
-        style={{ flexBasis: `${splitRatio * 100}%`, minWidth: 0, display: 'flex' }}
-      >
-        <SourcePane
-          value={value}
-          onChange={onChange}
-          autoFocus={autoFocus}
-          className="markdown-editor-source"
-        />
-      </div>
-      {/* biome-ignore lint/a11y/useSemanticElements: this is the ARIA window-splitter pattern (focusable, arrow-key operable separator); an <hr> cannot take focus or a value */}
-      <div
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize editor and preview"
-        aria-valuenow={Math.round(splitRatio * 100)}
-        aria-valuemin={MIN_SPLIT_RATIO * 100}
-        aria-valuemax={MAX_SPLIT_RATIO * 100}
-        tabIndex={0}
-        data-testid="markdown-split-divider"
-        onPointerDown={onDividerPointerDown}
-        onPointerMove={onDividerPointerMove}
-        onPointerUp={onDividerPointerUp}
-        onKeyDown={onDividerKeyDown}
-        className="bg-border hover:bg-ring focus-visible:bg-ring w-1 shrink-0 cursor-col-resize"
+    <div ref={rootRef} className={cn('flex h-full w-full min-w-0 flex-col', className)}>
+      <EditorToolbar
+        mode={mode}
+        onModeChange={changeMode}
+        splitAvailable={splitAvailable}
+        wordCount={wordCount}
+        formattingEnabled={effectiveMode !== 'read'}
+        onFormat={(delimiter) => sourceApiRef.current?.wrapSelection(delimiter)}
       />
-      <div
-        ref={previewScrollRef}
-        data-testid="markdown-preview-scroll"
-        style={{ flex: 1, minWidth: 0, overflow: 'auto' }}
-      >
-        <PreviewPane
-          value={debouncedValue}
-          maxWidth={maxWidth}
-          measure={resolvedMeasure}
-          theme={theme}
-        />
+      <div className="flex min-h-0 flex-1">
+        <div
+          ref={sourceWrapRef}
+          data-testid="markdown-source-wrap"
+          style={{
+            display: effectiveMode === 'read' ? 'none' : 'flex',
+            flexBasis: effectiveMode === 'split' ? `${splitRatio * 100}%` : '100%',
+            minWidth: 0,
+          }}
+        >
+          <SourcePane
+            value={value}
+            onChange={onChange}
+            autoFocus={autoFocus}
+            apiRef={sourceApiRef}
+            placeholderText="Write in Markdown…"
+            className="markdown-editor-source"
+          />
+        </div>
+        {effectiveMode === 'split' && (
+          // biome-ignore lint/a11y/useSemanticElements: this is the ARIA window-splitter pattern (focusable, arrow-key operable separator); an <hr> cannot take focus or a value
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize editor and preview"
+            aria-valuenow={Math.round(splitRatio * 100)}
+            aria-valuemin={MIN_SPLIT_RATIO * 100}
+            aria-valuemax={MAX_SPLIT_RATIO * 100}
+            tabIndex={0}
+            data-testid="markdown-split-divider"
+            onPointerDown={onDividerPointerDown}
+            onPointerMove={onDividerPointerMove}
+            onPointerUp={onDividerPointerUp}
+            onKeyDown={onDividerKeyDown}
+            className="bg-border hover:bg-ring focus-visible:bg-ring w-1 shrink-0 cursor-col-resize touch-none transition-colors duration-(--motion-duration-fast) focus-visible:outline-none"
+          />
+        )}
+        {effectiveMode !== 'write' && (
+          <div
+            ref={previewScrollRef}
+            data-testid="markdown-preview-scroll"
+            className="min-w-0 flex-1 overflow-auto"
+          >
+            <div className="mx-auto px-6 py-8" style={{ maxWidth: previewWidth + 48 }}>
+              {effectiveMode === 'read' && meta !== undefined && <DocumentHeader meta={meta} />}
+              {previewEmpty ? (
+                <p className="text-muted-foreground text-sm">Nothing to preview yet.</p>
+              ) : (
+                <PreviewPane
+                  value={debouncedValue}
+                  maxWidth={previewWidth}
+                  measure={resolvedMeasure}
+                  theme={theme}
+                />
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -2,10 +2,10 @@ import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirro
 import { markdown } from '@codemirror/lang-markdown'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { EditorSelection, EditorState, type StateCommand } from '@codemirror/state'
-import { EditorView, keymap } from '@codemirror/view'
+import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
 import { GFM } from '@lezer/markdown'
-import { useEffect, useRef } from 'react'
+import { type RefObject, useEffect, useRef } from 'react'
 import { minimalChange } from './minimal-change.js'
 
 // Wraps each selection range in `delimiter` (Mod-b -> **, Mod-i -> *). A
@@ -65,12 +65,26 @@ const markdownHighlightStyle = HighlightStyle.define([
   { tag: tags.processingInstruction, class: 'cm-md-marker' },
 ])
 
+/**
+ * Imperative surface the toolbar drives. Kept to commands that need the
+ * live `EditorView` (selection, focus) — everything else flows through the
+ * controlled `value`/`onChange` pair.
+ */
+export interface SourcePaneApi {
+  wrapSelection: (delimiter: string) => void
+  focus: () => void
+}
+
 export interface SourcePaneProps {
   value: string
   onChange: (next: string) => void
   className?: string
   /** Focus the editor as soon as it mounts (fresh-note flows). */
   autoFocus?: boolean
+  /** Shown while the document is empty. */
+  placeholderText?: string
+  /** Receives the imperative API while the view is mounted, null after. */
+  apiRef?: RefObject<SourcePaneApi | null>
 }
 
 /**
@@ -79,7 +93,14 @@ export interface SourcePaneProps {
  * kitchen sink (line numbers, search panel, etc.): this is an editing
  * surface for a markdown canvas, not a general-purpose IDE.
  */
-export function SourcePane({ value, onChange, className, autoFocus = false }: SourcePaneProps) {
+export function SourcePane({
+  value,
+  onChange,
+  className,
+  autoFocus = false,
+  placeholderText,
+  apiRef,
+}: SourcePaneProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
   // Always holds the latest onChange without forcing the effect below to
@@ -117,12 +138,28 @@ export function SourcePane({ value, onChange, className, autoFocus = false }: So
         // Prose, not code: long paragraphs soft-wrap instead of growing a
         // horizontal scrollbar.
         EditorView.lineWrapping,
+        ...(placeholderText !== undefined ? [placeholder(placeholderText)] : []),
         // Fill the host pane instead of sizing to content: without a
         // bounded height the scroller never scrolls and the pane collapses
         // to its padding inside a flex row.
+        //
+        // Prose, so the writing surface reads like the app, not a terminal:
+        // the scroller inherits the app font (CodeMirror's default is
+        // monospace) — which is also what makes index.css's `.cm-md-code`
+        // mono rule meaningful — and the content is a centered, bounded
+        // column (~70ch) like every serious writing surface, instead of
+        // lines that stretch across a widescreen pane.
         EditorView.theme({
-          '&': { height: '100%', width: '100%' },
-          '.cm-scroller': { overflow: 'auto' },
+          '&': { height: '100%', width: '100%', fontSize: '15px' },
+          '&.cm-focused': { outline: 'none' },
+          '.cm-scroller': { overflow: 'auto', fontFamily: 'inherit', lineHeight: '1.7' },
+          '.cm-content': {
+            maxWidth: '70ch',
+            margin: '0 auto',
+            padding: '24px 0 120px',
+            caretColor: 'var(--foreground)',
+          },
+          '.cm-line': { padding: '0 24px' },
         }),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
@@ -133,11 +170,21 @@ export function SourcePane({ value, onChange, className, autoFocus = false }: So
     })
     const view = new EditorView({ state, parent: host })
     viewRef.current = view
+    if (apiRef) {
+      apiRef.current = {
+        wrapSelection: (delimiter) => {
+          wrapSelectionWith(delimiter)({ state: view.state, dispatch: view.dispatch })
+          view.focus()
+        },
+        focus: () => view.focus(),
+      }
+    }
     if (autoFocus) view.focus()
 
     return () => {
       view.destroy()
       viewRef.current = null
+      if (apiRef) apiRef.current = null
     }
     // Intentionally created once per mount — external `value` changes are
     // reconciled below, not by recreating the view.

--- a/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
@@ -9,6 +9,7 @@ import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
   cleanup()
+  window.localStorage.clear()
 })
 
 describe('MarkdownEditor (real browser)', () => {
@@ -26,6 +27,28 @@ describe('MarkdownEditor (real browser)', () => {
     expect(onChange).toHaveBeenCalled()
     const lastCall = onChange.mock.calls.at(-1)?.[0]
     expect(lastCall).toBe('# Hello world')
+  })
+
+  it('the toolbar Bold button wraps the live selection without collapsing it', async () => {
+    const onChange = vi.fn()
+    const { getByTestId, getByRole } = render(
+      <MarkdownEditor value="make this bold" onChange={onChange} />,
+    )
+
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+
+    // Select the word "this" (offsets 5..9) from the document start.
+    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+    await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}')
+    await userEvent.keyboard('{Shift>}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{/Shift}')
+
+    await userEvent.click(getByRole('button', { name: 'Bold' }))
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('make **this** bold')
+
+    // The selection stayed live inside the delimiters: typing replaces it.
+    await userEvent.keyboard('that')
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('make **that** bold')
   })
 
   it('the preview SVG reflects real Canvas 2D text measurement: a longer preceding run yields a wider advance for the next run', async () => {

--- a/apps/web/src/components/markdown-editor/source-pane-reconcile.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/source-pane-reconcile.browser.test.tsx
@@ -69,7 +69,9 @@ describe('SourcePane external value reconciliation (real browser)', () => {
     const onChange = vi.fn()
     const { rerender } = render(<MarkdownEditor value={'keep me\ntail'} onChange={onChange} />)
 
-    await userEvent.click(editableOf())
+    // Click the FIRST LINE, not the content element: the content column has
+    // vertical padding, so its center point can map to a different line.
+    await userEvent.click(editableOf().querySelector('.cm-line') as HTMLElement)
     await userEvent.keyboard('{Home}')
     // Select "keep" on the first line.
     await userEvent.keyboard('{Shift>}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{/Shift}')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -688,6 +688,7 @@ export function BrowserLocalCanvasPage({
                   autoFocus
                   className="h-full"
                   theme={resolvedTheme}
+                  meta={markdownDoc.coreMeta}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary

Redesigns the OKF (markdown) editor surface in apps/web. The previous surface was a bare 50/50 CodeMirror + SVG split with the core facets hidden behind an info toggle; this replaces it with a designed writing/reading experience while keeping every product contract intact:

- **Single renderer preserved** — the preview still goes through canvas-codec → canvas-render (`renderMarkdownPreviewSvg`), the same parse → layout → SVG path spatial text nodes, export, and embedded notes use. No markdown-to-HTML renderer was introduced.
- **Facet contract preserved** — facet *editing* stays in `CanvasProperties` (whole-`CanvasCoreMeta` emits); the editor only *renders* facets.
- **CRDT contract preserved** — controlled `value`/`onChange` with `minimalChange` reconciliation is untouched.

## What changed

- **Write / Split / Read view modes** with a segmented control, persisted per browser (`localStorage`). Read hides the source pane without unmounting it, so CodeMirror undo history survives a Read → Write round trip. Containers narrower than 640px drop Split and fall back to Write without overwriting the stored preference — and the toolbar reflects the *effective* mode (review finding, fixed + pinned).
- **Facet rendering in Read mode**: the OKF core facets (title, `type` badge, `#tags`) render as a document header above the SVG body — the visible projection of the frontmatter.
- **Toolbar**: Bold / Italic / Code buttons (same `wrapSelection` commands as Mod-b/Mod-i, focus-preserving so the selection survives) plus a word count. Formatting disables in Read mode.
- **Writing surface**: app font instead of the CodeMirror monospace default, centered ~70ch column, placeholder, quiet marker colors.
- **Preview as a document**: layout width adapts to the pane (quantized to 64px steps so divider drags don't re-typeset per pointermove, clamped 320–720) and centers with padding; an empty document shows a quiet empty state instead of a blank pane.

## Review & tests

- Independent review workflow over the diff: 3 confirmed findings (1 correctness, 2 test-coverage), all resolved in follow-up commits with pinning tests.
- New coverage: mode switching/persistence, narrow-container fallback (stubbed ResizeObserver), Read-mode formatting-disabled state, facet document header, word count, and a real-browser regression for the Bold button.
- `pnpm test` failures on this machine are pre-existing/environmental only: 4 canvas-render pixel-goldens (macOS font rendering vs pinned goldens) and the spatial title round-trip test (`Ctrl+A` is not select-all on macOS; fails identically on baseline main — verified via clean stash run and a scratch worktree of `origin/main`).
- `typecheck`, `lint`, `knip` clean.

## Visual repro

Read mode, dark (facet header: title + type badge + tags above the SVG body):

![okf-editor-read-wide-dark.jpg](https://github.com/user-attachments/assets/0e798309-9319-4585-b4f2-07384451554a)

Read mode, light:

![okf-editor-read-wide-light.jpg](https://github.com/user-attachments/assets/41d32ec3-57ba-4b28-95e5-efb19939a801)

Narrow container (Split not offered, Write/Read only, word count hidden):

![okf-editor-read-narrow-light.jpg](https://github.com/user-attachments/assets/f8ae9b6c-dba6-430e-9392-30d3ad32e6a5)

## Test plan

- [x] jsdom + browser suites for `markdown-editor` (57 tests) green
- [x] Manual verification in Chrome: mode switching + persistence, facet header, Bold/Italic/Code, divider drag + keyboard, scroll sync, narrow fallback, both themes
- [x] Regression locked into jsdom + `web-browser` tests
