### PR TITLE
fix(web): authenticate paired-session WebSockets with the pairing token

### DIFF
--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -53,10 +53,11 @@ export interface DaemonCanvasPageProps {
   daemonBaseUrl: string
   workspaceId?: string
   slug?: string
-  // The bootstrap token seeded by useDaemonConnection into
-  // window.__WHITEBOARD_DAEMON_TOKEN__. DaemonBackend's WS auth reads that
-  // global directly (readDaemonTokenOnce); this prop is only for the HTTP
-  // side (createDaemonFetch's Authorization header).
+  // The daemon credential for this session: a bootstrap token (#wb= flow)
+  // or a pairing session token (pairing-grant flow). Feeds both the HTTP
+  // side (createDaemonFetch's Authorization header) and the WS upgrade
+  // (DaemonBackend's wsToken); when the #wb= flow also seeded
+  // window.__WHITEBOARD_DAEMON_TOKEN__, that global wins for the WS.
   token?: string
   capabilities?: WhiteboardCapabilities
   // Rendered as a "Continue in browser-local" escape next to the auth-error
@@ -117,7 +118,14 @@ export function DaemonCanvasPage({
         daemonBaseUrl,
       })
       if (transport !== 'sse') {
-        return new DaemonBackend(workspaceId, slug, daemonBaseUrl, { fetch: daemonFetch })
+        // wsToken carries the pairing session token into the WS upgrade —
+        // without it a pairing-grant session authenticates HTTP but opens
+        // the socket credential-less and is rejected 401 (edits then stay
+        // browser-only while the page looks connected).
+        return new DaemonBackend(workspaceId, slug, daemonBaseUrl, {
+          fetch: daemonFetch,
+          wsToken: () => token,
+        })
       }
       // Null where SharedWorker is unavailable; SseBackend then opens its own
       // stream, which is correct but not shared across tabs.

--- a/apps/web/src/pages/DaemonCanvasPage.ws-token.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.ws-token.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Pins the page-level half of the paired-session WS credential fix: the
+ * default (non-injected) backend wiring must hand the page's pairing token
+ * to DaemonBackend as `wsToken`. Without it, a pairing-grant session
+ * authenticates every HTTP call but opens the WebSocket credential-less and
+ * is rejected 401 — edits then silently stay browser-only while the page
+ * looks connected. The backend-side half (which subprotocol the token is
+ * offered on, bootstrap-global precedence) is pinned in
+ * packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts.
+ */
+import { act, cleanup, render as rtlRender, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+import { DaemonCanvasPage } from './DaemonCanvasPage.js'
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listCanvases: vi.fn(),
+  }
+})
+
+// Captures constructor options without opening a real socket.
+const constructed: { workspaceId: string; slug: string; wsToken: string | undefined }[] = []
+vi.mock('@kamiazya/whiteboard-mcp/daemon-backend', () => ({
+  DaemonBackend: class {
+    constructor(
+      workspaceId: string,
+      slug: string,
+      _locationHref: string,
+      apiTransport?: { wsToken?: () => string | undefined },
+    ) {
+      constructed.push({ workspaceId, slug, wsToken: apiTransport?.wsToken?.() })
+    }
+    connect(): void {}
+    disconnect(): void {}
+    pushLocalUpdate(): void {}
+    getFile(): Promise<Blob | null> {
+      return Promise.resolve(null)
+    }
+    putFile(): Promise<void> {
+      return Promise.resolve()
+    }
+    sendClientReady(): void {}
+    sendExportResponse(): void {}
+  },
+}))
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
+
+function MemoryRouterWrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={['/']}>{children}</MemoryRouter>
+}
+
+describe('DaemonCanvasPage default backend wiring', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    constructed.length = 0
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'main', id: 'id-main', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('hands the pairing token to DaemonBackend as the WS credential', async () => {
+    await act(async () => {
+      rtlRender(
+        <DaemonCanvasPage daemonBaseUrl="http://127.0.0.1:3099" token="pairing-session-token" />,
+        { wrapper: MemoryRouterWrapper, container: document.body },
+      )
+    })
+    await waitFor(() => expect(constructed.length).toBeGreaterThan(0))
+    expect(constructed[0]).toMatchObject({
+      workspaceId: 'w1',
+      slug: 'main',
+      wsToken: 'pairing-session-token',
+    })
+  })
+})

--- a/packages/mcp-server/src/shared/daemon-backend.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ts
@@ -42,11 +42,21 @@ import { parseServerTextMessage } from './ws-text-message.js'
  * apiFetch only resolves relative /api/... paths against the current page
  * origin, so a daemon paired from a different origin (apps/web talking to a
  * loopback daemon) needs its own fetch that targets the daemon's origin.
- * WS auth stays on readDaemonTokenOnce() regardless — it is subprotocol-based,
- * not header-based, so it is unaffected by this override.
  */
 export interface DaemonApiTransport {
   fetch: typeof globalThis.fetch
+  /**
+   * WS upgrade credential for a paired session. The server accepts an
+   * origin-scoped pairing session token through the same `daemon-token.`
+   * subprotocol as the shared daemon token (ws-auth.ts validates it against
+   * the upgrade's Origin), but that token lives in page memory — never in
+   * the `#wb=` bootstrap global readDaemonTokenOnce() reads. Without this,
+   * a pairing-grant session offers no credential at all and every upgrade
+   * is rejected 401 while the HTTP side keeps working. A function so a
+   * rotated session token is re-read on every reconnect attempt; the
+   * bootstrap global, when seeded, still wins.
+   */
+  wsToken?: () => string | undefined
 }
 
 // Browsers surface a WS handshake rejection (e.g. HTTP 401 on the upgrade
@@ -159,7 +169,7 @@ export class DaemonBackend implements CanvasBackend {
   private openSocket(handlers: CanvasBackendHandlers): void {
     if (this.cancelled) return
 
-    const daemonToken = readDaemonTokenOnce()
+    const daemonToken = readDaemonTokenOnce() ?? this.apiTransport?.wsToken?.() ?? null
 
     const ws = new WebSocket(
       buildWhiteboardWsUrl(this.locationHref, this.workspaceId, this.slug),

--- a/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+//
+// WS credential selection for a paired session. The server accepts an
+// origin-scoped pairing session token through the same `daemon-token.`
+// subprotocol carrier as the shared daemon token (ws-auth.ts), but the
+// client used to offer ONLY the bootstrap global (`#wb=` flow) — a
+// pairing-grant session therefore opened the socket with no credential at
+// all and was rejected 401, silently losing every edit. These tests pin
+// that the transport's wsToken reaches the upgrade offer.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resetTokenStoreForTests } from './token-store.js'
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  binaryType = 'blob'
+  onopen: (() => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: (() => void) | null = null
+  readonly url: string
+  readonly protocols: string | string[] | undefined
+
+  constructor(url: string | URL, protocols?: string | string[]) {
+    this.url = String(url)
+    this.protocols = protocols
+    FakeWebSocket.instances.push(this)
+  }
+
+  close(): void {
+    /* no-op */
+  }
+}
+
+const HANDLERS = {
+  onSnapshot: () => {},
+  onRemoteUpdate: () => {},
+  onVersionCreated: () => {},
+  onRestoreStarted: () => {},
+  onRestoreComplete: () => {},
+  onHeadChanged: () => {},
+  onViewportRequest: () => {},
+  onExportRequest: () => {},
+  onConnected: () => {},
+}
+
+describe('DaemonBackend WS credential selection', () => {
+  let originalWindow: unknown
+  let originalWebSocket: unknown
+
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    resetTokenStoreForTests()
+    originalWindow = (globalThis as Record<string, unknown>).window
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
+    ;(globalThis as Record<string, unknown>).window = {
+      location: { origin: 'http://localhost' },
+    }
+    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
+  })
+
+  afterEach(() => {
+    ;(globalThis as Record<string, unknown>).window = originalWindow
+    ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
+    resetTokenStoreForTests()
+  })
+
+  it('offers the transport wsToken via the daemon-token subprotocol when no bootstrap global is seeded', async () => {
+    const { DaemonBackend } = await import('./daemon-backend.js')
+    const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
+      fetch: globalThis.fetch,
+      wsToken: () => 'pairing-session-token',
+    })
+    backend.connect(HANDLERS)
+    expect(FakeWebSocket.instances[0]?.protocols).toEqual([
+      'excalidraw-v1',
+      'daemon-token.pairing-session-token',
+    ])
+  })
+
+  it('prefers the bootstrap global over the transport wsToken when both exist', async () => {
+    ;(globalThis as { window?: Record<string, unknown> }).window = {
+      location: { origin: 'http://localhost' },
+      __WHITEBOARD_DAEMON_TOKEN__: 'bootstrap-token',
+    }
+    const { DaemonBackend } = await import('./daemon-backend.js')
+    const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
+      fetch: globalThis.fetch,
+      wsToken: () => 'pairing-session-token',
+    })
+    backend.connect(HANDLERS)
+    expect(FakeWebSocket.instances[0]?.protocols).toEqual([
+      'excalidraw-v1',
+      'daemon-token.bootstrap-token',
+    ])
+  })
+
+  it('re-reads a rotated wsToken on every socket attempt', async () => {
+    const { DaemonBackend } = await import('./daemon-backend.js')
+    let current = 'first-token'
+    const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
+      fetch: globalThis.fetch,
+      wsToken: () => current,
+    })
+    backend.connect(HANDLERS)
+    current = 'rotated-token'
+    backend.disconnect()
+    backend.connect(HANDLERS)
+    expect(FakeWebSocket.instances[1]?.protocols).toEqual([
+      'excalidraw-v1',
+      'daemon-token.rotated-token',
+    ])
+  })
+
+  it('keeps the credential-less offer when neither source provides a token', async () => {
+    const { DaemonBackend } = await import('./daemon-backend.js')
+    const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
+      fetch: globalThis.fetch,
+    })
+    backend.connect(HANDLERS)
+    expect(FakeWebSocket.instances[0]?.protocols).toEqual(['excalidraw-v1'])
+  })
+})


### PR DESCRIPTION
## Summary

A pairing-grant browser session (the normal `/pair` → `#wb-grant` flow) could call every authenticated HTTP route but its WebSocket upgrade was rejected 401 — the chip showed "Sync off" / "The daemon rejected this session", and **edits were silently not persisted** while the page otherwise looked connected. Re-pairing didn't help.

Root cause: `DaemonBackend` authenticated the WS solely from `window.__WHITEBOARD_DAEMON_TOKEN__` (seeded only by the `#wb=` bootstrap flow), so a pairing-grant session offered no credential at all. The server has accepted an origin-scoped pairing session token through the same `daemon-token.` subprotocol all along (`ws-auth.ts` validates it against the upgrade's Origin) — only the client half was missing.

Fix:

- `DaemonApiTransport.wsToken?: () => string | undefined` — read on **every** socket attempt so a rotated session token survives reconnects. The bootstrap global, when seeded, still wins (dev/CLI-launched sessions unchanged).
- `DaemonCanvasPage` passes its session token as `wsToken` in the default backend wiring.

No ticket minting needed: `/api/ws-ticket` (ADR-0005) is for hosted-origin **OAuth grant** callers and stays untouched; the pairing-token subprotocol path is the one the server already implements for paired web sessions.

## Visual repro

Before (same environment): fresh paired page → chip "Sync off", console `WebSocket … failed: HTTP Authentication failed`, node added then reload → gone.

After: fresh page with `window.__WHITEBOARD_DAEMON_TOKEN__ === null` (pairing-token path, verified) → chip "Synced"; note added, reloaded, still present:

![paired-session-synced.png](https://github.com/user-attachments/assets/6ecbbf85-1f70-468b-9c48-9852eb3b7660)

## Test plan

- [x] `daemon-backend.ws-token.test.ts` (new, red-first): wsToken offered via `daemon-token.` subprotocol; bootstrap global precedence; rotated token re-read per attempt; credential-less offer unchanged when neither exists
- [x] `DaemonCanvasPage.ws-token.test.tsx` (new): default wiring hands the session token to DaemonBackend (mutation-checked — goes red with the wiring removed)
- [x] mcp-node suite green (3349 passed), web page suites green, typecheck / lint / knip clean
- [x] Manual verification against the dev daemon (pairing-grant session, no bootstrap global): Synced chip, edit persists across reload
