### PR TITLE
feat(ports): give DocumentIndex what the tool layer actually needs

### DIFF
--- a/packages/canvas-ports/src/document-index.ts
+++ b/packages/canvas-ports/src/document-index.ts
@@ -20,6 +20,14 @@ export const createDocumentInputSchema = z
   .strict()
 export type CreateDocumentInput = z.infer<typeof createDocumentInputSchema>
 
+export const createWorkspaceInputSchema = z.object({ workspaceId: workspaceIdSchema }).strict()
+export type CreateWorkspaceInput = z.infer<typeof createWorkspaceInputSchema>
+
+export const resolveDocumentByIdInputSchema = z
+  .object({ workspaceId: workspaceIdSchema, canvasId: canvasIdSchema })
+  .strict()
+export type ResolveDocumentByIdInput = z.infer<typeof resolveDocumentByIdInputSchema>
+
 export const resolveDocumentInputSchema = z
   .object({ workspaceId: workspaceIdSchema, path: documentPathSchema })
   .strict()
@@ -57,6 +65,20 @@ export function compareDocumentPaths(left: string, right: string): number {
     if (segmentA !== segmentB) return segmentA < segmentB ? -1 : 1
   }
   return a.length - b.length
+}
+
+/**
+ * Thrown when an operation names a workspace that does not exist.
+ *
+ * Workspaces never materialize implicitly here. A typo'd or hallucinated
+ * workspaceId is otherwise indistinguishable from a new one, and the caller
+ * gets a workspace nobody asked for with its data quietly inside.
+ */
+export class WorkspaceNotFoundError extends Error {
+  constructor(readonly workspaceId: string) {
+    super(`Workspace not found: "${workspaceId}". Create it before adding documents to it.`)
+    this.name = 'WorkspaceNotFoundError'
+  }
 }
 
 /**
@@ -136,13 +158,26 @@ export class DocumentMoveIntoSelfError extends Error {
  */
 export interface DocumentIndex {
   /**
-   * Fails if the path is taken. Creating never silently adopts an existing
+   * Idempotent: creating a workspace that exists is not an error, because the
+   * caller wants it to be there and it is. Explicit because `createDocument`
+   * refuses an absent workspace rather than conjuring one.
+   */
+  createWorkspace(input: CreateWorkspaceInput): Promise<void>
+  /**
+   * Fails `WorkspaceNotFoundError` if the workspace does not exist. Fails if
+   * the path is taken. Creating never silently adopts an existing
    * document, because the caller that wanted a new one would otherwise
    * start writing into somebody else's. Claiming the path and assigning the
    * `canvasId` is one step, not a check followed by a write.
    */
   createDocument(input: CreateDocumentInput): Promise<DocumentEntry>
   resolveDocument(input: ResolveDocumentInput): Promise<DocumentEntry | null>
+  /**
+   * The same lookup keyed by the id the index assigned. Still workspace-scoped:
+   * an id is a handle within a workspace, not a capability that reaches across
+   * them, so the wrong workspace resolves to null rather than to the document.
+   */
+  resolveDocumentById(input: ResolveDocumentByIdInput): Promise<DocumentEntry | null>
   /**
    * Ordered by path, compared SEGMENT BY SEGMENT — not as whole strings.
    * A hierarchical listing is the point of this index, and leaving the order

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -4,6 +4,7 @@ import {
   DocumentMoveIntoSelfError,
   DocumentNotFoundError,
   DocumentPathTakenError,
+  WorkspaceNotFoundError,
 } from '@kamiazya/whiteboard-canvas-ports'
 import { expect, it } from 'vitest'
 
@@ -27,11 +28,54 @@ export function describeDocumentIndexConformance(
   async function withIndex(body: (index: DocumentIndex) => Promise<void>): Promise<void> {
     const { index, dispose } = await makeIndex()
     try {
+      // Workspaces are explicit now, so the shared fixture makes the two the
+      // cases below use rather than each test repeating it.
+      await index.createWorkspace({ workspaceId: WS })
+      await index.createWorkspace({ workspaceId: 'ws-other' })
       await body(index)
     } finally {
       await dispose()
     }
   }
+
+  it('refuses to create a document in a workspace that does not exist', async () => {
+    await withIndex(async (index) => {
+      // A typo'd or hallucinated workspaceId must fail loudly rather than
+      // quietly bringing a workspace into being and writing into it.
+      await expect(
+        index.createDocument({ workspaceId: 'never-created', path: 'plan', kind: 'spatial' }),
+      ).rejects.toThrow(WorkspaceNotFoundError)
+    })
+  })
+
+  it('creates a workspace idempotently, and only then accepts documents', async () => {
+    await withIndex(async (index) => {
+      await index.createWorkspace({ workspaceId: 'fresh' })
+      await index.createWorkspace({ workspaceId: 'fresh' })
+      await expect(
+        index.createDocument({ workspaceId: 'fresh', path: 'plan', kind: 'spatial' }),
+      ).resolves.toMatchObject({ path: 'plan' })
+    })
+  })
+
+  it('resolves a document by the id it was assigned, scoped to its workspace', async () => {
+    await withIndex(async (index) => {
+      const created = await index.createDocument({
+        workspaceId: WS,
+        path: 'plan/sub',
+        kind: 'markdown',
+      })
+
+      expect(
+        await index.resolveDocumentById({ workspaceId: WS, canvasId: created.canvasId }),
+      ).toEqual(created)
+      // The id alone is not the address: another workspace must not see it.
+      await index.createWorkspace({ workspaceId: 'ws-other' })
+      expect(
+        await index.resolveDocumentById({ workspaceId: 'ws-other', canvasId: created.canvasId }),
+      ).toBeNull()
+    })
+  })
 
   it('creates a document a later resolve finds, and reports absent as null', async () => {
     await withIndex(async (index) => {

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -45,6 +45,12 @@ export function describeDocumentIndexConformance(
       await expect(
         index.createDocument({ workspaceId: 'never-created', path: 'plan', kind: 'spatial' }),
       ).rejects.toThrow(WorkspaceNotFoundError)
+      // A second attempt, because refusing is not the same as not creating:
+      // an implementation can materialize the workspace as a side effect and
+      // still throw, and then only the SECOND call reveals it by succeeding.
+      await expect(
+        index.createDocument({ workspaceId: 'never-created', path: 'plan-2', kind: 'spatial' }),
+      ).rejects.toThrow(WorkspaceNotFoundError)
     })
   })
 

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -1,10 +1,12 @@
 import type {
   CreateDocumentInput,
+  CreateWorkspaceInput,
   DeleteDocumentInput,
   DocumentEntry,
   DocumentIndex,
   ListDocumentsInput,
   MoveDocumentInput,
+  ResolveDocumentByIdInput,
   ResolveDocumentInput,
 } from '@kamiazya/whiteboard-canvas-ports'
 import {
@@ -13,6 +15,7 @@ import {
   DocumentMoveIntoSelfError,
   DocumentNotFoundError,
   DocumentPathTakenError,
+  WorkspaceNotFoundError,
 } from '@kamiazya/whiteboard-canvas-ports'
 import { generateCanvasId } from '@kamiazya/whiteboard-server-core'
 import type { Database } from './db/index.js'
@@ -44,9 +47,22 @@ function isSelfOrDescendant(path: string, ancestor: string): boolean {
 export class SqliteDocumentIndex implements DocumentIndex {
   constructor(private readonly db: Database) {}
 
+  async createWorkspace({ workspaceId }: CreateWorkspaceInput): Promise<void> {
+    await withWorkspaceWriteLock(workspaceId, async () => {
+      await upsertWorkspaceRow(this.db, workspaceId)
+    })
+  }
+
   async createDocument({ workspaceId, path, kind }: CreateDocumentInput): Promise<DocumentEntry> {
     return withWorkspaceWriteLock(workspaceId, async () => {
-      await upsertWorkspaceRow(this.db, workspaceId)
+      const workspace = await this.db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', workspaceId)
+        .executeTakeFirst()
+      if (!workspace) {
+        throw new WorkspaceNotFoundError(workspaceId)
+      }
       const canvasId = generateCanvasId()
       const now = Date.now()
       // One statement, so the check and the claim cannot be separated: the
@@ -84,6 +100,20 @@ export class SqliteDocumentIndex implements DocumentIndex {
       .select(['id', 'slug', 'kind'])
       .where('workspaceId', '=', workspaceId)
       .where('slug', '=', path)
+      .executeTakeFirst()
+    if (!row?.kind) return null
+    return { canvasId: row.id, path: row.slug, kind: row.kind }
+  }
+
+  async resolveDocumentById({
+    workspaceId,
+    canvasId,
+  }: ResolveDocumentByIdInput): Promise<DocumentEntry | null> {
+    const row = await this.db
+      .selectFrom('canvases')
+      .select(['id', 'slug', 'kind'])
+      .where('workspaceId', '=', workspaceId)
+      .where('id', '=', canvasId)
       .executeTakeFirst()
     if (!row?.kind) return null
     return { canvasId: row.id, path: row.slug, kind: row.kind }


### PR DESCRIPTION
Preparing `DocumentIndex` to actually back the MCP tools. Two gaps that only appeared when I started wiring layer 2b, and neither was visible from the port's own tests.

## Workspaces must not materialize implicitly

`wbCanvasCreate` refuses an unknown `workspaceId` on purpose, and says why:

> Workspaces never materialize implicitly: a typo'd or hallucinated workspaceId must fail loudly rather than silently writing data into a workspace nobody asked for.

My `createDocument` called `upsertWorkspaceRow` unconditionally. Wiring the tools onto it would have **dropped that guarantee silently** — the tool's loud failure replaced by a workspace quietly springing into existence.

Worth noting where this hid: an earlier review pass asked whether the pre-insert upsert violated "no effect at all" on a failed create, and the answer was no — workspace existence is not observable through any *contract* operation. That was correct and still missed this, because the rule lives in the layer above the contract. A port can be internally consistent and still be wrong for its only caller.

`createDocument` now fails `WorkspaceNotFoundError`; `createWorkspace` is its own idempotent operation.

## Membership is asked by id, not by path

`assertCanvasInWorkspace(store, workspaceId, canvasId)` is what **twelve** tools call, and it asks whether an id belongs to a workspace. The index could only resolve by path, so nothing could answer it.

`resolveDocumentById` answers it, and stays workspace-scoped: an id is a handle *within* a workspace, not a capability that reaches across them. The wrong workspace resolves to `null` rather than to the document.

## Mutation check

| mutation | fails |
|---|---|
| upsert the workspace instead of refusing | "refuses to create a document in a workspace that does not exist" |
| drop the workspace predicate from the id lookup | "resolves a document by the id it was assigned, scoped to its workspace" |
| non-idempotent `createWorkspace` | "creates a workspace idempotently, and only then accepts documents" |

## Verification

16 conformance cases (13 → 16). `mcp-node` + `canvas-ports-node`: 285 files / 3451 tests pass. `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean.

## Reach

`userReach`: **`foundation:`** — still nothing calls the index. The next PR rewires `canvas-crud` and `assertCanvasInWorkspace` onto it, which is the increment where an agent-created document starts appearing in the user's list. That one is unblocked now that #768 has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly creating workspaces.
  * Added workspace-scoped document lookup by canvas ID.
  * Workspace creation is safely repeatable without duplicating data.

* **Bug Fixes**
  * Document creation now rejects unknown workspaces instead of creating them implicitly.
  * Document lookups remain isolated between workspaces.

* **Tests**
  * Expanded coverage for workspace validation, repeatable creation, document lookup, and workspace isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->