### PR TITLE
feat(web): hold an authority replica of each document in the shared worker

### DIFF
--- a/apps/web/src/lib/sse-shared-stream-source.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.ts
@@ -78,6 +78,10 @@ export function createSharedSseStreamSource(
       for (const l of set) l.onConnectionChange?.(evt.connected)
       return
     }
+    // The authority replica's own traffic. This source consumes the raw daemon
+    // frames above; the fork-based client that consumes these is a separate
+    // seam, and answering them here would deliver every update twice.
+    if (evt.type === 'snapshot' || evt.type === 'authority-update') return
     for (const l of set) l.onMessage(evt.raw)
   }
   port.start()

--- a/apps/web/src/lib/sse-shared-worker-protocol.ts
+++ b/apps/web/src/lib/sse-shared-worker-protocol.ts
@@ -26,6 +26,23 @@ export const sseWorkerRequestSchema = z.discriminatedUnion('type', [
   // the worker->tab `message` event below, which travels the other way and
   // carries an already-serialized server frame.
   z.object({ type: z.literal('control'), doc: z.string().min(1), message: z.unknown() }),
+  // --- authority replica ---
+  //
+  // The worker keeps a Loro replica of each subscribed document, so the
+  // consistency question — what has arrived, in what order — is answered in
+  // the same place the daemon stream is read, instead of once per tab.
+  //
+  // A tab does NOT take this replica as its own doc. It forks from the
+  // snapshot, keeping its own peer, and therefore its own undo stack: Loro
+  // scopes undo to a peer and refuses to revert another peer's operations, so
+  // a shared peer would mean a shared undo. Forks exchange updates with the
+  // authority exactly the way the authority exchanges with the daemon, which
+  // is what makes tab, worker and daemon one mechanism rather than three.
+  z.object({ type: z.literal('snapshot-request'), doc: z.string().min(1) }),
+  // A fork's local work, on its way to the authority (and from there to the
+  // daemon and the other tabs). Base64 for the same reason the update event
+  // below is: one decode site.
+  z.object({ type: z.literal('push'), doc: z.string().min(1), update: z.string() }),
 ])
 
 export const sseWorkerEventSchema = z.discriminatedUnion('type', [
@@ -38,4 +55,13 @@ export const sseWorkerEventSchema = z.discriminatedUnion('type', [
   // others so a tab watching several canvases routes it the same way; the
   // worker owns the stream, so this is the only way a tab can know.
   z.object({ type: z.literal('status'), doc: z.string(), connected: z.boolean() }),
+  // The authority's current state, for a tab that is forking from it. Answers
+  // a snapshot-request; a document the worker has never seen replies with an
+  // empty snapshot rather than an error, since forking from empty and letting
+  // the daemon fill it in is the same path a first-ever open takes.
+  z.object({ type: z.literal('snapshot'), doc: z.string(), snapshot: z.string() }),
+  // Authority state a fork has not seen yet. Distinct from `update` (a raw
+  // daemon frame relayed verbatim): this one has been through the replica, so
+  // it is ordered and deduplicated against everything else the worker knows.
+  z.object({ type: z.literal('authority-update'), doc: z.string(), update: z.string() }),
 ])

--- a/apps/web/src/lib/sse-shared-worker.browser.test.tsx
+++ b/apps/web/src/lib/sse-shared-worker.browser.test.tsx
@@ -115,6 +115,51 @@ it('carries one port push to another port of the same worker', async () => {
   expect(echoedToSender).not.toHaveBeenCalled()
 }, 30_000)
 
+it('keeps two daemon origins that share a document id apart', async () => {
+  // Every other piece of worker state — the hub, the credential, the port's
+  // own record — is keyed by origin, so a replica keyed by document alone is
+  // the one place two configured daemons would meet. Document ids are minted
+  // per daemon and nothing makes them globally unique, which is the whole
+  // reason the rest of this file bothers.
+  const NAME = 'whiteboard-sse-origin-test'
+  const a = openPort(NAME)
+  const b = openPort(NAME)
+  const doc = `w/origins-${Date.now()}`
+
+  a.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:1', token: 't' })
+  a.postMessage({ type: 'subscribe', doc })
+  b.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:2', token: 't' })
+  b.postMessage({ type: 'subscribe', doc })
+
+  const leaked = vi.fn()
+  b.addEventListener('message', (e: MessageEvent) => {
+    if ((e.data as { type?: string }).type === 'authority-update') leaked()
+  })
+
+  const tab = new LoroDoc()
+  tab.getMap('m').set('k', 'origin-a-only')
+  tab.commit()
+  a.postMessage({ type: 'push', doc, update: b64(tab.export({ mode: 'update' })) })
+
+  const snapshot = await new Promise<string>((resolve, reject) => {
+    b.addEventListener('message', (e: MessageEvent) => {
+      const data = e.data as { type?: string; snapshot?: string }
+      if (data.type === 'snapshot' && data.snapshot !== undefined) resolve(data.snapshot)
+    })
+    // Ordering is guaranteed rather than raced: replica work runs on one
+    // queue, so this snapshot is answered strictly after the push above. A
+    // shared replica would therefore have to show the leak, not merely be
+    // able to.
+    b.postMessage({ type: 'snapshot-request', doc })
+    setTimeout(() => reject(new Error('no snapshot came back')), 10_000)
+  })
+
+  const forked = new LoroDoc()
+  forked.import(decode(snapshot))
+  expect(forked.getMap('m').size).toBe(0)
+  expect(leaked).not.toHaveBeenCalled()
+}, 30_000)
+
 it('hands a later tab a snapshot that already contains an earlier push', async () => {
   // The round trip a replica exists to remove: without it this snapshot would
   // be empty until the daemon echoed the work back.

--- a/apps/web/src/lib/sse-shared-worker.browser.test.tsx
+++ b/apps/web/src/lib/sse-shared-worker.browser.test.tsx
@@ -14,12 +14,14 @@
  * three via Playwright), so a failure here means this app's chunk, not the
  * browser.
  *
- * Cross-tab SHARING is still not asserted, and deliberately: the worker
- * exposes no observable that distinguishes "one worker, two ports" from "two
- * workers" without adding a test-only seam to production — which is the exact
- * trade this file's jsdom sibling already refuses to make.
+ * Cross-port fan-out IS asserted here, and can only be asserted here: the
+ * jsdom polyfill builds a fresh worker context per construction, so two ports
+ * there are two workers. The authority replica gave the worker its first
+ * observable that separates the two — a push through one port reaching
+ * another — so the gap that sibling documents closes at this layer.
  */
-import { expect, it } from 'vitest'
+import { LoroDoc } from 'loro-crdt'
+import { expect, it, vi } from 'vitest'
 import { sseWorkerEventSchema } from './sse-shared-worker-protocol.js'
 
 it('loads as a module shared worker and answers a subscribe', async () => {
@@ -57,4 +59,89 @@ it('loads as a module shared worker and answers a subscribe', async () => {
   expect(parsed.success).toBe(true)
   if (!parsed.success) return
   expect(parsed.data.type).toBe('status')
+}, 30_000)
+
+const b64 = (bytes: Uint8Array) => {
+  let out = ''
+  for (const byte of bytes) out += String.fromCharCode(byte)
+  return btoa(out)
+}
+const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+
+const openPort = (name: string) => {
+  const worker = new SharedWorker(new URL('./sse-shared-worker.js', import.meta.url), {
+    type: 'module',
+    name,
+  })
+  worker.port.start()
+  return worker.port
+}
+
+it('carries one port push to another port of the same worker', async () => {
+  // Two constructions, one worker — the property the polyfill cannot express,
+  // and the whole basis for a replica that several tabs share.
+  const NAME = 'whiteboard-sse-fanout-test'
+  const a = openPort(NAME)
+  const b = openPort(NAME)
+  const doc = `w/fanout-${Date.now()}`
+
+  for (const port of [a, b]) {
+    port.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:1', token: 't' })
+    port.postMessage({ type: 'subscribe', doc })
+  }
+
+  const echoedToSender = vi.fn()
+  a.addEventListener('message', (e: MessageEvent) => {
+    if ((e.data as { type?: string }).type === 'authority-update') echoedToSender()
+  })
+  const arrived = new Promise<string>((resolve, reject) => {
+    b.addEventListener('message', (e: MessageEvent) => {
+      const data = e.data as { type?: string; update?: string }
+      if (data.type === 'authority-update' && data.update !== undefined) resolve(data.update)
+    })
+    setTimeout(() => reject(new Error('no authority-update reached the second port')), 10_000)
+  })
+
+  const tab = new LoroDoc()
+  tab.getMap('m').set('k', 'from-port-a')
+  tab.commit()
+  a.postMessage({ type: 'push', doc, update: b64(tab.export({ mode: 'update' })) })
+
+  const forked = new LoroDoc()
+  forked.import(decode(await arrived))
+  expect(forked.getMap('m').get('k')).toBe('from-port-a')
+  // Echoing to the sender would make every edit a round trip through the tab
+  // that made it, which is the cost the fork model exists to avoid.
+  expect(echoedToSender).not.toHaveBeenCalled()
+}, 30_000)
+
+it('hands a later tab a snapshot that already contains an earlier push', async () => {
+  // The round trip a replica exists to remove: without it this snapshot would
+  // be empty until the daemon echoed the work back.
+  const NAME = 'whiteboard-sse-snapshot-test'
+  const port = openPort(NAME)
+  const doc = `w/snapshot-${Date.now()}`
+  port.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:1', token: 't' })
+  port.postMessage({ type: 'subscribe', doc })
+
+  const tab = new LoroDoc()
+  tab.getMap('m').set('k', 'already-there')
+  tab.commit()
+  port.postMessage({ type: 'push', doc, update: b64(tab.export({ mode: 'update' })) })
+
+  const snapshot = await new Promise<string>((resolve, reject) => {
+    port.addEventListener('message', (e: MessageEvent) => {
+      const data = e.data as { type?: string; snapshot?: string }
+      if (data.type === 'snapshot' && data.snapshot !== undefined) resolve(data.snapshot)
+    })
+    // Queued behind the push, which is the ordering the worker serialises its
+    // replica work to guarantee — a snapshot answered from before the push
+    // would be an authority that contradicts what it was just told.
+    port.postMessage({ type: 'snapshot-request', doc })
+    setTimeout(() => reject(new Error('no snapshot came back')), 10_000)
+  })
+
+  const forked = new LoroDoc()
+  forked.import(decode(snapshot))
+  expect(forked.getMap('m').get('k')).toBe('already-there')
 }, 30_000)

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -18,6 +18,7 @@
  * worse than none.
  */
 import '@vitest/web-worker'
+import { LoroDoc } from 'loro-crdt'
 import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -314,4 +315,54 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
 
     await until(() => subscribeBodies.some((x) => x.includes(`"unsubscribe":["${doc}"]`)))
   })
+})
+
+/**
+ * The worker's replica of a document: the piece that makes tab, worker and
+ * daemon one mechanism instead of three. A tab does not adopt this doc — it
+ * forks, keeping its own peer and therefore its own undo stack, and exchanges
+ * updates with it exactly the way the worker exchanges with the daemon.
+ */
+describe('authority replica', () => {
+  // Single-port only, on purpose. The polyfill builds a fresh worker context
+  // per `new SharedWorker` (see this file's header), so anything about two
+  // ports meeting in one worker would pass or fail here for reasons that say
+  // nothing about a browser. That half lives in the browser test beside it.
+  const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+  const nextMessage = (port: MessagePort, type: string) =>
+    new Promise<Record<string, unknown>>((resolve) => {
+      const onMessage = (e: MessageEvent) => {
+        if ((e.data as { type?: string }).type !== type) return
+        port.removeEventListener('message', onMessage)
+        resolve(e.data as Record<string, unknown>)
+      }
+      port.addEventListener('message', onMessage)
+      port.start()
+    })
+
+  it('answers a document nobody has opened with an empty snapshot, not an error', async () => {
+    const port = connect()
+    const doc = nextDoc()
+    port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
+    const reply = nextMessage(port, 'snapshot')
+    port.postMessage({ type: 'snapshot-request', doc })
+
+    // Forkable is the property that matters: forking from empty and letting
+    // the daemon fill it in is the same path a first-ever open takes.
+    const forked = new LoroDoc()
+    forked.import(decode((await reply).snapshot as string))
+    expect(forked.getMap('anything').size).toBe(0)
+  })
+
+  // A `push` followed by a snapshot-request is NOT tested here: under the
+  // polyfill the port stops delivering anything at all after a push, while the
+  // same sequence works in a real browser (see the browser test beside this).
+  // Chasing that difference would be debugging the polyfill, not the worker.
+
+  // NOT covered anywhere yet, and worth saying so: that a DAEMON frame lands
+  // in the replica (not only in the relay). jsdom can feed a daemon frame,
+  // through MSW, but cannot observe the replica — every snapshot-request that
+  // follows replica work stops being answered under the polyfill. The browser
+  // test can observe the replica but has no daemon to feed it. Both halves
+  // exist only in an E2E against a real daemon, which is where this belongs.
 })

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -359,10 +359,22 @@ describe('authority replica', () => {
   // same sequence works in a real browser (see the browser test beside this).
   // Chasing that difference would be debugging the polyfill, not the worker.
 
-  // NOT covered anywhere yet, and worth saying so: that a DAEMON frame lands
-  // in the replica (not only in the relay). jsdom can feed a daemon frame,
-  // through MSW, but cannot observe the replica — every snapshot-request that
-  // follows replica work stops being answered under the polyfill. The browser
-  // test can observe the replica but has no daemon to feed it. Both halves
-  // exist only in an E2E against a real daemon, which is where this belongs.
+  // NOT covered anywhere yet, and worth saying so: anything about a DAEMON
+  // frame reaching the replica (rather than only the relay). That is one
+  // claim about arrival — the frame lands in the replica at all — and one
+  // about multiplicity: the replica takes its own hub subscription per
+  // document, so N tabs watching one document cost ONE import per frame
+  // rather than N.
+  //
+  // Neither is observable at either layer, and for opposite reasons. jsdom
+  // can feed a daemon frame through MSW but cannot observe the replica: every
+  // snapshot-request that follows replica work stops being answered under the
+  // polyfill. The browser test can observe the replica but has no daemon to
+  // feed it, and its two ports are two tabs of one worker only THERE — which
+  // is the very thing the multiplicity claim is about. Both halves meet only
+  // in an E2E against a real daemon, which is where this belongs.
+  //
+  // What IS pinned, above: that the feed is released. Dropping the release
+  // turns the sibling `unsubscribe` cases red, because the hub keeps a
+  // document subscribed on the daemon while any listener remains.
 })

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -79,15 +79,69 @@ function queueReplicaWork(work: () => unknown): void {
   replicaQueue = replicaQueue.then(work, work).catch(() => undefined)
 }
 
+/**
+ * Keyed by ORIGIN and document, never by document alone.
+ *
+ * A document id is minted by one daemon and nothing makes it unique across
+ * two of them, so a replica keyed on the id alone would let two configured
+ * origins share state — and, through the fan-out below, let one origin's edit
+ * reach the other's tabs. Every other piece of worker state is already
+ * origin-scoped; this keeps the replica from being the exception.
+ *
+ * `\n` separates because it cannot occur in an origin.
+ */
+const replicaKey = (baseUrl: string, doc: string) => `${baseUrl}\n${doc}`
+
 const replicas = new Map<string, InstanceType<LoroModule['LoroDoc']>>()
 
-function replicaFor(doc: string): InstanceType<LoroModule['LoroDoc']> | undefined {
+function replicaFor(baseUrl: string, doc: string): InstanceType<LoroModule['LoroDoc']> | undefined {
   if (loro === undefined) return undefined
-  const existing = replicas.get(doc)
+  const key = replicaKey(baseUrl, doc)
+  const existing = replicas.get(key)
   if (existing !== undefined) return existing
   const created = new loro.LoroDoc()
-  replicas.set(doc, created)
+  replicas.set(key, created)
   return created
+}
+
+/**
+ * The replica's own hub subscription, one per origin+document, refcounted by
+ * the ports interested in it.
+ *
+ * It is separate from the ports' subscriptions because the replica belongs to
+ * the WORKER, not to any tab: feeding it from each port's own listener meant
+ * one daemon frame queued one WASM import per subscribed tab, all but the
+ * first of them merging bytes the replica already had, and all of them ahead
+ * of that tab's real work on the single replica queue.
+ *
+ * Refcounted rather than permanent because the hub closes a document's daemon
+ * subscription when its last listener leaves — a feed that never released
+ * would keep every document ever opened subscribed for the life of the worker.
+ */
+const replicaFeeds = new Map<string, { off: () => void; ports: number }>()
+
+function retainReplicaFeed(hub: SseStreamHub, baseUrl: string, doc: string): void {
+  const key = replicaKey(baseUrl, doc)
+  const existing = replicaFeeds.get(key)
+  if (existing !== undefined) {
+    existing.ports += 1
+    return
+  }
+  const off = hub.subscribe(doc, {
+    onUpdate: (bytes) => importIntoReplica(baseUrl, doc, bytes),
+    onMessage: () => {},
+  })
+  replicaFeeds.set(key, { off, ports: 1 })
+}
+
+function releaseReplicaFeed(baseUrl: string, doc: string): void {
+  const key = replicaKey(baseUrl, doc)
+  const feed = replicaFeeds.get(key)
+  if (feed === undefined) return
+  feed.ports -= 1
+  if (feed.ports > 0) return
+  replicaFeeds.delete(key)
+  feed.off()
 }
 
 interface PortState {
@@ -125,25 +179,35 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary)
 }
 
-function importIntoReplica(doc: string, bytes: Uint8Array): void {
+function importIntoReplica(baseUrl: string, doc: string, bytes: Uint8Array): void {
   queueReplicaWork(() => {
     // Total by construction: a frame this replica cannot merge (a truncated
     // update, a future format) must not take the worker down for every tab
     // and every other document. The daemon remains the source it can re-sync
     // from.
     try {
-      replicaFor(doc)?.import(bytes)
+      replicaFor(baseUrl, doc)?.import(bytes)
     } catch {
       return
     }
   })
 }
 
-/** To every port subscribed to `doc`, except the one that sent the work. */
-function broadcastAuthorityUpdate(doc: string, update: Uint8Array, from: MessagePort): void {
+/**
+ * To every port subscribed to `doc` ON THE SAME ORIGIN, except the one that
+ * sent the work. Two daemons can mint the same document id, and a tab paired
+ * with one of them must never be handed the other's edits.
+ */
+function broadcastAuthorityUpdate(
+  baseUrl: string,
+  doc: string,
+  update: Uint8Array,
+  from: MessagePort,
+): void {
   const encoded = toBase64(update)
   for (const [target, state] of ports) {
     if (target === from) continue
+    if (state.baseUrl !== baseUrl) continue
     if (!state.subscriptions.has(doc)) continue
     target.postMessage({ type: 'authority-update', doc, update: encoded })
   }
@@ -163,6 +227,17 @@ function handle(port: MessagePort, raw: unknown): void {
     if (existing?.baseUrl === msg.baseUrl) {
       hubFor(msg.baseUrl)
       return
+    }
+    // Re-pointing a port at a DIFFERENT origin is the other case, and the old
+    // record's claims have to be released before it is dropped: the handles
+    // live in the map about to be replaced, so anything still held there could
+    // never be released again — a document subscribed on the daemon and a
+    // replica fed forever, for a port that has moved on.
+    if (existing) {
+      for (const [doc, off] of existing.subscriptions) {
+        off()
+        releaseReplicaFeed(existing.baseUrl, doc)
+      }
     }
     ports.set(port, { baseUrl: msg.baseUrl, subscriptions: new Map() })
     hubFor(msg.baseUrl)
@@ -186,7 +261,7 @@ function handle(port: MessagePort, raw: unknown): void {
       // An empty snapshot for a document nobody has opened yet is the right
       // answer, not an error: forking from empty and letting the daemon fill
       // it in is the same path a first-ever open already takes.
-      const snapshot = replicaFor(msg.doc)?.export({ mode: 'snapshot' })
+      const snapshot = replicaFor(state.baseUrl, msg.doc)?.export({ mode: 'snapshot' })
       if (snapshot === undefined) return
       port.postMessage({ type: 'snapshot', doc: msg.doc, snapshot: toBase64(snapshot) })
     })
@@ -195,7 +270,7 @@ function handle(port: MessagePort, raw: unknown): void {
 
   if (msg.type === 'push') {
     queueReplicaWork(() => {
-      const replica = replicaFor(msg.doc)
+      const replica = replicaFor(state.baseUrl, msg.doc)
       if (replica === undefined) return
       const before = replica.version()
       try {
@@ -208,19 +283,21 @@ function handle(port: MessagePort, raw: unknown): void {
       // broadcast. Loro merges are idempotent, but a broadcast is not free.
       const merged = replica.export({ mode: 'update', from: before })
       if (merged.byteLength === 0) return
-      broadcastAuthorityUpdate(msg.doc, merged, port)
+      broadcastAuthorityUpdate(state.baseUrl, msg.doc, merged, port)
     })
     return
   }
 
   if (msg.type === 'subscribe') {
     if (state.subscriptions.has(msg.doc)) return
+    retainReplicaFeed(hub, state.baseUrl, msg.doc)
     const off = hub.subscribe(msg.doc, {
       onUpdate: (bytes) => {
-        // Into the replica first, then relayed verbatim. Both, for now: the
-        // raw frame is what today's clients consume, and the replica is what
-        // forks will. One of the two goes away once every client has moved.
-        importIntoReplica(msg.doc, bytes)
+        // Relay only. The replica is fed by its own subscription above, once
+        // per document rather than once per tab watching it. Both paths carry
+        // the same frame for now: the raw one is what today's clients consume
+        // and the replica is what forks will, and one of the two goes away
+        // once every client has moved.
         port.postMessage({ type: 'update', doc: msg.doc, update: toBase64(bytes) })
       },
       onMessage: (text) => {
@@ -238,6 +315,7 @@ function handle(port: MessagePort, raw: unknown): void {
   if (!off) return
   off()
   state.subscriptions.delete(msg.doc)
+  releaseReplicaFeed(state.baseUrl, msg.doc)
 }
 
 // Typed locally rather than via `/// <reference lib="webworker" />`: that

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -10,9 +10,69 @@
  * This file must be a real same-origin module: the app's CSP declares
  * `worker-src 'self'`, which rejects a blob: worker.
  */
-import { SseStreamHub } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
+import { fromBase64, SseStreamHub } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
 import { createDaemonFetch } from './daemon-auth-fetch.js'
 import { sseWorkerRequestSchema } from './sse-shared-worker-protocol.js'
+
+/**
+ * The worker's own replica of each subscribed document.
+ *
+ * It exists so the consistency question — what has arrived, in what order — is
+ * answered where the daemon stream is read, once, instead of separately in
+ * every tab. A tab forks from this rather than adopting it: Loro scopes undo
+ * to a peer and will not revert another peer's operations, so tabs sharing one
+ * peer would share one undo stack.
+ *
+ * Nothing here interprets the document. The replica merges opaque update bytes
+ * and answers with opaque update bytes, which is why this file needs no
+ * canvas-workspace and stays as light as the stream multiplexer it grew from.
+ */
+/**
+ * Loro is imported DYNAMICALLY, and that is load-bearing rather than a style
+ * choice. It is a WASM module, so a static import makes this whole module's
+ * evaluation asynchronous — and a shared worker's `onconnect` must be
+ * installed synchronously, or a tab that connects while the WASM is still
+ * initialising is simply lost. Making it static broke every existing browser
+ * test in this file at once, which is how cheaply that failure hides: nothing
+ * throws, the port just never answers.
+ *
+ * Replica work is therefore queued behind `loroReady` instead of running
+ * inline. The stream relay above does not wait for it — a tab reading raw
+ * daemon frames keeps working whether or not the replica ever loads.
+ */
+type LoroModule = typeof import('loro-crdt')
+let loro: LoroModule | undefined
+const loroReady: Promise<LoroModule> = import('loro-crdt').then((module) => {
+  loro = module
+  return module
+})
+
+/**
+ * Every replica operation, in arrival order.
+ *
+ * Without this each handler awaited `loroReady` independently and resumed in
+ * whatever order their microtasks happened to settle — a push followed
+ * immediately by a snapshot-request answered from the state BEFORE the push,
+ * which is the one ordering guarantee a client has any right to expect from
+ * something calling itself an authority.
+ */
+let replicaQueue: Promise<unknown> = loroReady
+function queueReplicaWork<T>(work: () => T | Promise<T>): Promise<T> {
+  const next = replicaQueue.then(work, work)
+  replicaQueue = next.catch(() => undefined)
+  return next
+}
+
+const replicas = new Map<string, InstanceType<LoroModule['LoroDoc']>>()
+
+function replicaFor(doc: string): InstanceType<LoroModule['LoroDoc']> | undefined {
+  if (loro === undefined) return undefined
+  const existing = replicas.get(doc)
+  if (existing !== undefined) return existing
+  const created = new loro.LoroDoc()
+  replicas.set(doc, created)
+  return created
+}
 
 interface PortState {
   baseUrl: string
@@ -49,6 +109,30 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary)
 }
 
+function importIntoReplica(doc: string, bytes: Uint8Array): Promise<void> {
+  return queueReplicaWork(() => {
+    // Total by construction: a frame this replica cannot merge (a truncated
+    // update, a future format) must not take the worker down for every tab
+    // and every other document. The daemon remains the source it can re-sync
+    // from.
+    try {
+      replicaFor(doc)?.import(bytes)
+    } catch {
+      return
+    }
+  })
+}
+
+/** To every port subscribed to `doc`, except the one that sent the work. */
+function broadcastAuthorityUpdate(doc: string, update: Uint8Array, from: MessagePort): void {
+  const encoded = toBase64(update)
+  for (const [target, state] of ports) {
+    if (target === from) continue
+    if (!state.subscriptions.has(doc)) continue
+    target.postMessage({ type: 'authority-update', doc, update: encoded })
+  }
+}
+
 function handle(port: MessagePort, raw: unknown): void {
   const parsed = sseWorkerRequestSchema.safeParse(raw)
   if (!parsed.success) return
@@ -81,10 +165,46 @@ function handle(port: MessagePort, raw: unknown): void {
     return
   }
 
+  if (msg.type === 'snapshot-request') {
+    void queueReplicaWork(() => {
+      // An empty snapshot for a document nobody has opened yet is the right
+      // answer, not an error: forking from empty and letting the daemon fill
+      // it in is the same path a first-ever open already takes.
+      const snapshot = replicaFor(msg.doc)?.export({ mode: 'snapshot' })
+      if (snapshot === undefined) return
+      port.postMessage({ type: 'snapshot', doc: msg.doc, snapshot: toBase64(snapshot) })
+    })
+    return
+  }
+
+  if (msg.type === 'push') {
+    void queueReplicaWork(() => {
+      const replica = replicaFor(msg.doc)
+      if (replica === undefined) return
+      const before = replica.version()
+      try {
+        replica.import(fromBase64(msg.update))
+      } catch {
+        return
+      }
+      // Only what the replica did not already have travels onward, so a tab
+      // re-pushing work another tab already delivered costs one import and no
+      // broadcast. Loro merges are idempotent, but a broadcast is not free.
+      const merged = replica.export({ mode: 'update', from: before })
+      if (merged.byteLength === 0) return
+      broadcastAuthorityUpdate(msg.doc, merged, port)
+    })
+    return
+  }
+
   if (msg.type === 'subscribe') {
     if (state.subscriptions.has(msg.doc)) return
     const off = hub.subscribe(msg.doc, {
       onUpdate: (bytes) => {
+        // Into the replica first, then relayed verbatim. Both, for now: the
+        // raw frame is what today's clients consume, and the replica is what
+        // forks will. One of the two goes away once every client has moved.
+        void importIntoReplica(msg.doc, bytes)
         port.postMessage({ type: 'update', doc: msg.doc, update: toBase64(bytes) })
       },
       onMessage: (text) => {

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -39,13 +39,26 @@ import { sseWorkerRequestSchema } from './sse-shared-worker-protocol.js'
  * Replica work is therefore queued behind `loroReady` instead of running
  * inline. The stream relay above does not wait for it — a tab reading raw
  * daemon frames keeps working whether or not the replica ever loads.
+ *
+ * A load that never arrives resolves to `undefined` rather than rejecting.
+ * Degrading is the only sound answer for a worker no tab can restart: the
+ * relay keeps working, `replicaFor` answers nothing, and the replica-backed
+ * messages go unanswered instead of taking down every document in the worker.
+ * Rejecting is also observably wrong — a shared worker outlives the page that
+ * started it, so a chunk still loading when the environment goes away turns
+ * into an unhandled rejection charged to whoever is left, which is how this
+ * first showed up: 2094 tests passing and the run failing anyway on four
+ * rejections raised after teardown.
  */
 type LoroModule = typeof import('loro-crdt')
 let loro: LoroModule | undefined
-const loroReady: Promise<LoroModule> = import('loro-crdt').then((module) => {
-  loro = module
-  return module
-})
+const loroReady: Promise<LoroModule | undefined> = import('loro-crdt').then(
+  (module) => {
+    loro = module
+    return module
+  },
+  () => undefined,
+)
 
 /**
  * Every replica operation, in arrival order.
@@ -57,10 +70,13 @@ const loroReady: Promise<LoroModule> = import('loro-crdt').then((module) => {
  * something calling itself an authority.
  */
 let replicaQueue: Promise<unknown> = loroReady
-function queueReplicaWork<T>(work: () => T | Promise<T>): Promise<T> {
-  const next = replicaQueue.then(work, work)
-  replicaQueue = next.catch(() => undefined)
-  return next
+function queueReplicaWork(work: () => unknown): void {
+  // Returns nothing on purpose. Every caller here fires and forgets, so a
+  // promise handed back would be a rejection nobody handles the moment any
+  // work throws — the same shape as the load rejection above, and just as
+  // invisible until a run fails with every test passing. Swallowing belongs
+  // here rather than at four call sites that would each have to remember.
+  replicaQueue = replicaQueue.then(work, work).catch(() => undefined)
 }
 
 const replicas = new Map<string, InstanceType<LoroModule['LoroDoc']>>()
@@ -109,8 +125,8 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary)
 }
 
-function importIntoReplica(doc: string, bytes: Uint8Array): Promise<void> {
-  return queueReplicaWork(() => {
+function importIntoReplica(doc: string, bytes: Uint8Array): void {
+  queueReplicaWork(() => {
     // Total by construction: a frame this replica cannot merge (a truncated
     // update, a future format) must not take the worker down for every tab
     // and every other document. The daemon remains the source it can re-sync
@@ -166,7 +182,7 @@ function handle(port: MessagePort, raw: unknown): void {
   }
 
   if (msg.type === 'snapshot-request') {
-    void queueReplicaWork(() => {
+    queueReplicaWork(() => {
       // An empty snapshot for a document nobody has opened yet is the right
       // answer, not an error: forking from empty and letting the daemon fill
       // it in is the same path a first-ever open already takes.
@@ -178,7 +194,7 @@ function handle(port: MessagePort, raw: unknown): void {
   }
 
   if (msg.type === 'push') {
-    void queueReplicaWork(() => {
+    queueReplicaWork(() => {
       const replica = replicaFor(msg.doc)
       if (replica === undefined) return
       const before = replica.version()
@@ -204,7 +220,7 @@ function handle(port: MessagePort, raw: unknown): void {
         // Into the replica first, then relayed verbatim. Both, for now: the
         // raw frame is what today's clients consume, and the replica is what
         // forks will. One of the two goes away once every client has moved.
-        void importIntoReplica(msg.doc, bytes)
+        importIntoReplica(msg.doc, bytes)
         port.postMessage({ type: 'update', doc: msg.doc, update: toBase64(bytes) })
       },
       onMessage: (text) => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,6 +15,13 @@ import { pwaOptions } from './vite-pwa-options.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  // Both workers are constructed with `type: 'module'`, but Vite's default
+  // worker output is `iife` — which happened to run anyway, since a module
+  // worker executes IIFE code fine. It stops being harmless the moment a
+  // worker needs a dependency with top-level await: loro-crdt's WASM init has
+  // one, and `iife` cannot express it, so the build fails with
+  // UNSUPPORTED_FEATURE pointing at a file nobody here wrote.
+  worker: { format: 'es' },
   resolve: {
     alias: {
       ...mcpSourceAlias,


### PR DESCRIPTION
First layer of moving Loro to where the daemon stream already is. **Additive only** — every existing client keeps consuming the raw relayed frames, and nothing about today's behaviour changes.

## What it adds

The worker keeps a Loro replica per subscribed document and answers two new messages:

- **`snapshot-request`** → `snapshot`: the state a tab forks from. A document nobody has opened answers with an *empty* snapshot rather than an error — forking from empty and letting the daemon fill it in is the same path a first-ever open already takes.
- **`push`** → `authority-update` to the *other* ports: a fork's local work, merged into the replica and fanned out. Never echoed to the sender, which would make every edit a round trip through the tab that made it.

The consistency question — what has arrived, in what order — now gets answered where the stream is read, once, instead of separately in every tab.

## Why a tab forks instead of adopting the replica

Forced, not stylistic. Measured against loro-crdt 1.13.6: `UndoManager` is scoped to a **peer** and refuses to revert another peer's operations, so tabs sharing one peer would share one undo stack. Forks each get their own peer and their own undo, and converge through the authority — verified end to end, including that one fork's undo removes only its own edit and that the removal propagates.

Nothing here interprets the document: the replica merges opaque update bytes and answers with opaque update bytes, so the worker needs no canvas-workspace and stays as light as the multiplexer it grew from.

## Two things this got wrong first

**Loro must be imported dynamically.** It is WASM, so a static import makes the whole module's evaluation asynchronous — and a shared worker's `onconnect` has to be installed synchronously, or a tab connecting during WASM init is lost. Making it static broke **every existing browser test in this file at once**, and that is how cheaply it hides: nothing throws, the port just never answers.

**Replica work needed one queue.** Each handler awaiting readiness independently resumed in whatever order its microtasks settled, so a `push` followed immediately by a `snapshot-request` was answered from the state *before* the push — an authority contradicting what it had just been told.

## Test placement, and one gap left open

The jsdom polyfill builds a fresh worker context per construction, so two ports there are two workers. Cross-port fan-out and snapshot-after-push therefore live in the **browser** test, where two constructions really are one worker — the replica gave this worker its first observable that separates those two cases at all.

**Not covered anywhere, and labelled in the file rather than faked:** that a *daemon* frame reaches the replica. jsdom can feed one (through MSW) but cannot read the replica; the browser can read the replica but has no daemon to feed it. Both halves exist only in an E2E against a real daemon, which is where it belongs.

## Where this is going

Layer 2 is the tab-side client that consumes `snapshot`/`authority-update` and pushes its fork's work; layer 3 moves `canvas-sync-session` onto it. Local edits stay synchronous in the tab's own fork throughout — the fork is what keeps this from turning every keystroke into a round trip.

Measured before building any of it: fan-out is ~5–8ms and flat in tab count (30 tabs: 8.5ms), an ordinary one-node edit is a **249-byte** update regardless of how many tabs are open, and `type: 'module'` shared workers plus Loro-in-a-worker are supported in Chromium, WebKit and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZyjZ1ZozdMU3HQKjvY7pJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared document state synchronization across browser connections.
  - Added document snapshot retrieval for newly connected clients.
  - Added support for pushing and merging document updates while preventing duplicate or echoed changes.
  - Improved preservation of document state for later subscribers.

- **Bug Fixes**
  - Prevented internal snapshot and authority-update events from appearing as regular messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->