### PR TITLE
fix(web): stop the facet card heading every document "note"

### DIFF
--- a/apps/web/src/hooks/use-canvas-file-seams.test.tsx
+++ b/apps/web/src/hooks/use-canvas-file-seams.test.tsx
@@ -149,26 +149,29 @@ describe('useCanvasFileSeams', () => {
 })
 
 describe('toFacetCard', () => {
-  it('maps a type-only facet set to a titled card with one row', () => {
-    expect(toFacetCard({ type: 'note' })).toEqual({
-      title: 'note',
+  it('heads a type-only facet set with the reference, and keeps type as a row', () => {
+    // Was `title: 'note'` — the type doubled as the heading. That reads the
+    // same on every card of a kind, so it identifies nothing; the reference
+    // does. `type` is still a row, which is where it says something.
+    expect(toFacetCard('spec-a1b2c3', { type: 'note' })).toEqual({
+      title: 'spec-a1b2c3',
       rows: [{ label: 'type', value: 'note' }],
     })
   })
 
   it('prefers the facet title over the type for the heading', () => {
-    expect(toFacetCard({ type: 'note', title: 'Spec' })).toEqual({
+    expect(toFacetCard('spec-a1b2c3', { type: 'note', title: 'Spec' })).toEqual({
       title: 'Spec',
       rows: [{ label: 'type', value: 'note' }],
     })
   })
 
   it('joins tags into one row and omits the row when there are none', () => {
-    expect(toFacetCard({ type: 'note', tags: ['a', 'b'] })?.rows).toEqual([
+    expect(toFacetCard('spec-a1b2c3', { type: 'note', tags: ['a', 'b'] })?.rows).toEqual([
       { label: 'type', value: 'note' },
       { label: 'tags', value: 'a, b' },
     ])
-    expect(toFacetCard({ type: 'note', tags: [] })?.rows).toEqual([
+    expect(toFacetCard('spec-a1b2c3', { type: 'note', tags: [] })?.rows).toEqual([
       { label: 'type', value: 'note' },
     ])
   })
@@ -179,12 +182,12 @@ describe('toFacetCard', () => {
     // `readCoreFacets` returns core facets PLUS `facetsRaw`, so the extra key
     // really does arrive at runtime even though the parameter narrows it away.
     const facets = { type: 'note', view: 'kanban/1', facetsRaw: { owner: 'x' } } as CoreFacets
-    const card = toFacetCard(facets)
+    const card = toFacetCard('spec-a1b2c3', facets)
     expect(card?.rows).toEqual([{ label: 'type', value: 'note' }])
   })
 
   it('has no card for a document with no readable facets', () => {
-    expect(toFacetCard(undefined)).toBeUndefined()
+    expect(toFacetCard('spec-a1b2c3', undefined)).toBeUndefined()
   })
 })
 
@@ -263,5 +266,24 @@ describe('useCanvasFileSeams empty canvases', () => {
 
     await waitFor(() => expect(result.current.resolveFileFacets('note')).toBeDefined())
     expect(result.current.resolveFileCanvas('note')).toBeUndefined()
+  })
+})
+
+describe('toFacetCard heading when the document has no stored title', () => {
+  it('falls back to the reference, not to the type', () => {
+    // The name moved to the workspace, so a document written through
+    // wb_document_set no longer stores a `title` facet. Falling back to
+    // `type` made every such card read "note" or "issue" — the same word on
+    // every card, identifying nothing. The reference is the slug, which is
+    // the fallback this model uses everywhere a name is absent.
+    expect(toFacetCard('release-plan', { type: 'note' })?.title).toBe('release-plan')
+  })
+
+  it('a stored title still wins, so browser-local documents are unaffected', () => {
+    // Browser-local canvases keep writing `title` into core facets; only the
+    // daemon path stopped. Both must keep working from this one function.
+    expect(toFacetCard('release-plan', { type: 'note', title: 'Release plan' })?.title).toBe(
+      'Release plan',
+    )
   })
 })

--- a/apps/web/src/hooks/use-canvas-file-seams.ts
+++ b/apps/web/src/hooks/use-canvas-file-seams.ts
@@ -166,7 +166,7 @@ export function useCanvasFileSeams({
     [embedContent],
   )
   const resolveFileFacets = useCallback(
-    (file: string) => toFacetCard(embedContent.get(file)?.facets),
+    (file: string) => toFacetCard(file, embedContent.get(file)?.facets),
     [embedContent],
   )
   const resolveFileImage = useCallback(
@@ -191,13 +191,26 @@ export function useCanvasFileSeams({
  * `view` selects a template rather than carrying content, and `facetsRaw`
  * holds keys with no agreed presentation, so neither renders.
  */
-export function toFacetCard(facets: CoreFacets | undefined): FacetCardData | undefined {
+export function toFacetCard(
+  ref: string,
+  facets: CoreFacets | undefined,
+): FacetCardData | undefined {
   if (facets === undefined) return undefined
   const rows = [{ label: 'type', value: facets.type }]
   if (facets.tags !== undefined && facets.tags.length > 0) {
     rows.push({ label: 'tags', value: facets.tags.join(', ') })
   }
-  // `type` is required by the schema, so a parsed facet set always yields a
-  // heading and at least one row — an empty card is unrepresentable here.
-  return { title: facets.title ?? facets.type, rows }
+  // The heading falls back to the REFERENCE, not to `type`. A document's name
+  // lives in the workspace now (ADR-0009 decision 2), so one written through
+  // wb_document_set stores no `title` facet at all — and `type` as a heading
+  // made every such card read "note", identifying nothing. `ref` is the slug,
+  // which is the fallback this model uses wherever a name is absent.
+  //
+  // A stored `title` still wins: browser-local canvases keep writing one, and
+  // both paths come through this function.
+  //
+  // ponytail: the slug, because the daemon's canvas summary carries no
+  // display name yet (see DaemonCanvasPage's note). Once it does, the real
+  // name goes here and this fallback moves behind it.
+  return { title: facets.title ?? ref, rows }
 }


### PR DESCRIPTION
## A regression I shipped in #770

Moving the name to the workspace means `wb_document_set` no longer stores a `title` facet. `toFacetCard`'s heading fell back to `facets.type`, so **every card for a daemon-written document read "note" or "issue"** — the same word on every card of a kind, identifying nothing, in exactly the place a reader is trying to tell one referenced document from another.

I checked server-side readers of `readCoreFacets` before shipping #770 and missed this one: `apps/web` reads the **referenced** document's facets through the daemon file adapter, two packages away from the change.

## The fix, and why it is marked as temporary

The heading falls back to the **reference** — the slug — which is what this model falls back to everywhere a name is absent. A stored `title` still wins, so browser-local canvases (which keep writing one) are unaffected; both paths come through this one function.

It carries a `ponytail:` marker rather than reading as an end state. The real fix is the daemon's canvas summary carrying a display name — which `DaemonCanvasPage`'s own comment already notes it does not:

> The daemon canvas summary carries no display name yet (only slug/updatedAt) — the slug doubles as `name` until that changes.

That is the same gap that made the card read `core.title` in the first place. Once the summary carries a name, it goes in front of this fallback.

## On the updated test

`maps a type-only facet set to a titled card with one row` asserted `title: 'note'` — it encoded the behaviour this changes on purpose. It is updated rather than deleted, renamed to say what it now checks, with the old expectation named in a comment so the change is visible rather than looking like a test that drifted.

## Verification

Red first (the new fallback test, plus the signature change taking the whole `toFacetCard` block red). `apps/web` jsdom: 169 files green. `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB