### PR TITLE
feat(mcp)!: make OKF title a projection of the workspace name, both ways

### DIFF
--- a/docs/contributing/adr/0009-mcp-tool-naming.md
+++ b/docs/contributing/adr/0009-mcp-tool-naming.md
@@ -99,6 +99,28 @@ the laid-out projection `canvas-render` already calls a **scene**.
    source; when a document is serialised to OKF, its frontmatter `title` is a
    **projection** of that name, not a second copy to keep in sync.
 
+   **OKF is an export format, not the storage model.** The Loro side keeps
+   its own OKF-*compatible* document; OKF is what that document is projected
+   into on the way out and parsed from on the way in. This settles a question
+   the paragraph above leaves open, because it only describes serialising:
+   what `wb_document_set` should do with a `title` in the OKF it is given.
+
+   It applies it to the workspace name. Parsing projects INTO the model
+   exactly as serialising projects out of it, so the name reaches the one
+   place that stores it — OKF owns no storage, and there is no second copy to
+   go out of sync. Ignoring the field instead would satisfy the letter of
+   "never a second place to write it" by making a read-edit-write round trip
+   drop the title silently, which is the failure this decision exists to
+   prevent, not an instance of following it.
+
+   Two consequences worth stating, both test-pinned:
+
+   - **Absent is not cleared.** An OKF with no `title` says nothing about the
+     name, so a write that omits it leaves the existing name alone.
+   - **The round trip normalises rather than preserving verbatim.** A blank
+     title is no title — `WorkspaceNode.displayName` treats absent and blank
+     as one state — so `title: ""` in, no `title` out.
+
 3. **Each format owns its own content structure. `Facet` belongs to OKF.**
    An OKF document has frontmatter (facets) and a markdown body. A JSON Canvas
    document has nodes and edges. Neither carries the other's shape, and a

--- a/packages/server-core/src/tools/document-set.test.ts
+++ b/packages/server-core/src/tools/document-set.test.ts
@@ -1,5 +1,6 @@
 import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import {
+  readCoreFacets,
   readDocumentKind,
   readFacets,
   readSpatialCanvas,
@@ -15,6 +16,8 @@ import {
 } from '../test-utils/fake-canvas-doc-store.js'
 import { createDocumentSetTool } from './document-set.js'
 import { DocumentContentLossError, DocumentKindMismatchError } from './errors.js'
+import { exportOkf } from './export-okf.js'
+import { loadWorkspaceTree } from './workspace-tree-io.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
@@ -244,5 +247,100 @@ describe('wb_document_set tool', () => {
     expect(readSpatialCanvas(doc).nodes).toHaveLength(1)
     // Refused, so still undeclared — the spatial path is what declares it.
     expect(readDocumentKind(doc)).toBeUndefined()
+  })
+})
+
+describe('OKF title is a projection of the workspace name, both ways', () => {
+  // OKF is an export format, not the storage model: the Loro side keeps its
+  // own OKF-compatible document, and the workspace owns the name. So parsing
+  // an OKF is projecting it INTO that model, exactly as serialising projects
+  // back out — `title` lands on the workspace, never in the content.
+  test('a title in the written OKF renames the document, and is not stored as a facet', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const deps = makeDeps(store)
+
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\ntitle: リリース計画 2026\n---\nBody.',
+    })
+
+    const tree = await loadWorkspaceTree(store, WORKSPACE_ID)
+    const node = tree.snapshot().nodes.find((n) => n.canvasId === CANVAS_ID)
+    expect(node?.displayName).toBe('リリース計画 2026')
+    expect(readCoreFacets(await loadDoc(store, CANVAS_ID))?.title).toBeUndefined()
+  })
+
+  test('writing OKF without a title leaves the existing name alone', async () => {
+    // Absent is not the same as cleared. An OKF with no `title` says nothing
+    // about the name, so a write that omits it must not erase one.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const deps = makeDeps(store)
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\ntitle: Keep me\n---\nOne.',
+    })
+
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nTwo.',
+    })
+
+    const tree = await loadWorkspaceTree(store, WORKSPACE_ID)
+    expect(tree.snapshot().nodes[0]?.displayName).toBe('Keep me')
+  })
+
+  test('the exported OKF carries the workspace name as its title', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const deps = makeDeps(store)
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\ntitle: Round trip\n---\nBody.',
+    })
+
+    const exported = await exportOkf(deps, { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(exported.frontmatter.title).toBe('Round trip')
+    expect(exported.markdown).toContain('title: Round trip')
+  })
+
+  test('a blank title round-trips to no title, not to an empty one', async () => {
+    // The shrunk counterexample from the round-trip property, pinned as the
+    // regression guard: {"frontmatter":{"type":" ","title":""},"body":""}.
+    // A blank name IS no name — the two are deliberately one state — so the
+    // round trip normalises here rather than preserving '' verbatim.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const deps = makeDeps(store)
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\ntitle: ""\n---\n',
+    })
+
+    const exported = await exportOkf(deps, { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(exported.frontmatter.title).toBeUndefined()
+  })
+
+  test('an unnamed document exports no title at all, rather than its slug', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    const deps = makeDeps(store)
+    await createDocumentSetTool(deps).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      markdown: '---\ntype: note\n---\nBody.',
+    })
+
+    const exported = await exportOkf(deps, { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
+
+    expect(exported.frontmatter.title).toBeUndefined()
   })
 })

--- a/packages/server-core/src/tools/document-set.ts
+++ b/packages/server-core/src/tools/document-set.ts
@@ -12,7 +12,11 @@ import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
 import { DocumentContentLossError, DocumentKindMismatchError } from './errors.js'
-import { assertCanvasInWorkspace } from './workspace-tree-io.js'
+import {
+  assertCanvasInWorkspace,
+  loadWorkspaceTree,
+  saveWorkspaceTree,
+} from './workspace-tree-io.js'
 
 const TEXT_NODE_ID = 'okf-body'
 
@@ -103,7 +107,23 @@ export function createDocumentSetTool(deps: ServerDeps) {
         )
       }
 
-      const { facets, ...coreMeta } = frontmatter
+      // OKF is an export format, not the storage model: the Loro side keeps
+      // its own OKF-compatible document, and the workspace owns the name. So
+      // parsing an OKF projects it INTO that model exactly as serialising
+      // projects back out, and `title` lands on the workspace rather than
+      // becoming a second stored copy (ADR-0009 decision 2).
+      //
+      // Absent is not cleared: an OKF with no `title` says nothing about the
+      // name, so omitting it must not erase one.
+      const { facets, title, ...coreMeta } = frontmatter
+      if (title !== undefined) {
+        const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
+        const node = tree.snapshot().nodes.find((n) => n.canvasId === input.canvasId)
+        if (node !== undefined) {
+          tree.setDisplayName(node.id, title)
+          await saveWorkspaceTree(deps.canvasDocStore, input.workspaceId, tree)
+        }
+      }
       writeCoreFacets(doc, coreMeta)
       if (facets) {
         writeFacets(doc, facets)

--- a/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
@@ -94,7 +94,17 @@ describe('wb_document_set -> the OKF exporter round-trip property', () => {
       const result = await exportOkf(deps, { workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID })
 
       expect(result.frontmatter.type).toBe(doc.frontmatter.type)
-      expect(result.frontmatter.title).toBe(doc.frontmatter.title)
+      // Not verbatim: the name lives on the workspace now, and a blank name
+      // is no name (they are one state by design), so the round trip
+      // normalises a whitespace-only title to absent. Everything else about
+      // the title is still verbatim — AGENTS.md allows a round-trip property
+      // to assert a well-defined normalisation, not a weaker equality.
+      const submittedTitle = doc.frontmatter.title
+      const expectedTitle =
+        submittedTitle === undefined || submittedTitle.trim() === ''
+          ? undefined
+          : submittedTitle.trim()
+      expect(result.frontmatter.title).toBe(expectedTitle)
       expect(result.frontmatter.tags).toEqual(doc.frontmatter.tags)
       expect(result.frontmatter.view).toBe(doc.frontmatter.view)
       const expectedFacets = 'facets' in doc.frontmatter ? doc.frontmatter.facets : {}

--- a/packages/server-core/src/tools/export-okf.ts
+++ b/packages/server-core/src/tools/export-okf.ts
@@ -5,6 +5,7 @@ import { readCoreFacets, readFacets } from '@kamiazya/whiteboard-canvas-workspac
 import { z } from 'zod'
 import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import type { ServerDeps } from '../server-deps.js'
+import { loadWorkspaceTree } from './workspace-tree-io.js'
 
 /**
  * OKF-Markdown is a single-document format (frontmatter + body); a spatial
@@ -51,10 +52,20 @@ const OKF_EXPORT_PLACEHOLDER_TYPE = 'canvas'
 export async function exportOkf(deps: ServerDeps, input: ExportOkfInput): Promise<ExportOkfOutput> {
   const { doc, canvas } = await loadSpatialCanvas(deps, input.canvasId)
   const coreMeta = readCoreFacets(doc)
+  // The name is the workspace's (ADR-0009 decision 2), so it is read from
+  // there rather than from stored content — the frontmatter `title` this
+  // emits is a projection, and an unnamed document emits none rather than
+  // being handed its slug as a title.
+  const tree = await loadWorkspaceTree(deps.canvasDocStore, input.workspaceId)
+  const displayName = tree.snapshot().nodes.find((n) => n.canvasId === input.canvasId)?.displayName
   const facets = readFacets(doc)
   const body = canvas.nodes.find((node) => node.type === 'text')?.text ?? ''
+  const { title: _storedTitle, ...storedMeta } = coreMeta ?? {
+    type: OKF_EXPORT_PLACEHOLDER_TYPE,
+  }
   const frontmatter: OkfMarkdownFrontmatter = {
-    ...(coreMeta ?? { type: OKF_EXPORT_PLACEHOLDER_TYPE }),
+    ...storedMeta,
+    ...(displayName === undefined ? {} : { title: displayName }),
     facets,
   }
   const markdown = serializeOkf({ frontmatter, body })


### PR DESCRIPTION
## The framing that settles it

ADR-0009 decision 2 said the workspace owns a document's name and OKF `title` is a projection of it — but it only described **serialising**, leaving open what `wb_document_set` should do with a `title` in the OKF it is handed. Three readings were defensible and they disagree about whether a read-edit-write round trip keeps the title.

The repo owner's framing resolves it: **OKF is an export format, not the storage model.** The Loro side keeps its own OKF-*compatible* document; OKF is what that document is projected into on the way out and parsed from on the way in.

So a title on the way **in** goes to the one place that stores a name — the workspace tree — exactly as it comes back **out** from there. There is no second copy, because OKF owns no storage at all. Ignoring the field instead would have honoured the letter of *"never a second place to write it"* by making a round trip drop the title **silently**, which is the failure the decision exists to prevent rather than an instance of following it.

`exportOkf` now reads the name from the tree and no longer echoes a stored `core.title`; `document_set` writes it to the tree and no longer stores one. The framing is recorded in the ADR, since it is the durable part.

## Two consequences, both pinned

- **Absent is not cleared.** An OKF with no `title` says nothing about the name, so a write that omits it leaves the existing name alone.
- **The round trip normalises rather than preserving verbatim.** A blank title is no title — `displayName` treats absent and blank as one state — so `title: ""` in gives no `title` out.

## The property earned its keep

Moving the name broke the round-trip property with a real counterexample:

```
Counterexample: [{"frontmatter":{"type":" ","title":""},"body":""}]
expected undefined to be ''
```

Per AGENTS.md the counterexample is pinned as an example test **first**, and the property now states the normalisation rather than being weakened — a round trip is allowed to equal a well-defined normalisation of its input, and this one is `trim`-then-absent-if-blank.

Mutation-checked: dropping the title projection fails the property **and** two examples, so neither is passing vacuously.

## Breaking

OKF `title` is no longer stored in core facets. A document whose name only ever existed in `core.title` needs it copied to the workspace first — `tmp/scripts/backfill-document-name.mts` does that for a local data dir, and was run here (6 documents; the one spatial document has no core facets and stays unnamed, which is the designed fallback to its segment).

## Verification

312 test files green across `server-core-node` + `mcp-node` + `mcp-smoke` + `canvas-workspace-node`; `pnpm -r typecheck`, lint clean; `pnpm smoke:e2e` ALL OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB