### PR TITLE
feat(web): carry daemon changes on the authority channel, not only tab pushes

### DIFF
--- a/apps/web/src/lib/sse-shared-worker.browser.test.tsx
+++ b/apps/web/src/lib/sse-shared-worker.browser.test.tsx
@@ -160,6 +160,32 @@ it('keeps two daemon origins that share a document id apart', async () => {
   expect(leaked).not.toHaveBeenCalled()
 }, 30_000)
 
+it('answers a document nobody has opened with an empty snapshot, not an error', async () => {
+  // Lives here rather than in the jsdom file because that file can host
+  // exactly one replica test — loro-crdt's WASM initialises once per realm and
+  // the polyfill runs every worker in the host's, so the second worker to
+  // import it is refused. The jsdom slot goes to the daemon case, which is the
+  // only one a real browser cannot run.
+  const port = openPort('whiteboard-sse-empty-snapshot-test')
+  const doc = `w/empty-${Date.now()}`
+  port.postMessage({ type: 'init', baseUrl: 'http://127.0.0.1:1', token: 't' })
+
+  const snapshot = await new Promise<string>((resolve, reject) => {
+    port.addEventListener('message', (e: MessageEvent) => {
+      const data = e.data as { type?: string; snapshot?: string }
+      if (data.type === 'snapshot' && data.snapshot !== undefined) resolve(data.snapshot)
+    })
+    port.postMessage({ type: 'snapshot-request', doc })
+    setTimeout(() => reject(new Error('no snapshot came back')), 10_000)
+  })
+
+  // Forkable is the property that matters: forking from empty and letting the
+  // daemon fill it in is the same path a first-ever open takes.
+  const forked = new LoroDoc()
+  forked.import(decode(snapshot))
+  expect(forked.getMap('anything').size).toBe(0)
+}, 30_000)
+
 it('hands a later tab a snapshot that already contains an earlier push', async () => {
   // The round trip a replica exists to remove: without it this snapshot would
   // be empty until the daemon echoed the work back.

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -324,57 +324,82 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
  * updates with it exactly the way the worker exchanges with the daemon.
  */
 describe('authority replica', () => {
-  // Single-port only, on purpose. The polyfill builds a fresh worker context
-  // per `new SharedWorker` (see this file's header), so anything about two
-  // ports meeting in one worker would pass or fail here for reasons that say
-  // nothing about a browser. That half lives in the browser test beside it.
+  /**
+   * EXACTLY ONE replica test can live in this file, and it has to be this one.
+   *
+   * `@vitest/web-worker` runs every worker in the host realm, and loro-crdt's
+   * WASM initialises once per realm: the FIRST worker to `import('loro-crdt')`
+   * gets the module, and in every worker after it the same import REJECTS with
+   * `TypeError: Cannot read properties of undefined (reading 'id')`. The
+   * worker degrades exactly as designed — the relay keeps running and replica
+   * messages go unanswered — so a second replica test does not fail loudly,
+   * it waits out its whole budget for a reply that was never coming.
+   *
+   * That makes "which replica test is first in the file" load-bearing, which
+   * is not a property to leave implicit. The slot goes to the daemon case
+   * because it is the ONLY one the browser file cannot host: a real browser
+   * runs loro in as many workers as you like, but there is no daemon there to
+   * feed a frame. Everything else about the replica — snapshots, cross-tab
+   * fan-out, a push a sibling receives — is in
+   * `sse-shared-worker.browser.test.tsx`, where it belongs.
+   *
+   * If you add a second replica test here, it will hang, and the reason will
+   * not be your test.
+   */
   const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
-  const nextMessage = (port: MessagePort, type: string) =>
-    new Promise<Record<string, unknown>>((resolve) => {
-      const onMessage = (e: MessageEvent) => {
-        if ((e.data as { type?: string }).type !== type) return
-        port.removeEventListener('message', onMessage)
-        resolve(e.data as Record<string, unknown>)
-      }
-      port.addEventListener('message', onMessage)
-      port.start()
-    })
+  const b64 = (bytes: Uint8Array) => {
+    let out = ''
+    for (const byte of bytes) out += String.fromCharCode(byte)
+    return btoa(out)
+  }
 
-  it('answers a document nobody has opened with an empty snapshot, not an error', async () => {
+  it('relays a daemon frame onward as authority state, not only verbatim', async () => {
+    // A tab that has forked from the replica reads `authority-update` and
+    // nothing else. If the replica only ever spoke when a TAB pushed, that tab
+    // would silently miss every change that did not originate in a sibling
+    // tab — an MCP tool writing to the canvas, another device, a restore. The
+    // channel has to carry the daemon too, or the fork model drops writes.
     const port = connect()
     const doc = nextDoc()
+    const authority = new Promise<string>((resolve) => {
+      port.addEventListener('message', (e: MessageEvent) => {
+        const data = e.data as { type?: string; update?: string }
+        if (data.type === 'authority-update' && data.update !== undefined) resolve(data.update)
+      })
+    })
     port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
-    const reply = nextMessage(port, 'snapshot')
-    port.postMessage({ type: 'snapshot-request', doc })
+    port.postMessage({ type: 'subscribe', doc })
+    await until(() => streamIdFor(doc) !== undefined)
 
-    // Forkable is the property that matters: forking from empty and letting
-    // the daemon fill it in is the same path a first-ever open takes.
+    // Real Loro bytes, so the replica genuinely merges rather than dropping a
+    // frame it cannot parse and passing for the wrong reason.
+    const daemon = new LoroDoc()
+    daemon.getMap('m').set('k', 'from-daemon')
+    daemon.commit()
+    pushTo(
+      doc,
+      `event: update\ndata: ${JSON.stringify({ doc, update: b64(daemon.export({ mode: 'update' })) })}\n\n`,
+    )
+
+    // Reconstructed rather than compared byte-for-byte: what travels is the
+    // replica's delta, which is not required to equal the frame that produced
+    // it — only to carry the same state.
     const forked = new LoroDoc()
-    forked.import(decode((await reply).snapshot as string))
-    expect(forked.getMap('anything').size).toBe(0)
-  })
+    forked.import(decode(await authority))
+    expect(forked.getMap('m').get('k')).toBe('from-daemon')
+    // Its own budget: this is the only case in the block that waits for a
+    // stream to open, and the sibling describe's 5s default is not a wait,
+    // it is a coin flip under a loaded suite.
+  }, 25_000)
 
-  // A `push` followed by a snapshot-request is NOT tested here: under the
-  // polyfill the port stops delivering anything at all after a push, while the
-  // same sequence works in a real browser (see the browser test beside this).
-  // Chasing that difference would be debugging the polyfill, not the worker.
-
-  // NOT covered anywhere yet, and worth saying so: anything about a DAEMON
-  // frame reaching the replica (rather than only the relay). That is one
-  // claim about arrival — the frame lands in the replica at all — and one
-  // about multiplicity: the replica takes its own hub subscription per
-  // document, so N tabs watching one document cost ONE import per frame
-  // rather than N.
+  // Still NOT covered, and worth saying so: that N tabs watching one document
+  // cost ONE replica import per daemon frame rather than N. The replica takes
+  // its own hub subscription per document precisely so they do, but the count
+  // is internal, and the two ports needed to observe it are two tabs of one
+  // worker only in the browser file — which has no daemon to feed. That one
+  // meets in an E2E.
   //
-  // Neither is observable at either layer, and for opposite reasons. jsdom
-  // can feed a daemon frame through MSW but cannot observe the replica: every
-  // snapshot-request that follows replica work stops being answered under the
-  // polyfill. The browser test can observe the replica but has no daemon to
-  // feed it, and its two ports are two tabs of one worker only THERE — which
-  // is the very thing the multiplicity claim is about. Both halves meet only
-  // in an E2E against a real daemon, which is where this belongs.
-  //
-  // What IS pinned, above: that the feed is released. Dropping the release
-  // turns the sibling `unsubscribe` cases red, because the hub keeps a
-  // document subscribed on the daemon while any listener remains.
+  // What IS pinned above, in the sibling describe: that the feed is released.
+  // Dropping the release turns the `unsubscribe` cases red, because the hub
+  // keeps a document subscribed on the daemon while any listener remains.
 })

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -128,7 +128,8 @@ function retainReplicaFeed(hub: SseStreamHub, baseUrl: string, doc: string): voi
     return
   }
   const off = hub.subscribe(doc, {
-    onUpdate: (bytes) => importIntoReplica(baseUrl, doc, bytes),
+    // `null`: the daemon is the source, so nobody is excluded from the fan-out.
+    onUpdate: (bytes) => ingest(baseUrl, doc, bytes, null),
     onMessage: () => {},
   })
   replicaFeeds.set(key, { off, ports: 1 })
@@ -179,38 +180,52 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary)
 }
 
-function importIntoReplica(baseUrl: string, doc: string, bytes: Uint8Array): void {
+/**
+ * Merge bytes into a document's replica and tell the interested tabs what
+ * actually changed.
+ *
+ * One function for both directions on purpose: a tab's push and a daemon
+ * frame differ only in who must NOT be told (`from` — the sender, or nobody
+ * when the daemon is the source). Everything else — merge, diff against what
+ * the replica already had, fan out — is the same, and writing it twice is how
+ * the two directions drift.
+ *
+ * The daemon direction is what makes `authority-update` a channel a client can
+ * live on alone. A replica that only spoke when a tab pushed would leave a
+ * forked tab silently missing every change that did not originate in a
+ * sibling tab: an MCP tool writing to the canvas, another device, a restore.
+ */
+function ingest(baseUrl: string, doc: string, bytes: Uint8Array, from: MessagePort | null): void {
   queueReplicaWork(() => {
+    const replica = replicaFor(baseUrl, doc)
+    if (replica === undefined) return
+    const before = replica.version()
     // Total by construction: a frame this replica cannot merge (a truncated
     // update, a future format) must not take the worker down for every tab
     // and every other document. The daemon remains the source it can re-sync
     // from.
     try {
-      replicaFor(baseUrl, doc)?.import(bytes)
+      replica.import(bytes)
     } catch {
       return
     }
+    // Only what the replica did not already have travels onward. Two things
+    // depend on this rather than on it being an optimisation: a tab
+    // re-pushing work a sibling already delivered costs no broadcast, and the
+    // daemon's echo of a tab's OWN push diffs to nothing — which is what stops
+    // the round trip from looping back out as authority state.
+    const merged = replica.export({ mode: 'update', from: before })
+    if (merged.byteLength === 0) return
+    const encoded = toBase64(merged)
+    for (const [target, state] of ports) {
+      if (target === from) continue
+      // Two daemons can mint the same document id, so a tab paired with one of
+      // them must never be handed the other's edits.
+      if (state.baseUrl !== baseUrl) continue
+      if (!state.subscriptions.has(doc)) continue
+      target.postMessage({ type: 'authority-update', doc, update: encoded })
+    }
   })
-}
-
-/**
- * To every port subscribed to `doc` ON THE SAME ORIGIN, except the one that
- * sent the work. Two daemons can mint the same document id, and a tab paired
- * with one of them must never be handed the other's edits.
- */
-function broadcastAuthorityUpdate(
-  baseUrl: string,
-  doc: string,
-  update: Uint8Array,
-  from: MessagePort,
-): void {
-  const encoded = toBase64(update)
-  for (const [target, state] of ports) {
-    if (target === from) continue
-    if (state.baseUrl !== baseUrl) continue
-    if (!state.subscriptions.has(doc)) continue
-    target.postMessage({ type: 'authority-update', doc, update: encoded })
-  }
 }
 
 function handle(port: MessagePort, raw: unknown): void {
@@ -269,22 +284,10 @@ function handle(port: MessagePort, raw: unknown): void {
   }
 
   if (msg.type === 'push') {
-    queueReplicaWork(() => {
-      const replica = replicaFor(state.baseUrl, msg.doc)
-      if (replica === undefined) return
-      const before = replica.version()
-      try {
-        replica.import(fromBase64(msg.update))
-      } catch {
-        return
-      }
-      // Only what the replica did not already have travels onward, so a tab
-      // re-pushing work another tab already delivered costs one import and no
-      // broadcast. Loro merges are idempotent, but a broadcast is not free.
-      const merged = replica.export({ mode: 'update', from: before })
-      if (merged.byteLength === 0) return
-      broadcastAuthorityUpdate(state.baseUrl, msg.doc, merged, port)
-    })
+    // Excluded from its own fan-out: echoing an edit back to the tab that made
+    // it would turn every stroke into a round trip through the tab that drew
+    // it, which is the cost the fork model exists to avoid.
+    ingest(state.baseUrl, msg.doc, fromBase64(msg.update), port)
     return
   }
 


### PR DESCRIPTION
Second increment of the Loro-authority work, after #779.

## The gap

The worker's replica ingested daemon frames and told nobody. Only a tab's `push` produced an `authority-update` — so a client that had forked from the replica and read that channel alone would have **silently missed every change that did not originate in a sibling tab**: an MCP tool writing to the canvas, another device, a restore.

That has to be closed before any tab-side client lands on the channel, or the fork model drops writes.

## The change is a deletion

The two directions are now one `ingest(baseUrl, doc, bytes, from)`. They only ever differed in who must NOT be told — the sending port, or nobody when the daemon is the source. Merge, diff against what the replica already had, fan out: identical. So this removes the duplicate rather than adding a second copy.

One consequence worth naming: the `merged.byteLength === 0` guard stops being an optimisation and becomes load-bearing. The daemon's echo of a tab's own push diffs to nothing, which is what keeps the round trip from coming back out as authority state.

## Test placement changed — read this before adding another replica test

`@vitest/web-worker` runs every worker in the host realm, and loro-crdt's WASM initialises **once per realm**. The first worker to `import('loro-crdt')` gets the module; every worker after it is refused with `TypeError: Cannot read properties of undefined (reading 'id')`.

The worker then degrades exactly as designed — relay up, replica silent — so a second replica test in that file does not fail loudly. It waits out its whole budget for a reply that was never coming.

So the jsdom file holds **exactly one** replica test, and it is now the daemon case — the only one a real browser cannot host, since there is no daemon there to feed a frame. The empty-snapshot case moves to the browser file beside the rest of the replica coverage.

That slot was previously occupied by accident: the snapshot test passed only because it happened to be first in the file. Nothing said so, and nothing would have.

This closes the "no test proves a daemon frame reaches the replica" gap that was labelled in the code and raised in review on #779.

## Verification

- New jsdom case feeds a real Loro update as a daemon frame and reconstructs the state from the `authority-update` that comes back (delta bytes need not equal the frame that produced them, so it reconstructs rather than compares).
- **Mutation-checked**: reverting the daemon direction to a bare import turns it red (25s timeout — the silent-degradation shape above).
- `web-jsdom` + `web-browser`: 538 passed.