### PR TITLE
feat(mcp-server): implement DocumentIndex over the canvases table, with a conformance suite

### DIFF
--- a/packages/canvas-ports/src/document-index.test.ts
+++ b/packages/canvas-ports/src/document-index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { compareDocumentPaths, documentEntrySchema } from './document-index.js'
+import { fc, fcTest } from './test-utils/fast-check.js'
+
+describe('compareDocumentPaths', () => {
+  it('keeps a subtree contiguous where whole-string comparison would split it', () => {
+    // `-` is 0x2D and `/` is 0x2F, so sorting these as strings puts `a-b`
+    // between `a` and its own child.
+    const sorted = ['a-b', 'a/b', 'a', 'a/2', 'a/10'].sort(compareDocumentPaths)
+    expect(sorted).toEqual(['a', 'a/10', 'a/2', 'a/b', 'a-b'])
+    expect(['a-b', 'a/b', 'a'].sort()).toEqual(['a', 'a-b', 'a/b'])
+  })
+
+  it('sorts a path before every path it prefixes', () => {
+    expect(compareDocumentPaths('x', 'x/y')).toBeLessThan(0)
+    expect(compareDocumentPaths('x/y', 'x')).toBeGreaterThan(0)
+  })
+
+  it('compares segments by code point rather than numerically', () => {
+    expect(compareDocumentPaths('a/10', 'a/2')).toBeLessThan(0)
+  })
+
+  const pathArbitrary = fc
+    .array(fc.stringMatching(/^[a-z0-9-]{1,3}$/), { minLength: 1, maxLength: 3 })
+    .map((segments) => segments.join('/'))
+
+  fcTest.prop([pathArbitrary, pathArbitrary])('is antisymmetric', (left, right) => {
+    expect(Math.sign(compareDocumentPaths(left, right))).toBe(
+      -Math.sign(compareDocumentPaths(right, left)),
+    )
+  })
+
+  fcTest.prop([pathArbitrary, pathArbitrary, pathArbitrary])(
+    'is transitive, so a sort over it is a total order',
+    (a, b, c) => {
+      const sorted = [a, b, c].sort(compareDocumentPaths)
+      for (let i = 0; i + 1 < sorted.length; i++) {
+        expect(
+          compareDocumentPaths(sorted[i] as string, sorted[i + 1] as string),
+        ).toBeLessThanOrEqual(0)
+      }
+    },
+  )
+})
+
+describe('documentEntrySchema', () => {
+  it('accepts a ULID canvasId with a path and a kind', () => {
+    const parsed = documentEntrySchema.safeParse({
+      canvasId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      path: 'plan/sub',
+      kind: 'markdown',
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects the nanoid row id the daemon mints for its own rows', () => {
+    // ADR-0007 point 5: the nanoid is a storage detail, the ULID is the id.
+    // Converging the two id spaces is what this schema is holding the line on.
+    const parsed = documentEntrySchema.safeParse({
+      canvasId: 'Go1G4OcJKUBu',
+      path: 'plan',
+      kind: 'spatial',
+    })
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/packages/canvas-ports/src/document-index.ts
+++ b/packages/canvas-ports/src/document-index.ts
@@ -39,6 +39,84 @@ export const deleteDocumentInputSchema = z
 export type DeleteDocumentInput = z.infer<typeof deleteDocumentInputSchema>
 
 /**
+ * The `listDocuments` order, as a function, so two implementations cannot
+ * write it two ways. Compares segment against segment by code point, and a
+ * path sorts before every path it prefixes.
+ *
+ * A pure model-only helper in a contracts package for the same reason
+ * `chunkSnapshot` is one: the rule is part of the contract, and a comparator
+ * every store re-derives from prose is a comparator they will re-derive
+ * differently.
+ */
+export function compareDocumentPaths(left: string, right: string): number {
+  const a = left.split('/')
+  const b = right.split('/')
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const segmentA = a[i] as string
+    const segmentB = b[i] as string
+    if (segmentA !== segmentB) return segmentA < segmentB ? -1 : 1
+  }
+  return a.length - b.length
+}
+
+/**
+ * Thrown when a path the caller wanted to occupy is already occupied.
+ *
+ * Named in the contract rather than left to each implementation: "fails if the
+ * path is taken" is not a guarantee a caller can act on if one store throws
+ * this and another surfaces whatever its unique index raised. A store whose
+ * backing has no unique constraint has to detect the collision itself, and
+ * only a named error makes that difference visible instead of silent.
+ */
+export class DocumentPathTakenError extends Error {
+  constructor(
+    readonly workspaceId: string,
+    readonly path: string,
+  ) {
+    super(`Document path "${path}" already exists in workspace "${workspaceId}"`)
+    this.name = 'DocumentPathTakenError'
+  }
+}
+
+/**
+ * Thrown when an operation names a document that is not there. Deleting an
+ * absent path is deliberately NOT this — the caller wanted it gone and it is —
+ * but moving one is: there is a destination involved, and silently doing
+ * nothing would look identical to having moved it.
+ */
+export class DocumentNotFoundError extends Error {
+  constructor(
+    readonly workspaceId: string,
+    readonly path: string,
+  ) {
+    super(`No document at "${path}" in workspace "${workspaceId}"`)
+    this.name = 'DocumentNotFoundError'
+  }
+}
+
+/** Thrown when an operation would strand or swallow the documents below its target. */
+export class DocumentHasDescendantsError extends Error {
+  constructor(
+    readonly path: string,
+    detail: string,
+  ) {
+    super(`Document "${path}" has descendants. ${detail}`)
+    this.name = 'DocumentHasDescendantsError'
+  }
+}
+
+/** Thrown when a move's destination lies inside the subtree being moved. */
+export class DocumentMoveIntoSelfError extends Error {
+  constructor(
+    readonly from: string,
+    readonly to: string,
+  ) {
+    super(`Cannot move "${from}" to "${to}": the destination is inside the subtree being moved`)
+    this.name = 'DocumentMoveIntoSelfError'
+  }
+}
+
+/**
  * The workspace's index of the documents it holds: which paths exist, what
  * each one is, and which stored document each names.
  *
@@ -95,6 +173,10 @@ export interface DocumentIndex {
    * even though `c` is free. The move is rejected whole in that case — a
    * partial move would silently merge two hierarchies, and the caller asked
    * to relocate one.
+   *
+   * Fails when `from` names nothing — unlike a delete, which is content with
+   * an absent path, a move has a destination and doing nothing quietly would
+   * be indistinguishable from succeeding.
    *
    * Also fails when `to` is inside `from`'s own subtree (`a` to `a/b`). The
    * produced paths do not actually collide there — prefix replacement keeps

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -154,6 +154,26 @@ export function describeDocumentIndexConformance(
     })
   })
 
+  it('orders a self-vacating move by depth, not by path order', async () => {
+    await withIndex(async (index) => {
+      // The contended pair here are NOT ancestor and descendant of each
+      // other: `a/b/x` and `a/b/b/x` branch below `a/b`. Moving `a/b` to `a`
+      // sends the second onto the path the first is vacating, so the first
+      // has to write before the second — and segment-wise path order puts
+      // them the other way round, because `b` sorts before `x`. Only depth
+      // separates them.
+      await index.createDocument({ workspaceId: WS, path: 'a/b/x', kind: 'spatial' })
+      await index.createDocument({ workspaceId: WS, path: 'a/b/b/x', kind: 'markdown' })
+
+      await index.moveDocument({ workspaceId: WS, from: 'a/b', to: 'a' })
+
+      expect((await index.listDocuments({ workspaceId: WS })).map((e) => e.path)).toEqual([
+        'a/b/x',
+        'a/x',
+      ])
+    })
+  })
+
   it('refuses a move into the moving subtree', async () => {
     await withIndex(async (index) => {
       await index.createDocument({ workspaceId: WS, path: 'a', kind: 'spatial' })

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -1,0 +1,216 @@
+import type { DocumentIndex } from '@kamiazya/whiteboard-canvas-ports'
+import {
+  DocumentHasDescendantsError,
+  DocumentMoveIntoSelfError,
+  DocumentNotFoundError,
+  DocumentPathTakenError,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { expect, it } from 'vitest'
+
+/**
+ * The `DocumentIndex` guarantees that a TypeScript signature cannot carry,
+ * expressed as tests every implementation has to pass. The port's doc
+ * comments state them; this is where they stop being prose.
+ *
+ * Taken as a factory rather than written inline against one implementation
+ * so the second one — the browser store, when `apps/web` grows a daemon-free
+ * document index — inherits the same bar by calling it. It lives beside the
+ * only current implementation instead of in `canvas-ports` because that
+ * package publishes no test-utils entry point, and adding one before a second
+ * caller exists would be plumbing for nobody.
+ */
+export function describeDocumentIndexConformance(
+  makeIndex: () => Promise<{ index: DocumentIndex; dispose: () => Promise<void> }>,
+): void {
+  const WS = 'ws-conformance'
+
+  async function withIndex(body: (index: DocumentIndex) => Promise<void>): Promise<void> {
+    const { index, dispose } = await makeIndex()
+    try {
+      await body(index)
+    } finally {
+      await dispose()
+    }
+  }
+
+  it('creates a document a later resolve finds, and reports absent as null', async () => {
+    await withIndex(async (index) => {
+      const created = await index.createDocument({ workspaceId: WS, path: 'plan', kind: 'spatial' })
+      expect(created.path).toBe('plan')
+      expect(created.kind).toBe('spatial')
+
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'plan' })).toEqual(created)
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'absent' })).toBeNull()
+    })
+  })
+
+  it('refuses to create over a path that is taken', async () => {
+    await withIndex(async (index) => {
+      await index.createDocument({ workspaceId: WS, path: 'plan', kind: 'spatial' })
+      await expect(
+        index.createDocument({ workspaceId: WS, path: 'plan', kind: 'markdown' }),
+      ).rejects.toThrow(DocumentPathTakenError)
+      // The loser must not have changed what is there.
+      expect((await index.resolveDocument({ workspaceId: WS, path: 'plan' }))?.kind).toBe('spatial')
+    })
+  })
+
+  it('lets exactly one of many concurrent creates of one path win', async () => {
+    await withIndex(async (index) => {
+      const attempts = await Promise.allSettled(
+        Array.from({ length: 8 }, () =>
+          index.createDocument({ workspaceId: WS, path: 'contended', kind: 'spatial' }),
+        ),
+      )
+      // Serialized per workspace: a check-then-write implementation can let two
+      // callers past the check, and the losers then fail some other way (a raw
+      // constraint violation) or not at all (a duplicate row).
+      expect(attempts.filter((a) => a.status === 'fulfilled')).toHaveLength(1)
+      expect(await index.listDocuments({ workspaceId: WS })).toHaveLength(1)
+    })
+  })
+
+  it('lists ordered segment-wise, segments by code point, a path before what it prefixes', async () => {
+    await withIndex(async (index) => {
+      // Insertion order deliberately unrelated to the expected order.
+      for (const path of ['a-b', 'a/b', 'a', 'a/2', 'a/10']) {
+        await index.createDocument({ workspaceId: WS, path, kind: 'spatial' })
+      }
+
+      const paths = (await index.listDocuments({ workspaceId: WS })).map((entry) => entry.path)
+      // `a-b` last because segment-wise compares `a` against `a-b` and the
+      // shorter sorts first; whole-string comparison would put it between `a`
+      // and `a/b` (`-` is 0x2D, `/` is 0x2F) and split the subtree. `a/10`
+      // before `a/2` because segments compare by code point, not numerically.
+      expect(paths).toEqual(['a', 'a/10', 'a/2', 'a/b', 'a-b'])
+    })
+  })
+
+  it('moves a document and every descendant with it', async () => {
+    await withIndex(async (index) => {
+      await index.createDocument({ workspaceId: WS, path: 'a', kind: 'spatial' })
+      const child = await index.createDocument({ workspaceId: WS, path: 'a/d', kind: 'markdown' })
+
+      await index.moveDocument({ workspaceId: WS, from: 'a', to: 'c' })
+
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a' })).toBeNull()
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a/d' })).toBeNull()
+      const moved = await index.resolveDocument({ workspaceId: WS, path: 'c/d' })
+      // The same document, relocated — not a new one.
+      expect(moved?.canvasId).toBe(child.canvasId)
+      expect(moved?.kind).toBe('markdown')
+    })
+  })
+
+  it('refuses a move that collides at a descendant, and changes nothing', async () => {
+    await withIndex(async (index) => {
+      for (const path of ['a', 'a/d', 'c/d']) {
+        await index.createDocument({ workspaceId: WS, path, kind: 'spatial' })
+      }
+      // `c` itself is free, so a check of the destination alone would allow it.
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'c' })).toBeNull()
+
+      // The named error, not merely "something threw": a backing store with a
+      // unique index throws on the write anyway, which would let an
+      // implementation that never checks pass this test.
+      await expect(index.moveDocument({ workspaceId: WS, from: 'a', to: 'c' })).rejects.toThrow(
+        DocumentPathTakenError,
+      )
+
+      // Rejected whole: no half-move left behind.
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a' })).not.toBeNull()
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a/d' })).not.toBeNull()
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'c' })).toBeNull()
+    })
+  })
+
+  it('allows a subtree to move up into a path it is itself vacating', async () => {
+    await withIndex(async (index) => {
+      // The one arrangement where a produced path equals a vacated one:
+      // `a/b` moving to `a` produces `a` and `a/b`, and `a/b` is exactly what
+      // the move is emptying. Treating it as occupied would refuse a move
+      // that is perfectly well defined.
+      await index.createDocument({ workspaceId: WS, path: 'a/b', kind: 'spatial' })
+      const grandchild = await index.createDocument({
+        workspaceId: WS,
+        path: 'a/b/b',
+        kind: 'markdown',
+      })
+
+      await index.moveDocument({ workspaceId: WS, from: 'a/b', to: 'a' })
+
+      expect((await index.listDocuments({ workspaceId: WS })).map((e) => e.path)).toEqual([
+        'a',
+        'a/b',
+      ])
+      expect((await index.resolveDocument({ workspaceId: WS, path: 'a/b' }))?.canvasId).toBe(
+        grandchild.canvasId,
+      )
+    })
+  })
+
+  it('refuses a move into the moving subtree', async () => {
+    await withIndex(async (index) => {
+      await index.createDocument({ workspaceId: WS, path: 'a', kind: 'spatial' })
+      await index.createDocument({ workspaceId: WS, path: 'a/x', kind: 'spatial' })
+
+      await expect(index.moveDocument({ workspaceId: WS, from: 'a', to: 'a/b' })).rejects.toThrow(
+        DocumentMoveIntoSelfError,
+      )
+
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a' })).not.toBeNull()
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a/x' })).not.toBeNull()
+    })
+  })
+
+  it('refuses to delete a document that still has descendants', async () => {
+    await withIndex(async (index) => {
+      await index.createDocument({ workspaceId: WS, path: 'a', kind: 'spatial' })
+      await index.createDocument({ workspaceId: WS, path: 'a/child', kind: 'spatial' })
+
+      await expect(index.deleteDocument({ workspaceId: WS, path: 'a' })).rejects.toThrow(
+        DocumentHasDescendantsError,
+      )
+      expect(await index.resolveDocument({ workspaceId: WS, path: 'a' })).not.toBeNull()
+
+      // Naming the child first is the way through.
+      await index.deleteDocument({ workspaceId: WS, path: 'a/child' })
+      await index.deleteDocument({ workspaceId: WS, path: 'a' })
+      expect(await index.listDocuments({ workspaceId: WS })).toEqual([])
+    })
+  })
+
+  it('refuses to move a path that names nothing', async () => {
+    await withIndex(async (index) => {
+      await expect(
+        index.moveDocument({ workspaceId: WS, from: 'absent', to: 'somewhere' }),
+      ).rejects.toThrow(DocumentNotFoundError)
+    })
+  })
+
+  it('treats deleting an absent path as done', async () => {
+    await withIndex(async (index) => {
+      await expect(
+        index.deleteDocument({ workspaceId: WS, path: 'never-existed' }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  it('scopes every operation to its workspace', async () => {
+    await withIndex(async (index) => {
+      const mine = await index.createDocument({ workspaceId: WS, path: 'p', kind: 'spatial' })
+      const theirs = await index.createDocument({
+        workspaceId: 'ws-other',
+        path: 'p',
+        kind: 'markdown',
+      })
+      expect(theirs.canvasId).not.toBe(mine.canvasId)
+
+      expect((await index.resolveDocument({ workspaceId: WS, path: 'p' }))?.kind).toBe('spatial')
+      expect(await index.listDocuments({ workspaceId: WS })).toHaveLength(1)
+
+      await index.deleteDocument({ workspaceId: WS, path: 'p' })
+      expect(await index.resolveDocument({ workspaceId: 'ws-other', path: 'p' })).not.toBeNull()
+    })
+  })
+}

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -130,12 +130,17 @@ export function describeDocumentIndexConformance(
       // `a/b` moving to `a` produces `a` and `a/b`, and `a/b` is exactly what
       // the move is emptying. Treating it as occupied would refuse a move
       // that is perfectly well defined.
-      await index.createDocument({ workspaceId: WS, path: 'a/b', kind: 'spatial' })
+      // Deepest first, deliberately. A store that rewrites rows in whatever
+      // order its query returned will then try `a/b/b` -> `a/b` while the
+      // original `a/b` is still there, and collide on a move the contract
+      // says must succeed. Creating the shallow one first hides that behind
+      // insertion order.
       const grandchild = await index.createDocument({
         workspaceId: WS,
         path: 'a/b/b',
         kind: 'markdown',
       })
+      await index.createDocument({ workspaceId: WS, path: 'a/b', kind: 'spatial' })
 
       await index.moveDocument({ workspaceId: WS, from: 'a/b', to: 'a' })
 

--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -1,0 +1,21 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe } from 'vitest'
+import { createIsolatedDb } from './db/test-helpers.js'
+import { describeDocumentIndexConformance } from './document-index-conformance.js'
+import { SqliteDocumentIndex } from './sqlite-document-index.js'
+
+describe('SqliteDocumentIndex', () => {
+  describeDocumentIndexConformance(async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-document-index-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    return {
+      index: new SqliteDocumentIndex(handle.db),
+      dispose: async () => {
+        await handle.dispose()
+        await rm(tempDir, { recursive: true, force: true })
+      },
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -117,6 +117,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
         const occupied = new Set(rows.map((row) => row.slug))
         const rewritten = moving.map((row) => ({
           id: row.id,
+          from: row.slug,
           slug: `${to}${row.slug.slice(from.length)}`,
         }))
         // Every produced path, not just `to`: moving `a` onto a free `c`
@@ -129,6 +130,15 @@ export class SqliteDocumentIndex implements DocumentIndex {
             throw new DocumentPathTakenError(workspaceId, row.slug)
           }
         }
+
+        // Shallowest source first. When a move goes UP into its own ancestor
+        // namespace the produced path of a deeper row equals the vacated path
+        // of a shallower one, so writing them in the order the query happened
+        // to return can hit the unique index on a move the contract says
+        // succeeds. `compareDocumentPaths` already sorts a parent before its
+        // descendants, which is exactly the order that frees each path before
+        // anything claims it.
+        rewritten.sort((left, right) => compareDocumentPaths(left.from, right.from))
 
         const now = Date.now()
         for (const row of rewritten) {

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -1,0 +1,166 @@
+import type {
+  CreateDocumentInput,
+  DeleteDocumentInput,
+  DocumentEntry,
+  DocumentIndex,
+  ListDocumentsInput,
+  MoveDocumentInput,
+  ResolveDocumentInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import {
+  compareDocumentPaths,
+  DocumentHasDescendantsError,
+  DocumentMoveIntoSelfError,
+  DocumentNotFoundError,
+  DocumentPathTakenError,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { generateCanvasId } from '@kamiazya/whiteboard-server-core'
+import type { Database } from './db/index.js'
+import { upsertWorkspaceRow } from './db/upsert-workspace.js'
+import { withWorkspaceWriteLock } from './workspace-lock.js'
+
+/** Whether `path` is `ancestor` itself or sits below it. */
+function isSelfOrDescendant(path: string, ancestor: string): boolean {
+  return path === ancestor || path.startsWith(`${ancestor}/`)
+}
+
+/**
+ * `DocumentIndex` over the daemon's `canvases` table — the store the user's
+ * canvas list, versions, branches and file GC already hang off, which is what
+ * makes an agent-created document one a user can see.
+ *
+ * New rows are assigned a ULID, not the nanoid `saveCanvas` mints for its own
+ * rows: ADR-0007 point 5 fixed the ULID as the `canvasId` and the nanoid as a
+ * storage detail, and `canvasIdSchema` in the port's `DocumentEntry` accepts
+ * only the former. A row predating this therefore does not round-trip through
+ * the port, which is a deliberate consequence of converging the two id spaces
+ * rather than an oversight.
+ */
+export class SqliteDocumentIndex implements DocumentIndex {
+  constructor(private readonly db: Database) {}
+
+  async createDocument({ workspaceId, path, kind }: CreateDocumentInput): Promise<DocumentEntry> {
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      await upsertWorkspaceRow(this.db, workspaceId)
+      const canvasId = generateCanvasId()
+      const now = Date.now()
+      // One statement, so the check and the claim cannot be separated: the
+      // unique (workspaceId, slug) index decides, and a loser inserts nothing.
+      const inserted = await this.db
+        .insertInto('canvases')
+        .values({
+          id: canvasId,
+          workspaceId,
+          slug: path,
+          displayName: null,
+          isPinned: 0,
+          pinOrder: null,
+          currentBranch: 'main',
+          createdAt: now,
+          updatedAt: now,
+          kind,
+        })
+        .onConflict((oc) => oc.columns(['workspaceId', 'slug']).doNothing())
+        .executeTakeFirst()
+
+      if ((inserted.numInsertedOrUpdatedRows ?? 0n) === 0n) {
+        throw new DocumentPathTakenError(workspaceId, path)
+      }
+      return { canvasId, path, kind }
+    })
+  }
+
+  async resolveDocument({
+    workspaceId,
+    path,
+  }: ResolveDocumentInput): Promise<DocumentEntry | null> {
+    const row = await this.db
+      .selectFrom('canvases')
+      .select(['id', 'slug', 'kind'])
+      .where('workspaceId', '=', workspaceId)
+      .where('slug', '=', path)
+      .executeTakeFirst()
+    if (!row?.kind) return null
+    return { canvasId: row.id, path: row.slug, kind: row.kind }
+  }
+
+  async listDocuments({ workspaceId }: ListDocumentsInput): Promise<DocumentEntry[]> {
+    const rows = await this.db
+      .selectFrom('canvases')
+      .select(['id', 'slug', 'kind'])
+      .where('workspaceId', '=', workspaceId)
+      .execute()
+    // Sorted here rather than in SQL: segment-wise order is not what any
+    // collation gives, and the row count per workspace is a list a human reads.
+    return rows
+      .filter((row) => row.kind !== null)
+      .map((row) => ({ canvasId: row.id, path: row.slug, kind: row.kind as DocumentEntry['kind'] }))
+      .sort((left, right) => compareDocumentPaths(left.path, right.path))
+  }
+
+  async moveDocument({ workspaceId, from, to }: MoveDocumentInput): Promise<void> {
+    if (isSelfOrDescendant(to, from)) {
+      throw new DocumentMoveIntoSelfError(from, to)
+    }
+    await withWorkspaceWriteLock(workspaceId, async () => {
+      await this.db.transaction().execute(async (trx) => {
+        const rows = await trx
+          .selectFrom('canvases')
+          .select(['id', 'slug'])
+          .where('workspaceId', '=', workspaceId)
+          .execute()
+
+        const moving = rows.filter((row) => isSelfOrDescendant(row.slug, from))
+        if (moving.length === 0) {
+          throw new DocumentNotFoundError(workspaceId, from)
+        }
+        const occupied = new Set(rows.map((row) => row.slug))
+        const rewritten = moving.map((row) => ({
+          id: row.id,
+          slug: `${to}${row.slug.slice(from.length)}`,
+        }))
+        // Every produced path, not just `to`: moving `a` onto a free `c`
+        // still collides when `a/d` and `c/d` both exist. Paths the move is
+        // vacating do not count as occupied, or relocating a subtree would
+        // always collide with itself.
+        const vacating = new Set(moving.map((row) => row.slug))
+        for (const row of rewritten) {
+          if (occupied.has(row.slug) && !vacating.has(row.slug)) {
+            throw new DocumentPathTakenError(workspaceId, row.slug)
+          }
+        }
+
+        const now = Date.now()
+        for (const row of rewritten) {
+          await trx
+            .updateTable('canvases')
+            .set({ slug: row.slug, updatedAt: now })
+            .where('id', '=', row.id)
+            .execute()
+        }
+      })
+    })
+  }
+
+  async deleteDocument({ workspaceId, path }: DeleteDocumentInput): Promise<void> {
+    await withWorkspaceWriteLock(workspaceId, async () => {
+      const descendant = await this.db
+        .selectFrom('canvases')
+        .select('slug')
+        .where('workspaceId', '=', workspaceId)
+        .where('slug', 'like', `${path}/%`)
+        .executeTakeFirst()
+      if (descendant) {
+        throw new DocumentHasDescendantsError(
+          path,
+          `Delete "${descendant.slug}" and any others below it first.`,
+        )
+      }
+      await this.db
+        .deleteFrom('canvases')
+        .where('workspaceId', '=', workspaceId)
+        .where('slug', '=', path)
+        .execute()
+    })
+  }
+}

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -19,6 +19,11 @@ import type { Database } from './db/index.js'
 import { upsertWorkspaceRow } from './db/upsert-workspace.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
+/** How many segments a path has. */
+function depth(path: string): number {
+  return path.split('/').length
+}
+
 /** Whether `path` is `ancestor` itself or sits below it. */
 function isSelfOrDescendant(path: string, ancestor: string): boolean {
   return path === ancestor || path.startsWith(`${ancestor}/`)
@@ -131,14 +136,18 @@ export class SqliteDocumentIndex implements DocumentIndex {
           }
         }
 
-        // Shallowest source first. When a move goes UP into its own ancestor
-        // namespace the produced path of a deeper row equals the vacated path
-        // of a shallower one, so writing them in the order the query happened
-        // to return can hit the unique index on a move the contract says
-        // succeeds. `compareDocumentPaths` already sorts a parent before its
-        // descendants, which is exactly the order that frees each path before
-        // anything claims it.
-        rewritten.sort((left, right) => compareDocumentPaths(left.from, right.from))
+        // Shallowest source first, by DEPTH — not by path order. A move up
+        // into its own ancestor namespace sends a deeper row onto the path a
+        // shallower one is vacating, so the shallower write has to land
+        // first or the unique index rejects a move the contract requires to
+        // succeed. The two contending rows need not be ancestor and
+        // descendant of each other (`a/b/x` and `a/b/b/x` both branch below
+        // `a/b`), which is why segment-wise path order is not enough here: it
+        // would put `a/b/b/x` first because `b` precedes `x`. Only the depth
+        // difference is guaranteed, and it is: the row producing a contested
+        // path is always deeper than the row vacating it, by exactly the
+        // number of segments the move removes.
+        rewritten.sort((left, right) => depth(left.from) - depth(right.from))
 
         const now = Date.now()
         for (const row of rewritten) {


### PR DESCRIPTION
Layer 2a of the convergence. #761 declared the contract; this is where its guarantees stop being prose.

## The conformance suite

Twelve cases, one per behaviour a TypeScript signature cannot carry, taken as a **factory** so the browser store inherits the same bar when `apps/web` grows a document index rather than re-deciding each rule.

Backed by `canvases` — the table the user's list, versions, branches and file GC already hang off — because that is what makes an agent-created document one a user can *see*.

New rows get a **ULID**. ADR-0007 point 5 fixed the ULID as the `canvasId` and the nanoid `saveCanvas` mints as a storage detail, and the port's `DocumentEntry` accepts only the former — so converging the two id spaces is **forced by the contract** rather than left as a later intention. A row predating this does not round-trip through the port; that is the deliberate consequence, and there is a test pinning the rejection.

## What writing it against the suite moved into the contract

| | |
|---|---|
| **Named errors** | "Fails if the path is taken" was satisfiable by whatever a store's unique index raised. `DocumentPathTakenError` / `DocumentHasDescendantsError` / `DocumentMoveIntoSelfError` / `DocumentNotFoundError` now live in the port. |
| **`moveDocument` on an absent source** | Unspecified. An absent *delete* is a no-op; an absent *move* has a destination, so doing nothing quietly is indistinguishable from having moved it. Now `DocumentNotFoundError`. |
| **`compareDocumentPaths`** | Moved to `canvas-ports` beside the ordering rule it implements. A comparator each store re-derives from prose is one they re-derive differently. |

## Mutation check — and the two that initially passed

| mutation | result |
|---|---|
| whole-string ordering | fails |
| drop descendant-collision check | **passed at first** |
| drop self-subtree refusal | fails |
| drop delete-descendant refusal | fails |
| drop the vacating exclusion | **passed at first** |
| create as check-then-insert | fails |

The first was the unnamed-error hole above: the DB's unique index threw anyway, so `.rejects.toThrow()` was satisfied by the constraint doing the implementation's job. Asserting the *named* error closed it — and that is precisely the case a store without a unique constraint would have gotten silently wrong.

The second looked like dead code. It is not: there is exactly one arrangement where a produced path equals a vacated one — a subtree moving **up** into its own ancestor namespace, `a/b` to `a` with `a/b/b` present, which produces `{a, a/b}` while vacating `{a/b, a/b/b}`. Deleting the exclusion as "unreachable" would have shipped a real bug. That case is now a test, and the mutation fails against it.

## Verification

`mcp-node` + `canvas-ports-node`: 285 files / 3447 tests pass. `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean.

One test failed once in an intermediate run and did not reproduce on re-run; its name was lost in log noise, so I am recording it as an unexplained one-off rather than claiming a diagnosis.

## Reach

`userReach`: **`foundation:`** — nothing calls `SqliteDocumentIndex` yet. Layer 2b rewires the MCP tools onto it, and is sequenced behind #768, which is editing `canvas-crud.ts` right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw
