### PR TITLE
feat(canvas-workspace): let the workspace tree carry a document's name

### DIFF
--- a/packages/canvas-workspace/src/workspace-tree.test.ts
+++ b/packages/canvas-workspace/src/workspace-tree.test.ts
@@ -353,3 +353,67 @@ describe('WorkspaceTree', () => {
     })
   })
 })
+
+describe('display name', () => {
+  // ADR-0009: a document's name lives in the workspace, not in its content —
+  // OKF frontmatter `title` is a projection of it on serialise. The tree is
+  // the only workspace store the shared layer can reach, so the name has to
+  // be expressible here before anything can project it.
+  it('a node created without one has no display name', () => {
+    const tree = new WorkspaceTree(new LoroDoc())
+    const id = tree.createNode('c1', 'notes')
+
+    expect(tree.getNode(id)?.displayName).toBeUndefined()
+  })
+
+  it('carries a display name given at creation', () => {
+    const tree = new WorkspaceTree(new LoroDoc())
+    const id = tree.createNode('c1', 'notes', undefined, undefined, '設計メモ')
+
+    expect(tree.getNode(id)?.displayName).toBe('設計メモ')
+  })
+
+  it('renames the display name without touching the segment', () => {
+    // The two are separate concerns: `segment` is placement and is
+    // slug-validated, the display name is what a human reads and is free
+    // text. Renaming one must not move the other.
+    const tree = new WorkspaceTree(new LoroDoc())
+    const id = tree.createNode('c1', 'notes', undefined, undefined, 'Notes')
+
+    tree.setDisplayName(id, 'Release plan 2026')
+
+    expect(tree.getNode(id)).toMatchObject({
+      segment: 'notes',
+      displayName: 'Release plan 2026',
+    })
+  })
+
+  it('accepts a display name a segment could never be', () => {
+    const tree = new WorkspaceTree(new LoroDoc())
+    const id = tree.createNode('c1', 'doc')
+
+    tree.setDisplayName(id, 'リリース計画 2026 / v2')
+
+    expect(tree.getNode(id)?.displayName).toBe('リリース計画 2026 / v2')
+  })
+
+  it('clears the display name when set to empty, rather than storing a blank', () => {
+    // An absent name and a blank one must not be two states: every reader
+    // would have to test for both, and one of them would forget.
+    const tree = new WorkspaceTree(new LoroDoc())
+    const id = tree.createNode('c1', 'doc', undefined, undefined, 'Doc')
+
+    tree.setDisplayName(id, '   ')
+
+    expect(tree.getNode(id)?.displayName).toBeUndefined()
+  })
+
+  it('survives a snapshot round-trip', () => {
+    const tree = new WorkspaceTree(new LoroDoc())
+    tree.createNode('c1', 'doc', undefined, undefined, 'Doc one')
+
+    const restored = WorkspaceTree.fromSnapshot(tree.exportSnapshot())
+
+    expect(restored.children().map((n) => n.displayName)).toEqual(['Doc one'])
+  })
+})

--- a/packages/canvas-workspace/src/workspace-tree.ts
+++ b/packages/canvas-workspace/src/workspace-tree.ts
@@ -7,6 +7,15 @@ export interface WorkspaceNode {
   readonly id: TreeID
   readonly canvasId: string
   readonly segment: string
+  /**
+   * What a human reads, as opposed to `segment`, which is placement and is
+   * slug-validated. Absent means the document has never been named — a
+   * reader falls back to the segment rather than inventing one.
+   *
+   * ADR-0009 makes this the document's name: OKF frontmatter `title` is a
+   * projection of it on serialise, never a second place to write it.
+   */
+  readonly displayName?: string
 }
 
 export interface WorkspaceTreeSnapshot {
@@ -15,13 +24,14 @@ export interface WorkspaceTreeSnapshot {
 
 export class WorkspaceTree {
   readonly #doc: LoroDoc
-  readonly #tree: LoroTree<{ canvasId: string; segment: string }>
+  readonly #tree: LoroTree<{ canvasId: string; segment: string; displayName?: string }>
 
   constructor(doc: LoroDoc) {
     this.#doc = doc
     this.#tree = doc.getTree(TREE_KEY) as LoroTree<{
       canvasId: string
       segment: string
+      displayName?: string
     }>
   }
 
@@ -39,14 +49,34 @@ export class WorkspaceTree {
     return new Uint8Array(encoded)
   }
 
-  createNode(canvasId: string, segment: string, parent?: TreeID, index?: number): TreeID {
+  createNode(
+    canvasId: string,
+    segment: string,
+    parent?: TreeID,
+    index?: number,
+    displayName?: string,
+  ): TreeID {
     validateSegment(segment)
     this.#assertNoSiblingConflict(parent, segment)
     const node = this.#tree.createNode(parent, index)
     node.data.set('canvasId', canvasId)
     node.data.set('segment', segment)
+    const normalized = normalizeDisplayName(displayName)
+    if (normalized !== undefined) node.data.set('displayName', normalized)
     this.#doc.commit()
     return node.id
+  }
+
+  /**
+   * Blank clears rather than stores: an absent name and a whitespace-only one
+   * would otherwise be two states meaning the same thing, and every reader
+   * would have to test for both.
+   */
+  setDisplayName(target: TreeID, displayName: string): void {
+    const node = this.#getNode(target)
+    const normalized = normalizeDisplayName(displayName)
+    node.data.set('displayName', normalized)
+    this.#doc.commit()
   }
 
   move(target: TreeID, newParent?: TreeID, index?: number): void {
@@ -105,7 +135,9 @@ export class WorkspaceTree {
     const node = this.#tree.getNodeByID(id)
     if (!node || this.#tree.isNodeDeleted(id)) return undefined
     const segments: string[] = []
-    let current: LoroTreeNode<{ canvasId: string; segment: string }> | undefined = node
+    let current:
+      | LoroTreeNode<{ canvasId: string; segment: string; displayName?: string }>
+      | undefined = node
     while (current) {
       const parent = current.parent()
       const disambiguated = disambiguateSegments(this.children(parent?.id))
@@ -120,7 +152,9 @@ export class WorkspaceTree {
 
     let candidates = this.#tree.getNodes().filter((n) => n.parent() === undefined)
 
-    let matched: LoroTreeNode<{ canvasId: string; segment: string }> | undefined
+    let matched:
+      | LoroTreeNode<{ canvasId: string; segment: string; displayName?: string }>
+      | undefined
 
     for (const part of parts) {
       const disambiguated = disambiguateSegments(candidates.map(toWorkspaceNode))
@@ -138,7 +172,7 @@ export class WorkspaceTree {
     }
   }
 
-  #getNode(id: TreeID): LoroTreeNode<{ canvasId: string; segment: string }> {
+  #getNode(id: TreeID): LoroTreeNode<{ canvasId: string; segment: string; displayName?: string }> {
     const node = this.#tree.getNodeByID(id)
     if (!node) throw new Error(`Tree node not found: ${id}`)
     return node
@@ -173,11 +207,20 @@ function validateSegment(segment: string): void {
   }
 }
 
-function toWorkspaceNode(node: LoroTreeNode<{ canvasId: string; segment: string }>): WorkspaceNode {
+function normalizeDisplayName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed
+}
+
+function toWorkspaceNode(
+  node: LoroTreeNode<{ canvasId: string; segment: string; displayName?: string }>,
+): WorkspaceNode {
+  const displayName = node.data.get('displayName')
   return {
     id: node.id,
     canvasId: node.data.get('canvasId') as string,
     segment: node.data.get('segment') as string,
+    ...(typeof displayName === 'string' && displayName !== '' ? { displayName } : {}),
   }
 }
 


### PR DESCRIPTION
## Why this is the first layer

ADR-0009 states a consequence that turns out **not to be implementable today**:

> A document's name lives in the workspace, not in its content. OKF frontmatter `title` is a *projection* of the workspace display name on serialise, never a second place to write it.

The name lives in mcp-server's SQL `canvases.displayName` (written by `setCanvasName`, read by `DaemonIndexPage` as `names?.canvases?.[c.slug] ?? c.slug`). OKF serialisation happens in **server-core**, which cannot reach a composition root's store. Meanwhile `apps/web`'s canvas header edits `core.title` and its own comment calls the facet *"the document's own truth"* — the exact inversion of the ADR.

The only workspace store the shared layer *can* reach is this tree, and it carried `canvasId` and `segment` only. So nothing could project a name even in principle.

## What this adds

`WorkspaceNode` gains an optional `displayName`, with `createNode(..., displayName?)` and `setDisplayName()`.

- **`segment` is unchanged**: placement, slug-validated. The name is free text — a display name is allowed to be `リリース計画 2026 / v2`, which no segment could be. One test pins that they move independently.
- **Blank clears rather than stores.** An absent name and a whitespace-only one would otherwise be two states meaning the same thing, and every reader would have to test for both — one of them eventually forgetting.

## userReach

`foundation` — nothing reads it yet. It unblocks two named follow-ups:

1. `exportOkf` projecting this into OKF `title` instead of echoing a stored `core.title`.
2. `apps/web`'s canvas header writing the name here instead of into core facets.

Those two are what make the ADR consequence true; this is the layer that makes them expressible.

## Verification

Red first — all five display-name tests failed before the implementation. `canvas-workspace-node` + `server-core-node` + `mcp-node` + `arch-lint-node`: 315 files / 3764 tests green. `pnpm -r typecheck`, `pnpm knip`, lint clean.

**One thing worth flagging.** An unrelated property test (`workspace-tree.alias.property.test.ts`, the alias round-trip) failed **once** during this work and never again: not alone, not from its reported seed (1867114059), not across four repeats of the same four-project parallel run, and not in a control run on unmodified `main`. Alias resolution reads `segment` only and that test sets no display name, so there is no path from this change to it. I lost the failure message by over-filtering the run output, which is the most useful thing about it. Recorded as a whiteboard issue (`alias-property-failed-once-unreproduced`) so a recurrence is a second data point rather than a first, per `integrator-flow.md`'s rule that a property failure is never waved through as a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace items can now have optional display names.
  - Display names can be assigned when creating an item or updated later.
  - Whitespace-only names are automatically cleared.
  - Display names are preserved when workspace data is saved and restored.
  - Names support unrestricted text values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->