### PR TITLE
feat(mcp-server): make DocumentIndex available to the server, and give a document a name

### DIFF
--- a/packages/canvas-ports/src/document-index.ts
+++ b/packages/canvas-ports/src/document-index.ts
@@ -11,12 +11,24 @@ export const documentEntrySchema = z
     canvasId: canvasIdSchema,
     path: documentPathSchema,
     kind: canvasKindSchema,
+    /**
+     * What a human reads, as opposed to `path`, which is an address. Absent
+     * rather than defaulted to the last path segment: a reader that wants
+     * that fallback can choose it, while a listing that invents one reads as
+     * though somebody typed the slug in as a title.
+     */
+    name: z.string().min(1).optional(),
   })
   .strict()
 export type DocumentEntry = z.infer<typeof documentEntrySchema>
 
 export const createDocumentInputSchema = z
-  .object({ workspaceId: workspaceIdSchema, path: documentPathSchema, kind: canvasKindSchema })
+  .object({
+    workspaceId: workspaceIdSchema,
+    path: documentPathSchema,
+    kind: canvasKindSchema,
+    name: z.string().min(1).optional(),
+  })
   .strict()
 export type CreateDocumentInput = z.infer<typeof createDocumentInputSchema>
 

--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -10,7 +10,7 @@ export function createContainer(storeModule: ContainerModule = storeMemoryModule
 }
 
 /**
- * Assembles ServerDeps by resolving the three store/sync port tokens from a
+ * Assembles ServerDeps by resolving the store/sync port tokens from a
  * DI container. Inversify already throws a descriptive "not bound" error
  * when a token has no binding, so this simply surfaces that failure instead
  * of letting a missing binding silently produce undefined deps.
@@ -19,5 +19,6 @@ export function resolveServerDeps(container: Container): ServerDeps {
   return {
     canvasDocStore: container.get(TOKENS.CanvasDocStore),
     blobStore: container.get(TOKENS.BlobStore),
+    documentIndex: container.get(TOKENS.DocumentIndex),
   }
 }

--- a/packages/mcp-server/src/di/store-local.module.ts
+++ b/packages/mcp-server/src/di/store-local.module.ts
@@ -4,6 +4,7 @@ import type { Kysely } from 'kysely'
 import type { DatabaseSchema } from '../server/store/db/schema.js'
 import { FsBlobStore } from '../server/store/fs/fs-blob-store.js'
 import { LibsqlCanvasDocStore } from '../server/store/libsql/libsql-canvas-doc-store.js'
+import { SqliteDocumentIndex } from '../server/store/sqlite-document-index.js'
 
 export interface StoreLocalModuleOptions {
   db: Kysely<DatabaseSchema>
@@ -17,6 +18,9 @@ export function createStoreLocalModule(opts: StoreLocalModuleOptions): Container
       .inSingletonScope()
     bind(TOKENS.BlobStore)
       .toDynamicValue(() => new FsBlobStore(opts.blobDir))
+      .inSingletonScope()
+    bind(TOKENS.DocumentIndex)
+      .toDynamicValue(() => new SqliteDocumentIndex(opts.db))
       .inSingletonScope()
   })
 }

--- a/packages/mcp-server/src/di/store-memory.module.ts
+++ b/packages/mcp-server/src/di/store-memory.module.ts
@@ -1,6 +1,10 @@
 import { TOKENS } from '@kamiazya/whiteboard-canvas-ports'
 import { ContainerModule } from 'inversify'
-import { InMemoryBlobStore, InMemoryCanvasDocStore } from '../server/store/inmemory/index.js'
+import {
+  InMemoryBlobStore,
+  InMemoryCanvasDocStore,
+  InMemoryDocumentIndex,
+} from '../server/store/inmemory/index.js'
 
 /**
  * Binds the storage ports to their in-memory test doubles. Test-level
@@ -13,5 +17,8 @@ export const storeMemoryModule = new ContainerModule(({ bind }) => {
     .inSingletonScope()
   bind(TOKENS.BlobStore)
     .toDynamicValue(() => new InMemoryBlobStore())
+    .inSingletonScope()
+  bind(TOKENS.DocumentIndex)
+    .toDynamicValue(() => new InMemoryDocumentIndex())
     .inSingletonScope()
 })

--- a/packages/mcp-server/src/server/store/document-index-conformance.ts
+++ b/packages/mcp-server/src/server/store/document-index-conformance.ts
@@ -38,6 +38,31 @@ export function describeDocumentIndexConformance(
     }
   }
 
+  it('carries a name when given one, and reports none as absent rather than null', async () => {
+    await withIndex(async (index) => {
+      const named = await index.createDocument({
+        workspaceId: WS,
+        path: 'named',
+        kind: 'spatial',
+        name: 'Quarterly plan',
+      })
+      expect(named.name).toBe('Quarterly plan')
+      expect((await index.resolveDocument({ workspaceId: WS, path: 'named' }))?.name).toBe(
+        'Quarterly plan',
+      )
+
+      const anonymous = await index.createDocument({
+        workspaceId: WS,
+        path: 'anonymous',
+        kind: 'spatial',
+      })
+      expect('name' in anonymous).toBe(false)
+      const readBack = await index.resolveDocument({ workspaceId: WS, path: 'anonymous' })
+      expect(readBack).not.toBeNull()
+      expect('name' in (readBack as object)).toBe(false)
+    })
+  })
+
   it('refuses to create a document in a workspace that does not exist', async () => {
     await withIndex(async (index) => {
       // A typo'd or hallucinated workspaceId must fail loudly rather than

--- a/packages/mcp-server/src/server/store/inmemory/in-memory-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/inmemory/in-memory-document-index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from 'vitest'
+import { describeDocumentIndexConformance } from '../document-index-conformance.js'
+import { InMemoryDocumentIndex } from './in-memory-document-index.js'
+
+// The same suite the sqlite store answers to. Two implementations is what
+// makes it a conformance suite rather than one store's tests.
+describe('InMemoryDocumentIndex', () => {
+  describeDocumentIndexConformance(async () => ({
+    index: new InMemoryDocumentIndex(),
+    dispose: async () => {},
+  }))
+})

--- a/packages/mcp-server/src/server/store/inmemory/in-memory-document-index.ts
+++ b/packages/mcp-server/src/server/store/inmemory/in-memory-document-index.ts
@@ -1,0 +1,147 @@
+import type {
+  CreateDocumentInput,
+  CreateWorkspaceInput,
+  DeleteDocumentInput,
+  DocumentEntry,
+  DocumentIndex,
+  ListDocumentsInput,
+  MoveDocumentInput,
+  ResolveDocumentByIdInput,
+  ResolveDocumentInput,
+} from '@kamiazya/whiteboard-canvas-ports'
+import {
+  compareDocumentPaths,
+  DocumentHasDescendantsError,
+  DocumentMoveIntoSelfError,
+  DocumentNotFoundError,
+  DocumentPathTakenError,
+  WorkspaceNotFoundError,
+} from '@kamiazya/whiteboard-canvas-ports'
+import { generateCanvasId } from '@kamiazya/whiteboard-server-core'
+
+/** Whether `path` is `ancestor` itself or sits below it. */
+function isSelfOrDescendant(path: string, ancestor: string): boolean {
+  return path === ancestor || path.startsWith(`${ancestor}/`)
+}
+
+/** How many segments a path has. */
+function depth(path: string): number {
+  return path.split('/').length
+}
+
+/**
+ * `DocumentIndex` with no persistence, for the DI module the tests compose
+ * against. It passes the same conformance suite as the sqlite implementation,
+ * which is the point: a double that satisfies the interface but not the
+ * guarantees would let a tool pass here and fail against the real store.
+ *
+ * Serialization comes free rather than from a lock — every operation below
+ * completes without awaiting, so no other caller can observe a half-applied
+ * one. That is an accident of the runtime, not a design to copy: a store that
+ * awaits mid-operation has to arrange it deliberately.
+ */
+export class InMemoryDocumentIndex implements DocumentIndex {
+  readonly #workspaces = new Set<string>()
+  /** Keyed by workspace, then by path — so a workspace's set is one lookup. */
+  readonly #documents = new Map<string, Map<string, DocumentEntry>>()
+
+  #inWorkspace(workspaceId: string): Map<string, DocumentEntry> {
+    let documents = this.#documents.get(workspaceId)
+    if (!documents) {
+      documents = new Map()
+      this.#documents.set(workspaceId, documents)
+    }
+    return documents
+  }
+
+  async createWorkspace({ workspaceId }: CreateWorkspaceInput): Promise<void> {
+    this.#workspaces.add(workspaceId)
+  }
+
+  async createDocument({
+    workspaceId,
+    path,
+    kind,
+    name,
+  }: CreateDocumentInput): Promise<DocumentEntry> {
+    if (!this.#workspaces.has(workspaceId)) {
+      throw new WorkspaceNotFoundError(workspaceId)
+    }
+    const documents = this.#inWorkspace(workspaceId)
+    if (documents.has(path)) {
+      throw new DocumentPathTakenError(workspaceId, path)
+    }
+    const entry: DocumentEntry = {
+      canvasId: generateCanvasId(),
+      path,
+      kind,
+      ...(name === undefined ? {} : { name }),
+    }
+    documents.set(path, entry)
+    return entry
+  }
+
+  async resolveDocument({
+    workspaceId,
+    path,
+  }: ResolveDocumentInput): Promise<DocumentEntry | null> {
+    return this.#inWorkspace(workspaceId).get(path) ?? null
+  }
+
+  async resolveDocumentById({
+    workspaceId,
+    canvasId,
+  }: ResolveDocumentByIdInput): Promise<DocumentEntry | null> {
+    for (const entry of this.#inWorkspace(workspaceId).values()) {
+      if (entry.canvasId === canvasId) return entry
+    }
+    return null
+  }
+
+  async listDocuments({ workspaceId }: ListDocumentsInput): Promise<DocumentEntry[]> {
+    return [...this.#inWorkspace(workspaceId).values()].sort((left, right) =>
+      compareDocumentPaths(left.path, right.path),
+    )
+  }
+
+  async moveDocument({ workspaceId, from, to }: MoveDocumentInput): Promise<void> {
+    if (isSelfOrDescendant(to, from)) {
+      throw new DocumentMoveIntoSelfError(from, to)
+    }
+    const documents = this.#inWorkspace(workspaceId)
+    const moving = [...documents.values()].filter((entry) => isSelfOrDescendant(entry.path, from))
+    if (moving.length === 0) {
+      throw new DocumentNotFoundError(workspaceId, from)
+    }
+    const vacating = new Set(moving.map((entry) => entry.path))
+    const rewritten = moving.map((entry) => ({
+      entry,
+      path: `${to}${entry.path.slice(from.length)}`,
+    }))
+    for (const { path } of rewritten) {
+      if (documents.has(path) && !vacating.has(path)) {
+        throw new DocumentPathTakenError(workspaceId, path)
+      }
+    }
+    // Shallowest source first, for the same reason the sqlite store sorts:
+    // moving up into one's own ancestor namespace sends a deeper row onto a
+    // path a shallower one is still vacating.
+    rewritten.sort((left, right) => depth(left.entry.path) - depth(right.entry.path))
+    for (const { entry, path } of rewritten) {
+      documents.delete(entry.path)
+      documents.set(path, { ...entry, path })
+    }
+  }
+
+  async deleteDocument({ workspaceId, path }: DeleteDocumentInput): Promise<void> {
+    const documents = this.#inWorkspace(workspaceId)
+    const descendant = [...documents.keys()].find((candidate) => candidate.startsWith(`${path}/`))
+    if (descendant !== undefined) {
+      throw new DocumentHasDescendantsError(
+        path,
+        `Delete "${descendant}" and any others below it first.`,
+      )
+    }
+    documents.delete(path)
+  }
+}

--- a/packages/mcp-server/src/server/store/inmemory/index.ts
+++ b/packages/mcp-server/src/server/store/inmemory/index.ts
@@ -1,2 +1,3 @@
 export { InMemoryBlobStore } from './in-memory-blob-store.js'
 export { InMemoryCanvasDocStore } from './in-memory-canvas-doc-store.js'
+export { InMemoryDocumentIndex } from './in-memory-document-index.js'

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -22,6 +22,25 @@ import type { Database } from './db/index.js'
 import { upsertWorkspaceRow } from './db/upsert-workspace.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
+/**
+ * A row becomes an entry. `displayName` is null for a document with no name
+ * of its own, and the port says absent rather than null, so the key is left
+ * off entirely instead of carrying a null a reader would have to re-check.
+ */
+function toEntry(row: {
+  id: string
+  slug: string
+  kind: string | null
+  displayName: string | null
+}): DocumentEntry {
+  return {
+    canvasId: row.id,
+    path: row.slug,
+    kind: row.kind as DocumentEntry['kind'],
+    ...(row.displayName === null ? {} : { name: row.displayName }),
+  }
+}
+
 /** How many segments a path has. */
 function depth(path: string): number {
   return path.split('/').length
@@ -53,7 +72,12 @@ export class SqliteDocumentIndex implements DocumentIndex {
     })
   }
 
-  async createDocument({ workspaceId, path, kind }: CreateDocumentInput): Promise<DocumentEntry> {
+  async createDocument({
+    workspaceId,
+    path,
+    kind,
+    name,
+  }: CreateDocumentInput): Promise<DocumentEntry> {
     return withWorkspaceWriteLock(workspaceId, async () => {
       const workspace = await this.db
         .selectFrom('workspaces')
@@ -73,7 +97,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
           id: canvasId,
           workspaceId,
           slug: path,
-          displayName: null,
+          displayName: name ?? null,
           isPinned: 0,
           pinOrder: null,
           currentBranch: 'main',
@@ -87,7 +111,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
       if ((inserted.numInsertedOrUpdatedRows ?? 0n) === 0n) {
         throw new DocumentPathTakenError(workspaceId, path)
       }
-      return { canvasId, path, kind }
+      return { canvasId, path, kind, ...(name === undefined ? {} : { name }) }
     })
   }
 
@@ -97,12 +121,12 @@ export class SqliteDocumentIndex implements DocumentIndex {
   }: ResolveDocumentInput): Promise<DocumentEntry | null> {
     const row = await this.db
       .selectFrom('canvases')
-      .select(['id', 'slug', 'kind'])
+      .select(['id', 'slug', 'kind', 'displayName'])
       .where('workspaceId', '=', workspaceId)
       .where('slug', '=', path)
       .executeTakeFirst()
     if (!row?.kind) return null
-    return { canvasId: row.id, path: row.slug, kind: row.kind }
+    return toEntry(row)
   }
 
   async resolveDocumentById({
@@ -111,25 +135,25 @@ export class SqliteDocumentIndex implements DocumentIndex {
   }: ResolveDocumentByIdInput): Promise<DocumentEntry | null> {
     const row = await this.db
       .selectFrom('canvases')
-      .select(['id', 'slug', 'kind'])
+      .select(['id', 'slug', 'kind', 'displayName'])
       .where('workspaceId', '=', workspaceId)
       .where('id', '=', canvasId)
       .executeTakeFirst()
     if (!row?.kind) return null
-    return { canvasId: row.id, path: row.slug, kind: row.kind }
+    return toEntry(row)
   }
 
   async listDocuments({ workspaceId }: ListDocumentsInput): Promise<DocumentEntry[]> {
     const rows = await this.db
       .selectFrom('canvases')
-      .select(['id', 'slug', 'kind'])
+      .select(['id', 'slug', 'kind', 'displayName'])
       .where('workspaceId', '=', workspaceId)
       .execute()
     // Sorted here rather than in SQL: segment-wise order is not what any
     // collation gives, and the row count per workspace is a list a human reads.
     return rows
       .filter((row) => row.kind !== null)
-      .map((row) => ({ canvasId: row.id, path: row.slug, kind: row.kind as DocumentEntry['kind'] }))
+      .map(toEntry)
       .sort((left, right) => compareDocumentPaths(left.path, right.path))
   }
 

--- a/packages/server-core/src/canvas-routes.test.ts
+++ b/packages/server-core/src/canvas-routes.test.ts
@@ -3,6 +3,7 @@ import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import { createServer } from './create-server.js'
 import { createInMemoryCanvasDocStore } from './test-utils/in-memory-canvas-doc-store.js'
+import { unusedDocumentIndex } from './test-utils/unused-document-index.js'
 import { createCanvasOutputSchema, listCanvasesOutputSchema } from './tools/canvas-crud.schemas.js'
 import { saveWorkspaceTree } from './tools/workspace-tree-io.js'
 
@@ -10,6 +11,7 @@ function makeServer() {
   return createServer({
     canvasDocStore: createInMemoryCanvasDocStore(),
     blobStore: {} as never,
+    documentIndex: unusedDocumentIndex(),
   })
 }
 
@@ -161,7 +163,11 @@ describe('canvas OKF read route', () => {
     // worth guarding: a node whose document was deleted, or written by an
     // older build that created nodes lazily, lands here.
     const store = createInMemoryCanvasDocStore()
-    const { app } = createServer({ canvasDocStore: store, blobStore: {} as never })
+    const { app } = createServer({
+      canvasDocStore: store,
+      blobStore: {} as never,
+      documentIndex: unusedDocumentIndex(),
+    })
     const tree = new WorkspaceTree(new LoroDoc())
     const canvasId = '01ARZ3NDEKTSV4RRFFQ69G5FAA'
     tree.createNode(canvasId, 'orphan')

--- a/packages/server-core/src/create-server.test.ts
+++ b/packages/server-core/src/create-server.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { createServer } from './create-server.js'
+import { unusedDocumentIndex } from './test-utils/unused-document-index.js'
 
 describe('createServer', () => {
   it('returns an app', () => {
     const { app } = createServer({
       canvasDocStore: {} as never,
       blobStore: {} as never,
+      documentIndex: unusedDocumentIndex(),
     })
     expect(app).toBeDefined()
     expect(app.fetch).toBeTypeOf('function')
@@ -15,6 +17,7 @@ describe('createServer', () => {
     const { tools } = createServer({
       canvasDocStore: {} as never,
       blobStore: {} as never,
+      documentIndex: unusedDocumentIndex(),
     })
     expect(tools.facetSet.name).toBe('wb_facet_set')
     expect(tools.facetSet.execute).toBeTypeOf('function')
@@ -24,6 +27,7 @@ describe('createServer', () => {
     const { tools } = createServer({
       canvasDocStore: {} as never,
       blobStore: {} as never,
+      documentIndex: unusedDocumentIndex(),
     })
 
     const expectations = [

--- a/packages/server-core/src/render/load-spatial-canvas.test.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.test.ts
@@ -2,6 +2,7 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { CanvasNotFoundError, loadSpatialCanvas } from './load-spatial-canvas.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -9,7 +10,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 describe('loadSpatialCanvas', () => {
   test('throws CanvasNotFoundError when no snapshot exists', async () => {
     const canvasDocStore = new FakeCanvasDocStore()
-    const deps = { canvasDocStore, blobStore: {} as never }
+    const deps = { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 
     await expect(loadSpatialCanvas(deps, CANVAS_ID)).rejects.toThrow(CanvasNotFoundError)
   })
@@ -23,7 +24,7 @@ describe('loadSpatialCanvas', () => {
       })
     })
 
-    const deps = { canvasDocStore, blobStore: {} as never }
+    const deps = { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
     const { doc, canvas } = await loadSpatialCanvas(deps, CANVAS_ID)
 
     expect(doc).toBeInstanceOf(LoroDoc)

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -1,6 +1,13 @@
-import type { BlobStore, CanvasDocStore } from '@kamiazya/whiteboard-canvas-ports'
+import type { BlobStore, CanvasDocStore, DocumentIndex } from '@kamiazya/whiteboard-canvas-ports'
 
 export interface ServerDeps {
   canvasDocStore: CanvasDocStore
   blobStore: BlobStore
+  /**
+   * Where a document's placement lives. Separate from `canvasDocStore`, which
+   * owns one document's bytes and knows nothing about where it sits — and the
+   * reason an agent-created document is one the user's canvas list can show:
+   * both surfaces now write the same index.
+   */
+  documentIndex: DocumentIndex
 }

--- a/packages/server-core/src/test-utils/unused-document-index.ts
+++ b/packages/server-core/src/test-utils/unused-document-index.ts
@@ -1,0 +1,29 @@
+import type { DocumentIndex } from '@kamiazya/whiteboard-canvas-ports'
+
+/**
+ * A `DocumentIndex` for tests whose subject is elsewhere. Every method
+ * throws, so a test that starts depending on placement fails loudly here
+ * instead of passing against a double that quietly answers.
+ *
+ * Deliberately not a working in-memory store: two of those already exist
+ * (the sqlite one and the DI module's), both held to the conformance suite,
+ * and a third that nothing checks is exactly how two implementations of one
+ * rule start to disagree.
+ */
+export function unusedDocumentIndex(): DocumentIndex {
+  const refuse = (operation: string) => () => {
+    throw new Error(
+      `${operation}: this test composed a DocumentIndex it does not exercise. ` +
+        'Compose a real one if the behaviour under test now depends on placement.',
+    )
+  }
+  return {
+    createWorkspace: refuse('createWorkspace'),
+    createDocument: refuse('createDocument'),
+    resolveDocument: refuse('resolveDocument'),
+    resolveDocumentById: refuse('resolveDocumentById'),
+    listDocuments: refuse('listDocuments'),
+    moveDocument: refuse('moveDocument'),
+    deleteDocument: refuse('deleteDocument'),
+  }
+}

--- a/packages/server-core/src/tools/body-patch.test.ts
+++ b/packages/server-core/src/tools/body-patch.test.ts
@@ -7,6 +7,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createBodyPatchTool } from './body-patch.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
 import { NodeNotFoundError, NotATextNodeError, PatchValidationError } from './errors.js'
@@ -31,7 +32,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('wb_body_patch tool', () => {

--- a/packages/server-core/src/tools/canvas-crud.test.ts
+++ b/packages/server-core/src/tools/canvas-crud.test.ts
@@ -4,6 +4,7 @@ import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import type { ServerDeps } from '../server-deps.js'
 import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import {
   CanvasNotFoundError,
   CanvasParentNotFoundError,
@@ -17,6 +18,7 @@ function makeDeps(): ServerDeps {
   return {
     canvasDocStore: createInMemoryCanvasDocStore(),
     blobStore: {} as never,
+    documentIndex: unusedDocumentIndex(),
   }
 }
 

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -3,13 +3,14 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createCanvasDigestTool } from './canvas-digest.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('wb_scene_digest tool', () => {

--- a/packages/server-core/src/tools/canvas-doc-io.test.ts
+++ b/packages/server-core/src/tools/canvas-doc-io.test.ts
@@ -1,6 +1,7 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, test } from 'vitest'
 import { FakeCanvasDocStore } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { loadCanvasDoc, saveCanvasDoc } from './canvas-doc-io.js'
 import { CanvasDocNotFoundError } from './errors.js'
 
@@ -9,6 +10,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const canvasDeps = (canvasDocStore: FakeCanvasDocStore) => ({
   canvasDocStore,
   blobStore: {} as never,
+  documentIndex: unusedDocumentIndex(),
 })
 
 describe('canvas-doc-io', () => {

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -2,13 +2,14 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createCanvasRenderSvgTool } from './canvas-render-svg.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('wb_scene_render tool', () => {

--- a/packages/server-core/src/tools/document-get.test.ts
+++ b/packages/server-core/src/tools/document-get.test.ts
@@ -2,12 +2,17 @@ import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import type { ServerDeps } from '../server-deps.js'
 import { createInMemoryCanvasDocStore } from '../test-utils/in-memory-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { wbCanvasCreate } from './canvas-crud.js'
 import { saveDocSnapshot } from './canvas-doc-io.js'
 import { createDocumentGetTool, DocumentKindUnknownError } from './document-get.js'
 
 function makeDeps(): ServerDeps {
-  return { canvasDocStore: createInMemoryCanvasDocStore(), blobStore: {} as never }
+  return {
+    canvasDocStore: createInMemoryCanvasDocStore(),
+    blobStore: {} as never,
+    documentIndex: unusedDocumentIndex(),
+  }
 }
 
 async function createDoc(deps: ServerDeps, kind: 'spatial' | 'markdown') {

--- a/packages/server-core/src/tools/document-set.test.ts
+++ b/packages/server-core/src/tools/document-set.test.ts
@@ -14,6 +14,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createDocumentSetTool } from './document-set.js'
 import { DocumentContentLossError, DocumentKindMismatchError } from './errors.js'
 import { exportOkf } from './export-okf.js'
@@ -23,7 +24,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {

--- a/packages/server-core/src/tools/edge-add.test.ts
+++ b/packages/server-core/src/tools/edge-add.test.ts
@@ -5,6 +5,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
 import { createEdgeAddTool, EdgeAlreadyExistsError } from './edge-add.js'
 import { DocumentKindMismatchError, PatchValidationError } from './errors.js'
@@ -13,7 +14,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 function node(id: string) {

--- a/packages/server-core/src/tools/edge-lock.test.ts
+++ b/packages/server-core/src/tools/edge-lock.test.ts
@@ -7,6 +7,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createEdgeLockTool } from './edge-lock.js'
 import { EdgeNotFoundError } from './errors.js'
 
@@ -38,7 +39,7 @@ async function seedCanvas(canvasDocStore: FakeCanvasDocStore): Promise<void> {
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 async function loadLocks(canvasDocStore: FakeCanvasDocStore): Promise<ReadonlySet<string>> {

--- a/packages/server-core/src/tools/edge-patch.test.ts
+++ b/packages/server-core/src/tools/edge-patch.test.ts
@@ -7,6 +7,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
 import { createEdgeLockTool } from './edge-lock.js'
@@ -33,7 +34,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 const BASE_CANVAS: SpatialCanvas = {

--- a/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.property.test.ts
@@ -9,6 +9,7 @@ import {
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createDocumentSetTool } from './document-set.js'
 import { exportOkf } from './export-okf.js'
 
@@ -76,7 +77,11 @@ const okfDocumentArbitrary = fc
 async function setupTools() {
   const store = new FakeCanvasDocStore()
   await registerCanvasInWorkspace(store, WORKSPACE_ID, CANVAS_ID)
-  const deps = { canvasDocStore: store, blobStore: {} as never }
+  const deps = {
+    canvasDocStore: store,
+    blobStore: {} as never,
+    documentIndex: unusedDocumentIndex(),
+  }
   return {
     deps,
     documentSet: createDocumentSetTool(deps),

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -8,6 +8,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { createDocumentSetTool, OkfParseError } from './document-set.js'
 import { exportJsonCanvas } from './export-json-canvas.js'
 import { exportOkf } from './export-okf.js'
@@ -16,7 +17,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {

--- a/packages/server-core/src/tools/export-json-canvas.test.ts
+++ b/packages/server-core/src/tools/export-json-canvas.test.ts
@@ -2,6 +2,7 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { exportJsonCanvas } from './export-json-canvas.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -22,7 +23,7 @@ const NODE_WITH_EXTENSION = {
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('exportJsonCanvas', () => {

--- a/packages/server-core/src/tools/export-okf.test.ts
+++ b/packages/server-core/src/tools/export-okf.test.ts
@@ -2,13 +2,14 @@ import { writeFacets, writeSpatialCanvas } from '@kamiazya/whiteboard-canvas-wor
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeCanvasDocStore, seedDoc } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { exportOkf } from './export-okf.js'
 
 const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('exportOkf', () => {

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -11,6 +11,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
 import { DocumentKindMismatchError } from './errors.js'
 import { createFacetSetTool, facetSetInputSchema } from './facet-set.js'
@@ -19,7 +20,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('wb_facet_set tool', () => {

--- a/packages/server-core/src/tools/node-add.test.ts
+++ b/packages/server-core/src/tools/node-add.test.ts
@@ -9,6 +9,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
 import { DocumentKindMismatchError } from './errors.js'
 import { createNodeAddTool, NodeAlreadyExistsError } from './node-add.js'
@@ -17,7 +18,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 const RECT = {

--- a/packages/server-core/src/tools/node-lock.test.ts
+++ b/packages/server-core/src/tools/node-lock.test.ts
@@ -7,6 +7,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { NodeNotFoundError } from './errors.js'
 import { createNodeLockTool } from './node-lock.js'
 
@@ -35,7 +36,7 @@ async function seedCanvas(canvasDocStore: FakeCanvasDocStore): Promise<void> {
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 async function loadLocks(canvasDocStore: FakeCanvasDocStore): Promise<ReadonlySet<string>> {

--- a/packages/server-core/src/tools/node-patch.test.ts
+++ b/packages/server-core/src/tools/node-patch.test.ts
@@ -7,6 +7,7 @@ import {
   FakeCanvasDocStore,
   registerCanvasInWorkspace,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
 import { CanvasDocNotFoundError, NodeLockedError, NodeNotFoundError } from './errors.js'
@@ -33,7 +34,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 describe('wb_node_patch tool', () => {

--- a/packages/server-core/src/tools/tidy-canvas.test.ts
+++ b/packages/server-core/src/tools/tidy-canvas.test.ts
@@ -12,6 +12,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { loadCanvasDoc } from './canvas-doc-io.js'
 import { DocumentKindMismatchError } from './errors.js'
 import { createTidyCanvasTool } from './tidy-canvas.js'
@@ -38,7 +39,7 @@ async function seedCanvas(
 }
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 const box = (id: string, x: number, y: number) => ({
@@ -171,7 +172,11 @@ describe('wb_canvas_tidy on a markdown document', () => {
         edges: [],
       })
     })
-    const deps = { canvasDocStore: store, blobStore: {} as never }
+    const deps = {
+      canvasDocStore: store,
+      blobStore: {} as never,
+      documentIndex: unusedDocumentIndex(),
+    }
 
     await expect(
       createTidyCanvasTool(deps).execute({ workspaceId: WORKSPACE_ID, canvasId: CANVAS_ID }),

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -7,6 +7,7 @@ import {
   registerCanvasInWorkspace,
   seedDoc,
 } from '../test-utils/fake-canvas-doc-store.js'
+import { unusedDocumentIndex } from '../test-utils/unused-document-index.js'
 import { CanvasNotFoundError } from './canvas-crud.errors.js'
 import { createVersionListTool } from './version-list.js'
 import { createVersionRestoreTool, VersionNotFoundError } from './version-restore.js'
@@ -16,7 +17,7 @@ const CANVAS_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
 
 function makeDeps(canvasDocStore: FakeCanvasDocStore) {
-  return { canvasDocStore, blobStore: {} as never }
+  return { canvasDocStore, blobStore: {} as never, documentIndex: unusedDocumentIndex() }
 }
 
 async function loadDoc(store: FakeCanvasDocStore, canvasId: string): Promise<LoroDoc> {


### PR DESCRIPTION
The wiring between the port and the tools that will use it. Nothing calls the index yet — this is what makes calling it possible, split out so the rewiring PR is a behaviour change and not also a wiring change.

## What lands

**A document gets a name.** `DocumentEntry` carries `name` — what a human reads, as against `path`, which is an address. Absent rather than null when there is none, so a listing does not invent a title out of the slug. It maps to the `displayName` column that already holds it.

This one was found by reading the tool surface rather than by design: `canvasDetail` returns `name`, `#768` had just added it to create, and the index could not have supplied it. The name currently lives in the **tree node's `displayName`** — a fourth home for a document's name, alongside the column, and OKF frontmatter's `title` which ADR-0009 already calls a projection. Converging on the column is part of the point.

**`ServerDeps` gains `documentIndex`**, and both DI modules bind an implementation: `SqliteDocumentIndex` for the local store, and a new `InMemoryDocumentIndex` for the module tests compose against.

**The in-memory implementation answers the same conformance suite** — all 17 cases, unchanged. That is what makes it a conformance suite rather than one store's tests: a double that satisfies the interface but not the guarantees would let a tool pass in tests and fail against the real store. It also validates the suite's own shape, since it was written as a factory for exactly this second caller.

## The test double that refuses

Twenty-one `server-core` test files compose `ServerDeps` and none of them touch placement. They get a `DocumentIndex` whose every method **throws**, not a third working store.

A quiet double would let a test pass here and fail against either real implementation. And a third implementation of one rule, held to nothing, is precisely how two implementations start to disagree — which is the defect this whole line of work exists to remove. When a `server-core` test genuinely needs placement, it should compose a real index and be held to the same suite.

## Verification

`mcp-node` + `canvas-ports-node` + `server-core-node` + `arch-lint-node`: 326 files / 3802 tests pass. `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean.

New name guarantees are mutation-checked: surfacing an absent name as `null` instead of omitting the key, and accepting `name` without storing it, each fail the case that pins them.

## Reach

`userReach`: **`foundation:`** — still nothing calls the index. The next PR rewires `canvas-crud`'s four handlers and `assertCanvasInWorkspace` onto it, which is the increment where an agent-created document starts appearing in the user's canvas list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhvRoF23tM99JwDwVJ4YHw
