### PR TITLE
fix(web): mount polite live regions before the message they announce

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -456,7 +456,7 @@ describe('WorkspaceTopBar browser mode', () => {
 
     // The announcement is still reachable in the accessibility tree even
     // though it is no longer a DOM child of the menu.
-    const status = screen.getByRole('status')
+    const status = screen.getByRole('status', { name: 'Copy status' })
     expect(status.textContent).toContain("Couldn't copy the canvas URL automatically.")
     expect(menu.contains(status)).toBe(false)
 

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -906,7 +906,9 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
       await vi.waitFor(() => expect(screen.getByText('Copied!')).toBeTruthy())
       expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/canvas/ws_1/canvas-a'))
       // Screen-reader-visible announcement, independent of the visible label.
-      expect(screen.getByRole('status').textContent).toContain('Canvas URL copied to clipboard.')
+      expect(screen.getByRole('status', { name: 'Copy status' }).textContent).toContain(
+        'Canvas URL copied to clipboard.',
+      )
 
       await act(async () => {
         vi.advanceTimersByTime(2000)
@@ -932,7 +934,7 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
     const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain("Couldn't copy automatically")
     expect(screen.queryByText('Copied!')).toBeNull()
-    expect(screen.getByRole('status').textContent).toContain(
+    expect(screen.getByRole('status', { name: 'Copy status' }).textContent).toContain(
       "Couldn't copy the canvas URL automatically.",
     )
 
@@ -959,7 +961,7 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
     fireEvent.pointerUp(copyItem)
 
     const alert = await screen.findByRole('alert')
-    const status = screen.getByRole('status')
+    const status = screen.getByRole('status', { name: 'Copy status' })
     const menu = screen.getByRole('menu')
 
     expect(menu.contains(alert)).toBe(false)

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1222,6 +1222,46 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
     expect(onCreateCanvas).toHaveBeenCalledTimes(1)
   })
 
+  it('announces the in-flight create through a region that was already there', async () => {
+    let resolveCreate: () => void = () => {}
+    const onCreateCanvas = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve
+        }),
+    )
+    render(
+      <WorkspaceTopBar
+        dataMode="local"
+        workspaceId="ws_1"
+        slug="canvas-a"
+        canvases={[{ slug: 'canvas-a', updatedAt: '2026-04-23T00:00:00Z', name: 'Canvas A' }]}
+        onToggleFullscreen={() => {}}
+        onNavigateToCanvas={() => {}}
+        onRenameCanvas={() => {}}
+        onCreateCanvas={onCreateCanvas}
+      />,
+      { container: document.body },
+    )
+
+    // Present and silent BEFORE anything happens: a polite region that
+    // arrives carrying its first message is announced unreliably.
+    const region = screen.getByRole('status', { name: 'New canvas status' })
+    expect(region.textContent).toBe('')
+
+    const switcher = screen.getByRole('button', { name: /^Workspace:/i })
+    fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
+    fireEvent.pointerUp(await screen.findByTestId('new-canvas-menu-item'))
+
+    await waitFor(() => expect(region.textContent).toBe('Creating canvas…'))
+    // The SAME element, not a replacement — this is what makes the update an
+    // announcement rather than an insertion.
+    expect(screen.getByRole('status', { name: 'New canvas status' })).toBe(region)
+
+    resolveCreate()
+    await waitFor(() => expect(region.textContent).toBe(''))
+  })
+
   it('never renders the daemon-only thumbnail <img> or the pin affordance in the canvas switcher', async () => {
     render(
       <WorkspaceTopBar

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -301,11 +301,17 @@ export default function WorkspaceTopBar({
             failure states render here beside the switcher. The status line
             replaces the deleted dialog's disabled "Creating…" button as the
             flow's announced busy indication (accessibility criterion 5). */}
-        {newCanvasBusy && (
-          <span aria-live="polite" role="status" className="text-xs text-muted-foreground">
-            Creating canvas…
-          </span>
-        )}
+        {/* Mounted even while silent: a polite region that arrives already
+            carrying its message is announced inconsistently, so this one is
+            always here and only its text changes. */}
+        <span
+          aria-live="polite"
+          role="status"
+          aria-label="New canvas status"
+          className="text-xs text-muted-foreground empty:hidden"
+        >
+          {newCanvasBusy ? 'Creating canvas…' : ''}
+        </span>
         {newCanvasError && (
           <span className="truncate text-xs text-destructive" role="alert">
             {newCanvasError}

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -303,12 +303,16 @@ export default function WorkspaceTopBar({
             flow's announced busy indication (accessibility criterion 5). */}
         {/* Mounted even while silent: a polite region that arrives already
             carrying its message is announced inconsistently, so this one is
-            always here and only its text changes. */}
+            always here and only its text changes.
+            `sr-only` rather than a `hidden` class while idle — display:none
+            would prune it from the accessibility tree, which is the same bug
+            with a stylesheet instead of a conditional. sr-only is absolutely
+            positioned, so an empty region also adds no gap to this flex row. */}
         <span
           aria-live="polite"
           role="status"
           aria-label="New canvas status"
-          className="text-xs text-muted-foreground empty:hidden"
+          className={newCanvasBusy ? 'text-xs text-muted-foreground' : 'sr-only'}
         >
           {newCanvasBusy ? 'Creating canvas…' : ''}
         </span>

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -65,13 +65,18 @@ export function ConnectionStatus({
   onDisconnect,
   children,
 }: ConnectionStatusProps) {
+  // Empty while sync is on: the region has to exist BEFORE the message, but
+  // an empty one must not claim a name either.
+  const syncOffAnnouncement = state === 'sync-off' ? 'Live sync off' : ''
+
   return (
     <Popover>
-      {state === 'sync-off' && (
-        <span role="status" aria-label="Live sync off" className="sr-only">
-          Live sync off
-        </span>
-      )}
+      {/* Always mounted, for the same reason as the busy line in
+          WorkspaceTopBar: sync going off is a CHANGE, and a live region that
+          appears together with its first message may never be announced. */}
+      <span role="status" aria-label={syncOffAnnouncement || undefined} className="sr-only">
+        {syncOffAnnouncement}
+      </span>
       <PopoverTrigger asChild>
         <button
           type="button"

--- a/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
+++ b/apps/web/src/components/spatial-editor/LinkUrlDialog.tsx
@@ -104,7 +104,7 @@ export function LinkUrlDialog({ title, initialUrl, onSubmit, onCancel }: LinkUrl
           id={errorId}
           data-testid="link-url-error"
           role="status"
-          className="max-w-72 text-destructive text-xs empty:hidden"
+          className={refusal === null ? 'sr-only' : 'max-w-72 text-destructive text-xs'}
         >
           {refusal ?? ''}
         </p>

--- a/apps/web/src/components/workspace-top-bar/CanvasActionsMenu.tsx
+++ b/apps/web/src/components/workspace-top-bar/CanvasActionsMenu.tsx
@@ -116,7 +116,7 @@ export function CanvasActionsMenu({
              this page's own DOM. */}
       {typeof document !== 'undefined' &&
         createPortal(
-          <div aria-live="polite" role="status" className="sr-only">
+          <div aria-live="polite" role="status" aria-label="Copy status" className="sr-only">
             {copyStatus === 'copied' && 'Canvas URL copied to clipboard.'}
             {copyStatus === 'error' && "Couldn't copy the canvas URL automatically."}
           </div>,

--- a/apps/web/src/polite-live-region.test.ts
+++ b/apps/web/src/polite-live-region.test.ts
@@ -48,10 +48,41 @@ function offendingLines(source: string): number[] {
   )
 }
 
+/**
+ * The opening tag of every `role="status"` element, so its own attributes can
+ * be examined.
+ */
+const STATUS_TAGS = /<[a-zA-Z][^<]*?role="status"[^<]*?>/gs
+
+/**
+ * `display: none` prunes a subtree from the accessibility tree, so a region
+ * hidden that way is not a live region at all while it is hidden — it starts
+ * existing, for assistive tech, in the same commit that gives it its text.
+ * That is the mount bug wearing a stylesheet. `sr-only` is the safe way to
+ * hide one: absolutely positioned and clipped, still in the tree, and out of
+ * flex flow so an empty region adds no gap.
+ */
+const DISPLAY_NONE_CLASSES = /\b(?:empty:)?hidden\b/
+
 describe('polite live regions are mounted before they speak', () => {
   it('scans a plausible number of sources, so a broken glob cannot pass vacuously', () => {
     expect(Object.keys(sourceModules).length).toBeGreaterThan(30)
     expect(Object.values(sourceModules).join('')).toContain('role="status"')
+  })
+
+  it('never hides a status region with display:none', () => {
+    const offenders = Object.entries(sourceModules)
+      .filter(([path]) => !path.includes('.test.'))
+      .flatMap(([path, source]) =>
+        [...source.matchAll(STATUS_TAGS)]
+          .filter((m) => DISPLAY_NONE_CLASSES.test(m[0]))
+          .map((m) => `${path}:${source.slice(0, m.index).split('\n').length}`),
+      )
+
+    expect(
+      offenders,
+      `Use sr-only, not a display:none class — a hidden region leaves the accessibility tree and re-enters it carrying its message, which is the bug this file exists to prevent: ${offenders.join(', ')}`,
+    ).toEqual([])
   })
 
   it('has no role="status" element behind a conditional render', () => {

--- a/apps/web/src/polite-live-region.test.ts
+++ b/apps/web/src/polite-live-region.test.ts
@@ -1,0 +1,67 @@
+/**
+ * A polite live region must be in the DOM BEFORE the text it announces.
+ *
+ * A `role="status"` element inserted already carrying its message is
+ * announced inconsistently — Safari with VoiceOver and several NVDA setups
+ * miss it — while one that is already mounted when its text changes is
+ * announced reliably. Rendering it as `{busy && <span role="status">…}` is
+ * therefore a silent accessibility bug: it looks correct, tests green, and
+ * the message simply never reaches the person who needed it most.
+ *
+ * `role="alert"` is deliberately NOT covered. Injecting an alert with its
+ * content is the widely-supported pattern for form errors, and sweeping the
+ * repo's fifteen of them into always-mounted containers would be churn
+ * without a defect behind it.
+ *
+ * Sources come from Vite's build-time `import.meta.glob` (raw text), the
+ * same shape as daemon-auth-seam.test.ts, so this needs no `node:fs` —
+ * apps/web is browser-only (see web-app-boundary.test.ts).
+ */
+import { describe, expect, it } from 'vitest'
+
+const sourceModules = import.meta.glob('./**/*.tsx', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+/**
+ * A live region whose CONTENT is a layout placeholder rather than a
+ * sentence. Mounting an empty skeleton grid permanently would put an
+ * invisible four-cell scaffold in every list page to announce nothing; the
+ * arrival of the real content is what these tell someone about, and that is
+ * a DOM replacement they perceive either way.
+ */
+const SKELETON_EXCEPTIONS = ['./pages/BrowserLocalIndexPage.tsx', './pages/DaemonIndexPage.tsx']
+
+/**
+ * `{cond && <el ... role="status"`, across the line breaks a formatter puts
+ * between the opening brace and the role. Deliberately loose about what sits
+ * between: any conditional that gates a status element is the bug, whatever
+ * the guard expression looks like.
+ */
+const CONDITIONAL_STATUS = /(?:&&|\?)\s*\(?\s*<[a-zA-Z][^>]{0,400}?role="status"/gs
+
+function offendingLines(source: string): number[] {
+  return [...source.matchAll(CONDITIONAL_STATUS)].map(
+    (m) => source.slice(0, m.index).split('\n').length,
+  )
+}
+
+describe('polite live regions are mounted before they speak', () => {
+  it('scans a plausible number of sources, so a broken glob cannot pass vacuously', () => {
+    expect(Object.keys(sourceModules).length).toBeGreaterThan(30)
+    expect(Object.values(sourceModules).join('')).toContain('role="status"')
+  })
+
+  it('has no role="status" element behind a conditional render', () => {
+    const offenders = Object.entries(sourceModules)
+      .filter(([path]) => !path.includes('.test.') && !SKELETON_EXCEPTIONS.includes(path))
+      .flatMap(([path, source]) => offendingLines(source).map((line) => `${path}:${line}`))
+
+    expect(
+      offenders,
+      `Mount the region and change its text instead — a role="status" that arrives WITH its message is announced inconsistently: ${offenders.join(', ')}`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-up to #793, which fixed one instance of this and noted the pattern was repo-wide.

A `role="status"` element **inserted already carrying its text** is announced inconsistently — Safari with VoiceOver and several NVDA setups miss it — while one already in the DOM when its text changes is announced reliably. It is a silent failure: the code looks right, the tests pass, and the message just never reaches the person who most needed it.

## Scope came from measuring, not from the report

The review on #793 named four sites. Scanning all of `apps/web` found **21** conditionally-mounted live regions — and then narrowed to **two**:

| | count | verdict |
|---|---|---|
| `role="alert"` | 15 | **left alone** — injecting an alert with its content is the widely-supported pattern for form errors; sweeping these is churn without a defect behind it |
| `role="status"` on a loading **skeleton** | 2 | **left alone** — a permanently mounted, empty four-cell scaffold announcing nothing is worse than what is there |
| `role="status"` carrying a **sentence** | **2** | **fixed** |

The two fixed: the `Creating canvas…` busy line in the top bar, and the sr-only `Live sync off` state in the connection chip.

## A guard, not a note

`polite-live-region.test.ts` scans every `apps/web` `.tsx` for a status role behind a conditional, with the two skeletons named as documented exceptions. **It found precisely the two sites this PR fixes — that is also its mutation check.** Same shape as `App.lazy-coverage.test.ts`, and for the same stated reason: a rule in a comment goes stale, a guard does not. Source is read through Vite's `?raw` glob, so no `node:fs` in browser-only apps/web.

It also asserts it scanned a plausible number of files and that `role="status"` appears at all, so a broken glob cannot pass vacuously.

## One consequence worth flagging

Both regions gained an accessible name. The top bar now has two live regions, and the existing copy-feedback tests queried `getByRole('status')` bare — an assertion that there is exactly **one** live region in the entire app. That was fragile before this change and would have broken on whatever added the next one; the queries are now name-scoped.

## Verification

- apps/web jsdom (the CI `test-jsdom` command) — 2136 + 75 passed
- `pnpm test --project web-browser` — 542 passed; typecheck and lint clean
- Real browser on a canvas page: all three polite regions present and **empty** before any message — which is the entire point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader announcements for canvas creation, connection sync issues, and copy actions.
  * Status messages now remain consistently available to assistive technologies while updating dynamically.
  * Added an accessible “Copy status” label for clearer clipboard feedback.

* **Tests**
  * Expanded accessibility coverage to verify live status regions behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->