### PR TITLE
fix(server): recover the documents the path model left behind, and stop one legacy row darkening the list

### DIFF
--- a/packages/mcp-server/src/server/store/canvas-store.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.test.ts
@@ -70,6 +70,25 @@ describe('saveCanvas / loadCanvas', () => {
     expect(loaded.getMovableList('elements').length).toBe(0)
   })
 
+  it('mints a canonical ULID for a new row, so both writers share one id space', async () => {
+    // The document index and saveCanvas both create rows in the same table.
+    // The index mints ULIDs (the port's DocumentEntry accepts nothing else),
+    // while saveCanvas minted nanoids — so every canvas created through the
+    // web UI became a row the agent surface must skip. Two writers, one
+    // table, one id policy.
+    await saveCanvas('session1', 'ulid-mint', new LoroDoc())
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const db = await getDb(getDataDir())
+    const row = await db
+      .selectFrom('canvases')
+      .select(['id'])
+      .where('workspaceId', '=', 'session1')
+      .where('slug', '=', 'ulid-mint')
+      .executeTakeFirst()
+    expect(row?.id).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+  })
+
   it('saves and restores a LoroDoc with elements', async () => {
     const doc = new LoroDoc()
     const list = doc.getMovableList('elements')

--- a/packages/mcp-server/src/server/store/canvas-store.ts
+++ b/packages/mcp-server/src/server/store/canvas-store.ts
@@ -1,9 +1,9 @@
 import { access, mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
+import { generateCanvasId } from '@kamiazya/whiteboard-canvas-model'
 import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap } from 'loro-crdt'
-import { nanoid } from 'nanoid'
 import type { CanvasSummary } from '../../shared/api-contracts/canvas.js'
 import { getDataDir } from '../config.js'
 import { getLogger } from '../log.js'
@@ -30,7 +30,7 @@ export class ConflictError extends Error {
 
 // ── canvas blob path helpers ──
 // Snapshots live under {dataDir}/blobs/{workspaceId}/canvas/{canvasId}.loro.
-// The canvasId is the stable nanoid PK from the canvases table, so renaming a
+// The canvasId is the stable row PK from the canvases table, so renaming a
 // canvas slug does not move blobs around.
 function blobsRoot(): string {
   return join(getDataDir(), 'blobs')
@@ -88,7 +88,11 @@ export async function saveCanvas(
     // before any metadata row commits. If the FS write fails (ENOSPC, EACCES,
     // transient corruption) we leave no DB row behind, so a retry can succeed
     // instead of hitting a phantom ConflictError on the orphan.
-    const canvasId = existingCanvasId ?? nanoid(12)
+    // A ULID, not a nanoid: the document index creates rows in this same
+    // table and the port's DocumentEntry accepts only a canonical ULID, so a
+    // second minting policy here would keep producing rows the agent surface
+    // has to skip. One table, one id space.
+    const canvasId = existingCanvasId ?? generateCanvasId()
     const path = canvasBlobPath(workspaceId, canvasId)
     await mkdir(dirname(path), { recursive: true })
     const snapshot = doc.export({ mode: 'snapshot' })

--- a/packages/mcp-server/src/server/store/db/migrations/0007-adopt-workspace-tree.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0007-adopt-workspace-tree.test.ts
@@ -1,0 +1,194 @@
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+import { migration as migration0001 } from './0001-init.js'
+import { migration as migration0002 } from './0002-canvases-last-compacted-at.js'
+import { migration as migration0003 } from './0003-canvas-doc-store.js'
+import { migration as migration0005 } from './0005-canvases-kind.js'
+import { migration } from './0007-adopt-workspace-tree.js'
+
+async function createMemoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  await migration0001.up(db as unknown as Kysely<unknown>)
+  await migration0002.up(db as unknown as Kysely<unknown>)
+  await migration0003.up(db as unknown as Kysely<unknown>)
+  await migration0005.up(db as unknown as Kysely<unknown>)
+  return db
+}
+
+/** Store a doc as ONE snapshot chunk, the way the doc store writes it. */
+async function storeDoc(db: Kysely<DatabaseSchema>, docKey: string, doc: LoroDoc): Promise<void> {
+  const bytes = doc.export({ mode: 'snapshot' })
+  const frontier = new Uint8Array([0])
+  await db
+    .insertInto('canvasDocSnapshots')
+    .values({
+      docKey,
+      chunkCount: 1,
+      totalBytes: bytes.byteLength,
+      maxChunkBytes: 1 << 20,
+      frontier,
+    })
+    .execute()
+  await db.insertInto('canvasDocSnapshotChunks').values({ docKey, chunkIndex: 0, bytes }).execute()
+  await db.insertInto('canvasDocFrontiers').values({ docKey, frontier }).execute()
+}
+
+/**
+ * A workspace tree exactly as the retired format stored it: a LoroDoc with a
+ * LoroTree under the container key `tree`, node data `{ canvasId, segment,
+ * displayName? }`. Frozen here rather than imported: the living code that
+ * wrote this format was deleted when the tree retired, which is the point of
+ * the migration existing.
+ */
+function retiredTree(
+  docs: { canvasId: string; segments: string[]; displayName?: string }[],
+): LoroDoc {
+  const doc = new LoroDoc()
+  const tree = doc.getTree('tree')
+  const byPath = new Map<string, ReturnType<typeof tree.createNode>>()
+  for (const entry of docs) {
+    let parent: ReturnType<typeof tree.createNode> | undefined
+    for (let depth = 0; depth < entry.segments.length; depth++) {
+      const prefix = entry.segments.slice(0, depth + 1).join('/')
+      let node = byPath.get(prefix)
+      if (!node) {
+        node = parent === undefined ? tree.createNode() : parent.createNode()
+        node.data.set('segment', entry.segments[depth] as string)
+        byPath.set(prefix, node)
+      }
+      parent = node
+    }
+    const leaf = byPath.get(entry.segments.join('/'))
+    if (!leaf) throw new Error('unreachable')
+    leaf.data.set('canvasId', entry.canvasId)
+    if (entry.displayName !== undefined) leaf.data.set('displayName', entry.displayName)
+  }
+  doc.commit()
+  return doc
+}
+
+/** A canvas doc carrying its kind the way loro-bridge stores it. */
+function canvasDoc(kind: 'spatial' | 'markdown'): LoroDoc {
+  const doc = new LoroDoc()
+  doc.getMap('document').set('kind', kind)
+  doc.commit()
+  return doc
+}
+
+const ULID_A = '01ARZ3NDEKTSV4RRFFQ69G5FAA'
+const ULID_B = '01ARZ3NDEKTSV4RRFFQ69G5FAB'
+const ULID_C = '01ARZ3NDEKTSV4RRFFQ69G5FAC'
+
+describe('0007-adopt-workspace-tree migration', () => {
+  it('adopts tree documents into the canvases table with derived paths, names and kinds', async () => {
+    const db = await createMemoryDb()
+    try {
+      await storeDoc(
+        db,
+        'workspace-tree:default',
+        retiredTree([
+          { canvasId: ULID_A, segments: ['notes'], displayName: 'My notes' },
+          { canvasId: ULID_B, segments: ['plans', 'q3'] },
+        ]),
+      )
+      await storeDoc(db, `canvas:${ULID_A}`, canvasDoc('markdown'))
+      await storeDoc(db, `canvas:${ULID_B}`, canvasDoc('spatial'))
+
+      await migration.up(db as unknown as Kysely<unknown>)
+
+      const rows = await db
+        .selectFrom('canvases')
+        .select(['id', 'workspaceId', 'slug', 'kind', 'displayName'])
+        .orderBy('slug', 'asc')
+        .execute()
+      expect(rows).toEqual([
+        {
+          id: ULID_A,
+          workspaceId: 'default',
+          slug: 'notes',
+          kind: 'markdown',
+          displayName: 'My notes',
+        },
+        {
+          id: ULID_B,
+          workspaceId: 'default',
+          slug: 'plans/q3',
+          kind: 'spatial',
+          displayName: null,
+        },
+      ])
+      const workspaces = await db.selectFrom('workspaces').select('id').execute()
+      expect(workspaces).toEqual([{ id: 'default' }])
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  it('leaves an already-adopted document alone and suffixes a taken path', async () => {
+    const db = await createMemoryDb()
+    try {
+      // ULID_A is already in the table (say, adopted by an earlier run, or
+      // the same id was re-created through the index): the migration must be
+      // idempotent for it. ULID_C wants the path `notes`, which is taken by a
+      // ROW THE TREE NEVER KNEW — a gallery canvas — so it adopts under a
+      // suffixed path instead of failing the whole migration.
+      const now = Date.now()
+      await db
+        .insertInto('workspaces')
+        .values({ id: 'default', createdAt: now, updatedAt: now })
+        .execute()
+      await db
+        .insertInto('canvases')
+        .values([
+          {
+            id: ULID_A,
+            workspaceId: 'default',
+            slug: 'already-here',
+            kind: 'spatial',
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: 'Go1G4OcJKUBu',
+            workspaceId: 'default',
+            slug: 'notes',
+            kind: 'spatial',
+            createdAt: now,
+            updatedAt: now,
+          },
+        ])
+        .execute()
+      await storeDoc(
+        db,
+        'workspace-tree:default',
+        retiredTree([
+          { canvasId: ULID_A, segments: ['moved-elsewhere'] },
+          { canvasId: ULID_C, segments: ['notes'] },
+        ]),
+      )
+      await storeDoc(db, `canvas:${ULID_C}`, canvasDoc('markdown'))
+
+      await migration.up(db as unknown as Kysely<unknown>)
+
+      const rows = await db.selectFrom('canvases').select(['id', 'slug']).execute()
+      const bySlug = new Map(rows.map((r) => [r.id, r.slug]))
+      // Untouched: adoption never re-paths a row that already exists.
+      expect(bySlug.get(ULID_A)).toBe('already-here')
+      expect(bySlug.get('Go1G4OcJKUBu')).toBe('notes')
+      // Adopted beside the occupant rather than over it or not at all.
+      expect(bySlug.get(ULID_C)).toBe('notes-2')
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0007-adopt-workspace-tree.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0007-adopt-workspace-tree.ts
@@ -1,0 +1,223 @@
+import type { Kysely } from 'kysely'
+import { LoroDoc } from 'loro-crdt'
+
+/**
+ * Adopt documents that exist only in the RETIRED workspace-tree docs into the
+ * `canvases` table.
+ *
+ * When document addressing moved onto the canvases table, everything the old
+ * workspace-tree Loro doc knew — every document an agent had created through
+ * the MCP tools — became unreachable: the snapshots were still on disk, but
+ * no row named them, so every list and lookup answered "not found" over data
+ * that was fully intact. This walks each `workspace-tree:<workspaceId>` doc
+ * still in the snapshot store and inserts the missing rows.
+ *
+ * The retired format is FROZEN here rather than imported: the code that wrote
+ * it was deleted in the same change that retired it, which is exactly why a
+ * migration cannot depend on living code. Shape: a LoroDoc whose LoroTree
+ * lives under the container key `tree`, node data
+ * `{ canvasId, segment, displayName? }`; a document's path is its root-to-leaf
+ * segment chain; a node with no `canvasId` is a pure folder. A document's
+ * `kind` was never in the tree — it lives in the canvas doc itself, under
+ * `getMap('document').get('kind')`, where it still lives today.
+ *
+ * Rules, each carrying a reason:
+ * - A canvasId that already has a row anywhere in the workspace is SKIPPED:
+ *   adoption must be idempotent, and never re-paths a row somebody can see.
+ * - A derived path already taken by another row adopts under `<path>-2`,
+ *   `<path>-3`, … instead of failing: the occupant is typically a gallery
+ *   canvas the tree never knew, and one collision must not abort the whole
+ *   recovery.
+ * - A tree whose snapshot cannot be decoded is skipped, not fatal: this runs
+ *   inside db bootstrap, and refusing to start the daemon over one corrupt
+ *   retired doc would turn a recovery into an outage.
+ * - The tree docs themselves are left in place. They are inert — nothing
+ *   reads them any more — and a migration that deletes its own input cannot
+ *   be re-run to diagnose what it did.
+ */
+export const migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    const tdb = db as Kysely<MigrationSchema>
+    const treeRows = await tdb
+      .selectFrom('canvasDocSnapshots')
+      .select(['docKey'])
+      .where('docKey', 'like', 'workspace-tree:%')
+      .execute()
+
+    for (const { docKey } of treeRows) {
+      const workspaceId = docKey.slice('workspace-tree:'.length)
+      const treeDoc = await loadStoredDoc(tdb, docKey)
+      if (treeDoc === null) continue
+
+      const documents = walkRetiredTree(treeDoc)
+      if (documents.length === 0) continue
+
+      const now = Date.now()
+      await tdb
+        .insertInto('workspaces')
+        .values({ id: workspaceId, createdAt: now, updatedAt: now })
+        .onConflict((oc) => oc.column('id').doNothing())
+        .execute()
+
+      const existing = await tdb
+        .selectFrom('canvases')
+        .select(['id', 'slug'])
+        .where('workspaceId', '=', workspaceId)
+        .execute()
+      const adoptedIds = new Set(existing.map((row) => row.id))
+      const takenPaths = new Set(existing.map((row) => row.slug))
+
+      for (const entry of documents) {
+        if (adoptedIds.has(entry.canvasId)) continue
+        let path = entry.path
+        for (let suffix = 2; takenPaths.has(path); suffix++) {
+          path = `${entry.path}-${suffix}`
+        }
+        const kind = await readStoredKind(tdb, entry.canvasId)
+        await tdb
+          .insertInto('canvases')
+          .values({
+            id: entry.canvasId,
+            workspaceId,
+            slug: path,
+            displayName: entry.displayName ?? null,
+            isPinned: 0,
+            pinOrder: null,
+            currentBranch: 'main',
+            createdAt: now,
+            updatedAt: now,
+            kind,
+          })
+          .execute()
+        adoptedIds.add(entry.canvasId)
+        takenPaths.add(path)
+      }
+    }
+  },
+
+  async down(): Promise<void> {
+    // Adoption only inserts rows for documents that had none; there is no
+    // record of which rows it created, so down is a no-op by design.
+  },
+}
+
+interface MigrationSchema {
+  workspaces: {
+    id: string
+    createdAt: number
+    updatedAt: number
+  }
+  canvases: {
+    id: string
+    workspaceId: string
+    slug: string
+    displayName: string | null
+    isPinned: number
+    pinOrder: number | null
+    currentBranch: string
+    createdAt: number
+    updatedAt: number
+    kind: string | null
+  }
+  canvasDocSnapshots: {
+    docKey: string
+    chunkCount: number
+    totalBytes: number
+    maxChunkBytes: number
+    frontier: Uint8Array
+  }
+  canvasDocSnapshotChunks: {
+    docKey: string
+    chunkIndex: number
+    bytes: Uint8Array
+  }
+  canvasDocDeltas: {
+    docKey: string
+    seq: number
+    bytes: Uint8Array
+    frontier: Uint8Array
+  }
+}
+
+/** Reassemble and import a stored doc: snapshot chunks in order, then deltas. */
+async function loadStoredDoc(db: Kysely<MigrationSchema>, docKey: string): Promise<LoroDoc | null> {
+  try {
+    const chunks = await db
+      .selectFrom('canvasDocSnapshotChunks')
+      .select(['chunkIndex', 'bytes'])
+      .where('docKey', '=', docKey)
+      .orderBy('chunkIndex', 'asc')
+      .execute()
+    if (chunks.length === 0) return null
+    const doc = new LoroDoc()
+    const total = chunks.reduce((sum, chunk) => sum + toBytes(chunk.bytes).byteLength, 0)
+    const snapshot = new Uint8Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+      const bytes = toBytes(chunk.bytes)
+      snapshot.set(bytes, offset)
+      offset += bytes.byteLength
+    }
+    doc.import(snapshot)
+    const deltas = await db
+      .selectFrom('canvasDocDeltas')
+      .select(['bytes'])
+      .where('docKey', '=', docKey)
+      .orderBy('seq', 'asc')
+      .execute()
+    for (const delta of deltas) {
+      doc.import(toBytes(delta.bytes))
+    }
+    return doc
+  } catch {
+    return null
+  }
+}
+
+/** Drivers hand blobs back as Buffer or Uint8Array depending on dialect. */
+function toBytes(value: Uint8Array): Uint8Array {
+  return value instanceof Uint8Array ? value : new Uint8Array(value)
+}
+
+interface RetiredDocument {
+  canvasId: string
+  path: string
+  displayName?: string
+}
+
+function walkRetiredTree(doc: LoroDoc): RetiredDocument[] {
+  const out: RetiredDocument[] = []
+  const tree = doc.getTree('tree')
+  const visit = (node: TreeNodeLike, prefix: string[]): void => {
+    const segment = node.data.get('segment')
+    const chain = typeof segment === 'string' ? [...prefix, segment] : prefix
+    const canvasId = node.data.get('canvasId')
+    if (typeof canvasId === 'string' && chain.length > 0) {
+      const displayName = node.data.get('displayName')
+      out.push({
+        canvasId,
+        path: chain.join('/'),
+        ...(typeof displayName === 'string' ? { displayName } : {}),
+      })
+    }
+    for (const child of node.children() ?? []) visit(child, chain)
+  }
+  for (const root of tree.roots()) visit(root as TreeNodeLike, [])
+  return out
+}
+
+/** The slice of LoroTreeNode this walk touches, so loro-crdt type churn cannot break the frozen reader. */
+interface TreeNodeLike {
+  data: { get(key: string): unknown }
+  children(): TreeNodeLike[] | undefined
+}
+
+async function readStoredKind(
+  db: Kysely<MigrationSchema>,
+  canvasId: string,
+): Promise<string | null> {
+  const doc = await loadStoredDoc(db, `canvas:${canvasId}`)
+  if (doc === null) return null
+  const kind = doc.getMap('document').get('kind')
+  return kind === 'spatial' || kind === 'markdown' ? kind : null
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -5,6 +5,7 @@ import { migration as canvasDocStore } from './0003-canvas-doc-store.js'
 import { migration as workspaceIndex } from './0004-workspace-index.js'
 import { migration as canvasesKind } from './0005-canvases-kind.js'
 import { migration as dropWorkspaceIndex } from './0006-drop-workspace-index.js'
+import { migration as adoptWorkspaceTree } from './0007-adopt-workspace-tree.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0002-canvases-last-compacted-at is a no-op kept only so databases created by the
@@ -16,4 +17,5 @@ export const migrations: Record<string, Migration> = {
   '0004-workspace-index': workspaceIndex,
   '0005-canvases-kind': canvasesKind,
   '0006-drop-workspace-index': dropWorkspaceIndex,
+  '0007-adopt-workspace-tree': adoptWorkspaceTree,
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -17,4 +17,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0004-workspace-index',
   '0005-canvases-kind',
   '0006-drop-workspace-index',
+  '0007-adopt-workspace-tree',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-canvas-ports/test-utils'
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createIsolatedDb } from './db/test-helpers.js'
 import { SqliteDocumentIndex } from './sqlite-document-index.js'
 
@@ -16,6 +16,45 @@ describe('SqliteDocumentIndex', () => {
         await handle.dispose()
         await rm(tempDir, { recursive: true, force: true })
       },
+    }
+  })
+
+  it('lists past a legacy nanoid row instead of letting it poison the whole listing', async () => {
+    // `saveCanvas` minted nanoid row ids before the id spaces converged, and
+    // rows outlive minting policy. One such row per workspace was enough to
+    // make every entry unreadable: the port's DocumentEntry accepts only a
+    // canonical ULID canvasId, so a listing that mapped the legacy row blew
+    // up output validation for the ENTIRE list — the agent surface went dark
+    // over a row it could never have created. The honest degradation is the
+    // one these rows always had: visible to the user's gallery, absent from
+    // the agent surface, and said in a log rather than an abort.
+    const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-document-index-legacy-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    try {
+      const index = new SqliteDocumentIndex(handle.db)
+      await index.createWorkspace({ workspaceId: 'ws1' })
+      const created = await index.createDocument({
+        workspaceId: 'ws1',
+        path: 'modern',
+        kind: 'spatial',
+      })
+      await handle.db
+        .insertInto('canvases')
+        .values({
+          id: 'Go1G4OcJKUBu',
+          workspaceId: 'ws1',
+          slug: 'legacy-row',
+          kind: 'spatial',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        })
+        .execute()
+
+      const entries = await index.listDocuments({ workspaceId: 'ws1' })
+      expect(entries.map((e) => e.canvasId)).toEqual([created.canvasId])
+    } finally {
+      await handle.dispose()
+      await rm(tempDir, { recursive: true, force: true })
     }
   })
 })

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -1,4 +1,4 @@
-import { generateCanvasId } from '@kamiazya/whiteboard-canvas-model'
+import { canvasIdSchema, generateCanvasId } from '@kamiazya/whiteboard-canvas-model'
 import type {
   CreateDocumentInput,
   CreateWorkspaceInput,
@@ -19,6 +19,7 @@ import {
   DocumentPathTakenError,
   WorkspaceNotFoundError,
 } from '@kamiazya/whiteboard-canvas-ports'
+import { getLogger } from '../log.js'
 import type { Database } from './db/index.js'
 import { upsertWorkspaceRow } from './db/upsert-workspace.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
@@ -60,10 +61,13 @@ function isSelfOrDescendant(path: string, ancestor: string): boolean {
  * New rows are assigned a ULID, not the nanoid `saveCanvas` mints for its own
  * rows: ADR-0007 point 5 fixed the ULID as the `canvasId` and the nanoid as a
  * storage detail, and `canvasIdSchema` in the port's `DocumentEntry` accepts
- * only the former. A row predating this therefore does not round-trip through
- * the port, which is a deliberate consequence of converging the two id spaces
- * rather than an oversight.
+ * only the former. A row predating this cannot round-trip through the port —
+ * a deliberate consequence of converging the two id spaces — so `listDocuments`
+ * skips such rows (see its comment) rather than letting one of them fail
+ * validation for the whole listing.
  */
+const log = getLogger('document-index')
+
 export class SqliteDocumentIndex implements DocumentIndex {
   constructor(private readonly db: Database) {}
 
@@ -172,10 +176,28 @@ export class SqliteDocumentIndex implements DocumentIndex {
       .execute()
     // Sorted here rather than in SQL: segment-wise order is not what any
     // collation gives, and the row count per workspace is a list a human reads.
-    return rows
-      .filter((row) => row.kind !== null)
-      .map(toEntry)
-      .sort((left, right) => compareDocumentPaths(left.path, right.path))
+    //
+    // Rows whose id is not a canonical ULID are SKIPPED, not surfaced:
+    // `saveCanvas` minted nanoid row ids before the id spaces converged, and
+    // rows outlive minting policy. The port's DocumentEntry accepts only a
+    // ULID, so mapping such a row does not degrade to one bad entry — it
+    // fails output validation for the ENTIRE listing, and one legacy row per
+    // workspace turns the whole agent surface dark. Skipping keeps those
+    // rows exactly as reachable as they were before the convergence (the
+    // user's gallery), and the log is where the absence is said.
+    const entries: DocumentEntry[] = []
+    for (const row of rows) {
+      if (row.kind === null) continue
+      if (!canvasIdSchema.safeParse(row.id).success) {
+        log.warning(
+          { workspaceId, slug: row.slug },
+          'skipping a pre-convergence row the port cannot carry',
+        )
+        continue
+      }
+      entries.push(toEntry(row))
+    }
+    return entries.sort((left, right) => compareDocumentPaths(left.path, right.path))
   }
 
   async moveDocument({ workspaceId, from, to }: MoveDocumentInput): Promise<void> {


### PR DESCRIPTION
Fixes the live regression left by #795 on any data dir that predates it. Reported to the session that shipped #795 twice (both messages expired unapproved), then taken over with the user's knowledge — no in-flight branch touches these files.

## What broke

Retiring the workspace tree converged the agent surface onto the `canvases` table, but shipped **no migration** and left **one minting policy unconverged**. On a pre-existing data dir:

- Every document that existed only in the retired `workspace-tree:<ws>` docs — this repo's own issue backlog among them — answered **"not found"** over Loro snapshots fully intact on disk.
- `wb_document_list` **aborted outright**: the listing mapped legacy nanoid rows into port entries, the port's own `canvasIdSchema` rejected them, and one legacy row per workspace failed output validation for the entire list.
- And the leak was ongoing: `saveCanvas` (the web UI's create path) still minted nanoids into the same table the index mints ULIDs into.

## Three fixes, each pinned red-first

1. **Migration `0007-adopt-workspace-tree`.** Walks each retired tree doc still in the snapshot store and inserts the missing rows: path from the root-to-leaf segment chain, display name carried over, kind read from the canvas doc itself. The retired format is **frozen inside the migration** — the code that wrote it was deleted in the change that retired it, which is exactly why a migration cannot lean on living code. Idempotent; a taken path adopts under `-2`, `-3`, …; a corrupt tree doc is skipped rather than turning bootstrap into an outage; the tree docs are left in place (inert, and a migration that deletes its own input cannot be re-run to diagnose what it did).
2. **`listDocuments` skips a non-ULID row with a warning log** instead of letting it fail validation for the whole listing. Skipped rows stay exactly as reachable as before the convergence: the user's gallery.
3. **`saveCanvas` mints ULIDs for new rows.** One table, one id space. Existing nanoid rows keep their ids — a PK rewrite reaches branches/versions FKs and blob paths, and is deliberately not this fix.

## Verification

- **Against a copy of this machine's real data dir** — the very dir where the regression was found — the migration recovers **all eleven orphaned documents** with their ULIDs, paths, kinds and display names.
- **Mutation-checked five ways**: kind-read dropped, idempotence dropped, collision suffix dropped (each fails a different assertion), list-skip removed, ULID shape pinned.
- The `published-migration-names` manifest guard caught the missing registration exactly as designed — registered in the same commit.
- `mcp-node` 3359 passed, arch-lint 76 passed, typecheck/lint/knip clean.

## Vocabulary drive-by

One comment calling the row PK "the stable nanoid PK" now says "row PK", since nanoid is no longer the policy.