### PR TITLE
test(server): guard the pre-ULID canvasId row that breaks wb_document_list

### DIFF
--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { documentEntrySchema } from '@kamiazya/whiteboard-canvas-ports'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-canvas-ports/test-utils'
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createIsolatedDb } from './db/test-helpers.js'
 import { SqliteDocumentIndex } from './sqlite-document-index.js'
 
@@ -17,5 +18,71 @@ describe('SqliteDocumentIndex', () => {
         await rm(tempDir, { recursive: true, force: true })
       },
     }
+  })
+})
+
+describe('rows written before canvasIds were ULIDs', () => {
+  // A daemon that predates ADR-0007 decision 5 has nanoid ids in `canvases`.
+  // The index reads that table directly now, so such a row reaches every
+  // caller — and `wb_document_list` declares an outputSchema the MCP SDK
+  // validates at runtime, so ONE of them makes the whole listing fail rather
+  // than degrading. The index must not hand out an entry that violates the
+  // schema its own port declares.
+  async function withLegacyRow(body: (index: SqliteDocumentIndex) => Promise<void>): Promise<void> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-legacy-id-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    try {
+      await handle.db
+        .insertInto('workspaces')
+        .values({ id: 'ws-legacy', createdAt: 0, updatedAt: 0 })
+        .execute()
+      await handle.db
+        .insertInto('canvases')
+        .values({
+          id: 'uH6qTx6Ai2hl',
+          workspaceId: 'ws-legacy',
+          slug: 'pre-ulid-doc',
+          displayName: null,
+          isPinned: 0,
+          pinOrder: null,
+          currentBranch: 'main',
+          createdAt: 0,
+          updatedAt: 0,
+          kind: 'spatial',
+        })
+        .execute()
+      await body(new SqliteDocumentIndex(handle.db))
+    } finally {
+      await handle.dispose()
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+
+  // KNOWN GAP, deliberately not fixed here (user decision 2026-08-15): the
+  // product keeps emitting the offending entry, and the affected local data
+  // was repaired by hand instead. `it.fails` is the guard — it passes while
+  // the gap is open and turns RED the moment someone closes it, which forces
+  // whoever does to come here and flip it rather than leaving a stale test.
+  // The fix is a migration that rewrites pre-ULID ids and moves the blobs and
+  // every table that references them; see the task for the surface.
+  it.fails('does not emit a listing entry that fails its own schema', async () => {
+    await withLegacyRow(async (index) => {
+      const entries = await index.listDocuments({ workspaceId: 'ws-legacy' })
+      for (const entry of entries) {
+        expect(
+          documentEntrySchema.safeParse(entry).success,
+          `entry violates documentEntrySchema: ${JSON.stringify(entry)}`,
+        ).toBe(true)
+      }
+    })
+  })
+
+  it('still accounts for the document rather than silently dropping it', async () => {
+    // Whatever the fix, the row must not just vanish: a listing that quietly
+    // omits stored data is the same dishonest surface a 200-empty was.
+    await withLegacyRow(async (index) => {
+      const entries = await index.listDocuments({ workspaceId: 'ws-legacy' })
+      expect(entries.map((entry) => entry.path)).toContain('pre-ulid-doc')
+    })
   })
 })


### PR DESCRIPTION
Confirms and guards the regression reported against #795.

## What broke

`wb_document_list` failed **entirely**, on real data:

```
Output validation error: Invalid structured content for tool wb_document_list:
canvases.0.canvasId: must be a canonical ULID
```

The list is where this repo's own ticketing flow starts, so it stopped with it.

## Why

Two `canvases` rows in the local `default` workspace predate ADR-0007 decision 5
and carry nanoid ids (`uH6qTx6Ai2hl`, `Go1G4OcJKUBu`). Before #795 the listing
came from the workspace tree, which never held them. #795 made
`SqliteDocumentIndex.listDocuments` read the table directly, so both rows now
reach the caller — and the tool's `outputSchema` requires a canonical ULID.
The MCP SDK validates `structuredContent` at runtime, so **one** bad row fails
the whole response rather than degrading.

This is exactly the drift class AGENTS.md says the smoke is the last defense
against. It didn't catch this one because `pnpm smoke:e2e` runs against a clean
data dir and never sees a legacy row.

## What this PR contains

Only the guard. The affected data was repaired by hand rather than by a
migration (user decision), so the product gap stays open — and the test says so
rather than pretending otherwise:

- `it.fails` on "does not emit a listing entry that fails its own schema":
  passes while the gap is open, turns **red** the moment someone closes it,
  which forces them here to flip it instead of leaving a stale test.
- A plain passing assertion that the document is still *accounted for*. That
  one rules out the tempting fix — filtering non-ULID rows out of the listing —
  which is the same dishonest surface #798 had just finished removing.

Task filed with the fix shape and the measurements behind it.

## Second finding, same investigation

`listDocuments` also drops rows with `kind IS NULL` (sqlite-document-index.ts:176),
so a document written before `kind` existed is invisible in every listing while
its bytes sit on disk. Locally that hid a 75-node diagram. Same class as above,
also introduced by #795; recorded in the task rather than fixed here, with the
ripple already measured (`DocumentEntry.kind` has one non-test consumer and the
MCP list output does not carry `kind` at all).

## Verification

`mcp-node` on the touched file: 23 passed, 1 expected-fail. Full `pnpm -r typecheck`
and `pnpm lint` green.

Local data repaired non-destructively and verified through the real daemon —
`wb_document_list` now returns both documents. Worth recording for whoever writes
the migration: `versions`/`branches` carry a foreign key onto `canvases.id`, so
the id rewrite needs `PRAGMA defer_foreign_keys = ON` inside the transaction or
the very first UPDATE is already a violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3
