### PR TITLE
feat(mcp): give a document a name, separate from its slug

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -191,6 +191,25 @@ async function main() {
   const canvasId = created.canvasId
   console.log(`[e2e] wb_document_create → ${canvasId}`)
 
+  // A document's name is the workspace's, not its content's (ADR-0009), so
+  // it round-trips through create -> list without any document read.
+  const named = await callTool('wb_document_create', {
+    workspaceId: WORKSPACE_ID,
+    segment: 'e2e-named',
+    kind: 'markdown',
+    name: 'リリース計画 2026 / v2',
+  })
+  const namedList = await callTool('wb_document_list', { workspaceId: WORKSPACE_ID })
+  const namedRow = namedList.canvases.find((c) => c.canvasId === named.canvasId)
+  if (namedRow?.name !== 'リリース計画 2026 / v2') {
+    throw new Error(`wb_document_list lost the document name: ${JSON.stringify(namedRow)}`)
+  }
+  const unnamedRow = namedList.canvases.find((c) => c.canvasId === canvasId)
+  if (unnamedRow === undefined || 'name' in unnamedRow) {
+    throw new Error(`an unnamed document should carry no name: ${JSON.stringify(unnamedRow)}`)
+  }
+  console.log('[e2e] wb_document_create/list → name round-trips, unnamed stays unnamed')
+
   // wb_facet_set: seed extension-facet state so wb_version_save has content.
   const facets = await callTool('wb_facet_set', {
     workspaceId: WORKSPACE_ID,

--- a/packages/server-core/src/tools/canvas-crud.schemas.ts
+++ b/packages/server-core/src/tools/canvas-crud.schemas.ts
@@ -26,6 +26,12 @@ export const createCanvasInputSchema = z
       'What the document is. `markdown` serialises as OKF, `spatial` as JSON Canvas. Required: the format follows from the document rather than from a read parameter, so a document created without one cannot be read back.',
     ),
     parentId: treeIdSchema.optional(),
+    name: z
+      .string()
+      .optional()
+      .describe(
+        'What a human reads. Free text, unlike `segment`, which is a slug and decides placement. Omit it and the document has no name of its own — a reader falls back to the segment rather than being handed the slug as a title.',
+      ),
     // Workspaces are never materialized implicitly: a typo'd or hallucinated
     // workspaceId must fail loudly instead of silently writing data into a
     // workspace nobody asked for. Creating a genuinely new workspace is an
@@ -56,6 +62,10 @@ const canvasDetailSchema = z
     canvasId: canvasIdSchema,
     segment: z.string(),
     alias: z.string(),
+    // Absent rather than defaulted to the segment: a reader that wants that
+    // fallback can choose it, and a listing that invents one reads as if
+    // somebody typed the slug as the title.
+    name: z.string().optional(),
   })
   .strict()
 

--- a/packages/server-core/src/tools/canvas-crud.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.test.ts
@@ -300,3 +300,73 @@ async function loadTreeForAssertions(deps: ServerDeps) {
   const { loadWorkspaceTree } = await import('./workspace-tree-io.js')
   return loadWorkspaceTree(deps.canvasDocStore, 'ws-1')
 }
+
+describe('document name', () => {
+  // ADR-0009: the name lives in the workspace, not in the document's content.
+  // Until this, creation took a `segment` only — a slug — so a document had
+  // no name of its own and every reader fell back to showing the slug.
+  it('creation accepts a name and the listing returns it', async () => {
+    const deps = makeDeps()
+    const { canvasId } = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'release-plan',
+      kind: 'markdown',
+      createWorkspace: true,
+      name: 'リリース計画 2026',
+    })
+
+    const { canvases } = await wbCanvasList(deps, { workspaceId: 'ws-1' })
+
+    expect(canvases).toEqual([
+      { canvasId, segment: 'release-plan', alias: 'release-plan', name: 'リリース計画 2026' },
+    ])
+  })
+
+  it('omits the name entirely when none was given, rather than echoing the segment', async () => {
+    // A reader that wants a fallback can choose one; a listing that invents
+    // `name: 'release-plan'` takes that choice away and reads as if someone
+    // typed the slug as the title.
+    const deps = makeDeps()
+    await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'release-plan',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+
+    const { canvases } = await wbCanvasList(deps, { workspaceId: 'ws-1' })
+
+    expect(canvases[0]).not.toHaveProperty('name')
+  })
+
+  it('a name is free text, not a second segment', async () => {
+    const deps = makeDeps()
+    await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'plan',
+      kind: 'markdown',
+      createWorkspace: true,
+      name: 'Release plan 2026 / v2 (draft)',
+    })
+
+    const { canvases } = await wbCanvasList(deps, { workspaceId: 'ws-1' })
+
+    expect(canvases[0]?.name).toBe('Release plan 2026 / v2 (draft)')
+    expect(canvases[0]?.segment).toBe('plan')
+  })
+
+  it('wbCanvasGet returns the name too', async () => {
+    const deps = makeDeps()
+    const { canvasId } = await wbCanvasCreate(deps, {
+      workspaceId: 'ws-1',
+      segment: 'doc',
+      kind: 'markdown',
+      createWorkspace: true,
+      name: 'Doc one',
+    })
+
+    await expect(wbCanvasGet(deps, { workspaceId: 'ws-1', canvasId })).resolves.toMatchObject({
+      name: 'Doc one',
+    })
+  })
+})

--- a/packages/server-core/src/tools/canvas-crud.ts
+++ b/packages/server-core/src/tools/canvas-crud.ts
@@ -63,7 +63,7 @@ export async function wbCanvasCreate(
   }
 
   const canvasId = generateCanvasId()
-  tree.createNode(canvasId, input.segment, parentId)
+  tree.createNode(canvasId, input.segment, parentId, undefined, input.name)
   await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
 
   // Persist the document, not only its place in the tree. Creation used to
@@ -84,7 +84,12 @@ export async function wbCanvasGet(
   const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
   const node = findNodeOrThrow(tree, input.workspaceId, input.canvasId)
   const alias = tree.resolveAlias(node.id)
-  return { canvasId: node.canvasId, segment: node.segment, alias: alias ?? node.segment }
+  return {
+    canvasId: node.canvasId,
+    segment: node.segment,
+    alias: alias ?? node.segment,
+    ...(node.displayName === undefined ? {} : { name: node.displayName }),
+  }
 }
 
 export async function wbCanvasList(
@@ -103,6 +108,7 @@ export async function wbCanvasList(
       canvasId: node.canvasId,
       segment: node.segment,
       alias: tree.resolveAlias(node.id) ?? node.segment,
+      ...(node.displayName === undefined ? {} : { name: node.displayName }),
     })),
   }
 }


### PR DESCRIPTION
## What

Creation took a `segment` only — a slug — so a document had **no name of its own**, and every reader fell back to showing the slug. `wb_document_create` now takes an optional `name`, and `wb_document_list` / `wb_document_resolve` return it. It is stored on the workspace tree, which is where ADR-0009 says a document's name belongs (#764 made the tree able to hold one).

```
wb_document_create { segment: 'release-plan', name: 'リリース計画 2026 / v2' }
wb_document_list   → { canvasId, segment: 'release-plan', alias: 'release-plan',
                       name: 'リリース計画 2026 / v2' }
```

**Absent stays absent** rather than defaulting to the segment. A reader that wants that fallback can choose it; a listing that invents `name: 'release-plan'` takes the choice away and reads as if somebody typed the slug as a title. One test pins that an unnamed document carries no `name` property at all.

## Why writer and reader ship together

#764's tree field landed unread, and a reader alone would have had nothing to return. The ADR consequence only becomes true when both ends exist — so this is the increment where an MCP client can actually name a document and see the name.

## What is deliberately NOT here

`exportOkf` projecting this into OKF `title`. It cannot come yet: existing documents have a stored `core.title` and **no** tree name, so flipping the reader today would erase every title that exists from its own export. The order is backfill (same shape as the recent document-kind one) → reader flip → drop the stored `core.title` write.

## Verification

Red first — three of the four new tests failed before the implementation. `server-core-node` 34 files / 248 tests, plus `mcp-node` and `canvas-workspace-node` green; `pnpm -r typecheck`, `pnpm knip`, lint clean.

`pnpm smoke:e2e` covers the round-trip through the real MCP SDK, since this changes a published tool contract:

```
[e2e] wb_document_create/list → name round-trips, unnamed stays unnamed
```

One unrelated failure seen and dismissed with a reason: `file-gc-sweeper`'s timer test failed in a four-project parallel run and passes with `mcp-node` alone (268 files). Same load-dependent test that failed at the start of this session's work on an unrelated branch — noted rather than re-run silently, since `integrator-flow.md` promotes a second occurrence to a root-cause lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB