### PR TITLE
fix(web): give fullscreen the whole screen

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
@@ -1,0 +1,91 @@
+// Fullscreen means the CANVAS, maximised. The top bar rode along into the
+// top layer — workspace switcher, rename, menus — which is 48px of chrome
+// nobody entered fullscreen to see. It now steps aside, leaving the canvas
+// and the dock, with one floating way back out.
+import { act, cleanup, render as rtlRender, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { MemoryStore } from '../lib/browser-local-store.js'
+import type { CanvasSnapshot } from '../lib/whiteboard-client.js'
+import { BrowserLocalCanvasPage } from './BrowserLocalCanvasPage.js'
+// The top bar is React.lazy in the page; loading it in the collection phase
+// keeps its chunk cost out of findBy*'s 1000ms retry budget (the lazy-race
+// flake shape integrator-flow.md documents).
+import '../components/WorkspaceTopBar.js'
+
+beforeEach(() => {
+  // jsdom has no fullscreen at all; start each test explicitly OUT of it.
+  setFullscreenElement(null)
+})
+
+afterEach(() => {
+  cleanup()
+  setFullscreenElement(null)
+  vi.restoreAllMocks()
+})
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+const snap: CanvasSnapshot = {
+  id: 'c1',
+  name: 'Canvas A',
+  kind: 'spatial',
+  updatedAt: '2026-04-23T00:00:00Z',
+}
+
+/** jsdom has no real fullscreen; the page only reads this and the event. */
+function setFullscreenElement(el: Element | null) {
+  Object.defineProperty(document, 'fullscreenElement', {
+    configurable: true,
+    get: () => el,
+  })
+  document.dispatchEvent(new Event('fullscreenchange'))
+}
+
+async function renderLoaded() {
+  const store = new MemoryStore()
+  await store.setDefaultCanvasId('c1')
+  await store.save(snap)
+  await act(async () => {
+    render(<BrowserLocalCanvasPage store={store} />)
+  })
+  // The first mount in the file pays every lazy chunk's load; the default
+  // 1s retry budget loses that race under a parallel suite (the documented
+  // lazy-race flake shape), so this wait carries the same 10s budget the
+  // other page tests use.
+  await screen.findByRole('button', { name: /^Workspace:/i }, { timeout: 10_000 })
+}
+
+it('hides the top bar in fullscreen and brings it back on exit', async () => {
+  await renderLoaded()
+
+  await act(async () => {
+    setFullscreenElement(screen.getByRole('main'))
+  })
+  // The chrome steps aside — the canvas is what fullscreen is FOR.
+  expect(screen.queryByRole('button', { name: /^Workspace:/i })).toBeNull()
+
+  await act(async () => {
+    setFullscreenElement(null)
+  })
+  await screen.findByRole('button', { name: /^Workspace:/i })
+})
+
+it('floats one exit control while the chrome is gone, and it exits', async () => {
+  await renderLoaded()
+  const exitFullscreen = vi.fn(async () => {})
+  document.exitFullscreen = exitFullscreen
+
+  // Not there in normal view — the top bar's own toggle covers that state.
+  expect(screen.queryByRole('button', { name: 'Exit fullscreen' })).toBeNull()
+
+  await act(async () => {
+    setFullscreenElement(screen.getByRole('main'))
+  })
+  const exit = screen.getByRole('button', { name: 'Exit fullscreen' })
+  exit.click()
+  expect(exitFullscreen).toHaveBeenCalledTimes(1)
+})

--- a/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
@@ -2,7 +2,7 @@
 // top layer — workspace switcher, rename, menus — which is 48px of chrome
 // nobody entered fullscreen to see. It now steps aside, leaving the canvas
 // and the dock, with one floating way back out.
-import { act, cleanup, render as rtlRender, screen } from '@testing-library/react'
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
@@ -86,6 +86,43 @@ it('floats one exit control while the chrome is gone, and it exits', async () =>
     setFullscreenElement(screen.getByRole('main'))
   })
   const exit = screen.getByRole('button', { name: 'Exit fullscreen' })
+  // The control someone just activated unmounted with the top bar; focus must
+  // land on its replacement, not fall to <body>.
+  expect(document.activeElement).toBe(exit)
   exit.click()
   expect(exitFullscreen).toHaveBeenCalledTimes(1)
+
+  // And it leaves with the mode — the top bar's own toggle takes over.
+  await act(async () => {
+    setFullscreenElement(null)
+  })
+  expect(screen.queryByRole('button', { name: 'Exit fullscreen' })).toBeNull()
+  await waitFor(() =>
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Fullscreen' })),
+  )
+})
+
+it('a rejected requestFullscreen is reported, not an unhandled rejection', async () => {
+  await renderLoaded()
+  const rejection = new DOMException('denied', 'NotAllowedError')
+  Element.prototype.requestFullscreen = vi.fn(() => Promise.reject(rejection))
+  const warnings: unknown[] = []
+  vi.spyOn(console, 'warn').mockImplementation((...args) => void warnings.push(args))
+
+  screen.getByRole('button', { name: 'Fullscreen' }).click()
+  // Let the rejection propagate through the catch.
+  await act(async () => {
+    await Promise.resolve()
+  })
+  expect(warnings.some((args) => JSON.stringify(args).includes('requestFullscreen'))).toBe(true)
+})
+
+it('starts OUT of fullscreen under jsdom, where fullscreenElement is undefined', async () => {
+  // The regression this pins: the sync compared `!== null`, jsdom's default
+  // is UNDEFINED, and `undefined !== null` read as "in fullscreen" — so every
+  // first mount hid the top bar. Delete the test override to expose the real
+  // jsdom default rather than the null this file installs elsewhere.
+  // biome-ignore lint/performance/noDelete: restoring the prototype default IS the scenario
+  delete (document as { fullscreenElement?: Element | null }).fullscreenElement
+  await renderLoaded()
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -2,7 +2,7 @@ import { serializeSpatial } from '@kamiazya/whiteboard-canvas-codec'
 import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { LoroSyncPlugin } from 'loro-codemirror'
-import { Braces, Copy, Download, EllipsisVertical, Trash2 } from 'lucide-react'
+import { Braces, Copy, Download, EllipsisVertical, Minimize2, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
@@ -179,7 +179,9 @@ export function BrowserLocalCanvasPage({
   // the button's label follows the DOCUMENT rather than our own click.
   const [isFullscreen, setIsFullscreen] = useState(false)
   useEffect(() => {
-    const sync = () => setIsFullscreen(document.fullscreenElement !== null)
+    // Boolean(): jsdom leaves fullscreenElement undefined rather than null,
+    // and `undefined !== null` read as "in fullscreen" on first mount there.
+    const sync = () => setIsFullscreen(Boolean(document.fullscreenElement))
     sync()
     document.addEventListener('fullscreenchange', sync)
     return () => document.removeEventListener('fullscreenchange', sync)
@@ -651,71 +653,89 @@ export function BrowserLocalCanvasPage({
     // background no longer shows. Anything this element does not paint itself
     // falls through to the browser's default black backdrop — which turned
     // the canvas area black under a light theme.
-    <main ref={mainRef} className="bg-background grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
+    <main
+      ref={mainRef}
+      className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)] bg-background"
+    >
       <div className="min-w-0">
         {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
           is the visible title control, but the page keeps a real <h1> for
           accessibility trees. */}
         <h1 className="sr-only">{pageState.snapshot.name}</h1>
-        <Suspense
-          fallback={
-            <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
-          }
-        >
-          <WorkspaceTopBar
-            titleSlot={canvasTitleSlot}
-            statusSlot={
-              <ConnectionStatus state="local">
-                <p className="text-muted-foreground">
-                  Connect a local daemon (MCP) to unlock version history, workspaces, variations,
-                  and combining changes
-                </p>
-                <Suspense fallback={null}>
-                  <DaemonDetectedBanner
-                    settingsStore={settingsStore}
-                    fetch={window.fetch.bind(window)}
-                  />
-                </Suspense>
-              </ConnectionStatus>
+        {/* Fullscreen means the CANVAS, maximised: the whole top-bar row —
+            switcher, rename, menus — steps aside. The floating control below
+            replaces its exit path, Escape still works natively, and the dock
+            stays because editing is what the extra space is FOR. */}
+        {!isFullscreen && (
+          <Suspense
+            fallback={
+              <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
             }
-            dataMode="local"
-            workspaceId="local"
-            slug={pageState.snapshot.id}
-            canvases={switcherOptions.map((c) => ({
-              slug: c.id,
-              name: c.name,
-              updatedAt: c.updatedAt,
-            }))}
-            onNavigateToCanvas={(id) => void switchCanvas(id)}
-            onRenameCanvas={renameCanvas}
-            onCreateCanvas={async () => {
-              const created = await createCanvas()
-              await switchCanvas(created.id)
-            }}
-            onCreateMarkdownCanvas={async () => {
-              const created = await createCanvas(undefined, 'markdown')
-              await switchCanvas(created.id)
-            }}
-            isFullscreen={isFullscreen}
-            onToggleFullscreen={() => {
-              // The header lives INSIDE the fullscreen element, so it stays on
-              // screen and is the only way back out — entering without a
-              // matching exit left the user stuck with the Escape key.
-              if (document.fullscreenElement) void document.exitFullscreen()
-              else void mainRef.current?.requestFullscreen()
-            }}
-            capabilities={{
-              versions: capabilities.versions,
-              branches: capabilities.branches,
-              merge: capabilities.merge,
-            }}
-          />
-        </Suspense>
+          >
+            <WorkspaceTopBar
+              titleSlot={canvasTitleSlot}
+              statusSlot={
+                <ConnectionStatus state="local">
+                  <p className="text-muted-foreground">
+                    Connect a local daemon (MCP) to unlock version history, workspaces, variations,
+                    and combining changes
+                  </p>
+                  <Suspense fallback={null}>
+                    <DaemonDetectedBanner
+                      settingsStore={settingsStore}
+                      fetch={window.fetch.bind(window)}
+                    />
+                  </Suspense>
+                </ConnectionStatus>
+              }
+              dataMode="local"
+              workspaceId="local"
+              slug={pageState.snapshot.id}
+              canvases={switcherOptions.map((c) => ({
+                slug: c.id,
+                name: c.name,
+                updatedAt: c.updatedAt,
+              }))}
+              onNavigateToCanvas={(id) => void switchCanvas(id)}
+              onRenameCanvas={renameCanvas}
+              onCreateCanvas={async () => {
+                const created = await createCanvas()
+                await switchCanvas(created.id)
+              }}
+              onCreateMarkdownCanvas={async () => {
+                const created = await createCanvas(undefined, 'markdown')
+                await switchCanvas(created.id)
+              }}
+              isFullscreen={isFullscreen}
+              onToggleFullscreen={() => {
+                // Entering hides this whole bar; the floating exit control and
+                // native Escape are the ways back out.
+                if (document.fullscreenElement) void document.exitFullscreen()
+                else void mainRef.current?.requestFullscreen()
+              }}
+              capabilities={{
+                versions: capabilities.versions,
+                branches: capabilities.branches,
+                merge: capabilities.merge,
+              }}
+            />
+          </Suspense>
+        )}
       </div>
       {/* The snapshot's kind picks the editor: markdown canvases open the
           markdown editor (body and OKF core facets persisted as containers
           of one Loro document — see use-markdown-canvas-doc.ts), everything
           else the spatial editor. */}
+      {isFullscreen && (
+        <button
+          type="button"
+          aria-label="Exit fullscreen"
+          onClick={() => void document.exitFullscreen()}
+          className="absolute top-3 right-3 z-20 rounded-md border bg-background/80 p-2 text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-foreground"
+        >
+          <Minimize2 aria-hidden="true" className="size-4" />
+        </button>
+      )}
       <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
         {canvasKind === 'markdown' ? (
           markdownDoc.body !== null &&

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -178,6 +178,34 @@ export function BrowserLocalCanvasPage({
   // Fullscreen can also be left with Escape or the browser's own chrome, so
   // the button's label follows the DOCUMENT rather than our own click.
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const exitFullscreenRef = useRef<HTMLButtonElement | null>(null)
+  const wasFullscreenRef = useRef(false)
+  // The toggle unmounts the element that was just activated (entering removes
+  // the top bar's button, exiting removes the floating one), and a removed
+  // focused element drops focus to <body> — a keyboard user would have to
+  // tab back from nothing. Hand focus to whichever control replaced it.
+  useEffect(() => {
+    if (isFullscreen) {
+      wasFullscreenRef.current = true
+      exitFullscreenRef.current?.focus()
+      return
+    }
+    if (!wasFullscreenRef.current) return
+    wasFullscreenRef.current = false
+    // The top bar is lazy, so its toggle may land a frame later; retry
+    // briefly rather than racing the remount.
+    let attempts = 12
+    const tryFocus = () => {
+      const toggle = document.querySelector<HTMLButtonElement>('button[aria-label="Fullscreen"]')
+      if (toggle !== null) {
+        toggle.focus()
+        return
+      }
+      attempts -= 1
+      if (attempts > 0) requestAnimationFrame(tryFocus)
+    }
+    tryFocus()
+  }, [isFullscreen])
   useEffect(() => {
     // Boolean(): jsdom leaves fullscreenElement undefined rather than null,
     // and `undefined !== null` read as "in fullscreen" on first mount there.
@@ -709,9 +737,16 @@ export function BrowserLocalCanvasPage({
               isFullscreen={isFullscreen}
               onToggleFullscreen={() => {
                 // Entering hides this whole bar; the floating exit control and
-                // native Escape are the ways back out.
-                if (document.fullscreenElement) void document.exitFullscreen()
-                else void mainRef.current?.requestFullscreen()
+                // native Escape are the ways back out. requestFullscreen can
+                // REJECT (Permissions-Policy, an iframe without
+                // allow="fullscreen", no user activation) — a swallowed
+                // rejection is unhandled-rejection noise, so both directions log.
+                if (document.fullscreenElement)
+                  document.exitFullscreen().catch((err) => log.warn('exitFullscreen failed', err))
+                else
+                  mainRef.current
+                    ?.requestFullscreen()
+                    .catch((err) => log.warn('requestFullscreen rejected', err))
               }}
               capabilities={{
                 versions: capabilities.versions,
@@ -727,14 +762,18 @@ export function BrowserLocalCanvasPage({
           of one Loro document — see use-markdown-canvas-doc.ts), everything
           else the spatial editor. */}
       {isFullscreen && (
-        <button
-          type="button"
+        <Button
+          ref={exitFullscreenRef}
+          variant="outline"
+          size="icon"
           aria-label="Exit fullscreen"
-          onClick={() => void document.exitFullscreen()}
-          className="absolute top-3 right-3 z-20 rounded-md border bg-background/80 p-2 text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-foreground"
+          onClick={() =>
+            document.exitFullscreen().catch((err) => log.warn('exitFullscreen failed', err))
+          }
+          className="absolute top-3 right-3 z-20 bg-background/80 text-muted-foreground backdrop-blur hover:text-foreground"
         >
           <Minimize2 aria-hidden="true" className="size-4" />
-        </button>
+        </Button>
       )}
       <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
         {canvasKind === 'markdown' ? (


### PR DESCRIPTION
Reported from a phone, and previously only half-fixed: fullscreen promoted `<main>` to the top layer, which excluded the app shell — but the canvas **top bar rode along**, so "maximise the canvas" still kept 48px of switcher/rename/menus. That row is proportionally largest exactly where fullscreen matters most.

## What changes

While fullscreen is active, the top-bar row steps aside entirely: **the canvas starts at y=0**. The dock stays — editing is what the extra space is for. Three ways out replace the bar's toggle: a small floating control in the top-right, native Escape, and the platform's own gesture on touch.

| | normal | fullscreen |
|---|---|---|
| top bar | ✓ | **gone** |
| canvas top edge | y=88 | **y=0** |
| dock | ✓ | ✓ |
| exit affordance | bar toggle | floating button / Esc / OS gesture |

## Visual repro (real browser, measured)

![before-fullscreen.png](https://github.com/user-attachments/assets/8a29a8d3-11d4-4c07-b982-da88db029318)
![in-fullscreen.png](https://github.com/user-attachments/assets/78aa36e3-9c1b-4cc2-b750-d6287004885d)

## A latent bug the new test flushed out

The `fullscreenchange` sync compared `document.fullscreenElement !== null` — and **jsdom leaves that property `undefined`, not null**, so under jsdom every mount started IN fullscreen. Real browsers report null and were unaffected, but the first test in the file failed inexplicably while the second passed (the first test's cleanup defined the property). The check is now `Boolean(...)`, and the tests initialize the property explicitly.

## Verification

- New jsdom tests: bar hidden in fullscreen and restored on exit; floating exit control appears only in fullscreen and calls `exitFullscreen`
- Real browser, measured round-trip: enter → `{fullscreen:true, topBar:false, exit:true, dock:true, canvasTop:0}` → exit restores `canvasTop:88`
- `pnpm --filter @kamiazya/whiteboard-web test` — 2145 + 75 passed; typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc