### PR TITLE
fix(render): keep boundary spaces visible between inline runs

### DIFF
--- a/packages/canvas-render/src/layout/mdast-blocks.properties.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.properties.test.ts
@@ -19,7 +19,7 @@
  * What these properties do NOT cover, verified by mutation rather than
  * assumed: the SEPARATOR-GEOMETRY defects (a trailing space lost between a
  * wrapped chunk and its next inline sibling; that same space counted
- * twice). Deleting either fix leaves all four properties green, because
+ * twice). Deleting either fix leaves these properties green, because
  * `wrapAndPush` emits one run per word — the token sequence survives
  * intact and only the runs' x positions are wrong. Stating that as a
  * property would need to know which adjacent runs had whitespace between
@@ -220,4 +220,50 @@ describe('layoutMdastBlocks properties', () => {
     const rendered = textRuns(layout(root)).flatMap(({ run }) => tokens(run.text))
     expect(rendered).toStrictEqual(sourceTokens(root))
   })
+
+  // XML — and therefore an SVG <text> element — strips leading/trailing
+  // whitespace and squeezes interior whitespace to one space, so a run
+  // whose TEXT is not already in that collapsed form paints its glyphs
+  // left of where layout measured them ("`code` and" as "codeand").
+  // Generator note: prose text elsewhere in this file never carries
+  // boundary whitespace, so this property pads its own text leaves — an
+  // unpadded generator passes vacuously (mutation-checked).
+  const padArb = fc.constantFrom('', ' ', '  ', '\n')
+  const paddedTextArb = fc.tuple(padArb, proseArb, padArb).map(
+    ([lead, core, trail]): MdastPhrasingContent => ({
+      type: 'text',
+      value: `${lead}${core}${trail}`,
+    }),
+  )
+  const paddedChildrenArb = fc.array(
+    fc.oneof(
+      paddedTextArb,
+      proseArb.map((value): MdastPhrasingContent => ({ type: 'inlineCode', value })),
+      paddedTextArb.map((text): MdastPhrasingContent => ({ type: 'strong', children: [text] })),
+      paddedTextArb.map(
+        (text): MdastPhrasingContent => ({
+          type: 'link',
+          url: 'https://example.com',
+          children: [text],
+        }),
+      ),
+    ),
+    { minLength: 1, maxLength: 4 },
+  )
+  const paddedRootArb = paddedChildrenArb.map((children) =>
+    rootOf([{ type: 'paragraph', children }]),
+  )
+
+  fcTest.prop([paddedRootArb], withDefaults())(
+    'every prose run is XML-collapse-stable (no boundary whitespace, single interior spaces)',
+    (root) => {
+      for (const { run } of textRuns(layout(root))) {
+        // Atomic runs (inline code) keep their source text verbatim by
+        // contract and are exempt.
+        if (run.code === true) continue
+        expect(run.text).not.toBe('')
+        expect(run.text).toBe(run.text.trim().replace(/\s+/g, ' '))
+      }
+    },
+  )
 })

--- a/packages/canvas-render/src/layout/mdast-blocks.test.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.test.ts
@@ -252,9 +252,19 @@ describe('layoutMdastBlocks — inline cursor', () => {
     expect(second.bbox.y).toBe(third.bbox.y)
 
     // x is a monotonically increasing running cursor, never reset to 0.
+    // Boundary spaces in the source ("plain ", " tail") are cursor
+    // advances, not run characters (XML collapses them inside <text>).
+    const fontSize = first.appearance?.fontSize ?? 0
+    const spaceWidth = measure(' ', {
+      family: 'sans-serif',
+      fallbackChain: [],
+      weight: 400,
+      style: 'normal',
+      sizePx: fontSize,
+    }).advanceWidth
     expect(first.bbox.x).toBe(0)
-    expect(second.bbox.x).toBe(first.bbox.x + first.bbox.w)
-    expect(third.bbox.x).toBe(second.bbox.x + second.bbox.w)
+    expect(second.bbox.x).toBeCloseTo(first.bbox.x + first.bbox.w + spaceWidth, 5)
+    expect(third.bbox.x).toBeCloseTo(second.bbox.x + second.bbox.w + spaceWidth, 5)
 
     // No pair of runs overlaps horizontally.
     expect(first.bbox.x + first.bbox.w).toBeLessThanOrEqual(second.bbox.x)
@@ -534,5 +544,86 @@ describe('layoutMdastBlocks — single render path', () => {
     const exportRender = layoutMdastBlocks(root, options)
     expect(preview).toEqual(spatialTextNode)
     expect(spatialTextNode).toEqual(exportRender)
+  })
+})
+
+describe('layoutMdastBlocks — whitespace at inline-run boundaries', () => {
+  // XML (and therefore SVG <text>) collapses leading/trailing whitespace,
+  // so a run whose TEXT carries a boundary space paints its first glyph a
+  // space-width left of where layout measured it — "`inline code` and"
+  // renders as "inline codeand". Boundary whitespace must be geometry
+  // (cursor advance), never run content.
+  it('emits collapse-stable run text and carries boundary spaces as cursor advances', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'inlineCode', value: 'inline code' },
+            { type: 'text', value: ' and a ' },
+            {
+              type: 'link',
+              url: 'https://example.com',
+              children: [{ type: 'text', value: 'link' }],
+            },
+            { type: 'text', value: ' too.' },
+          ],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, options)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    expect(paragraph?.kind).toBe('paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+
+    expect(paragraph.runs.map((r) => r.text)).toEqual(['inline code', 'and a', 'link', 'too.'])
+
+    const [code, andA, link, too] = paragraph.runs
+    const fontSize = code.appearance?.fontSize ?? 0
+    expect(fontSize).toBeGreaterThan(0)
+    const spaceWidth = measure(' ', {
+      family: 'sans-serif',
+      fallbackChain: [],
+      weight: 400,
+      style: 'normal',
+      sizePx: fontSize,
+    }).advanceWidth
+    expect(andA.bbox.x).toBeCloseTo(code.bbox.x + code.bbox.w + spaceWidth, 5)
+    expect(link.bbox.x).toBeCloseTo(andA.bbox.x + andA.bbox.w + spaceWidth, 5)
+    expect(too.bbox.x).toBeCloseTo(link.bbox.x + link.bbox.w + spaceWidth, 5)
+  })
+
+  it('collapses interior whitespace sequences to the single space XML will paint', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'kept  double\nsoft' }] }],
+    }
+    const scene = layoutMdastBlocks(root, options)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs.map((r) => r.text)).toEqual(['kept double soft'])
+  })
+
+  it('a whitespace-only text node becomes an advance, never an empty run', () => {
+    const root: MdastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'strong', children: [{ type: 'text', value: 'a' }] },
+            { type: 'text', value: ' ' },
+            { type: 'strong', children: [{ type: 'text', value: 'b' }] },
+          ],
+        },
+      ],
+    }
+    const scene = layoutMdastBlocks(root, options)
+    const paragraph = scene.nodes.find((n) => n.kind === 'paragraph')
+    if (paragraph?.kind !== 'paragraph') throw new Error('unreachable')
+    expect(paragraph.runs.map((r) => r.text)).toEqual(['a', 'b'])
+    const [a, b] = paragraph.runs
+    expect(b.bbox.x).toBeGreaterThan(a.bbox.x + a.bbox.w)
   })
 })

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -170,33 +170,25 @@ function layoutPhrasing(
     extra: Partial<TextRunNode>,
     runStyle: { emphasis?: boolean; strong?: boolean; deleted?: boolean },
   ) => {
-    const words = text.split(/\s+/).filter((word) => word.length > 0)
+    // Input arrives collapse-normalized from `emit` (no boundary
+    // whitespace, single-space separated), so a separator is due before
+    // every word except the first — `emit` has already advanced the cursor
+    // for the chunk's own leading space when one existed in the source.
+    const words = text.split(' ')
     const spaceWidth = measureRunWidth(options.measure, options.fontFamily, ' ', fontSizePx)
-    // `split(/\s+/)` discards this chunk's own leading/trailing whitespace.
-    // mdast represents "prose " + strong("word") as two adjacent phrasing
-    // children, so a trailing space stripped here would otherwise vanish
-    // between this chunk's last word and the next sibling's first run — a
-    // separator is due before the loop's first word in that case exactly
-    // like it is due before every subsequent word in this chunk, so both
-    // cases share the same separator-add-or-wrap logic below (a chunk's
-    // interior words are always whitespace-separated by construction).
-    const chunkHasLeadingSpace = /^\s/.test(text)
     words.forEach((word, index) => {
       const width = measureRunWidth(options.measure, options.fontFamily, word, fontSizePx)
-      const needsSeparator = index === 0 ? chunkHasLeadingSpace : true
-      if (needsSeparator && line.x > 0) {
-        if (line.x + spaceWidth + width > options.maxWidth) {
+      if (line.x > 0) {
+        const separator = index > 0 ? spaceWidth : 0
+        if (line.x + separator + width > options.maxWidth) {
           line.x = 0
           line.index += 1
         } else {
-          line.x += spaceWidth
+          line.x += separator
         }
       }
       pushRun(word, extra, runStyle)
     })
-    if (words.length > 0 && /\s$/.test(text)) {
-      line.x += spaceWidth
-    }
   }
 
   const emit = (
@@ -208,15 +200,35 @@ function layoutPhrasing(
     // in their source text is not a word boundary.
     wrappable = true,
   ) => {
-    if (canWrap && wrappable) {
-      const fullWidth = measureRunWidth(options.measure, options.fontFamily, text, fontSizePx)
-      const overflows = line.x + fullWidth > options.maxWidth
-      if (overflows && /\s/.test(text)) {
-        wrapAndPush(text, extra, runStyle)
-        return
+    if (!wrappable) {
+      pushRun(text, extra, runStyle)
+      return
+    }
+    // XML — and therefore an SVG <text> element — strips leading/trailing
+    // whitespace and squeezes interior whitespace sequences to one space.
+    // A run's text must already be in that collapsed form, with boundary
+    // whitespace carried as CURSOR ADVANCES instead of characters,
+    // otherwise the painted glyphs land a space-width left of where layout
+    // measured them ("`code` and" painting as "codeand"). Atomic runs above
+    // are exempt: their source text is verbatim by contract.
+    const collapsed = text.trim().replace(/\s+/g, ' ')
+    const spaceWidth = measureRunWidth(options.measure, options.fontFamily, ' ', fontSizePx)
+    // A boundary space at the start of a line is dropped, not advanced —
+    // the same rule wrapAndPush applies to its separators.
+    if (/^\s/.test(text) && line.x > 0) {
+      line.x += spaceWidth
+    }
+    if (collapsed !== '') {
+      const fullWidth = measureRunWidth(options.measure, options.fontFamily, collapsed, fontSizePx)
+      if (canWrap && line.x + fullWidth > options.maxWidth && /\s/.test(collapsed)) {
+        wrapAndPush(collapsed, extra, runStyle)
+      } else {
+        pushRun(collapsed, extra, runStyle)
       }
     }
-    pushRun(text, extra, runStyle)
+    if (/\s$/.test(text)) {
+      line.x += spaceWidth
+    }
   }
 
   /** Walk `nodes`, then stamp `link` provenance onto every run they produced. */


### PR DESCRIPTION
## Summary

Fixes a rendering defect in `layoutMdastBlocks` (canvas-render): boundary spaces around inline runs disappeared in the painted output. `` `inline code` and a [link](…) too. `` rendered as **"inline codeand a linktoo."** — in the markdown editor preview, spatial text nodes, and SVG export alike, since all three share this one render path.

## Root cause

XML — and therefore an SVG `<text>` element — strips leading/trailing whitespace and squeezes interior whitespace sequences to one space. `layoutPhrasing` emitted prose runs verbatim (`" and a "`) while *measuring* the whitespace into their advance width: layout positions were correct, but the painted glyphs started a space-width left of them.

## Fix

Prose run text is now **collapse-stable** (trimmed, interior whitespace squeezed to one space), with boundary whitespace carried as cursor advances instead of characters. Atomic runs (inline code, raw HTML, inline math) keep their verbatim contract. `wrapAndPush` simplifies to collapsed input and gains a wrap check for its first word (previously a chunk's first word could overrun the line instead of wrapping).

The SVG serializer is untouched — no golden regeneration, exported bytes for scenes without boundary-space runs are identical.

## Tests

- Three example tests pin the repro (boundary advances, interior collapse, whitespace-only text nodes).
- New property: *every prose run is XML-collapse-stable* — with a padded-text generator, since the existing generator never produces boundary whitespace and would pass vacuously. **Mutation-checked**: reverting the fix turns the property red.
- One pre-existing assertion updated: it pinned the old representation (`second.x === first.x + first.w` with the space inside the run); the intent (same line, monotonic cursor, no overlap) is preserved under the new representation.
- `canvas-render-node` 600/600, `canvas-render-browser`, viewers, `mcp-node` 3441, and the apps/web markdown-editor suites all green.

## Visual repro

Before (editor Read mode — "inline codeand a  linktoo.", "the newOKF"):

![inline-space-before.jpg](https://github.com/user-attachments/assets/74c07b7b-5bb3-4dee-ab79-fc5b95b426db)

After (same document — "inline code and a link too.", "the new OKF"):

![inline-space-after.jpg](https://github.com/user-attachments/assets/9f780c0a-7d86-4d6a-9f3e-06570c43b80f)
