### PR TITLE
feat(web): store daemon file refs by immutable canvas id

### DIFF
--- a/apps/web/src/lib/daemon-file-adapter.test.ts
+++ b/apps/web/src/lib/daemon-file-adapter.test.ts
@@ -163,3 +163,37 @@ describe('createDaemonFileAdapter', () => {
     expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/a%20b/snapshot`)
   })
 })
+
+describe('createDaemonFileAdapter — id references', () => {
+  it('resolves an id reference to its CURRENT slug through the injected lookup', async () => {
+    const daemonFetch = vi.fn(async () => new Response(snapshotOf('hello') as BodyInit))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+      resolveRefSlug: (ref) => (ref === 'nanoid-123' ? 'renamed-canvas' : undefined),
+    })
+    const loaded = await adapter.loadDocument('nanoid-123')
+    expect(loaded).toBeDefined()
+    expect(String((daemonFetch.mock.calls as unknown[][])[0]?.[0])).toContain(
+      '/api/canvas/ws-1/renamed-canvas/snapshot',
+    )
+  })
+
+  it('falls back to treating an unknown reference as a legacy slug', async () => {
+    const daemonFetch = vi.fn(async () => new Response(snapshotOf('legacy') as BodyInit))
+    const adapter = createDaemonFileAdapter({
+      daemonFetch,
+      daemonBaseUrl: BASE,
+      workspaceId: WS,
+      slug: SLUG,
+      resolveRefSlug: () => undefined,
+    })
+    const loaded = await adapter.loadDocument('old-slug-ref')
+    expect(loaded).toBeDefined()
+    expect(String((daemonFetch.mock.calls as unknown[][])[0]?.[0])).toContain(
+      '/api/canvas/ws-1/old-slug-ref/snapshot',
+    )
+  })
+})

--- a/apps/web/src/lib/daemon-file-adapter.ts
+++ b/apps/web/src/lib/daemon-file-adapter.ts
@@ -22,6 +22,15 @@ export interface DaemonFileAdapterOptions {
   readonly daemonBaseUrl: string
   readonly workspaceId: string
   readonly slug: string
+  /**
+   * Maps an immutable canvas id to its CURRENT slug (undefined when the
+   * ref is not a known id). New file nodes store ids so a slug rename
+   * cannot dangle them; the daemon's read routes stay slug-addressed, so
+   * resolution happens here. Refs are resolved by LOOKUP, never by format:
+   * the id alphabet overlaps the slug charset, so an unknown ref is
+   * treated as a legacy slug reference.
+   */
+  readonly resolveRefSlug?: (ref: string) => string | undefined
 }
 
 export function createDaemonFileAdapter({
@@ -29,6 +38,7 @@ export function createDaemonFileAdapter({
   daemonBaseUrl,
   workspaceId,
   slug,
+  resolveRefSlug,
 }: DaemonFileAdapterOptions): CanvasFileAdapter {
   const canvasPath = (target: string) =>
     `${daemonBaseUrl}/api/canvas/${workspaceId}/${encodeURIComponent(target)}`
@@ -38,7 +48,8 @@ export function createDaemonFileAdapter({
 
     async loadDocument(ref) {
       try {
-        const res = await daemonFetch(`${canvasPath(ref)}/snapshot`)
+        const target = resolveRefSlug?.(ref) ?? ref
+        const res = await daemonFetch(`${canvasPath(target)}/snapshot`)
         if (!res.ok) return undefined
         const doc = new Loro()
         doc.import(new Uint8Array(await res.arrayBuffer()))

--- a/apps/web/src/pages/DaemonCanvasPage.file-refs.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.file-refs.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * File-reference identity on the daemon page: new file nodes reference the
+ * target canvas's immutable id (rename-safe, ADR-0008), while everything
+ * user-facing stays on slugs. These tests pin the page-level wiring — the
+ * options handed to the editor carry ids labeled with slugs, and opening a
+ * ref resolves the id back to the CURRENT slug by lookup, with unknown refs
+ * passing through as legacy slug references.
+ */
+import type {
+  CanvasBackend,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SpatialEditorProps } from '../components/spatial-editor/index.js'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+import { DaemonCanvasPage } from './DaemonCanvasPage.js'
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listCanvases: vi.fn(),
+  }
+})
+
+// Captures the editor's file-ref props without mounting the real canvas —
+// what this file tests is the page's wiring, not the editor's rendering.
+let capturedEditorProps: SpatialEditorProps | null = null
+vi.mock('../components/spatial-editor/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/spatial-editor/index.js')>()
+  return {
+    ...actual,
+    SpatialEditor: (props: SpatialEditorProps) => {
+      capturedEditorProps = props
+      return <div data-testid="stub-spatial-editor" />
+    },
+  }
+})
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
+
+class FakeBackend implements CanvasBackend {
+  constructor(
+    public workspaceId: string,
+    public slug: string,
+  ) {
+    createdBackends.push(this)
+  }
+  connect(handlers: CanvasBackendHandlers): void {
+    handlers.onConnected()
+    const { LoroDoc } = require('loro-crdt') as typeof import('loro-crdt')
+    handlers.onSnapshot(new LoroDoc().export({ mode: 'snapshot' }))
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const createdBackends: FakeBackend[] = []
+
+function MemoryRouterWrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={['/']}>{children}</MemoryRouter>
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+async function renderPage() {
+  await act(async () => {
+    rtlRender(
+      <DaemonCanvasPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        createBackend={(workspaceId, slug) => new FakeBackend(workspaceId, slug)}
+      />,
+      { wrapper: MemoryRouterWrapper, container: document.body },
+    )
+  })
+  await waitFor(() => expect(screen.getByTestId('stub-spatial-editor')).toBeTruthy())
+  await waitFor(() => expect(capturedEditorProps?.fileRefOptions?.length).toBeGreaterThan(0))
+}
+
+describe('DaemonCanvasPage file refs', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    capturedEditorProps = null
+    createdBackends.length = 0
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [
+        { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('offers other canvases as id-valued refs labeled with their slug', async () => {
+    await renderPage()
+    // The open canvas (main) is excluded; the ref stored into the document
+    // is the id, the label the user sees is the slug.
+    expect(capturedEditorProps?.fileRefOptions).toEqual([{ file: 'id-second', label: 'second' }])
+  })
+
+  it('opens an id ref on the target canvas current slug', async () => {
+    await renderPage()
+    await act(async () => {
+      capturedEditorProps?.onOpenFileRef?.('id-second')
+    })
+    await waitFor(() =>
+      expect(createdBackends.at(-1)).toMatchObject({ workspaceId: 'w1', slug: 'second' }),
+    )
+  })
+
+  it('passes an unknown ref through unchanged as a legacy slug reference', async () => {
+    await renderPage()
+    await act(async () => {
+      capturedEditorProps?.onOpenFileRef?.('second')
+    })
+    await waitFor(() =>
+      expect(createdBackends.at(-1)).toMatchObject({ workspaceId: 'w1', slug: 'second' }),
+    )
+  })
+
+  it('falls back to slug refs for entries an older daemon lists without ids', async () => {
+    mockListCanvases.mockResolvedValue({
+      canvases: [
+        { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+      ],
+    })
+    await renderPage()
+    expect(capturedEditorProps?.fileRefOptions).toEqual([{ file: 'second', label: 'second' }])
+  })
+})

--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -127,8 +127,8 @@ describe('DaemonCanvasPage', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
-        { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+        { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
   })
@@ -246,13 +246,15 @@ describe('DaemonCanvasPage', () => {
       mockListCanvases.mockImplementation((_fetch, _base, workspaceId) => {
         if (workspaceId === 'w2') {
           return Promise.resolve({
-            canvases: [{ slug: 'w2-main', updatedAt: '2026-02-01', kind: 'spatial' }],
+            canvases: [
+              { slug: 'w2-main', id: 'id-w2-main', updatedAt: '2026-02-01', kind: 'spatial' },
+            ],
           })
         }
         return Promise.resolve({
           canvases: [
-            { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
-            { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+            { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+            { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
           ],
         })
       })
@@ -291,8 +293,8 @@ describe('DaemonCanvasPage', () => {
         if (workspaceId === 'w2') return Promise.resolve({ canvases: [] })
         return Promise.resolve({
           canvases: [
-            { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
-            { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+            { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+            { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
           ],
         })
       })
@@ -336,8 +338,8 @@ describe('DaemonCanvasPage', () => {
       })
       mockListCanvases.mockResolvedValueOnce({
         canvases: [
-          { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
-          { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+          { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+          { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
         ],
       })
 
@@ -620,8 +622,8 @@ describe('DaemonCanvasPage', () => {
       if (workspaceId === 'w2') return Promise.resolve({ canvases: [] })
       return Promise.resolve({
         canvases: [
-          { slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' },
-          { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+          { slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' },
+          { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
         ],
       })
     })
@@ -786,7 +788,7 @@ describe('DaemonCanvasPage', () => {
     mockListCanvases.mockResolvedValueOnce({ canvases: [] })
     mockCreateCanvas.mockResolvedValue({ slug: 'untitled' })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'untitled', updatedAt: '2026-01-03', kind: 'spatial' }],
+      canvases: [{ slug: 'untitled', id: 'id-untitled', updatedAt: '2026-01-03', kind: 'spatial' }],
     })
 
     await act(async () => {

--- a/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
@@ -91,7 +91,7 @@ describe('DaemonCanvasPage theme wiring', () => {
     window.localStorage.clear()
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
   })
   afterEach(() => {

--- a/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.thumbnail.test.tsx
@@ -87,7 +87,7 @@ describe('DaemonCanvasPage thumbnail wiring', () => {
     capturedProps.length = 0
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
   })
   afterEach(() => {

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -223,6 +223,20 @@ export function DaemonCanvasPage({
     identity: canvas ?? undefined,
   })
 
+  // New file nodes store the target's immutable id (ADR-0008: stored
+  // references key on ids, so a slug rename cannot dangle them); the
+  // daemon's read routes stay slug-addressed, so refs resolve to the
+  // CURRENT slug through the live canvases list. Read through a ref so the
+  // adapter identity survives list refreshes; the lookup itself resolves by
+  // membership, never by format — legacy slug refs miss it and pass
+  // through unchanged.
+  const canvasesRef = useRef(controller.canvases)
+  canvasesRef.current = controller.canvases
+  const resolveRefSlug = useCallback(
+    (ref: string) => canvasesRef.current.find((entry) => entry.id === ref)?.slug,
+    [],
+  )
+
   // Canvas embeds (J5a) and image nodes (J5b), over the daemon's own file and
   // snapshot routes. The staleness stamp is the referenced canvas's
   // updatedAt, exactly as in browser-local mode.
@@ -235,11 +249,20 @@ export function DaemonCanvasPage({
           daemonBaseUrl,
           workspaceId: canvas?.workspaceId ?? '',
           slug: canvas?.slug ?? '',
+          resolveRefSlug,
         }),
-      [daemonFetch, daemonBaseUrl, canvas?.workspaceId, canvas?.slug],
+      [daemonFetch, daemonBaseUrl, canvas?.workspaceId, canvas?.slug, resolveRefSlug],
     ),
+    // Keyed by BOTH id and slug so id refs and legacy slug refs each find
+    // their staleness stamp.
     stampOf: useMemo(
-      () => new Map(controller.canvases.map((entry) => [entry.slug, entry.updatedAt ?? ''])),
+      () =>
+        new Map(
+          controller.canvases.flatMap((entry) => [
+            [entry.slug, entry.updatedAt ?? ''] as const,
+            ...(entry.id ? [[entry.id, entry.updatedAt ?? ''] as const] : []),
+          ]),
+        ),
       [controller.canvases],
     ),
   })
@@ -637,12 +660,16 @@ export function DaemonCanvasPage({
               onChange={onChange}
               externalVersion={externalVersion}
               theme={resolvedTheme}
-              // File-node reference = the canvas slug within this workspace
-              // (the daemon's alias path); the current canvas is excluded.
+              // File-node reference = the target's immutable id (rename-
+              // safe); the label shows its current slug and the current
+              // canvas is excluded. Legacy documents still carry slug refs,
+              // which resolveRefSlug misses and switchCanvas takes as-is.
+              // An older daemon's list has no ids yet; those entries fall
+              // back to slug refs (same behavior as before ids existed).
               fileRefOptions={controller.canvases
                 .filter((entry) => entry.slug !== canvas?.slug)
-                .map((entry) => ({ file: entry.slug, label: entry.slug }))}
-              onOpenFileRef={(file) => controller.switchCanvas(file)}
+                .map((entry) => ({ file: entry.id ?? entry.slug, label: entry.slug }))}
+              onOpenFileRef={(file) => controller.switchCanvas(resolveRefSlug(file) ?? file)}
               {...fileSeams}
               lockedNodeIds={lockedNodeIds}
               lockedEdgeIds={lockedEdgeIds}

--- a/apps/web/src/pages/DaemonCanvasPage.webmcp.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.webmcp.test.tsx
@@ -85,7 +85,7 @@ describe('DaemonCanvasPage WebMCP wiring', () => {
   beforeEach(() => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
   })
 

--- a/apps/web/src/pages/use-daemon-canvas-controller.test.ts
+++ b/apps/web/src/pages/use-daemon-canvas-controller.test.ts
@@ -26,7 +26,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -42,8 +42,8 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'first', updatedAt: '2026-01-01', kind: 'spatial' },
-        { slug: 'second', updatedAt: '2026-01-02', kind: 'spatial' },
+        { slug: 'first', id: 'id-first', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
 
@@ -77,7 +77,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w-explicit' }, { workspaceId: 'w-other' }],
     })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'explicit', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'explicit', id: 'id-explicit', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -104,7 +104,7 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValue({
-      canvases: [{ slug: 'main', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     const { result } = renderHook(() =>
@@ -121,7 +121,9 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w1-canvas', id: 'id-w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+      ],
     })
 
     const { result } = renderHook(() =>
@@ -132,7 +134,9 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.slug).toBe('w1-canvas')
 
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w2-canvas', id: 'id-w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' },
+      ],
     })
 
     await act(async () => {
@@ -143,7 +147,7 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.workspaceId).toBe('w2')
     expect(result.current.slug).toBe('w2-canvas')
     expect(result.current.canvases).toEqual([
-      { slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' },
+      { slug: 'w2-canvas', id: 'id-w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' },
     ])
   })
 
@@ -152,7 +156,9 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w1-canvas', id: 'id-w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+      ],
     })
 
     const { result } = renderHook(() =>
@@ -175,7 +181,9 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }, { workspaceId: 'w3' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w1-canvas', id: 'id-w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+      ],
     })
 
     const { result } = renderHook(() =>
@@ -184,16 +192,18 @@ describe('useDaemonCanvasController', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     let resolveW2: (value: {
-      canvases: { slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
+      canvases: { slug: string; id: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
     }) => void = () => {}
     const w2Promise = new Promise<{
-      canvases: { slug: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
+      canvases: { slug: string; id: string; updatedAt: string; kind: 'spatial' | 'markdown' }[]
     }>((resolve) => {
       resolveW2 = resolve
     })
     mockListCanvases.mockReturnValueOnce(w2Promise)
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w3-canvas', updatedAt: '2026-01-03', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w3-canvas', id: 'id-w3-canvas', updatedAt: '2026-01-03', kind: 'spatial' },
+      ],
     })
 
     let switchW2Done: Promise<void> = Promise.resolve()
@@ -207,7 +217,11 @@ describe('useDaemonCanvasController', () => {
 
     // The stale w2 response resolves after w3 already won; it must be discarded.
     await act(async () => {
-      resolveW2({ canvases: [{ slug: 'w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' }] })
+      resolveW2({
+        canvases: [
+          { slug: 'w2-canvas', id: 'id-w2-canvas', updatedAt: '2026-01-02', kind: 'spatial' },
+        ],
+      })
       await switchW2Done
     })
 
@@ -219,8 +233,8 @@ describe('useDaemonCanvasController', () => {
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [
-        { slug: 'a', updatedAt: '2026-01-01', kind: 'spatial' },
-        { slug: 'b', updatedAt: '2026-01-02', kind: 'spatial' },
+        { slug: 'a', id: 'id-a', updatedAt: '2026-01-01', kind: 'spatial' },
+        { slug: 'b', id: 'id-b', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
 
@@ -240,7 +254,9 @@ describe('useDaemonCanvasController', () => {
     mockListCanvases.mockResolvedValueOnce({ canvases: [] })
     mockCreateCanvas.mockResolvedValue({ slug: 'brand-new' })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'brand-new', updatedAt: '2026-01-03', kind: 'spatial' }],
+      canvases: [
+        { slug: 'brand-new', id: 'id-brand-new', updatedAt: '2026-01-03', kind: 'spatial' },
+      ],
     })
 
     const { result } = renderHook(() =>
@@ -288,7 +304,7 @@ describe('useDaemonCanvasController', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'untitled', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [{ slug: 'untitled', id: 'id-untitled', updatedAt: '2026-01-01', kind: 'spatial' }],
     })
 
     await act(async () => {
@@ -298,7 +314,7 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.createError).toBe('slug already exists')
     // The refreshed list now shows the slug another client already took.
     expect(result.current.canvases).toEqual([
-      { slug: 'untitled', updatedAt: '2026-01-01', kind: 'spatial' },
+      { slug: 'untitled', id: 'id-untitled', updatedAt: '2026-01-01', kind: 'spatial' },
     ])
   })
 
@@ -335,7 +351,9 @@ describe('useDaemonCanvasController', () => {
       workspaces: [{ workspaceId: 'w1' }, { workspaceId: 'w2' }],
     })
     mockListCanvases.mockResolvedValueOnce({
-      canvases: [{ slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' }],
+      canvases: [
+        { slug: 'w1-canvas', id: 'id-w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+      ],
     })
 
     const { result } = renderHook(() =>
@@ -354,7 +372,7 @@ describe('useDaemonCanvasController', () => {
     expect(result.current.workspaceId).toBe('w1')
     expect(result.current.slug).toBe('w1-canvas')
     expect(result.current.canvases).toEqual([
-      { slug: 'w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
+      { slug: 'w1-canvas', id: 'id-w1-canvas', updatedAt: '2026-01-01', kind: 'spatial' },
     ])
   })
 })

--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -299,6 +299,18 @@ describe('listCanvases', () => {
     expect(list[0].updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
+  it('includes the immutable canvas id on each entry, stable across a slug rename', async () => {
+    await saveCanvas('session1', 'canvas-a', new LoroDoc())
+    const before = await listCanvases('session1')
+    expect(before[0].id).toBeTruthy()
+
+    await renameCanvasSlug('session1', 'canvas-a', 'canvas-renamed')
+    const after = await listCanvases('session1')
+    expect(after[0].slug).toBe('canvas-renamed')
+    // The id is what stored references key on; a rename must not move it.
+    expect(after[0].id).toBe(before[0].id)
+  })
+
   it('persists kind: markdown and lists it back', async () => {
     await saveCanvas('session1', 'note', new LoroDoc(), { kind: 'markdown' })
     const list = await listCanvases('session1')

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -590,16 +590,17 @@ export async function renameCanvasSlug(
 // ── list canvases from the canvases table ──
 export async function listCanvases(
   workspaceId: string,
-): Promise<Pick<CanvasSummary, 'slug' | 'updatedAt' | 'kind'>[]> {
+): Promise<Pick<CanvasSummary, 'slug' | 'id' | 'updatedAt' | 'kind'>[]> {
   validateWorkspaceId(workspaceId)
   const db = await dbReady()
   const rows = await db
     .selectFrom('canvases')
-    .select(['slug', 'updatedAt', 'kind'])
+    .select(['slug', 'id', 'updatedAt', 'kind'])
     .where('workspaceId', '=', workspaceId)
     .execute()
   return rows.map((r) => ({
     slug: r.slug,
+    id: r.id,
     updatedAt: new Date(r.updatedAt).toISOString(),
     kind: r.kind ?? 'spatial',
   }))

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -137,6 +137,16 @@ export const listWorkspacesResponseSchema = z.object({
 
 export const canvasSummarySchema = z.object({
   slug: z.string(),
+  // The immutable id behind the slug (the canvases row's nanoid PK).
+  // Stored references (file nodes) key on this so a slug rename cannot
+  // dangle them (ADR-0008: stored links key on ids); the slug stays the
+  // user-facing, URL-addressed identity. Deliberately not pattern-bound:
+  // clients must treat it as opaque and resolve refs by LOOKUP, never by
+  // format — the nanoid alphabet overlaps the slug charset.
+  // Optional so a new client can still parse an older daemon's id-less list
+  // (the web app and the locally installed daemon version independently);
+  // clients fall back to the slug when the id is absent.
+  id: z.string().min(1).optional(),
   updatedAt: z.string(),
   // Rows stored before this field existed have no recorded kind and read
   // back as spatial — the only kind that existed then.


### PR DESCRIPTION
## Summary

Canvas-reference (file) nodes on the daemon page now store the target canvas's **immutable id** instead of its slug, so renaming a canvas no longer dangles every reference pointing at it (ADR-0008: stored links key on ids). Everything user-facing stays on slugs:

- **Server** — `listCanvases` returns each canvas's nanoid PK alongside the slug (`canvasSummarySchema.id`). Optional in the schema so a newer client still parses an older daemon's id-less list.
- **Web** — new file nodes reference `entry.id`; the picker label and everything the user sees stays the slug. `createDaemonFileAdapter` resolves an id ref to the **current** slug by lookup against the live canvases list before hitting the slug-addressed read routes. Resolution is by **lookup, never by format** (the nanoid alphabet overlaps the slug charset), so an unknown ref passes through unchanged as a legacy slug reference — existing documents keep working with no migration.
- Entries an older daemon lists without ids fall back to slug refs (exactly the pre-change behavior).

Follow-up (tracked as a whiteboard issue): project id↔slug on JSON Canvas export/import in `server-core`, the same export-projection pattern wikiLinks use.

## Visual repro

Reference node created on `test` pointing at `sibling-renamed`, persisted through the daemon:

![ref-persisted-after-reload.png](https://github.com/user-attachments/assets/cfb235cb-fb3e-4e41-ac1e-340775a2c909)

After renaming the target's slug to `sibling-v3` (id unchanged), the **same stored node** re-resolves and renders the new slug; "Open canvas" connects to `ws/…/sibling-v3`:

![ref-after-second-rename.png](https://github.com/user-attachments/assets/3a01883a-4e72-4ac0-b45e-f4e2815fbf83)

Verified live against the dev daemon: created the ref, renamed the target slug twice via `PUT …/slug`, confirmed the node label follows the current slug and Open canvas opens the renamed target.

## Test plan

- [x] `canvas-store.test.ts`: listCanvases carries the immutable id, stable across a slug rename (mcp-node, 269 files green)
- [x] `daemon-file-adapter.test.ts`: id ref resolves to current slug; unknown ref treated as legacy slug
- [x] `DaemonCanvasPage.file-refs.test.tsx` (new): fileRefOptions carry id-valued refs labeled with slugs; onOpenFileRef resolves id→current slug; unknown ref passes through; id-less (old daemon) entries fall back to slugs
- [x] `pnpm --filter @kamiazya/whiteboard-web test` all green (2095 tests), typecheck / lint / knip clean
- [x] Manual verification in the running app (rename scenario above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Canvas file references now use stable canvas identifiers, so links continue working when canvas slugs are renamed.
  - Canvas listings can include an identifier alongside the canvas slug.
  - Current slugs are resolved automatically when opening referenced files.

- **Bug Fixes**
  - Improved compatibility with older documents and services that use slug-based references or do not provide canvas identifiers.
  - Preserved accurate stale-reference detection across renamed canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->