### PR TITLE
feat(web): stop offering facets on a spatial canvas

### DIFF
--- a/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.test.tsx
@@ -189,3 +189,35 @@ describe('CanvasProperties inline variant (merged header row)', () => {
     expect(disclosure.className).toContain('absolute')
   })
 })
+
+describe('a spatial document has no facets to edit', () => {
+  // ADR-0009 decision 3: a facet is OKF frontmatter, and a JSON Canvas
+  // document has none to hold one. The server refuses to write facets there;
+  // offering the editor is the same claim made in the UI.
+  it('offers no properties disclosure', () => {
+    render(<CanvasProperties meta={meta()} onChange={vi.fn()} showFacets={false} />)
+
+    expect(screen.queryByRole('button', { name: /properties/i })).toBeNull()
+  })
+
+  it('still shows the title, which is the workspace name and not a facet', () => {
+    // The name is a workspace concern (ADR-0009 decision 2) that this editor
+    // still keeps in core meta for browser-local canvases. Hiding the facet
+    // disclosure must not take the name with it.
+    render(
+      <CanvasProperties
+        meta={meta({ title: 'Architecture' })}
+        onChange={vi.fn()}
+        showFacets={false}
+      />,
+    )
+
+    expect(textboxValue(/title/i)).toBe('Architecture')
+  })
+
+  it('a markdown document keeps the disclosure', () => {
+    render(<CanvasProperties meta={meta()} onChange={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /properties/i })).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -13,6 +13,18 @@ export interface CanvasPropertiesProps {
    */
   inline?: boolean
   readonly meta: CanvasCoreMeta
+  /**
+   * Whether this document can hold facets at all. A facet is OKF frontmatter
+   * (ADR-0009 decision 3) and a JSON Canvas document has none, so a spatial
+   * canvas passes `false` and gets no disclosure — the server refuses to
+   * write facets there, and offering the editor would make the same claim
+   * in the UI that the server just stopped honouring.
+   *
+   * The title is unaffected: it is the document's NAME, a workspace concern
+   * (decision 2), which this editor still keeps in core meta for
+   * browser-local canvases.
+   */
+  readonly showFacets?: boolean
   readonly onChange: (next: CanvasCoreMeta) => void
   /** Offered as datalist completions for `type`; the field stays free text. */
   readonly typeSuggestions?: readonly string[]
@@ -59,6 +71,7 @@ const DEFAULT_TYPE_SUGGESTIONS = ['markdown', 'note', 'issue', 'spec', 'meeting'
  */
 export function CanvasProperties({
   inline = false,
+  showFacets = true,
   meta,
   onChange,
   typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
@@ -127,28 +140,30 @@ export function CanvasProperties({
             inline ? 'text-sm' : 'text-base'
           }`}
         />
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => setOpen((current) => !current)}
-              aria-label="Properties"
-              aria-expanded={open}
-              aria-controls={`${suggestionsId}-disclosure`}
-              className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
-            >
-              <Info aria-hidden="true" className="size-4" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Properties</TooltipContent>
-        </Tooltip>
+        {showFacets && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setOpen((current) => !current)}
+                aria-label="Properties"
+                aria-expanded={open}
+                aria-controls={`${suggestionsId}-disclosure`}
+                className="text-muted-foreground hover:text-foreground shrink-0 rounded p-1.5"
+              >
+                <Info aria-hidden="true" className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Properties</TooltipContent>
+          </Tooltip>
+        )}
         {settings}
         {actions !== undefined && (
           <div className="ml-auto flex shrink-0 items-center gap-1.5">{actions}</div>
         )}
       </div>
 
-      {open && (
+      {showFacets && open && (
         <div
           id={`${suggestionsId}-disclosure`}
           className={

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -595,6 +595,10 @@ export function BrowserLocalCanvasPage({
     ) : (
       <CanvasProperties
         inline
+        // A facet is OKF frontmatter and this branch is the SPATIAL canvas,
+        // which has none to hold one (ADR-0009 decision 3) — wb_facet_set
+        // refuses to write them here, so the editor does not offer them.
+        showFacets={false}
         key={canvasId ?? 'no-canvas'}
         status={<SaveStatusChip state={pageState.persistence} />}
         settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}


### PR DESCRIPTION
## What

ADR-0009 decision 3: a facet is OKF frontmatter, and a JSON Canvas document has none to hold one. #774 made the server **refuse** to write facets to a spatial document — but the editor was still offering the Type/Tags disclosure on one, which makes in the UI the same claim the server just stopped honouring. A user could edit a field whose write would now be rejected.

`showFacets` defaults to `true`, so the markdown branch and every other caller are untouched; only the spatial branch opts out.

## The title stays, and a test pins that

The title is the document's **name** — a workspace concern (decision 2), which this editor still keeps in core meta for browser-local canvases. Hiding the facet disclosure must not take the name with it, so that is asserted rather than left to inspection.

## Deliberately not here: where the name is stored

The server moved the name to the workspace tree today (#764/#768/#770). Browser-local still keeps it in core meta and reaches **its own IndexedDB store without going through server-core at all**, so moving it is a storage decision about that editor's model, not a consequence of this one. Doing it here would have coupled a UI fix to an unsettled question.

## Verification

Red first — the disclosure test failed before the prop existed. `apps/web` jsdom: 172 files green. `pnpm -r typecheck` clean.

One note on the pre-push gate: its `test-node` step failed twice and `pnpm test --project mcp-node` passes alone (269 files), which is the load-dependent shape `integrator-flow.md` describes — it runs concurrently with `typecheck` in the hook. The third attempt passed and the remote tip was verified against local rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wjXL66r2XiwYf4qMYHrGB