### PR TITLE
feat(server)!: address the live-canvas API by document path

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -64,9 +64,9 @@ Not a work queue — a lookup, so you can recognise one when you open a file.
   package names — `render` and `viewer` are arguably correct (they are about
   the spatial scene); `model`, `codec`, `ports` and `workspace` are not
 - `/w/:ws/canvas/:slug` and `/local/:canvasId` routes, and the UI copy around
-  them. The shape is now workspace-first, but the tail is still a `slug` rather
-  than the document's path — it stays that way until the page stops loading
-  through `/api/canvas/:workspaceId/:slug`
+  them. The UI tail is still one segment, but the data path under it
+  (`/api/w/:ws/canvas/<path>/*`) now takes a document path — widening the UI
+  regex is the remaining step
 - MCP tool names — ADR-0009 point 5, its own increment
 - Core facets written to spatial documents (`CanvasProperties` mounted for
   both kinds) — this one is a behaviour change, not a rename; see ADR-0009

--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -110,7 +110,7 @@ describe('importOneCanvas', () => {
     })
 
     const [updateUrl, updateInit] = fetchMock.mock.calls[1] as [string, RequestInit]
-    expect(updateUrl).toBe(`http://127.0.0.1:3099/api/canvas/${encodedWs}/my-canvas/update`)
+    expect(updateUrl).toBe(`http://127.0.0.1:3099/api/w/${encodedWs}/canvas/my-canvas/update`)
     expect((updateInit.headers as Record<string, string>)['Content-Type']).toBe(
       'application/octet-stream',
     )

--- a/apps/web/src/components/migration/import-browser-local.ts
+++ b/apps/web/src/components/migration/import-browser-local.ts
@@ -1,5 +1,6 @@
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import {
+  canvasApiUrl,
   createCanvasRequestSchema,
   createCanvasResponseSchema,
   problemDetailsErrorSchema,
@@ -140,7 +141,7 @@ async function importOneCanvasUnsafe(
   const mergedSnapshot = mergeToSnapshot(loroLoad.snapshot, loroLoad.deltas ?? [])
 
   const updateRes = await fetch(
-    `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(createdSlug)}/update`,
+    `${daemonBaseUrl}${canvasApiUrl(workspaceId, createdSlug, 'update')}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },

--- a/apps/web/src/lib/app-routes.test.ts
+++ b/apps/web/src/lib/app-routes.test.ts
@@ -64,7 +64,7 @@ describe('parseDaemonRoute', () => {
 
   it('does not yet accept a multi-segment tail', () => {
     // The shape leaves room for a document path here, but the page below
-    // still loads by slug through /api/canvas/:workspaceId/:slug — a URL the
+    // still loads by a single-segment slug — a URL the
     // app cannot open is worse than a not-found, so it stays not-a-route
     // until that data path converges too.
     expect(parseDaemonRoute('/w/w1/canvas/notes/2026/plan')).toBeNull()

--- a/apps/web/src/lib/canvas-embed-content.ts
+++ b/apps/web/src/lib/canvas-embed-content.ts
@@ -93,7 +93,7 @@ async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
  * The browser-local binding of the editor's file seams. Declared here beside
  * the four functions it wires so the page is left with no backend knowledge
  * of its own — the daemon page supplies its own adapter over the daemon's
- * `/api/canvas/:workspaceId/:slug/file/:fileId` endpoints.
+ * `/api/w/:workspaceId/canvas/:slug/file/:fileId` endpoints.
  */
 export const BROWSER_LOCAL_FILE_ADAPTER: CanvasFileAdapter = {
   isImageRef,

--- a/apps/web/src/lib/daemon-api-client.test.ts
+++ b/apps/web/src/lib/daemon-api-client.test.ts
@@ -223,7 +223,7 @@ describe('getCanvasSnapshot', () => {
     )
     const result = await getCanvasSnapshot(fetchFn, DAEMON_BASE_URL, 'w1', 'main')
     expect(new Uint8Array(result)).toEqual(bytes)
-    expect(fetchFn).toHaveBeenCalledWith(`${DAEMON_BASE_URL}/api/canvas/w1/main/snapshot`)
+    expect(fetchFn).toHaveBeenCalledWith(`${DAEMON_BASE_URL}/api/w/w1/canvas/main/snapshot`)
   })
 
   it('rejects on a non-2xx response, surfacing problem+json detail', async () => {
@@ -241,7 +241,7 @@ describe('updateCanvas', () => {
     const result = await updateCanvas(fetchFn, DAEMON_BASE_URL, 'w1', 'main', bytes)
     expect(result).toEqual({ ok: true })
     const [urlArg, initArg] = fetchFn.mock.calls[0]
-    expect(String(urlArg)).toBe(`${DAEMON_BASE_URL}/api/canvas/w1/main/update`)
+    expect(String(urlArg)).toBe(`${DAEMON_BASE_URL}/api/w/w1/canvas/main/update`)
     expect(initArg?.method).toBe('POST')
     expect(initArg?.body).toBe(bytes)
   })

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -2,6 +2,7 @@ import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import {
   type CanvasOkfV1Response,
   type CreateCanvasResponse,
+  canvasApiUrl,
   canvasOkfV1ResponseSchema,
   createCanvasResponseSchema,
   type DeleteCanvasResponse,
@@ -121,7 +122,7 @@ export function deleteCanvas(
   )
 }
 
-// GET /api/canvas/:workspaceId/:slug/snapshot returns raw Loro bytes
+// GET /api/w/:workspaceId/canvas/:slug/snapshot returns raw Loro bytes
 // (application/octet-stream), not JSON — kept separate from fetchAndParse,
 // which always calls res.json().
 export async function getCanvasSnapshot(
@@ -130,7 +131,7 @@ export async function getCanvasSnapshot(
   workspaceId: string,
   slug: string,
 ): Promise<Uint8Array> {
-  const url = `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}/snapshot`
+  const url = `${daemonBaseUrl}${canvasApiUrl(workspaceId, slug, 'snapshot')}`
   const res = await fetchFn(url)
   if (!res.ok) {
     throw new Error(await parseProblemDetails(res))
@@ -147,7 +148,7 @@ export function updateCanvas(
 ): Promise<UpdateCanvasResponse> {
   return fetchAndParse(
     fetchFn,
-    `${daemonBaseUrl}/api/canvas/${encodeURIComponent(workspaceId)}/${encodeURIComponent(slug)}/update`,
+    `${daemonBaseUrl}${canvasApiUrl(workspaceId, slug, 'update')}`,
     updateCanvasResponseSchema,
     { method: 'POST', body: snapshot as BodyInit },
   )

--- a/apps/web/src/lib/daemon-backend-alias.browser.test.tsx
+++ b/apps/web/src/lib/daemon-backend-alias.browser.test.tsx
@@ -15,6 +15,6 @@ describe('daemon-backend alias resolution (browser)', () => {
 
     expect(injectedFetch).toHaveBeenCalledTimes(1)
     const [url] = injectedFetch.mock.calls[0]
-    expect(String(url)).toContain('/api/canvas/ws1/main/file/file-1')
+    expect(String(url)).toContain('/api/w/ws1/canvas/main/file/file-1')
   })
 })

--- a/apps/web/src/lib/daemon-backend-alias.test.ts
+++ b/apps/web/src/lib/daemon-backend-alias.test.ts
@@ -18,6 +18,6 @@ describe('daemon-backend alias resolution', () => {
 
     expect(injectedFetch).toHaveBeenCalledTimes(1)
     const [url] = injectedFetch.mock.calls[0]
-    expect(String(url)).toContain('/api/canvas/ws1/main/file/file-1')
+    expect(String(url)).toContain('/api/w/ws1/canvas/main/file/file-1')
   })
 })

--- a/apps/web/src/lib/daemon-file-adapter.test.ts
+++ b/apps/web/src/lib/daemon-file-adapter.test.ts
@@ -66,7 +66,7 @@ describe('createDaemonFileAdapter', () => {
 
     const url = await adapter.loadImageUrl('asset:file-abc')
 
-    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/${SLUG}/file/file-abc`)
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/w/${WS}/canvas/${SLUG}/file/file-abc`)
     expect(url).toBe(FAKE_OBJECT_URL)
   })
 
@@ -97,7 +97,7 @@ describe('createDaemonFileAdapter', () => {
 
     expect(ref).toBe(`asset:${FAKE_UUID}`)
     const [url, init] = daemonFetch.mock.calls[0] as unknown as [string, RequestInit]
-    expect(url).toBe(`${BASE}/api/canvas/${WS}/${SLUG}/file/${FAKE_UUID}`)
+    expect(url).toBe(`${BASE}/api/w/${WS}/canvas/${SLUG}/file/${FAKE_UUID}`)
     expect(init.method).toBe('PUT')
     // The route rejects an unrecognised Content-Type with 415, so the
     // picked file's own type has to travel.
@@ -131,7 +131,7 @@ describe('createDaemonFileAdapter', () => {
 
     const loaded = await adapter.loadDocument('sibling')
 
-    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/sibling/snapshot`)
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/w/${WS}/canvas/sibling/snapshot`)
     expect(loaded?.canvas?.nodes[0]).toMatchObject({ id: 'n1', text: 'hello' })
   })
 
@@ -160,7 +160,7 @@ describe('createDaemonFileAdapter', () => {
 
     await adapter.loadDocument('a b')
 
-    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/canvas/${WS}/a%20b/snapshot`)
+    expect(daemonFetch).toHaveBeenCalledWith(`${BASE}/api/w/${WS}/canvas/a%20b/snapshot`)
   })
 })
 
@@ -177,7 +177,7 @@ describe('createDaemonFileAdapter — id references', () => {
     const loaded = await adapter.loadDocument('nanoid-123')
     expect(loaded).toBeDefined()
     expect(String((daemonFetch.mock.calls as unknown[][])[0]?.[0])).toContain(
-      '/api/canvas/ws-1/renamed-canvas/snapshot',
+      '/api/w/ws-1/canvas/renamed-canvas/snapshot',
     )
   })
 
@@ -193,7 +193,7 @@ describe('createDaemonFileAdapter — id references', () => {
     const loaded = await adapter.loadDocument('old-slug-ref')
     expect(loaded).toBeDefined()
     expect(String((daemonFetch.mock.calls as unknown[][])[0]?.[0])).toContain(
-      '/api/canvas/ws-1/old-slug-ref/snapshot',
+      '/api/w/ws-1/canvas/old-slug-ref/snapshot',
     )
   })
 })

--- a/apps/web/src/lib/daemon-file-adapter.ts
+++ b/apps/web/src/lib/daemon-file-adapter.ts
@@ -41,7 +41,7 @@ export function createDaemonFileAdapter({
   resolveRefSlug,
 }: DaemonFileAdapterOptions): CanvasFileAdapter {
   const canvasPath = (target: string) =>
-    `${daemonBaseUrl}/api/canvas/${workspaceId}/${encodeURIComponent(target)}`
+    `${daemonBaseUrl}/api/w/${encodeURIComponent(workspaceId)}/canvas/${encodeURIComponent(target)}`
 
   return {
     isImageRef,

--- a/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
@@ -56,7 +56,7 @@ const server = setupServer(
   // The canvas update route: where a push lands, after the worker's replica
   // has merged it. Addressed by workspace and slug, which the worker
   // reconstructs from the document key it routes everything else by.
-  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+  http.post(`${BASE}/api/w/:workspaceId/canvas/:slug/update`, async ({ request, params }) => {
     daemonWrites.push({
       doc: `${String(params.workspaceId)}/${String(params.slug)}`,
       body: new Uint8Array(await request.arrayBuffer()),

--- a/apps/web/src/lib/sse-shared-worker-resend.test.ts
+++ b/apps/web/src/lib/sse-shared-worker-resend.test.ts
@@ -50,7 +50,7 @@ const server = setupServer(
     subscribeBodies.push(await request.text())
     return HttpResponse.json({ ok: true })
   }),
-  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+  http.post(`${BASE}/api/w/:workspaceId/canvas/:slug/update`, async ({ request, params }) => {
     // A refusal that ANSWERS rather than drops the connection: a 5xx is the
     // shape a restarting daemon actually produces, and it is the one a
     // `fetch().catch()` cannot see — fetch resolves, so a writer that only

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -85,7 +85,7 @@ const server = setupServer(
   // Addressed by workspace and slug rather than by the document key the rest
   // of the worker routes on — the key IS `${workspaceId}/${slug}`, which is
   // what lets the worker reconstruct this URL at all.
-  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+  http.post(`${BASE}/api/w/:workspaceId/canvas/:slug/update`, async ({ request, params }) => {
     updateWrites.push({
       workspaceId: String(params.workspaceId),
       slug: String(params.slug),

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -83,7 +83,7 @@ function installFetchMock(routes: MockRoutes) {
       }
       return Promise.resolve(jsonResponse(names))
     }
-    const snapshotMatch = url.match(/\/api\/canvas\/([^/]+)\/([^/]+)\/snapshot$/)
+    const snapshotMatch = url.match(/\/api\/w\/([^/]+)\/canvas\/(.+)\/snapshot$/)
     if (snapshotMatch) {
       const slug = decodeURIComponent(snapshotMatch[2])
       const bytes = routes.snapshotByCanvas?.[slug]
@@ -95,7 +95,7 @@ function installFetchMock(routes: MockRoutes) {
         }),
       )
     }
-    const updateMatch = url.match(/\/api\/canvas\/([^/]+)\/([^/]+)\/update$/)
+    const updateMatch = url.match(/\/api\/w\/([^/]+)\/canvas\/(.+)\/update$/)
     if (updateMatch && init?.method === 'POST') {
       const workspaceId = decodeURIComponent(updateMatch[1])
       const slug = decodeURIComponent(updateMatch[2])
@@ -505,7 +505,7 @@ describe('DaemonIndexPage', () => {
       if (url.endsWith('/api/workspaces/ws-a/names')) {
         return Promise.resolve(jsonResponse({ canvases: { alpha: 'Alpha' }, pinned: [] }))
       }
-      if (url.endsWith('/api/canvas/ws-a/alpha/snapshot')) {
+      if (url.endsWith('/api/w/ws-a/canvas/alpha/snapshot')) {
         snapshotCalls++
         return new Promise<Response>((resolve) => {
           resolveSnapshot = resolve
@@ -591,7 +591,7 @@ describe('DaemonIndexPage', () => {
       ) {
         return Promise.resolve(jsonResponse({ canvases: {}, pinned: [] }))
       }
-      if (url.endsWith('/api/canvas/ws-a/alpha/snapshot')) {
+      if (url.endsWith('/api/w/ws-a/canvas/alpha/snapshot')) {
         return new Promise<Response>((resolve) => {
           resolveSnapshot = resolve
         })

--- a/packages/mcp-server/src/cli/server-run-auth.test.ts
+++ b/packages/mcp-server/src/cli/server-run-auth.test.ts
@@ -50,7 +50,7 @@ function authInput(
 ): AuthAuthorizeInput {
   return {
     method: 'GET',
-    path: '/api/canvas/ws1/test',
+    path: '/api/w/ws1/canvas/test',
     authorizationHeader: jwt ? `Bearer ${jwt}` : undefined,
     requiredScopes: scopes as never,
   }

--- a/packages/mcp-server/src/server/app.server-mode.test.ts
+++ b/packages/mcp-server/src/server/app.server-mode.test.ts
@@ -430,17 +430,17 @@ describe('app — server-mode composition', () => {
       expect(res.status).not.toBe(403)
     })
 
-    it('GET /api/canvas/:wid/:slug/snapshot → 403 with canvas:write only (requires canvas:read)', async () => {
+    it('GET /api/w/:wid/canvas/:slug/snapshot → 403 with canvas:write only (requires canvas:read)', async () => {
       const app = createApp(makeServerModeOptions(['canvas:write']))
-      const res = await app.request('/api/canvas/w1/canvas-a/snapshot', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/snapshot', {
         headers: { authorization: BEARER },
       })
       expect(res.status).toBe(403)
     })
 
-    it('POST /api/canvas/:wid/:slug/update → 403 with canvas:read only (requires canvas:write)', async () => {
+    it('POST /api/w/:wid/canvas/:slug/update → 403 with canvas:read only (requires canvas:write)', async () => {
       const app = createApp(makeServerModeOptions(['canvas:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/update', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { authorization: BEARER },
       })
@@ -470,23 +470,23 @@ describe('app — server-mode composition', () => {
 
   // Req 6: files scope through composed app
   describe('server-mode files scope via composed app', () => {
-    it('GET /api/canvas/:wid/:slug/file/:fileId → 401 without auth', async () => {
+    it('GET /api/w/:wid/canvas/:slug/file/:fileId → 401 without auth', async () => {
       const app = createApp(makeServerModeOptions(['files:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/file/file-001')
+      const res = await app.request('/api/w/w1/canvas/canvas-a/file/file-001')
       expect(res.status).toBe(401)
     })
 
-    it('GET /api/canvas/:wid/:slug/file/:fileId → 403 with files:write only', async () => {
+    it('GET /api/w/:wid/canvas/:slug/file/:fileId → 403 with files:write only', async () => {
       const app = createApp(makeServerModeOptions(['files:write']))
-      const res = await app.request('/api/canvas/w1/canvas-a/file/file-001', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/file/file-001', {
         headers: { authorization: BEARER },
       })
       expect(res.status).toBe(403)
     })
 
-    it('PUT /api/canvas/:wid/:slug/file/:fileId → 403 with files:read only', async () => {
+    it('PUT /api/w/:wid/canvas/:slug/file/:fileId → 403 with files:read only', async () => {
       const app = createApp(makeServerModeOptions(['files:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/file/file-001', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/file/file-001', {
         method: 'PUT',
         headers: { authorization: BEARER, 'Content-Type': 'image/png' },
         body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
@@ -506,7 +506,7 @@ describe('app — server-mode composition', () => {
   // Req 8: insufficient scope → 403 + no WWW-Authenticate
   it('insufficient scope → 403 + no WWW-Authenticate through composed app', async () => {
     const app = createApp(makeServerModeOptions(['workspace:read']))
-    const res = await app.request('/api/canvas/w1/c1/snapshot', {
+    const res = await app.request('/api/w/w1/canvas/c1/snapshot', {
       headers: { authorization: BEARER },
     })
     expect(res.status).toBe(403)
@@ -515,9 +515,9 @@ describe('app — server-mode composition', () => {
 
   // Previously-unguarded routes: export, viewport, status
   describe('server-mode: previously-unguarded routes are auth-gated', () => {
-    it('POST /api/canvas/:wid/:slug/export → 401 without auth', async () => {
+    it('POST /api/w/:wid/canvas/:slug/export → 401 without auth', async () => {
       const app = createApp(makeServerModeOptions(['canvas:write']))
-      const res = await app.request('/api/canvas/w1/canvas-a/export', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/export', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),
@@ -525,9 +525,9 @@ describe('app — server-mode composition', () => {
       expect(res.status).toBe(401)
     })
 
-    it('POST /api/canvas/:wid/:slug/export → 403 with canvas:read only (requires canvas:write)', async () => {
+    it('POST /api/w/:wid/canvas/:slug/export → 403 with canvas:read only (requires canvas:write)', async () => {
       const app = createApp(makeServerModeOptions(['canvas:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/export', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/export', {
         method: 'POST',
         headers: { authorization: BEARER, 'content-type': 'application/json' },
         body: JSON.stringify({}),
@@ -535,9 +535,9 @@ describe('app — server-mode composition', () => {
       expect(res.status).toBe(403)
     })
 
-    it('POST /api/canvas/:wid/:slug/viewport → 401 without auth', async () => {
+    it('POST /api/w/:wid/canvas/:slug/viewport → 401 without auth', async () => {
       const app = createApp(makeServerModeOptions(['canvas:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/viewport', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/viewport', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),
@@ -545,11 +545,11 @@ describe('app — server-mode composition', () => {
       expect(res.status).toBe(401)
     })
 
-    it('POST /api/canvas/:wid/:slug/viewport → 403 with canvas:read only (requires canvas:write)', async () => {
+    it('POST /api/w/:wid/canvas/:slug/viewport → 403 with canvas:read only (requires canvas:write)', async () => {
       // Regression (security MEDIUM-1): viewport is a mutating POST that fell through the
-      // /api/canvas/ catch-all and was authorized with canvas:read. It must require canvas:write.
+      // /api/w/*/canvas/ catch-all and was authorized with canvas:read. It must require canvas:write.
       const app = createApp(makeServerModeOptions(['canvas:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/viewport', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/viewport', {
         method: 'POST',
         headers: { authorization: BEARER, 'content-type': 'application/json' },
         body: JSON.stringify({}),
@@ -557,9 +557,9 @@ describe('app — server-mode composition', () => {
       expect(res.status).toBe(403)
     })
 
-    it('POST /api/canvas/:wid/:slug/viewport passes auth layer with canvas:write', async () => {
+    it('POST /api/w/:wid/canvas/:slug/viewport passes auth layer with canvas:write', async () => {
       const app = createApp(makeServerModeOptions(['canvas:write']))
-      const res = await app.request('/api/canvas/w1/canvas-a/viewport', {
+      const res = await app.request('/api/w/w1/canvas/canvas-a/viewport', {
         method: 'POST',
         headers: { authorization: BEARER, 'content-type': 'application/json' },
         body: JSON.stringify({}),
@@ -568,9 +568,9 @@ describe('app — server-mode composition', () => {
       expect(res.status).not.toBe(403)
     })
 
-    it('GET /api/canvas/:wid/:slug/client-count → 401 without auth', async () => {
+    it('GET /api/w/:wid/canvas/:slug/client-count → 401 without auth', async () => {
       const app = createApp(makeServerModeOptions(['canvas:read']))
-      const res = await app.request('/api/canvas/w1/canvas-a/client-count')
+      const res = await app.request('/api/w/w1/canvas/canvas-a/client-count')
       expect(res.status).toBe(401)
     })
 

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -34,6 +34,10 @@ describe('api-contracts barrel scope', () => {
       '@kamiazya/whiteboard-server-core',
       './branches.js',
       './canvas.js',
+      // canvas-url: the live-canvas API's URL shape, exported so apps/web
+      // builds request URLs through the same function the daemon's own
+      // clients use instead of re-deriving the shape by hand.
+      './canvas-url.js',
       './pairing.js',
       './runtime.js',
     ])

--- a/packages/mcp-server/src/server/routes/auth-oauth.test.ts
+++ b/packages/mcp-server/src/server/routes/auth-oauth.test.ts
@@ -12,8 +12,8 @@ function createApp(grantStore?: ReturnType<typeof createOAuthTransactionStore>) 
   return app
 }
 
-const READ_PATH = '/api/canvas/session-1/demo/snapshot'
-const WRITE_PATH = '/api/canvas/session-1/demo/update'
+const READ_PATH = '/api/w/session-1/canvas/demo/snapshot'
+const WRITE_PATH = '/api/w/session-1/canvas/demo/update'
 const UNDECLARED_PATH = '/api/not-in-the-registry'
 
 async function request(

--- a/packages/mcp-server/src/server/routes/auth.test.ts
+++ b/packages/mcp-server/src/server/routes/auth.test.ts
@@ -12,11 +12,11 @@ describe('requiresDaemonAuth', () => {
     // it server-side costs nothing on the happy path and closes the
     // read-without-a-token surface for anyone else.
     expect(requiresDaemonAuth('/api/workspaces')).toBe(true)
-    expect(requiresDaemonAuth('/api/canvas/session-1/demo/snapshot')).toBe(true)
+    expect(requiresDaemonAuth('/api/w/session-1/canvas/demo/snapshot')).toBe(true)
     expect(
       requiresDaemonAuth('/api/workspaces/session-1/canvases/demo/versions/v1/thumbnail'),
     ).toBe(true)
-    expect(requiresDaemonAuth('/api/canvas/session-1/demo/file/f1')).toBe(true)
+    expect(requiresDaemonAuth('/api/w/session-1/canvas/demo/file/f1')).toBe(true)
   })
 
   it('allows only /api/runtime/ping to bypass the middleware', () => {

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -155,6 +155,39 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(json.title!.length).toBeGreaterThan(0)
   })
 
+  it('serves a nested document path at /api/w/:workspaceId/canvas/*', async () => {
+    // The path-addressed shape (task #33, decided 2026-08-15): the document
+    // path is the URL tail, one segment per path segment, with the action
+    // suffix anchoring the parse. A nested path is exactly what the old
+    // :slug param could never match.
+    const app = createCanvasRouter()
+    const createRes = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'notes/2026/plan', kind: 'spatial' }),
+    })
+    expect(createRes.status).toBe(200)
+
+    const exists = await app.request('/api/w/ws1/canvas/notes/2026/plan/exists')
+    expect(exists.status).toBe(200)
+    expect(await exists.json()).toEqual({ exists: true })
+
+    const snapshot = await app.request('/api/w/ws1/canvas/notes/2026/plan/snapshot')
+    expect(snapshot.status).toBe(200)
+
+    // A document whose LAST segment is an action name stays unambiguous,
+    // because the action suffix is mandatory: /a/snapshot/snapshot is the
+    // document a/snapshot.
+    const collide = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'a/snapshot', kind: 'spatial' }),
+    })
+    expect(collide.status).toBe(200)
+    const collideSnapshot = await app.request('/api/w/ws1/canvas/a/snapshot/snapshot')
+    expect(collideSnapshot.status).toBe(200)
+  })
+
   it('creates a kind:markdown canvas, and the list carries it back', async () => {
     const app = createCanvasRouter()
     const createRes = await app.request('/api/workspaces/ws1/canvases', {
@@ -173,7 +206,7 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
 
     // The empty LoroDoc a markdown-kind create saves loads without error —
     // an empty doc is a valid initial document for either kind.
-    const snapshotRes = await app.request('/api/canvas/ws1/note/snapshot')
+    const snapshotRes = await app.request('/api/w/ws1/canvas/note/snapshot')
     expect(snapshotRes.status).toBe(200)
   })
 
@@ -267,10 +300,10 @@ describe('DELETE /api/workspaces/:workspaceId/canvases/:slug', () => {
     const listJson = (await listRes.json()) as { canvases: { slug: string }[] }
     expect(listJson.canvases.map((c) => c.slug)).not.toContain('canvas-a')
 
-    const existsRes = await app.request('/api/canvas/session1/canvas-a/exists')
+    const existsRes = await app.request('/api/w/session1/canvas/canvas-a/exists')
     expect(await existsRes.json()).toEqual({ exists: false })
 
-    const snapshotRes = await app.request('/api/canvas/session1/canvas-a/snapshot')
+    const snapshotRes = await app.request('/api/w/session1/canvas/canvas-a/snapshot')
     expect(snapshotRes.status).toBe(404)
   })
 
@@ -350,7 +383,7 @@ describe('DELETE /api/workspaces/:workspaceId/canvases/:slug', () => {
     clientDoc.commit()
     const update = clientDoc.export({ mode: 'update', from: prevVV })
     // Warm the doc-cache via the update path, matching real client traffic.
-    await app.request('/api/canvas/session1/cached/update', {
+    await app.request('/api/w/session1/canvas/cached/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -370,7 +403,7 @@ describe('DELETE /api/workspaces/:workspaceId/canvases/:slug', () => {
     })
     expect(createRes.status).toBe(200)
 
-    const snapshotRes = await app.request('/api/canvas/session1/cached/snapshot')
+    const snapshotRes = await app.request('/api/w/session1/canvas/cached/snapshot')
     expect(snapshotRes.status).toBe(200)
     const buf = await snapshotRes.arrayBuffer()
     const restored = LoroDoc.fromSnapshot(new Uint8Array(buf))
@@ -406,7 +439,7 @@ describe('PUT /api/workspaces/:workspaceId/canvases/:slug/slug', () => {
     expect(slugs).toContain('b')
     expect(slugs).not.toContain('a')
 
-    const oldSnapshotRes = await app.request('/api/canvas/session1/a/snapshot')
+    const oldSnapshotRes = await app.request('/api/w/session1/canvas/a/snapshot')
     expect(oldSnapshotRes.status).toBe(404)
 
     const recreateRes = await app.request('/api/workspaces/session1/canvases', {
@@ -484,7 +517,7 @@ describe('PUT /api/workspaces/:workspaceId/canvases/:slug/slug', () => {
       return actual.getDoc(workspaceId, slug)
     })
 
-    const updatePromise = app.request('/api/canvas/session1/a/update', {
+    const updatePromise = app.request('/api/w/session1/canvas/a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -572,7 +605,7 @@ describe('PUT /api/workspaces/:workspaceId/canvases/:slug/slug', () => {
     clientDoc.commit()
     const update = clientDoc.export({ mode: 'update', from: prevVV })
     // Warm the doc-cache via the update path, matching real client traffic.
-    await app.request('/api/canvas/session1/a/update', {
+    await app.request('/api/w/session1/canvas/a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -587,7 +620,7 @@ describe('PUT /api/workspaces/:workspaceId/canvases/:slug/slug', () => {
     expect(renameRes.status).toBe(200)
 
     // The renamed canvas keeps its content, now reachable at the new slug.
-    const bSnapshotRes = await app.request('/api/canvas/session1/b/snapshot')
+    const bSnapshotRes = await app.request('/api/w/session1/canvas/b/snapshot')
     expect(bSnapshotRes.status).toBe(200)
     const bBuf = await bSnapshotRes.arrayBuffer()
     const bRestored = LoroDoc.fromSnapshot(new Uint8Array(bBuf))
@@ -604,13 +637,13 @@ describe('PUT /api/workspaces/:workspaceId/canvases/:slug/slug', () => {
     anotherM.set('id', 'fresh-element')
     anotherClientDoc.commit()
     const anotherUpdate = anotherClientDoc.export({ mode: 'update', from: anotherPrevVV })
-    await app.request('/api/canvas/session1/a/update', {
+    await app.request('/api/w/session1/canvas/a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: anotherUpdate,
     })
 
-    const freshSnapshotRes = await app.request('/api/canvas/session1/a/snapshot')
+    const freshSnapshotRes = await app.request('/api/w/session1/canvas/a/snapshot')
     expect(freshSnapshotRes.status).toBe(200)
     const freshBuf = await freshSnapshotRes.arrayBuffer()
     const freshRestored = LoroDoc.fromSnapshot(new Uint8Array(freshBuf))
@@ -726,7 +759,7 @@ describe('GET /api/workspaces/:workspaceId/canvases', () => {
   })
 })
 
-describe('GET /api/canvas/:workspaceId/:slug/snapshot', () => {
+describe('GET /api/w/:workspaceId/canvas/:slug/snapshot', () => {
   beforeEach(async () => {
     await mkdir(join(tmp.dir, 'session1'), { recursive: true })
     clearCache()
@@ -744,7 +777,7 @@ describe('GET /api/canvas/:workspaceId/:slug/snapshot', () => {
     await saveCanvas('session1', 'canvas-a', doc)
 
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/snapshot')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/snapshot')
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('application/octet-stream')
 
@@ -760,13 +793,13 @@ describe('GET /api/canvas/:workspaceId/:slug/snapshot', () => {
 
   it('returns 400 for an invalid slug', async () => {
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/bad.slug/snapshot')
+    const res = await app.request('/api/w/session1/canvas/bad.slug/snapshot')
     expect(res.status).toBe(400)
   })
 
   it('returns 404 with Problem Details { title } for a canvas that was never created', async () => {
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/never-created/snapshot')
+    const res = await app.request('/api/w/session1/canvas/never-created/snapshot')
     expect(res.status).toBe(404)
     const json = (await res.json()) as { title?: string }
     // Same shape as DELETE's 404 — the client parses problem-details for
@@ -781,12 +814,12 @@ describe('GET /api/canvas/:workspaceId/:slug/snapshot', () => {
     const app = createCanvasRouter()
     await app.request('/api/workspaces/session1/canvases/canvas-a', { method: 'DELETE' })
 
-    const res = await app.request('/api/canvas/session1/canvas-a/snapshot')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/snapshot')
     expect(res.status).toBe(404)
   })
 })
 
-describe('GET /api/canvas/:workspaceId/:slug/exists', () => {
+describe('GET /api/w/:workspaceId/canvas/:slug/exists', () => {
   beforeEach(async () => {
     await mkdir(join(tmp.dir, 'session1'), { recursive: true })
     clearCache()
@@ -800,26 +833,26 @@ describe('GET /api/canvas/:workspaceId/:slug/exists', () => {
     await saveCanvas('session1', 'canvas-a', doc)
 
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/exists')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/exists')
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ exists: true })
   })
 
   it('returns exists:false for an unregistered canvas without creating it', async () => {
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/never-created/exists')
+    const res = await app.request('/api/w/session1/canvas/never-created/exists')
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ exists: false })
 
     // GET /exists must never have the getDoc/loadCanvas side effect that
     // /snapshot has: the canvas should still be absent afterward.
-    const followUp = await app.request('/api/canvas/session1/never-created/exists')
+    const followUp = await app.request('/api/w/session1/canvas/never-created/exists')
     expect(await followUp.json()).toEqual({ exists: false })
   })
 
   it('returns 400 for an invalid slug', async () => {
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/bad.slug/exists')
+    const res = await app.request('/api/w/session1/canvas/bad.slug/exists')
     expect(res.status).toBe(400)
   })
 })
@@ -984,7 +1017,7 @@ describe('POST /api/workspaces/:workspaceId/canvases/optimize-all', () => {
 // failure modes covered above no longer apply. DB-side error handling is
 // exercised through unit tests on names-store directly.
 
-describe('POST /api/canvas/:workspaceId/:slug/update', () => {
+describe('POST /api/w/:workspaceId/canvas/:slug/update', () => {
   beforeEach(async () => {
     await mkdir(join(tmp.dir, 'session1'), { recursive: true })
     clearCache()
@@ -1005,7 +1038,7 @@ describe('POST /api/canvas/:workspaceId/:slug/update', () => {
     const update = clientDoc.export({ mode: 'update', from: prevVV })
 
     const app = createCanvasRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/update', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -1029,7 +1062,7 @@ describe('POST /api/canvas/:workspaceId/:slug/update', () => {
   it('rejects an oversized update body with 413 payload_too_large', async () => {
     const app = createCanvasRouter()
     const oversized = new Uint8Array(16 * 1024 * 1024 + 1)
-    const res = await app.request('/api/canvas/session1/canvas-a/update', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: oversized,
@@ -1051,7 +1084,7 @@ describe('POST /api/canvas/:workspaceId/:slug/update', () => {
     await saveCanvas('session1', 'canvas-a', initial)
 
     // Pull it into the doc-cache so there is a live cached doc to poison.
-    await app.request('/api/canvas/session1/canvas-a/snapshot')
+    await app.request('/api/w/session1/canvas/canvas-a/snapshot')
     expect(peekDoc('session1', 'canvas-a')).toBeDefined()
 
     // Build a client update that adds a second element.
@@ -1068,7 +1101,7 @@ describe('POST /api/canvas/:workspaceId/:slug/update', () => {
     const exportSpy = vi.spyOn(LoroDoc.prototype, 'export').mockImplementationOnce(() => {
       throw new Error('simulated snapshot failure')
     })
-    const res = await app.request('/api/canvas/session1/canvas-a/update', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -1108,7 +1141,7 @@ describe('versions API', () => {
     const update = clientDoc.export({ mode: 'update', from: prevVV })
 
     const app = createCanvasRouter({ autoVersionIntervalMs: 0 })
-    const resUpdate = await app.request('/api/canvas/session1/canvas-a/update', {
+    const resUpdate = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -1206,7 +1239,7 @@ describe('versions API', () => {
     const update = clientDoc.export({ mode: 'update', from: prevVV })
 
     const app = createCanvasRouter({ autoVersionIntervalMs: 0 })
-    const resUpdate = await app.request('/api/canvas/session1/canvas-a/update', {
+    const resUpdate = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,
@@ -1237,7 +1270,7 @@ describe('versions API', () => {
     m0.set('id', 'keep-me')
     m0.set('type', 'rectangle')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv0 }),
@@ -1261,7 +1294,7 @@ describe('versions API', () => {
     m2.set('id', 'added-2')
     m2.set('type', 'diamond')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv1 }),
@@ -1285,7 +1318,7 @@ describe('versions API', () => {
     const m0 = list.insertContainer(0, new LoroMap())
     m0.set('id', 'keep-me')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv0 }),
@@ -1304,7 +1337,7 @@ describe('versions API', () => {
     const m1 = list.insertContainer(list.length, new LoroMap())
     m1.set('id', 'added-after-v1')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv1 }),
@@ -1356,7 +1389,7 @@ describe('versions API', () => {
     const m0 = list.insertContainer(0, new LoroMap())
     m0.set('id', 'keep-me')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv0 }),
@@ -1372,7 +1405,7 @@ describe('versions API', () => {
     const m1 = list.insertContainer(list.length, new LoroMap())
     m1.set('id', 'added-after-v1')
     initial.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: initial.export({ mode: 'update', from: vv1 }),
@@ -1439,7 +1472,7 @@ describe('versions API', () => {
       const m0 = list.insertContainer(0, new LoroMap())
       m0.set('id', 'keep-me')
       initial.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: initial.export({ mode: 'update', from: vv0 }),
@@ -1456,7 +1489,7 @@ describe('versions API', () => {
       const m1 = list.insertContainer(list.length, new LoroMap())
       m1.set('id', 'added-after-v1')
       initial.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: initial.export({ mode: 'update', from: vv1 }),
@@ -1499,7 +1532,7 @@ describe('versions API', () => {
       const m0 = list.insertContainer(0, new LoroMap())
       m0.set('id', 'keep-me')
       initial.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: initial.export({ mode: 'update', from: vv0 }),
@@ -1534,7 +1567,7 @@ describe('versions API', () => {
       const sm0 = sourceList.insertContainer(0, new LoroMap())
       sm0.set('id', 'keep-me')
       sourceDoc.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -1553,7 +1586,7 @@ describe('versions API', () => {
       const tm0 = targetList.insertContainer(0, new LoroMap())
       tm0.set('id', 'b-only')
       targetDoc.commit()
-      await app.request('/api/canvas/session1/canvas-b/update', {
+      await app.request('/api/w/session1/canvas/canvas-b/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: targetDoc.export({ mode: 'update', from: tvv0 }),
@@ -1589,7 +1622,7 @@ describe('versions API', () => {
       const sm0 = sourceList.insertContainer(0, new LoroMap())
       sm0.set('id', 'keep-me')
       sourceDoc.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -1631,7 +1664,7 @@ describe('versions API', () => {
       const svv0 = sourceDoc.version()
       sourceDoc.getText('body').insert(0, 'hello')
       sourceDoc.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -1678,7 +1711,7 @@ describe('versions API', () => {
       const svv0 = sourceDoc.version()
       sourceDoc.getText('body').insert(0, 'hello')
       sourceDoc.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -1716,7 +1749,7 @@ describe('versions API', () => {
       const sm0 = sourceList.insertContainer(0, new LoroMap())
       sm0.set('id', 'keep-me')
       sourceDoc.commit()
-      await app.request('/api/canvas/session1/canvas-a/update', {
+      await app.request('/api/w/session1/canvas/canvas-a/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -1728,7 +1761,7 @@ describe('versions API', () => {
       })
       const saveBody = (await saveRes.json()) as { version: { id: string } }
 
-      await app.request('/api/canvas/session1/canvas-b/update', {
+      await app.request('/api/w/session1/canvas/canvas-b/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream' },
         body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -2193,7 +2226,7 @@ describe('auto-version corruption handling', () => {
       autoVersionIntervalMs: 0,
       versionStore,
     })
-    const res = await app.request('/api/canvas/session1/canvas-a/update', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: update,

--- a/packages/mcp-server/src/server/routes/canvas/export-svg.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/export-svg.test.ts
@@ -39,7 +39,7 @@ function makeApp() {
   return app
 }
 
-describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
+describe('POST /api/w/:workspaceId/canvas/:slug/export-svg', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-svg-test-'))
     mockExportCanvasHeadlessSvg.mockReset()
@@ -53,7 +53,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
   it('renders headlessly and writes a real .svg file to the default exports dir', async () => {
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', { method: 'POST' })
 
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
@@ -74,8 +74,8 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
     vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
     try {
       const [resA, resB] = await Promise.all([
-        app.request('/api/canvas/s1/canvas-a/export-svg', { method: 'POST' }),
-        app.request('/api/canvas/s1/canvas-a/export-svg', { method: 'POST' }),
+        app.request('/api/w/s1/canvas/canvas-a/export-svg', { method: 'POST' }),
+        app.request('/api/w/s1/canvas/canvas-a/export-svg', { method: 'POST' }),
       ])
       const bodyA = (await resA.json()) as { filePath: string }
       const bodyB = (await resB.json()) as { filePath: string }
@@ -88,7 +88,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
   it('forwards padding, frameId, and theme to exportCanvasHeadlessSvg', async () => {
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ padding: 24, frameId: 'frame-1', theme: 'dark' }),
@@ -106,14 +106,14 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
 
   it('rejects invalid workspaceId or slug with 400', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/bad.sid/canvas-a/export-svg', { method: 'POST' })
+    const res = await app.request('/api/w/bad.sid/canvas/canvas-a/export-svg', { method: 'POST' })
     expect(res.status).toBe(400)
     expect(mockExportCanvasHeadlessSvg).not.toHaveBeenCalled()
   })
 
   it('rejects a whitespace-only body with 400 invalid_request instead of throwing', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '   ',
@@ -125,7 +125,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
 
   it('rejects an invalid theme with 400 invalid_request', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ theme: 'sepia' }),
@@ -139,7 +139,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'custom.svg')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath }),
@@ -152,7 +152,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
 
   it('rejects an outputPath outside the workspace exports dir with 400 invalid_output_path', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: join(tempDir, 'daemon.json') }),
@@ -168,7 +168,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
     await writeFile(outputPath, '<svg>OLD</svg>')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath }),
@@ -184,7 +184,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
     await writeFile(outputPath, '<svg>OLD</svg>')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath, overwrite: true }),
@@ -196,7 +196,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
   it('rejects an oversized request body with 413 payload_too_large', async () => {
     const app = makeApp()
     const oversized = 'x'.repeat(1024 * 1024 + 1)
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: oversized,
@@ -209,7 +209,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export-svg', () => {
   it('returns 500 headless_export_failed when rendering throws', async () => {
     mockExportCanvasHeadlessSvg.mockRejectedValue(new Error('boom'))
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export-svg', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export-svg', { method: 'POST' })
     expect(res.status).toBe(500)
     const body = (await res.json()) as { error: string; message: string }
     expect(body.error).toBe('headless_export_failed')

--- a/packages/mcp-server/src/server/routes/canvas/export-svg.ts
+++ b/packages/mcp-server/src/server/routes/canvas/export-svg.ts
@@ -11,8 +11,8 @@ import {
 import { getDataDir } from '../../config.js'
 import { exportCanvasHeadlessSvg } from '../../export/headless-export.js'
 import { OutputPathError, validateOutputPath } from '../../output-path.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { toCanvasOutputPathErrorBody } from '../canvas-output-path-error.js'
+import { onCanvasAction } from './path-route.js'
 
 // The body is a small JSON options object (padding/frameId/theme/outputPath),
 // never canvas content — the export itself is rendered server-side from the
@@ -20,7 +20,7 @@ import { toCanvasOutputPathErrorBody } from '../canvas-output-path-error.js'
 // bounding an adversarial request.
 const EXPORT_OPTIONS_BODY_LIMIT_BYTES = 1024 * 1024
 
-// POST /api/canvas/:workspaceId/:slug/export-svg
+// POST /api/w/:workspaceId/canvas/<path>/export-svg
 //
 // Unlike PNG export, this always renders headless straight from the
 // persisted LoroDoc — unlike export.ts (PNG, which prefers the browser). SVG
@@ -30,30 +30,11 @@ const EXPORT_OPTIONS_BODY_LIMIT_BYTES = 1024 * 1024
 export function createCanvasSvgExportRouter() {
   const app = new Hono()
 
-  app.post(
-    '/api/canvas/:workspaceId/:slug/export-svg',
-    bodyLimit({
-      maxSize: EXPORT_OPTIONS_BODY_LIMIT_BYTES,
-      onError: (c) =>
-        c.json(
-          {
-            error: 'payload_too_large',
-            message: `Request body exceeds ${EXPORT_OPTIONS_BODY_LIMIT_BYTES} bytes limit.`,
-          },
-          413,
-        ),
-    }),
-    async (c) => {
-      const { workspaceId, slug } = c.req.param()
-      try {
-        validateWorkspaceId(workspaceId)
-        validateSlug(slug)
-      } catch (err) {
-        const body = validationErrorBody(err)
-        if (body) return c.json(body, 400)
-        throw err
-      }
-
+  onCanvasAction(
+    app,
+    'post',
+    'export-svg',
+    async (c, workspaceId, path) => {
       const rawText = await c.req.text()
       let body: ExportSvgRequest = {}
       if (rawText.length > 0) {
@@ -97,7 +78,9 @@ export function createCanvasSvgExportRouter() {
       try {
         const result = await exportCanvasHeadlessSvg({
           workspaceId,
-          slug,
+          // The store layer still speaks `slug`; renaming it through
+          // headless-export and canvas-store is its own sweep.
+          slug: path,
           options: { padding: body.padding, frameId: body.frameId, theme: body.theme },
         })
         svg = result.svg
@@ -109,23 +92,34 @@ export function createCanvasSvgExportRouter() {
         return c.json(errBody, 500)
       }
 
-      const filePath = outputPath ?? defaultSvgExportPath(workspaceId, slug)
+      const filePath = outputPath ?? defaultSvgExportPath(workspaceId, path)
       await mkdir(dirname(filePath), { recursive: true })
       await writeFile(filePath, svg, 'utf-8')
       return c.json({ filePath })
     },
+    bodyLimit({
+      maxSize: EXPORT_OPTIONS_BODY_LIMIT_BYTES,
+      onError: (c) =>
+        c.json(
+          {
+            error: 'payload_too_large',
+            message: `Request body exceeds ${EXPORT_OPTIONS_BODY_LIMIT_BYTES} bytes limit.`,
+          },
+          413,
+        ),
+    }),
   )
 
   return app
 }
 
-function defaultSvgExportPath(workspaceId: string, slug: string): string {
+function defaultSvgExportPath(workspaceId: string, path: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
   // The millisecond timestamp alone is not unique: two exports issued fast
   // enough to land in the same millisecond would collide and the second
   // write would silently clobber the first. The random suffix guarantees
   // uniqueness regardless of call timing, matching the PNG and JSON export
   // routes' default-path convention.
-  const fileName = `${slug}-${timestamp}-${nanoid(6)}.svg`
+  const fileName = `${path}-${timestamp}-${nanoid(6)}.svg`
   return join(getDataDir(), workspaceId, 'exports', fileName)
 }

--- a/packages/mcp-server/src/server/routes/canvas/live-doc.ts
+++ b/packages/mcp-server/src/server/routes/canvas/live-doc.ts
@@ -1,4 +1,4 @@
-import { type Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { LoroDoc } from 'loro-crdt'
 import type {
@@ -10,8 +10,8 @@ import { canvasExists, saveCanvas } from '../../store/canvas-store.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionEntry } from '../../store/version-store.js'
 import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { getBroadcastFn } from './_shared.js'
+import { onCanvasAction } from './path-route.js'
 
 // A Loro update embeds any attachment-affecting deltas since the client's
 // last sync, so it can approach the file-upload ceiling in the worst case.
@@ -22,62 +22,88 @@ const LIVE_DOC_UPDATE_LIMIT_BYTES = 16 * 1024 * 1024
 export interface LiveDocRouterOptions {
   triggerAutoVersion: (
     workspaceId: string,
-    slug: string,
+    path: string,
     doc: LoroDoc,
   ) => Promise<VersionEntry | null>
 }
 
-// Validate the shared :workspaceId/:slug path params. Returns a 400 JSON
-// Response to short-circuit the handler on invalid input, or the parsed
-// params on success. Rethrows non-validation errors unchanged.
-function validatePathParams(c: Context): { workspaceId: string; slug: string } | Response {
-  const { workspaceId, slug } = c.req.param()
-  try {
-    validateWorkspaceId(workspaceId)
-    validateSlug(slug)
-  } catch (err) {
-    const body = validationErrorBody(err)
-    if (body) return c.json(body, 400)
-    throw err
-  }
-  return { workspaceId, slug }
-}
-
-// GET /api/canvas/:workspaceId/:slug/snapshot
-// GET /api/canvas/:workspaceId/:slug/exists
-// POST /api/canvas/:workspaceId/:slug/update
+// GET /api/w/:workspaceId/canvas/*/snapshot
+// GET /api/w/:workspaceId/canvas/*/exists
+// POST /api/w/:workspaceId/canvas/*/update
 export function createLiveDocRouter(options: LiveDocRouterOptions) {
   const app = new Hono()
 
-  app.get('/api/canvas/:workspaceId/:slug/exists', async (c) => {
-    const params = validatePathParams(c)
-    if (params instanceof Response) return params
-    const { workspaceId, slug } = params
-    const response: CanvasExistsResponse = { exists: await canvasExists(workspaceId, slug) }
+  onCanvasAction(app, 'get', 'exists', async (c, workspaceId, path) => {
+    const response: CanvasExistsResponse = { exists: await canvasExists(workspaceId, path) }
     return c.json(response)
   })
 
-  app.get('/api/canvas/:workspaceId/:slug/snapshot', async (c) => {
-    const params = validatePathParams(c)
-    if (params instanceof Response) return params
-    const { workspaceId, slug } = params
+  onCanvasAction(app, 'get', 'snapshot', async (c, workspaceId, path) => {
     // getDoc()'s lazy-create would otherwise silently hand back an empty
     // doc for a canvas that does not exist — indistinguishable from a
     // never-created OR just-deleted canvas. Same problem-details { title }
     // shape as DELETE, deliberately not thumbnails/restore's { error,
     // message }: the client parses problem-details for both routes.
-    if (!(await canvasExists(workspaceId, slug))) {
-      return c.json({ title: `Canvas "${slug}" not found` }, 404)
+    if (!(await canvasExists(workspaceId, path))) {
+      return c.json({ title: `Canvas "${path}" not found` }, 404)
     }
-    const doc = await getDoc(workspaceId, slug)
+    const doc = await getDoc(workspaceId, path)
     const snapshot = doc.export({ mode: 'snapshot' }) as Uint8Array<ArrayBuffer>
     return c.body(snapshot, 200, {
       'Content-Type': 'application/octet-stream',
     })
   })
 
-  app.post(
-    '/api/canvas/:workspaceId/:slug/update',
+  onCanvasAction(
+    app,
+    'post',
+    'update',
+    async (c, workspaceId, path) => {
+      const bytes = new Uint8Array(await c.req.arrayBuffer())
+
+      // Resolve the doc AND persist it inside one lock hold. getDoc() alone is
+      // unlocked, so a rename that runs its whole lock-protected section
+      // between an unlocked read here and saveCanvas()'s own later lock
+      // acquisition would find no row left at the old path (renameCanvasSlug
+      // moved it) and silently insert a brand-new phantom canvas back at
+      // that path instead of erroring or landing on the renamed one. Sharing
+      // the workspace write lock across the read and the write closes that
+      // window: the two operations settle into one definite order instead of
+      // interleaving through a stale read.
+      const doc = await withWorkspaceWriteLock(workspaceId, async () => {
+        const resolved = await getDoc(workspaceId, path)
+        resolved.import(bytes)
+        try {
+          await saveCanvas(workspaceId, path, resolved, { overwrite: true })
+        } catch (err) {
+          // doc.import() above already mutated the cached doc, so a failed save
+          // would otherwise leave the cache ahead of durable state. Evict it so
+          // the next read reloads the last successfully persisted snapshot.
+          evictDoc(workspaceId, path)
+          throw err
+        }
+        return resolved
+      })
+
+      // Broadcast to all WS clients because the originating WS context is unknown on HTTP requests.
+      getBroadcastFn()(workspaceId, path, bytes)
+
+      // Trigger auto-versioning. The throttle is built in, so below-threshold calls return null.
+      // Even if saving the version fails, keep this API at 200 because the update itself is the priority.
+      options
+        .triggerAutoVersion(workspaceId, path, doc)
+        .then(async (entry) => {
+          if (!entry) return
+          const { sendVersionCreated } = await import('../ws.js')
+          sendVersionCreated(workspaceId, path, entry)
+        })
+        .catch((err: unknown) => {
+          getLogger('canvas').error({ err: err as Error }, 'auto-version trigger failed')
+        })
+
+      const response: UpdateCanvasResponse = { ok: true }
+      return c.json(response)
+    },
     bodyLimit({
       maxSize: LIVE_DOC_UPDATE_LIMIT_BYTES,
       onError: (c) =>
@@ -89,55 +115,6 @@ export function createLiveDocRouter(options: LiveDocRouterOptions) {
           413,
         ),
     }),
-    async (c) => {
-      const params = validatePathParams(c)
-      if (params instanceof Response) return params
-      const { workspaceId, slug } = params
-      const bytes = new Uint8Array(await c.req.arrayBuffer())
-
-      // Resolve the doc AND persist it inside one lock hold. getDoc() alone is
-      // unlocked, so a rename that runs its whole lock-protected section
-      // between an unlocked read here and saveCanvas()'s own later lock
-      // acquisition would find no row left at the old slug (renameCanvasSlug
-      // moved it) and silently insert a brand-new phantom canvas back at
-      // that slug instead of erroring or landing on the renamed one. Sharing
-      // the workspace write lock across the read and the write closes that
-      // window: the two operations settle into one definite order instead of
-      // interleaving through a stale read.
-      const doc = await withWorkspaceWriteLock(workspaceId, async () => {
-        const resolved = await getDoc(workspaceId, slug)
-        resolved.import(bytes)
-        try {
-          await saveCanvas(workspaceId, slug, resolved, { overwrite: true })
-        } catch (err) {
-          // doc.import() above already mutated the cached doc, so a failed save
-          // would otherwise leave the cache ahead of durable state. Evict it so
-          // the next read reloads the last successfully persisted snapshot.
-          evictDoc(workspaceId, slug)
-          throw err
-        }
-        return resolved
-      })
-
-      // Broadcast to all WS clients because the originating WS context is unknown on HTTP requests.
-      getBroadcastFn()(workspaceId, slug, bytes)
-
-      // Trigger auto-versioning. The throttle is built in, so below-threshold calls return null.
-      // Even if saving the version fails, keep this API at 200 because the update itself is the priority.
-      options
-        .triggerAutoVersion(workspaceId, slug, doc)
-        .then(async (entry) => {
-          if (!entry) return
-          const { sendVersionCreated } = await import('../ws.js')
-          sendVersionCreated(workspaceId, slug, entry)
-        })
-        .catch((err: unknown) => {
-          getLogger('canvas').error({ err: err as Error }, 'auto-version trigger failed')
-        })
-
-      const response: UpdateCanvasResponse = { ok: true }
-      return c.json(response)
-    },
   )
 
   return app

--- a/packages/mcp-server/src/server/routes/canvas/path-route.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/path-route.test.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { onCanvasAction, onCanvasFile } from './path-route.js'
+
+describe('onCanvasAction', () => {
+  function appWith(action: string) {
+    const app = new Hono()
+    onCanvasAction(app, 'get', action, (c, workspaceId, path) => c.json({ workspaceId, path }))
+    return app
+  }
+
+  it('parses a nested document path with the action suffix anchoring it', async () => {
+    const res = await appWith('snapshot').request('/api/w/ws1/canvas/notes/2026/plan/snapshot')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ workspaceId: 'ws1', path: 'notes/2026/plan' })
+  })
+
+  it('keeps a path whose last segment collides with the action unambiguous', async () => {
+    const res = await appWith('snapshot').request('/api/w/ws1/canvas/a/snapshot/snapshot')
+    expect(await res.json()).toEqual({ workspaceId: 'ws1', path: 'a/snapshot' })
+  })
+
+  it('falls through on a non-matching action so siblings get their turn', async () => {
+    const app = new Hono()
+    onCanvasAction(app, 'get', 'exists', (c) => c.json({ hit: 'exists' }))
+    onCanvasAction(app, 'get', 'snapshot', (c) => c.json({ hit: 'snapshot' }))
+    const res = await app.request('/api/w/ws1/canvas/doc/snapshot')
+    expect(await res.json()).toEqual({ hit: 'snapshot' })
+  })
+
+  it('rejects an invalid path segment with 400, not a match failure', async () => {
+    const res = await appWith('exists').request('/api/w/ws1/canvas/has%20space/exists')
+    expect(res.status).toBe(400)
+  })
+
+  it('does not swallow a bare action with no document path', async () => {
+    const res = await appWith('exists').request('/api/w/ws1/canvas/exists')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('onCanvasFile', () => {
+  it('splits the file tail off a nested document path', async () => {
+    const app = new Hono()
+    onCanvasFile(app, 'get', (c, workspaceId, path, fileId) =>
+      c.json({ workspaceId, path, fileId }),
+    )
+    const res = await app.request('/api/w/ws1/canvas/a/file/b/file/c')
+    expect(res.status).toBe(200)
+    // Greedy: the LAST /file/<id> is the file tail, the rest is the path.
+    expect(await res.json()).toEqual({ workspaceId: 'ws1', path: 'a/file/b', fileId: 'c' })
+  })
+})

--- a/packages/mcp-server/src/server/routes/canvas/path-route.ts
+++ b/packages/mcp-server/src/server/routes/canvas/path-route.ts
@@ -1,0 +1,72 @@
+import type { Context, Hono, MiddlewareHandler, Next } from 'hono'
+import {
+  canvasPathForAction,
+  canvasPathForFile,
+  parseCanvasApiPath,
+} from '../../../shared/api-contracts/canvas-url.js'
+import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
+
+export const CANVAS_WILDCARD = '/api/w/:workspaceId/canvas/*'
+
+type CanvasHandler = (c: Context, workspaceId: string, path: string) => Promise<Response> | Response
+type CanvasFileHandler = (
+  c: Context,
+  workspaceId: string,
+  path: string,
+  fileId: string,
+) => Promise<Response> | Response
+
+function validated(c: Context, workspaceId: string, path: string): Response | null {
+  try {
+    validateWorkspaceId(workspaceId)
+    validateSlug(path)
+  } catch (err) {
+    const body = validationErrorBody(err)
+    if (body) return c.json(body, 400)
+    throw err
+  }
+  return null
+}
+
+/**
+ * Registers `<method> /api/w/:workspaceId/canvas/<document path>/<action>`.
+ *
+ * Every action shares one wildcard route and dispatches on the parsed tail —
+ * a non-matching action falls through to `next()` so sibling registrations
+ * (and the composed routers after this one) still get their turn. See
+ * parseCanvasApiPath for why this is a hand parse instead of a `{.+}` param.
+ */
+export function onCanvasAction(
+  app: Hono,
+  method: 'get' | 'post' | 'put',
+  action: string,
+  handler: CanvasHandler,
+  ...middleware: MiddlewareHandler[]
+): void {
+  const dispatch = async (c: Context, next: Next) => {
+    const parsed = parseCanvasApiPath(c.req.path)
+    const path = parsed === null ? null : canvasPathForAction(parsed.tail, action)
+    if (parsed === null || path === null) return next()
+    return validated(c, parsed.workspaceId, path) ?? handler(c, parsed.workspaceId, path)
+  }
+  app[method](CANVAS_WILDCARD, ...(middleware as []), dispatch)
+}
+
+/** Same, for the `<document path>/file/<fileId>` tail. */
+export function onCanvasFile(
+  app: Hono,
+  method: 'get' | 'put',
+  handler: CanvasFileHandler,
+  ...middleware: MiddlewareHandler[]
+): void {
+  const dispatch = async (c: Context, next: Next) => {
+    const parsed = parseCanvasApiPath(c.req.path)
+    const file = parsed === null ? null : canvasPathForFile(parsed.tail)
+    if (parsed === null || file === null) return next()
+    return (
+      validated(c, parsed.workspaceId, file.path) ??
+      handler(c, parsed.workspaceId, file.path, file.fileId)
+    )
+  }
+  app[method](CANVAS_WILDCARD, ...(middleware as []), dispatch)
+}

--- a/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore-race.test.ts
@@ -51,7 +51,7 @@ describe('restore targetSlug-overwrite vs delete race', () => {
     const sm0 = sourceList.insertContainer(0, new LoroMap())
     sm0.set('id', 'keep-me')
     sourceDoc.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -70,7 +70,7 @@ describe('restore targetSlug-overwrite vs delete race', () => {
     const tm0 = targetList.insertContainer(0, new LoroMap())
     tm0.set('id', 'b-only')
     targetDoc.commit()
-    await app.request('/api/canvas/session1/canvas-b/update', {
+    await app.request('/api/w/session1/canvas/canvas-b/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: targetDoc.export({ mode: 'update', from: tvv0 }),
@@ -146,7 +146,7 @@ describe('restore in-place vs delete race', () => {
     const sm0 = sourceList.insertContainer(0, new LoroMap())
     sm0.set('id', 'keep-me')
     sourceDoc.commit()
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: sourceDoc.export({ mode: 'update', from: svv0 }),

--- a/packages/mcp-server/src/server/routes/canvas/restore.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.test.ts
@@ -73,7 +73,7 @@ describe('restore router (real node counts)', () => {
       ],
       edges: [],
     })
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: sourceDoc.export({ mode: 'update', from: svv0 }),
@@ -102,7 +102,7 @@ describe('restore router (real node counts)', () => {
     const app = createCanvasRouter({ autoVersionIntervalMs: 60_000 })
 
     // Source canvas with one node, saved as a version.
-    await app.request('/api/canvas/session1/canvas-a/update', {
+    await app.request('/api/w/session1/canvas/canvas-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: nodesModelDocUpdate(['keep-me']),
@@ -115,7 +115,7 @@ describe('restore router (real node counts)', () => {
     const saveBody = (await saveRes.json()) as { version: { id: string } }
 
     // Target canvas already exists with a different node.
-    await app.request('/api/canvas/session1/canvas-b/update', {
+    await app.request('/api/w/session1/canvas/canvas-b/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: nodesModelDocUpdate(['b-only']),
@@ -158,7 +158,7 @@ describe('restore router (kind propagation)', () => {
     // A markdown document: its OKF body is a text node, so the restored
     // content alone cannot say which editor should open it.
     await saveCanvas('session1', 'note-a', new LoroDoc(), { kind: 'markdown' })
-    await app.request('/api/canvas/session1/note-a/update', {
+    await app.request('/api/w/session1/canvas/note-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: nodesModelDocUpdate(['okf-body']),
@@ -188,7 +188,7 @@ describe('restore router (kind propagation)', () => {
     // document predating kinds was created. Copying a guess here would be
     // worse than copying the gap: the target keeps it forever, and a
     // markdown document restored as spatial opens in the wrong editor.
-    await app.request('/api/canvas/session1/unknown-a/update', {
+    await app.request('/api/w/session1/canvas/unknown-a/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: nodesModelDocUpdate(['n1']),

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -75,7 +75,7 @@ function makeApp() {
 const SAMPLE_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 
-describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
+describe('POST /api/w/:workspaceId/canvas/:slug/export - error handling', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-test-'))
     mockGetClientCount.mockReset()
@@ -99,7 +99,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
 
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
@@ -118,7 +118,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
 
     mockGetClientCount.mockReturnValue(0)
-    const resNoClient = await makeApp().request('/api/canvas/s1/canvas-a/export', {
+    const resNoClient = await makeApp().request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ padding: 20 }),
@@ -127,7 +127,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
     mockExportCanvasHeadless.mockClear()
     mockGetClientCount.mockReturnValue(3)
-    const resWithClients = await makeApp().request('/api/canvas/s1/canvas-a/export', {
+    const resWithClients = await makeApp().request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ padding: 20 }),
@@ -150,8 +150,8 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
     try {
       const [resA, resB] = await Promise.all([
-        app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' }),
-        app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' }),
+        app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' }),
+        app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' }),
       ])
       const bodyA = (await resA.json()) as { filePath: string }
       const bodyB = (await resB.json()) as { filePath: string }
@@ -169,7 +169,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     mockCanvasExists.mockResolvedValueOnce(false)
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/missing-canvas/export', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/missing-canvas/export', { method: 'POST' })
 
     expect(res.status).toBe(404)
     const body = (await res.json()) as { error: string; message?: string }
@@ -181,7 +181,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   it('returns 500 with headless_export_failed when headless rendering throws', async () => {
     mockExportCanvasHeadless.mockRejectedValue(new Error('boom'))
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
     expect(res.status).toBe(500)
     const body = (await res.json()) as { error: string; message: string }
     expect(body.error).toBe('headless_export_failed')
@@ -199,7 +199,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
         }),
     )
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
     expect(res.status).toBe(200)
   })
 
@@ -211,7 +211,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ padding: 48 }),
@@ -230,7 +230,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ padding: 32, scale: 2, minFontPx: 14 }),
@@ -250,7 +250,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ theme: 'dark', padding: 16 }),
@@ -267,7 +267,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
   it('rejects invalid theme values with 400 invalid_request', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ theme: 'sepia' }),
@@ -280,7 +280,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   it('rejects an oversized request body with 413 payload_too_large', async () => {
     const app = makeApp()
     const oversized = 'x'.repeat(1024 * 1024 + 1)
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: oversized,
@@ -298,7 +298,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ frameId: 'frame-abc', padding: 24 }),
@@ -319,7 +319,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
     expect(body.filePath).toMatch(/canvas-a-.*\.png$/)
@@ -341,9 +341,9 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
     try {
-      const resA = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+      const resA = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
       const bodyA = (await resA.json()) as { filePath: string }
-      const resB = await app.request('/api/canvas/s1/canvas-a/export', { method: 'POST' })
+      const resB = await app.request('/api/w/s1/canvas/canvas-a/export', { method: 'POST' })
       const bodyB = (await resB.json()) as { filePath: string }
 
       expect(resA.status).toBe(200)
@@ -366,7 +366,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const app = makeApp()
 
     // MCP sends the slug through encodeURIComponent, so it arrives as one segment with `%2F`.
-    const res = await app.request('/api/canvas/s1/architecture%2Foverview/export', {
+    const res = await app.request('/api/w/s1/canvas/architecture%2Foverview/export', {
       method: 'POST',
     })
     expect(res.status).toBe(200)
@@ -377,12 +377,12 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
   it('returns 400 for invalid workspaceId or slug without reaching the headless renderer', async () => {
     const app = makeApp()
 
-    const badSession = await app.request('/api/canvas/bad.sid/canvas-a/export', {
+    const badSession = await app.request('/api/w/bad.sid/canvas/canvas-a/export', {
       method: 'POST',
     })
     expect(badSession.status).toBe(400)
 
-    const badSlug = await app.request('/api/canvas/s1/bad.slug/export', {
+    const badSlug = await app.request('/api/w/s1/canvas/bad.slug/export', {
       method: 'POST',
     })
     expect(badSlug.status).toBe(400)
@@ -398,7 +398,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'subdir', 'custom.excalidraw.png')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath }),
@@ -415,7 +415,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const app = makeApp()
     // ${DATA_DIR}/daemon.json is inside DATA_DIR but not inside ${DATA_DIR}/s1/exports
     const daemonFile = join(tempDir, 'daemon.json')
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: daemonFile }),
@@ -429,7 +429,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const app = makeApp()
     // ${DATA_DIR}/s1/.checkpoints is inside DATA_DIR/s1 but not in ${DATA_DIR}/s1/exports
     const checkpointFile = join(tempDir, 's1', '.checkpoints', 'v1.json')
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: checkpointFile }),
@@ -441,7 +441,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
   it('rejects outputPath fully outside DATA_DIR', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: '/tmp/attack.png' }),
@@ -453,7 +453,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
   it('does not leak internal paths in invalid_output_path error response', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: join(tempDir, 'daemon.json') }),
@@ -470,7 +470,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     const outputPath = join(tempDir, 's1', 'exports', 'exists.png')
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
     await writeFile(outputPath, 'OLD')
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath }),
@@ -484,7 +484,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
 
   it('rejects a relative PNG outputPath with 400 invalid_output_path', async () => {
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath: 'relative/out.png' }),
@@ -505,7 +505,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
     await writeFile(outputPath, 'OLD')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath }),
@@ -527,7 +527,7 @@ describe('POST /api/canvas/:workspaceId/:slug/export - error handling', () => {
     await mkdir(join(tempDir, 's1', 'exports'), { recursive: true })
     await writeFile(outputPath, 'OLD')
 
-    const res = await app.request('/api/canvas/s1/canvas-a/export', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ outputPath, overwrite: true }),

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -13,7 +13,7 @@ import { getDataDir } from '../config.js'
 import { exportCanvasHeadless } from '../export/headless-export.js'
 import { OutputPathError, validateOutputPath } from '../output-path.js'
 import { canvasExists } from '../store/canvas-store.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../validators.js'
+import { onCanvasAction } from './canvas/path-route.js'
 import { toCanvasOutputPathErrorBody } from './canvas-output-path-error.js'
 
 // The body is a small JSON options object (padding/scale/frameId/theme/
@@ -25,31 +25,12 @@ const EXPORT_OPTIONS_BODY_LIMIT_BYTES = 1024 * 1024
 export function createExportRouter() {
   const app = new Hono()
 
-  // POST /api/canvas/:workspaceId/:slug/export
-  app.post(
-    '/api/canvas/:workspaceId/:slug/export',
-    bodyLimit({
-      maxSize: EXPORT_OPTIONS_BODY_LIMIT_BYTES,
-      onError: (c) =>
-        c.json(
-          {
-            error: 'payload_too_large',
-            message: `Request body exceeds ${EXPORT_OPTIONS_BODY_LIMIT_BYTES} bytes limit.`,
-          },
-          413,
-        ),
-    }),
-    async (c) => {
-      const { workspaceId, slug } = c.req.param()
-      try {
-        validateWorkspaceId(workspaceId)
-        validateSlug(slug)
-      } catch (err) {
-        const body = validationErrorBody(err)
-        if (body) return c.json(body, 400)
-        throw err
-      }
-
+  // POST /api/w/:workspaceId/canvas/<path>/export
+  onCanvasAction(
+    app,
+    'post',
+    'export',
+    async (c, workspaceId, path) => {
       // The body is optional. Empty body is fine; malformed JSON or
       // schema-invalid payloads are rejected with 400 instead of being
       // silently dropped.
@@ -97,20 +78,20 @@ export function createExportRouter() {
 
       // The headless path operates directly on the LoroDoc and does NOT
       // verify that the canvas actually exists — getDoc / loadCanvas return
-      // an empty doc on cache miss, so a typoed slug would otherwise emit a
+      // an empty doc on cache miss, so a typoed path would otherwise emit a
       // blank PNG. Reject up front with 404 so callers learn about the typo
       // instead of shipping the silently-empty file.
-      if (!(await canvasExists(workspaceId, slug))) {
+      if (!(await canvasExists(workspaceId, path))) {
         const errBody: ExportErrorBody = {
           error: 'canvas_not_found',
-          message: `Canvas not found: ${workspaceId}/${slug}`,
+          message: `Canvas not found: ${workspaceId}/${path}`,
         }
         return c.json(errBody, 404)
       }
 
       let pngBuffer: Buffer
       try {
-        pngBuffer = await renderHeadless(workspaceId, slug, body)
+        pngBuffer = await renderHeadless(workspaceId, path, body)
       } catch (err) {
         const errBody: ExportErrorBody = {
           error: 'headless_export_failed',
@@ -122,10 +103,21 @@ export function createExportRouter() {
       const filePath =
         outputPath !== undefined
           ? await writeExplicitOutput(outputPath, pngBuffer)
-          : await writeDefaultOutput(workspaceId, slug, pngBuffer)
+          : await writeDefaultOutput(workspaceId, path, pngBuffer)
       const response: ExportResponse = { filePath }
       return c.json(response)
     },
+    bodyLimit({
+      maxSize: EXPORT_OPTIONS_BODY_LIMIT_BYTES,
+      onError: (c) =>
+        c.json(
+          {
+            error: 'payload_too_large',
+            message: `Request body exceeds ${EXPORT_OPTIONS_BODY_LIMIT_BYTES} bytes limit.`,
+          },
+          413,
+        ),
+    }),
   )
 
   return app
@@ -133,12 +125,14 @@ export function createExportRouter() {
 
 async function renderHeadless(
   workspaceId: string,
-  slug: string,
+  path: string,
   body: z.infer<typeof exportRequestSchema>,
 ): Promise<Buffer> {
   const result = await exportCanvasHeadless({
     workspaceId,
-    slug,
+    // The store layer still speaks `slug`; renaming it through canvas-store
+    // is its own sweep.
+    slug: path,
     options: {
       padding: body.padding,
       scale: body.scale,
@@ -153,9 +147,9 @@ async function renderHeadless(
 // A plain PNG: the headless renderer no longer embeds scene JSON, so a
 // `.excalidraw.png` suffix would falsely claim the file is re-importable as
 // a scene.
-function defaultExportPath(workspaceId: string, slug: string): string {
+function defaultExportPath(workspaceId: string, path: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-  const fileName = `${slug}-${timestamp}-${nanoid(6)}.png`
+  const fileName = `${path}-${timestamp}-${nanoid(6)}.png`
   return join(getDataDir(), workspaceId, 'exports', fileName)
 }
 
@@ -169,12 +163,12 @@ const MAX_DEFAULT_PATH_ATTEMPTS = 5
 
 async function writeDefaultOutput(
   workspaceId: string,
-  slug: string,
+  path: string,
   pngBuffer: Buffer,
 ): Promise<string> {
   let lastFilePath: string | undefined
   for (let attempt = 0; attempt < MAX_DEFAULT_PATH_ATTEMPTS; attempt++) {
-    const filePath = defaultExportPath(workspaceId, slug)
+    const filePath = defaultExportPath(workspaceId, path)
     lastFilePath = filePath
     await mkdir(dirname(filePath), { recursive: true })
     try {

--- a/packages/mcp-server/src/server/routes/files.test.ts
+++ b/packages/mcp-server/src/server/routes/files.test.ts
@@ -44,7 +44,7 @@ const { createFilesRouter } = await import('./files.js')
 const { IncompleteFileGcScanError } = await import('../store/file-gc.js')
 const { corruptStoredData } = await import('../store/corrupt-stored-data.js')
 
-describe('PUT /api/canvas/:workspaceId/:slug/file/:fileId', () => {
+describe('PUT /api/w/:workspaceId/canvas/:slug/file/:fileId', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-files-test-'))
     await mkdir(join(tempDir, 'session1'), { recursive: true })
@@ -58,7 +58,7 @@ describe('PUT /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]) // PNG magic bytes
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001', {
       method: 'PUT',
       headers: { 'Content-Type': 'image/png' },
       body: imageData,
@@ -76,7 +76,7 @@ describe('PUT /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001', {
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001', {
       method: 'PUT',
       headers: { 'Content-Type': 'image/png' },
       body: imageData,
@@ -106,7 +106,7 @@ describe('PUT /api/canvas/:workspaceId/:slug/file/:fileId', () => {
 
     const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
     const app = createFilesRouter()
-    const responsePromise = app.request('/api/canvas/session1/canvas-a/file/file-001', {
+    const responsePromise = app.request('/api/w/session1/canvas/canvas-a/file/file-001', {
       method: 'PUT',
       headers: { 'Content-Type': 'image/png' },
       body: imageData,
@@ -130,7 +130,7 @@ describe('PUT /api/canvas/:workspaceId/:slug/file/:fileId', () => {
   })
 })
 
-describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
+describe('GET /api/w/:workspaceId/canvas/:slug/file/:fileId', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-files-test-'))
     await mkdir(join(tempDir, 'session1', 'files'), { recursive: true })
@@ -146,7 +146,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     await writeFile(join(tempDir, 'session1', 'files', 'file-001.png'), imageData)
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001')
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('image/png')
 
@@ -156,7 +156,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
 
   it('returns 404 for a missing fileId', async () => {
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/nonexistent')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/nonexistent')
     expect(res.status).toBe(404)
   })
 
@@ -164,7 +164,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     await rm(join(tempDir, 'session1', 'files'), { recursive: true, force: true })
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001')
 
     expect(res.status).toBe(404)
   })
@@ -175,7 +175,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     await writeFile(join(tempDir, 'session1', 'files'), 'not-a-directory')
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001')
 
     expect(res.status).toBe(500)
     await expect(res.json()).resolves.toEqual({
@@ -188,7 +188,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     await mkdir(join(tempDir, 'session1', 'files', 'file-001.png'), { recursive: true })
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001')
 
     expect(res.status).toBe(500)
     await expect(res.json()).resolves.toEqual({
@@ -208,7 +208,7 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
     )
 
     const app = createFilesRouter()
-    const res = await app.request('/api/canvas/session1/canvas-a/file/file-001')
+    const res = await app.request('/api/w/session1/canvas/canvas-a/file/file-001')
     expect(res.status).toBe(200)
 
     const buf = await res.arrayBuffer()
@@ -219,10 +219,10 @@ describe('GET /api/canvas/:workspaceId/:slug/file/:fileId', () => {
   it('returns 400 for invalid workspaceId / fileId', async () => {
     const app = createFilesRouter()
 
-    const badSession = await app.request('/api/canvas/bad.sid/canvas-a/file/file-001')
+    const badSession = await app.request('/api/w/bad.sid/canvas/canvas-a/file/file-001')
     expect(badSession.status).toBe(400)
 
-    const badFileId = await app.request('/api/canvas/session1/canvas-a/file/bad.id')
+    const badFileId = await app.request('/api/w/session1/canvas/canvas-a/file/bad.id')
     expect(badFileId.status).toBe(400)
   })
 })

--- a/packages/mcp-server/src/server/routes/files.ts
+++ b/packages/mcp-server/src/server/routes/files.ts
@@ -11,12 +11,8 @@ import {
 import { incompleteFileGcScanErrorBody, purgeDanglingFiles } from '../store/file-gc.js'
 import type { VersionStore } from '../store/version-store.js'
 import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
-import {
-  validateFileId,
-  validateSlug,
-  validateWorkspaceId,
-  validationErrorBody,
-} from '../validators.js'
+import { validateFileId, validateWorkspaceId, validationErrorBody } from '../validators.js'
+import { onCanvasFile } from './canvas/path-route.js'
 
 // Per-file size limit. Loro thumbnails are around 2 MiB and assets pasted into
 // Excalidraw normally fit inside this range. Return 413 when exceeded to avoid
@@ -60,26 +56,13 @@ export interface FilesRouterOptions {
 export function createFilesRouter(options: FilesRouterOptions = {}) {
   const app = new Hono()
 
-  // PUT /api/canvas/:workspaceId/:slug/file/:fileId
+  // PUT /api/w/:workspaceId/canvas/<path>/file/:fileId
   // Called by MCP load_image. fileId is already generated on the MCP side with nanoid().
-  app.put(
-    '/api/canvas/:workspaceId/:slug/file/:fileId',
-    bodyLimit({
-      maxSize: MAX_FILE_UPLOAD_BYTES,
-      onError: (c) =>
-        c.json(
-          {
-            error: 'payload_too_large',
-            message: `Upload exceeds ${MAX_FILE_UPLOAD_BYTES} bytes limit.`,
-          },
-          413,
-        ),
-    }),
-    async (c) => {
-      const { workspaceId, slug, fileId } = c.req.param()
+  onCanvasFile(
+    app,
+    'put',
+    async (c, workspaceId, _path, fileId) => {
       try {
-        validateWorkspaceId(workspaceId)
-        validateSlug(slug)
         validateFileId(fileId)
       } catch (err) {
         const body = validationErrorBody(err)
@@ -111,15 +94,23 @@ export function createFilesRouter(options: FilesRouterOptions = {}) {
       })
       return c.body(null, 204)
     },
+    bodyLimit({
+      maxSize: MAX_FILE_UPLOAD_BYTES,
+      onError: (c) =>
+        c.json(
+          {
+            error: 'payload_too_large',
+            message: `Upload exceeds ${MAX_FILE_UPLOAD_BYTES} bytes limit.`,
+          },
+          413,
+        ),
+    }),
   )
 
-  // GET /api/canvas/:workspaceId/:slug/file/:fileId
+  // GET /api/w/:workspaceId/canvas/<path>/file/:fileId
   // Browser-facing route. Find a file under files/ whose stem matches fileId exactly.
-  app.get('/api/canvas/:workspaceId/:slug/file/:fileId', async (c) => {
-    const { workspaceId, slug, fileId } = c.req.param()
+  onCanvasFile(app, 'get', async (c, workspaceId, _path, fileId) => {
     try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
       validateFileId(fileId)
     } catch (err) {
       const body = validationErrorBody(err)

--- a/packages/mcp-server/src/server/routes/status.test.ts
+++ b/packages/mcp-server/src/server/routes/status.test.ts
@@ -10,13 +10,13 @@ const { getClientCount } = await import('./ws.js')
 const { getReadyClientCount } = await import('./ws.js')
 const { createStatusRouter } = await import('./status.js')
 
-describe('GET /api/canvas/:workspaceId/:slug/client-count', () => {
+describe('GET /api/w/:workspaceId/canvas/:slug/client-count', () => {
   it('returns count=0 when no clients are connected', async () => {
     ;(getClientCount as unknown as ReturnType<typeof vi.fn>).mockReturnValue(0)
     ;(getReadyClientCount as unknown as ReturnType<typeof vi.fn>).mockReturnValue(0)
     const app = new Hono()
     app.route('/', createStatusRouter())
-    const res = await app.request('/api/canvas/s1/canvas-a/client-count')
+    const res = await app.request('/api/w/s1/canvas/canvas-a/client-count')
     expect(res.status).toBe(200)
     const body = (await res.json()) as { count: number; readyCount: number }
     expect(body.count).toBe(0)
@@ -28,7 +28,7 @@ describe('GET /api/canvas/:workspaceId/:slug/client-count', () => {
     ;(getReadyClientCount as unknown as ReturnType<typeof vi.fn>).mockReturnValue(1)
     const app = new Hono()
     app.route('/', createStatusRouter())
-    const res = await app.request('/api/canvas/s1/canvas-a/client-count')
+    const res = await app.request('/api/w/s1/canvas/canvas-a/client-count')
     const body = (await res.json()) as { count: number; readyCount: number }
     expect(body.count).toBe(2)
     expect(body.readyCount).toBe(1)
@@ -38,10 +38,10 @@ describe('GET /api/canvas/:workspaceId/:slug/client-count', () => {
     const app = new Hono()
     app.route('/', createStatusRouter())
 
-    const badSession = await app.request('/api/canvas/bad.sid/canvas-a/client-count')
+    const badSession = await app.request('/api/w/bad.sid/canvas/canvas-a/client-count')
     expect(badSession.status).toBe(400)
 
-    const badSlug = await app.request('/api/canvas/s1/bad.slug/client-count')
+    const badSlug = await app.request('/api/w/s1/canvas/bad.slug/client-count')
     expect(badSlug.status).toBe(400)
   })
 })

--- a/packages/mcp-server/src/server/routes/status.ts
+++ b/packages/mcp-server/src/server/routes/status.ts
@@ -1,13 +1,13 @@
 import { Hono } from 'hono'
 import type { ClientCountResponse } from '../../shared/api-contracts/canvas-runtime.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../validators.js'
+import { onCanvasAction } from './canvas/path-route.js'
 import { getClientCount, getReadyClientCount } from './ws.js'
 
 // Lightweight route for polling whether the browser connected after canvas_open.
 // It only reads the WS connection map through getClientCount, so it stays O(1).
 //
 // Usage:
-//   GET /api/canvas/:workspaceId/:slug/client-count → { count: number }
+//   GET /api/w/:workspaceId/canvas/<path>/client-count → { count: number }
 //
 // When canvas_open uses waitForClient=true, poll this endpoint every 100 ms until
 // count >= 1 or timeout. That avoids the canvas_open -> export_canvas race where
@@ -16,19 +16,10 @@ import { getClientCount, getReadyClientCount } from './ws.js'
 export function createStatusRouter() {
   const app = new Hono()
 
-  app.get('/api/canvas/:workspaceId/:slug/client-count', (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasAction(app, 'get', 'client-count', (c, workspaceId, path) => {
     const response: ClientCountResponse = {
-      count: getClientCount(workspaceId, slug),
-      readyCount: getReadyClientCount(workspaceId, slug),
+      count: getClientCount(workspaceId, path),
+      readyCount: getReadyClientCount(workspaceId, path),
     }
     return c.json(response)
   })

--- a/packages/mcp-server/src/server/routes/sync-sse.test.ts
+++ b/packages/mcp-server/src/server/routes/sync-sse.test.ts
@@ -4,7 +4,7 @@
 // Plain http fetch to loopback IS allowed from a secure page, so the same
 // sync protocol rides SSE downstream and POST upstream.
 //
-// The initial snapshot is NOT carried here: GET /api/canvas/:ws/:slug/snapshot
+// The initial snapshot is NOT carried here: GET /api/w/:ws/canvas/:slug/snapshot
 // already serves it as binary, and routing the largest payload through SSE
 // would only add base64 inflation. This stream carries incremental updates.
 import { afterEach, describe, expect, it } from 'vitest'

--- a/packages/mcp-server/src/server/routes/viewport.test.ts
+++ b/packages/mcp-server/src/server/routes/viewport.test.ts
@@ -40,7 +40,7 @@ function makeApp(options: { timeoutMs?: number } = {}) {
   return app
 }
 
-describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => {
+describe('POST /api/w/:workspaceId/canvas/:slug/viewport - error handling', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-viewport-test-'))
     mockGetClientCount.mockReset()
@@ -56,7 +56,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     const app = makeApp()
 
     const start = Date.now()
-    const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', { method: 'POST' })
     const elapsed = Date.now() - start
 
     expect(res.status).toBe(503)
@@ -67,7 +67,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
   it('includes a canvas_open hint in the zero-client error JSON', async () => {
     mockGetClientCount.mockReturnValue(0)
     const app = makeApp()
-    const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', { method: 'POST' })
     const body = (await res.json()) as { error: string; message: string; hint?: string }
     expect(body.error).toBe('no_client')
     expect(body.message.toLowerCase()).toContain('no browser')
@@ -78,7 +78,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     mockGetClientCount.mockReturnValue(1)
     const app = makeApp({ timeoutMs: 50 })
 
-    const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', { method: 'POST' })
 
     expect(res.status).toBe(504)
     const body = (await res.json()) as { error: string; message: string }
@@ -94,7 +94,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/viewport', {
+    const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -123,7 +123,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     })
     const app = makeApp()
 
-    await app.request('/api/canvas/s1/canvas-a/viewport', {
+    await app.request('/api/w/s1/canvas/canvas-a/viewport', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ mode: 'move', scrollX: 100, scrollY: 200, zoom: 1.5 }),
@@ -144,7 +144,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     })
     const app = makeApp()
 
-    const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+    const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', { method: 'POST' })
     expect(res.status).toBe(200)
     // The browser side falls back to its default mode when the body is empty.
     const call = mockSendViewportRequest.mock.calls[0]
@@ -163,7 +163,7 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
 
     vi.useFakeTimers()
     try {
-      const res = await app.request('/api/canvas/s1/canvas-a/viewport', { method: 'POST' })
+      const res = await app.request('/api/w/s1/canvas/canvas-a/viewport', { method: 'POST' })
       expect(res.status).toBe(200)
       // A leaked timer would still be pending here, ticking until timeoutMs.
       expect(vi.getTimerCount()).toBe(0)
@@ -176,12 +176,12 @@ describe('POST /api/canvas/:workspaceId/:slug/viewport - error handling', () => 
     mockGetClientCount.mockReturnValue(1)
     const app = makeApp()
 
-    const badSession = await app.request('/api/canvas/bad.sid/canvas-a/viewport', {
+    const badSession = await app.request('/api/w/bad.sid/canvas/canvas-a/viewport', {
       method: 'POST',
     })
     expect(badSession.status).toBe(400)
 
-    const badSlug = await app.request('/api/canvas/s1/bad.slug/viewport', {
+    const badSlug = await app.request('/api/w/s1/canvas/bad.slug/viewport', {
       method: 'POST',
     })
     expect(badSlug.status).toBe(400)

--- a/packages/mcp-server/src/server/routes/viewport.ts
+++ b/packages/mcp-server/src/server/routes/viewport.ts
@@ -4,7 +4,7 @@ import type {
   ViewportErrorBody,
   ViewportResponse,
 } from '../../shared/api-contracts/canvas-runtime.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../validators.js'
+import { onCanvasAction } from './canvas/path-route.js'
 import { getClientCount, sendViewportRequest } from './ws.js'
 
 // requestId -> { resolve, reject }
@@ -25,18 +25,7 @@ export function createViewportRouter(options: CreateViewportRouterOptions = {}) 
   const timeoutMs = options.timeoutMs ?? 5_000
   const app = new Hono()
 
-  // POST /api/canvas/:workspaceId/:slug/viewport
-  app.post('/api/canvas/:workspaceId/:slug/viewport', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
-
+  onCanvasAction(app, 'post', 'viewport', async (c, workspaceId, path) => {
     // The body is optional. Forward all viewport parameters (mode / elementIds /
     // padding / animate / scrollX / scrollY / zoom) to the browser, which applies defaults.
     const body = await c.req
@@ -44,7 +33,7 @@ export function createViewportRouter(options: CreateViewportRouterOptions = {}) 
       .catch(() => ({}) as Record<string, unknown>)
 
     // Fast-fail with 503 if no WS client is connected.
-    if (getClientCount(workspaceId, slug) === 0) {
+    if (getClientCount(workspaceId, path) === 0) {
       const noClient: ViewportErrorBody = {
         error: 'no_client',
         message:
@@ -60,7 +49,7 @@ export function createViewportRouter(options: CreateViewportRouterOptions = {}) 
     try {
       await new Promise<void>((resolve, reject) => {
         pendingViewport.set(requestId, { resolve, reject })
-        sendViewportRequest(workspaceId, slug, requestId, body)
+        sendViewportRequest(workspaceId, path, requestId, body)
 
         timer = setTimeout(() => {
           if (pendingViewport.has(requestId)) {

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -185,7 +185,7 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
   // (or POST) file route later silently authorizes a mutation with a
   // read-only credential.
   it('any write verb on a file route requires files:write, not just PUT', () => {
-    const filePath = '/api/canvas/ws1/main/file/abc'
+    const filePath = '/api/w/ws1/canvas/main/file/abc'
     expect(resolveApiRouteScope('GET', filePath)).toEqual({
       kind: 'scoped',
       scopes: ['files:read'],

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -60,19 +60,22 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
 
   const isWrite = isWriteMethod(method)
 
-  // File routes: reading/writing a canvas's attached binary file.
-  if (/^\/api\/canvas\/[^/]+\/[^/]+\/file\//.test(path)) {
+  // File routes: reading/writing a canvas's attached binary file. The
+  // document path is multi-segment, so the discriminator is the mandatory
+  // `/file/<fileId>` suffix — the same suffix-anchored parse the router uses.
+  if (/^\/api\/w\/[^/]+\/canvas\/.+\/file\/[^/]+$/.test(path)) {
     return { kind: 'scoped', scopes: [isWrite ? 'files:write' : 'files:read'] }
   }
 
   // Canvas write operations that arrive as POST but mutate state.
-  if (/^\/api\/canvas\/[^/]+\/[^/]+\/(update|export)$/.test(path) && method === 'POST') {
+  if (/^\/api\/w\/[^/]+\/canvas\/.+\/(update|export)$/.test(path) && method === 'POST') {
     return { kind: 'scoped', scopes: ['canvas:write'] }
   }
-  // Remaining /api/canvas/* routes: honor the write/read split so a mutating
-  // POST (e.g. /viewport) isn't authorized by canvas:read alone. The
-  // specific write routes above still take precedence via ordering.
-  if (path.startsWith('/api/canvas/')) {
+  // Remaining /api/w/:workspaceId/canvas/* routes: honor the write/read
+  // split so a mutating POST (e.g. /viewport) isn't authorized by
+  // canvas:read alone. The specific write routes above still take
+  // precedence via ordering.
+  if (/^\/api\/w\/[^/]+\/canvas\//.test(path)) {
     return { kind: 'scoped', scopes: [isWrite ? 'canvas:write' : 'canvas:read'] }
   }
 

--- a/packages/mcp-server/src/shared/api-contracts/canvas-runtime.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas-runtime.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 
-// Schemas for the thin /api/canvas/:workspaceId/:slug/* endpoints that drive
+// Schemas for the thin /api/w/:workspaceId/canvas/<path>/* endpoints that drive
 // browser-side state (viewport, client-count). These bridge MCP tools to the
 // daemon, so a wire-format change has exactly one place to update.
 
-// ── POST /api/canvas/:workspaceId/:slug/viewport ──────────────────────────
+// ── POST /api/w/:workspaceId/canvas/<path>/viewport ───────────────────────
 // The request body is forwarded to the browser unchanged (mode / elementIds /
 // padding / animate / scrollX / scrollY / zoom) with no server-side schema —
 // the canonical shape lives in shared/ws-messages.ts as
@@ -21,7 +21,7 @@ const viewportErrorBodySchema = z.object({
   hint: z.string().optional(),
 })
 
-// ── GET /api/canvas/:workspaceId/:slug/client-count ───────────────────────
+// ── GET /api/w/:workspaceId/canvas/<path>/client-count ────────────────────
 const clientCountResponseSchema = z.object({
   count: z.number().int().nonnegative(),
   readyCount: z.number().int().nonnegative(),

--- a/packages/mcp-server/src/shared/api-contracts/canvas-url.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas-url.ts
@@ -1,0 +1,74 @@
+// The one place the live-canvas API's URL shape is written down. The server
+// parses request paths with parseCanvasApiPath; every client builds request
+// URLs through canvasApiUrl. Both sides importing this file is what keeps
+// them from drifting apart segment by segment.
+//
+// Shape: /api/w/:workspaceId/canvas/<document path>/<action>
+//
+// The document path is multi-segment (`notes/2026/plan`), so the action
+// suffix is what makes parsing unambiguous: it is mandatory and drawn from a
+// closed set, so stripping the known action off the end leaves exactly the
+// path — including a document whose own last segment collides with an action
+// name (`.../canvas/a/snapshot/snapshot` is the document `a/snapshot`).
+
+/** Per-segment encoding: the separators are structure, not data. */
+export function encodeCanvasPath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
+export function canvasApiUrl(
+  workspaceId: string,
+  path: string,
+  action: 'snapshot' | 'exists' | 'update' | 'export' | 'export-svg' | 'viewport' | 'client-count',
+): string {
+  return `/api/w/${encodeURIComponent(workspaceId)}/canvas/${encodeCanvasPath(path)}/${action}`
+}
+
+export function canvasFileApiUrl(workspaceId: string, path: string, fileId: string): string {
+  return `/api/w/${encodeURIComponent(workspaceId)}/canvas/${encodeCanvasPath(path)}/file/${encodeURIComponent(fileId)}`
+}
+
+/**
+ * Splits a request path in the shape above into its parts, or null when it
+ * is not one. Written by hand rather than as a Hono `{.+}` param: Hono's
+ * SmartRouter picks its underlying router on the FIRST request, and with the
+ * full route table that pick lands on one where a regex param cannot span
+ * slashes — the route then 404s, but only after some other request has been
+ * served first, which is as misleading as bugs get. A wildcard route plus
+ * this parse depends on no router internals.
+ *
+ * Segments are percent-decoded one by one; a malformed segment makes the
+ * whole path not-a-match rather than a throw.
+ */
+export function parseCanvasApiPath(
+  requestPath: string,
+): { workspaceId: string; tail: string[] } | null {
+  const match = requestPath.match(/^\/api\/w\/([^/]+)\/canvas\/(.+)$/)
+  if (match === null) return null
+  const workspaceId = decodeSegment(match[1])
+  const tail = match[2].split('/').map(decodeSegment)
+  if (workspaceId === null || tail.some((segment) => segment === null || segment === '')) {
+    return null
+  }
+  return { workspaceId, tail: tail as string[] }
+}
+
+/** The document path when the tail ends in `action`, else null. */
+export function canvasPathForAction(tail: string[], action: string): string | null {
+  if (tail.length < 2 || tail[tail.length - 1] !== action) return null
+  return tail.slice(0, -1).join('/')
+}
+
+/** The document path + fileId when the tail is `<path>/file/<fileId>`, else null. */
+export function canvasPathForFile(tail: string[]): { path: string; fileId: string } | null {
+  if (tail.length < 3 || tail[tail.length - 2] !== 'file') return null
+  return { path: tail.slice(0, -2).join('/'), fileId: tail[tail.length - 1] as string }
+}
+
+function decodeSegment(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return null
+  }
+}

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -98,7 +98,7 @@ export const createCanvasResponseSchema = z.object({
   slug: z.string(),
 })
 
-// POST /api/canvas/:workspaceId/:slug/update — success body.
+// POST /api/w/:workspaceId/canvas/<path>/update — success body.
 export const updateCanvasResponseSchema = z.object({
   ok: z.literal(true),
 })
@@ -118,7 +118,7 @@ export const renameCanvasSlugResponseSchema = z.object({
   slug: z.string(),
 })
 
-// GET /api/canvas/:workspaceId/:slug/exists — success body. Read-only lookup
+// GET /api/w/:workspaceId/canvas/<path>/exists — success body. Read-only lookup
 // so callers can distinguish "canvas not yet created" from a live doc,
 // without the snapshot/update routes' silent lazy-create side effect.
 export const canvasExistsResponseSchema = z.object({

--- a/packages/mcp-server/src/shared/api-contracts/export-svg.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export-svg.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-// Request schema for POST /api/canvas/:workspaceId/:slug/export-svg.
+// Request schema for POST /api/w/:workspaceId/canvas/<path>/export-svg.
 // Imported by the route handler so the wire format has exactly one place
 // to update. Unlike PNG export, SVG rendering always runs headless from
 // the persisted document (see routes/canvas/export-svg.ts) — there is no

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-// Request / response schemas for POST /api/canvas/:workspaceId/:slug/export.
+// Request / response schemas for POST /api/w/:workspaceId/canvas/<path>/export.
 // Imported by the route handler, which validates incoming bodies against
 // exportRequestSchema and types its `c.json(...)` responses via the
 // ExportResponse/ExportErrorBody types derived below.

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -20,6 +20,7 @@ export {
 } from '@kamiazya/whiteboard-server-core'
 export * from './branches.js'
 export * from './canvas.js'
+export * from './canvas-url.js'
 export type { ListGrantsResponse, PairingTokenResponse } from './pairing.js'
 export {
   listGrantsResponseSchema,

--- a/packages/mcp-server/src/shared/daemon-backend.api-transport.test.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.api-transport.test.ts
@@ -27,7 +27,7 @@ describe('DaemonBackend apiTransport', () => {
 
     expect(injectedFetch).toHaveBeenCalledTimes(1)
     const [url] = injectedFetch.mock.calls[0] as [string]
-    expect(url).toBe('/api/canvas/ws-1/canvas-1/file/file-1')
+    expect(url).toBe('/api/w/ws-1/canvas/canvas-1/file/file-1')
     // The module-level fetch (used by the default same-origin apiFetch) must
     // not be touched when an apiTransport override is supplied.
     expect(fetch).not.toHaveBeenCalled()
@@ -92,7 +92,7 @@ describe('DaemonBackend apiTransport', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1)
     const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
-    expect(url).toBe('/api/canvas/ws-1/canvas-1/file/file-a')
+    expect(url).toBe('/api/w/ws-1/canvas/canvas-1/file/file-a')
     expect(init.method).toBe('PUT')
     expect(onSuccess).toHaveBeenCalledWith('file-a')
   })

--- a/packages/mcp-server/src/shared/daemon-backend.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ts
@@ -22,6 +22,7 @@
  */
 
 import { apiFetch } from './api-client.js'
+import { canvasFileApiUrl } from './api-contracts/canvas-url.js'
 import type {
   BinaryFileDataLike,
   CanvasBackend,
@@ -129,9 +130,7 @@ export class DaemonBackend implements CanvasBackend {
 
   async getFile(fileId: string): Promise<Blob | null> {
     const fetchFn = this.apiTransport?.fetch ?? apiFetch
-    const res = await fetchFn(
-      `/api/canvas/${this.workspaceId}/${encodeURIComponent(this.slug)}/file/${encodeURIComponent(fileId)}`,
-    )
+    const res = await fetchFn(canvasFileApiUrl(this.workspaceId, this.slug, fileId))
     if (!res.ok) return null
     return res.blob()
   }

--- a/packages/mcp-server/src/shared/sse-backend.test.ts
+++ b/packages/mcp-server/src/shared/sse-backend.test.ts
@@ -90,7 +90,9 @@ describe('SseBackend', () => {
     await vi.waitFor(() => expect(snapshots.length).toBe(1))
 
     expect(snapshots[0]).toEqual(new Uint8Array([7, 7, 7]))
-    expect(fake.calls.some((c) => c.url.includes('/api/canvas/ws-1/canvas-a/snapshot'))).toBe(true)
+    expect(fake.calls.some((c) => c.url.includes('/api/w/ws-1/canvas/canvas-a/snapshot'))).toBe(
+      true,
+    )
     backend.disconnect()
   })
 
@@ -213,7 +215,7 @@ describe('SseBackend', () => {
 
     await vi.waitFor(() => {
       const post = fake.calls.find(
-        (c) => c.url.includes('/api/canvas/ws-1/canvas-a/update') && c.method === 'POST',
+        (c) => c.url.includes('/api/w/ws-1/canvas/canvas-a/update') && c.method === 'POST',
       )
       expect(post).toBeDefined()
     })

--- a/packages/mcp-server/src/shared/sse-backend.ts
+++ b/packages/mcp-server/src/shared/sse-backend.ts
@@ -13,7 +13,9 @@
  * and any access log that sees it. Reading the body ourselves keeps the token
  * in a header and works unchanged inside a SharedWorker.
  */
+
 import { apiFetch } from './api-client.js'
+import { canvasApiUrl, canvasFileApiUrl } from './api-contracts/canvas-url.js'
 import type {
   BinaryFileDataLike,
   CanvasBackend,
@@ -73,9 +75,7 @@ export class SseBackend implements CanvasBackend {
     // that started reading before seeding would apply deltas to an empty doc.
     try {
       const res = await this.fetchFn(
-        this.url(
-          `/api/canvas/${encodeURIComponent(this.workspaceId)}/${encodeURIComponent(this.slug)}/snapshot`,
-        ),
+        this.url(canvasApiUrl(this.workspaceId, this.slug, 'snapshot')),
       )
       if (this.cancelled) return
       if (res.ok) {
@@ -157,11 +157,7 @@ export class SseBackend implements CanvasBackend {
   }
 
   async getFile(fileId: string): Promise<Blob | null> {
-    const res = await this.fetchFn(
-      this.url(
-        `/api/canvas/${encodeURIComponent(this.workspaceId)}/${encodeURIComponent(this.slug)}/file/${encodeURIComponent(fileId)}`,
-      ),
-    )
+    const res = await this.fetchFn(this.url(canvasFileApiUrl(this.workspaceId, this.slug, fileId)))
     if (!res.ok) return null
     return res.blob()
   }

--- a/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
@@ -45,7 +45,7 @@ function createHarness(): SseStreamSourceHarness {
     }
     // The canvas update route, which is where a push lands. Matched before the
     // JSON parse below: its body is raw update bytes, not JSON.
-    const canvasUpdate = /\/api\/canvas\/([^/]+)\/([^/]+)\/update$/.exec(url)
+    const canvasUpdate = /\/api\/w\/([^/]+)\/canvas\/(.+)\/update$/.exec(url)
     if (canvasUpdate) {
       const [, workspaceId, slug] = canvasUpdate
       daemonWrites.push({

--- a/packages/mcp-server/src/shared/sse-stream-hub.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.ts
@@ -11,7 +11,9 @@
  * verbatim inside a SharedWorker, which is what makes the sharing span tabs
  * rather than just the canvases within one tab.
  */
+
 import type { z } from 'zod'
+import { canvasApiUrl } from './api-contracts/canvas-url.js'
 import {
   syncMessageEventSchema,
   syncReadyEventSchema,
@@ -169,7 +171,7 @@ export function canvasUpdateUrl(baseUrl: string, doc: string): string | null {
   if (slash <= 0 || slash === doc.length - 1) return null
   const workspaceId = encodeURIComponent(doc.slice(0, slash))
   const slug = encodeURIComponent(doc.slice(slash + 1))
-  return `${baseUrl.replace(/\/$/, '')}/api/canvas/${workspaceId}/${slug}/update`
+  return `${baseUrl.replace(/\/$/, '')}${canvasApiUrl(workspaceId, slug, 'update')}`
 }
 
 export class SseStreamHub implements SseStreamSource {

--- a/packages/mcp-server/src/shared/sync-sse-contract.ts
+++ b/packages/mcp-server/src/shared/sync-sse-contract.ts
@@ -30,7 +30,7 @@ export const syncUpdateEventSchema = z.object({
   doc: z.string().min(1),
   // SSE frames are text, so Loro update bytes travel base64-encoded. Only
   // incremental updates go through here — the initial snapshot is served as
-  // binary by GET /api/canvas/:workspaceId/:slug/snapshot, so the largest
+  // binary by GET /api/w/:workspaceId/canvas/<path>/snapshot, so the largest
   // payload never pays the base64 inflation.
   update: z.string(),
 })

--- a/packages/mcp-server/src/shared/upload-files.ts
+++ b/packages/mcp-server/src/shared/upload-files.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from './api-client.js'
+import { canvasFileApiUrl } from './api-contracts/canvas-url.js'
 import type { BinaryFileDataLike } from './canvas-backend-contract.js'
 
 /**
@@ -27,14 +28,11 @@ export async function uploadFiles(
         throw new Error(`file ${fileId}: malformed dataURL (no base64 payload)`)
       }
       const binary = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
-      const res = await fetchFn(
-        `/api/canvas/${workspaceId}/${encodeURIComponent(slug)}/file/${encodeURIComponent(fileId)}`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': fd.mimeType },
-          body: binary,
-        },
-      )
+      const res = await fetchFn(canvasFileApiUrl(workspaceId, slug, fileId), {
+        method: 'PUT',
+        headers: { 'Content-Type': fd.mimeType },
+        body: binary,
+      })
       if (!res.ok) {
         throw new Error(`PUT /file/${fileId} failed: ${res.status}`)
       }

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -267,7 +267,7 @@ try {
   // would no longer match.
   const snapshotARes = await authedFetch(
     daemonA,
-    `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(SEED_CANVAS_SLUG)}/snapshot`,
+    `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(SEED_CANVAS_SLUG)}/snapshot`,
   )
   if (!snapshotARes.ok) {
     throw new Error(`daemon A snapshot fetch failed: ${snapshotARes.status}`)
@@ -399,7 +399,7 @@ try {
   // daemon B to actually `loadCanvas` the restored file.
   const snapshotBRes = await authedFetch(
     daemonB,
-    `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(SEED_CANVAS_SLUG)}/snapshot`,
+    `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(SEED_CANVAS_SLUG)}/snapshot`,
   )
   if (!snapshotBRes.ok) {
     throw new Error(`daemon B snapshot fetch failed: ${snapshotBRes.status}`)

--- a/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-app-smoke.mjs
@@ -310,22 +310,24 @@ try {
   }
   console.log('[server-mode-smoke] scenario 5a (workspaces auth): PASS')
 
-  // --- Scenario 5b: POST /api/canvas/:wid/:slug/export — canvas:write ---
+  // --- Scenario 5b: POST /api/w/:wid/canvas/:slug/export — canvas:write ---
   {
     const appEmpty = makeApp([])
-    const res401 = await req(appEmpty, 'POST', '/api/canvas/w1/s1/export')
+    const res401 = await req(appEmpty, 'POST', '/api/w/w1/canvas/s1/export')
     if (res401.status !== 401) fail('5b: expected 401 without auth', { status: res401.status })
     assertNoLeak('5b 401', await res401.text())
 
     const appRead = makeApp(['canvas:read'])
-    const res403 = await req(appRead, 'POST', '/api/canvas/w1/s1/export', { bearer: SMOKE_TOKEN })
+    const res403 = await req(appRead, 'POST', '/api/w/w1/canvas/s1/export', { bearer: SMOKE_TOKEN })
     if (res403.status !== 403) {
       fail('5b: canvas:read must be 403 on canvas:write export route', { status: res403.status })
     }
     assertNoLeak('5b 403', await res403.text())
 
     const appWrite = makeApp(['canvas:write'])
-    const resPass = await req(appWrite, 'POST', '/api/canvas/w1/s1/export', { bearer: SMOKE_TOKEN })
+    const resPass = await req(appWrite, 'POST', '/api/w/w1/canvas/s1/export', {
+      bearer: SMOKE_TOKEN,
+    })
     if (resPass.status === 401 || resPass.status === 403) {
       fail('5b: canvas:write must pass auth gate on export', { status: resPass.status })
     }

--- a/tests/e2e/distribution/packaged-server-mode-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-backup-restore-smoke.mjs
@@ -11,7 +11,7 @@
 //   3.  Start container A with a fresh source data volume.
 //   4.  Seed via valid JWT:
 //         - workspace + canvas (Loro snapshot via canvas POST)
-//         - file blob  (PUT /api/canvas/:ws/:slug/file/:fileId)
+//         - file blob  (PUT /api/w/:ws/canvas/:slug/file/:fileId)
 //         - manual version + thumbnail
 //         - palette entry  (PUT /api/workspaces/:ws/palette, no auth needed)
 //   5.  Capture snapshot bytes from server A for byte-equality check.
@@ -407,7 +407,7 @@ try {
     // Capture Loro snapshot bytes (canvas:read).
     const snapshotRes = await authedFetch(
       serverBaseUrl,
-      `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(CANVAS_SLUG)}/snapshot`,
+      `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(CANVAS_SLUG)}/snapshot`,
       jwt,
     )
     if (!snapshotRes.ok) fail(`scenario 3: snapshot fetch failed with ${snapshotRes.status}`)
@@ -417,7 +417,7 @@ try {
     // Upload file blob (files:write).
     const uploadRes = await authedFetch(
       serverBaseUrl,
-      `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(CANVAS_SLUG)}/file/${FILE_ID}`,
+      `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(CANVAS_SLUG)}/file/${FILE_ID}`,
       jwt,
       { method: 'PUT', headers: { 'Content-Type': 'image/png' }, body: MINIMAL_PNG },
     )
@@ -574,7 +574,7 @@ try {
     // Snapshot byte-equality (canvas:read).
     const snapshotRes = await authedFetch(
       serverBaseUrl,
-      `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(CANVAS_SLUG)}/snapshot`,
+      `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(CANVAS_SLUG)}/snapshot`,
       jwt,
     )
     if (!snapshotRes.ok)
@@ -596,7 +596,7 @@ try {
     // File blob (files:read).
     const fileRes = await authedFetch(
       serverBaseUrl,
-      `/api/canvas/${encodeURIComponent(WORKSPACE_ID)}/${encodeURIComponent(CANVAS_SLUG)}/file/${FILE_ID}`,
+      `/api/w/${encodeURIComponent(WORKSPACE_ID)}/canvas/${encodeURIComponent(CANVAS_SLUG)}/file/${FILE_ID}`,
       jwt,
     )
     if (!fileRes.ok) fail(`scenario 7: file GET on restored server failed with ${fileRes.status}`)

--- a/tests/e2e/distribution/packaged-server-mode-docker-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-docker-smoke.mjs
@@ -332,7 +332,7 @@ try {
 
   // Scenario 5: protected route, no auth → 401
   {
-    const resp = await fetch(`${serverBaseUrl}/api/canvas/test-ws/test-canvas/viewport`)
+    const resp = await fetch(`${serverBaseUrl}/api/w/test-ws/canvas/test-canvas/viewport`)
     if (resp.status !== 401) fail(`scenario 5: no-auth expected 401, got ${resp.status}`)
     assertNoLeak('scenario 5 body', await resp.text())
     console.log('[docker-smoke] scenario 5 PASS: no-auth → 401')
@@ -353,7 +353,7 @@ try {
         exp: now + 3600,
       },
     )
-    const resp = await fetch(`${serverBaseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
+    const resp = await fetch(`${serverBaseUrl}/api/w/test-ws/canvas/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${jwt}` },
     })
     if (resp.status === 401 || resp.status === 403)
@@ -379,7 +379,7 @@ try {
         exp: now + 3600,
       },
     )
-    const resp = await fetch(`${serverBaseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
+    const resp = await fetch(`${serverBaseUrl}/api/w/test-ws/canvas/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${jwt}` },
     })
     if (resp.status !== 403) fail(`scenario 7: wrong scope expected 403, got ${resp.status}`)

--- a/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
+++ b/tests/e2e/distribution/packaged-server-mode-entrypoint-smoke.mjs
@@ -514,7 +514,7 @@ const REQUIRED_FLAGS = [
     }
 
     // Protected route with no auth → 401
-    const noAuthResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`)
+    const noAuthResp = await fetch(`${baseUrl}/api/w/test-ws/canvas/test-canvas/viewport`)
     if (noAuthResp.status !== 401)
       fail(`scenario 8: no-auth protected route expected 401, got ${noAuthResp.status}`)
     const noAuthBody = await noAuthResp.text()
@@ -534,7 +534,7 @@ const REQUIRED_FLAGS = [
         exp: now + 3600,
       },
     )
-    const authResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
+    const authResp = await fetch(`${baseUrl}/api/w/test-ws/canvas/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${validJwt}` },
     })
     if (authResp.status === 401 || authResp.status === 403)
@@ -556,7 +556,7 @@ const REQUIRED_FLAGS = [
         exp: now + 3600,
       },
     )
-    const scopeResp = await fetch(`${baseUrl}/api/canvas/test-ws/test-canvas/viewport`, {
+    const scopeResp = await fetch(`${baseUrl}/api/w/test-ws/canvas/test-canvas/viewport`, {
       headers: { Authorization: `Bearer ${wrongScopeJwt}` },
     })
     if (scopeResp.status !== 403)


### PR DESCRIPTION
Task #33's decided slice: the live-canvas API converges on **path addressing**.

```
/api/canvas/:workspaceId/:slug/*   →   /api/w/:workspaceId/canvas/<document path>/<action>
```

Converted: `exists`, `snapshot`, `update`, `export`, `export-svg`, `viewport`,
`client-count`, and file GET/PUT. The URL is the document's placement — nested
paths included — and matches the UI's `/w/:workspaceId/canvas/*` shape from #799.

## One shape, one module

`api-contracts/canvas-url.ts` is the single place the shape is written down.
Clients build URLs through `canvasApiUrl`/`canvasFileApiUrl` — the daemon's own
(sse-backend, daemon-backend, upload-files, sse-stream-hub) and apps/web's
(daemon-api-client, import-browser-local) alike, via the api-contracts barrel —
and the server parses requests with the same module. The multi-segment path is
made unambiguous by the **mandatory action suffix**: `.../canvas/a/snapshot/snapshot`
is the document `a/snapshot`, pinned by test.

## The bug worth reading about

The obvious implementation — Hono's `:path{.+}` regex param — **passes in
isolation and 404s in production shape**. Hono's SmartRouter picks its
underlying router on the *first request*, and with the full route table that
pick lands on one where a regex param cannot span slashes. The route then 404s,
but only after some other request has been served first: a probe of the route
alone passed, the composed router alone passed, and only replaying the failing
test's exact sequence (POST first, then GET) reproduced it.

The shipped parse is therefore a hand parse over one wildcard route
(`routes/canvas/path-route.ts`), with the reason pinned in a comment. Sibling
actions share the wildcard and fall through via `next()`.

## Also in this change

- **route-scope-registry** moves with the shape: file/update/export/viewport
  keep their write-scope split under the new prefix (covered by the existing
  server-mode auth tests, all rewritten to the new URLs).
- **Vocabulary**: `slug` → `path` through the touched route handlers. The
  store layer below still speaks `slug`; the two bridge at the call sites with
  a comment — renaming through canvas-store is its own sweep.
- **Not converged**: the `/api/workspaces/:workspaceId/canvases/:slug/*` family
  (create/delete/rename/versions/thumbnails/restore) is already workspace-first
  and single-segment; widening it is the follow-up increment, after which the
  UI tail in `app-routes.ts` can widen too.
- The old URL shape answers **404**. At 0.0.x nothing redirects.

## Verification

All local gates green: `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`,
mcp-node (3,369), apps/web jsdom (2,143 + 75), web-browser (544),
`pnpm build`, `pnpm smoke:e2e`.

Against the **real daemon** (not mocks), after creating `notes/2026/plan` and
`a/snapshot` through the existing create route:

```
exists:     {"exists":true}
snapshot:   200 application/octet-stream
collide-sn: 200        (a/snapshot + /snapshot suffix parses as the document a/snapshot)
clientcnt:  {"count":0,"readyCount":0}
old shape:  404        (/api/canvas/... retired)
bad seg:    400        (encoded space is decoded, then refused by the slug rule)
unauth:     401        (scope registry still guards the new prefix)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3
