### PR TITLE
feat(web,render): surface dangling canvas references instead of dead-ending

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -110,6 +110,7 @@ export interface CanvasContextMenuProps {
   readonly selectedId: string | null
   readonly groupSelection: (memberIds: readonly string[]) => void
   readonly isImageFileRef?: (file: string) => boolean
+  readonly missingFileRef?: (file: string) => boolean
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
   readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
   readonly copySelection: () => ClipboardFragment | null
@@ -148,6 +149,7 @@ export function CanvasContextMenu({
   selectedId,
   groupSelection,
   isImageFileRef,
+  missingFileRef,
   onOpenFileRef,
   openLinkNode,
   copySelection,
@@ -485,7 +487,11 @@ export function CanvasContextMenu({
           items.push({ kind: 'separator' })
         }
         if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
-          if (onOpenFileRef !== undefined) {
+          // A missing target makes Open a dead end (worse: the daemon's
+          // slug routes lazily create, so following would mint an empty
+          // canvas under the dangling ref). Change target stays — it is
+          // the repair affordance.
+          if (onOpenFileRef !== undefined && missingFileRef?.(node.file) !== true) {
             items.push({
               label: 'Open canvas',
               icon: <ExternalLink />,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -314,6 +314,15 @@ export interface SpatialEditorProps {
   /** Follows a file node's reference (navigation). Absent → follow hides. */
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
   /**
+   * Marks a file reference whose target no longer exists (deleted canvas,
+   * ref imported into a store that never had it). The card renders a quiet
+   * "Missing reference" label and the follow affordances (context menu,
+   * double-click) hide — following would dead-end, or worse lazily create
+   * an empty canvas under the dangling ref. Deciding missing is the host's
+   * lookup against its live document list; absent → nothing is missing.
+   */
+  readonly missingFileRef?: (file: string) => boolean
+  /**
    * Host controls (undo/redo/version history) docked as the palette's
    * leading group — the palette is the single bottom-chrome container.
    */
@@ -433,6 +442,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       onToggleNodeLock,
       fileRefOptions,
       onOpenFileRef,
+      missingFileRef,
       paletteLeading,
       resolveFileCanvas,
       resolveFileFacets,
@@ -654,13 +664,32 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const fileSeamOptions = useMemo(
       () => ({
         resolveFileLabel,
+        resolveFileMissing: missingFileRef,
         resolveFileCanvas,
         expandFileNode,
         resolveFileImage,
         resolveFileFacets,
       }),
-      [resolveFileLabel, resolveFileCanvas, expandFileNode, resolveFileImage, resolveFileFacets],
+      [
+        resolveFileLabel,
+        missingFileRef,
+        resolveFileCanvas,
+        expandFileNode,
+        resolveFileImage,
+        resolveFileFacets,
+      ],
     )
+    // The plain-data twin of the resolveFileMissing seam, so the worker path
+    // (which cannot take a function) sees the same missing set the
+    // synchronous and drag paths compute through the callback.
+    const missingFileRefs = useMemo(() => {
+      if (missingFileRef === undefined) return undefined
+      const refs = new Set<string>()
+      for (const node of canvas.nodes) {
+        if (node.type === 'file' && missingFileRef(node.file)) refs.add(node.file)
+      }
+      return refs.size === 0 ? undefined : [...refs]
+    }, [canvas, missingFileRef])
     // The COMMITTED scene, laid out in a worker when it can be. The drag
     // layers below keep their own synchronous paths: a gesture already has a
     // fast route through carried-side caching, and a round trip per frame
@@ -671,6 +700,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       { measure: resolvedMeasure, theme },
       fileSeamOptions,
       fileRefOptions,
+      missingFileRefs,
     )
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
@@ -1713,7 +1743,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         if (
           node?.type === 'file' &&
           onOpenFileRef !== undefined &&
-          isImageFileRef?.(node.file) !== true
+          isImageFileRef?.(node.file) !== true &&
+          missingFileRef?.(node.file) !== true
         ) {
           applyResult(result)
           onOpenFileRef(node.file, node.subpath)
@@ -2828,6 +2859,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             selectedId={selectedId}
             groupSelection={groupSelection}
             isImageFileRef={isImageFileRef}
+            missingFileRef={missingFileRef}
             onOpenFileRef={onOpenFileRef}
             openLinkNode={openLinkNode}
             copySelection={copySelection}

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -127,6 +127,46 @@ it('the file context menu offers Open canvas and Change target retargets via the
   expect(latest.commands).toContain('set-node-file')
 })
 
+it('a missing reference renders a quiet missing label and hides the follow affordances', async () => {
+  const opened: string[] = []
+  const dangling: SpatialCanvas = {
+    nodes: [{ id: 'f1', type: 'file', x: 100, y: 100, width: 200, height: 60, file: 'gone-id' }],
+    edges: [],
+  }
+  function MissingHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(dangling)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+          fileRefOptions={OPTIONS}
+          onOpenFileRef={(file) => opened.push(file)}
+          missingFileRef={(file) => file === 'gone-id'}
+        />
+      </div>
+    )
+  }
+  const { container } = render(<MissingHost />)
+
+  // The card says what happened instead of leaking the opaque ref string.
+  await vi.waitFor(() => expect(container.textContent).toContain('Missing reference'))
+  expect(container.textContent).not.toContain('gone-id')
+
+  // Double press does not follow a dead reference…
+  await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 130 } })
+  expect(opened).toEqual([])
+
+  // …and the context menu drops Open canvas but keeps Change target — the
+  // repair affordance.
+  rightClick(rootOf(container), 200, 130)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(container.textContent).not.toContain('Open canvas')
+  expect(container.textContent).toContain('Change target')
+})
+
 it('without host seams, neither the Add canvas button nor file follow-affordances appear', async () => {
   const bare: SpatialCanvas = withFileNode
   function BareHost() {

--- a/apps/web/src/components/spatial-editor/scene-render-core.ts
+++ b/apps/web/src/components/spatial-editor/scene-render-core.ts
@@ -33,6 +33,7 @@ export interface RenderCanvasCoreOptions {
   readonly parseBody: (text: string) => MdastRoot
   readonly theme?: ResolvedTheme
   readonly resolveFileLabel?: (file: string) => string | undefined
+  readonly resolveFileMissing?: (file: string) => boolean
   readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
   readonly resolveFileImage?: (
@@ -56,6 +57,7 @@ export function renderCanvasToSvgWith(
     parseBody: options.parseBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
     resolveFileLabel: options.resolveFileLabel,
+    resolveFileMissing: options.resolveFileMissing,
     resolveFileCanvas: options.resolveFileCanvas,
     expandFileNode: options.expandFileNode,
     resolveFileImage: options.resolveFileImage,

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -24,6 +24,8 @@ export interface RenderCanvasOptions {
   readonly theme?: ResolvedTheme
   /** Passed through to layout: opaque file references become readable labels. */
   readonly resolveFileLabel?: (file: string) => string | undefined
+  /** Passed through to layout: dangling references render a quiet missing state. */
+  readonly resolveFileMissing?: (file: string) => boolean
   /** Passed through to layout: referenced canvas content for inline embeds. */
   readonly resolveFileCanvas?: (file: string) => SpatialCanvas | undefined
   /** Passed through to layout: the LOD gate deciding card vs miniature. */

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -91,6 +91,10 @@ export function useWorkerScene(
   base: { readonly measure: MeasureText; readonly theme: ResolvedTheme },
   fileSeamOptions: Omit<RenderCanvasOptions, 'measure' | 'theme'>,
   fileRefLabels: readonly FileRefLabel[] | undefined,
+  // The plain-data twin of fileSeamOptions.resolveFileMissing: the refs the
+  // host resolved as dangling in THIS canvas. The function serves the
+  // synchronous path; only this list can cross to the worker.
+  missingFileRefs?: readonly string[],
 ): RenderedCanvas {
   const options = useMemo(
     () => ({ ...base, ...fileSeamOptions }),
@@ -120,8 +124,8 @@ export function useWorkerScene(
   const shownFor = useRef<unknown>(null)
 
   const inputs = useMemo(
-    () => ({ canvas, theme: options.theme, fileRefLabels }),
-    [canvas, options.theme, fileRefLabels],
+    () => ({ canvas, theme: options.theme, fileRefLabels, missingFileRefs }),
+    [canvas, options.theme, fileRefLabels, missingFileRefs],
   )
 
   useEffect(() => {
@@ -168,6 +172,7 @@ export function useWorkerScene(
       canvas: inputs.canvas,
       theme: inputs.theme,
       fileRefLabels: inputs.fileRefLabels,
+      missingFileRefs: inputs.missingFileRefs,
       bodies: parseBodies(inputs.canvas),
     }
     worker.postMessage(request)

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -42,6 +42,10 @@ export type LayoutRequest = {
   readonly canvas: SpatialCanvas
   readonly theme: ResolvedTheme
   readonly fileRefLabels?: readonly FileRefLabel[]
+  /** File refs the host resolved as dangling — the plain-data form of the
+   * resolveFileMissing seam, precomputed against THIS canvas's file nodes
+   * (a function cannot cross the wire; a small ref list can). */
+  readonly missingFileRefs?: readonly string[]
   readonly bodies: readonly ParsedBody[]
 }
 

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -55,12 +55,14 @@ self.onmessage = async (event: MessageEvent<LayoutRequest>) => {
       return
     }
     const labels = new Map((request.fileRefLabels ?? []).map((o) => [o.file, o.label]))
+    const missingRefs = new Set(request.missingFileRefs ?? [])
     const bodies = new Map(request.bodies.map((b) => [b.text, b.mdast]))
     let missing: string | undefined
     const { svg, bounds, scene } = renderCanvasToSvgWith(request.canvas, {
       measure,
       theme: request.theme,
       resolveFileLabel: labels.size === 0 ? undefined : (file) => labels.get(file),
+      resolveFileMissing: missingRefs.size === 0 ? undefined : (file) => missingRefs.has(file),
       parseBody: (text: string) => {
         const parsed = bodies.get(text)
         if (parsed === undefined) {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,5 +1,6 @@
 import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
+import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { Braces, Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -192,6 +193,16 @@ export function BrowserLocalCanvasPage({
   // clobber a newer refresh triggered by a fast switch.
   const [canvases, setCanvases] = useState<CanvasSnapshot[]>([])
   const listGenerationRef = useRef(0)
+  // A ref that matches no live canvas id points at a deleted canvas: the
+  // editor renders a quiet "Missing reference" and hides the follow
+  // affordances instead of navigating to a dead route. Image refs live in
+  // the file store, not this list; undefined while the list has not loaded
+  // keeps everything ordinary.
+  const missingFileRef = useMemo(() => {
+    if (canvases.length === 0) return undefined
+    const known = new Set(canvases.map((entry) => entry.id))
+    return (ref: string) => !isImageRef(ref) && !known.has(ref)
+  }, [canvases])
   // Fullscreen target for WorkspaceTopBar's onToggleFullscreen; the whole page
   // (editor + chrome), not just the Excalidraw canvas.
   const mainRef = useRef<HTMLElement | null>(null)
@@ -744,6 +755,7 @@ export function BrowserLocalCanvasPage({
                   .filter((entry) => entry.id !== canvasId)
                   .map((entry) => ({ file: entry.id, label: entry.name }))}
                 onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
+                missingFileRef={missingFileRef}
                 {...fileSeams}
                 lockedNodeIds={lockedNodeIds}
                 lockedEdgeIds={lockedEdgeIds}

--- a/apps/web/src/pages/DaemonCanvasPage.file-refs.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.file-refs.test.tsx
@@ -136,6 +136,19 @@ describe('DaemonCanvasPage file refs', () => {
     )
   })
 
+  it('marks refs matching neither a live id nor a live slug as missing, sparing image refs', async () => {
+    await renderPage()
+    const missing = capturedEditorProps?.missingFileRef
+    expect(missing).toBeDefined()
+    // Live id and live slug (a legacy ref) are both known; a ref matching
+    // neither points at a deleted canvas. Image refs live in the file
+    // store, not the canvases list, so they are never "missing" here.
+    expect(missing?.('id-second')).toBe(false)
+    expect(missing?.('second')).toBe(false)
+    expect(missing?.('deleted-canvas-id')).toBe(true)
+    expect(missing?.('asset:0f5bffa1-9d0f-4d2f-a2c4-0f0d4a1a2b3c')).toBe(false)
+  })
+
   it('falls back to slug refs for entries an older daemon lists without ids', async () => {
     mockListCanvases.mockResolvedValue({
       canvases: [

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -1,3 +1,4 @@
+import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
@@ -244,6 +245,19 @@ export function DaemonCanvasPage({
     (ref: string) => canvasesRef.current.find((entry) => entry.id === ref)?.slug,
     [],
   )
+
+  // A ref that matches NEITHER a live id nor a live slug points at a deleted
+  // canvas (or one imported from elsewhere): the editor renders it as a quiet
+  // "Missing reference" and hides the follow affordances — following would
+  // lazily create an empty canvas under the dangling ref. Image refs live in
+  // the file store, not the canvases list, so they are never "missing" here;
+  // undefined while the list has not loaded keeps everything ordinary.
+  const missingFileRef = useMemo(() => {
+    const entries = controller.canvases
+    if (entries.length === 0) return undefined
+    const known = new Set(entries.flatMap((entry) => [entry.slug, ...(entry.id ? [entry.id] : [])]))
+    return (ref: string) => !isImageRef(ref) && !known.has(ref)
+  }, [controller.canvases])
 
   // Canvas embeds (J5a) and image nodes (J5b), over the daemon's own file and
   // snapshot routes. The staleness stamp is the referenced canvas's
@@ -678,6 +692,7 @@ export function DaemonCanvasPage({
                 .filter((entry) => entry.slug !== canvas?.slug)
                 .map((entry) => ({ file: entry.id ?? entry.slug, label: entry.slug }))}
               onOpenFileRef={(file) => controller.switchCanvas(resolveRefSlug(file) ?? file)}
+              missingFileRef={missingFileRef}
               {...fileSeams}
               lockedNodeIds={lockedNodeIds}
               lockedEdgeIds={lockedEdgeIds}

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -351,6 +351,48 @@ describe('layoutSpatialCanvas', () => {
     )
   })
 
+  it('resolveFileMissing renders a quiet missing label instead of the raw reference', () => {
+    const node: Extract<SpatialNode, { type: 'file' }> = {
+      id: 'f1',
+      type: 'file',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      file: 'dangling-id-123',
+      subpath: '#heading',
+    }
+    const missing = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileMissing: (file) => file === 'dangling-id-123',
+    })
+    // The raw reference is an opaque id — useless to a reader — and the
+    // subpath is moot without a target, so neither appears.
+    expect(missing.nodes.find((n): n is TextRunNode => n.kind === 'textRun')?.text).toBe(
+      'Missing reference',
+    )
+
+    // Not missing -> the ordinary label path (raw ref + subpath) is untouched.
+    const present = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileMissing: () => false,
+    })
+    expect(present.nodes.find((n): n is TextRunNode => n.kind === 'textRun')?.text).toBe(
+      'dangling-id-123#heading',
+    )
+
+    // A throwing callback degrades to not-missing (total-layout rule).
+    const throwing = layoutSpatialCanvas(canvas([node]), {
+      ...baseOptions(),
+      resolveFileMissing: () => {
+        throw new Error('boom')
+      },
+    })
+    expect(throwing.nodes.find((n): n is TextRunNode => n.kind === 'textRun')?.text).toBe(
+      'dangling-id-123#heading',
+    )
+  })
+
   it('renders a link node as chrome plus a label containing the url', () => {
     const node: Extract<SpatialNode, { type: 'link' }> = {
       id: 'l1',

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -115,6 +115,17 @@ export interface SpatialLayoutOptions {
    */
   readonly resolveFileLabel?: (file: string) => string | undefined
   /**
+   * Marks a file node's reference as pointing at a target that no longer
+   * exists (deleted canvas, imported ref into a store that never had it).
+   * `true` renders a quiet "Missing reference" label instead of the raw
+   * reference — an opaque id tells a reader nothing — while `false`,
+   * absence, or a throw (total-layout rule) keeps the ordinary label
+   * path. This package only paints the state; deciding it (a lookup
+   * against the live document list) is the caller's job, same as every
+   * other injected resolver here.
+   */
+  readonly resolveFileMissing?: (file: string) => boolean
+  /**
    * Resolves a file node's reference to the referenced spatial canvas for
    * INLINE embedding. Absent, or `undefined` for a reference, keeps the
    * card-only rendering. Recursion is depth-capped (3) with path-local
@@ -297,6 +308,15 @@ function labelOf(
 ): string | undefined {
   switch (node.type) {
     case 'file': {
+      let missing = false
+      try {
+        missing = options.resolveFileMissing?.(node.file) === true
+      } catch {
+        missing = false
+      }
+      // The raw reference is an opaque id — useless to a reader — and the
+      // subpath is moot without a target, so neither appears.
+      if (missing) return 'Missing reference'
       let resolved: string | undefined
       try {
         resolved = options.resolveFileLabel?.(node.file)

--- a/packages/mcp-server/src/server/store/file-gc-sweeper.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc-sweeper.test.ts
@@ -147,13 +147,10 @@ describe('createFileGcSweeper scheduling', () => {
 
   it('runs a pass after intervalMs elapses and reschedules', async () => {
     // Each pass blocks on its own gate until the test releases it. The
-    // reschedule arm only lands after a pass COMPLETES, so while a gate is
-    // held no further pass can fire — which is what makes the exact call
-    // counts below deterministic. The previous shape (auto-resolving purge
-    // plus bounded extra advances) tolerated the second pass slipping LATE,
-    // but under heavy parallel-worker load a single advance step could land
-    // pass 1's call AND fire pass 2 before the count was inspected, failing
-    // `toHaveBeenCalledTimes(1)` in the other direction.
+    // sweeper schedules the next timeout from the completed pass's `finally`
+    // handler, so while a gate is held no further pass can fire — releasing
+    // a gate is the explicit boundary between passes that makes the exact
+    // call counts below deterministic under any scheduler load.
     const gates = [
       deferred<{ purgedCount: number; purgedBytes: number }>(),
       deferred<{ purgedCount: number; purgedBytes: number }>(),


### PR DESCRIPTION
## Summary

A file node whose target canvas was deleted used to show the raw opaque ref string on the card, and following it dead-ended — or worse, the daemon's slug routes lazily create, so "Open canvas" could mint an empty canvas under the dangling ref.

- **canvas-render**: new `resolveFileMissing` seam (same injected-resolver class as `resolveFileLabel`, total — a throw degrades to not-missing). A missing ref renders a quiet **"Missing reference"** label; the opaque id never shows.
- **SpatialEditor**: new `missingFileRef` prop feeds the render seam and hides the follow affordances — context-menu **Open canvas** and double-click — while keeping **Change target** as the repair affordance. Missing-ness crosses to the layout worker as a precomputed ref list (a function cannot cross the wire), so worker offload stays available.
- **Pages**: both compute missing by lookup against their live canvases list — id **or** slug on the daemon page (legacy slug refs stay valid), id browser-local — sparing image refs, and treating nothing as missing until the list has loaded.

Also carries a one-comment cleanup applying CodeRabbit's post-merge finding on #788 (test comment carried PR chronology).

Closes item 3 of the `canvas-ref-rename-resilience-v2` backlog issue (items 1-2, the export projection + ref-encoding decision, stay deferred — no shipped JSON Canvas export surface for daemon canvases exists yet).

## Visual repro

Live ref (card shows the target's slug):

![ref-before-delete.png](https://github.com/user-attachments/assets/574328e5-38b3-487c-92b5-f4ea03dd28e4)

Target deleted → the same stored node renders the quiet missing state; verified in the running app that double-click no longer opens a socket to the dangling slug and the context menu offers Change target but not Open canvas:

![ref-missing-after-delete.png](https://github.com/user-attachments/assets/1cf979ae-ebae-4099-95ad-6bc75bef4da5)

## Test plan

- [x] `canvas-render` layout test (red-first): missing → "Missing reference"; not-missing and throwing callbacks keep the raw-ref label path (609/609 green)
- [x] `canvas-ref-node.browser.test.tsx`: missing ref renders the label, double-click does not follow, context menu drops Open canvas and keeps Change target (browser mode, 5/5)
- [x] `DaemonCanvasPage.file-refs.test.tsx`: missing decided by id-or-slug lookup, image refs spared (5/5)
- [x] apps/web full suite green, typecheck / lint / knip clean
- [x] Manual verification in the running app (create ref → delete target → missing state, follow suppressed, node deletable)
