### PR TITLE
feat(web): give the shared worker's replica the daemon write

### DIFF
--- a/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
@@ -24,6 +24,7 @@ const BASE = 'http://127.0.0.1:3099'
 // separate one case's traffic from another's.
 let streamOpens = 0
 const openedStreamIds: string[] = []
+const daemonWrites: { doc: string; body: Uint8Array }[] = []
 const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
 const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
 let pushFrame: ((frame: string) => void) | null = null
@@ -50,6 +51,16 @@ const server = setupServer(
   }),
   http.post(`${BASE}/api/sync/subscribe`, async ({ request }) => {
     subscribeBodies.push((await request.json()) as (typeof subscribeBodies)[number])
+    return HttpResponse.json({ ok: true })
+  }),
+  // The canvas update route: where a push lands, after the worker's replica
+  // has merged it. Addressed by workspace and slug, which the worker
+  // reconstructs from the document key it routes everything else by.
+  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+    daemonWrites.push({
+      doc: `${String(params.workspaceId)}/${String(params.slug)}`,
+      body: new Uint8Array(await request.arrayBuffer()),
+    })
     return HttpResponse.json({ ok: true })
   }),
   http.post(`${BASE}/api/sync/message`, async ({ request }) => {
@@ -83,6 +94,7 @@ function createHarness(): SseStreamSourceHarness {
     unsubscribedDocs: () => subscribeBodies.flatMap((b) => b.unsubscribe ?? []),
     controlMessages: () => controlMessages,
     openedStreamIds: () => openedStreamIds,
+    daemonWrites: () => daemonWrites,
     ready: async () => {
       await vi.waitFor(() => {
         if (pushFrame === null) throw new Error('stream not open')

--- a/apps/web/src/lib/sse-shared-stream-source.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.ts
@@ -7,7 +7,7 @@
  * stream — correct, just without the cross-tab sharing.
  */
 import type { DocListener, SseStreamSource } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
-import { fromBase64 } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
+import { fromBase64, toBase64 } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
 import { sseWorkerEventSchema } from './sse-shared-worker-protocol.js'
 
 const sources = new Map<string, { source: SseStreamSource; port: MessagePort }>()
@@ -69,7 +69,13 @@ export function createSharedSseStreamSource(
     const evt = parsed.data
     const set = listeners.get(evt.doc)
     if (!set) return
-    if (evt.type === 'update') {
+    // The two inbound channels, deliberately both delivered. `update` is a raw
+    // daemon frame; `authority-update` has been through the worker's replica,
+    // so it also carries what a SIBLING TAB did — which never reaches the
+    // daemon and back in time to be useful, and is the whole point of the
+    // replica. Loro merges are idempotent, so anything that arrives on both is
+    // absorbed rather than double-applied.
+    if (evt.type === 'update' || evt.type === 'authority-update') {
       const bytes = fromBase64(evt.update)
       for (const l of set) l.onUpdate(bytes)
       return
@@ -78,10 +84,10 @@ export function createSharedSseStreamSource(
       for (const l of set) l.onConnectionChange?.(evt.connected)
       return
     }
-    // The authority replica's own traffic. This source consumes the raw daemon
-    // frames above; the fork-based client that consumes these is a separate
-    // seam, and answering them here would deliver every update twice.
-    if (evt.type === 'snapshot' || evt.type === 'authority-update') return
+    // Answered only when something asked, which nothing here does yet: a tab
+    // still builds its document from the daemon's export flow rather than
+    // forking the replica.
+    if (evt.type === 'snapshot') return
     for (const l of set) l.onMessage(evt.raw)
   }
   port.start()
@@ -109,6 +115,14 @@ export function createSharedSseStreamSource(
     },
     sendMessage(doc, message) {
       port.postMessage({ type: 'control', doc, message })
+    },
+    push(doc, update) {
+      // To the worker's replica, not to the daemon. The replica merges this
+      // against everything it already has — the other tabs' work and the
+      // daemon's — and is what carries the result onward in both directions,
+      // so a tab posting to the daemon itself would be writing around the very
+      // thing meant to order these writes.
+      port.postMessage({ type: 'push', doc, update: toBase64(update) })
     },
   }
 

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -35,6 +35,12 @@ let streamSeq = 0
 let subscribeBodies: string[] = []
 let subscribeAuth: (string | null)[] = []
 let messageBodies: string[] = []
+let updateWrites: {
+  workspaceId: string
+  slug: string
+  auth: string | null
+  body: Uint8Array
+}[] = []
 /**
  * Keyed by stream id, NOT a single "most recent" handle. Workers from earlier
  * tests cannot be terminated and keep opening streams of their own, so a lone
@@ -75,6 +81,19 @@ const server = setupServer(
     messageBodies.push(await request.text())
     return HttpResponse.json({ ok: true })
   }),
+  // The daemon's own update route, which the worker writes a tab's work to.
+  // Addressed by workspace and slug rather than by the document key the rest
+  // of the worker routes on — the key IS `${workspaceId}/${slug}`, which is
+  // what lets the worker reconstruct this URL at all.
+  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+    updateWrites.push({
+      workspaceId: String(params.workspaceId),
+      slug: String(params.slug),
+      auth: request.headers.get('Authorization'),
+      body: new Uint8Array(await request.arrayBuffer()),
+    })
+    return HttpResponse.json({ ok: true })
+  }),
 )
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
@@ -83,6 +102,7 @@ beforeEach(() => {
   subscribeBodies = []
   subscribeAuth = []
   messageBodies = []
+  updateWrites = []
   pushByStream.clear()
 })
 afterEach(() => server.resetHandlers())
@@ -387,6 +407,35 @@ describe('authority replica', () => {
     const forked = new LoroDoc()
     forked.import(decode(await authority))
     expect(forked.getMap('m').get('k')).toBe('from-daemon')
+
+    // The return leg, in the same case because the file has room for exactly
+    // one replica test (see above) and a one-way authority is not the claim
+    // worth making. A tab pushes to the worker and nowhere else; the worker is
+    // what reaches the daemon.
+    const tab = new LoroDoc()
+    tab.getMap('m').set('from-tab', 'written-through')
+    tab.commit()
+    port.postMessage({ type: 'push', doc, update: b64(tab.export({ mode: 'update' })) })
+
+    await until(() => updateWrites.length >= 1)
+    const write = updateWrites[0]
+    if (!write) throw new Error('no write')
+    // The document key is `${workspaceId}/${slug}`, so the worker addressing
+    // the route correctly is the whole reason it can own this write at all.
+    expect(`${write.workspaceId}/${write.slug}`).toBe(doc)
+    // The credential travels with the write. `daemon-auth-seam.test.ts` scans
+    // the source to prove no OTHER place assembles this header; only an actual
+    // request proves the one place that should, does — and an unauthenticated
+    // write is silently dropped by the daemon, which looks exactly like a tab
+    // whose edits never persist.
+    expect(write.auth).toBe('Bearer t')
+    // What travels is the replica's delta, and it must carry the tab's work
+    // WITHOUT re-sending what the daemon just told us: a write that echoed the
+    // inbound frame back would loop.
+    const received = new LoroDoc()
+    received.import(write.body)
+    expect(received.getMap('m').get('from-tab')).toBe('written-through')
+    expect(received.getMap('m').get('k')).toBeUndefined()
     // Its own budget: this is the only case in the block that waits for a
     // stream to open, and the sibling describe's 5s default is not a wait,
     // it is a coin flip under a loaded suite.

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -10,7 +10,7 @@
  * This file must be a real same-origin module: the app's CSP declares
  * `worker-src 'self'`, which rejects a blob: worker.
  */
-import { fromBase64, SseStreamHub } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
+import { fromBase64, SseStreamHub, toBase64 } from '@kamiazya/whiteboard-mcp/sse-stream-hub'
 import { createDaemonFetch } from './daemon-auth-fetch.js'
 import { sseWorkerRequestSchema } from './sse-shared-worker-protocol.js'
 
@@ -174,12 +174,6 @@ function hubFor(baseUrl: string): SseStreamHub {
   return hub
 }
 
-function toBase64(bytes: Uint8Array): string {
-  let binary = ''
-  for (const byte of bytes) binary += String.fromCharCode(byte)
-  return btoa(binary)
-}
-
 /**
  * Merge bytes into a document's replica and tell the interested tabs what
  * actually changed.
@@ -216,6 +210,11 @@ function ingest(baseUrl: string, doc: string, bytes: Uint8Array, from: MessagePo
     // the round trip from looping back out as authority state.
     const merged = replica.export({ mode: 'update', from: before })
     if (merged.byteLength === 0) return
+    // Tab-originated work goes on to the daemon; daemon-originated work is
+    // already there. The empty-diff return above is what makes that split safe
+    // to state so plainly — a tab re-pushing what the daemon just sent never
+    // reaches here to be written back.
+    if (from !== null) hubFor(baseUrl).push(doc, merged)
     const encoded = toBase64(merged)
     for (const [target, state] of ports) {
       if (target === from) continue

--- a/packages/mcp-server/src/shared/sse-backend.ts
+++ b/packages/mcp-server/src/shared/sse-backend.ts
@@ -144,24 +144,13 @@ export class SseBackend implements CanvasBackend {
   }
 
   pushLocalUpdate(bytes: Uint8Array): void {
-    // The existing update route already imports, persists and broadcasts, and
-    // its broadcast now reaches SSE subscribers too — no sync-specific upstream
-    // endpoint is needed.
-    void this.fetchFn(
-      this.url(
-        `/api/canvas/${encodeURIComponent(this.workspaceId)}/${encodeURIComponent(this.slug)}/update`,
-      ),
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        // `.buffer` of a fresh slice, not the view: this module is also built
-        // for Node's dts pass, where the DOM's BodyInit type is unavailable.
-        body: bytes.slice().buffer as ArrayBuffer,
-      },
-    ).catch(() => {
-      // Dropping a local update here would lose the edit silently; the caller's
-      // CRDT still holds it and the next update carries the same state forward.
-    })
+    // Through the source, not straight to the daemon, because the source is
+    // what knows where this document's authority lives. With no SharedWorker
+    // that is the daemon and this is the same POST it always was; with one, the
+    // worker's replica merges the bytes against everything else it has seen
+    // and writes onward itself. Posting here regardless would write around
+    // that replica and re-send state the daemon had just delivered.
+    this.resolveSource().push(this.docKey, bytes)
   }
 
   async getFile(fileId: string): Promise<Blob | null> {

--- a/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
@@ -19,6 +19,7 @@ function createHarness(): SseStreamSourceHarness {
   const openedStreamIds: string[] = []
   const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
   const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
+  const daemonWrites: { doc: string; body: Uint8Array }[] = []
   let push: ((frame: string) => void) | null = null
   let endStream: (() => void) | null = null
 
@@ -41,6 +42,17 @@ function createHarness(): SseStreamSourceHarness {
         }),
         { status: 200 },
       )
+    }
+    // The canvas update route, which is where a push lands. Matched before the
+    // JSON parse below: its body is raw update bytes, not JSON.
+    const canvasUpdate = /\/api\/canvas\/([^/]+)\/([^/]+)\/update$/.exec(url)
+    if (canvasUpdate) {
+      const [, workspaceId, slug] = canvasUpdate
+      daemonWrites.push({
+        doc: `${decodeURIComponent(workspaceId as string)}/${decodeURIComponent(slug as string)}`,
+        body: new Uint8Array(init?.body as ArrayBuffer),
+      })
+      return new Response('{}', { status: 200 })
     }
     const body = init?.body ? JSON.parse(String(init.body)) : {}
     if (url.includes('/api/sync/subscribe')) subscribeBodies.push(body)
@@ -65,6 +77,7 @@ function createHarness(): SseStreamSourceHarness {
     unsubscribedDocs: () => subscribeBodies.flatMap((b) => b.unsubscribe ?? []),
     controlMessages: () => controlMessages,
     openedStreamIds: () => openedStreamIds,
+    daemonWrites: () => daemonWrites,
     ready: async () => {
       await vi.waitFor(() => {
         if (push === null) throw new Error('stream not open')

--- a/packages/mcp-server/src/shared/sse-stream-hub.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.ts
@@ -63,6 +63,19 @@ export interface SseStreamSource {
    * the worker's, not the caller's.
    */
   sendMessage(doc: string, message: unknown): void
+  /**
+   * Get a document's new state to the authority for it.
+   *
+   * Which authority that is, is exactly what the two implementations disagree
+   * about, and why this belongs on the source rather than at the call site.
+   * The hub writes straight to the daemon. The SharedWorker-backed source
+   * hands the bytes to the worker's replica, which merges them in arrival
+   * order against everything else it knows — its own tabs and the daemon —
+   * and writes onward itself. A caller that posted to the daemon directly
+   * would be writing around the replica that is meant to be authoritative,
+   * and would re-send state the daemon had just delivered.
+   */
+  push(doc: string, update: Uint8Array): void
 }
 
 export interface SseStreamHubOptions {
@@ -130,6 +143,29 @@ export function fromBase64(value: string): Uint8Array {
   return bytes
 }
 
+/** The mirror of `fromBase64`, exported for the same reason: the worker and the
+ *  tab-side source both encode update bytes, and two copies drift. */
+export function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+/**
+ * The daemon's update route for a document.
+ *
+ * A document key IS `${workspaceId}/${slug}`, which is the only reason
+ * anything holding just the key can address this route. First slash only: a
+ * slug may contain more, a workspace id never does.
+ */
+export function canvasUpdateUrl(baseUrl: string, doc: string): string | null {
+  const slash = doc.indexOf('/')
+  if (slash <= 0 || slash === doc.length - 1) return null
+  const workspaceId = encodeURIComponent(doc.slice(0, slash))
+  const slug = encodeURIComponent(doc.slice(slash + 1))
+  return `${baseUrl.replace(/\/$/, '')}/api/canvas/${workspaceId}/${slug}/update`
+}
+
 export class SseStreamHub implements SseStreamSource {
   private readonly options: SseStreamHubOptions
   /**
@@ -194,6 +230,29 @@ export class SseStreamHub implements SseStreamSource {
     // control messages are inert server-side, so dropping them costs nothing.
     if (this.streamId === null) return
     void this.post('/api/sync/message', { streamId: this.streamId, doc, message })
+  }
+
+  /**
+   * Straight to the daemon: with no worker in front, the daemon IS the
+   * authority. The existing update route already imports, persists and
+   * broadcasts, and its broadcast reaches SSE subscribers, so sync needs no
+   * endpoint of its own.
+   */
+  push(doc: string, update: Uint8Array): void {
+    const url = canvasUpdateUrl(this.options.baseUrl, doc)
+    if (url === null) return
+    void this.options
+      .fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        // `.buffer` of a fresh slice, not the view: this module is also built
+        // for Node's dts pass, where the DOM's BodyInit type is unavailable.
+        body: update.slice().buffer as ArrayBuffer,
+      })
+      .catch(() => {
+        // Dropping it here would lose the edit silently; the caller's CRDT
+        // still holds the state and the next update carries it forward.
+      })
   }
 
   private async post(path: string, body: unknown): Promise<void> {

--- a/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
@@ -14,8 +14,22 @@
  * inside either suite. Only a contract run against every implementation makes
  * a new implementation's untested behaviour a failure rather than a silence.
  */
+import { LoroDoc } from 'loro-crdt'
 import { expect, it, vi } from 'vitest'
 import type { SseStreamSource } from '../sse-stream-hub.js'
+
+/**
+ * Real Loro bytes, so an implementation that merges the push through a replica
+ * produces something and one that forwards it verbatim stays comparable.
+ * Arbitrary bytes would be dropped by the replica as unparseable and the case
+ * would pass or fail for the wrong reason.
+ */
+const LORO_UPDATE: Uint8Array = (() => {
+  const doc = new LoroDoc()
+  doc.getMap('contract').set('pushed', 'through')
+  doc.commit()
+  return doc.export({ mode: 'update' })
+})()
 
 /**
  * A running implementation plus the daemon-side observations the contract
@@ -37,6 +51,12 @@ export interface SseStreamSourceHarness {
   controlMessages(): { streamId: string; doc: string; message: unknown }[]
   /** Stream ids the daemon minted for this source. */
   openedStreamIds(): string[]
+  /**
+   * Update bodies the daemon received on its own canvas route, with the
+   * document each was addressed to — reassembled from the URL, since that
+   * addressing is half of what the push contract asserts.
+   */
+  daemonWrites(): { doc: string; body: Uint8Array }[]
   /** Wait until the daemon has an open stream ready to receive frames. */
   ready(): Promise<void>
   /** End the current stream the way a dropped connection does. */
@@ -157,6 +177,30 @@ export function sseStreamSourceContract(
     const sent = h.controlMessages().find((m) => m.doc === doc)
     expect(sent?.message).toEqual({ type: 'client_ready' })
     expect(h.openedStreamIds()).toContain(sent?.streamId)
+    h.cleanup()
+  })
+
+  it('gets a pushed update to the daemon, addressed by workspace and slug', async () => {
+    // Both implementations reach the daemon, by different routes — the hub
+    // posts, the worker-backed source hands the bytes to a replica that posts
+    // — and a caller cannot tell which it has. If either stopped arriving, an
+    // edit would be applied locally, shown to the user, echoed to sibling
+    // tabs, and never persisted: the failure looks exactly like success until
+    // the page is reloaded.
+    const h = await create()
+    const doc = nextDoc()
+    await subscribed(h, doc)
+
+    h.source.push(doc, LORO_UPDATE)
+
+    await until(() => h.daemonWrites().some((w) => w.doc === doc))
+    const write = h.daemonWrites().find((w) => w.doc === doc)
+    // Reconstructed, not compared byte-for-byte: an implementation that merges
+    // through a replica sends that replica's delta, which carries the same
+    // state without being the same bytes.
+    const received = new LoroDoc()
+    received.import(write?.body as Uint8Array)
+    expect(received.getMap('contract').get('pushed')).toBe('through')
     h.cleanup()
   })
 


### PR DESCRIPTION
Third increment of the Loro-authority work, after #779 and #783. This is the one that reaches a user.

## What changes for someone using the app

**A sibling tab's edit now arrives at worker speed instead of after a daemon round trip.** That is the whole point of holding a replica in the worker, and until this PR nothing consumed it.

## The shape

`push(doc, update)` joins `SseStreamSource`, because *which* authority a document has is exactly what the two implementations disagree about — and the one thing a caller should not have to know.

- `SseStreamHub.push` is the POST `SseBackend.pushLocalUpdate` used to make, **moved rather than copied**. With no SharedWorker the daemon IS the authority and nothing changes.
- The SharedWorker-backed source hands the bytes to the replica instead. The replica merges them in arrival order against everything else it knows — the other tabs' work and the daemon's — and writes onward itself.

That ordering is the reason for the move. A tab posting its own edits cannot know what the daemon has already told the worker, so it re-sends state that just arrived. The replica diffs against what it holds, and the existing empty-diff return drops the echo before it can loop — which is also what makes *"tab work goes to the daemon, daemon work does not"* safe to state as one line.

The tab-side source also stops ignoring `authority-update` and delivers it as inbound state. Both channels are delivered during the transition; Loro absorbs the overlap.

## Why the contract suite earned its keep again

Two implementations now reach the daemon by different routes, and a caller cannot tell which it holds. If either stopped arriving, the failure would look exactly like success: the edit applied locally, shown to the user, echoed to sibling tabs, and **never persisted** — visible only after a reload.

So the push case goes in the shared contract, run against both harnesses. It pushes real Loro bytes and reconstructs state rather than comparing bytes, since an implementation that merges through a replica sends that replica's delta, not the bytes it was handed.

## Deletions that came with it

- `toBase64` joins `fromBase64` as an export — the worker and the tab source each had a copy.
- `canvasUpdateUrl` holds the `${workspaceId}/${slug}` reconstruction the hub and the worker both need. That the document key IS the workspace-and-slug pair is the only reason anything holding just the key can address the route, and it is now said once.

## Verification

- **Mutation-checked twice.** Dropping the write turns the worker case red. Writing *unconditionally* also turns it red — the daemon's own frame becomes the first write, which is precisely the loop the `from !== null` guard prevents. The test discriminates both failure modes, not just absence.
- The jsdom worker case asserts the `Authorization` header on the real request. `daemon-auth-seam.test.ts` scans source to prove no *other* place assembles that header; only an actual request proves the one place that should, does — and an unauthenticated write is dropped by the daemon, which looks identical to a tab whose edits never persist.
- `mcp-node`: 3360 passed. `web-jsdom` + `web-browser`: 538 passed. `arch-lint-node`: 76 passed. knip clean.

## Known ceiling, marked in source

A delta dropped by a failed write is still never re-sent, and centralising the write means one failure now costs every tab's edit rather than one tab's. The old shape did not re-send either — this concentrates an existing gap rather than creating one. A resend queue keyed on the replica's version is the upgrade path, and it is tracked.