### PR TITLE
refactor(web): one vocabulary for the things you can create, and drop the rectangle

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -41,7 +41,6 @@ import {
   Scissors,
   SendToBack,
   Sparkles,
-  Square,
   SquareDashed,
   StickyNote,
   Tag,
@@ -55,6 +54,7 @@ import { alignableBoxesOf, alignBoxes, distributeBoxes } from './align.js'
 import type { FileRefOption } from './CanvasPickerDialog.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
+import { CREATION_LABELS } from './creation-labels.js'
 import { type GestureResult, type GestureState, reduceGesture } from './gestures.js'
 import type { Point } from './viewport.js'
 
@@ -95,8 +95,6 @@ export interface CanvasContextMenuProps {
   readonly setGroupLabelEditId: (id: string | null) => void
   readonly pasteClipboard: (at?: Point) => boolean
   readonly createNodeAt: (point: Point) => void
-  /** Places a text node nobody typed into — no editor opens. */
-  readonly createRectangleAt: (point: Point) => void
   readonly createGroupAtViewportCenter: (at?: Point) => void
   readonly setLinkDialog: (state: LinkDialogState | null) => void
   readonly fileRefOptions?: readonly FileRefOption[]
@@ -135,7 +133,6 @@ export function CanvasContextMenu({
   setGroupLabelEditId,
   pasteClipboard,
   createNodeAt,
-  createRectangleAt,
   createGroupAtViewportCenter,
   setLinkDialog,
   fileRefOptions,
@@ -374,36 +371,31 @@ export function CanvasContextMenu({
                 ]
               : []),
             {
-              label: 'Add note here',
+              label: CREATION_LABELS.note,
               icon: <StickyNote />,
               onSelect: () => createNodeAt(contextMenu.point),
             },
             {
-              label: 'Add rectangle here',
-              icon: <Square />,
-              onSelect: () => createRectangleAt(contextMenu.point),
-            },
-            {
-              label: 'Add link here',
+              label: CREATION_LABELS.link,
               icon: <Link />,
               onSelect: () => setLinkDialog({ mode: 'create', point: contextMenu.point }),
             },
             {
-              label: 'Add group here',
+              label: CREATION_LABELS.group,
               icon: <Frame />,
               onSelect: () => createGroupAtViewportCenter(contextMenu.point),
             },
           ]
           if (fileRefOptions !== undefined) {
             emptyItems.push({
-              label: 'Add canvas here',
+              label: CREATION_LABELS.document,
               icon: <FileBox />,
               onSelect: () => setCanvasPicker({ mode: 'create', point: contextMenu.point }),
             })
           }
           if (onAddImage !== undefined) {
             emptyItems.push({
-              label: 'Add image here',
+              label: CREATION_LABELS.image,
               icon: <ImageIcon />,
               onSelect: () => {
                 pendingImagePointRef.current = contextMenu.point

--- a/apps/web/src/components/spatial-editor/CanvasPickerDialog.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasPickerDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * Canvas picker — the reference-entry surface for file nodes, used by the
- * palette's "Add canvas" (create) and the context menu's "Change target"
+ * palette's Document entry (create) and the context menu's "Change target"
  * (retarget). The host page supplies the options: the editor treats a
  * file reference as an opaque string whose meaning (browser-local canvas
  * id, daemon alias path) the composition root owns.

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * URL entry surface for link nodes — used both by the palette's "Add link"
+ * URL entry surface for link nodes — used both by the palette's Link entry
  * (create) and the context menu's "Edit URL" (rewrite).
  *
  * Validation delegates to the same rule the canvas-model schema enforces

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -72,7 +72,7 @@ async function addNoteViaMenu() {
     .getByTestId('add-button')
     .element()
     .dispatchEvent(new MouseEvent('click', { bubbles: true }))
-  const item = page.getByRole('menuitem', { name: 'Add note' })
+  const item = page.getByRole('menuitem', { name: 'Note' })
   await expect.element(item).toBeInTheDocument()
   await item.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
 }
@@ -1298,7 +1298,7 @@ describe('SpatialEditor (browser)', () => {
     // button's click — the bug that made this button do nothing in the
     // running app while this test stayed green.
     await userEvent.click(page.getByTestId('add-button'))
-    await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Note' }))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [next, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]

--- a/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.test.tsx
@@ -52,7 +52,7 @@ describe('Add button (creation menu)', () => {
     expect(button.getAttribute('aria-haspopup')).toBe('menu')
 
     fireEvent.click(button)
-    const item = getByRole('menuitem', { name: 'Add note' })
+    const item = getByRole('menuitem', { name: 'Note' })
     fireEvent.click(item)
     expect(onChange).toHaveBeenCalled()
     const command = onChange.mock.calls[0][1] as { kind: string }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -14,7 +14,7 @@
  * onto another node, OR Enter/Space the connect handle then Tab to a
  * target node's connect-target control and Enter/Space it; Escape cancels
  * an in-flight gesture from the keyboard too), create a node (double-click
- * empty canvas space, or the keyboard-reachable "Add note" button — both
+ * empty canvas space, or the keyboard-reachable "+" menu's Note entry — both
  * open the new node for typing immediately), delete the current
  * selection (Delete/Backspace, disabled while its text editor is open so
  * Backspace-while-typing edits text instead of deleting the node), select
@@ -22,15 +22,15 @@
  * edge's label (double-click its line; commits on blur, empty removes,
  * Escape cancels), and restyle an edge from its context menu (arrowhead
  * direction per JSON Canvas fromEnd/toEnd, and per-endpoint side pinning
- * with an auto option), create a link node (the palette's "Add link" URL
+ * with an auto option), create a link node (the palette's Link entry (URL
  * dialog), follow it (double-click, or "Open link" in its context menu —
  * opens in a new tab with noopener), rewrite its URL ("Edit URL"), create
- * a group frame (the palette's "Add group" empty frame, or "Group
+ * a group frame (the palette's Group entry (an empty frame), or "Group
  * selection" from a multi-selected node's context menu), move a frame
  * with its geometrically contained members, edit the frame's label
  * (double-click, or "Edit label" in its context menu; empty removes),
  * and — when the host supplies the seams — create a file node referencing
- * another canvas (the palette's "Add canvas" picker), follow it
+ * another canvas (the palette's Document picker), follow it
  * (double-click / "Open canvas"), and retarget it ("Change target").
  *
  * The component is CONTROLLED and owns no persistence: every mutating
@@ -110,6 +110,7 @@ import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand, buildFragmentInsertCommand } from './commands.js'
+import { CREATION_LABELS } from './creation-labels.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
 import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
@@ -307,7 +308,7 @@ export interface SpatialEditorProps {
   /**
    * Canvas references the picker offers for file nodes. The reference is an
    * OPAQUE string owned by the composition root (browser-local canvas id,
-   * daemon alias path). Absent → the "Add canvas" affordance hides.
+   * daemon alias path). Absent → the Document affordance hides.
    */
   readonly fileRefOptions?: readonly FileRefOption[]
   /** Follows a file node's reference (navigation). Absent → follow hides. */
@@ -479,7 +480,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // OOUI interaction mode (S6/S7): Hand (navigation) is the default —
     // Select restores the pre-tool editing behavior byte-for-byte; Connect
     // arms object-first click-A, click-B edge creation. Creation is
-    // deliberately NOT a mode — the palette's Add note works in every mode.
+    // deliberately NOT a mode — the palette's Note entry works in every mode.
     const [tool, setTool] = useState<EditorTool>(defaultTool)
     const toolChosenByUserRef = useRef(false)
     const initialToolAppliedRef = useRef(false)
@@ -2256,17 +2257,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
-     * A rectangle: the same node Add-note makes, with no editor opened on
-     * top of it. Not a new node type — see the reducer's `create-closed-node`.
-     */
-    const createRectangleAt = (point: Point) => {
-      applyResult(
-        reduceGesture(gestureState, canvas, { type: 'create-closed-node', point }, { createId }),
-      )
-      applySelection({ type: 'collapse-extras' })
-    }
-
-    /**
      * The button path (unlike double-click, whose point comes straight from
      * the pointer) always resolves to the same viewport-center point, so
      * without a placement rule every click here would stack an identical,
@@ -2366,31 +2356,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /** Places one of the directly-creatable kinds at a canvas-space point. */
     const createAt = (kind: DraggableCreation, point: Point) => {
       if (kind === 'note') createNodeAt(point)
-      else if (kind === 'rectangle') createRectangleAt(point)
       else createGroupAtViewportCenter(point)
-    }
-
-    /**
-     * Same cascade as the note path: the tap path always resolves to the one
-     * viewport-centre point, so without it every press stacks an identical
-     * rectangle on the last one and looks like nothing happened.
-     */
-    const createRectangleAtViewportCenter = () => {
-      const preferred = screenToCanvas(viewportCenterScreen(), viewport)
-      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = findFreeSpot(
-        preferred,
-        { width: NEW_NODE_WIDTH, height: NEW_NODE_HEIGHT },
-        occupied,
-        visibleCanvasRect(),
-      )
-      createRectangleAt(point)
-      panToShow({
-        x: Math.round(point.x - NEW_NODE_WIDTH / 2),
-        y: Math.round(point.y - NEW_NODE_HEIGHT / 2),
-        width: NEW_NODE_WIDTH,
-        height: NEW_NODE_HEIGHT,
-      })
     }
 
     const createNodeAtViewportCenter = () => {
@@ -2757,7 +2723,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           onCreateNode={createNodeAtViewportCenter}
           onCreateLink={() => setLinkDialog({ mode: 'create' })}
           onCreateGroup={createGroupAtViewportCenter}
-          onCreateRectangle={createRectangleAtViewportCenter}
           onCreateCanvasRef={
             fileRefOptions === undefined ? undefined : () => setCanvasPicker({ mode: 'create' })
           }
@@ -2848,7 +2813,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             setGroupLabelEditId={setGroupLabelEditId}
             pasteClipboard={pasteClipboard}
             createNodeAt={createNodeAt}
-            createRectangleAt={createRectangleAt}
             createGroupAtViewportCenter={createGroupAtViewportCenter}
             setLinkDialog={setLinkDialog}
             fileRefOptions={fileRefOptions}
@@ -2874,7 +2838,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         )}
         {canvasPicker !== null && fileRefOptions !== undefined && (
           <CanvasPickerDialog
-            title={canvasPicker.mode === 'create' ? 'Add canvas' : 'Change target'}
+            title={
+              canvasPicker.mode === 'create' ? `Add ${CREATION_LABELS.document}` : 'Change target'
+            }
             options={fileRefOptions}
             currentFile={
               canvasPicker.mode === 'retarget'
@@ -2900,7 +2866,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         )}
         {linkDialog !== null && (
           <LinkUrlDialog
-            title={linkDialog.mode === 'create' ? 'Add link' : 'Edit URL'}
+            title={linkDialog.mode === 'create' ? `Add ${CREATION_LABELS.link}` : 'Edit URL'}
             initialUrl={
               linkDialog.mode === 'edit'
                 ? (() => {

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -33,12 +33,12 @@ import {
   MousePointer2,
   Plus,
   Spline,
-  Square,
   StickyNote,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { DOCK_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { CREATION_LABELS } from './creation-labels.js'
 
 export type EditorTool = 'select' | 'hand' | 'connect'
 
@@ -60,10 +60,10 @@ export function draggedCreation(types: readonly string[]): DraggableCreation | n
   const type = types.find((t) => t.startsWith(CREATE_DRAG_MIME_PREFIX))
   if (type === undefined) return null
   const kind = type.slice(CREATE_DRAG_MIME_PREFIX.length)
-  return kind === 'note' || kind === 'rectangle' || kind === 'group' ? kind : null
+  return kind === 'note' || kind === 'group' ? kind : null
 }
 /** Creations that place directly, so a drop point is all they need. */
-export type DraggableCreation = 'note' | 'rectangle' | 'group'
+export type DraggableCreation = 'note' | 'group'
 
 interface ToolPaletteProps {
   /** Host-supplied controls (undo/redo/versions) docked as the leading group. */
@@ -71,8 +71,6 @@ interface ToolPaletteProps {
   readonly onCreateNode: () => void
   readonly onCreateLink: () => void
   readonly onCreateGroup: () => void
-  /** Creates a text node nobody typed into, at the viewport center. */
-  readonly onCreateRectangle: () => void
   /** Absent when the host supplies no canvas listing — the entry hides. */
   readonly onCreateCanvasRef?: () => void
   /** Absent when the host supplies no image storage — the entry hides. */
@@ -112,7 +110,6 @@ export function ToolPalette({
   onCreateNode,
   onCreateLink,
   onCreateGroup,
-  onCreateRectangle,
   onCreateCanvasRef,
   onCreateImage,
   tool,
@@ -146,24 +143,18 @@ export function ToolPalette({
 
   const entries: readonly AddMenuEntry[] = [
     {
-      label: 'Add note',
+      label: CREATION_LABELS.note,
       icon: <StickyNote aria-hidden="true" className="size-4" />,
       onSelect: onCreateNode,
       drag: 'note',
     },
     {
-      label: 'Add rectangle',
-      icon: <Square aria-hidden="true" className="size-4" />,
-      onSelect: onCreateRectangle,
-      drag: 'rectangle',
-    },
-    {
-      label: 'Add link',
+      label: CREATION_LABELS.link,
       icon: <Link aria-hidden="true" className="size-4" />,
       onSelect: onCreateLink,
     },
     {
-      label: 'Add group',
+      label: CREATION_LABELS.group,
       icon: <Frame aria-hidden="true" className="size-4" />,
       onSelect: onCreateGroup,
       drag: 'group',
@@ -171,7 +162,7 @@ export function ToolPalette({
     ...(onCreateCanvasRef !== undefined
       ? [
           {
-            label: 'Add canvas',
+            label: CREATION_LABELS.document,
             icon: <FileBox aria-hidden="true" className="size-4" />,
             onSelect: onCreateCanvasRef,
           },
@@ -180,7 +171,7 @@ export function ToolPalette({
     ...(onCreateImage !== undefined
       ? [
           {
-            label: 'Add image',
+            label: CREATION_LABELS.image,
             icon: <ImageIcon aria-hidden="true" className="size-4" />,
             onSelect: onCreateImage,
           },
@@ -342,7 +333,7 @@ export function ToolPalette({
               <span aria-hidden="true" className="text-muted-foreground">
                 {entry.icon}
               </span>
-              {entry.label.replace(/^Add /, '')}
+              {entry.label}
             </button>
           ))}
         </div>

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -1,4 +1,4 @@
-// Regression: pressing "Add note" with a REAL pointer sequence must create
+// Regression: pressing "Note" with a REAL pointer sequence must create
 // a node. The root gesture handler used to capture the pointer on the
 // button's own pointerdown (it hit-tests as empty canvas space), and an
 // active capture retargets the subsequent `click` to the capturing element —
@@ -32,12 +32,12 @@ function Host({ onCommand }: { onCommand: (kind: string) => void }) {
   )
 }
 
-it('a real pointer click on "Add note" creates a node and opens its editor', async () => {
+it('a real pointer click on "Note" creates a node and opens its editor', async () => {
   const commands: string[] = []
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
 
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Note' }))
 
   expect(commands).toEqual(['create-node'])
   expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
@@ -49,7 +49,7 @@ it('committing the new note untouched keeps a visible empty node, not a blank ca
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
 
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add note' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Note' }))
   // Click empty canvas space without typing — the editor commits the (empty)
   // pending text and the node must survive as a visible box.
   await userEvent.click(container.querySelector('[data-testid="spatial-editor"]') as Element, {

--- a/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/bottom-dock.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
 import '../../index.css'
 import { HistoryCluster } from '../history-cluster/HistoryCluster.js'
+import { CREATION_LABELS } from './creation-labels.js'
 import { SpatialEditor } from './SpatialEditor.js'
 import { DOCK_OCCLUSION_PX } from './ToolPalette.js'
 
@@ -99,7 +100,7 @@ it('creation entries live in the + menu, which opens upward inside the viewport'
   const palette = container.querySelector('[data-testid="tool-palette"]') as HTMLElement
 
   // No flat per-type creation buttons on the dock itself.
-  for (const label of ['Add note', 'Add rectangle', 'Add link', 'Add group', 'Add canvas']) {
+  for (const label of Object.values(CREATION_LABELS)) {
     expect(
       [...palette.querySelectorAll(':scope > button, :scope [data-slot="tooltip-trigger"]')].some(
         (b) => b.getAttribute('aria-label') === label,
@@ -112,7 +113,7 @@ it('creation entries live in the + menu, which opens upward inside the viewport'
   const items = [...menu.querySelectorAll('[role="menuitem"]')].map((b) =>
     b.getAttribute('aria-label'),
   )
-  expect(items).toEqual(['Add note', 'Add rectangle', 'Add link', 'Add group', 'Add canvas'])
+  expect(items).toEqual(['Note', 'Link', 'Group', 'Document'])
 
   // Opens upward from the dock and stays inside the host, above the dock.
   const menuRect = menu.getBoundingClientRect()

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -69,7 +69,7 @@ it('Add canvas opens the picker and picking creates a file node with that refere
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   fireEvent.click(
     [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
-      (b) => b.getAttribute('aria-label') === 'Add canvas',
+      (b) => b.getAttribute('aria-label') === 'Document',
     ) as HTMLElement,
   )
   await expect.element(page.getByTestId('canvas-picker-dialog')).toBeInTheDocument()
@@ -148,7 +148,7 @@ it('without host seams, neither the Add canvas button nor file follow-affordance
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   expect(
     [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].some(
-      (b) => b.getAttribute('aria-label') === 'Add canvas',
+      (b) => b.getAttribute('aria-label') === 'Document',
     ),
   ).toBe(false)
   await userEvent.keyboard('{Escape}')

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { CREATION_LABELS } from './creation-labels.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -82,7 +83,7 @@ it('right-clicking empty space offers creation at that point', async () => {
   rightClick(rootOf(container), 600, 450)
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add note here' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Note' }))
 
   expect(commands).toContain('create-node')
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
@@ -117,56 +118,24 @@ it('empty space offers the full creation set, anchored at the click point', asyn
 
   // The dock's + menu creation set, repeated "here" (canvas entry appears
   // because the host supplies the reference seam).
+  // Image is absent because this host supplies no image storage seam; the
+  // rest is the whole creation set, in the same words the dock uses.
   for (const label of [
-    'Add note here',
-    'Add rectangle here',
-    'Add link here',
-    'Add group here',
-    'Add canvas here',
+    CREATION_LABELS.note,
+    CREATION_LABELS.link,
+    CREATION_LABELS.group,
+    CREATION_LABELS.document,
   ]) {
     expect(container.textContent).toContain(label)
   }
 
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add group here' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Group' }))
   await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(true))
   const frame = latest.canvas.nodes.find((n) => n.type === 'group')
   if (frame === undefined) throw new Error('frame missing')
   // Centered on the click point (600,450 screen = canvas at identity view).
   expect(frame.x + frame.width / 2).toBeCloseTo(600, 0)
   expect(frame.y + frame.height / 2).toBeCloseTo(450, 0)
-})
-
-it('Add rectangle here lands on the click point, with no editor over it', async () => {
-  const { Host, latest } = (() => {
-    const l: { canvas: SpatialCanvas } = { canvas: start }
-    function H() {
-      const [canvas, setCanvas] = useState<SpatialCanvas>(start)
-      l.canvas = canvas
-      return (
-        <div style={{ width: 900, height: 700 }}>
-          <SpatialEditor
-            defaultTool="select"
-            canvas={canvas}
-            onChange={(next) => setCanvas(next)}
-            theme="light"
-          />
-        </div>
-      )
-    }
-    return { Host: H, latest: l }
-  })()
-  const { container } = render(<Host />)
-  rightClick(rootOf(container), 600, 450)
-  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
-
-  const before = latest.canvas.nodes.length
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add rectangle here' }))
-  await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(before + 1))
-  const node = latest.canvas.nodes.at(-1)
-  if (node === undefined) throw new Error('node missing')
-  expect(node.x + node.width / 2).toBeCloseTo(600, 0)
-  expect(node.y + node.height / 2).toBeCloseTo(450, 0)
-  expect(container.querySelector('[data-testid="text-node-editor"]')).toBeNull()
 })
 
 it('Escape closes the menu without acting', async () => {
@@ -233,7 +202,7 @@ it('right-clicking an edge offers Edit label and Delete, not node creation', asy
   const mid = edgeMidpoint(container)
   rightClick(rootOf(container), mid.x, mid.y)
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
-  expect(container.textContent).not.toContain('Add note here')
+  expect(container.textContent).not.toContain('Note')
 
   await userEvent.click(page.getByRole('menuitem', { name: 'Edit label' }))
   await vi.waitFor(() =>

--- a/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/create-placement.browser.test.tsx
@@ -39,30 +39,26 @@ function soleNodeCentre(canvas: SpatialCanvas) {
   return { x: node.x + node.width / 2, y: node.y + node.height / 2 }
 }
 
-it('Add rectangle creates an empty node and leaves the editor closed', () => {
+it('Group creates a frame and leaves no editor open', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
   openAddMenu(container)
-  fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Group' }))
 
   expect(latest.canvas.nodes).toHaveLength(1)
-  const node = latest.canvas.nodes[0]
-  // A rectangle is not a new node type — JSON Canvas has none, and the
-  // x-whiteboard extension is deliberately not an escape hatch for new
-  // visual primitives. It is a text node nobody typed into.
-  expect(node?.type).toBe('text')
-  expect(node?.type === 'text' ? node.text : 'unset').toBe('')
-  // The one behavioural difference from Add note: no editor opens.
+  expect(latest.canvas.nodes[0]?.type).toBe('group')
+  // Group is the creation that needs no typing, which is what makes it the
+  // one these placement tests drive: no editor to dismiss between steps.
   expect(container.querySelector('[data-testid="text-node-editor"]')).toBeNull()
 })
 
-it('Add note still opens its editor — the rectangle path did not change it', () => {
+it('Note opens its editor immediately', () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
 
   openAddMenu(container)
-  fireEvent.click(screen.getByRole('menuitem', { name: 'Add note' }))
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Note' }))
 
   expect(container.querySelector('[data-testid="text-node-editor"]')).not.toBeNull()
 })
@@ -74,7 +70,7 @@ it('dragging a menu entry onto the canvas creates it AT THE DROP POINT, not the 
   const r = root.getBoundingClientRect()
 
   openAddMenu(container)
-  const entry = screen.getByRole('menuitem', { name: 'Add rectangle' })
+  const entry = screen.getByRole('menuitem', { name: 'Group' })
   // Real DragEvents, not fireEvent's synthesised ones: `dataTransfer` is
   // read-only on a DragEvent, so an assigned property never reaches the
   // handler and the drag silently carries nothing.
@@ -88,7 +84,7 @@ it('dragging a menu entry onto the canvas creates it AT THE DROP POINT, not the 
   fireEvent(entry, dragEvent('dragstart'))
   // The kind rides in the MIME type — `types` survives protected mode, the
   // data does not (see CREATE_DRAG_MIME_PREFIX).
-  expect([...dataTransfer.types]).toContain('application/x-whiteboard-create+rectangle')
+  expect([...dataTransfer.types]).toContain('application/x-whiteboard-create+group')
 
   // Well away from the viewport centre (400,300 in root-local pixels).
   const drop: [number, number] = [640, 120]
@@ -114,13 +110,13 @@ it('dragging a menu entry onto the canvas creates it AT THE DROP POINT, not the 
   expect(container.querySelector('[data-testid="add-menu"]')).toBeNull()
 })
 
-it('two rectangles from the menu do not stack on the same spot', () => {
+it('two creations from the menu do not stack on the same spot', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
   for (let i = 0; i < 2; i++) {
     openAddMenu(container)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Group' }))
   }
 
   const [first, second] = latest.canvas.nodes
@@ -136,7 +132,7 @@ it('tapping a menu entry keeps placing it at the viewport centre', () => {
   const { container } = render(<Host />)
 
   openAddMenu(container)
-  fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Group' }))
 
   const centre = soleNodeCentre(latest.canvas)
   expect(centre.x).toBeCloseTo(400, 0)
@@ -150,11 +146,12 @@ it('creating repeatedly does not move the viewport while the screen has room', (
     (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style.transform
   const before = transform()
 
-  // Four is well within what an 800x600 view holds at 200x100 per node —
-  // enough to prove the point without making this the suite's heaviest file.
+  // Notes, not group frames: four 200x100 notes fit an 800x600 view with
+  // room to spare, which is the condition this pins. Opening the menu blurs
+  // the previous note's editor, which commits it — no dismissal needed.
   for (let i = 0; i < 4; i++) {
     openAddMenu(container)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Note' }))
   }
 
   // Making something is not a request to go somewhere: the canvas under the
@@ -170,7 +167,7 @@ it('nothing is ever parked under the dock', () => {
 
   for (let i = 0; i < 5; i++) {
     openAddMenu(container)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Add rectangle' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Group' }))
   }
 
   const rootRect = root.getBoundingClientRect()

--- a/apps/web/src/components/spatial-editor/creation-labels.ts
+++ b/apps/web/src/components/spatial-editor/creation-labels.ts
@@ -1,0 +1,24 @@
+/**
+ * The words the editor uses for the things a person can create, in ONE place
+ * so the two surfaces that offer them — the dock's "+" menu and the canvas
+ * context menu — cannot drift apart.
+ *
+ * Object names, not sentences: the surface already says what will happen
+ * (a menu called "Add", or a press on empty canvas), so "Add note here"
+ * repeated the context twice and made the same object read differently
+ * depending on where it was offered.
+ *
+ * `document` follows ADR-0009: what a workspace holds is a Document, and
+ * Canvas is the spatial surface and its file format. The picker behind this
+ * entry lists markdown documents too, so the old "Canvas" was not only
+ * off-vocabulary, it was untrue.
+ */
+export const CREATION_LABELS = {
+  note: 'Note',
+  link: 'Link',
+  group: 'Group',
+  document: 'Document',
+  image: 'Image',
+} as const
+
+export type CreationLabel = (typeof CREATION_LABELS)[keyof typeof CREATION_LABELS]

--- a/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
@@ -36,7 +36,7 @@ describe('Escape while typing a brand-new note (real browser)', () => {
     render(<Host onCanvas={(c) => (latest = c)} />)
 
     await userEvent.click(screen.getByRole('button', { name: 'Add' }))
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Note' }))
     const editor = await screen.findByRole('textbox')
     await waitFor(() => expect(latest.nodes).toHaveLength(1))
 
@@ -51,7 +51,7 @@ describe('Escape while typing a brand-new note (real browser)', () => {
     render(<Host onCanvas={(c) => (latest = c)} />)
 
     await userEvent.click(screen.getByRole('button', { name: 'Add' }))
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Note' }))
     const editor = await screen.findByRole('textbox')
     await userEvent.type(editor, 'kept')
     // Commit, then reopen the SAME node and cancel: the node survives.

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -467,48 +467,6 @@ describe('text-edit gesture', () => {
   })
 })
 
-describe('create-closed-node (the rectangle path)', () => {
-  it('creates the same node dblclick-empty does, selects it, and opens NO editor', () => {
-    const c = canvas()
-    const result = reduceGesture(
-      createIdleState(),
-      c,
-      { type: 'create-closed-node', point: { x: 300, y: 200 } },
-      { createId: () => 'new-node' },
-    )
-    expect(result.commands).toEqual([
-      {
-        kind: 'create-node',
-        node: { id: 'new-node', type: 'text', text: '', x: 200, y: 150, width: 200, height: 100 },
-      },
-    ])
-    // Selecting it is what gives the new rectangle its handles: without this
-    // it lands on the canvas with nothing to grab, move or delete it by.
-    expect(result.selectedId).toBe('new-node')
-    // The whole difference from a note. `editing-text` here would open the
-    // editor on a shape nobody asked to type into.
-    expect(result.state).toEqual({ kind: 'idle' })
-  })
-
-  it('commits an open text edit first, exactly as the note path does', () => {
-    const c = canvas()
-    const editing = reduceGesture(createIdleState(), c, {
-      type: 'start-text-edit',
-      nodeId: 'a',
-      text: 'hi',
-    })
-    const result = reduceGesture(
-      editing.state,
-      c,
-      { type: 'create-closed-node', point: { x: 10, y: 10 } },
-      { createId: () => 'new-node' },
-    )
-    // Creating something else must not be a way to lose what was typed.
-    expect(result.commands[0]).toMatchObject({ kind: 'set-text', id: 'a' })
-    expect(result.commands.some((cmd) => cmd.kind === 'create-node')).toBe(true)
-  })
-})
-
 describe('dblclick-empty (create-node)', () => {
   it('creates a text node centered on the point, selects it, and opens it for typing immediately', () => {
     const c = canvas()

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -111,14 +111,6 @@ export type GestureEvent =
   | { readonly type: 'pointerdown-connect'; readonly nodeId: string }
   | { readonly type: 'pointerdown-empty' }
   | { readonly type: 'dblclick-empty'; readonly point: Point }
-  /**
-   * The same text node `dblclick-empty` makes, left CLOSED. JSON Canvas has
-   * no shape type and the `x-whiteboard` extension is deliberately not an
-   * escape hatch for new visual primitives, so a rectangle is a text node
-   * nobody typed into — the only difference from a note is that no editor
-   * opens on top of it.
-   */
-  | { readonly type: 'create-closed-node'; readonly point: Point }
   | { readonly type: 'delete-selection'; readonly nodeId: string }
   | { readonly type: 'pointermove'; readonly point: Point }
   | { readonly type: 'pointerup'; readonly point: Point; readonly targetNodeId?: string }
@@ -410,14 +402,6 @@ export function reduceGesture(
         commands: [],
         selectedId: null,
       })
-    case 'create-closed-node': {
-      const id = createId()
-      return withPendingTextCommit(state, {
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-node', node: newTextNodeAt(event.point, id) }],
-        selectedId: id,
-      })
-    }
     case 'dblclick-empty':
       return withPendingTextCommit(state, reduceCreateTextNodeAt(event.point, createId))
     case 'delete-selection':

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -74,7 +74,7 @@ it('the palette Add group button creates an empty frame at the bottom of the z-o
   render(<Host />)
 
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add group' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Group' }))
   await vi.waitFor(() => expect(latest.canvas.nodes).toHaveLength(1))
   expect(latest.canvas.nodes[0]).toMatchObject({ type: 'group' })
   expect(latest.commands).toContain('create-group')
@@ -237,7 +237,7 @@ it('a palette-created frame that lands off-screen pans the viewport to show it',
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   fireEvent.click(
     [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
-      (b) => b.getAttribute('aria-label') === 'Add group',
+      (b) => b.getAttribute('aria-label') === 'Group',
     ) as HTMLElement,
   )
   await vi.waitFor(() => expect(latest.canvas.nodes.some((n) => n.type === 'group')).toBe(true))

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -70,7 +70,7 @@ it('picking an image via the + menu stores it and renders an <image> in the node
 
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   const item = [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
-    (b) => b.getAttribute('aria-label') === 'Add image',
+    (b) => b.getAttribute('aria-label') === 'Image',
   ) as HTMLElement
   expect(item).toBeDefined()
   fireEvent.click(item)
@@ -136,7 +136,7 @@ it('without the storage seam, image affordances hide and non-image drops are ign
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   expect(
     [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].some(
-      (b) => b.getAttribute('aria-label') === 'Add image',
+      (b) => b.getAttribute('aria-label') === 'Image',
     ),
   ).toBe(false)
 })

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -85,7 +85,7 @@ it('Add link opens the URL dialog and a valid submit creates a link node', async
   const { container } = render(<Host />)
 
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Link' }))
   await expect.element(page.getByTestId('link-url-dialog')).toBeInTheDocument()
 
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
@@ -110,7 +110,7 @@ it('an invalid URL cannot be submitted', async () => {
   const { container } = render(<Host />)
 
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Link' }))
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
   await userEvent.fill(input, 'not a url')
 
@@ -207,7 +207,7 @@ it('a javascript: URL is neither followable nor accepted by the dialog', async (
 
   // And the dialog refuses to mint one in the first place.
   await userEvent.click(page.getByRole('button', { name: 'Add' }))
-  await userEvent.click(page.getByRole('menuitem', { name: 'Add link' }))
+  await userEvent.click(page.getByRole('menuitem', { name: 'Link' }))
   const input = container.querySelector('[data-testid="link-url-dialog"] input') as HTMLInputElement
   await userEvent.fill(input, 'javascript:alert(1)')
   const ok = [...container.querySelectorAll('button')].find(

--- a/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
@@ -231,7 +231,7 @@ it('palette creation replaces the whole selection with the new node', async () =
   fireEvent.click(container.querySelector('[data-testid="add-button"]') as HTMLElement)
   fireEvent.click(
     [...container.querySelectorAll('[data-testid="add-menu"] [role="menuitem"]')].find(
-      (b) => b.getAttribute('aria-label') === 'Add note',
+      (b) => b.getAttribute('aria-label') === 'Note',
     ) as HTMLElement,
   )
   await vi.waitFor(() => expect(latest.nodes.length).toBe(4))

--- a/apps/web/src/pages/BrowserLocalCanvasPage.initial-tool.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.initial-tool.browser.test.tsx
@@ -55,7 +55,7 @@ describe('initial tool follows the canvas shape (real browser)', () => {
     // fixture — is what the next mount reads. Radix menus need real pointer
     // events (trigger opens on pointerdown, items select on pointerup).
     await userEvent.click(screen.getByRole('button', { name: 'Add' }))
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Add note' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Note' }))
     // The new node's inline editor opens focused; commit it by clicking away.
     await userEvent.click(screen.getByTestId('spatial-editor-container'))
     await waitFor(


### PR DESCRIPTION
Three changes to the two menus that offer creation, all from the same conversation.

## Rectangle is gone

It was a **text node with no text** — a second entrance to the object `Note` already creates, not a kind of its own. JSON Canvas has no shape type, so the honest home for "this note is drawn as a rectangle" is a **facet the renderer reads**, not a second creation with its own reducer case. The case, both call paths and their tests go with it; nothing is left standing for a facet to be bolted onto later.

## The entries are object names, in one place

`Note` / `Link` / `Group` / `Document` / `Image`, from a single `CREATION_LABELS` constant that both the dock's "+" menu and the canvas context menu read.

The surface already says what will happen — a menu called **Add**, or a press on empty canvas — so `Add note here` said the context twice, and the same object read differently depending on where it was offered. The palette also no longer strips `Add ` off its own labels to display them; the label **is** the display text.

## Canvas → Document

Per ADR-0009: what a workspace holds is a **Document**; *Canvas* is the spatial surface and its file format. It was also plainly untrue — the picker behind that entry lists **markdown documents** too.

Worth stating because it came up: **nothing about JSON Canvas compatibility changes here.** That entry has always created a standard `file` node, exactly as Link creates a standard `link` node. No `+` menu entry writes the `x-whiteboard` extension, and none did before.

## Verification

- `pnpm test --project web-browser` — 534 passed; apps/web jsdom 2093; `pnpm -r typecheck`, `pnpm knip`, `pnpm lint` clean
- The label change rippled through 12 test files; each was updated to the new word rather than given an alias
- The context-menu and dock tests now assert against `CREATION_LABELS` itself, so the two surfaces cannot drift apart again

**Note for whoever owns #777:** its new test — `a block ![[embed]] renders the target note's body inline in the preview` — timed out at ~31s twice under the full browser suite on this machine, and passed both in isolation and on a third full run. It is load-sensitive rather than broken; flagging it rather than silently re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc