### PR TITLE
feat(web): bind the markdown source pane to the Loro document

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "loro-codemirror": "^0.3.3",
     "loro-crdt": "catalog:",
     "lucide-react": "^1.28.0",
     "mathjax-full": "^3.2.2",

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import type { Extension } from '@codemirror/state'
 import type { AliasResolver } from '@kamiazya/whiteboard-canvas-codec'
 import { type CanvasCoreMeta, canvasIdSchema } from '@kamiazya/whiteboard-canvas-model'
 import type { MdastLayoutOptions, MeasureText } from '@kamiazya/whiteboard-canvas-render'
@@ -63,6 +64,13 @@ export interface MarkdownEditorProps {
    * MathJax/mermaid loaders (markdown-fragment-renderers.ts).
    */
   fragmentLoaders?: FragmentLoaders
+  /**
+   * Host-supplied CodeMirror extensions for the source pane — the CRDT
+   * binding seam (see SourcePane.extensions). When set, external `value`
+   * reconciliation is disabled: the binding owns editor<->document sync
+   * and `value` flows only outward (preview, word count).
+   */
+  sourceExtensions?: readonly Extension[]
 }
 
 const DEFAULT_MAX_WIDTH = 720
@@ -83,10 +91,10 @@ const MIN_PREVIEW_WIDTH = 320
  * without overwriting the stored preference.
  *
  * Deliberately out of scope, each for a specific reason:
- * - CRDT binding (`loro-codemirror`) belongs to the sync slice: binding a
- *   CodeMirror instance to a CRDT document is a persistence/collaboration
- *   concern, and this component is a plain controlled `value`/`onChange`
- *   pair that owns neither.
+ * - CRDT binding (`loro-codemirror`) is the HOST's concern, wired through
+ *   `sourceExtensions`: this component stays a plain controlled
+ *   `value`/`onChange` pair, and a bound host disables the value-reconcile
+ *   path because the binding owns editor<->document sync.
  * - Inline `$math$` renders as plain text runs: the layout's phrasing path
  *   has no fragment seam, and a sized inline fragment inside a wrapped
  *   line is its own layout problem. Block math and mermaid fences render
@@ -193,6 +201,7 @@ export function MarkdownEditor({
   onOpenCanvas,
   resolveEmbed,
   fragmentLoaders,
+  sourceExtensions,
 }: MarkdownEditorProps) {
   const resolvedMeasure = useMemo(() => measure ?? createBrowserMeasureText(), [measure])
   const debouncedValue = useDebouncedValue(value, previewDebounceMs)
@@ -370,6 +379,10 @@ export function MarkdownEditor({
             apiRef={sourceApiRef}
             placeholderText="Write in Markdown…"
             className="markdown-editor-source"
+            extensions={sourceExtensions}
+            // A CRDT binding owns editor<->document sync; the controlled
+            // reconcile path would race it (see SourcePane).
+            reconcileExternalValue={sourceExtensions === undefined}
           />
         </div>
         {effectiveMode === 'split' && (

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -1,7 +1,13 @@
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { EditorSelection, EditorState, Prec, type StateCommand } from '@codemirror/state'
+import {
+  EditorSelection,
+  EditorState,
+  type Extension,
+  Prec,
+  type StateCommand,
+} from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
 import { GFM } from '@lezer/markdown'
@@ -96,6 +102,21 @@ export interface SourcePaneProps {
   placeholderText?: string
   /** Receives the imperative API while the view is mounted, null after. */
   apiRef?: RefObject<SourcePaneApi | null>
+  /**
+   * Host-supplied CodeMirror extensions, appended at view creation — the
+   * seam a composition root uses to bind this editor to a CRDT document
+   * (loro-codemirror). The view is created once per mount, so a host that
+   * gains its extension later must remount (key) rather than expect a
+   * live reconfigure.
+   */
+  extensions?: readonly Extension[]
+  /**
+   * When false, external `value` changes are NOT reconciled into the view
+   * — for CRDT-bound hosts, where the binding itself applies remote
+   * changes and a second reconcile path would race it and double-apply.
+   * The view's content then flows only editor->out. Default true.
+   */
+  reconcileExternalValue?: boolean
 }
 
 /**
@@ -111,6 +132,8 @@ export function SourcePane({
   autoFocus = false,
   placeholderText,
   apiRef,
+  extensions,
+  reconcileExternalValue = true,
 }: SourcePaneProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
@@ -156,6 +179,9 @@ export function SourcePane({
         // horizontal scrollbar.
         EditorView.lineWrapping,
         ...(placeholderText !== undefined ? [placeholder(placeholderText)] : []),
+        // Host extensions last, after every built-in: a CRDT binding must
+        // observe the final document the built-ins produce.
+        ...(extensions ?? []),
         // Fill the host pane instead of sizing to content: without a
         // bounded height the scroller never scrolls and the pane collapses
         // to its padding inside a flex row.
@@ -216,6 +242,9 @@ export function SourcePane({
   }, [])
 
   useEffect(() => {
+    // A CRDT-bound host applies external changes through the binding
+    // itself; reconciling here as well would race it and double-apply.
+    if (!reconcileExternalValue) return
     const view = viewRef.current
     if (!view) return
     const current = view.state.doc.toString()
@@ -231,7 +260,7 @@ export function SourcePane({
     // what makes a remote CRDT update land without yanking the local caret
     // out of the word being typed.
     view.dispatch({ changes: minimalChange(current, value) })
-  }, [value])
+  }, [value, reconcileExternalValue])
 
   return (
     <div

--- a/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * CRDT binding for the markdown source pane (loro-codemirror), the wiring a
+ * composition root supplies through MarkdownEditor's `sourceExtensions`.
+ * Real browser: caret behavior across remote edits is exactly what jsdom
+ * cannot fake. What these pin:
+ *
+ * - typing lands in the Loro 'body' text container as real deltas,
+ * - a REMOTE edit (an import from another peer) merges into the visible
+ *   editor without going through the controlled `value` at all, and the
+ *   local caret moves by exactly the inserted length — the precision the
+ *   minimalChange reconcile path can only approximate.
+ */
+import { cleanup, render } from '@testing-library/react'
+import { LoroSyncPlugin } from 'loro-codemirror'
+import { Loro, type LoroDoc } from 'loro-crdt'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+afterEach(cleanup)
+
+function mountBound(initialBody: string) {
+  const doc = new Loro()
+  doc.getText('body').insert(0, initialBody)
+  doc.commit()
+  const binding = [LoroSyncPlugin(doc as LoroDoc, (d) => d.getText('body'))]
+  const utils = render(
+    <div style={{ width: 800, height: 300 }}>
+      <MarkdownEditor
+        value={initialBody}
+        onChange={() => {}}
+        previewDebounceMs={0}
+        sourceExtensions={binding}
+      />
+    </div>,
+  )
+  return { doc, ...utils }
+}
+
+it('typing in the editor lands in the Loro body container', async () => {
+  const { doc, container } = mountBound('hello ')
+  const cm = container.querySelector('.cm-content') as HTMLElement
+  await userEvent.click(cm)
+  await userEvent.keyboard('{End}world')
+  await vi.waitFor(() => {
+    expect(doc.getText('body').toString()).toBe('hello world')
+  })
+})
+
+it('a remote edit merges into the editor and shifts the caret exactly', async () => {
+  const { doc, container } = mountBound('alpha omega')
+  const cm = container.querySelector('.cm-content') as HTMLElement
+  await userEvent.click(cm)
+  // Park the caret between the words: after "alpha " (position 6).
+  await userEvent.keyboard(
+    '{Home}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}',
+  )
+
+  // A second peer prepends text and its update is imported — the transport
+  // this simulates does not matter (SharedWorker, websocket, file import).
+  const remote = new Loro()
+  remote.import(doc.export({ mode: 'snapshot' }))
+  remote.getText('body').insert(0, 'REMOTE ')
+  remote.commit()
+  doc.import(remote.export({ mode: 'update' }))
+
+  await vi.waitFor(() => {
+    const view = container.querySelector('.cm-content') as HTMLElement
+    expect(view.textContent).toContain('REMOTE alpha omega')
+  })
+
+  // The caret sat at 6 ("alpha |omega" minus the remote prefix); a 7-char
+  // remote insert BEFORE it must land it at 13 — still between the words.
+  await userEvent.keyboard('X')
+  await vi.waitFor(() => {
+    expect(doc.getText('body').toString()).toBe('REMOTE alpha Xomega')
+  })
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -1,8 +1,9 @@
 import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
+import { LoroSyncPlugin } from 'loro-codemirror'
 import { Braces, Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { CanvasProperties } from '../components/canvas-properties/CanvasProperties.js'
@@ -211,6 +212,19 @@ export function BrowserLocalCanvasPage({
   const canvasName = pageState.kind === 'editing' ? pageState.snapshot.name : null
   const canvasKind = pageState.kind === 'editing' ? pageState.snapshot.kind : 'spatial'
   const markdownDoc = useMarkdownCanvasDoc(resolvedLoro, canvasId, canvasKind === 'markdown')
+  // Binds CodeMirror straight to the document's 'body' text container:
+  // edits land in the CRDT with real deltas (not the wholesale replace
+  // setBody does), and an external change moves the local caret exactly.
+  // The hook's doc subscription keeps body state and the save schedule in
+  // step with the binding's commits, so onChange has nothing left to do.
+  const markdownBinding = useMemo(
+    () =>
+      markdownDoc.doc === null
+        ? undefined
+        : [LoroSyncPlugin(markdownDoc.doc, (d) => d.getText('body'))],
+    [markdownDoc.doc],
+  )
+  const noopChange = useCallback(() => {}, [])
   const currentUpdatedAt = pageState.kind === 'editing' ? pageState.snapshot.updatedAt : null
 
   // [[Name]] resolution for the markdown preview: display names from the
@@ -711,7 +725,8 @@ export function BrowserLocalCanvasPage({
                 <MarkdownEditor
                   key={canvasId ?? 'no-canvas'}
                   value={markdownDoc.body}
-                  onChange={markdownDoc.setBody}
+                  onChange={markdownBinding === undefined ? markdownDoc.setBody : noopChange}
+                  sourceExtensions={markdownBinding}
                   autoFocus
                   className="h-full"
                   theme={resolvedTheme}

--- a/apps/web/src/pages/use-markdown-canvas-doc.test.ts
+++ b/apps/web/src/pages/use-markdown-canvas-doc.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The CRDT-binding half of the markdown document hook: the loaded Loro
+ * instance is exposed so the composition root can bind CodeMirror to it
+ * (loro-codemirror), and doc changes committed OUTSIDE setBody — exactly
+ * what the binding produces — still refresh the body state and schedule a
+ * save. Without that, a binding-driven edit would be on screen and in the
+ * CRDT but never persisted and never reflected in the preview.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { Loro } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import type { LoroStoreLike } from './use-browser-local-canvas-controller.js'
+import { useMarkdownCanvasDoc } from './use-markdown-canvas-doc.js'
+
+function fakeStore(): LoroStoreLike & { saves: Uint8Array[] } {
+  const saves: Uint8Array[] = []
+  return {
+    saves,
+    async save(_canvasId, snapshot) {
+      saves.push(snapshot)
+    },
+    createEmptySnapshot() {
+      return new Uint8Array()
+    },
+    async load() {
+      return { kind: 'missing' } as never
+    },
+  }
+}
+
+describe('useMarkdownCanvasDoc CRDT exposure', () => {
+  // Real timers throughout: the doc subscription delivers on the microtask
+  // queue and the save debounce is 500ms — condition-waiting on both beats
+  // fake-timer choreography (see the fake-timers-vs-threadpool flake class).
+
+  it('exposes the loaded Loro doc for composition-root bindings', async () => {
+    const store = fakeStore()
+    const { result } = renderHook(() => useMarkdownCanvasDoc(store, 'c1', true))
+    expect(result.current.doc).toBeNull()
+    await waitFor(() => expect(result.current.doc).not.toBeNull())
+  })
+
+  it('refreshes body state and schedules a save for a commit made outside setBody', async () => {
+    const store = fakeStore()
+    const { result } = renderHook(() => useMarkdownCanvasDoc(store, 'c1', true))
+    await waitFor(() => expect(result.current.doc).not.toBeNull())
+
+    // What the loro-codemirror binding does on a keystroke: mutate the text
+    // container and commit — never through setBody.
+    const doc = result.current.doc as Loro
+    await act(async () => {
+      doc.getText('body').insert(0, 'typed via binding')
+      doc.commit()
+    })
+
+    await waitFor(() => expect(result.current.body).toBe('typed via binding'))
+    await waitFor(() => expect(store.saves.length).toBeGreaterThan(0), { timeout: 3000 })
+  })
+})

--- a/apps/web/src/pages/use-markdown-canvas-doc.ts
+++ b/apps/web/src/pages/use-markdown-canvas-doc.ts
@@ -38,6 +38,14 @@ export interface MarkdownCanvasDocState {
   /** Null until the initial load resolves, mirroring `body`. */
   readonly coreMeta: CanvasCoreMeta | null
   readonly setCoreMeta: (next: CanvasCoreMeta) => void
+  /**
+   * The loaded Loro instance, for composition-root CRDT bindings
+   * (loro-codemirror). Null until the initial load resolves. A binding
+   * mutates the 'body' text container and commits directly — the doc
+   * subscription below is what keeps `body` state and the save schedule in
+   * step with commits this hook did not make.
+   */
+  readonly doc: Loro | null
 }
 
 export function useMarkdownCanvasDoc(
@@ -47,6 +55,7 @@ export function useMarkdownCanvasDoc(
 ): MarkdownCanvasDocState {
   const [body, setBodyState] = useState<string | null>(null)
   const [coreMeta, setCoreMetaState] = useState<CanvasCoreMeta | null>(null)
+  const [doc, setDoc] = useState<Loro | null>(null)
   const docRef = useRef<Loro | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loroRef = useRef(loro)
@@ -55,11 +64,13 @@ export function useMarkdownCanvasDoc(
   useEffect(() => {
     if (!enabled || canvasId === null) {
       docRef.current = null
+      setDoc(null)
       setBodyState(null)
       setCoreMetaState(null)
       return
     }
     let cancelled = false
+    let unsubscribe: (() => void) | undefined
     void loroRef.current.load(canvasId).then((result) => {
       if (cancelled) return
       const doc = new Loro()
@@ -72,11 +83,23 @@ export function useMarkdownCanvasDoc(
         }
       }
       docRef.current = doc
+      // Subscribed AFTER the initial import, so loading never schedules a
+      // save of what was just loaded. This is how commits made OUTSIDE
+      // setBody — a CRDT binding mutating the 'body' container directly —
+      // still reach the body state (and the preview) and get persisted.
+      unsubscribe = doc.subscribe((event) => {
+        if (cancelled) return
+        setBodyState(doc.getText('body').toString())
+        setCoreMetaState(readCoreFacets(doc) ?? DEFAULT_MARKDOWN_CORE_META)
+        if (event.by === 'local') scheduleSaveRef.current?.()
+      })
+      setDoc(doc)
       setBodyState(doc.getText('body').toString())
       setCoreMetaState(readCoreFacets(doc) ?? DEFAULT_MARKDOWN_CORE_META)
     })
     return () => {
       cancelled = true
+      unsubscribe?.()
       // FLUSH, not cancel. A pending debounce holds edits that are already in
       // the document and already on screen; dropping it loses whatever was
       // typed in the last 500ms before a canvas switch or unmount. For the
@@ -95,7 +118,10 @@ export function useMarkdownCanvasDoc(
   }, [canvasId, enabled])
 
   // One timer for both writers: they export the same document, so a second
-  // independent debounce would only duplicate the save.
+  // independent debounce would only duplicate the save. Reached through a
+  // ref from the doc subscription, which is created inside the load effect
+  // before this binding initializes on the first render.
+  const scheduleSaveRef = useRef<(() => void) | null>(null)
   const scheduleSave = useCallback(() => {
     if (canvasId === null) return
     if (timerRef.current !== null) clearTimeout(timerRef.current)
@@ -106,6 +132,7 @@ export function useMarkdownCanvasDoc(
       void loroRef.current.save(canvasId, doc.export({ mode: 'snapshot' }))
     }, SAVE_DEBOUNCE_MS)
   }, [canvasId])
+  scheduleSaveRef.current = scheduleSave
 
   const setBody = useCallback(
     (next: string) => {
@@ -138,5 +165,5 @@ export function useMarkdownCanvasDoc(
     [scheduleSave],
   )
 
-  return { body, setBody, coreMeta, setCoreMeta }
+  return { body, setBody, coreMeta, setCoreMeta, doc }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      loro-codemirror:
+        specifier: ^0.3.3
+        version: 0.3.3(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)(loro-crdt@1.13.6)
       loro-crdt:
         specifier: 'catalog:'
         version: 1.13.6
@@ -6076,6 +6079,13 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loro-codemirror@0.3.3:
+    resolution: {integrity: sha512-C6qAUmDjMTyoXVeDxKWixvr/TSTo/jXFrvgGW+wn6RAHeIzNFovBDLQNi/Sary4Ahx8DaYADTCm9eCaRAjvWtw==}
+    peerDependencies:
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.7.0
+      loro-crdt: ^1.8.2
 
   loro-crdt@1.13.6:
     resolution: {integrity: sha512-OsnKW64J+1XdCMafAqR+aASn/wQEgDzwcDwu6dDOVSxxbLPFgnU6LX8ja+hd5PnEcT+kuz9eXSagvlYXsRbQIw==}
@@ -13408,6 +13418,12 @@ snapshots:
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
+
+  loro-codemirror@0.3.3(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)(loro-crdt@1.13.6):
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.7
+      loro-crdt: 1.13.6
 
   loro-crdt@1.13.6: {}
 


### PR DESCRIPTION
## Summary

The markdown source pane now binds directly to the Loro document (`loro-codemirror`'s `LoroSyncPlugin`), wired at the composition root — resolving the `loro-codemirror-binding` backlog issue on its own terms:

- **Hook** (`useMarkdownCanvasDoc`): exposes the loaded `Loro` instance and subscribes to it, so commits made outside `setBody` — exactly what the binding produces — refresh the body state (preview, word count) and schedule the debounced save. Local commits only; loading/imports are never re-persisted.
- **Editor seam**: `SourcePane` accepts host `extensions` at view creation, `MarkdownEditor` passes them through as `sourceExtensions`. A bound host disables the controlled value-reconcile path — the binding owns editor↔document sync, and reconciling as well would race it and double-apply. MarkdownEditor stays a plain controlled component for tests and non-CRDT hosts, exactly as the issue asked ("alternative wiring, not a rewrite").
- **Page**: browser-local markdown notes get the binding; edits land in the `'body'` text container as **real deltas** instead of `setBody`'s wholesale delete-all+insert (whose comment had promised exactly this slice), and `onChange` becomes a no-op under the binding since the doc subscription drives state and saves.

`loro-codemirror@0.3.3` (peer `loro-crdt ^1.8.2`, ours 1.13.6) rides in the lazy page chunk.

## What the browser test pins

Real-browser (`loro-binding.browser.test.tsx`):
1. Typing lands in the Loro body container.
2. A **remote edit** (an import from a second peer, prepending 7 chars) merges into the visible editor without touching the controlled `value`, and the local caret shifts by exactly the inserted length — typing after the merge inserts at the same logical spot (`REMOTE alpha Xomega`). This is the exact-caret behavior the `minimalChange` reconcile could only approximate.

`source-pane-reconcile.browser.test.tsx` (the non-bound path's pinned caret behavior) stays green and untouched.

## Visual repro

Typed through the binding, reloaded — the text persisted via the subscription-driven save and renders in both panes:

![loro-binding.png](https://github.com/user-attachments/assets/82414a0a-85ce-476a-b843-ee624f064a27)

## Test plan

- [x] Hook tests (red-first): doc exposure; a commit made outside `setBody` refreshes body state and persists
- [x] Browser binding tests: typing→CRDT deltas; remote-merge caret exactness
- [x] Full web suites (jsdom + browser markdown-editor), `pnpm -r typecheck`, lint, knip green
- [x] Manual verification in the running app (type → reload → persisted, no console errors)
