### PR TITLE
feat(mcp)!: refuse wb_facet_set on a spatial document

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -94,10 +94,23 @@ async function callTool(name, args) {
   return JSON.parse(text)
 }
 
-async function expectToolError(name, args, because = 'without createWorkspace') {
+/**
+ * `expecting` is required, and checked against the error text: isError alone
+ * says a call failed, not that it failed for the reason under test. Every
+ * step here refuses on a guard, and a typo'd id or an unrelated regression
+ * also produces isError — which would keep the step green while testing
+ * nothing.
+ */
+async function expectToolError(name, args, because, expecting) {
   const res = await rpc('tools/call', { name, arguments: args })
   if (!res?.isError) {
     throw new Error(`expected ${name} to fail, got: ${JSON.stringify(res)}`)
+  }
+  const text = res.content?.[0]?.text ?? ''
+  if (!text.includes(expecting)) {
+    throw new Error(
+      `${name} failed for the wrong reason.\n  expected text containing: ${expecting}\n  got: ${text}`,
+    )
   }
   console.log(`[e2e] ${name} ${because} → isError (expected)`)
 }
@@ -172,11 +185,12 @@ async function main() {
 
   // Unknown-workspace guard: without createWorkspace the create must fail
   // (workspaces never materialize implicitly from a typo'd workspaceId).
-  await expectToolError('wb_document_create', {
-    workspaceId: WORKSPACE_ID,
-    segment: 'e2e-src',
-    kind: 'spatial',
-  })
+  await expectToolError(
+    'wb_document_create',
+    { workspaceId: WORKSPACE_ID, segment: 'e2e-src', kind: 'spatial' },
+    'without createWorkspace',
+    'Workspace not found',
+  )
 
   // wb_document_create: first daemon-dependent RPC (cold-start latency).
   const created = await callTool('wb_document_create', {
@@ -210,10 +224,8 @@ async function main() {
   }
   console.log('[e2e] wb_document_create/list → name round-trips, unnamed stays unnamed')
 
-  // wb_facet_set: a facet is OKF frontmatter, so it goes on the markdown
-  // document. The spatial one used to carry it, to give wb_version_save
-  // content — wb_node_add does that now, which is content the format can
-  // actually hold.
+  // A facet is OKF frontmatter, so it belongs to the markdown document; the
+  // spatial one refuses it.
   const facets = await callTool('wb_facet_set', {
     workspaceId: WORKSPACE_ID,
     canvasId: named.canvasId,
@@ -228,6 +240,7 @@ async function main() {
     'wb_facet_set',
     { workspaceId: WORKSPACE_ID, canvasId, facets: { 'e2e/1': { note: 'nope' } } },
     'on a spatial document',
+    'Facets are OKF frontmatter',
   )
 
   // wb_node_add: the only MCP path that puts a node on a spatial canvas,
@@ -250,6 +263,7 @@ async function main() {
       node: { id: 'lockable', type: 'text', x: 1, y: 1, width: 10, height: 10, text: 'clobber' },
     },
     'on an id that is already taken',
+    'already exists on canvas',
   )
 
   // wb_edge_add: the only MCP path that connects two nodes. Needs a second
@@ -279,6 +293,7 @@ async function main() {
       edge: { id: 'dangling', fromNode: 'lockable', toNode: 'ghost' },
     },
     'with an endpoint the canvas does not have',
+    'references nonexistent toNode',
   )
 
   const nodeLocked = await callTool('wb_node_lock', {
@@ -301,6 +316,7 @@ async function main() {
     'wb_node_patch',
     { workspaceId: WORKSPACE_ID, canvasId, nodeId: 'lockable', patch: { x: 999 } },
     'on a locked node',
+    'node is locked',
   )
 
   // The lock is editor state, never canvas content: it must not appear in
@@ -387,12 +403,14 @@ async function main() {
     'wb_edge_patch',
     { workspaceId: WORKSPACE_ID, canvasId, edgeId: 'link', patch: { label: 'nope' } },
     'on a locked edge',
+    'edge is locked',
   )
 
   await expectToolError(
     'wb_edge_lock',
     { workspaceId: WORKSPACE_ID, canvasId, edgeId: 'no-such-edge', locked: true },
     'with an id the canvas does not have',
+    'edge not found',
   )
 
   // wb_version_save
@@ -459,6 +477,7 @@ async function main() {
     'wb_document_set',
     { workspaceId: WORKSPACE_ID, canvasId, markdown: '---\ntype: note\n---\nBody.' },
     'on a spatial document',
+    'This writes OKF Markdown',
   )
   await expectToolError(
     'wb_node_add',
@@ -468,6 +487,7 @@ async function main() {
       node: { id: 'stray', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'stray' },
     },
     'on a markdown document',
+    'This adds a JSON Canvas node',
   )
 
   const importMarkdown = [

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -210,16 +210,25 @@ async function main() {
   }
   console.log('[e2e] wb_document_create/list → name round-trips, unnamed stays unnamed')
 
-  // wb_facet_set: seed extension-facet state so wb_version_save has content.
+  // wb_facet_set: a facet is OKF frontmatter, so it goes on the markdown
+  // document. The spatial one used to carry it, to give wb_version_save
+  // content — wb_node_add does that now, which is content the format can
+  // actually hold.
   const facets = await callTool('wb_facet_set', {
     workspaceId: WORKSPACE_ID,
-    canvasId,
+    canvasId: named.canvasId,
     facets: { 'e2e/1': { note: 'before-save' } },
   })
-  if (facets.canvasId !== canvasId) {
+  if (facets.canvasId !== named.canvasId) {
     throw new Error(`wb_facet_set returned unexpected shape: ${JSON.stringify(facets)}`)
   }
-  console.log('[e2e] wb_facet_set → seeded canvas state')
+  console.log('[e2e] wb_facet_set → set on the markdown document')
+
+  await expectToolError(
+    'wb_facet_set',
+    { workspaceId: WORKSPACE_ID, canvasId, facets: { 'e2e/1': { note: 'nope' } } },
+    'on a spatial document',
+  )
 
   // wb_node_add: the only MCP path that puts a node on a spatial canvas,
   // and what the lock round-trip below needs to have something to lock.

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -63,7 +63,10 @@ export function triggerDaemonCanvasCreate(
     callTool('wb_document_create', {
       workspaceId: WORKSPACE_ID,
       segment: 'e2e-src',
-      kind: 'spatial',
+      // markdown, because the flow below sets a facet on it — facets are OKF
+      // frontmatter, and nothing here needs a spatial canvas: version
+      // save/list/restore is about history, not content shape.
+      kind: 'markdown',
       createWorkspace: true,
     })
   return options.retryDaemonStartup
@@ -255,8 +258,8 @@ export async function runE2eCheckpointSmoke({
     const canvasId = created.canvasId
     console.log(`[e2e] wb_document_create → ${canvasId}`)
 
-    // wb_facet_set seeds extension-facet state on the created canvas so the version
-    // saved below has content to round-trip through restore.
+    // wb_facet_set seeds extension-facet state on the created document so the
+    // version saved below has content to round-trip through restore.
     const facets = await callTool('wb_facet_set', {
       workspaceId: WORKSPACE_ID,
       canvasId,

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -1,12 +1,18 @@
 import { reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
-import { readFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import {
+  readFacets,
+  writeDocumentKind,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
+  seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
+import { DocumentKindMismatchError } from './errors.js'
 import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -119,5 +125,63 @@ describe('wb_facet_set tool', () => {
         facets: { title: 'not an extension facet' },
       }),
     ).toThrow()
+  })
+})
+
+describe('facets belong to OKF (ADR-0009 decision 3)', () => {
+  test('refuses a spatial document', async () => {
+    // A facet is OKF frontmatter. A JSON Canvas document has nodes and edges
+    // and no frontmatter to put one in, so a facet stored on one is metadata
+    // no reader of that format can ever surface.
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeDocumentKind(doc, 'spatial')
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'n' }],
+        edges: [],
+      })
+    })
+
+    await expect(
+      createFacetSetTool(makeDeps(store)).execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        facets: { 'example/1': { status: 'open' } },
+      }),
+    ).rejects.toThrow(DocumentKindMismatchError)
+  })
+
+  test('a refused write stores nothing', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => writeDocumentKind(doc, 'spatial'))
+
+    await expect(
+      createFacetSetTool(makeDeps(store)).execute({
+        workspaceId: WORKSPACE_ID,
+        canvasId: CANVAS_ID,
+        facets: { 'example/1': { status: 'open' } },
+      }),
+    ).rejects.toThrow(DocumentKindMismatchError)
+
+    const snap = await store.loadSnapshot({ docRef: { kind: 'canvas', canvasId: CANVAS_ID } })
+    const doc = new LoroDoc()
+    if (snap) doc.import(reassembleSnapshot(snap.manifest, snap.chunks))
+    expect(readFacets(doc)).toEqual({})
+  })
+
+  test('a markdown document still takes facets', async () => {
+    const store = new FakeCanvasDocStore()
+    await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
+    await seedDoc(store, CANVAS_ID, (doc) => writeDocumentKind(doc, 'markdown'))
+
+    const result = await createFacetSetTool(makeDeps(store)).execute({
+      workspaceId: WORKSPACE_ID,
+      canvasId: CANVAS_ID,
+      facets: { 'example/1': { status: 'open' } },
+    })
+
+    expect(result.facets).toEqual({ 'example/1': { status: 'open' } })
   })
 })

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -4,10 +4,11 @@ import {
   extensionFacetsSchema,
   workspaceIdSchema,
 } from '@kamiazya/whiteboard-canvas-model'
-import { readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
+import { readDocumentKind, readFacets, writeFacets } from '@kamiazya/whiteboard-canvas-workspace'
 import { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { loadOrCreateCanvasDoc, saveDocSnapshot } from './canvas-doc-io.js'
+import { DocumentKindMismatchError } from './errors.js'
 import { assertCanvasInWorkspace } from './workspace-tree-io.js'
 
 /**
@@ -44,6 +45,23 @@ export function createFacetSetTool(deps: ServerDeps) {
     execute: async (input: FacetSetInput): Promise<FacetSetOutput> => {
       await assertCanvasInWorkspace(deps.canvasDocStore, input.workspaceId, input.canvasId)
       const doc = await loadOrCreateCanvasDoc(deps, input.canvasId)
+
+      // A facet is OKF frontmatter (ADR-0009 decision 3). A JSON Canvas
+      // document has nodes and edges and no frontmatter to put one in, so a
+      // facet stored on one is metadata no reader of that format can surface
+      // — written, kept, and invisible.
+      //
+      // A document with no kind is allowed through and NOT declared: unlike
+      // an OKF content write this replaces nothing, so it has neither
+      // something to lose nor any evidence to offer about the format.
+      const kind = readDocumentKind(doc)
+      if (kind === 'spatial') {
+        throw new DocumentKindMismatchError(
+          input.canvasId,
+          kind,
+          'Facets are OKF frontmatter, and a JSON Canvas document has none to hold them. Set them on the markdown document this one refers to, or write its content with wb_document_set.',
+        )
+      }
 
       const mergedFacets: ExtensionFacets = { ...readFacets(doc), ...input.facets }
       writeFacets(doc, mergedFacets)


### PR DESCRIPTION
## What

ADR-0009 decision 3: **a facet is OKF frontmatter.** A JSON Canvas document has nodes and edges and no frontmatter to hold one, so a facet written to one is metadata no reader of that format can ever surface — stored, kept, and invisible. `wb_facet_set` refuses it now, and names the markdown document to set it on instead.

A document with **no** kind is allowed through and **not** declared, unlike an OKF content write: setting a facet replaces nothing, so it has neither something to lose nor any evidence to offer about the format. Same reasoning as `wb_canvas_tidy`'s guard.

## Both smokes were seeding facets onto a spatial document

For the same stated reason — to give `wb_version_save` content — and neither needs to:

- **`mcp-e2e-smoke.mjs`** has `wb_node_add` now, which is content the spatial format can actually hold. Its facet moves to the markdown document, and the spatial one gets a refusal check instead.
- **`mcp-e2e-checkpoint`**'s flow is `create → facet_set → version save/list/restore`, none of it spatial-specific, so its document is created as markdown.

The checkpoint one is **the second smoke**, and the `mcp-smoke` vitest project is what caught it — the same two-smokes trap this session already hit once, working as intended this time.

## Verification

Red first. Mutation-checked: disabling the guard fails both new tests and nothing else.

305 test files green (`server-core-node` + `mcp-node` + `mcp-smoke`); `pnpm smoke:e2e` ALL OK with both new lines:

```
[e2e] wb_facet_set → set on the markdown document
[e2e] wb_facet_set on a spatial document → isError (expected)
```

`pnpm -r typecheck`, `pnpm knip`, lint clean.

## Scope note

This is the server half of ADR-0009 decision 3. The `apps/web` half is separate and not here: browser-local canvases do not go through server-core at all — they use their own IndexedDB store and keep writing core facets — so what the spatial canvas header should offer is a decision about that editor's own model, not a reflection of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added facet support for Markdown documents, including merging and persistence of facet values.
* **Bug Fixes**
  * Prevented facets from being applied to spatial documents, avoiding unsupported or inconsistent document metadata.
  * Added clearer validation when facet operations are attempted on incompatible document types.
* **Tests**
  * Expanded coverage for successful Markdown facet updates and rejected spatial-document updates.
  * Updated end-to-end checks to validate the supported and unsupported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->