### PR TITLE
perf(web): parse markdown inside the layout worker, not on the main thread

### DIFF
--- a/apps/web/mcp-source-alias-coverage.test.ts
+++ b/apps/web/mcp-source-alias-coverage.test.ts
@@ -4,6 +4,7 @@ import viteConfig from './vite.config.js'
 import vitestBrowserConfig from './vitest.browser.config.js'
 import vitestConfig from './vitest.config.js'
 import vitestDocsSnapshotsConfig from './vitest.docs-snapshots.config.js'
+import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 
 // Each config below independently resolves `@kamiazya/whiteboard-mcp/*`
 // subpaths to source (see mcp-source-alias.ts). A subpath added to
@@ -22,6 +23,20 @@ describe('mcpSourceAlias coverage across apps/web configs', () => {
     // factory/promise form leaves `alias` empty here, which fails red.
     const alias = (config.resolve?.alias ?? {}) as Record<string, unknown>
     for (const [key, value] of Object.entries(mcpSourceAlias)) {
+      expect(alias[key]).toBe(value)
+    }
+  })
+
+  // Same drift class, worse failure mode: the browser config's copy is the one
+  // every test exercises, so a vite.config.ts that lost the pin would ship a
+  // production worker chunk that throws `document is not defined` at
+  // evaluation while the whole suite stays green.
+  it.each([
+    ['vite.config.ts', viteConfig],
+    ['vitest.browser.config.ts', vitestBrowserConfig],
+  ] as const)('%s aliases every workerSafeDepsAlias key', (_name, config) => {
+    const alias = (config.resolve?.alias ?? {}) as Record<string, unknown>
+    for (const [key, value] of Object.entries(workerSafeDepsAlias)) {
       expect(alias[key]).toBe(value)
     }
   })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -68,6 +68,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/browser-playwright": "catalog:",
     "@vitest/web-worker": "^4.1.10",
+    "decode-named-character-reference": "^1.3.0",
     "fake-indexeddb": "^6.2.5",
     "fast-check": "^4.7.0",
     "msw": "^2.15.0",

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -103,6 +103,9 @@ export function useWorkerScene(
   const workerRef = useRef<Worker | null>(null)
   /** Latched: a realm that cannot load the face never will within a session. */
   const fontDegraded = useRef(false)
+  /** Latched on a worker `error` event: module evaluation that failed once
+   * fails identically on every reconstruction, so the session stays sync. */
+  const workerDead = useRef(false)
   const requestRef = useRef(0)
   const [rendered, setRendered] = useState<RenderedCanvas>(renderNow)
   // The inputs the currently-displayed scene was built from, so a scene that
@@ -121,7 +124,7 @@ export function useWorkerScene(
       shownFor.current = inputs
       return
     }
-    if (fontDegraded.current) {
+    if (fontDegraded.current || workerDead.current) {
       shownFor.current = inputs
       setRendered(renderNow())
       return
@@ -152,6 +155,23 @@ export function useWorkerScene(
       setRendered(response.type === 'laid-out' ? response : renderNow())
     }
     worker.addEventListener('message', onMessage)
+    // A worker whose MODULE fails to evaluate never throws at construction —
+    // it fires this event instead, and no `message` will ever come. Without a
+    // listener the request would hang and the previous scene would stay on
+    // screen for every later edit, which breaks this file's own "a degraded
+    // worker costs responsiveness, never content" invariant. Eval failure is
+    // as permanent as a missing font face, so the worker is retired the same
+    // way and the session stays synchronous.
+    const onError = () => {
+      worker.removeEventListener('message', onMessage)
+      worker.removeEventListener('error', onError)
+      worker.terminate()
+      workerRef.current = null
+      workerDead.current = true
+      shownFor.current = inputs
+      setRendered(renderNow())
+    }
+    worker.addEventListener('error', onError)
     const request: LayoutRequest = {
       type: 'layout',
       id,
@@ -161,7 +181,10 @@ export function useWorkerScene(
       missingFileRefs: inputs.missingFileRefs,
     }
     worker.postMessage(request)
-    return () => worker.removeEventListener('message', onMessage)
+    return () => {
+      worker.removeEventListener('message', onMessage)
+      worker.removeEventListener('error', onError)
+    }
     // `renderNow` closes over the current inputs by design: a fallback must
     // lay out what was asked for, not what the effect last saw.
     // biome-ignore lint/correctness/useExhaustiveDependencies: see above.
@@ -173,7 +196,7 @@ export function useWorkerScene(
   // moment, since it is also a user's first impression of the canvas. Warming
   // it while they are still reading brings that edit back to the steady state.
   useEffect(() => {
-    if (!offloadable || fontDegraded.current) return
+    if (!offloadable || fontDegraded.current || workerDead.current) return
     workerRef.current ??= createLayoutWorker()
   }, [offloadable])
 

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -19,10 +19,9 @@
  *   back to laying the same canvas out synchronously. A degraded worker costs
  *   responsiveness, never content.
  *
- * Markdown is parsed HERE rather than in the worker (see the protocol's note):
- * that is the 15-19ms this cannot remove, against the 81-339ms it can.
+ * Markdown is parsed in the WORKER along with layout (see the protocol's
+ * note), so an offloaded commit costs this thread nothing but the postMessage.
  */
-import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -33,7 +32,6 @@ import {
   FONT_DEGRADED,
   type LayoutRequest,
   type LayoutResponse,
-  type ParsedBody,
 } from '../../lib/layout-worker-protocol.js'
 import { type RenderCanvasOptions, renderCanvasToSvg } from './scene-render.js'
 import type { RenderedCanvas } from './scene-render-core.js'
@@ -56,18 +54,6 @@ const OFFLOAD_MIN_ELEMENTS = 12
 
 function worthOffloading(canvas: SpatialCanvas): boolean {
   return canvas.nodes.length + canvas.edges.length >= OFFLOAD_MIN_ELEMENTS
-}
-
-/** Every body the worker could be asked for, parsed on this thread. */
-function parseBodies(canvas: SpatialCanvas): ParsedBody[] {
-  const seen = new Set<string>()
-  const bodies: ParsedBody[] = []
-  for (const node of canvas.nodes) {
-    if (node.type !== 'text' || seen.has(node.text)) continue
-    seen.add(node.text)
-    bodies.push({ text: node.text, mdast: parseMarkdownBody(node.text) })
-  }
-  return bodies
 }
 
 function createLayoutWorker(): Worker | null {
@@ -173,7 +159,6 @@ export function useWorkerScene(
       theme: inputs.theme,
       fileRefLabels: inputs.fileRefLabels,
       missingFileRefs: inputs.missingFileRefs,
-      bodies: parseBodies(inputs.canvas),
     }
     worker.postMessage(request)
     return () => worker.removeEventListener('message', onMessage)

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -86,7 +86,7 @@ export function useWorkerScene(
     () => ({ ...base, ...fileSeamOptions }),
     [base.measure, base.theme, fileSeamOptions],
   )
-  const offloadable = canLayoutInWorker(fileSeamOptions) && worthOffloading(canvas)
+  const offloadable = canLayoutInWorker(fileSeamOptions, canvas) && worthOffloading(canvas)
   // Synchronous layout of the CURRENT inputs, computed only when it is needed:
   // the first render, and any render the worker cannot serve.
   const renderNow = () => renderCanvasToSvg(canvas, options)

--- a/apps/web/src/components/spatial-editor/use-worker-scene.worker-error.test.tsx
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.worker-error.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * A worker whose MODULE fails to evaluate does not throw at construction —
+ * it fires an async `error` event. Nothing about the request path may hang on
+ * that: the file's own invariant is "a degraded worker costs responsiveness,
+ * never content", and a pending request that never resolves leaves the
+ * PREVIOUS scene on screen for every later edit.
+ *
+ * This is jsdom on purpose: the failure under test is the event wiring, not
+ * browser layout, and a stub Worker is the only way to fire the event
+ * deterministically. The real-eval-failure case (the
+ * decode-named-character-reference alias) is covered by the parity browser
+ * test; this covers what the EDITOR does if that class of failure ever ships.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { useWorkerScene } from './use-worker-scene.js'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const fakeMeasure = () => ({ advanceWidth: 30, ascent: 10, descent: 2, lineGap: 0 })
+
+/** Past the offload threshold, no function seams — the worker path engages. */
+const canvasWith = (marker: string): SpatialCanvas => ({
+  nodes: Array.from({ length: 13 }, (_, i) => ({
+    id: `n${i}`,
+    type: 'text' as const,
+    x: i * 220,
+    y: 0,
+    width: 200,
+    height: 100,
+    text: i === 0 ? marker : `node ${i}`,
+  })),
+  edges: [],
+})
+
+class FakeWorker {
+  static instances: FakeWorker[] = []
+  private listeners = new Map<string, Set<(e: unknown) => void>>()
+  constructor() {
+    FakeWorker.instances.push(this)
+  }
+  addEventListener(type: string, fn: (e: unknown) => void) {
+    let set = this.listeners.get(type)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(type, set)
+    }
+    set.add(fn)
+  }
+  removeEventListener(type: string, fn: (e: unknown) => void) {
+    this.listeners.get(type)?.delete(fn)
+  }
+  postMessage() {}
+  terminate() {}
+  fire(type: string, event: unknown) {
+    for (const fn of this.listeners.get(type) ?? []) fn(event)
+  }
+}
+
+it('falls back to a synchronous layout when the worker module fails to evaluate', async () => {
+  vi.stubGlobal('Worker', FakeWorker)
+  const base = { measure: fakeMeasure, theme: 'light' as const }
+  const seams = {}
+  const { result, rerender } = renderHook(
+    ({ canvas }: { canvas: SpatialCanvas }) => useWorkerScene(canvas, base, seams, undefined),
+    { initialProps: { canvas: canvasWith('first-scene') } },
+  )
+  expect(result.current.svg).toContain('first-scene')
+
+  // The edit whose layout the (dead) worker is asked for.
+  await act(async () => {
+    rerender({ canvas: canvasWith('second-scene') })
+  })
+  const worker = FakeWorker.instances.at(-1)
+  expect(worker, 'the request should have engaged the worker path').toBeDefined()
+
+  // Module evaluation failing is an async `error` event, never a throw.
+  await act(async () => {
+    worker?.fire('error', new Event('error'))
+  })
+
+  expect(result.current.svg).toContain('second-scene')
+})

--- a/apps/web/src/lib/layout-worker-parity.browser.test.tsx
+++ b/apps/web/src/lib/layout-worker-parity.browser.test.tsx
@@ -12,7 +12,6 @@
  * canvas-viewer's font.ts already documents having shipped once.
  */
 
-import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import {
   createBrowserMeasureText,
@@ -21,12 +20,6 @@ import {
 import { expect, it } from 'vitest'
 import { renderCanvasToSvg } from '../components/spatial-editor/scene-render.js'
 import type { LayoutRequest, LayoutResponse } from './layout-worker-protocol.js'
-
-/** Every body the worker will be asked for, parsed the way the editor will. */
-const bodiesOf = (c: SpatialCanvas) =>
-  c.nodes
-    .filter((n): n is Extract<typeof n, { type: 'text' }> => n.type === 'text')
-    .map((n) => ({ text: n.text, mdast: parseMarkdownBody(n.text) }))
 
 // Text that wraps, punctuation that kerns, and a mix of scripts: measurement
 // differences show up in wrapped-line counts, not in a single short word.
@@ -97,7 +90,6 @@ it('the worker scene is deeply equal to the main-thread scene', async () => {
     id: 1,
     canvas,
     theme: 'light',
-    bodies: bodiesOf(canvas),
   })
 
   expect(fromWorker.type).toBe('laid-out')
@@ -126,10 +118,45 @@ it('carries the file-label seam across the wire', async () => {
     canvas: withFile,
     theme: 'light',
     fileRefLabels: labels,
-    bodies: bodiesOf(withFile),
   })
   expect(fromWorker.type).toBe('laid-out')
   if (fromWorker.type !== 'laid-out') return
   expect(fromWorker.svg).toContain('Readable name')
+  expect(fromWorker.svg).toBe(onMain.svg)
+}, 60_000)
+
+it('parses markdown itself — no pre-parsed bodies cross the wire', async () => {
+  // The named character reference is the load-bearing detail: decoding it
+  // walks decode-named-character-reference, whose `browser` entry touches
+  // `document` at module top level and killed any worker importing remark
+  // until the vite alias pinned the worker-safe entry. A worker that cannot
+  // parse — or cannot even evaluate its chunk — fails this case loudly.
+  expect(await ensureViewerFontLoaded()).toBe('loaded')
+  const withMarkdown: SpatialCanvas = {
+    nodes: [
+      {
+        id: 'm',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 240,
+        height: 140,
+        text: '# Ampersands &amp; entities\n\nSome *emphasis* to lay out.',
+      },
+    ],
+    edges: [],
+  } as SpatialCanvas
+  const onMain = renderCanvasToSvg(withMarkdown, {
+    measure: createBrowserMeasureText(),
+    theme: 'light',
+  })
+  const fromWorker = await layoutInWorker({
+    type: 'layout',
+    id: 3,
+    canvas: withMarkdown,
+    theme: 'light',
+  })
+  expect(fromWorker.type).toBe('laid-out')
+  if (fromWorker.type !== 'laid-out') return
   expect(fromWorker.svg).toBe(onMain.svg)
 }, 60_000)

--- a/apps/web/src/lib/layout-worker-protocol.test.ts
+++ b/apps/web/src/lib/layout-worker-protocol.test.ts
@@ -1,0 +1,42 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { describe, expect, it } from 'vitest'
+import { canLayoutInWorker } from './layout-worker-protocol.js'
+
+const textOnly: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'hi' }],
+  edges: [],
+}
+const withFile: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'hi' },
+    { id: 'f', type: 'file', x: 200, y: 0, width: 100, height: 60, file: 'doc-1' },
+  ],
+  edges: [],
+}
+const seams = {
+  resolveFileCanvas: () => undefined,
+  expandFileNode: () => false,
+  resolveFileImage: () => undefined,
+  resolveFileFacets: () => undefined,
+}
+
+describe('canLayoutInWorker', () => {
+  it('offloads a canvas with no file nodes even when the host supplies file seams', () => {
+    // The real pages ALWAYS supply the seams (useCanvasFileSeams returns them
+    // unconditionally), so a presence check disables the worker for every
+    // production canvas — including the plain text-and-edges ones the seams
+    // can never influence. Every seam is keyed on a file reference; a canvas
+    // without a file node cannot call one.
+    expect(canLayoutInWorker(seams, textOnly)).toBe(true)
+  })
+
+  it('stays synchronous when a file node could actually call a seam', () => {
+    // A function cannot cross a postMessage, so a canvas whose layout depends
+    // on one must fall back rather than silently render without it.
+    expect(canLayoutInWorker(seams, withFile)).toBe(false)
+  })
+
+  it('offloads a canvas with file nodes when no seam is supplied', () => {
+    expect(canLayoutInWorker({}, withFile)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -79,12 +79,24 @@ export const FONT_DEGRADED = 'font-degraded'
  * silent content regression — worse than the jank this worker exists to
  * remove.
  */
-export function canLayoutInWorker(options: {
-  readonly resolveFileCanvas?: unknown
-  readonly expandFileNode?: unknown
-  readonly resolveFileImage?: unknown
-  readonly resolveFileFacets?: unknown
-}): boolean {
+export function canLayoutInWorker(
+  options: {
+    readonly resolveFileCanvas?: unknown
+    readonly expandFileNode?: unknown
+    readonly resolveFileImage?: unknown
+    readonly resolveFileFacets?: unknown
+  },
+  canvas: SpatialCanvas,
+): boolean {
+  // The seams only disqualify a canvas that could actually CALL one: every
+  // seam here is keyed on a file reference, so a canvas without a file node
+  // lays out identically with or without them. This is judged per canvas
+  // rather than per host because the real pages supply the seams
+  // UNCONDITIONALLY (useCanvasFileSeams returns them whether or not any file
+  // node exists) — a presence check reads as "this host has file support"
+  // and silently turns the worker off for every production canvas.
+  const hasFileNode = canvas.nodes.some((node) => node.type === 'file')
+  if (!hasFileNode) return true
   return (
     options.resolveFileCanvas === undefined &&
     options.expandFileNode === undefined &&

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -9,12 +9,11 @@
  * a canvas that needs any of the other four falls back to main-thread layout
  * rather than silently rendering without them (see `canLayoutInWorker`).
  *
- * Markdown is parsed on the MAIN thread and the mdast travels here as plain
- * data, rather than the worker importing canvas-codec. Two reasons, one
- * measured and one structural: parsing is 15-19ms of an 81-339ms layout (4-19%),
- * so leaving it behind still removes the overwhelming majority of the block;
- * and it keeps remark/unified out of the worker chunk entirely, which also
- * sidesteps their refusal to evaluate in a module worker under the dev server.
+ * Markdown text crosses as part of the canvas and the WORKER parses it, so
+ * parse and layout leave the main thread together. The old blocker was never
+ * remark itself: decode-named-character-reference's `browser` entry touches
+ * `document` at module top level, and vite.config.ts now pins the DOM-free
+ * build (see workerSafeEntityDecoder there).
  *
  * Transport is plain postMessage, i.e. structuredClone. That was measured
  * rather than assumed: 0.90ms to clone the scene of a 60-node/200-edge canvas
@@ -25,15 +24,11 @@
  */
 
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import type { BoundingBox, Scene } from '@kamiazya/whiteboard-canvas-render'
 import type { ResolvedTheme } from '../hooks/useThemeMode.js'
 
 /** Opaque file reference -> readable label, the plain-data form of the seam. */
 export type FileRefLabel = { readonly file: string; readonly label: string }
-
-/** A node body already turned into mdast on the main thread. */
-export type ParsedBody = { readonly text: string; readonly mdast: MdastRoot }
 
 export type LayoutRequest = {
   readonly type: 'layout'
@@ -46,7 +41,6 @@ export type LayoutRequest = {
    * resolveFileMissing seam, precomputed against THIS canvas's file nodes
    * (a function cannot cross the wire; a small ref list can). */
   readonly missingFileRefs?: readonly string[]
-  readonly bodies: readonly ParsedBody[]
 }
 
 export type LayoutResponse =

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -7,11 +7,11 @@
  * committed change (add a node, drop a drag, edit text). Moving it here does
  * not make it faster; it stops it freezing the UI.
  *
- * Markdown arrives already parsed (see the protocol's note): this module
- * never imports canvas-codec, so remark and unified stay out of the worker
- * chunk. A body nobody pre-parsed is answered with `failed` rather than an
- * empty paragraph — a slower frame is recoverable, a silently different scene
- * is not.
+ * Markdown is parsed HERE, with the same `parseMarkdownBody` the main thread
+ * uses, so the whole per-commit block — parse plus layout — leaves the main
+ * thread. This is only possible because vite.config.ts pins
+ * decode-named-character-reference to its DOM-free entry; without the alias
+ * this chunk throws `document is not defined` before handling a message.
  *
  * The one thing that would make this WRONG is a scene that differs from what
  * the main thread would have produced. Text measurement is where that would
@@ -26,6 +26,7 @@
 // `CanvasViewer` and `mountCanvasViewer`, whose module graphs touch
 // `document` on evaluation, and a worker has none — importing it throws
 // `document is not defined` before a single message is handled.
+import { parseMarkdownBody } from '@kamiazya/whiteboard-canvas-codec'
 import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer/measure-text'
 import { renderCanvasToSvgWith } from '../components/spatial-editor/scene-render-core.js'
@@ -56,31 +57,13 @@ self.onmessage = async (event: MessageEvent<LayoutRequest>) => {
     }
     const labels = new Map((request.fileRefLabels ?? []).map((o) => [o.file, o.label]))
     const missingRefs = new Set(request.missingFileRefs ?? [])
-    const bodies = new Map(request.bodies.map((b) => [b.text, b.mdast]))
-    let missing: string | undefined
     const { svg, bounds, scene } = renderCanvasToSvgWith(request.canvas, {
       measure,
       theme: request.theme,
       resolveFileLabel: labels.size === 0 ? undefined : (file) => labels.get(file),
       resolveFileMissing: missingRefs.size === 0 ? undefined : (file) => missingRefs.has(file),
-      parseBody: (text: string) => {
-        const parsed = bodies.get(text)
-        if (parsed === undefined) {
-          missing ??= text
-          return { type: 'root', children: [] }
-        }
-        return parsed
-      },
+      parseBody: parseMarkdownBody,
     })
-    if (missing !== undefined) {
-      const response: LayoutResponse = {
-        type: 'failed',
-        id: request.id,
-        reason: `no pre-parsed body for ${JSON.stringify(missing.slice(0, 40))}`,
-      }
-      self.postMessage(response)
-      return
-    }
     const response: LayoutResponse = { type: 'laid-out', id: request.id, svg, bounds, scene }
     self.postMessage(response)
   } catch (error) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
@@ -12,22 +11,9 @@ import { mcpSourceAlias } from './mcp-source-alias.js'
 import { cloudflareDevHeadersPlugin } from './vite-dev-headers.js'
 import { stripWasmSourceMapPlugin } from './vite-plugin-strip-wasm-sourcemap.js'
 import { pwaOptions } from './vite-pwa-options.js'
+import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-
-/**
- * decode-named-character-reference (micromark's entity decoder, deep in the
- * remark graph) maps its `browser` condition to `index.dom.js`, which calls
- * `document.createElement` AT MODULE TOP LEVEL — so any worker whose chunk
- * contains remark dies on evaluation, dev and production alike. The package
- * ships a `worker` condition pointing at the DOM-free build, but Vite
- * resolves `browser` first even for worker chunks, so the alias pins the
- * DOM-free entry for every context. `require.resolve` applies Node's own
- * conditions (no `browser`), which lands on exactly that build.
- */
-const workerSafeEntityDecoder = createRequire(import.meta.url).resolve(
-  'decode-named-character-reference',
-)
 
 export default defineConfig({
   // Both workers are constructed with `type: 'module'`, but Vite's default
@@ -51,9 +37,9 @@ export default defineConfig({
       // entry vite already uses in dev via the `browser.development`
       // condition, so dev and prod behavior converge.
       'loro-crdt': 'loro-crdt/bundler',
-      // See workerSafeEntityDecoder above: without this, importing remark in
-      // a worker throws `document is not defined` at chunk evaluation.
-      'decode-named-character-reference': workerSafeEntityDecoder,
+      // Without these, importing remark in a worker throws
+      // `document is not defined` at chunk evaluation — see the module.
+      ...workerSafeDepsAlias,
     },
   },
   build: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
@@ -13,6 +14,20 @@ import { stripWasmSourceMapPlugin } from './vite-plugin-strip-wasm-sourcemap.js'
 import { pwaOptions } from './vite-pwa-options.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * decode-named-character-reference (micromark's entity decoder, deep in the
+ * remark graph) maps its `browser` condition to `index.dom.js`, which calls
+ * `document.createElement` AT MODULE TOP LEVEL — so any worker whose chunk
+ * contains remark dies on evaluation, dev and production alike. The package
+ * ships a `worker` condition pointing at the DOM-free build, but Vite
+ * resolves `browser` first even for worker chunks, so the alias pins the
+ * DOM-free entry for every context. `require.resolve` applies Node's own
+ * conditions (no `browser`), which lands on exactly that build.
+ */
+const workerSafeEntityDecoder = createRequire(import.meta.url).resolve(
+  'decode-named-character-reference',
+)
 
 export default defineConfig({
   // Both workers are constructed with `type: 'module'`, but Vite's default
@@ -36,6 +51,9 @@ export default defineConfig({
       // entry vite already uses in dev via the `browser.development`
       // condition, so dev and prod behavior converge.
       'loro-crdt': 'loro-crdt/bundler',
+      // See workerSafeEntityDecoder above: without this, importing remark in
+      // a worker throws `document is not defined` at chunk evaluation.
+      'decode-named-character-reference': workerSafeEntityDecoder,
     },
   },
   build: {

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
@@ -40,6 +41,12 @@ export default defineConfig({
       '@kamiazya/whiteboard-canvas-viewer': resolve(
         __dirname,
         '../../packages/canvas-viewer/src/index.ts',
+      ),
+      // Same pin as vite.config.ts: the package's `browser` entry touches
+      // `document` at module top level, which kills any worker chunk that
+      // contains remark. Node's resolver lands on the DOM-free build.
+      'decode-named-character-reference': createRequire(import.meta.url).resolve(
+        'decode-named-character-reference',
       ),
     },
   },

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
@@ -10,6 +9,7 @@ import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
 import { mcpSourceAlias } from './mcp-source-alias.js'
+import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -42,12 +42,7 @@ export default defineConfig({
         __dirname,
         '../../packages/canvas-viewer/src/index.ts',
       ),
-      // Same pin as vite.config.ts: the package's `browser` entry touches
-      // `document` at module top level, which kills any worker chunk that
-      // contains remark. Node's resolver lands on the DOM-free build.
-      'decode-named-character-reference': createRequire(import.meta.url).resolve(
-        'decode-named-character-reference',
-      ),
+      ...workerSafeDepsAlias,
     },
   },
   // tailwindcss: layout browser tests import src/index.css to assert real

--- a/apps/web/worker-safe-deps-alias.ts
+++ b/apps/web/worker-safe-deps-alias.ts
@@ -1,0 +1,25 @@
+import { createRequire } from 'node:module'
+
+/**
+ * Dependencies whose `browser` export condition breaks inside a Worker,
+ * pinned to their DOM-free builds.
+ *
+ * decode-named-character-reference (micromark's entity decoder, deep in the
+ * remark graph) maps `browser` to a build that calls `document.createElement`
+ * AT MODULE TOP LEVEL — so any worker chunk containing remark dies on
+ * evaluation, dev and production alike. The package ships a `worker`
+ * condition pointing at the DOM-free build, but Vite resolves `browser`
+ * first even for worker chunks. `require.resolve` applies Node's own
+ * conditions (no `browser`), which lands on exactly that build.
+ *
+ * Shared by vite.config.ts and vitest.browser.config.ts for the same reason
+ * mcp-source-alias.ts is: two hand-kept copies drift, and the drifted copy
+ * here would ship a production worker that throws before handling a message
+ * while the test suite (running on the other copy) stays green.
+ * mcp-source-alias-coverage.test.ts pins that both configs spread this map.
+ */
+export const workerSafeDepsAlias: Record<string, string> = {
+  'decode-named-character-reference': createRequire(import.meta.url).resolve(
+    'decode-named-character-reference',
+  ),
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -96,6 +96,12 @@
     }
   },
   "ignoreDependencies": [
+    // Referenced only as a createRequire().resolve() string in apps/web's
+    // vite.config.ts / vitest.browser.config.ts: the direct devDependency is
+    // what makes that resolve legal under pnpm's strict node_modules, and the
+    // alias it feeds pins the package's DOM-free build so worker chunks that
+    // contain remark can evaluate. Knip only follows import statements.
+    "decode-named-character-reference",
     // docs-snapshots `@docs-assets/*` alias resolves through Vite's
     // `resolve.alias` (vitest.docs-snapshots.config.ts) to files under
     // docs/assets/, not an npm package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@vitest/web-worker':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      decode-named-character-reference:
+        specifier: ^1.3.0
+        version: 1.3.0
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5


### PR DESCRIPTION
## What

First half of the worker-first direction's #39: the per-commit markdown parse (15–19ms of an 81–339ms layout block) moves off the main thread into the layout worker, so an offloaded commit costs the main thread only a postMessage. The pre-parsed `bodies` wire field and its `failed: no pre-parsed body` path are deleted.

## The root cause that made this possible

The documented blocker — "remark refuses to evaluate in a module worker" — was never remark and never the dev server. `decode-named-character-reference` (micromark's entity decoder, deep in the remark graph) maps its **`browser` export condition** to a build that calls `document.createElement('i')` **at module top level**, so any worker chunk containing remark threw `document is not defined` before handling a single message — dev and production alike. The package already ships a DOM-free `worker` condition; Vite just resolves `browser` first even for worker chunks.

Fix: `vite.config.ts` / `vitest.browser.config.ts` pin the DOM-free entry via `createRequire().resolve()` (Node's conditions land on exactly that build), with the package added as a direct devDependency so the resolve is legal under pnpm's strict `node_modules`.

## Test evidence

- New parity case: a markdown body with a named character reference (`&amp;`), **no pre-parsed bodies on the wire**, lays out in the worker with byte-equal SVG to the main thread. Mutation-checked: removing the alias turns it red with `Uncaught ReferenceError: document is not defined`.
- Existing parity cases (deep-equal scene, file-label seam) updated to the body-less protocol and green.
- Full suites on this branch: jsdom 2143, node 75, browser 556, `pnpm -r typecheck`, `pnpm knip` — all green.

## Measured

- Critical-path JS unchanged: 118.9 KB gzip before and after (bundle-size gate green).
- The lazily-loaded layout-worker chunk grows 119 → 316 KB raw carrying remark; it is warmed at editor mount, off the interaction path.

The second half of #39 (drag start/commit render promotion) is a separate increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ