### PR TITLE
feat(web): markdown list ergonomics — empty-item exit, checkbox toggle, Mod-e

### DIFF
--- a/apps/web/src/components/markdown-editor/EditorToolbar.tsx
+++ b/apps/web/src/components/markdown-editor/EditorToolbar.tsx
@@ -39,7 +39,7 @@ interface FormatAction {
 const FORMAT_ACTIONS: readonly FormatAction[] = [
   { label: 'Bold', delimiter: '**', icon: Bold, shortcut: '⌘B' },
   { label: 'Italic', delimiter: '*', icon: Italic, shortcut: '⌘I' },
-  { label: 'Code', delimiter: '`', icon: Code, shortcut: '' },
+  { label: 'Code', delimiter: '`', icon: Code, shortcut: '⌘E' },
 ]
 
 /**

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -1,12 +1,14 @@
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { EditorSelection, EditorState, type StateCommand } from '@codemirror/state'
+import { EditorSelection, EditorState, Prec, type StateCommand } from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
 import { GFM } from '@lezer/markdown'
 import { type RefObject, useEffect, useRef } from 'react'
+import { exitEmptyListItem } from './exit-empty-list-item.js'
 import { minimalChange } from './minimal-change.js'
+import { toggleTaskCheckbox } from './toggle-task-checkbox.js'
 
 // Wraps each selection range in `delimiter` (Mod-b -> **, Mod-i -> *). A
 // collapsed selection inserts an empty pair and parks the cursor between
@@ -31,6 +33,8 @@ function wrapSelectionWith(delimiter: string): StateCommand {
 const styleKeymap = [
   { key: 'Mod-b', run: wrapSelectionWith('**') },
   { key: 'Mod-i', run: wrapSelectionWith('*') },
+  { key: 'Mod-e', run: wrapSelectionWith('`') },
+  { key: 'Mod-Enter', run: toggleTaskCheckbox },
 ]
 
 /**
@@ -128,6 +132,12 @@ export function SourcePane({
         // an escaped-source placeholder anyway (see render-preview.ts), so
         // there is nothing yet for a source-side math grammar to agree with.
         markdown({ extensions: [GFM] }),
+        // Above the language keymap's own Enter (`markdown()` registers
+        // lang-markdown's auto-continuation at high precedence): Enter on
+        // an EMPTY list item must delete the marker, not march it down
+        // another line. Everywhere else this reports unhandled and
+        // continuation runs as usual.
+        Prec.highest(keymap.of([{ key: 'Enter', run: exitEmptyListItem }])),
         syntaxHighlighting(markdownHighlightStyle),
         history(),
         // styleKeymap precedes defaultKeymap so Mod-b/Mod-i win over any

--- a/apps/web/src/components/markdown-editor/exit-empty-list-item.test.ts
+++ b/apps/web/src/components/markdown-editor/exit-empty-list-item.test.ts
@@ -1,0 +1,35 @@
+import { EditorSelection, EditorState } from '@codemirror/state'
+import { describe, expect, it } from 'vitest'
+import { exitEmptyListItem } from './exit-empty-list-item.js'
+
+function apply(doc: string, caret: number): string | null {
+  const state = EditorState.create({ doc, selection: EditorSelection.single(caret) })
+  let next: string | null = null
+  const handled = exitEmptyListItem({
+    state,
+    dispatch: (tr) => {
+      next = tr.state.doc.toString()
+    },
+  })
+  return handled ? next : null
+}
+
+describe('exitEmptyListItem', () => {
+  it('deletes a bare unordered marker at the caret line end', () => {
+    expect(apply('- one\n- ', 8)).toBe('- one\n')
+  })
+
+  it('deletes ordered and task markers too, keeping indentation lines intact', () => {
+    expect(apply('1. one\n2. ', 10)).toBe('1. one\n')
+    expect(apply('- [ ] ', 6)).toBe('')
+  })
+
+  it('reports unhandled on an item WITH content, so continuation still runs', () => {
+    expect(apply('- one', 5)).toBeNull()
+  })
+
+  it('reports unhandled mid-line and on non-list lines', () => {
+    expect(apply('- ', 1)).toBeNull()
+    expect(apply('prose', 5)).toBeNull()
+  })
+})

--- a/apps/web/src/components/markdown-editor/exit-empty-list-item.ts
+++ b/apps/web/src/components/markdown-editor/exit-empty-list-item.ts
@@ -1,0 +1,30 @@
+import type { StateCommand } from '@codemirror/state'
+
+/**
+ * A list line that carries only its marker (optionally a task checkbox)
+ * and no content — the state one Enter of auto-continuation leaves behind.
+ */
+const EMPTY_ITEM_RE = /^\s*(?:[-*+]|\d+[.)])\s*(?:\[[ xX]\]\s*)?$/
+
+/**
+ * Enter on an empty list item DELETES the marker instead of continuing
+ * the list — the standard escape hatch (Typora, Obsidian, every rich list
+ * editor) from lang-markdown's auto-continuation, which would otherwise
+ * march the marker down line after line. Bound ABOVE the language keymap;
+ * reports unhandled everywhere else so continuation keeps working.
+ */
+export const exitEmptyListItem: StateCommand = ({ state, dispatch }) => {
+  const range = state.selection.main
+  if (!range.empty) return false
+  const line = state.doc.lineAt(range.head)
+  if (range.head !== line.to) return false
+  if (!EMPTY_ITEM_RE.test(line.text)) return false
+  dispatch(
+    state.update({
+      changes: { from: line.from, to: line.to, insert: '' },
+      selection: { anchor: line.from },
+      userEvent: 'delete',
+    }),
+  )
+  return true
+}

--- a/apps/web/src/components/markdown-editor/source-pane-keymap.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/source-pane-keymap.browser.test.tsx
@@ -90,3 +90,48 @@ describe('SourcePane keymap (real browser)', () => {
     await expect.poll(() => scroller.scrollWidth <= scroller.clientWidth + 1).toBe(true)
   })
 })
+
+describe('SourcePane markdown ergonomics (real browser)', () => {
+  it('Enter continues an unordered list marker', async () => {
+    const { onChange, editable } = mountEditor()
+    await userEvent.click(editable)
+    await userEvent.keyboard('- one{Enter}two')
+    expect(lastValue(onChange)).toBe('- one\n- two')
+  })
+
+  it('Enter increments an ordered list marker', async () => {
+    const { onChange, editable } = mountEditor()
+    await userEvent.click(editable)
+    await userEvent.keyboard('1. one{Enter}two')
+    expect(lastValue(onChange)).toBe('1. one\n2. two')
+  })
+
+  it('Enter on an empty list item removes the marker instead of continuing forever', async () => {
+    const { onChange, editable } = mountEditor()
+    await userEvent.click(editable)
+    // First Enter continues to "- "; the second, on the now-empty item,
+    // deletes the marker and leaves the caret on the emptied line.
+    await userEvent.keyboard('- one{Enter}{Enter}after')
+    expect(lastValue(onChange)).toBe('- one\nafter')
+  })
+
+  it('Mod-Enter toggles a task checkbox on the caret line', async () => {
+    const { onChange, editable } = mountEditor()
+    await userEvent.click(editable)
+    // `[[` is userEvent.keyboard's escape for a literal `[`.
+    await userEvent.keyboard('- [[ ] task')
+    await userEvent.keyboard(mod('{Enter}'))
+    expect(lastValue(onChange)).toBe('- [x] task')
+    await userEvent.keyboard(mod('{Enter}'))
+    expect(lastValue(onChange)).toBe('- [ ] task')
+  })
+
+  it('Mod-e wraps the selection in backticks', async () => {
+    const { onChange, editable } = mountEditor()
+    await userEvent.click(editable)
+    await userEvent.keyboard('code')
+    await userEvent.keyboard(mod('a'))
+    await userEvent.keyboard(mod('e'))
+    expect(lastValue(onChange)).toBe('`code`')
+  })
+})

--- a/apps/web/src/components/markdown-editor/toggle-task-checkbox.test.ts
+++ b/apps/web/src/components/markdown-editor/toggle-task-checkbox.test.ts
@@ -1,0 +1,44 @@
+import { EditorSelection, EditorState } from '@codemirror/state'
+import { describe, expect, it } from 'vitest'
+import { toggleTaskCheckbox } from './toggle-task-checkbox.js'
+
+function apply(doc: string, anchor: number, head = anchor): string | null {
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.single(anchor, head),
+  })
+  let next: string | null = null
+  const handled = toggleTaskCheckbox({
+    state,
+    dispatch: (tr) => {
+      next = tr.state.doc.toString()
+    },
+  })
+  return handled ? next : null
+}
+
+describe('toggleTaskCheckbox', () => {
+  it('checks an unchecked task item under the caret', () => {
+    expect(apply('- [ ] write tests', 5)).toBe('- [x] write tests')
+  })
+
+  it('unchecks a checked task item, whichever case the x has', () => {
+    expect(apply('- [x] done', 3)).toBe('- [ ] done')
+    expect(apply('- [X] done', 3)).toBe('- [ ] done')
+  })
+
+  it('toggles every task line covered by the selection, skipping non-task lines', () => {
+    const doc = '- [ ] one\nplain prose\n- [x] two'
+    expect(apply(doc, 0, doc.length)).toBe('- [x] one\nplain prose\n- [ ] two')
+  })
+
+  it('supports ordered-list and indented task items', () => {
+    expect(apply('1. [ ] ordered', 4)).toBe('1. [x] ordered')
+    expect(apply('  - [ ] nested', 6)).toBe('  - [x] nested')
+  })
+
+  it('returns false and dispatches nothing when no selected line is a task item', () => {
+    expect(apply('plain prose', 2)).toBeNull()
+    expect(apply('- list without checkbox', 2)).toBeNull()
+  })
+})

--- a/apps/web/src/components/markdown-editor/toggle-task-checkbox.ts
+++ b/apps/web/src/components/markdown-editor/toggle-task-checkbox.ts
@@ -1,0 +1,37 @@
+import type { StateCommand } from '@codemirror/state'
+
+/**
+ * `- [ ]` / `- [x]` at the start of a list item, with the checkbox-state
+ * character captured on its own so the toggle replaces exactly one char.
+ * Deliberately line-anchored text matching rather than lexer work: a task
+ * marker is only ever list-marker + `[state]` at line start, and the
+ * source pane's other insert commands (`wrapSelectionWith`) set the same
+ * predictability-over-cleverness precedent.
+ */
+const TASK_ITEM_RE = /^(\s*(?:[-*+]|\d+[.)])\s+\[)([ xX])\]/
+
+/**
+ * Toggles the checkbox of every task item covered by the selection —
+ * `[ ]` becomes `[x]` and `[x]`/`[X]` becomes `[ ]`. Lines that are not
+ * task items are left untouched; when NO covered line is one, the command
+ * reports unhandled so the key can fall through to other bindings.
+ */
+export const toggleTaskCheckbox: StateCommand = ({ state, dispatch }) => {
+  const lineNumbers = new Set<number>()
+  for (const range of state.selection.ranges) {
+    const first = state.doc.lineAt(range.from).number
+    const last = state.doc.lineAt(range.to).number
+    for (let n = first; n <= last; n++) lineNumbers.add(n)
+  }
+  const changes: { from: number; to: number; insert: string }[] = []
+  for (const n of lineNumbers) {
+    const line = state.doc.line(n)
+    const match = TASK_ITEM_RE.exec(line.text)
+    if (!match) continue
+    const statePos = line.from + match[1].length
+    changes.push({ from: statePos, to: statePos + 1, insert: match[2] === ' ' ? 'x' : ' ' })
+  }
+  if (changes.length === 0) return false
+  dispatch(state.update({ changes, userEvent: 'input' }))
+  return true
+}


### PR DESCRIPTION
## Summary

Everyday list ergonomics for the markdown source pane. `@codemirror/lang-markdown`'s auto-continuation (Enter continues `- ` / incrementing `1. `, Backspace deletes markup) already ships inside `markdown()` — this PR adds what was missing around it:

- **Enter on an empty list item exits the list**: the marker is deleted instead of marching down another line (the Typora/Obsidian escape hatch). Bound above the language keymap with `Prec.highest`; reports unhandled everywhere else so continuation keeps working.
- **`Mod-Enter` toggles task checkboxes**: `- [ ]` ⇄ `- [x]` on every task line the selection covers (multi-line aware, `[X]` accepted, ordered/indented items included); reports unhandled when no covered line is a task item so the key falls through.
- **`Mod-e` wraps the selection in backticks**, same insert-only contract as the existing `Mod-b`/`Mod-i`; the toolbar's Code tooltip now shows `⌘E`.

## Tests

- New unit tests for both commands (`toggle-task-checkbox`, `exit-empty-list-item`): caret/selection coverage, non-task lines untouched, unhandled fallthrough.
- New browser tests in `source-pane-keymap.browser.test.tsx`: continuation (`- ` continues, `1.` increments) — pinned so a future `markdown()` option change can't silently drop it — plus empty-item exit, `Mod-Enter` toggle, and `Mod-e` wrap through real key events.
- Manually verified in Chrome: continuation, empty-item exit, checkbox toggle, `Mod-e` (a stale Vite transform cache initially masked the new keymap; verified after a `--force` dev-server restart).

## Notes

- No new dependencies; the two commands are small `StateCommand`s beside the existing `wrapSelectionWith`.
- Controlled `value`/`onChange` contract untouched.
