### PR TITLE
test(model,codec): exclude blank html values that trip an upstream assert

### DIFF
--- a/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
+++ b/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
@@ -1,5 +1,5 @@
 import { mdastFlowContentArbitrary } from '@kamiazya/whiteboard-canvas-model/test-utils'
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { fc, fcTest, hasNoEmptyContainer, withDefaults } from '../test-utils/fast-check.js'
 import { parseMarkdownBody, stringifyMarkdownBody } from './pipeline.js'
 
@@ -25,4 +25,20 @@ describe('markdown body parse totality (including lists)', () => {
       parseMarkdownBody(text)
     },
   )
+})
+
+describe('upstream task-list continuation crash (canary)', () => {
+  // A GFM checkbox stranded on a bullet's continuation line trips a
+  // DEV-ONLY assert inside mdast-util-gfm-task-list-item@2.0.0 (exitCheck,
+  // via devlop — production builds no-op it, so deployed parsing does not
+  // throw; the dev server and this test runner do). The totality
+  // arbitrary excludes the one model shape whose serialization produces
+  // this text (a blank-valued html node emptying a checked item's first
+  // paragraph — unreachable from any real parse). This canary pins the
+  // upstream behavior itself: when a dependency bump makes it stop
+  // throwing, delete this test and the html-value exclusion in
+  // canvas-model's arbitraries together.
+  it('still throws on a checkbox stranded on a continuation line', () => {
+    expect(() => parseMarkdownBody('*\n[ ] x')).toThrow()
+  })
 })

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -187,9 +187,18 @@ const inlineCodeLeafArbitrary = fc
   .string({ maxLength: 20 })
   .map((value) => ({ type: 'inlineCode' as const, value }))
 const breakLeafArbitrary: fc.Arbitrary<{ type: 'break' }> = fc.constant({ type: 'break' })
-const htmlLeafArbitrary = fc
-  .string({ maxLength: 20 })
-  .map((value) => ({ type: 'html' as const, value }))
+// html values carry a non-whitespace character by construction: a real
+// parse can never produce an html node whose value is blank (the value IS
+// the raw source of an html construct), and a blank one serializes to
+// nothing — which strands a GFM task-list checkbox onto a continuation
+// line (`*\n[ ] x`) and trips a dev-only upstream assert
+// (mdast-util-gfm-task-list-item@2.0.0 exitCheck, via devlop; production
+// builds no-op the assert). Exclusion, not a fix: tracked as the
+// remark-taskitem-continuation-crash issue until upstream repairs it.
+const nonBlankHtmlValue = fc
+  .string({ minLength: 1, maxLength: 20 })
+  .filter((value) => value.trim().length > 0)
+const htmlLeafArbitrary = nonBlankHtmlValue.map((value) => ({ type: 'html' as const, value }))
 const imageLeafArbitrary = fc
   .record({ url: fc.webUrl(), title: optionalNullableString, alt: optionalNullableString })
   .map(({ url, title, alt }) => ({ type: 'image' as const, url, title, alt }))
@@ -322,9 +331,11 @@ const definitionLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
     url,
     title,
   }))
-const flowHtmlLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
-  .string({ maxLength: 20 })
-  .map((value) => ({ type: 'html', value }))
+// Same non-blank rule as htmlLeafArbitrary above, same upstream reason.
+const flowHtmlLeafArbitrary: fc.Arbitrary<MdastFlowContent> = nonBlankHtmlValue.map((value) => ({
+  type: 'html',
+  value,
+}))
 const mathLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
   .record({
     value: fc.string({ maxLength: 20 }),


### PR DESCRIPTION
## Summary

Root-cause for the genuine property failure that hit PR #800's `test-unit (2)` (`parseMarkdownBody(stringifyMarkdownBody(x)) never throws`, seed 609638238) — reproduced with the seed per the no-rerun rule, never waved through.

**Chain**: the generator produced a checked list item whose first paragraph held a **blank-valued `html` node** → the blank value serializes to nothing, stranding the GFM checkbox onto a bullet continuation line (`*\n[ ] x`) → `mdast-util-gfm-task-list-item@2.0.0`'s `exitCheck` **asserts** on that input (via `devlop`). Dev-only: production builds no-op the assert, so deployed parsing is unaffected; the dev server and test runners crash. Latest upstream versions still have it; no matching upstream issue found.

**Fix shape** (exclusion, not a fix — per the property-test discipline):
- A blank `html` value is unreachable from any real parse (the value IS the raw source of an html construct), so `canvas-model`'s html arbitraries now require a non-whitespace character, with the upstream rationale at the filter.
- A **canary example** pins the upstream throw itself (`parseMarkdownBody('*\n[ ] x')` throws): the dependency bump that repairs it turns this test red, pointing at both removals (canary + exclusion).
- Verified under the original failing seed: green.

Tracking: `remark-taskitem-continuation-crash` whiteboard issue (upstream report text prepared there).

## Test plan

- [x] Reproduced the CI failure locally with seed 609638238; green after the exclusion under the same seed
- [x] canvas-codec (88) and canvas-model (151) suites green; `pnpm -r typecheck`, lint green
