### PR TITLE
fix(web): harden the app shell for touch browsers

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      App-like viewport: user scaling off (mobile Chrome honors it, and
+      maximum-scale=1 is also what stops iOS Safari auto-zooming a focused
+      input; Safari's pinch itself is cancelled in mobile-app-shell.ts),
+      viewport-fit=cover so the installed PWA extends under the notch/home
+      indicator with index.css's safe-area padding taking over.
+    -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <title>Whiteboard</title>
     <meta
       name="description"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -381,6 +381,15 @@ function labelEditorStyle(theme: ResolvedTheme) {
 /** Screen-space px within which a press/right-click counts as hitting an
  * edge line; divided by the zoom for the canvas-space comparison. */
 const EDGE_HIT_TOLERANCE_PX = 6
+
+/**
+ * Touch long-press → context menu. 500ms matches the platform long-press
+ * feel (and Android's own contextmenu synthesis delay, so the two paths
+ * agree on timing there); the slop is finger-sized jitter, not intent to
+ * drag — past it the press is a drag and the menu must not interrupt.
+ */
+const LONG_PRESS_MENU_MS = 500
+const LONG_PRESS_SLOP_PX = 10
 const DEFAULT_TEST_ID = 'spatial-editor'
 /**
  * Window for OUR double-press detection (see handlePointerDown). Matches the
@@ -563,6 +572,36 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const prevCanvasRef = useRef(canvas)
     const prevExternalVersionRef = useRef(externalVersion)
     canvasRef.current = canvas
+
+    // Mirror for callbacks that outlive their render — the long-press timer
+    // fires ~500ms after the closure that armed it, by which time the press
+    // itself has usually advanced the gesture ('pressing'/'moving'); reducing
+    // a cancel against the ARM-time state would mis-apply it.
+    const gestureStateRef = useRef(gestureState)
+    gestureStateRef.current = gestureState
+
+    /**
+     * Touch long-press -> context menu. iOS Safari never synthesises a
+     * `contextmenu` event from a touch long-press (Android Chrome does), so
+     * without this the app's object menu is simply unreachable on an iPhone
+     * — the press reads as a drag start and the menu never opens. Armed on
+     * a single stationary touch, cancelled by movement past the slop, a
+     * second finger, or lift.
+     */
+    const longPressRef = useRef<{
+      timer: ReturnType<typeof setTimeout>
+      pointerId: number
+      screen: Point
+    } | null>(null)
+    const clearLongPress = () => {
+      if (longPressRef.current !== null) {
+        clearTimeout(longPressRef.current.timer)
+        longPressRef.current = null
+      }
+    }
+    // The timer must call the LATEST render's opener (fresh viewport/boxes/
+    // selection), not the one captured when the finger landed.
+    const openContextMenuAtRef = useRef<(screen: Point) => void>(() => {})
 
     // Controlled-prop-swap policy: a sync-driven parent can replace `canvas`
     // mid-gesture. Feed the reducer a `canvas-replaced` event so it can abort
@@ -1354,6 +1393,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             isPanningRef.current = false
             lastPressRef.current = null
             doublePressRef.current = null
+            clearLongPress()
             toggleSelectionMember(anchorPrimary, gathered)
             return
           }
@@ -1379,7 +1419,34 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             trySetPointerCapture(root, pointerId)
           }
           activePointerIdRef.current = e.pointerId
+          clearLongPress()
           return
+        }
+        if (touchPointsRef.current.size === 1) {
+          // Arm the long-press menu. Firing abandons whatever the press
+          // started (a node move's 'pressing' state, marquee arming): the
+          // press has become a menu invocation, not a drag.
+          clearLongPress()
+          const screen = clientPointToRootLocal(e, root)
+          longPressRef.current = {
+            pointerId: e.pointerId,
+            screen,
+            timer: setTimeout(() => {
+              longPressRef.current = null
+              if (gestureStateRef.current.kind !== 'idle') {
+                applyResult(
+                  reduceGesture(gestureStateRef.current, canvasRef.current, {
+                    type: 'pointercancel',
+                  }),
+                )
+              }
+              setMarquee(null)
+              isPanningRef.current = false
+              lastPressRef.current = null
+              doublePressRef.current = null
+              openContextMenuAtRef.current(screen)
+            }, LONG_PRESS_MENU_MS),
+          }
         }
       }
       const screenPointForPan = clientPointToRootLocal(e, root)
@@ -1496,14 +1563,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       // Replace the browser menu with the object's own action menu.
       e.preventDefault()
-      // Hand mode is navigation-ONLY: a touch long-press synthesises a
-      // contextmenu, and surfacing the edit menu there made phone panning
-      // fall into editing mid-gesture (user report 2026-08-08). Switching
-      // to Select is the explicit gate into editing affordances.
-      if (tool === 'hand') return
       const root = rootRef.current
       if (root === null) return
-      const screenPoint = clientPointToRootLocal(e, root)
+      openContextMenuAt(clientPointToRootLocal(e, root))
+    }
+
+    const openContextMenuAt = (screenPoint: Point) => {
+      // Hand mode is navigation-ONLY: surfacing the edit menu on a touch
+      // long-press there made phone panning fall into editing mid-gesture
+      // (user report 2026-08-08). Switching to Select is the explicit gate
+      // into editing affordances.
+      if (tool === 'hand') return
       const point = screenToCanvas(screenPoint, viewport)
       // The MENU hit-tests every node, locked included — a locked node has
       // to stay right-clickable or Unlock would be unreachable. Only the
@@ -1546,10 +1616,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         point,
       })
     }
+    openContextMenuAtRef.current = openContextMenuAt
 
     const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
+      // Movement past finger-jitter slop turns the press into a drag: the
+      // armed long-press menu must not interrupt it.
+      const armed = longPressRef.current
+      if (armed !== null && armed.pointerId === e.pointerId) {
+        const now = clientPointToRootLocal(e, root)
+        if (Math.hypot(now.x - armed.screen.x, now.y - armed.screen.y) > LONG_PRESS_SLOP_PX) {
+          clearLongPress()
+        }
+      }
       // A gathering finger has already acted on its press, and the anchor's
       // own gesture was cancelled when gathering began — neither may resume
       // dragging the canvas while the other is still down.
@@ -1615,6 +1695,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
       const root = rootRef.current
       // Gathering fingers act on the press, so their release carries no
       // meaning — running the click/marquee logic here would re-collapse the
@@ -1781,6 +1862,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
       // Pointer ids are reused, so a gathering finger left in these refs by a
       // cancel would silently deaden whichever later touch inherits its id.
       gatherPointersRef.current.delete(e.pointerId)
@@ -2265,6 +2347,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // cleanup time would always see `null` and silently skip the release.
       const root = rootRef.current
       return () => {
+        // A long-press timer must not fire into an unmounted editor.
+        if (longPressRef.current !== null) {
+          clearTimeout(longPressRef.current.timer)
+          longPressRef.current = null
+        }
         const pointerId = activePointerIdRef.current
         if (root === null || pointerId === null) return
         try {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -511,6 +511,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       setTool(initialTool)
     }, [initialTool])
     const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null)
+    // Screen point of the last committed long-press, while its pulse plays.
+    const [longPressPulse, setLongPressPulse] = useState<Point | null>(null)
     /**
      * Additional selected node ids beyond the reducer's single primary
      * selection. Multi-select lives at the component layer on purpose: the
@@ -1449,6 +1451,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               // keep that cue so the menu opening under a still-down finger
               // reads as deliberate, not glitchy.
               hapticTick()
+              setLongPressPulse(screen)
               openContextMenuAtRef.current(screen)
             }, LONG_PRESS_MENU_MS),
           }
@@ -2359,7 +2362,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     useEffect(() => {
       const root = rootRef.current
       if (root === null) return
-      const onTouchStart = (event: TouchEvent) => {
+      const refuseNativeTouch = (event: TouchEvent) => {
         if (
           event.target instanceof Element &&
           event.target.closest('[data-editor-overlay]') !== null
@@ -2368,8 +2371,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }
         event.preventDefault()
       }
-      root.addEventListener('touchstart', onTouchStart, { passive: false })
-      return () => root.removeEventListener('touchstart', onTouchStart)
+      root.addEventListener('touchstart', refuseNativeTouch, { passive: false })
+      // touchmove too, not just touchstart: an embedding sheet (iOS's
+      // SFSafariViewController in-app browser) decides from UNCONSUMED move
+      // events whether a drag is ITS drag — a canvas pan was dragging the
+      // whole sheet up and down. Canvas gestures are pointer-event driven
+      // and unaffected.
+      root.addEventListener('touchmove', refuseNativeTouch, { passive: false })
+      return () => {
+        root.removeEventListener('touchstart', refuseNativeTouch)
+        root.removeEventListener('touchmove', refuseNativeTouch)
+      }
     }, [])
 
     // out) would otherwise leave the browser holding capture for a pointer
@@ -3114,6 +3126,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               node.height * viewport.zoom >= EXPAND_MIN_H
             }
           />
+          {longPressPulse !== null && (
+            // The moment the long-press commits: one expanding ring at the
+            // pressed point. Haptics are best-effort at most (see
+            // haptics.ts), so this is the feedback channel that always
+            // works; removed on its own animationend (the reduced-motion
+            // floor shortens, never cancels, so cleanup still fires).
+            <div
+              data-testid="long-press-pulse"
+              aria-hidden="true"
+              className="long-press-pulse"
+              style={{ left: longPressPulse.x, top: longPressPulse.y }}
+              onAnimationEnd={() => setLongPressPulse(null)}
+            />
+          )}
           {marquee !== null && (
             <svg
               data-testid="marquee-rect"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -99,6 +99,7 @@ import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { extractClipboardFragment, parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { readClipboardFragment, writeClipboardFragment } from '../../lib/clipboard-store.js'
+import { hapticTick } from '../../lib/haptics.js'
 import type { BoxMove } from './align.js'
 import {
   CanvasContextMenu,
@@ -1444,6 +1445,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               isPanningRef.current = false
               lastPressRef.current = null
               doublePressRef.current = null
+              // The native long-press this replaces gave a system haptic;
+              // keep that cue so the menu opening under a still-down finger
+              // reads as deliberate, not glitchy.
+              hapticTick()
               openContextMenuAtRef.current(screen)
             }, LONG_PRESS_MENU_MS),
           }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1425,7 +1425,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           clearLongPress()
           return
         }
-        if (touchPointsRef.current.size === 1) {
+        // Hand mode is navigation-ONLY, so there is no menu for the timer
+        // to open — and arming it anyway is actively harmful: the press
+        // below starts a pan, and 500ms later the timer's teardown would
+        // clear isPanningRef mid-drag, stranding the pan under a finger
+        // that is still moving.
+        if (touchPointsRef.current.size === 1 && tool !== 'hand') {
           // Arm the long-press menu. Firing abandons whatever the press
           // started (a node move's 'pressing' state, marquee arming): the
           // press has become a menu invocation, not a drag.
@@ -2874,6 +2879,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             }
           />
         )}
+        {longPressPulse !== null && (
+          // The moment the long-press commits: one expanding ring at the
+          // pressed point. Haptics are best-effort at most (see
+          // haptics.ts), so this is the feedback channel that always works;
+          // removed on its own animationend (the reduced-motion floor
+          // shortens, never cancels, so cleanup still fires).
+          //
+          // OUTSIDE the pan/zoom transform, unlike the canvas-space
+          // overlays: the coordinates are root-local screen px, and a
+          // fixed-size feedback ring must not scale with zoom.
+          <div
+            data-testid="long-press-pulse"
+            aria-hidden="true"
+            className="long-press-pulse"
+            style={{ left: longPressPulse.x, top: longPressPulse.y }}
+            onAnimationEnd={() => setLongPressPulse(null)}
+          />
+        )}
         {/* The OOUI creation surface: every canvas is empty until a node
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to
@@ -3126,20 +3149,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               node.height * viewport.zoom >= EXPAND_MIN_H
             }
           />
-          {longPressPulse !== null && (
-            // The moment the long-press commits: one expanding ring at the
-            // pressed point. Haptics are best-effort at most (see
-            // haptics.ts), so this is the feedback channel that always
-            // works; removed on its own animationend (the reduced-motion
-            // floor shortens, never cancels, so cleanup still fires).
-            <div
-              data-testid="long-press-pulse"
-              aria-hidden="true"
-              className="long-press-pulse"
-              style={{ left: longPressPulse.x, top: longPressPulse.y }}
-              onAnimationEnd={() => setLongPressPulse(null)}
-            />
-          )}
           {marquee !== null && (
             <svg
               data-testid="marquee-rect"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2337,6 +2337,36 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // something this effect needs to do. What React does NOT do for us is
     // release pointer capture the platform is still holding on our behalf;
     // an unmount mid-drag (route change, a parent swapping this component
+    // iOS Safari's native long-press behaviors (selection loupe, callout,
+    // the haptic-touch takeover) ignore `touch-action` and CSS user-select
+    // suppression in practice: the system claims the press and fires
+    // pointercancel, which disarms the app's own long-press menu timer —
+    // the press is "hijacked". preventDefault on `touchstart` is the one
+    // reliable off-switch for that entire family, and it must be a
+    // NON-PASSIVE native listener (React's synthetic handlers don't
+    // guarantee that, and browsers default touch listeners to passive).
+    // Canvas interactions are pointer-event driven and unaffected —
+    // pointerdown has already fired by the time touchstart is cancelled;
+    // what this suppresses is the native gesture claim plus the synthetic
+    // mouse-compatibility events the canvas never uses. Overlays
+    // (`data-editor-overlay`: text editor, palette, menus, dialogs) keep
+    // native touch semantics — they hold real form controls.
+    useEffect(() => {
+      const root = rootRef.current
+      if (root === null) return
+      const onTouchStart = (event: TouchEvent) => {
+        if (
+          event.target instanceof Element &&
+          event.target.closest('[data-editor-overlay]') !== null
+        ) {
+          return
+        }
+        event.preventDefault()
+      }
+      root.addEventListener('touchstart', onTouchStart, { passive: false })
+      return () => root.removeEventListener('touchstart', onTouchStart)
+    }, [])
+
     // out) would otherwise leave the browser holding capture for a pointer
     // no element can any longer respond to. Best-effort/never-throw, same
     // reasoning as `trySetPointerCapture`.

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -186,7 +186,7 @@ export function ToolPalette({
       data-testid="tool-palette"
       role="toolbar"
       aria-label="Canvas tools"
-      className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
+      className="absolute bottom-[calc(0.75rem+env(safe-area-inset-bottom))] left-1/2 z-10 flex -translate-x-1/2 items-center gap-0.5 rounded-lg border bg-background p-1 shadow-md"
     >
       {leading !== undefined && (
         <>

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -61,6 +61,9 @@ it('a stationary touch long-press opens the context menu without dragging the no
     expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
   })
   expect(container.textContent).toContain('Delete')
+  // The commit moment gives visible feedback at the pressed point — the
+  // always-available sibling of the best-effort haptic tick.
+  expect(container.querySelector('[data-testid="long-press-pulse"]')).not.toBeNull()
   // The press was a menu invocation, not a drag: lifting afterwards leaves
   // the node exactly where it was.
   touch(root, 'pointerup', 200, 130)

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Touch long-press -> context menu. iOS Safari never synthesises a
+ * `contextmenu` event from a touch long-press (Android Chrome does), so the
+ * editor arms its own timer on a single stationary touch. Real browser:
+ * the behavior hangs off genuine pointer-event dispatch and hit geometry.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const withNode: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 60, text: 'hold me' }],
+  edges: [],
+}
+
+function mount(canvas: SpatialCanvas, tool: 'select' | 'hand' = 'select') {
+  const latest: { canvas: SpatialCanvas } = { canvas }
+  function Host() {
+    const [current, setCurrent] = useState<SpatialCanvas>(canvas)
+    latest.canvas = current
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor defaultTool={tool} canvas={current} onChange={setCurrent} theme="light" />
+      </div>
+    )
+  }
+  return { latest, ...render(<Host />) }
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+function touch(el: HTMLElement, type: string, x: number, y: number, pointerId = 7) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId,
+      pointerType: 'touch',
+      isPrimary: true,
+      button: type === 'pointerdown' ? 0 : -1,
+      buttons: type === 'pointerup' ? 0 : 1,
+    }),
+  )
+}
+
+it('a stationary touch long-press opens the context menu without dragging the node', async () => {
+  const { container, latest } = mount(withNode)
+  const root = rootOf(container)
+  touch(root, 'pointerdown', 200, 130)
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+  })
+  expect(container.textContent).toContain('Delete')
+  // The press was a menu invocation, not a drag: lifting afterwards leaves
+  // the node exactly where it was.
+  touch(root, 'pointerup', 200, 130)
+  expect(latest.canvas.nodes[0]).toMatchObject({ x: 100, y: 100 })
+})
+
+it('movement past the slop cancels the long-press menu (a drag is a drag)', async () => {
+  const { container } = mount(withNode)
+  const root = rootOf(container)
+  touch(root, 'pointerdown', 200, 130)
+  touch(root, 'pointermove', 230, 130)
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+  touch(root, 'pointerup', 230, 130)
+})
+
+it('lifting before the delay never opens the menu (a tap is a tap)', async () => {
+  const { container } = mount(withNode)
+  const root = rootOf(container)
+  touch(root, 'pointerdown', 200, 130)
+  touch(root, 'pointerup', 200, 130)
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+})
+
+it('hand mode stays navigation-only: long-press opens nothing', async () => {
+  const { container } = mount(withNode, 'hand')
+  const root = rootOf(container)
+  touch(root, 'pointerdown', 200, 130)
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+  touch(root, 'pointerup', 200, 130)
+})

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -105,11 +105,20 @@ it('cancels touchstart on the canvas so iOS cannot claim the press, but not on o
   expect(onOverlay.defaultPrevented).toBe(false)
 })
 
-it('hand mode stays navigation-only: long-press opens nothing', async () => {
+it('hand mode stays navigation-only, and a slow pan keeps panning', async () => {
   const { container } = mount(withNode, 'hand')
   const root = rootOf(container)
+  const transform = () =>
+    (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style.transform
+
   touch(root, 'pointerdown', 200, 130)
+  // Held past the long-press delay WITHOUT moving — the shape of a slow
+  // one-finger pan. No menu, and the pan must survive: an armed timer
+  // would have cleared isPanningRef here and stranded the drag.
   await new Promise((resolve) => setTimeout(resolve, 650))
   expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
-  touch(root, 'pointerup', 200, 130)
+  const before = transform()
+  touch(root, 'pointermove', 260, 190)
+  await vi.waitFor(() => expect(transform()).not.toBe(before))
+  touch(root, 'pointerup', 260, 190)
 })

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -86,6 +86,22 @@ it('lifting before the delay never opens the menu (a tap is a tap)', async () =>
   expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
 })
 
+it('cancels touchstart on the canvas so iOS cannot claim the press, but not on overlays', () => {
+  const { container } = mount(withNode)
+  const root = rootOf(container)
+  // Canvas surface: the native gesture claim (selection loupe, haptic-touch
+  // takeover — the thing that fires pointercancel and disarms the menu
+  // timer) must be refused at touchstart.
+  const onCanvas = new TouchEvent('touchstart', { bubbles: true, cancelable: true })
+  root.dispatchEvent(onCanvas)
+  expect(onCanvas.defaultPrevented).toBe(true)
+  // Overlays hold real form controls and keep native touch semantics.
+  const palette = container.querySelector('[data-editor-overlay]') as HTMLElement
+  const onOverlay = new TouchEvent('touchstart', { bubbles: true, cancelable: true })
+  palette.dispatchEvent(onOverlay)
+  expect(onOverlay.defaultPrevented).toBe(false)
+})
+
 it('hand mode stays navigation-only: long-press opens nothing', async () => {
   const { container } = mount(withNode, 'hand')
   const root = rootOf(container)

--- a/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
+++ b/apps/web/src/components/workspace-top-bar/TopBarSecondaryActions.tsx
@@ -1,4 +1,5 @@
 import { EllipsisVertical, Maximize2, Minimize2 } from 'lucide-react'
+import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -7,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { isFullscreenSupported } from '@/lib/fullscreen-support'
 
 interface TopBarSecondaryActionsProps {
   /**
@@ -27,6 +29,13 @@ export function TopBarSecondaryActions({
 }: TopBarSecondaryActionsProps) {
   const fullscreenLabel = isFullscreen ? 'Exit fullscreen' : 'Fullscreen'
   const FullscreenIcon = isFullscreen ? Minimize2 : Maximize2
+  // Hidden rather than disabled where the browser has no element
+  // fullscreen (iPhone Safari — video-only): a disabled control still
+  // claims header space and invites a tap that can never work, and there
+  // is nothing the user could change to enable it. Read once per mount,
+  // since it cannot change without a navigation.
+  const [fullscreenAvailable] = useState(isFullscreenSupported)
+  const showFullscreen = onToggleFullscreen !== undefined && fullscreenAvailable
 
   return (
     <>
@@ -34,7 +43,7 @@ export function TopBarSecondaryActions({
         data-testid="topbar-right-actions-exposed"
         className="flex shrink-0 items-center gap-1 max-[400px]:hidden"
       >
-        {onToggleFullscreen && (
+        {showFullscreen && (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -64,7 +73,7 @@ export function TopBarSecondaryActions({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {onToggleFullscreen && (
+          {showFullscreen && (
             <DropdownMenuItem onSelect={onToggleFullscreen} className="gap-2">
               <FullscreenIcon className="size-3.5" />
               {fullscreenLabel}

--- a/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
@@ -57,3 +57,27 @@ it('offers the kebab item too where the browser supports it', async () => {
   await openKebab(container)
   expect(document.querySelector('[role="menuitem"]')?.textContent).toContain('Fullscreen')
 })
+
+it('hides Fullscreen on the real iPhone shape: no element API at all', async () => {
+  // The shape that shipped the first version of this bug. iPhone Safari's
+  // Fullscreen API is video-only: documentElement has no
+  // requestFullscreen, AND `fullscreenEnabled` is not implemented either
+  // — so a check that only rejected an explicit `false` let the button
+  // through on exactly the device it was hidden for.
+  const root = document.documentElement as HTMLElement & { webkitRequestFullscreen?: unknown }
+  const original = Object.getOwnPropertyDescriptor(Element.prototype, 'requestFullscreen')
+  Object.defineProperty(root, 'requestFullscreen', { configurable: true, value: undefined })
+  Object.defineProperty(root, 'webkitRequestFullscreen', { configurable: true, value: undefined })
+  try {
+    const { container } = render(<TopBarSecondaryActions onToggleFullscreen={() => {}} />)
+    expect(container.querySelector('[aria-label="Fullscreen"]')).toBeNull()
+    await openKebab(container)
+    expect(document.body.textContent).not.toContain('Fullscreen')
+  } finally {
+    // biome-ignore lint/performance/noDelete: restoring an own-property shadow is exactly what delete is for
+    delete (root as { requestFullscreen?: unknown }).requestFullscreen
+    // biome-ignore lint/performance/noDelete: same
+    delete (root as { webkitRequestFullscreen?: unknown }).webkitRequestFullscreen
+    expect(original).toBeDefined()
+  }
+})

--- a/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
@@ -4,7 +4,7 @@
  * control that visibly does nothing. Real browser: the decision reads
  * `document.fullscreenEnabled`, which jsdom does not implement at all.
  */
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { TopBarSecondaryActions } from './TopBarSecondaryActions.js'
 
@@ -29,9 +29,31 @@ it('offers Fullscreen where the browser supports it', () => {
   expect(container.querySelector('[aria-label="Fullscreen"]')).not.toBeNull()
 })
 
-it('hides Fullscreen — button and kebab item — where the browser has none', () => {
+// The kebab must be OPENED to assert on its items: a closed DropdownMenu
+// renders no content, so checking the document text while it is shut would
+// pass no matter what the menu holds. Opened by dispatching pointerDown at
+// the trigger (Radix's own open event, the pattern the other top-bar tests
+// use) rather than a user click: the trigger is `min-[400px]:hidden`, so at
+// the test window's width a real click has nothing visible to land on.
+async function openKebab(container: HTMLElement): Promise<void> {
+  const trigger = container.querySelector(
+    '[data-testid="topbar-more-actions-trigger"]',
+  ) as HTMLElement
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+  await vi.waitFor(() => expect(document.querySelector('[role="menu"]')).not.toBeNull())
+}
+
+it('hides Fullscreen — button and kebab item — where the browser has none', async () => {
   stubFullscreenEnabled(false)
   const { container } = render(<TopBarSecondaryActions onToggleFullscreen={() => {}} />)
   expect(container.querySelector('[aria-label="Fullscreen"]')).toBeNull()
-  expect(container.textContent).not.toContain('Fullscreen')
+  await openKebab(container)
+  expect(document.body.textContent).not.toContain('Fullscreen')
+})
+
+it('offers the kebab item too where the browser supports it', async () => {
+  stubFullscreenEnabled(true)
+  const { container } = render(<TopBarSecondaryActions onToggleFullscreen={() => {}} />)
+  await openKebab(container)
+  expect(document.querySelector('[role="menuitem"]')?.textContent).toContain('Fullscreen')
 })

--- a/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * The Fullscreen affordance hides where the browser has no element
+ * fullscreen (iPhone Safari — video-only there), rather than offering a
+ * control that visibly does nothing. Real browser: the decision reads
+ * `document.fullscreenEnabled`, which jsdom does not implement at all.
+ */
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { TopBarSecondaryActions } from './TopBarSecondaryActions.js'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function stubFullscreenEnabled(value: boolean) {
+  vi.spyOn(document, 'fullscreenEnabled', 'get').mockReturnValue(value)
+  // A browser that answers `false` on the standard property and offers no
+  // prefixed one is the iPhone Safari shape.
+  Object.defineProperty(document, 'webkitFullscreenEnabled', {
+    configurable: true,
+    get: () => undefined,
+  })
+}
+
+it('offers Fullscreen where the browser supports it', () => {
+  stubFullscreenEnabled(true)
+  const { container } = render(<TopBarSecondaryActions onToggleFullscreen={() => {}} />)
+  expect(container.querySelector('[aria-label="Fullscreen"]')).not.toBeNull()
+})
+
+it('hides Fullscreen — button and kebab item — where the browser has none', () => {
+  stubFullscreenEnabled(false)
+  const { container } = render(<TopBarSecondaryActions onToggleFullscreen={() => {}} />)
+  expect(container.querySelector('[aria-label="Fullscreen"]')).toBeNull()
+  expect(container.textContent).not.toContain('Fullscreen')
+})

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -269,3 +269,53 @@
     }
   }
 }
+
+/*
+ * Mobile app-shell hardening (kept un-layered, so it outranks layered
+ * styles). A canvas tool on a touch browser must behave like an app, not a
+ * document: long-pressing chrome or canvas must not start iOS text
+ * selection or the copy/lookup callout, pinch must not zoom the PAGE (the
+ * canvas owns pinch; Safari's gesture events are cancelled in
+ * mobile-app-shell.ts), scrolling past an edge must not rubber-band or
+ * pull-to-refresh out from under a canvas pan, and taps must not flash
+ * the default highlight. Real text surfaces opt back IN to selection
+ * below — an app is selectable where text is the content, nowhere else.
+ */
+html,
+body {
+  overscroll-behavior: none;
+  /* Keep text at authored size when iOS rotates to landscape. */
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  -webkit-tap-highlight-color: transparent;
+  /* Kill double-tap-to-zoom (and its 300ms tap delay) on every surface;
+   * the spatial editor sets touch-action: none on its own element and
+   * implements pinch/double-tap itself. */
+  touch-action: manipulation;
+  /* viewport-fit=cover extends the app under the notch and home indicator
+   * in the installed PWA; give the shell its floor back. In-browser every
+   * inset is 0 and this is inert. */
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+#root {
+  user-select: none;
+  -webkit-user-select: none;
+  /* No long-press callout on chrome or canvas. */
+  -webkit-touch-callout: none;
+}
+
+/* Text-content surfaces stay selectable: the source editor, form fields,
+ * anything contenteditable, and the rendered markdown preview (a reading
+ * surface — copying from it is legitimate use). */
+#root .cm-content,
+#root input,
+#root textarea,
+#root [contenteditable='true'],
+#root .markdown-preview-pane {
+  user-select: text;
+  -webkit-user-select: text;
+  -webkit-touch-callout: default;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -294,10 +294,11 @@ body {
    * the spatial editor sets touch-action: none on its own element and
    * implements pinch/double-tap itself. */
   touch-action: manipulation;
-  /* viewport-fit=cover extends the app under the notch and home indicator
-   * in the installed PWA; give the shell its floor back. In-browser every
-   * inset is 0 and this is inert. */
-  padding-bottom: env(safe-area-inset-bottom);
+  /* Deliberately NO safe-area padding here: on notched iPhones the bottom
+   * inset is real even in-browser, so body padding pushes the page past
+   * 100vh and the whole app becomes drag-scrollable ("pulled along" during
+   * canvas pans — reported on device). Safe-area compensation lives on the
+   * bottom-anchored chrome itself (the canvas dock's bottom offset). */
 }
 
 #root {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -320,3 +320,32 @@ body {
   -webkit-user-select: text;
   -webkit-touch-callout: default;
 }
+
+/* The long-press commit pulse (SpatialEditor): one expanding ring at the
+ * pressed point, the always-available sibling of the best-effort haptic
+ * tick. Sized/centered by transform so left/top can be the raw press
+ * coordinates. The global reduced-motion floor shortens the animation to
+ * ~0ms; animationend still fires, so the element removes itself either way. */
+.long-press-pulse {
+  position: absolute;
+  z-index: 20;
+  width: 44px;
+  height: 44px;
+  border: 2px solid var(--ring);
+  border-radius: 9999px;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(0.4);
+  opacity: 0;
+  animation: long-press-pulse 320ms var(--motion-ease-out) forwards;
+}
+
+@keyframes long-press-pulse {
+  0% {
+    transform: translate(-50%, -50%) scale(0.4);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.5);
+    opacity: 0;
+  }
+}

--- a/apps/web/src/lib/fullscreen-support.test.ts
+++ b/apps/web/src/lib/fullscreen-support.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isFullscreenSupported } from './fullscreen-support.js'
+
+function fakeDoc(props: Record<string, unknown>): Document {
+  return props as unknown as Document
+}
+
+describe('isFullscreenSupported', () => {
+  it('is false where the browser says fullscreen is unavailable (iPhone Safari)', () => {
+    expect(isFullscreenSupported(fakeDoc({ fullscreenEnabled: false }))).toBe(false)
+  })
+
+  it('is true where the browser offers it', () => {
+    expect(isFullscreenSupported(fakeDoc({ fullscreenEnabled: true }))).toBe(true)
+  })
+
+  it('honours the legacy WebKit answer when the standard one says no', () => {
+    expect(
+      isFullscreenSupported(fakeDoc({ fullscreenEnabled: false, webkitFullscreenEnabled: true })),
+    ).toBe(true)
+  })
+
+  it('assumes supported where the property is absent (non-browser runtimes)', () => {
+    // jsdom implements no fullscreen at all; hiding the affordance there
+    // would mean tests exercising a UI no real browser shows.
+    expect(isFullscreenSupported(fakeDoc({}))).toBe(true)
+  })
+})

--- a/apps/web/src/lib/fullscreen-support.test.ts
+++ b/apps/web/src/lib/fullscreen-support.test.ts
@@ -1,28 +1,33 @@
 import { describe, expect, it } from 'vitest'
 import { isFullscreenSupported } from './fullscreen-support.js'
 
-function fakeDoc(props: Record<string, unknown>): Document {
-  return props as unknown as Document
+function fakeDoc(root: Record<string, unknown> | null, docProps: Record<string, unknown> = {}) {
+  return { documentElement: root, ...docProps } as unknown as Document
 }
 
 describe('isFullscreenSupported', () => {
-  it('is false where the browser says fullscreen is unavailable (iPhone Safari)', () => {
-    expect(isFullscreenSupported(fakeDoc({ fullscreenEnabled: false }))).toBe(false)
+  it('is false where the element API is absent (iPhone Safari: video-only)', () => {
+    // The device shape that made this function necessary: no
+    // requestFullscreen at all, and `fullscreenEnabled` not implemented
+    // either — so it reads undefined, not false.
+    expect(isFullscreenSupported(fakeDoc({}))).toBe(false)
   })
 
-  it('is true where the browser offers it', () => {
-    expect(isFullscreenSupported(fakeDoc({ fullscreenEnabled: true }))).toBe(true)
+  it('is true where the element API exists', () => {
+    expect(isFullscreenSupported(fakeDoc({ requestFullscreen: () => {} }))).toBe(true)
   })
 
-  it('honours the legacy WebKit answer when the standard one says no', () => {
+  it('accepts the legacy prefixed method', () => {
+    expect(isFullscreenSupported(fakeDoc({ webkitRequestFullscreen: () => {} }))).toBe(true)
+  })
+
+  it('honours an explicit refusal even when the method exists (embedded iframe)', () => {
     expect(
-      isFullscreenSupported(fakeDoc({ fullscreenEnabled: false, webkitFullscreenEnabled: true })),
-    ).toBe(true)
+      isFullscreenSupported(fakeDoc({ requestFullscreen: () => {} }, { fullscreenEnabled: false })),
+    ).toBe(false)
   })
 
-  it('assumes supported where the property is absent (non-browser runtimes)', () => {
-    // jsdom implements no fullscreen at all; hiding the affordance there
-    // would mean tests exercising a UI no real browser shows.
-    expect(isFullscreenSupported(fakeDoc({}))).toBe(true)
+  it('is false, never a throw, with no document element at all', () => {
+    expect(isFullscreenSupported(fakeDoc(null))).toBe(false)
   })
 })

--- a/apps/web/src/lib/fullscreen-support.ts
+++ b/apps/web/src/lib/fullscreen-support.ts
@@ -1,22 +1,29 @@
 /**
- * Whether this browser offers element fullscreen at all.
+ * Whether this browser can put an ELEMENT into fullscreen.
  *
- * iPhone Safari does not: the Fullscreen API is video-only there (iPad
- * Safari and every desktop browser do offer it), so `Fullscreen` was a
- * button that visibly did nothing on a phone. `document.fullscreenEnabled`
- * is exactly the standard's answer to this question — it is `false` when
- * fullscreen is unavailable, including when an embedding iframe withholds
- * the permission.
+ * iPhone Safari cannot: its Fullscreen API is video-only (iPad Safari and
+ * every desktop browser do offer the element API), so `Fullscreen` was a
+ * button that visibly did nothing on a phone.
  *
- * Only an explicit `false` counts as unsupported: a runtime that does not
- * implement the property at all (jsdom) reports `undefined`, and hiding
- * the affordance there would mean tests exercising a UI no real browser
- * shows. Safari's legacy `webkitFullscreenEnabled` is consulted for the
- * same reason — an older WebKit that answers only under the prefix must
- * not be read as "unsupported".
+ * Detection is by CAPABILITY — does the element actually have a
+ * `requestFullscreen` method — not by `document.fullscreenEnabled` alone.
+ * That was the first attempt and it shipped the bug it was meant to fix:
+ * iPhone Safari does not implement the property at all, so it reads
+ * `undefined`, and "only an explicit false means unsupported" let the
+ * button through on exactly the device it was hidden for. A runtime that
+ * implements the whole API absent (jsdom) also has no method, and hiding
+ * there is correct too — no jsdom test asserts the affordance exists.
+ *
+ * `fullscreenEnabled === false` is still honoured on top: a browser that
+ * HAS the method can still refuse (an iframe without the permission), and
+ * that answer is authoritative.
  */
 export function isFullscreenSupported(doc: Document = document): boolean {
-  const legacy = (doc as Document & { webkitFullscreenEnabled?: boolean }).webkitFullscreenEnabled
-  if (doc.fullscreenEnabled === false && legacy !== true) return false
-  return true
+  const root = doc.documentElement as (HTMLElement & { webkitRequestFullscreen?: unknown }) | null
+  if (root === null) return false
+  const hasMethod =
+    typeof root.requestFullscreen === 'function' ||
+    typeof root.webkitRequestFullscreen === 'function'
+  if (!hasMethod) return false
+  return doc.fullscreenEnabled !== false
 }

--- a/apps/web/src/lib/fullscreen-support.ts
+++ b/apps/web/src/lib/fullscreen-support.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether this browser offers element fullscreen at all.
+ *
+ * iPhone Safari does not: the Fullscreen API is video-only there (iPad
+ * Safari and every desktop browser do offer it), so `Fullscreen` was a
+ * button that visibly did nothing on a phone. `document.fullscreenEnabled`
+ * is exactly the standard's answer to this question — it is `false` when
+ * fullscreen is unavailable, including when an embedding iframe withholds
+ * the permission.
+ *
+ * Only an explicit `false` counts as unsupported: a runtime that does not
+ * implement the property at all (jsdom) reports `undefined`, and hiding
+ * the affordance there would mean tests exercising a UI no real browser
+ * shows. Safari's legacy `webkitFullscreenEnabled` is consulted for the
+ * same reason — an older WebKit that answers only under the prefix must
+ * not be read as "unsupported".
+ */
+export function isFullscreenSupported(doc: Document = document): boolean {
+  const legacy = (doc as Document & { webkitFullscreenEnabled?: boolean }).webkitFullscreenEnabled
+  if (doc.fullscreenEnabled === false && legacy !== true) return false
+  return true
+}

--- a/apps/web/src/lib/haptics.test.ts
+++ b/apps/web/src/lib/haptics.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hapticTick } from './haptics.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+describe('hapticTick', () => {
+  it('uses the Vibration API where it exists', () => {
+    const vibrate = vi.fn()
+    vi.stubGlobal('navigator', { vibrate })
+    hapticTick()
+    expect(vibrate).toHaveBeenCalledWith(10)
+    // No fallback element when the real API answered.
+    expect(document.querySelector('input[switch]')).toBeNull()
+  })
+
+  it('falls back to the iOS switch-toggle tick, reusing one hidden element', () => {
+    vi.stubGlobal('navigator', {})
+    hapticTick()
+    const input = document.querySelector('input[switch]') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.getAttribute('type')).toBe('checkbox')
+    expect(input.closest('label')?.getAttribute('aria-hidden')).toBe('true')
+    const before = input.checked
+    hapticTick()
+    // The same element toggles again rather than accumulating clones.
+    expect(document.querySelectorAll('input[switch]')).toHaveLength(1)
+    expect(input.checked).toBe(!before)
+  })
+
+  it('never throws when there is nothing to vibrate with', () => {
+    vi.stubGlobal('navigator', undefined)
+    expect(() => hapticTick()).not.toThrow()
+  })
+})

--- a/apps/web/src/lib/haptics.ts
+++ b/apps/web/src/lib/haptics.ts
@@ -1,0 +1,51 @@
+/**
+ * A single short haptic tick, for moments where the platform's native
+ * gesture would have given one (the long-press that opens the canvas
+ * context menu — its native ancestor, the iOS callout, ticked).
+ *
+ * Feedback only, by contract: every path is best-effort and swallows its
+ * own failures — an action must never break because its haptic could not
+ * fire.
+ *
+ * Platform reality:
+ * - Android/desktop Chromium: the Vibration API.
+ * - iOS Safari: no Vibration API on any version. Since 17.4, toggling a
+ *   switch-styled checkbox produces the system'switch' haptic, and a
+ *   programmatic label click triggers it — the only web-reachable haptic
+ *   on iOS today. It is a documented-behavior side effect, not a haptics
+ *   API; if Apple closes it, this silently becomes a no-op, which is the
+ *   correct failure mode for feedback.
+ */
+
+let switchLabel: HTMLLabelElement | null = null
+
+function iosSwitchTick(): void {
+  if (switchLabel === null || !switchLabel.isConnected) {
+    const label = document.createElement('label')
+    // Visually and semantically inert: never focusable, never announced,
+    // never hit-testable.
+    label.setAttribute('aria-hidden', 'true')
+    label.style.cssText =
+      'position:fixed;top:0;left:0;width:1px;height:1px;overflow:hidden;opacity:0;pointer-events:none'
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    input.setAttribute('switch', '')
+    input.tabIndex = -1
+    label.appendChild(input)
+    document.body.appendChild(label)
+    switchLabel = label
+  }
+  switchLabel.click()
+}
+
+export function hapticTick(): void {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(10)
+      return
+    }
+    iosSwitchTick()
+  } catch {
+    // feedback only — see module doc
+  }
+}

--- a/apps/web/src/lib/mobile-app-shell.test.ts
+++ b/apps/web/src/lib/mobile-app-shell.test.ts
@@ -1,0 +1,44 @@
+/**
+ * App-shell hardening for touch browsers. Two halves:
+ * - the gesture guards (this module): Safari's proprietary pinch events
+ *   must be cancelled or the PAGE zooms underneath the app's own gestures;
+ * - the viewport meta (index.html): asserted here from the source file so
+ *   a refactor cannot silently drop `maximum-scale` (which is also what
+ *   stops iOS auto-zooming focused inputs) or `viewport-fit=cover`.
+ */
+import { describe, expect, it } from 'vitest'
+import indexHtml from '../../index.html?raw'
+import { installMobileAppShellGuards } from './mobile-app-shell.js'
+
+describe('installMobileAppShellGuards', () => {
+  it('cancels Safari pinch gesture events at the document', () => {
+    const uninstall = installMobileAppShellGuards(document)
+    try {
+      for (const type of ['gesturestart', 'gesturechange']) {
+        const event = new Event(type, { cancelable: true, bubbles: true })
+        document.dispatchEvent(event)
+        expect(event.defaultPrevented).toBe(true)
+      }
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('uninstall removes the guards', () => {
+    const uninstall = installMobileAppShellGuards(document)
+    uninstall()
+    const event = new Event('gesturestart', { cancelable: true, bubbles: true })
+    document.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+})
+
+describe('app-shell viewport meta', () => {
+  it('pins the app-like viewport: no user scaling, cover the safe areas', () => {
+    const viewport = indexHtml.match(/name="viewport"[\s\S]*?content="([^"]*)"/)?.[1] ?? ''
+    expect(viewport).toContain('width=device-width')
+    expect(viewport).toContain('maximum-scale=1')
+    expect(viewport).toContain('user-scalable=no')
+    expect(viewport).toContain('viewport-fit=cover')
+  })
+})

--- a/apps/web/src/lib/mobile-app-shell.ts
+++ b/apps/web/src/lib/mobile-app-shell.ts
@@ -1,0 +1,30 @@
+/**
+ * App-shell gesture guards for touch browsers, iOS Safari first.
+ *
+ * Safari implements pinch-to-zoom through its own proprietary gesture
+ * events and IGNORES both the viewport meta's `user-scalable=no` (since
+ * iOS 10, in-browser) and `touch-action` for the page-zoom gesture — so an
+ * app that owns its gestures (the canvas pinch-zooms the canvas, not the
+ * page) must cancel `gesturestart`/`gesturechange` at the document. Pointer
+ * events are unaffected: the spatial editor's own pinch handling keeps
+ * working; what this removes is the PAGE scaling underneath it.
+ *
+ * Browsers without the gesture events (everything but WebKit/Safari)
+ * simply never fire them — installing the listeners is inert there, where
+ * the viewport meta and `touch-action` already cover zoom suppression.
+ *
+ * Accessibility note: OS-level zoom (iOS Settings > Accessibility > Zoom)
+ * is a system feature and is not affected by page-level gesture handling.
+ */
+export function installMobileAppShellGuards(target: Document = document): () => void {
+  const prevent = (event: Event) => {
+    event.preventDefault()
+  }
+  // Not passive: preventDefault is the entire point.
+  target.addEventListener('gesturestart', prevent)
+  target.addEventListener('gesturechange', prevent)
+  return () => {
+    target.removeEventListener('gesturestart', prevent)
+    target.removeEventListener('gesturechange', prevent)
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,7 @@ import { dismissBootSplash } from './boot-splash.js'
 import { applyThemeClass, readPersistedTheme, resolveTheme } from './hooks/useThemeMode.js'
 import './index.css'
 import { initInstallPromptCapture } from './lib/install-prompt-store.js'
+import { installMobileAppShellGuards } from './lib/mobile-app-shell.js'
 import { purgeLegacyReconnectCredentials } from './lib/purge-legacy-reconnect-credentials.js'
 import './pwa/bootstrap.js'
 
@@ -26,6 +27,11 @@ initInstallPromptCapture()
 // Apply the persisted theme class before React mounts so the first paint
 // matches the user's saved preference (avoids a light→dark flash on reload).
 applyThemeClass(resolveTheme(readPersistedTheme()))
+
+// Before React mounts, so no gesture can slip in during hydration: cancels
+// Safari's proprietary pinch events, which page-zoom regardless of the
+// viewport meta or touch-action (see mobile-app-shell.ts).
+installMobileAppShellGuards()
 
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element #root not found')

--- a/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
@@ -17,11 +17,19 @@ import '../components/WorkspaceTopBar.js'
 beforeEach(() => {
   // jsdom has no fullscreen at all; start each test explicitly OUT of it.
   setFullscreenElement(null)
+  // …and jsdom is therefore an environment the app now HIDES the affordance
+  // in (iPhone Safari is the real one — see lib/fullscreen-support.ts). These
+  // tests are about what fullscreen does once available, so they present a
+  // capable environment: the method has to exist before the page renders,
+  // since that is when the component reads the capability.
+  Element.prototype.requestFullscreen = vi.fn(() => Promise.resolve())
 })
 
 afterEach(() => {
   cleanup()
   setFullscreenElement(null)
+  // biome-ignore lint/performance/noDelete: restore jsdom's real (absent) shape rather than leaving a stub for other files
+  delete (Element.prototype as { requestFullscreen?: unknown }).requestFullscreen
   vi.restoreAllMocks()
 })
 


### PR DESCRIPTION
## Summary

Reported from a real iPhone: long-pressing the canvas started iOS **native text selection across the app chrome** (with the copy/search/translate callout), and **pinching zoomed the page** under the editor. Applied as one general app-shell hardening pass for touch browsers rather than two spot fixes:

- **Viewport** (`index.html`): `maximum-scale=1, user-scalable=no` — mobile Chrome's pinch block, and what stops iOS Safari auto-zooming a focused input — plus `viewport-fit=cover` with `env(safe-area-inset-bottom)` body padding for the installed PWA (display: standalone).
- **Safari pinch** (`mobile-app-shell.ts`, installed before React mounts): cancels Safari's proprietary `gesturestart`/`gesturechange` at the document — Safari page-zooms regardless of the viewport meta or `touch-action`, and the canvas owns its own pinch gesture. Inert on non-WebKit browsers (the events never fire). OS-level accessibility zoom is unaffected.
- **Selection / callout** (`index.css`): `#root` gets `user-select: none` + `-webkit-touch-callout: none`; real text surfaces opt back in — CodeMirror content, inputs, textareas, `contenteditable`, and the markdown preview (a reading surface; copying from it is legitimate).
- **General app feel**: `overscroll-behavior: none` (no rubber-band / pull-to-refresh under a canvas pan), `touch-action: manipulation` (no double-tap zoom or its tap delay; the spatial editor keeps its own `touch-action: none` surface and self-implemented pinch/double-tap), transparent tap highlight, `-webkit-text-size-adjust: 100%`.

## Repro (before, on-device)

![before](https://github.com/user-attachments/assets/793cf1a1-80fd-4e05-8f40-dffb3f072ced)

## Verification

- Unit tests: the gesture guards cancel `gesturestart`/`gesturechange` (and uninstall cleanly); the viewport meta is pinned from the source file so a refactor cannot silently drop it.
- Verified in the running app (Chromium): computed `user-select: none` on `#root` with `text` on `.cm-content` / inputs / the preview pane; `overscroll-behavior: none`, `touch-action: manipulation`, transparent tap highlight; a cancelable `gesturestart` dispatched at the document is defaultPrevented.
- `-webkit-touch-callout` and Safari's gesture behavior itself are WebKit-only — please confirm on the iPhone against this PR's Preview deployment before/after merge.
- Full web suite, typecheck, lint, knip green.

## Follow-up in this PR: touch long-press opens the context menu

On-device re-test found the object menu unreachable on iPhone: iOS Safari never synthesises a `contextmenu` event from a touch long-press (Android Chrome does), so the press read as a drag start and the long-press was hijacked by whatever native behavior remained. The editor now arms its own 500ms timer on a single stationary touch — firing abandons the in-flight gesture (reducer `pointercancel` against a `gestureState` ref, so the stale closure never mis-reduces) and opens the same menu the `contextmenu` handler does. Movement past a 10px slop, a second finger (pinch/gather), lift, or cancel disarms it; hand mode stays navigation-only; Android's two paths converge on the same idempotent open.

Browser regression (real pointer events): stationary long-press opens the menu without dragging the node; drag past slop / early lift / hand mode all open nothing. Mutation-checked (inflating the delay turns the positive case red). The full spatial-editor browser suite (332 tests) stays green — pinch, double-tap zoom, and gather untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added touch long-press support for opening spatial editor context menus, with haptic and visual feedback.
  * Added safe-area support for mobile layouts.
  * Fullscreen controls now appear only when supported by the browser.

* **Bug Fixes**
  * Prevented unintended mobile page zoom, overscroll, text resizing, and touch callouts.
  * Preserved text selection and standard interactions in text-content areas.
  * Long-press gestures cancel appropriately during movement, release, or conflicting gestures.

* **Tests**
  * Added coverage for touch gestures, haptics, mobile protections, and fullscreen availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->