### PR TITLE
refactor(web)!: nest the canvas URL under its workspace

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -63,8 +63,10 @@ Not a work queue — a lookup, so you can recognise one when you open a file.
 - The `@kamiazya/whiteboard-canvas-{model,codec,render,ports,workspace,viewer}`
   package names — `render` and `viewer` are arguably correct (they are about
   the spatial scene); `model`, `codec`, `ports` and `workspace` are not
-- `/canvas/:ws/:slug` and `/local/:canvasId` routes, and the UI copy around
-  them — published surface, so its own increment
+- `/w/:ws/canvas/:slug` and `/local/:canvasId` routes, and the UI copy around
+  them. The shape is now workspace-first, but the tail is still a `slug` rather
+  than the document's path — it stays that way until the page stops loading
+  through `/api/canvas/:workspaceId/:slug`
 - MCP tool names — ADR-0009 point 5, its own increment
 - Core facets written to spatial documents (`CanvasProperties` mounted for
   both kinds) — this one is a behaviour change, not a rename; see ADR-0009

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Add to `~/.gemini/settings.json`:
 
 ### Verify
 
-In your agent session, ask it to call `wb_canvas_create({ workspaceId: "default", segment: "smoke" })`. The call creates `~/.whiteboard/{workspaceId}/`; open `http://127.0.0.1:<port>/canvas/{workspaceId}/smoke` in a browser tab to see it.
+In your agent session, ask it to call `wb_document_create({ workspaceId: "default", path: "smoke", kind: "spatial" })`. The call creates `~/.whiteboard/{workspaceId}/`; open `http://127.0.0.1:<port>/w/{workspaceId}/canvas/smoke` in a browser tab to see it.
 
 ## Pair with your local daemon
 
@@ -189,18 +189,19 @@ Three opinionated `SKILL.md` packs ship inside the npm package. The recommended 
 You    Use whiteboard to sketch the request flow for our auth service:
        client → API gateway → token service → DB. Highlight where caching lives.
 
-Agent  { canvasId } = wb_canvas_create({ workspaceId: "default", segment: "auth-flow" })
-       node_patch({ canvasId, nodes: [ /* 4 service boxes */ ] })
-       edge_patch({ canvasId, edges: [ /* arrows between them */ ] })
-       node_patch({ canvasId, nodes: [ { id: "cache-note", type: "text",
-                                         x: 240, y: 360, text: "cache lives here" } ] })
-       canvas_render_svg({ canvasId })
+Agent  { canvasId } = wb_document_create({ workspaceId: "default",
+                                          path: "auth-flow", kind: "spatial" })
+       wb_node_add({ canvasId, node: /* one of 4 service boxes */ })
+       wb_edge_add({ canvasId, edge: /* an arrow between two of them */ })
+       wb_node_add({ canvasId, node: { id: "cache-note", type: "text",
+                                       x: 240, y: 360, text: "cache lives here" } })
+       wb_scene_render({ canvasId })
 
        Drew a 4-stage flow on the auth-flow canvas. Cache callout placed
        between API gateway and token service. SVG attached.
 ```
 
-The agent returns the `canvas_render_svg` result so the next turn can reason about what was actually drawn — closing the loop between prompt and pixels.
+The agent returns the `wb_scene_render` result so the next turn can reason about what was actually drawn — closing the loop between prompt and pixels.
 
 ## Documentation
 
@@ -218,7 +219,7 @@ The agent returns the `canvas_render_svg` result so the next turn can reason abo
 
 ## Limitations
 
-- No MCP tool currently returns a raster (PNG) image or `ImageContent` — `canvas_render_svg` is the closest equivalent for handing a rendered canvas back to an LLM.
+- No MCP tool currently returns a raster (PNG) image or `ImageContent` — `wb_scene_render` is the closest equivalent for handing a rendered canvas back to an LLM.
 - The published transport is `stdio`. The HTTP MCP endpoint (`pnpm mcp:http:dev`) is for local development.
 
 See [docs/reference/configuration.md](docs/reference/configuration.md#codex-sandbox-constraints) for sandbox quirks.

--- a/apps/web/public/_redirects
+++ b/apps/web/public/_redirects
@@ -1,5 +1,6 @@
-# SPA fallback: apps/web now has client-side routes (/canvas/:workspaceId/:slug,
-# /w/:workspaceId, /local/:canvasId) that have no matching file in dist/. Without
+# SPA fallback: apps/web now has client-side routes (/w/:workspaceId,
+# /w/:workspaceId/canvas/:slug, /local/:canvasId) that have no matching file in
+# dist/. Without
 # this rule, Cloudflare Pages 404s any direct load or reload of those URLs —
 # only requests that land on '/' first and navigate client-side ever worked.
 # A 200 rewrite (not a 3xx redirect) keeps the deep-linked URL in the address

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -851,8 +851,8 @@ describe('App URL routing', () => {
     mockDaemonConnectionResult = { status: 'none' }
   })
 
-  it('cold-loads a /canvas/:workspaceId/:slug deep link straight into DaemonCanvasPage', async () => {
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/canvas/w1/main')
+  it('cold-loads a /w/:workspaceId/canvas/:slug deep link straight into DaemonCanvasPage', async () => {
+    renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/canvas/main')
     expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
     expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
     expect(receivedDaemonPageProps?.slug).toBe('main')
@@ -875,11 +875,11 @@ describe('App URL routing', () => {
       onOpenCanvas('w1', 'main')
     })
     await screen.findByTestId('daemon-canvas-page')
-    expect(router.state.location.pathname).toBe('/canvas/w1/main')
+    expect(router.state.location.pathname).toBe('/w/w1/canvas/main')
   })
 
   it('updates the URL back to the gallery when onNavigateBack fires', async () => {
-    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/canvas/w1/main')
+    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/canvas/main')
     await screen.findByTestId('daemon-canvas-page')
     const onNavigateBack = receivedDaemonPageProps?.onNavigateBack as () => void
     act(() => {
@@ -926,7 +926,7 @@ describe('App URL routing', () => {
     }
     const router = renderAppWithRouter(BROWSER_LOCAL_STATE, '/')
     await screen.findByTestId('daemon-canvas-page')
-    expect(router.state.location.pathname).toBe('/canvas/w1/main')
+    expect(router.state.location.pathname).toBe('/w/w1/canvas/main')
     // The replace must not have added a new history entry: going back from
     // here should leave the SPA (nothing left to land on inside this test's
     // single-entry history), not bounce to a stale pre-pairing '/' entry.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -210,7 +210,7 @@ export function App({ providerState }: AppProps) {
   // starts on the gallery pre-scoped to that workspace rather than
   // whichever workspace the daemon happens to list first. Absent a fragment
   // (local-daemon's runtime-config path, or a same-origin cold load of a
-  // `/canvas/:workspaceId/:slug` or `/w/:workspaceId` URL — e.g. a bookmark,
+  // `/w/:workspaceId/canvas/:slug` or `/w/:workspaceId` URL — e.g. a bookmark,
   // a shared link, or R3's "Open the local app" deep link), the URL itself
   // seeds the view. Lazy initializer: both the payload and the pathname at
   // mount time are fixed for the life of the mount.

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -904,7 +904,7 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
       fireEvent.pointerUp(copyItem)
 
       await vi.waitFor(() => expect(screen.getByText('Copied!')).toBeTruthy())
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/canvas/ws_1/canvas-a'))
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/w/ws_1/canvas/canvas-a'))
       // Screen-reader-visible announcement, independent of the visible label.
       expect(screen.getByRole('status').textContent).toContain('Canvas URL copied to clipboard.')
 
@@ -938,7 +938,7 @@ describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
 
     // Fallback: the URL is still available as selectable text.
     const fallbackInput = screen.getByLabelText('Canvas URL') as HTMLInputElement
-    expect(fallbackInput.value).toContain('/canvas/ws_1/canvas-a')
+    expect(fallbackInput.value).toContain('/w/ws_1/canvas/canvas-a')
     expect(fallbackInput.readOnly).toBe(true)
   })
 

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -7,6 +7,7 @@ import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import type { SceneExportFormat } from '@/hooks/useCanvasSync'
 import { useDirtyState } from '@/hooks/useDirtyState'
 import { getAppLogger } from '@/lib/app-logger'
+import { canvasPath } from '../lib/app-routes.js'
 import { HeaderBranchChip } from './HeaderBranchChip'
 import { HeaderSaveDot } from './HeaderSaveDot'
 import { CanvasActionsMenu } from './workspace-top-bar/CanvasActionsMenu'
@@ -204,7 +205,7 @@ export default function WorkspaceTopBar({
 
   // Kept outside copyCanvasUrl so the failure-path fallback can render the
   // same URL as selectable text without recomputing it.
-  const canvasUrl = `${window.location.origin}/canvas/${workspaceId}/${encodeURIComponent(slug)}`
+  const canvasUrl = `${window.location.origin}${canvasPath(workspaceId, slug)}`
   const { copyStatus, copyCanvasUrl, resetCopyStatus } = useCopyCanvasUrl(
     canvasUrl,
     log,

--- a/apps/web/src/lib/app-routes.test.ts
+++ b/apps/web/src/lib/app-routes.test.ts
@@ -22,12 +22,12 @@ describe('app-routes', () => {
     expect(workspacePath('w1')).toBe('/w/w1')
   })
 
-  it('builds a canvas path', () => {
-    expect(canvasPath('w1', 'main')).toBe('/canvas/w1/main')
+  it('builds a canvas path under the workspace it belongs to', () => {
+    expect(canvasPath('w1', 'main')).toBe('/w/w1/canvas/main')
   })
 
-  it('percent-encodes workspaceId and slug segments', () => {
-    expect(canvasPath('w 1', 'my/slug')).toBe('/canvas/w%201/my%2Fslug')
+  it('percent-encodes the workspace and the slug', () => {
+    expect(canvasPath('w 1', 'my/slug')).toBe('/w/w%201/canvas/my%2Fslug')
     expect(workspacePath('w/1')).toBe('/w/w%2F1')
   })
 
@@ -47,7 +47,7 @@ describe('parseDaemonRoute', () => {
   })
 
   it('parses a canvas route', () => {
-    expect(parseDaemonRoute('/canvas/w1/main')).toEqual({
+    expect(parseDaemonRoute('/w/w1/canvas/main')).toEqual({
       kind: 'canvas',
       workspaceId: 'w1',
       slug: 'main',
@@ -55,22 +55,39 @@ describe('parseDaemonRoute', () => {
   })
 
   it('decodes percent-encoded segments', () => {
-    expect(parseDaemonRoute('/canvas/w%201/my%2Fslug')).toEqual({
+    expect(parseDaemonRoute('/w/w%201/canvas/my%2Fslug')).toEqual({
       kind: 'canvas',
       workspaceId: 'w 1',
       slug: 'my/slug',
     })
   })
 
+  it('does not yet accept a multi-segment tail', () => {
+    // The shape leaves room for a document path here, but the page below
+    // still loads by slug through /api/canvas/:workspaceId/:slug — a URL the
+    // app cannot open is worse than a not-found, so it stays not-a-route
+    // until that data path converges too.
+    expect(parseDaemonRoute('/w/w1/canvas/notes/2026/plan')).toBeNull()
+  })
+
+  it('is not confused by the workspace-index route it now nests under', () => {
+    // `/w/w1` and `/w/w1/canvas/...` share a prefix; the canvas branch must
+    // not swallow the bare workspace route, nor the reverse.
+    expect(parseDaemonRoute('/w/w1')).toEqual({ kind: 'index', workspaceId: 'w1' })
+    expect(parseDaemonRoute('/w/w1/canvas')).toBeNull()
+  })
+
   it('returns null for an unrelated path (e.g. the browser-local route space)', () => {
     expect(parseDaemonRoute('/local/abc')).toBeNull()
     expect(parseDaemonRoute('/something/else')).toBeNull()
+    // The retired shape is not a route any more.
+    expect(parseDaemonRoute('/canvas/w1/main')).toBeNull()
   })
 
   it('round-trips through daemonRoutePath', () => {
-    const route = parseDaemonRoute('/canvas/w1/main')
+    const route = parseDaemonRoute('/w/w1/canvas/main')
     expect(route).not.toBeNull()
-    expect(daemonRoutePath(route!)).toBe('/canvas/w1/main')
+    expect(daemonRoutePath(route!)).toBe('/w/w1/canvas/main')
   })
 })
 
@@ -85,7 +102,7 @@ describe('daemonRoutePath', () => {
 
   it('builds a canvas path', () => {
     expect(daemonRoutePath({ kind: 'canvas', workspaceId: 'w1', slug: 'main' })).toBe(
-      '/canvas/w1/main',
+      '/w/w1/canvas/main',
     )
   })
 })
@@ -97,7 +114,7 @@ describe('parseBrowserLocalRoute', () => {
 
   it('returns null for the bare /local index and unrelated paths', () => {
     expect(parseBrowserLocalRoute('/local')).toBeNull()
-    expect(parseBrowserLocalRoute('/canvas/w1/main')).toBeNull()
+    expect(parseBrowserLocalRoute('/w/w1/canvas/main')).toBeNull()
   })
 })
 
@@ -106,8 +123,8 @@ describe('parseBrowserLocalRoute', () => {
 // index.
 describe('malformed percent-encoding', () => {
   it('treats an undecodable segment as not-a-route instead of throwing', () => {
-    expect(parseDaemonRoute('/canvas/w%1/main')).toBeNull()
-    expect(parseDaemonRoute('/canvas/w1/ma%in')).toBeNull()
+    expect(parseDaemonRoute('/w/w%1/canvas/main')).toBeNull()
+    expect(parseDaemonRoute('/w/w1/canvas/ma%in')).toBeNull()
     expect(parseDaemonRoute('/w/%E0%A4%A')).toBeNull()
     expect(parseBrowserLocalRoute('/local/%zz')).toBeNull()
   })
@@ -118,7 +135,7 @@ describe('isKnownAppPath', () => {
     for (const p of [
       '/',
       '/w/ws1',
-      '/canvas/ws1/main',
+      '/w/ws1/canvas/main',
       '/local',
       '/local/c1',
       '/pair',
@@ -132,7 +149,14 @@ describe('isKnownAppPath', () => {
   })
 
   it('rejects unknown paths so App can show not-found instead of silently falling through', () => {
-    for (const p of ['/nope', '/canvas/onlyws', '/local/a/b', '/w/', '/settings/nope']) {
+    for (const p of [
+      '/nope',
+      '/canvas/ws1/main',
+      '/w/ws1/canvas',
+      '/local/a/b',
+      '/w/',
+      '/settings/nope',
+    ]) {
       expect(isKnownAppPath(p)).toBe(false)
     }
   })

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -2,7 +2,7 @@
 // functions (no React Router import) so the shape is unit-testable without a
 // router context and has exactly one place that can drift from
 // DaemonDetectedBanner's deep link (which builds the same
-// `/canvas/:workspaceId/:slug` shape independently, since it runs on a
+// `/w/:workspaceId/canvas/*` shape independently, since it runs on a
 // different origin — the daemon's — and cannot import a client-side route
 // table).
 export function indexPath(): string {
@@ -13,8 +13,11 @@ export function workspacePath(workspaceId: string): string {
   return `/w/${encodeURIComponent(workspaceId)}`
 }
 
+// Nested under the workspace it belongs to, so the URL reads as placement
+// rather than as two unrelated ids. The tail is one encoded segment: the
+// page below still loads by slug, so a document path cannot go here yet.
 export function canvasPath(workspaceId: string, slug: string): string {
-  return `/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}`
+  return `${workspacePath(workspaceId)}/canvas/${encodeURIComponent(slug)}`
 }
 
 export function browserLocalIndexPath(): string {
@@ -34,7 +37,10 @@ export type DaemonRoute =
 // tree exists to match against), and keeping it framework-agnostic lets it
 // be unit-tested without a Router context.
 export function parseDaemonRoute(pathname: string): DaemonRoute | null {
-  const canvasMatch = pathname.match(/^\/canvas\/([^/]+)\/([^/]+)\/?$/)
+  // The canvas branch is checked first: `/w/:ws` and `/w/:ws/canvas/...`
+  // share a prefix, and the workspace pattern below is anchored so it cannot
+  // swallow a canvas URL either way.
+  const canvasMatch = pathname.match(/^\/w\/([^/]+)\/canvas\/([^/]+)\/?$/)
   if (canvasMatch) {
     const workspaceId = decodeSegment(canvasMatch[1])
     const slug = decodeSegment(canvasMatch[2])
@@ -53,7 +59,7 @@ export function parseDaemonRoute(pathname: string): DaemonRoute | null {
 }
 
 // decodeURIComponent throws URIError on a malformed percent sequence
-// (`/canvas/w%1/main`). These parsers run inside render-phase lazy
+// (`/w/w%1/canvas/main`). These parsers run inside render-phase lazy
 // initializers, so a throw here takes down the whole app; an unparseable URL
 // is a not-a-route, not a crash.
 function decodeSegment(segment: string): string | null {

--- a/apps/web/src/lib/canvas-fullscreen-hash.test.ts
+++ b/apps/web/src/lib/canvas-fullscreen-hash.test.ts
@@ -51,7 +51,7 @@ describe('syncFullscreenHash', () => {
 
   it('preserves a non-fullscreen hash on initial mount in non-fullscreen mode', () => {
     const out = run(false, {
-      pathname: '/canvas/ws_a/design',
+      pathname: '/w/ws_a/canvas/design',
       search: '',
       hash: '#addLibrary=https%3A%2F%2Flibs.example%2Fpack',
     })
@@ -61,7 +61,7 @@ describe('syncFullscreenHash', () => {
 
   it('writes #fullscreen when toggled on, even if a different hash existed', () => {
     const out = run(true, {
-      pathname: '/canvas/ws_a/design',
+      pathname: '/w/ws_a/canvas/design',
       search: '?x=1',
       hash: '#addLibrary=foo',
     })
@@ -71,7 +71,7 @@ describe('syncFullscreenHash', () => {
 
   it('clears the hash only when leaving fullscreen mode', () => {
     const out = run(false, {
-      pathname: '/canvas/ws_a/design',
+      pathname: '/w/ws_a/canvas/design',
       search: '',
       hash: '#fullscreen',
     })
@@ -91,7 +91,7 @@ describe('syncFullscreenHash', () => {
     // that already updated the URL. The effect must not aggressively
     // re-write the hash to empty just because isFullscreen is false.
     const out = run(false, {
-      pathname: '/canvas/ws_a/design',
+      pathname: '/w/ws_a/canvas/design',
       search: '',
       hash: '#someOther=1',
     })

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -49,7 +49,7 @@ This project is split into three main runtime layers:
 
 ### Browser collaboration path
 
-1. A browser opens `/canvas/{workspaceId}/{slug}`.
+1. A browser opens `/w/{workspaceId}/canvas/{slug}`.
 2. The app loads the current canvas snapshot from the daemon.
 3. Local edits update the in-memory document and are persisted through daemon routes.
 4. WebSocket events broadcast document changes, version events, and branch head changes.


### PR DESCRIPTION
`/canvas/:workspaceId/:slug` → `/w/:workspaceId/canvas/:slug`.

The address bar now reads as placement — a canvas inside the workspace that
holds it — instead of two unrelated ids in their own namespace. `/w/:workspaceId`
(the gallery) already existed; the canvas simply nests under it.

## The tail stays one segment, deliberately

The shape leaves room for a document path there, and after #795 the index can
address one. The page below cannot: it still loads through
`/api/canvas/:workspaceId/:slug`, whose Hono `:slug` param will never match
`notes/2026/plan`. A URL the app cannot open is worse than a not-found, so a
multi-segment tail parses as **not-a-route**, pinned by a test that says why.

Widening it is one regex and belongs with the change that converges that data
path — not here, where it would ship a URL nothing can load.

## Also

`WorkspaceTopBar` built the share URL by hand rather than calling `canvasPath` —
exactly the drift `app-routes.ts`'s own header warns about — so it now goes
through the single builder. `DaemonDetectedBanner` stays an independent copy on
purpose: it runs on the daemon's origin and cannot import the client route table.

The old shape is **not** redirected. At 0.0.x a stale bookmark gets the honest
not-found rather than a compatibility layer nobody will remove.

## Verification

`pnpm -r typecheck`, `pnpm knip`, and `pnpm --filter @kamiazya/whiteboard-web test`
(2,136 jsdom + 75 node) green. `App.test.tsx` cold-loads `/w/w1/canvas/main`
into the real app and asserts `DaemonCanvasPage` mounts, and that in-app
navigation writes the same shape back to the URL — that is the behaviour this
change is about, exercised end to end at the routing layer.

Server side, checked against a running dev server from the shell: the SPA
fallback serves the app for `/w/ws1`, `/w/ws1/canvas/main`, and a multi-segment
tail alike (the routing decision is client-side, which is what makes the
not-a-route case a client concern rather than a 404).

**Not done: an in-browser click-through.** The Chrome available to this session
reports `osPlatform: macOS, isLocal: false` — it is a different machine from the
shell, so `localhost:5173` there is not the dev server started here. It served
the pre-change `canvasPath` while `curl` from the shell served the new one; I
chased that as a stale Vite cache and a service worker before measuring what it
actually was. Saying so rather than pasting a screenshot of somebody else's
working tree.

The full `pnpm test` run showed 7 `web-browser` failures; all 7 pass in
isolation and none touch the daemon route (browser-local and editor-focus
tests). That is the load-dependent family documented in `integrator-flow.md`,
and this machine was running several suites concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3
