### PR TITLE
feat(sync): make the SSE pipeline unidirectional through the worker replica

### DIFF
--- a/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.contract.test.ts
@@ -25,6 +25,7 @@ const BASE = 'http://127.0.0.1:3099'
 let streamOpens = 0
 const openedStreamIds: string[] = []
 const daemonWrites: { doc: string; body: Uint8Array }[] = []
+const daemonState = new Map<string, Uint8Array>()
 const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
 const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
 let pushFrame: ((frame: string) => void) | null = null
@@ -52,6 +53,17 @@ const server = setupServer(
   http.post(`${BASE}/api/sync/subscribe`, async ({ request }) => {
     subscribeBodies.push((await request.json()) as (typeof subscribeBodies)[number])
     return HttpResponse.json({ ok: true })
+  }),
+  // The daemon's snapshot route: what the worker seeds its replica from on
+  // first touch of a document. Pre-existing content lives here.
+  http.get(`${BASE}/api/canvas/:workspaceId/:slug/snapshot`, ({ params }) => {
+    const doc = `${String(params.workspaceId)}/${String(params.slug)}`
+    const bytes = daemonState.get(doc)
+    if (!bytes) return HttpResponse.json({ title: 'Canvas not found' }, { status: 404 })
+    return new HttpResponse(bytes.slice().buffer as ArrayBuffer, {
+      status: 200,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    })
   }),
   // The canvas update route: where a push lands, after the worker's replica
   // has merged it. Addressed by workspace and slug, which the worker
@@ -95,6 +107,7 @@ function createHarness(): SseStreamSourceHarness {
     controlMessages: () => controlMessages,
     openedStreamIds: () => openedStreamIds,
     daemonWrites: () => daemonWrites,
+    seedDaemonState: (doc, bytes) => daemonState.set(doc, bytes),
     ready: async () => {
       await vi.waitFor(() => {
         if (pushFrame === null) throw new Error('stream not open')

--- a/apps/web/src/lib/sse-shared-stream-source.ts
+++ b/apps/web/src/lib/sse-shared-stream-source.ts
@@ -38,6 +38,14 @@ export function createSharedSseStreamSource(
   }
 
   const listeners = new Map<string, Set<DocListener>>()
+  /**
+   * Tabs waiting on a snapshot, keyed by doc. Keyed rather than queued
+   * because the worker's reply carries the doc and nothing else — two
+   * concurrent requests for the same document share whichever state the
+   * replica holds when it answers, which is exactly what they would have
+   * gotten asking separately.
+   */
+  const snapshotWaiters = new Map<string, Set<(bytes: Uint8Array) => void>>()
   const port = worker.port
 
   // A module worker that fails to LOAD does not throw above — construction
@@ -67,15 +75,24 @@ export function createSharedSseStreamSource(
     const parsed = sseWorkerEventSchema.safeParse(e.data)
     if (!parsed.success) return
     const evt = parsed.data
+    if (evt.type === 'snapshot') {
+      // Answered ahead of the listener gate below: the backend snapshots
+      // BEFORE it subscribes — the seed must exist before the stream's deltas
+      // land on it — so at reply time the document routinely has no listener
+      // yet, and gating this on one would deadlock every first open.
+      const waiters = snapshotWaiters.get(evt.doc)
+      if (!waiters) return
+      snapshotWaiters.delete(evt.doc)
+      const bytes = fromBase64(evt.snapshot)
+      for (const resolve of waiters) resolve(bytes)
+      return
+    }
     const set = listeners.get(evt.doc)
     if (!set) return
-    // The two inbound channels, deliberately both delivered. `update` is a raw
-    // daemon frame; `authority-update` has been through the worker's replica,
-    // so it also carries what a SIBLING TAB did — which never reaches the
-    // daemon and back in time to be useful, and is the whole point of the
-    // replica. Loro merges are idempotent, so anything that arrives on both is
-    // absorbed rather than double-applied.
-    if (evt.type === 'update' || evt.type === 'authority-update') {
+    // The ONE inbound channel. Every byte a tab applies has been through the
+    // worker's replica — ordered and deduplicated against the daemon's frames
+    // and every sibling tab's pushes — so all tabs observe the same sequence.
+    if (evt.type === 'authority-update') {
       const bytes = fromBase64(evt.update)
       for (const l of set) l.onUpdate(bytes)
       return
@@ -84,10 +101,6 @@ export function createSharedSseStreamSource(
       for (const l of set) l.onConnectionChange?.(evt.connected)
       return
     }
-    // Answered only when something asked, which nothing here does yet: a tab
-    // still builds its document from the daemon's export flow rather than
-    // forking the replica.
-    if (evt.type === 'snapshot') return
     for (const l of set) l.onMessage(evt.raw)
   }
   port.start()
@@ -123,6 +136,22 @@ export function createSharedSseStreamSource(
       // so a tab posting to the daemon itself would be writing around the very
       // thing meant to order these writes.
       port.postMessage({ type: 'push', doc, update: toBase64(update) })
+    },
+    snapshot(doc) {
+      // From the worker's replica, not the daemon: the worker seeds itself
+      // once per document and every later tab is answered from memory. The
+      // worker replies even for a document nobody has (an empty snapshot),
+      // so this resolves rather than racing a timeout — `null` is reserved
+      // for the hub implementation's 404, which has a daemon to ask.
+      return new Promise((resolve) => {
+        let waiters = snapshotWaiters.get(doc)
+        if (!waiters) {
+          waiters = new Set()
+          snapshotWaiters.set(doc, waiters)
+        }
+        waiters.add(resolve)
+        port.postMessage({ type: 'snapshot-request', doc })
+      })
     },
   }
 

--- a/apps/web/src/lib/sse-shared-worker-protocol.ts
+++ b/apps/web/src/lib/sse-shared-worker-protocol.ts
@@ -46,10 +46,6 @@ export const sseWorkerRequestSchema = z.discriminatedUnion('type', [
 ])
 
 export const sseWorkerEventSchema = z.discriminatedUnion('type', [
-  // Loro update bytes stay base64 here: structured clone could carry the bytes,
-  // but keeping the worker's output identical to the wire frame means the
-  // decode lives in exactly one place.
-  z.object({ type: z.literal('update'), doc: z.string(), update: z.string() }),
   z.object({ type: z.literal('message'), doc: z.string(), raw: z.string() }),
   // Whether a stream is currently carrying this document. Addressed like the
   // others so a tab watching several canvases routes it the same way; the

--- a/apps/web/src/lib/sse-shared-worker-resend.test.ts
+++ b/apps/web/src/lib/sse-shared-worker-resend.test.ts
@@ -50,6 +50,12 @@ const server = setupServer(
     subscribeBodies.push(await request.text())
     return HttpResponse.json({ ok: true })
   }),
+  // Answered rather than left to `bypass`: the worker seeds every subscribed
+  // document from this route, and an unhandled request would escape to
+  // whatever real daemon is on this port.
+  http.get(`${BASE}/api/canvas/:workspaceId/:slug/snapshot`, () =>
+    HttpResponse.json({ title: 'Canvas not found' }, { status: 404 }),
+  ),
   http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
     // A refusal that ANSWERS rather than drops the connection: a 5xx is the
     // shape a restarting daemon actually produces, and it is the one a

--- a/apps/web/src/lib/sse-shared-worker-seed.test.ts
+++ b/apps/web/src/lib/sse-shared-worker-seed.test.ts
@@ -27,6 +27,9 @@ const pushByStream = new Map<string, (frame: string) => void>()
 /** Pre-existing content per doc key, served by the daemon's snapshot route. */
 const snapshotByDoc = new Map<string, Uint8Array>()
 const snapshotHits: string[] = []
+/** Docs whose snapshot fetch answers 503 while listed — the outage case. */
+const failingSnapshots = new Set<string>()
+const updateWrites: { doc: string; body: Uint8Array }[] = []
 
 const server = setupServer(
   http.get(`${BASE}/api/sync/stream`, () => {
@@ -51,10 +54,17 @@ const server = setupServer(
     return HttpResponse.json({ ok: true })
   }),
   http.get(`${BASE}/api/canvas/:workspaceId/:slug/update`, () => HttpResponse.json({ ok: true })),
-  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, () => HttpResponse.json({ ok: true })),
+  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, async ({ request, params }) => {
+    updateWrites.push({
+      doc: `${String(params.workspaceId)}/${String(params.slug)}`,
+      body: new Uint8Array(await request.arrayBuffer()),
+    })
+    return HttpResponse.json({ ok: true })
+  }),
   http.get(`${BASE}/api/canvas/:workspaceId/:slug/snapshot`, ({ params }) => {
     const doc = `${String(params.workspaceId)}/${String(params.slug)}`
     snapshotHits.push(doc)
+    if (failingSnapshots.has(doc)) return HttpResponse.json({ title: 'boom' }, { status: 503 })
     const bytes = snapshotByDoc.get(doc)
     if (!bytes) return HttpResponse.json({ title: 'Canvas not found' }, { status: 404 })
     return new HttpResponse(bytes.slice().buffer as ArrayBuffer, {
@@ -123,5 +133,104 @@ describe('worker replica seeding', { timeout: 25_000 }, () => {
 
     await requestSnapshot(doc)
     expect(snapshotHits.filter((hit) => hit === doc).length).toBe(1)
+  })
+
+  it('re-seeds a document that was fully released, so a daemon-side change in the gap is not lost', async () => {
+    // While no tab holds a document the daemon deregisters its routing, so a
+    // write landing in that gap (an MCP tool, another device) never reaches
+    // this worker's stream. If the seed were remembered for the worker's
+    // LIFETIME, reopening the document would serve the pre-gap state forever
+    // — so a full release must also forget the seed, and the next subscriber
+    // pays one fresh snapshot fetch, exactly like a first open.
+    const doc = nextDoc()
+    const before = new LoroDoc()
+    before.getMap('m').set('phase', 'before-gap')
+    before.commit()
+    snapshotByDoc.set(doc, before.export({ mode: 'snapshot' }))
+
+    port.postMessage({ type: 'subscribe', doc })
+    const first = new LoroDoc()
+    first.import(await requestSnapshot(doc))
+    expect(first.getMap('m').get('phase')).toBe('before-gap')
+
+    port.postMessage({ type: 'unsubscribe', doc })
+    // The daemon-side write that happens while nobody is subscribed.
+    const after = before.fork()
+    after.getMap('m').set('written-in-gap', 'yes')
+    after.commit()
+    snapshotByDoc.set(doc, after.export({ mode: 'snapshot' }))
+
+    port.postMessage({ type: 'subscribe', doc })
+    const reopened = new LoroDoc()
+    reopened.import(await requestSnapshot(doc))
+    expect(reopened.getMap('m').get('written-in-gap')).toBe('yes')
+    expect(snapshotHits.filter((hit) => hit === doc).length).toBe(2)
+  })
+
+  it('acknowledges the seeded state, so the first push after a seed travels as a delta', async () => {
+    // The daemon HAS the seed by definition. If the seed did not advance the
+    // acknowledged baseline, the first tab push would re-send the entire
+    // seeded document — bandwidth Loro merges away, but paid on every open
+    // of every document, which is the cost the replica exists to remove.
+    const doc = nextDoc()
+    const seeded = new LoroDoc()
+    seeded.getMap('m').set('phase', 'seeded-history')
+    seeded.commit()
+    snapshotByDoc.set(doc, seeded.export({ mode: 'snapshot' }))
+
+    port.postMessage({ type: 'subscribe', doc })
+    await requestSnapshot(doc)
+
+    // An independent peer's edit: its ops carry no deps on the seed, so a
+    // clean delta imports readably into a fresh doc below — while a
+    // regressed baseline would drag the seeded ops along with it.
+    const tab = new LoroDoc()
+    tab.getMap('m').set('edit', 'after-seed')
+    tab.commit()
+    const b64 = (bytes: Uint8Array) => {
+      let out = ''
+      for (const byte of bytes) out += String.fromCharCode(byte)
+      return btoa(out)
+    }
+    port.postMessage({ type: 'push', doc, update: b64(tab.export({ mode: 'update' })) })
+
+    await new Promise<void>((resolve, reject) => {
+      const t = setInterval(() => {
+        if (updateWrites.some((w) => w.doc === doc)) {
+          clearInterval(t)
+          resolve()
+        }
+      }, 25)
+      setTimeout(() => reject(new Error('no daemon write')), 12_000)
+    })
+    const write = updateWrites.find((w) => w.doc === doc)
+    const delta = new LoroDoc()
+    delta.import(write?.body as Uint8Array)
+    expect(delta.getMap('m').get('edit')).toBe('after-seed')
+    expect(delta.getMap('m').get('phase')).toBeUndefined()
+  })
+
+  it('retries the seed after a transport failure instead of remembering it', async () => {
+    // A 404 is an answer; a 503 or a dropped connection is not. Remembering
+    // a failed fetch as "seeded" would hand every later tab an empty
+    // document that the daemon actually has content for. While the outage
+    // lasts the answer is empty (each request retries and fails again); the
+    // first request after recovery gets the real state.
+    const doc = nextDoc()
+    const content = new LoroDoc()
+    content.getMap('m').set('survives', 'the-outage')
+    content.commit()
+    snapshotByDoc.set(doc, content.export({ mode: 'snapshot' }))
+    failingSnapshots.add(doc)
+
+    port.postMessage({ type: 'subscribe', doc })
+    const during = new LoroDoc()
+    during.import(await requestSnapshot(doc))
+    expect(during.getMap('m').get('survives')).toBeUndefined()
+
+    failingSnapshots.delete(doc)
+    const after = new LoroDoc()
+    after.import(await requestSnapshot(doc))
+    expect(after.getMap('m').get('survives')).toBe('the-outage')
   })
 })

--- a/apps/web/src/lib/sse-shared-worker-seed.test.ts
+++ b/apps/web/src/lib/sse-shared-worker-seed.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The worker replica must know a document's PRE-EXISTING state, not only what
+ * arrived while the worker happened to be alive.
+ *
+ * The SSE stream carries incremental updates from subscription onward — the
+ * daemon's subscribe route registers routing and seeds nothing. A replica fed
+ * only by the stream therefore holds a document's history since the worker
+ * booted, and answers `snapshot-request` with a state that silently omits
+ * everything older. A tab forking from that answer starts from partial truth,
+ * which is worse than an error in exactly the way a wrong empty state is.
+ *
+ * Its own file because `@vitest/web-worker` runs every worker in the host
+ * realm and loro-crdt's WASM initialises once per realm: the file gets ONE
+ * replica-capable worker, shared across cases, separated by document key.
+ */
+import '@vitest/web-worker'
+import { LoroDoc } from 'loro-crdt'
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const BASE = 'http://127.0.0.1:3099'
+
+let streamSeq = 0
+const subscribeBodies: string[] = []
+const pushByStream = new Map<string, (frame: string) => void>()
+/** Pre-existing content per doc key, served by the daemon's snapshot route. */
+const snapshotByDoc = new Map<string, Uint8Array>()
+const snapshotHits: string[] = []
+
+const server = setupServer(
+  http.get(`${BASE}/api/sync/stream`, () => {
+    streamSeq += 1
+    const id = `seed-${streamSeq}`
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder()
+        controller.enqueue(
+          enc.encode(`event: ready\ndata: ${JSON.stringify({ streamId: id })}\n\n`),
+        )
+        pushByStream.set(id, (f) => controller.enqueue(enc.encode(f)))
+      },
+    })
+    return new HttpResponse(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    })
+  }),
+  http.post(`${BASE}/api/sync/subscribe`, async ({ request }) => {
+    subscribeBodies.push(await request.text())
+    return HttpResponse.json({ ok: true })
+  }),
+  http.get(`${BASE}/api/canvas/:workspaceId/:slug/update`, () => HttpResponse.json({ ok: true })),
+  http.post(`${BASE}/api/canvas/:workspaceId/:slug/update`, () => HttpResponse.json({ ok: true })),
+  http.get(`${BASE}/api/canvas/:workspaceId/:slug/snapshot`, ({ params }) => {
+    const doc = `${String(params.workspaceId)}/${String(params.slug)}`
+    snapshotHits.push(doc)
+    const bytes = snapshotByDoc.get(doc)
+    if (!bytes) return HttpResponse.json({ title: 'Canvas not found' }, { status: 404 })
+    return new HttpResponse(bytes.slice().buffer as ArrayBuffer, {
+      status: 200,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    })
+  }),
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+afterAll(() => server.close())
+
+const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+
+let docSeq = 0
+const nextDoc = () => `seed-ws/doc-${++docSeq}`
+
+let port: MessagePort
+beforeAll(() => {
+  const worker = new SharedWorker(new URL('./sse-shared-worker.ts', import.meta.url), {
+    type: 'module',
+  })
+  port = worker.port
+  port.start()
+  port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
+})
+
+function requestSnapshot(doc: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (e: MessageEvent) => {
+      const data = e.data as { type?: string; doc?: string; snapshot?: string }
+      if (data.type !== 'snapshot' || data.doc !== doc || data.snapshot === undefined) return
+      port.removeEventListener('message', onMessage)
+      resolve(decode(data.snapshot))
+    }
+    port.addEventListener('message', onMessage)
+    port.postMessage({ type: 'snapshot-request', doc })
+    setTimeout(() => reject(new Error(`no snapshot for ${doc}`)), 12_000)
+  })
+}
+
+describe('worker replica seeding', { timeout: 25_000 }, () => {
+  it('answers a snapshot-request with state that predates the worker', async () => {
+    const doc = nextDoc()
+    const existing = new LoroDoc()
+    existing.getMap('m').set('history', 'before-the-worker')
+    existing.commit()
+    snapshotByDoc.set(doc, existing.export({ mode: 'snapshot' }))
+
+    port.postMessage({ type: 'subscribe', doc })
+    const forked = new LoroDoc()
+    forked.import(await requestSnapshot(doc))
+    expect(forked.getMap('m').get('history')).toBe('before-the-worker')
+  })
+
+  it('answers empty for a document the daemon does not know, and only asks the daemon once', async () => {
+    // A 404 is an answer, not a failure: forking from empty is the same path
+    // a first-ever open takes. And it must be REMEMBERED — re-fetching the
+    // snapshot on every request would turn each open into the daemon round
+    // trip the replica exists to remove.
+    const doc = nextDoc()
+    port.postMessage({ type: 'subscribe', doc })
+    const first = new LoroDoc()
+    first.import(await requestSnapshot(doc))
+    expect(first.getMap('m').size).toBe(0)
+
+    await requestSnapshot(doc)
+    expect(snapshotHits.filter((hit) => hit === doc).length).toBe(1)
+  })
+})

--- a/apps/web/src/lib/sse-shared-worker.test.ts
+++ b/apps/web/src/lib/sse-shared-worker.test.ts
@@ -94,6 +94,12 @@ const server = setupServer(
     })
     return HttpResponse.json({ ok: true })
   }),
+  // The worker seeds every subscribed document's replica from this route.
+  // Answered (with "unknown") rather than left unhandled: `bypass` would let
+  // the request escape to whatever real daemon is listening on this port.
+  http.get(`${BASE}/api/canvas/:workspaceId/:slug/snapshot`, () =>
+    HttpResponse.json({ title: 'Canvas not found' }, { status: 404 }),
+  ),
 )
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
@@ -103,7 +109,9 @@ beforeEach(() => {
   subscribeAuth = []
   messageBodies = []
   updateWrites = []
-  pushByStream.clear()
+  // pushByStream is NOT cleared: the replica port's stream is opened once and
+  // spans tests, and its ids are unique for the file's lifetime, so clearing
+  // would orphan a live stream while colliding with nothing.
 })
 afterEach(() => server.resetHandlers())
 
@@ -113,6 +121,32 @@ afterEach(() => server.resetHandlers())
 let docSeq = 0
 const nextDoc = () => `w/doc-${++docSeq}`
 
+const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+const b64 = (bytes: Uint8Array) => {
+  let out = ''
+  for (const byte of bytes) out += String.fromCharCode(byte)
+  return btoa(out)
+}
+
+/** A one-key Loro update whose state a test can recognise on arrival. */
+const loroUpdate = (key: string, value: string): Uint8Array => {
+  const doc = new LoroDoc()
+  doc.getMap('m').set(key, value)
+  doc.commit()
+  return doc.export({ mode: 'update' })
+}
+
+/** The value of `m.<key>` after importing every collected authority frame. */
+const reconstruct = (frames: unknown[], key: string): unknown => {
+  const doc = new LoroDoc()
+  for (const frame of frames) {
+    const data = frame as { type?: string; update?: string }
+    if (data.type === 'authority-update' && data.update !== undefined)
+      doc.import(decode(data.update))
+  }
+  return doc.getMap('m').get(key)
+}
+
 function connect(): MessagePort {
   const worker = new SharedWorker(new URL('./sse-shared-worker.ts', import.meta.url), {
     type: 'module',
@@ -120,6 +154,43 @@ function connect(): MessagePort {
   worker.port.start()
   return worker.port
 }
+
+/**
+ * The ONE replica-capable worker in this file, created before every other.
+ *
+ * `@vitest/web-worker` evaluates each worker in the host realm and loro-crdt's
+ * WASM initialises once per realm: whichever worker's `import('loro-crdt')`
+ * settles first wins, and a worker that loses degrades exactly as designed —
+ * its replica work goes unanswered. Since the raw relay's retirement that
+ * degradation means the worker delivers NOTHING to its tabs, so which worker
+ * wins cannot be left to a race decided by module timing. It is pinned here:
+ * every case that asserts port-side delivery drives this port, and per-test
+ * workers serve only assertions that read the DAEMON side (subscribe bodies,
+ * control messages, headers), which a degraded worker still performs.
+ *
+ * Listeners on this shared port must scope to the doc keys their own test
+ * minted — another case's authority traffic is not a mis-forwarded frame.
+ */
+let replicaPort: MessagePort
+beforeAll(async () => {
+  replicaPort = connect()
+  replicaPort.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
+  // Awaited until the replica ANSWERS, not merely created: what poisons a
+  // worker's loro is another worker's loro-crdt evaluation racing this one's
+  // still-loading import. A snapshot reply proves the import settled while
+  // this worker was still the realm's only one.
+  const probe = nextDoc()
+  await new Promise<void>((resolve) => {
+    const onMessage = (e: MessageEvent) => {
+      const data = e.data as { type?: string; doc?: string }
+      if (data.type !== 'snapshot' || data.doc !== probe) return
+      replicaPort.removeEventListener('message', onMessage)
+      resolve()
+    }
+    replicaPort.addEventListener('message', onMessage)
+    replicaPort.postMessage({ type: 'snapshot-request', doc: probe })
+  })
+}, 20_000)
 
 // The worker's module load, its connect dispatch and its first fetch are all
 // async, and a fixed sleep long enough on an idle machine is not long enough
@@ -198,33 +269,45 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
   })
 
   it('forwards only the subscribed document, not every frame on the stream', async () => {
-    const port = connect()
+    const port = replicaPort
     // Status events are liveness, not document frames; this case is about
-    // which documents' frames are forwarded.
+    // which documents' frames are forwarded. Scoped to this test's own keys
+    // because the port is shared.
     const seen: unknown[] = []
-    port.onmessage = (e) => {
-      if ((e.data as { type?: string }).type !== 'status') seen.push(e.data)
-    }
     const doc = nextDoc()
-    port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
+    const listener = (e: MessageEvent) => {
+      const data = e.data as { type?: string; doc?: string }
+      if (data.type === 'status') return
+      if (data.doc !== doc && data.doc !== 'w/other') return
+      seen.push(e.data)
+    }
+    port.addEventListener('message', listener)
     port.postMessage({ type: 'subscribe', doc })
     await until(() => streamIdFor(doc) !== undefined)
 
     // The unsubscribed frame is pushed alone and given a real window to be
     // wrongly forwarded in. Sending both at once would prove nothing: they
     // would land in the same parser call, so the assertion would hold whether
-    // or not the addressing worked.
+    // or not the addressing worked. Real Loro bytes on both: the replica
+    // behind `authority-update` drops a frame it cannot merge, so garbage
+    // would make the negative half pass with the addressing broken.
     pushTo(
       doc,
-      `event: update\ndata: ${JSON.stringify({ doc: 'w/other', update: btoa('\x09') })}\n\n`,
+      `event: update\ndata: ${JSON.stringify({ doc: 'w/other', update: b64(loroUpdate('leak', 'wrong-doc')) })}\n\n`,
     )
     await settle()
     expect(seen).toEqual([])
 
-    pushTo(doc, `event: update\ndata: ${JSON.stringify({ doc, update: btoa('\x07') })}\n\n`)
+    pushTo(
+      doc,
+      `event: update\ndata: ${JSON.stringify({ doc, update: b64(loroUpdate('mine', 'delivered')) })}\n\n`,
+    )
     await until(() => seen.length >= 1)
 
-    expect(seen).toEqual([{ type: 'update', doc, update: btoa('\x07') }])
+    // State, not bytes: what travels is the replica's delta for this doc.
+    expect(reconstruct(seen, 'mine')).toBe('delivered')
+    expect(reconstruct(seen, 'leak')).toBeUndefined()
+    port.removeEventListener('message', listener)
   })
 
   it('sends a control message under the stream id the worker actually opened', async () => {
@@ -284,13 +367,6 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
 
   // The hazard every assertion in this file is written around, made explicit
   // and deterministic. A SharedWorker cannot be terminated, so a worker from an
-  // earlier test is still running and can open its stream at any moment —
-  // including between this test's own connect and its assertion. Standing one
-  // up on purpose is the only way to reproduce that ordering on demand;
-  // waiting for it to happen by luck under load is what made these tests flake
-  // in CI and pass in isolation.
-  // The hazard every assertion in this file is written around, made explicit
-  // and deterministic. A SharedWorker cannot be terminated, so a worker from an
   // earlier test is still running and can open a stream at any moment —
   // including AFTER this test has opened its own. Order matters: a leftover
   // worker opening first is harmless, because anything keyed on "the most
@@ -300,13 +376,14 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
   // CI. Standing the neighbour up on purpose is the only way to reproduce it
   // on demand.
   it('keeps routing to its own stream when another worker opens one later', async () => {
-    const port = connect()
+    const port = replicaPort
     const doc = nextDoc()
     const seen: unknown[] = []
-    port.onmessage = (e) => {
-      if ((e.data as { type?: string }).type !== 'status') seen.push(e.data)
+    const listener = (e: MessageEvent) => {
+      const data = e.data as { type?: string; doc?: string }
+      if (data.type !== 'status' && data.doc === doc) seen.push(e.data)
     }
-    port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
+    port.addEventListener('message', listener)
     port.postMessage({ type: 'subscribe', doc })
     await until(() => streamIdFor(doc) !== undefined)
 
@@ -318,9 +395,13 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
     await until(() => streamIdFor(neighbourDoc) !== undefined)
     expect(streamIdFor(doc)).not.toBe(streamIdFor(neighbourDoc))
 
-    pushTo(doc, `event: update\ndata: ${JSON.stringify({ doc, update: btoa('\x07') })}\n\n`)
+    pushTo(
+      doc,
+      `event: update\ndata: ${JSON.stringify({ doc, update: b64(loroUpdate('routed', 'to-own-stream')) })}\n\n`,
+    )
     await until(() => seen.length >= 1)
-    expect(seen).toEqual([{ type: 'update', doc, update: btoa('\x07') }])
+    expect(reconstruct(seen, 'routed')).toBe('to-own-stream')
+    port.removeEventListener('message', listener)
   })
 
   it('takes a document back off the stream once it is unsubscribed', async () => {
@@ -345,49 +426,29 @@ describe('sse-shared-worker', { timeout: WAIT_MS + 10_000 }, () => {
  */
 describe('authority replica', () => {
   /**
-   * EXACTLY ONE replica test can live in this file, and it has to be this one.
-   *
-   * `@vitest/web-worker` runs every worker in the host realm, and loro-crdt's
-   * WASM initialises once per realm: the FIRST worker to `import('loro-crdt')`
-   * gets the module, and in every worker after it the same import REJECTS with
-   * `TypeError: Cannot read properties of undefined (reading 'id')`. The
-   * worker degrades exactly as designed — the relay keeps running and replica
-   * messages go unanswered — so a second replica test does not fail loudly,
-   * it waits out its whole budget for a reply that was never coming.
-   *
-   * That makes "which replica test is first in the file" load-bearing, which
-   * is not a property to leave implicit. The slot goes to the daemon case
-   * because it is the ONLY one the browser file cannot host: a real browser
-   * runs loro in as many workers as you like, but there is no daemon there to
-   * feed a frame. Everything else about the replica — snapshots, cross-tab
-   * fan-out, a push a sibling receives — is in
+   * Every replica case in this file drives `replicaPort` — see its comment for
+   * why only that one worker can answer. This deep case keeps the slot it has
+   * always had because it is the ONLY one the browser file cannot host: a real
+   * browser runs loro in as many workers as you like, but there is no daemon
+   * there to feed a frame. Everything else about the replica — snapshots,
+   * cross-tab fan-out, a push a sibling receives — is in
    * `sse-shared-worker.browser.test.tsx`, where it belongs.
-   *
-   * If you add a second replica test here, it will hang, and the reason will
-   * not be your test.
    */
-  const decode = (encoded: string) => Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
-  const b64 = (bytes: Uint8Array) => {
-    let out = ''
-    for (const byte of bytes) out += String.fromCharCode(byte)
-    return btoa(out)
-  }
-
   it('relays a daemon frame onward as authority state, not only verbatim', async () => {
     // A tab that has forked from the replica reads `authority-update` and
     // nothing else. If the replica only ever spoke when a TAB pushed, that tab
     // would silently miss every change that did not originate in a sibling
     // tab — an MCP tool writing to the canvas, another device, a restore. The
     // channel has to carry the daemon too, or the fork model drops writes.
-    const port = connect()
+    const port = replicaPort
     const doc = nextDoc()
     const authority = new Promise<string>((resolve) => {
       port.addEventListener('message', (e: MessageEvent) => {
-        const data = e.data as { type?: string; update?: string }
-        if (data.type === 'authority-update' && data.update !== undefined) resolve(data.update)
+        const data = e.data as { type?: string; doc?: string; update?: string }
+        if (data.type === 'authority-update' && data.doc === doc && data.update !== undefined)
+          resolve(data.update)
       })
     })
-    port.postMessage({ type: 'init', baseUrl: BASE, token: 't' })
     port.postMessage({ type: 'subscribe', doc })
     await until(() => streamIdFor(doc) !== undefined)
 

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -212,6 +212,13 @@ function releaseReplicaFeed(baseUrl: string, doc: string): void {
   if (feed.ports > 0) return
   replicaFeeds.delete(key)
   feed.off()
+  // The seed is only current while the stream covers the document: releasing
+  // the last claim deregisters the daemon's routing, so anything written in
+  // the gap (an MCP tool, another device) never reaches this replica. The
+  // next subscriber must pay one fresh snapshot fetch — the same price as a
+  // first open — or it would be served the pre-gap state for the worker's
+  // whole lifetime.
+  seededDocs.delete(key)
 }
 
 interface PortState {

--- a/apps/web/src/lib/sse-shared-worker.ts
+++ b/apps/web/src/lib/sse-shared-worker.ts
@@ -128,6 +128,57 @@ function replicaFor(baseUrl: string, doc: string): InstanceType<LoroModule['Loro
  */
 const replicaFeeds = new Map<string, { off: () => void; ports: number }>()
 
+/**
+ * Whether the replica has been given the document's PRE-EXISTING state.
+ *
+ * The SSE stream carries only incremental updates from subscription onward —
+ * the daemon's subscribe route registers routing and seeds nothing — so a
+ * replica fed by the stream alone holds a document's history since this
+ * worker booted, and a snapshot answered from it silently omits everything
+ * older. The seed is one snapshot fetch per origin+document per worker
+ * lifetime, done HERE so no tab pays it on the main thread and every later
+ * tab is answered from memory.
+ *
+ * A daemon that answers 404 counts as seeded: empty IS that document's
+ * state, and re-asking on every request would reintroduce the round trip
+ * the replica exists to remove. A transport failure does NOT count, so the
+ * next request retries.
+ */
+const seededDocs = new Set<string>()
+
+function ensureSeeded(baseUrl: string, doc: string): void {
+  const key = replicaKey(baseUrl, doc)
+  if (seededDocs.has(key)) return
+  // Marked before the await and unmarked on failure, not the other way
+  // around: two callers racing this (a subscribe and a snapshot-request)
+  // must not start two fetches.
+  seededDocs.add(key)
+  queueReplicaWork(async () => {
+    try {
+      const bytes = await hubFor(baseUrl).snapshot(doc)
+      if (bytes === null || bytes.byteLength === 0) return
+      const replica = replicaFor(baseUrl, doc)
+      if (replica === undefined) return
+      // Straight into the replica, NOT through ingest(): the seed is state
+      // the daemon already holds, so it must never be written back
+      // (scheduleWrite) nor broadcast as an authority-update to ports that
+      // will fetch their own snapshot anyway. It also must not advance
+      // ackedVersions here — the acked baseline moves only on a successful
+      // write, and the seed is not a write.
+      const before = replica.version()
+      replica.import(bytes)
+      // The daemon HAS this state by definition, so acknowledge it: without
+      // this, the first tab push would re-send the entire seeded document.
+      const acked = ackedVersions.get(key)
+      if (acked !== undefined && acked.compare(before) === 0) {
+        ackedVersions.set(key, replica.version())
+      }
+    } catch {
+      seededDocs.delete(key)
+    }
+  })
+}
+
 function retainReplicaFeed(hub: SseStreamHub, baseUrl: string, doc: string): void {
   const key = replicaKey(baseUrl, doc)
   const existing = replicaFeeds.get(key)
@@ -135,6 +186,7 @@ function retainReplicaFeed(hub: SseStreamHub, baseUrl: string, doc: string): voi
     existing.ports += 1
     return
   }
+  ensureSeeded(baseUrl, doc)
   const off = hub.subscribe(doc, {
     // `null`: the daemon is the source, so nobody is excluded from the fan-out.
     onUpdate: (bytes) => ingest(baseUrl, doc, bytes, null),
@@ -347,10 +399,15 @@ function handle(port: MessagePort, raw: unknown): void {
   }
 
   if (msg.type === 'snapshot-request') {
+    // Seed first: a request can arrive before any subscribe (the backend
+    // snapshots, then subscribes), and the replica queue serialises the seed
+    // ahead of the answer below, so the reply carries the document's real
+    // pre-existing state rather than only what this worker has seen.
+    ensureSeeded(state.baseUrl, msg.doc)
     queueReplicaWork(() => {
-      // An empty snapshot for a document nobody has opened yet is the right
-      // answer, not an error: forking from empty and letting the daemon fill
-      // it in is the same path a first-ever open already takes.
+      // An empty snapshot for a document the daemon does not know is the
+      // right answer, not an error: forking from empty and letting updates
+      // fill it in is the same path a first-ever open already takes.
       const snapshot = replicaFor(state.baseUrl, msg.doc)?.export({ mode: 'snapshot' })
       if (snapshot === undefined) return
       port.postMessage({ type: 'snapshot', doc: msg.doc, snapshot: toBase64(snapshot) })
@@ -370,14 +427,13 @@ function handle(port: MessagePort, raw: unknown): void {
     if (state.subscriptions.has(msg.doc)) return
     retainReplicaFeed(hub, state.baseUrl, msg.doc)
     const off = hub.subscribe(msg.doc, {
-      onUpdate: (bytes) => {
-        // Relay only. The replica is fed by its own subscription above, once
-        // per document rather than once per tab watching it. Both paths carry
-        // the same frame for now: the raw one is what today's clients consume
-        // and the replica is what forks will, and one of the two goes away
-        // once every client has moved.
-        port.postMessage({ type: 'update', doc: msg.doc, update: toBase64(bytes) })
-      },
+      // No raw relay: a daemon frame reaches this port as an
+      // `authority-update`, after the replica has ordered and deduplicated it
+      // against everything else the worker knows. One inbound channel means
+      // every tab observes the SAME sequence — the raw per-port relay was the
+      // transition path while clients moved, and delivering both meant every
+      // daemon frame crossed each port twice.
+      onUpdate: () => {},
       onMessage: (text) => {
         port.postMessage({ type: 'message', doc: msg.doc, raw: text })
       },

--- a/packages/mcp-server/src/shared/sse-backend.ts
+++ b/packages/mcp-server/src/shared/sse-backend.ts
@@ -71,18 +71,18 @@ export class SseBackend implements CanvasBackend {
   private async run(handlers: CanvasBackendHandlers): Promise<void> {
     // Snapshot first: the stream carries only incremental updates, so a client
     // that started reading before seeding would apply deltas to an empty doc.
+    // Through the source, not a direct fetch, for the same reason push is:
+    // which authority answers is the implementations' difference. The hub
+    // asks the daemon (the same GET this method used to make itself); the
+    // worker-backed source asks the worker's replica, so a second tab opens
+    // without a daemon round trip and off this thread.
     try {
-      const res = await this.fetchFn(
-        this.url(
-          `/api/canvas/${encodeURIComponent(this.workspaceId)}/${encodeURIComponent(this.slug)}/snapshot`,
-        ),
-      )
+      const bytes = await this.resolveSource().snapshot(this.docKey)
       if (this.cancelled) return
-      if (res.ok) {
-        // Reading the body is a second await: re-check, or a disconnect landing
-        // in that window seeds a document the caller has already torn down.
-        const bytes = new Uint8Array(await res.arrayBuffer())
-        if (this.cancelled) return
+      // `null` is "the authority does not know this document" — the caller
+      // keeps its own state and the stream fills in from empty, the same
+      // path a first-ever open takes.
+      if (bytes !== null && bytes.byteLength > 0) {
         handlers.onSnapshot(bytes)
       }
     } catch {

--- a/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.contract.test.ts
@@ -20,6 +20,7 @@ function createHarness(): SseStreamSourceHarness {
   const subscribeBodies: { subscribe?: string[]; unsubscribe?: string[] }[] = []
   const controlMessages: { streamId: string; doc: string; message: unknown }[] = []
   const daemonWrites: { doc: string; body: Uint8Array }[] = []
+  const daemonState = new Map<string, Uint8Array>()
   let push: ((frame: string) => void) | null = null
   let endStream: (() => void) | null = null
 
@@ -45,6 +46,14 @@ function createHarness(): SseStreamSourceHarness {
     }
     // The canvas update route, which is where a push lands. Matched before the
     // JSON parse below: its body is raw update bytes, not JSON.
+    const canvasSnapshot = /\/api\/canvas\/([^/]+)\/([^/]+)\/snapshot$/.exec(url)
+    if (canvasSnapshot) {
+      const [, workspaceId, slug] = canvasSnapshot
+      const doc = `${decodeURIComponent(workspaceId as string)}/${decodeURIComponent(slug as string)}`
+      const bytes = daemonState.get(doc)
+      if (!bytes) return new Response('{"title":"Canvas not found"}', { status: 404 })
+      return new Response(bytes.slice().buffer as ArrayBuffer, { status: 200 })
+    }
     const canvasUpdate = /\/api\/canvas\/([^/]+)\/([^/]+)\/update$/.exec(url)
     if (canvasUpdate) {
       const [, workspaceId, slug] = canvasUpdate
@@ -78,6 +87,7 @@ function createHarness(): SseStreamSourceHarness {
     controlMessages: () => controlMessages,
     openedStreamIds: () => openedStreamIds,
     daemonWrites: () => daemonWrites,
+    seedDaemonState: (doc, bytes) => daemonState.set(doc, bytes),
     ready: async () => {
       await vi.waitFor(() => {
         if (push === null) throw new Error('stream not open')

--- a/packages/mcp-server/src/shared/sse-stream-hub.ts
+++ b/packages/mcp-server/src/shared/sse-stream-hub.ts
@@ -82,6 +82,17 @@ export interface SseStreamSource {
    * the daemon would be waiting on the wrong thing.
    */
   push(doc: string, update: Uint8Array): void | Promise<void>
+  /**
+   * The document's current state, for a caller about to reconstruct it.
+   *
+   * On the source rather than the caller for the same reason `push` is:
+   * which authority answers is what the implementations disagree about. The
+   * hub asks the daemon; the worker-backed source asks the worker's replica,
+   * which is what lets a second tab open a document without any daemon round
+   * trip. `null` means the authority does not know the document — fork from
+   * empty, the same path a first-ever open takes.
+   */
+  snapshot(doc: string): Promise<Uint8Array | null>
 }
 
 export interface SseStreamHubOptions {
@@ -165,11 +176,20 @@ export function toBase64(bytes: Uint8Array): string {
  * slug may contain more, a workspace id never does.
  */
 export function canvasUpdateUrl(baseUrl: string, doc: string): string | null {
+  return canvasDocUrl(baseUrl, doc, 'update')
+}
+
+/** The snapshot twin of `canvasUpdateUrl`, splitting on the same first slash. */
+export function canvasSnapshotUrl(baseUrl: string, doc: string): string | null {
+  return canvasDocUrl(baseUrl, doc, 'snapshot')
+}
+
+function canvasDocUrl(baseUrl: string, doc: string, tail: string): string | null {
   const slash = doc.indexOf('/')
   if (slash <= 0 || slash === doc.length - 1) return null
   const workspaceId = encodeURIComponent(doc.slice(0, slash))
   const slug = encodeURIComponent(doc.slice(slash + 1))
-  return `${baseUrl.replace(/\/$/, '')}/api/canvas/${workspaceId}/${slug}/update`
+  return `${baseUrl.replace(/\/$/, '')}/api/canvas/${workspaceId}/${slug}/${tail}`
 }
 
 export class SseStreamHub implements SseStreamSource {
@@ -260,6 +280,26 @@ export class SseStreamHub implements SseStreamSource {
     // moves its acknowledged version forward over an edit the daemon never
     // took. Failing loudly here is what lets a caller keep the bytes.
     if (!res.ok) throw new Error(`update refused: ${res.status}`)
+  }
+
+  /**
+   * The document's current state, from the daemon. The SSE stream carries
+   * only INCREMENTAL updates from subscription onward — the subscribe route
+   * registers routing and seeds nothing — so anything reconstructing a
+   * document needs this once before the stream's deltas mean anything.
+   *
+   * `null` for a document the daemon does not know: forking from empty is
+   * the same path a first-ever open takes, and conflating that answer with a
+   * transport failure is how a reachable daemon gets treated as an absent
+   * one. Everything else non-ok throws, same reasoning as `push`.
+   */
+  async snapshot(doc: string): Promise<Uint8Array | null> {
+    const url = canvasSnapshotUrl(this.options.baseUrl, doc)
+    if (url === null) throw new Error(`not a document key: ${doc}`)
+    const res = await this.options.fetch(url)
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`snapshot refused: ${res.status}`)
+    return new Uint8Array(await res.arrayBuffer())
   }
 
   private async post(path: string, body: unknown): Promise<void> {

--- a/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
+++ b/packages/mcp-server/src/shared/test-utils/sse-stream-source-contract.ts
@@ -57,6 +57,12 @@ export interface SseStreamSourceHarness {
    * addressing is half of what the push contract asserts.
    */
   daemonWrites(): { doc: string; body: Uint8Array }[]
+  /**
+   * Install pre-existing content for `doc` on the fake daemon's snapshot
+   * route, as Loro update/snapshot bytes. "Pre-existing" is the point: the
+   * snapshot contract is about state the source never saw arrive.
+   */
+  seedDaemonState(doc: string, bytes: Uint8Array): void
   /** Wait until the daemon has an open stream ready to receive frames. */
   ready(): Promise<void>
   /** End the current stream the way a dropped connection does. */
@@ -119,15 +125,22 @@ export function sseStreamSourceContract(
     h.cleanup()
   })
 
-  it('delivers an update for a subscribed document', async () => {
+  it('delivers a daemon change to a subscribed listener', async () => {
+    // Asserted by STATE, not by byte identity: the hub relays the daemon's
+    // frame verbatim, while the worker-backed source delivers its replica's
+    // delta — same state, not the same bytes. Valid Loro bytes on purpose:
+    // the replica drops a frame it cannot merge, so garbage bytes would make
+    // this case pass or fail on frame policy rather than on delivery.
     const h = await create()
     const doc = nextDoc()
     const { updates } = await subscribed(h, doc)
 
-    h.pushUpdate(doc, new Uint8Array([1, 2, 255]))
+    h.pushUpdate(doc, LORO_UPDATE)
 
-    await until(() => updates.length === 1)
-    expect(updates[0]).toEqual(new Uint8Array([1, 2, 255]))
+    await until(() => updates.length >= 1)
+    const reconstructed = new LoroDoc()
+    for (const bytes of updates) reconstructed.import(bytes)
+    expect(reconstructed.getMap('contract').get('pushed')).toBe('through')
     h.cleanup()
   })
 
@@ -139,7 +152,9 @@ export function sseStreamSourceContract(
     const other = nextDoc()
     const { updates } = await subscribed(h, doc)
 
-    h.pushUpdate(other, new Uint8Array([9]))
+    // Valid Loro bytes: a replica-backed source drops garbage regardless of
+    // routing, which would let a broken router pass this case vacuously.
+    h.pushUpdate(other, LORO_UPDATE)
     await settle()
 
     expect(updates).toEqual([])
@@ -204,6 +219,29 @@ export function sseStreamSourceContract(
     h.cleanup()
   })
 
+  it('answers a snapshot with state the source did not witness arrive', async () => {
+    // The stream carries only incremental updates from subscription onward,
+    // so "the document's current state" is a question the stream cannot
+    // answer. The hub asks the daemon; the worker-backed source seeds its
+    // replica once and answers from memory. Either way, a document with
+    // PRE-EXISTING content must come back whole — an implementation that
+    // reconstructs from stream traffic alone passes every other case in this
+    // file and still hands a forking tab partial truth.
+    const h = await create()
+    const doc = nextDoc()
+    h.seedDaemonState(doc, LORO_UPDATE)
+    // BEFORE any subscription, because that is the order the backend uses: it
+    // seeds from the snapshot first so the stream's deltas have something to
+    // land on. An implementation that only answers documents it already has
+    // listeners for deadlocks that first open.
+    const bytes = await h.source.snapshot(doc)
+    expect(bytes).not.toBeNull()
+    const reconstructed = new LoroDoc()
+    reconstructed.import(bytes as Uint8Array)
+    expect(reconstructed.getMap('contract').get('pushed')).toBe('through')
+    h.cleanup()
+  })
+
   it('tells its subscribers when the stream drops', async () => {
     // A subscriber told only about frames cannot tell "nothing has changed"
     // from "nothing is arriving", so a dropped stream looks exactly like a
@@ -235,7 +273,9 @@ export function sseStreamSourceContract(
 
     off()
     await until(() => h.unsubscribedDocs().includes(doc))
-    h.pushUpdate(doc, new Uint8Array([7]))
+    // Valid Loro bytes for the same reason as the other-document case: a
+    // replica would drop garbage even with the unsubscribe broken.
+    h.pushUpdate(doc, LORO_UPDATE)
     await settle()
 
     expect(updates).toEqual([])
@@ -251,9 +291,9 @@ export function sseStreamSourceContract(
     const second = collect(h.source, doc)
 
     first.off()
-    h.pushUpdate(doc, new Uint8Array([3]))
+    h.pushUpdate(doc, LORO_UPDATE)
 
-    await until(() => second.updates.length === 1)
+    await until(() => second.updates.length >= 1)
     expect(first.updates).toEqual([])
     h.cleanup()
   })


### PR DESCRIPTION
## What

Task #40 of the worker-first architecture direction: the data pipeline between daemon, SharedWorker and tabs becomes unidirectional, and the remaining tab-side daemon round trip moves off the main thread into the worker.

- **Retire the raw per-port `update` relay.** A daemon frame now reaches a tab only as an `authority-update`, after the worker's replica has ordered and deduplicated it against every sibling tab's pushes — one inbound channel, every tab observes the same sequence. The protocol's `update` event is deleted. (The relay was the documented transition path while clients moved; delivering both meant every daemon frame crossed each port twice.)
- **Seed the worker replica with pre-existing state.** The SSE subscribe route registers routing and seeds nothing, so a replica fed by the stream alone held only history since the worker booted — and answered `snapshot-request` with silently partial truth. The worker now fetches the daemon snapshot once per origin+document (off the main thread), remembers a 404 as "empty IS the state", and retries only transport failures.
- **`snapshot(doc)` joins the `SseStreamSource` contract**, run against both implementations. The hub asks the daemon; the worker-backed source asks the replica — a second tab opens a document with no daemon round trip. `SseBackend` seeds through the source instead of its own inline fetch.
- **Fix a first-open deadlock the contract caught:** the tab source resolved snapshot replies only for documents that already had listeners, but the backend snapshots *before* subscribing. The contract case now requests the snapshot pre-subscription (the backend's real order) and went red against the bug before the fix.

## Test evidence

All layers green on the final code:

| suite | result |
|---|---|
| `pnpm --filter @kamiazya/whiteboard-web test` | 2146 + 75 passed |
| `pnpm test --project mcp-node` | 3360 passed |
| `pnpm run test:browser` | 555 passed |
| `pnpm -r typecheck` / `pnpm knip` | clean |

Mutation checks on the seed: no-op `ensureSeeded` → both seed tests red; drop the seeded-memoization → exactly the 404-once test red.

Test-infra note: `@vitest/web-worker` runs workers in the host realm and loro's WASM tolerates exactly one cleanly-initialised worker per realm, with the winner decided by import timing. With the relay gone, a degraded worker delivers *nothing*, so `sse-shared-worker.test.ts` now pins one module-scope replica worker whose loro import is awaited before any other worker exists; delivery assertions all drive that port, scoped to test-minted doc keys. Contract negative cases push real Loro bytes so a replica-backed source can't pass them vacuously (a replica drops garbage regardless of routing).

Real-browser verification is pending (no reachable browser from this machine right now) and will be done before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ