### PR TITLE
fix(web): say why the link dialog is refusing a URL

### DIFF
--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.test.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.test.tsx
@@ -1,0 +1,83 @@
+// Why the OK button is dead, said out loud.
+//
+// The dialog used to disable OK and explain nothing: a disabled button is
+// not focusable, so someone on a screen reader could not even reach the
+// control that was refusing them, let alone learn why. The two ways to be
+// invalid need different sentences — "that is not an address" and "that
+// address is one we will not open" are different problems with different
+// fixes.
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { LinkUrlDialog } from './LinkUrlDialog.js'
+
+afterEach(cleanup)
+
+function renderDialog() {
+  const submitted: string[] = []
+  const { container } = render(
+    <LinkUrlDialog title="Add Link" onSubmit={(url) => submitted.push(url)} onCancel={() => {}} />,
+  )
+  const input = container.querySelector('input') as HTMLInputElement
+  const ok = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent === 'OK',
+  ) as HTMLButtonElement
+  return { container, input, ok, submitted }
+}
+
+it('says nothing while the field is still empty', () => {
+  const { container, ok } = renderDialog()
+
+  // An untouched field is not a mistake, and an error sitting there before
+  // anyone has typed reads as a broken dialog.
+  expect(container.querySelector('[data-testid="link-url-error"]')).toBeNull()
+  expect(ok.disabled).toBe(true)
+})
+
+it('explains what is missing when the text is not an address at all', () => {
+  const { input } = renderDialog()
+
+  fireEvent.change(input, { target: { value: 'example.com' } })
+
+  const error = screen.getByTestId('link-url-error')
+  expect(error.textContent).toMatch(/https:\/\//)
+})
+
+it('explains the refusal separately when the address is one we will not open', () => {
+  const { input, ok } = renderDialog()
+
+  fireEvent.change(input, { target: { value: 'javascript:alert(1)' } })
+
+  // A parseable URL we decline to follow is a different problem from a typo,
+  // and telling someone to "add https://" here would be wrong advice — they
+  // typed a complete address; it is the scheme we refuse.
+  const refusal = screen.getByTestId('link-url-error').textContent
+  expect(refusal).not.toMatch(/starting with/i)
+  expect(refusal).toMatch(/only/i)
+  expect(ok.disabled).toBe(true)
+
+  // And the two failures must not collapse into one sentence.
+  fireEvent.change(input, { target: { value: 'example.com' } })
+  expect(screen.getByTestId('link-url-error').textContent).not.toBe(refusal)
+})
+
+it('wires the message to the field so it is announced, not just painted', () => {
+  const { input } = renderDialog()
+
+  fireEvent.change(input, { target: { value: 'nope' } })
+
+  const error = screen.getByTestId('link-url-error')
+  expect(input.getAttribute('aria-invalid')).toBe('true')
+  expect(input.getAttribute('aria-describedby')).toBe(error.id)
+  expect(error.id).not.toBe('')
+})
+
+it('takes the message back down once the address is usable', () => {
+  const { input, ok } = renderDialog()
+
+  fireEvent.change(input, { target: { value: 'nope' } })
+  fireEvent.change(input, { target: { value: 'https://example.com' } })
+
+  expect(screen.queryByTestId('link-url-error')).toBeNull()
+  expect(input.getAttribute('aria-invalid')).toBe('false')
+  expect(ok.disabled).toBe(false)
+})

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.test.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.test.tsx
@@ -21,15 +21,17 @@ function renderDialog() {
   const ok = [...container.querySelectorAll('button')].find(
     (b) => b.textContent === 'OK',
   ) as HTMLButtonElement
-  return { container, input, ok, submitted }
+  return { input, ok, submitted }
 }
 
 it('says nothing while the field is still empty', () => {
-  const { container, ok } = renderDialog()
+  const { ok } = renderDialog()
 
   // An untouched field is not a mistake, and an error sitting there before
   // anyone has typed reads as a broken dialog.
-  expect(container.querySelector('[data-testid="link-url-error"]')).toBeNull()
+  // The live region itself IS present — one that appears together with its
+  // first message is announced inconsistently — but it says nothing.
+  expect(screen.getByTestId('link-url-error').textContent).toBe('')
   expect(ok.disabled).toBe(true)
 })
 
@@ -77,7 +79,10 @@ it('takes the message back down once the address is usable', () => {
   fireEvent.change(input, { target: { value: 'nope' } })
   fireEvent.change(input, { target: { value: 'https://example.com' } })
 
-  expect(screen.queryByTestId('link-url-error')).toBeNull()
+  expect(screen.getByTestId('link-url-error').textContent).toBe('')
   expect(input.getAttribute('aria-invalid')).toBe('false')
+  // And the field stops pointing at it: a description that resolves to
+  // nothing is worse than no description.
+  expect(input.hasAttribute('aria-describedby')).toBe(false)
   expect(ok.disabled).toBe(false)
 })

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -94,18 +94,20 @@ export function LinkUrlDialog({ title, initialUrl, onSubmit, onCancel }: LinkUrl
             className="w-72 rounded border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
           />
         </label>
-        {refusal !== null && (
-          // Polite, not assertive: this updates on every keystroke, and an
-          // alert on each one would talk over the typing it is describing.
-          <p
-            id={errorId}
-            data-testid="link-url-error"
-            role="status"
-            className="max-w-72 text-destructive text-xs"
-          >
-            {refusal}
-          </p>
-        )}
+        {/* Always mounted, even while empty. A live region that arrives in
+            the DOM already carrying its message is announced inconsistently
+            (Safari+VoiceOver, some NVDA setups); one that is already there
+            when its text changes is not. Polite rather than assertive
+            because this updates on every keystroke, and an alert on each one
+            would talk over the typing it is describing. */}
+        <p
+          id={errorId}
+          data-testid="link-url-error"
+          role="status"
+          className="max-w-72 text-destructive text-xs empty:hidden"
+        >
+          {refusal ?? ''}
+        </p>
         <div className="flex justify-end gap-2">
           <button
             type="button"

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -11,7 +11,7 @@
  * context menu: it must behave identically where the app stylesheet is
  * absent (browser-mode component tests).
  */
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { z } from 'zod'
 import { isFollowableUrl } from './followable-url.js'
 
@@ -26,9 +26,30 @@ export interface LinkUrlDialogProps {
   readonly onCancel: () => void
 }
 
+/**
+ * Why this text cannot be used, in the words that tell someone what to do
+ * next — or null when there is nothing to say. An empty field is not a
+ * mistake, and the two failures need different advice: a typo wants the
+ * missing scheme, a `javascript:` URL wants to know we will not open it at
+ * all, and telling THAT person to "add https://" would be wrong.
+ */
+function refusalFor(value: string): string | null {
+  if (value.trim() === '') return null
+  if (urlSchema.safeParse(value).success) return null
+  return isParseableUrl(value)
+    ? 'Only http:// and https:// links can be opened.'
+    : 'Enter a full address, starting with https://'
+}
+
+function isParseableUrl(value: string): boolean {
+  return z.url().safeParse(value).success
+}
+
 export function LinkUrlDialog({ title, initialUrl, onSubmit, onCancel }: LinkUrlDialogProps) {
   const [value, setValue] = useState(initialUrl ?? '')
   const isValid = urlSchema.safeParse(value).success
+  const refusal = refusalFor(value)
+  const errorId = useId()
 
   return (
     <div
@@ -67,10 +88,24 @@ export function LinkUrlDialog({ title, initialUrl, onSubmit, onCancel }: LinkUrl
             type="url"
             value={value}
             placeholder="https://example.com"
+            aria-invalid={refusal !== null}
+            aria-describedby={refusal === null ? undefined : errorId}
             onChange={(e) => setValue(e.target.value)}
             className="w-72 rounded border bg-background px-2 py-1 text-sm text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
           />
         </label>
+        {refusal !== null && (
+          // Polite, not assertive: this updates on every keystroke, and an
+          // alert on each one would talk over the typing it is describing.
+          <p
+            id={errorId}
+            data-testid="link-url-error"
+            role="status"
+            className="max-w-72 text-destructive text-xs"
+          >
+            {refusal}
+          </p>
+        )}
         <div className="flex justify-end gap-2">
           <button
             type="button"


### PR DESCRIPTION
Found by the QA lane on #781, as a pre-existing gap rather than a regression: the link dialog **disabled OK and explained nothing**.

A disabled button is not focusable, so someone on a screen reader could not even reach the control that was refusing them, let alone learn why. With a mouse it reads as a broken dialog rather than a rejected value.

## Two failures, two sentences

They need different sentences because they need different fixes:

| typed | message |
|---|---|
| `example.com` | Enter a full address, starting with `https://` |
| `javascript:alert(1)` | Only `http://` and `https://` links can be opened. |

Telling the second person to "add https://" would be **wrong advice about what they typed** — that is a complete address; it is the scheme we decline to follow (`isFollowableUrl`, the same guard that protects the open sink).

![error-not-an-address.png](https://github.com/user-attachments/assets/80b91d6d-ec75-41bb-8b51-331379ac17e8)
![error-refused-scheme.png](https://github.com/user-attachments/assets/a5615e90-8b31-415b-8238-2378a79e4007)

## Announced, not just painted

`aria-invalid` on the field, `aria-describedby` pointing at the message, and the message in a **polite** live region — it updates on every keystroke, and an assertive one would talk over the typing it is describing. An empty field stays silent: nothing has been got wrong yet.

## The mutation check earned its keep here

My first version of the scheme-refusal test asserted `toMatch(/http/)` — which the *typo* message also satisfies, because it contains `https://`. Collapsing both branches into one sentence left all five tests green. The test now pins that the two messages differ and that the refusal does not say "starting with", and the same mutation turns it red.

## Verification

- `pnpm --filter @kamiazya/whiteboard-web test` — 2119 + 75 passed (the CI `test-jsdom` command)
- `pnpm test --project web-browser` — 539 passed; typecheck and lint clean
- Real browser, all four states: empty (silent, OK disabled) → typo → refused scheme → valid (message gone, `aria-invalid=false`, OK enabled)

Behaviour deliberately unchanged: OK stays disabled while invalid. Keeping it enabled and reporting on submit is the other valid pattern, but it is a bigger change than the gap being closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc