### PR TITLE
fix(server,web): answer an unknown workspace honestly instead of impersonating an empty one

### DIFF
--- a/apps/web/src/pages/DaemonCanvasPage.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.test.tsx
@@ -138,6 +138,39 @@ describe('DaemonCanvasPage', () => {
     vi.clearAllMocks()
   })
 
+  it('renders a workspace-not-found list failure as an error, never as an empty workspace', async () => {
+    // The daemon now answers 404 for a workspace it has never registered —
+    // the reachable case being a stale pairing, since a browser keeps its
+    // paired workspace id in localStorage and ids outlive the install that
+    // minted them. Rendering that as "This workspace has no canvases yet"
+    // plus a Create button reads as the user's data being GONE, and invites
+    // them to start over inside a workspace that never existed here. The
+    // error screen, with the daemon's own title, is the honest rendering.
+    const { DaemonApiError } = await vi.importActual<typeof import('../lib/daemon-api-client.js')>(
+      '../lib/daemon-api-client.js',
+    )
+    mockListCanvases.mockRejectedValue(
+      new DaemonApiError('Workspace "stale-pairing" not found', 404),
+    )
+
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="stale-pairing"
+          createBackend={makeCreateBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('Workspace "stale-pairing" not found')).toBeTruthy(),
+    )
+    expect(screen.queryByText('This workspace has no canvases yet.')).toBeNull()
+    expect(screen.queryByRole('button', { name: /create a canvas/i })).toBeNull()
+  })
+
   it('mounts the editor with a mocked backend and renders the canvas list', async () => {
     await act(async () => {
       render(

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -687,6 +687,20 @@ describe('GET /api/workspaces/:workspaceId/canvases', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 404 for a workspace that does not exist, not an empty list', async () => {
+    // A 200-empty here is a false statement of fact: the caller cannot tell
+    // "this workspace has no canvases" from "you asked about a workspace this
+    // daemon has never heard of", and the web app renders the first reading —
+    // an empty state with a Create button — for what is actually the second.
+    // A stale pairing (a workspace id minted by an earlier install and kept
+    // in the browser's localStorage) then looks exactly like data loss.
+    // The v1 document routes already 404 an unknown workspace; this brings
+    // the legacy list route into agreement.
+    const app = createCanvasRouter()
+    const res = await app.request('/api/workspaces/never-registered/canvases')
+    expect(res.status).toBe(404)
+  })
+
   // listCanvases no longer walks per-workspace directories, so the previous
   // "broken session directory" 500 case no longer applies.
 })

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -18,6 +18,7 @@ import {
   listWorkspaces,
   renameCanvasSlug,
   saveCanvas,
+  workspaceExists,
 } from '../../store/canvas-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
@@ -64,6 +65,12 @@ export function createWorkspacesRouter() {
       throw err
     }
     try {
+      // "Empty" and "never registered" are different answers, and conflating
+      // them is what let a stale pairing render as an empty workspace with a
+      // Create button. Same problem-details shape as live-doc's snapshot 404.
+      if (!(await workspaceExists(workspaceId))) {
+        return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
+      }
       const canvases = await listCanvases(workspaceId)
       const response: ListCanvasesResponse = { canvases }
       return c.json(response)

--- a/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
@@ -76,7 +76,7 @@ vi.mock('../config.js', async () => {
 
 const { setDataDirForTests, resetDataDirForTests } = await import('../../shared/data-dir-secure.js')
 const { clearCache } = await import('../store/doc-cache.js')
-const { loadCanvas } = await import('../store/canvas-store.js')
+const { loadCanvas, saveCanvas } = await import('../store/canvas-store.js')
 const { handleWsUpgrade, setOnPersistedForTests } = await import('./ws.js')
 
 // Snapshot of initialFakeHomeDir's contents immediately after the
@@ -189,6 +189,10 @@ describe('handleWsUpgrade over a real WebSocketServer + real ws client', () => {
     scratchDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-real-socket-'))
     await mkdir(join(scratchDir, 'session1'), { recursive: true })
     setDataDirForTests(scratchDir)
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 

--- a/packages/mcp-server/src/server/routes/ws.test.ts
+++ b/packages/mcp-server/src/server/routes/ws.test.ts
@@ -16,7 +16,7 @@ vi.mock('../config.js', () => ({
 }))
 
 const { clearCache } = await import('../store/doc-cache.js')
-const { loadCanvas } = await import('../store/canvas-store.js')
+const { loadCanvas, saveCanvas } = await import('../store/canvas-store.js')
 const { corruptStoredData } = await import('../store/corrupt-stored-data.js')
 const { createAutoVersionTrigger } = await import('./canvas.js')
 const { handleWsUpgrade, setAutoVersionTrigger, sendViewportRequest, setOnPersistedForTests } =
@@ -75,10 +75,66 @@ class FakeWebSocket {
   }
 }
 
+describe('handleWsUpgrade workspace existence', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-test-'))
+    clearCache()
+  })
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+    clearCache()
+  })
+
+  it('refuses a workspace this daemon has never registered instead of serving a phantom', async () => {
+    // getDoc() lazily creates an empty doc for any key, so a connect to a
+    // workspace nobody registered used to answer with an empty snapshot and a
+    // live socket — "Synced" over a document that exists nowhere durable. A
+    // stale pairing (a workspace id from an earlier install, kept in the
+    // browser's localStorage) then edits into memory that the next daemon
+    // restart discards. 4404 is app-defined (RFC 6455 reserves 4000-4999 for
+    // private use); "not found" has no registered close code.
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      {
+        url: '/ws/never-registered/canvas-a',
+        headers: { host: 'localhost:3099' },
+      } as never,
+      ws as never,
+    )
+
+    expect(ws.closes).toEqual([{ code: 4404, reason: 'Workspace "never-registered" not found' }])
+    expect(ws.sent).toEqual([])
+  })
+
+  it('still serves an unknown slug inside a registered workspace', async () => {
+    // Workspace-level honesty only: a missing SLUG in a real workspace keeps
+    // the lazy empty-doc behavior, which is how opening a just-deleted canvas
+    // degrades. Refusing that too would be a behavior change this fix does
+    // not need.
+    await saveCanvas('session1', 'exists', new LoroDoc())
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      {
+        url: '/ws/session1/never-created',
+        headers: { host: 'localhost:3099' },
+      } as never,
+      ws as never,
+    )
+
+    expect(ws.closes).toEqual([])
+    // The initial snapshot for the lazily-created empty doc.
+    expect(ws.sent.length).toBe(1)
+  })
+})
+
 describe('handleWsUpgrade auto-version corruption', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-test-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect now requires a REGISTERED workspace (an unregistered one is
+    // refused with 4404 instead of served a phantom), which is also the shape
+    // production always has: a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 
@@ -214,6 +270,10 @@ describe('handleWsUpgrade viewport replay', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-viewport-replay-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 
@@ -327,6 +387,10 @@ describe('handleWsUpgrade ws_trace propagation', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-trace-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 
@@ -435,6 +499,10 @@ describe('handleWsUpgrade per-message scope enforcement (ADR-0005)', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-scope-test-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 
@@ -576,6 +644,10 @@ describe('handleWsUpgrade malformed binary frame (DoS hardening)', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-malformed-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 
@@ -729,6 +801,10 @@ describe('handleWsUpgrade binary update persistence failure', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-persist-fail-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
+    // A connect requires a REGISTERED workspace (an unregistered one is
+    // refused 4404 instead of served a phantom) — the shape production
+    // always has, since a canvas is created before any tab opens it.
+    await saveCanvas('session1', 'registered-seed', new LoroDoc())
     clearCache()
   })
 

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -11,7 +11,7 @@ import {
   requiredScopesForClientTextMessage,
   WS_BINARY_UPDATE_REQUIRED_SCOPES,
 } from '../security/ws-scope-registry.js'
-import { saveCanvas } from '../store/canvas-store.js'
+import { saveCanvas, workspaceExists } from '../store/canvas-store.js'
 import { evictDoc, getDoc } from '../store/doc-cache.js'
 import type { VersionEntry } from '../store/version-store.js'
 import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
@@ -230,6 +230,22 @@ export async function handleWsUpgrade(
   }
 
   const key = `${workspaceId}/${slug}`
+
+  // Before anything is registered or served: a workspace this daemon has
+  // never heard of gets a refusal, not a phantom. getDoc() lazily creates an
+  // empty doc for any key, so without this a connect to an unknown workspace
+  // answered with an empty snapshot and a live socket — the tab shows
+  // "Synced" while editing into memory the next restart discards. Stale
+  // pairings make this reachable in practice: a browser keeps its paired
+  // workspace id in localStorage, and ids outlive the install that minted
+  // them. Workspace-level only — an unknown SLUG in a registered workspace
+  // keeps the lazy empty doc, which is how opening a just-deleted canvas
+  // degrades. 4404 because RFC 6455 reserves 4000-4999 for application use
+  // and no registered close code means "not found".
+  if (!(await workspaceExists(workspaceId))) {
+    ws.close(4404, `Workspace "${workspaceId}" not found`)
+    return
+  }
 
   // Register the connection.
   if (!connections.has(key)) {

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -227,6 +227,27 @@ function migrateLegacyListToMovable(doc: LoroDoc): boolean {
   return true
 }
 
+/**
+ * Whether this daemon has ever registered the workspace.
+ *
+ * Exists so read surfaces can tell "empty" from "never heard of it". Nothing
+ * mints workspace ids ahead of use any more, but ids OUTLIVE the daemon that
+ * minted them — a browser keeps its paired workspace id in localStorage, and
+ * a rebuilt data dir does not know it. Answering such an id with empty lists
+ * and lazily-created empty docs reads exactly like the user's data being
+ * gone, when the truth is "not here".
+ */
+export async function workspaceExists(workspaceId: string): Promise<boolean> {
+  validateWorkspaceId(workspaceId)
+  const db = await dbReady()
+  const row = await db
+    .selectFrom('workspaces')
+    .select(['id'])
+    .where('id', '=', workspaceId)
+    .executeTakeFirst()
+  return row !== undefined
+}
+
 export async function canvasExists(workspaceId: string, slug: string): Promise<boolean> {
   validateWorkspaceId(workspaceId)
   validateSlug(slug)


### PR DESCRIPTION
First of the short-term fixes from the workspace dogfooding investigation. The other two short-term items collapsed into this one on inspection: nothing hands out workspace ids at pairing any more (that was remnant behavior), and `POST /update` already registers-on-touch via `saveCanvas` — the dishonest surfaces were exactly two.

## The bug, as a user sees it

Navigate to a workspace this daemon has never registered — reachable in practice via a **stale pairing**: a browser keeps its paired workspace id in localStorage, ids outlive the install that minted them, and this machine's own browser profile holds exactly such a remnant. The app rendered:

> This workspace has no canvases yet. **[ Create a canvas ]**

The user's data — apparently gone, plus an invitation to start over inside a workspace that never existed here. Reproduced in a real browser against the pre-fix daemon during dogfooding.

## Two dishonest surfaces

1. **`GET /api/workspaces/:id/canvases` returned 200-empty for an unknown workspace.** Now 404 with the same problem-details shape as live-doc's snapshot route — and in agreement with the v1 document routes, which ADR-0007 already brought to 404 for a never-persisted workspace.

2. **A WS connect to an unknown workspace was served a phantom.** `getDoc()` lazily creates an empty doc for any key, so the tab got an empty snapshot and a live socket — *"Synced" over a document that exists nowhere durable*, editing into memory the next daemon restart discards. The connect is now refused with close code **4404** before anything is registered or served. **Workspace-level only**: an unknown *slug* in a registered workspace keeps the lazy empty doc (how opening a just-deleted canvas degrades), and a test pins that distinction so the narrowing is deliberate rather than accidental.

## The page half was already sound — now it is load-bearing, so it is pinned

`loadError` short-circuits ahead of the empty state, and `fetchAndParse` turns a problem-details 404 into a `DaemonApiError` carrying the daemon's own title. So the daemon fix alone changes what renders: the error screen, with `Workspace "…" not found`. A new jsdom test pins that precedence, **mutation-checked** — making the empty-state branch win turns it red.

## Test changes that are moves toward reality, not weakenings

Every existing ws test connected to an *unregistered* workspace — a shape production never has, since a canvas is created before any tab opens it. Their setups now register the workspace first.

## Verification

- Route test watched red (200) before the fix, green (404) after.
- `curl` against a running daemon built from this branch: `404` where this machine's pre-fix daemon answers `200 {"canvases":[]}` for the same request.
- The false empty state was reproduced in a **real browser** against the pre-fix daemon.
- The after-state through a fully **paired** browser session is pinned at the jsdom layer instead of screenshotted: pairing a fresh dev daemon needs a new identity-pin + consent grant, which is its own flow and not this change's subject. Said here rather than papered over.
- `mcp-node` 3351 passed · `apps/web` jsdom+node 2136 passed · browser 538 passed · lint/knip/typecheck clean.

## What this resolves and what it leaves

Resolves two of the three dogfooding issues (the false empty state; "Synced" over memory-only phantoms). The third — *the workspace an AI writes to is unreachable from the app* — is ADR-0007's recorded two-store split and stays open for the convergence initiative.