### PR TITLE
fix(web): surface a shared-worker load failure instead of hanging on it

### DIFF
--- a/apps/web/src/lib/sse-shared-stream-source.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The failure mode this covers is not a thrown error: a module shared worker
+ * whose chunk fails to load constructs FINE and reports through `onerror`
+ * afterwards. The try/catch around the constructor cannot see that, so before
+ * this the port was a hole — every subscribe posted into it, nothing answered,
+ * and the caller never learned it should have opened its own stream.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSharedSseStreamSource } from './sse-shared-stream-source.js'
+
+type ErrorHandler = ((event: { message?: string }) => void) | null
+
+class FakeSharedWorker {
+  static instances: FakeSharedWorker[] = []
+  onerror: ErrorHandler = null
+  readonly port = {
+    postMessage: vi.fn(),
+    start: vi.fn(),
+    onmessage: null as ((e: MessageEvent) => void) | null,
+  }
+  constructor() {
+    FakeSharedWorker.instances.push(this)
+  }
+  fail() {
+    this.onerror?.({ message: 'chunk failed to load' })
+  }
+}
+
+const original = globalThis.SharedWorker
+
+beforeEach(() => {
+  FakeSharedWorker.instances = []
+  globalThis.SharedWorker = FakeSharedWorker as unknown as typeof SharedWorker
+})
+afterEach(() => {
+  globalThis.SharedWorker = original
+})
+
+describe('a shared worker that fails to load', () => {
+  it('tells its listeners they are disconnected instead of going quiet', () => {
+    const source = createSharedSseStreamSource('http://daemon.test', 't')
+    expect(source).not.toBeNull()
+    const onConnectionChange = vi.fn()
+    source?.subscribe('w/doc', { onUpdate: vi.fn(), onMessage: vi.fn(), onConnectionChange })
+
+    FakeSharedWorker.instances[0]?.fail()
+
+    expect(onConnectionChange).toHaveBeenCalledWith(false)
+  })
+
+  it('is evicted, so the next caller gets a fresh worker rather than the dead one', () => {
+    createSharedSseStreamSource('http://daemon.test', 't')
+    expect(FakeSharedWorker.instances).toHaveLength(1)
+
+    // Without eviction this returns the cached source built on the dead
+    // worker, and the hole outlives the failure for the whole session.
+    createSharedSseStreamSource('http://daemon.test', 't')
+    expect(FakeSharedWorker.instances).toHaveLength(1)
+
+    FakeSharedWorker.instances[0]?.fail()
+    createSharedSseStreamSource('http://daemon.test', 't')
+    expect(FakeSharedWorker.instances).toHaveLength(2)
+  })
+})

--- a/apps/web/src/lib/sse-shared-stream-source.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.ts
@@ -39,6 +39,30 @@ export function createSharedSseStreamSource(
 
   const listeners = new Map<string, Set<DocListener>>()
   const port = worker.port
+
+  // A module worker that fails to LOAD does not throw above — construction
+  // succeeds and the failure arrives here instead. Without this the port is a
+  // hole: every subscribe posts into it, nothing ever answers, and the caller
+  // never learns it should have opened its own stream. That is a silent hang,
+  // which is strictly worse than the missing cross-tab sharing the null return
+  // degrades to.
+  //
+  // Verified as reachable-in-principle rather than observed: `type: 'module'`
+  // shared workers load in Chromium, WebKit and Firefox (see
+  // sse-shared-worker.browser.test.tsx), so today this fires only for a
+  // missing chunk or a CSP refusal. It stays because a source of truth behind
+  // this worker would make a silent hole much more expensive than it is now.
+  worker.onerror = () => {
+    // Tell whoever is watching that they are not connected — the UI reads this
+    // to stop claiming a live daemon.
+    for (const set of listeners.values()) {
+      for (const listener of set) listener.onConnectionChange?.(false)
+    }
+    listeners.clear()
+    // Evicted, so the next creation for this origin builds a fresh worker
+    // rather than handing out the dead one from the cache forever.
+    sources.delete(baseUrl)
+  }
   port.onmessage = (e: MessageEvent) => {
     const parsed = sseWorkerEventSchema.safeParse(e.data)
     if (!parsed.success) return

--- a/apps/web/src/lib/sse-shared-worker.browser.test.tsx
+++ b/apps/web/src/lib/sse-shared-worker.browser.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * The SSE shared worker, loaded the way the app loads it, in a real browser.
+ *
+ * Everything else covering this worker runs under `@vitest/web-worker` in
+ * jsdom — a polyfill that builds a fresh worker context per construction, so
+ * it can exercise the message protocol but never the browser's own
+ * SharedWorker: not the module load, not `type: 'module'` support, not the
+ * same-origin/CSP path. That left the app's ONLY SharedWorker with no evidence
+ * it loads at all outside a polyfill, which is a poor foundation for anything
+ * that would put more state behind it.
+ *
+ * Verified while writing this: `type: 'module'` shared workers are supported
+ * in Chromium, WebKit and Firefox (checked with static module files in all
+ * three via Playwright), so a failure here means this app's chunk, not the
+ * browser.
+ *
+ * Cross-tab SHARING is still not asserted, and deliberately: the worker
+ * exposes no observable that distinguishes "one worker, two ports" from "two
+ * workers" without adding a test-only seam to production — which is the exact
+ * trade this file's jsdom sibling already refuses to make.
+ */
+import { expect, it } from 'vitest'
+import { sseWorkerEventSchema } from './sse-shared-worker-protocol.js'
+
+it('loads as a module shared worker and answers a subscribe', async () => {
+  const outcome = await new Promise<
+    { kind: 'replied'; data: unknown } | { kind: 'construct-threw' | 'error-event' | 'silent' }
+  >((resolve) => {
+    let worker: SharedWorker
+    try {
+      worker = new SharedWorker(new URL('./sse-shared-worker.js', import.meta.url), {
+        type: 'module',
+        name: 'whiteboard-sse-browser-test',
+      })
+    } catch {
+      resolve({ kind: 'construct-threw' })
+      return
+    }
+    // A module worker that fails to LOAD does not throw at construction — it
+    // fires this instead, which is why the app's try/catch cannot see it.
+    worker.onerror = () => resolve({ kind: 'error-event' })
+    worker.port.onmessage = (e: MessageEvent) => resolve({ kind: 'replied', data: e.data })
+    worker.port.start()
+    // Pointed at a port nothing listens on: the stream fails to open and the
+    // worker reports it, which is a real answer from a running worker and
+    // needs no server to stand up.
+    worker.port.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:1', token: 't' })
+    worker.port.postMessage({ type: 'subscribe', doc: 'w/browser-probe' })
+    setTimeout(() => resolve({ kind: 'silent' }), 8000)
+  })
+
+  expect(outcome.kind).toBe('replied')
+  if (outcome.kind !== 'replied') return
+  // Parsed through the production schema: a reply that does not satisfy it is
+  // a protocol drift, not a passing test.
+  const parsed = sseWorkerEventSchema.safeParse(outcome.data)
+  expect(parsed.success).toBe(true)
+  if (!parsed.success) return
+  expect(parsed.data.type).toBe('status')
+}, 30_000)


### PR DESCRIPTION
Groundwork for the "Loro as the source of truth behind a worker" direction: before putting more state behind a SharedWorker, check that the one already there actually works. It does — and the check turned up a real hole next to it.

## The hole

```ts
try {
  worker = new SharedWorker(url, { type: 'module', name: 'whiteboard-sse' })
} catch {
  return null   // caller opens its own per-tab stream
}
```

**A module worker whose chunk fails to load does not throw.** Construction succeeds and the failure arrives as an `error` event. So the catch never fires, the caller gets a source built on a dead port, every subscribe posts into a hole, and nothing ever answers — a **silent hang**, where the `null` return would have degraded to "correct, just not shared across tabs". The file's own doc comment claims it "falls back where SharedWorker is unavailable", which covers only `typeof SharedWorker === 'undefined'` and a constructor throw.

`worker.onerror` now tells every listener it is disconnected and evicts the cached source, so the next creation builds a fresh worker rather than handing out the dead one for the rest of the session. Both behaviours mutation-checked.

## Not observed in the field — and I nearly reported that it was

An early probe had module SharedWorkers failing in **all three** engines, which looked like a shipped bug in this exact code path. It was not: Vite's dev server cannot serve a hand-written `.ts` to a module shared worker. With static module files, `type: 'module'` shared workers load in **Chromium, WebKit and Firefox** (checked through Playwright in each), and the app's own worker loads fine.

So today this fires only for a missing chunk or a CSP refusal. It is worth fixing anyway because of what the investigation was for — a silent hole is much more expensive behind a source of truth than behind a stream that has a per-tab fallback.

## The coverage gap that made this findable

The app's only SharedWorker had never been exercised outside `@vitest/web-worker`'s jsdom polyfill, which builds a fresh context per construction and therefore cannot cover the module load, `type: 'module'` support, or the same-origin/CSP path.

`sse-shared-worker.browser.test.tsx` now loads it the way the app does, in a real browser, and parses the reply through the production schema so a protocol drift fails rather than passes. Green in all three engines.

**Cross-tab sharing stays unasserted, deliberately.** The worker exposes no observable that separates "one worker, two ports" from "two workers" without adding a test-only seam to production — the exact trade its jsdom sibling already refuses to make, and the reason that file says so in its header.

## For the architecture question this came from

Both prerequisites check out: `loro-crdt` runs in a worker and its `subscribe` fires, and `type: 'module'` SharedWorkers are supported everywhere tested. The blockers for putting the doc behind one are design questions (undo semantics with a shared doc, local-edit latency), not platform ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ