### PR TITLE
feat(server)!: take a document path everywhere the canvases family took a slug

### DIFF
--- a/apps/web/src/components/CanvasThumb.test.tsx
+++ b/apps/web/src/components/CanvasThumb.test.tsx
@@ -7,12 +7,12 @@ import { CanvasThumb } from './CanvasThumb.js'
 afterEach(() => cleanup())
 
 describe('CanvasThumb', () => {
-  it('renders an img pointed at the latest-thumbnail route, url-encoding the slug', () => {
+  it('renders an img pointed at the latest-thumbnail route, encoding each path segment', () => {
     const { container } = render(<CanvasThumb workspaceId="ws-1" slug="my canvas/x" />)
     const img = container.querySelector('img') as HTMLImageElement
     expect(img).not.toBeNull()
     expect(img.getAttribute('src')).toBe(
-      '/api/workspaces/ws-1/canvases/my%20canvas%2Fx/latest-thumbnail',
+      '/api/workspaces/ws-1/canvases/my%20canvas/x/latest-thumbnail',
     )
     expect(img.getAttribute('loading')).toBe('lazy')
     expect(img.getAttribute('decoding')).toBe('async')

--- a/apps/web/src/components/CanvasThumb.tsx
+++ b/apps/web/src/components/CanvasThumb.tsx
@@ -1,3 +1,4 @@
+import { canvasesApiUrl } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { FileText } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useDaemonApi, useHasDaemonApi } from '@/contexts/DaemonApiContext'
@@ -31,7 +32,7 @@ export function CanvasThumb({ workspaceId, slug, size = 'dropdown', className }:
   const daemonFetch = useDaemonApi()
   const [failed, setFailed] = useState(false)
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
-  const src = `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/latest-thumbnail`
+  const src = canvasesApiUrl(workspaceId, slug, 'latest-thumbnail')
   // Instances are reused across re-renders with a new slug/workspaceId (e.g.
   // the canvas switcher dropdown), so a stale `failed` flag from a previous
   // src must not leak into the next canvas's thumbnail. Reset during render

--- a/apps/web/src/components/MergeDialog.tsx
+++ b/apps/web/src/components/MergeDialog.tsx
@@ -1,5 +1,6 @@
 import {
   type BranchMeta,
+  canvasesApiUrl,
   listVersionsResponseSchema,
   type MergeRequest,
   type MergeResponse,
@@ -261,9 +262,7 @@ export function MergeDialog({
     setThumbsLoading(true)
     ;(async () => {
       try {
-        const res = await fetchFn(
-          `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
-        )
+        const res = await fetchFn(canvasesApiUrl(workspaceId, slug, 'versions'))
         if (!res.ok) {
           if (!cancelled) setThumbs({ target: null, source: null })
           return

--- a/apps/web/src/components/MergeToast.tsx
+++ b/apps/web/src/components/MergeToast.tsx
@@ -1,3 +1,4 @@
+import { canvasesApiUrl } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { CheckCircle2, Undo2, X } from 'lucide-react'
 import { type JSX, useEffect, useRef, useState } from 'react'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
@@ -96,7 +97,11 @@ export function MergeToast({ workspaceId, slug, onRestored }: MergeToastProps): 
       // Restore the canvas the merge actually happened on, not whichever
       // canvas is currently selected — the toast can outlive a canvas switch.
       const res = await fetchFn(
-        `/api/workspaces/${mergeWorkspaceId}/canvases/${encodeURIComponent(mergeSlug)}/versions/${encodeURIComponent(preMergeVersionId)}/restore`,
+        canvasesApiUrl(
+          mergeWorkspaceId,
+          mergeSlug,
+          `versions/${encodeURIComponent(preMergeVersionId)}/restore`,
+        ),
         { method: 'POST' },
       )
       if (res.ok) {

--- a/apps/web/src/components/VersionThumbnail.test.tsx
+++ b/apps/web/src/components/VersionThumbnail.test.tsx
@@ -8,7 +8,9 @@ import { VersionThumbnail } from './VersionThumbnail.js'
 const WORKSPACE_ID = 'w 1#a'
 const SLUG = 'main/x'
 const VERSION_ID = 'v?1'
-const THUMBNAIL_PATH = `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases/${encodeURIComponent(SLUG)}/versions/${encodeURIComponent(VERSION_ID)}/thumbnail`
+// The slug is a document path: each segment is encoded, the separators are
+// structure (the canvasesApiUrl contract).
+const THUMBNAIL_PATH = `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/canvases/${SLUG.split('/').map(encodeURIComponent).join('/')}/versions/${encodeURIComponent(VERSION_ID)}/thumbnail`
 
 function renderInDaemonMode(fetchFn: typeof fetch, props: Partial<{ versionId: string }> = {}) {
   return render(

--- a/apps/web/src/components/VersionThumbnail.tsx
+++ b/apps/web/src/components/VersionThumbnail.tsx
@@ -1,3 +1,4 @@
+import { canvasesApiUrl } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useEffect, useState } from 'react'
 import { useDaemonApi, useHasDaemonApi } from '@/contexts/DaemonApiContext'
 
@@ -40,7 +41,11 @@ export function VersionThumbnail({
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
   const [failed, setFailed] = useState(false)
 
-  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/versions/${encodeURIComponent(versionId)}/thumbnail`
+  const path = canvasesApiUrl(
+    workspaceId,
+    slug,
+    `versions/${encodeURIComponent(versionId)}/thumbnail`,
+  )
 
   useEffect(() => {
     if (!hasThumbnail || !hasDaemonApi) return

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -1,4 +1,5 @@
 import {
+  canvasesApiUrl,
   listVersionsResponseSchema,
   type OperatorInfo,
   type VersionEntry,
@@ -93,9 +94,7 @@ export default function VersionTimeline({ workspaceId, slug, onRestored, refresh
     const seq = ++fetchSeqRef.current
     setLoading(true)
     try {
-      const res = await fetchFn(
-        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions`,
-      )
+      const res = await fetchFn(canvasesApiUrl(workspaceId, slug, 'versions'))
       if (seq !== fetchSeqRef.current) return
       if (res.ok) {
         const parsed = listVersionsResponseSchema.safeParse(await res.json())
@@ -178,10 +177,9 @@ export default function VersionTimeline({ workspaceId, slug, onRestored, refresh
     // actually happened. A failed request keeps the dialog open with an error
     // so the caller never discards undo history for a restore that didn't occur.
     try {
-      const res = await fetchFn(
-        `/api/workspaces/${workspaceId}/canvases/${encodeURIComponent(slug)}/versions/${v.id}/restore`,
-        { method: 'POST' },
-      )
+      const res = await fetchFn(canvasesApiUrl(workspaceId, slug, `versions/${v.id}/restore`), {
+        method: 'POST',
+      })
       if (!res.ok) {
         log.error('restore request failed', { status: res.status, versionId: v.id })
         setRestoreError('Restore failed. Please try again.')

--- a/apps/web/src/components/workspace-top-bar/useCanvasNames.ts
+++ b/apps/web/src/components/workspace-top-bar/useCanvasNames.ts
@@ -1,4 +1,8 @@
-import { type WorkspaceNames, workspaceNamesSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import {
+  canvasesApiUrl,
+  type WorkspaceNames,
+  workspaceNamesSchema,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { CanvasInfo } from './types'
 
@@ -67,14 +71,11 @@ export function useCanvasNames({
   const renameCanvas = useCallback(
     async (targetSlug: string, name: string): Promise<boolean> => {
       try {
-        const res = await daemonFetch(
-          `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(targetSlug)}/name`,
-          {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name }),
-          },
-        )
+        const res = await daemonFetch(canvasesApiUrl(workspaceId, targetSlug, 'name'), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        })
         if (res.ok) {
           setNames(workspaceNamesSchema.parse(await res.json()))
           return true
@@ -92,14 +93,11 @@ export function useCanvasNames({
   const togglePin = useCallback(
     async (targetSlug: string, pinned: boolean) => {
       try {
-        const res = await daemonFetch(
-          `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(targetSlug)}/pin`,
-          {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ pinned }),
-          },
-        )
+        const res = await daemonFetch(canvasesApiUrl(workspaceId, targetSlug, 'pin'), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pinned }),
+        })
         if (res.ok) setNames(workspaceNamesSchema.parse(await res.json()))
       } catch {
         /* Pin failures stay silent; the UX does not need explicit retry handling here. */

--- a/apps/web/src/components/workspace-top-bar/useSaveVersion.ts
+++ b/apps/web/src/components/workspace-top-bar/useSaveVersion.ts
@@ -1,4 +1,4 @@
-import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { canvasesApiUrl, saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirtyEventDetail } from '@/hooks/useDirtyState'
 import type { AppLogger } from '@/lib/app-logger'
@@ -37,14 +37,11 @@ export function useSaveVersion({
       savingRef.current = true
       setSaving(true)
       try {
-        const res = await daemonFetch(
-          `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/versions`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ label }),
-          },
-        )
+        const res = await daemonFetch(canvasesApiUrl(workspaceId, slug, 'versions'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label }),
+        })
         if (!res.ok) return false
         const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
         if (!parsed.success) {
@@ -62,14 +59,11 @@ export function useSaveVersion({
           try {
             const blob = await getThumbnailBlob()
             if (blob) {
-              await daemonFetch(
-                `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/versions/${id}/thumbnail`,
-                {
-                  method: 'PUT',
-                  headers: { 'Content-Type': 'image/png' },
-                  body: blob,
-                },
-              )
+              await daemonFetch(canvasesApiUrl(workspaceId, slug, `versions/${id}/thumbnail`), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'image/png' },
+                body: blob,
+              })
             }
           } catch (err) {
             log?.error('manual-save thumbnail upload failed:', err)

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -3,6 +3,7 @@ import {
   type CanvasOkfV1Response,
   type CreateCanvasResponse,
   canvasApiUrl,
+  canvasesApiUrl,
   canvasOkfV1ResponseSchema,
   createCanvasResponseSchema,
   type DeleteCanvasResponse,
@@ -116,7 +117,7 @@ export function deleteCanvas(
 ): Promise<DeleteCanvasResponse> {
   return fetchAndParse(
     fetchFn,
-    `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}`,
+    `${daemonBaseUrl}${canvasesApiUrl(workspaceId, slug)}`,
     deleteCanvasResponseSchema,
     { method: 'DELETE' },
   )
@@ -163,7 +164,7 @@ export function setCanvasName(
 ): Promise<WorkspaceNames> {
   return fetchAndParse(
     fetchFn,
-    `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeURIComponent(slug)}/name`,
+    `${daemonBaseUrl}${canvasesApiUrl(workspaceId, slug, 'name')}`,
     workspaceNamesSchema,
     {
       method: 'PUT',

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -1,5 +1,5 @@
 import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
-import { saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { canvasesApiUrl, saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { selectCanvasTransport } from '@kamiazya/whiteboard-mcp/select-canvas-transport'
@@ -361,7 +361,7 @@ export function DaemonCanvasPage({
     setSaveVersionMessage(null)
     try {
       const res = await daemonFetch(
-        `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(canvas.workspaceId)}/canvases/${encodeURIComponent(canvas.slug)}/versions`,
+        `${daemonBaseUrl}${canvasesApiUrl(canvas.workspaceId, canvas.slug, 'versions')}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/packages/mcp-server/src/server/routes/branches.ts
+++ b/packages/mcp-server/src/server/routes/branches.ts
@@ -29,6 +29,7 @@ import {
   validateWorkspaceId,
   validationErrorBody,
 } from '../validators.js'
+import { onCanvasesRoute } from './canvas/path-route.js'
 
 // Branches router, spec §4.
 // Resolve fromVersionId through DI (resolveFromVersionFrontiers) to avoid a circular dependency.
@@ -132,16 +133,7 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   const branchNotFound = (message: string) => ({ error: 'branch_not_found', message })
 
   // ── GET /api/workspaces/:sid/canvases/:slug/branches ──
-  app.get('/api/workspaces/:sid/canvases/:slug/branches', async (c) => {
-    const { sid, slug } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'get', ['branches'], async (c, sid, slug) => {
     try {
       const state: CanvasBranchesState = await loadCanvasBranches(sid, slug)
       return c.json(state)
@@ -153,16 +145,7 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   })
 
   // ── POST /api/workspaces/:sid/canvases/:slug/branches ──
-  app.post('/api/workspaces/:sid/canvases/:slug/branches', async (c) => {
-    const { sid, slug } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'post', ['branches'], async (c, sid, slug) => {
     let rawBody: unknown
     try {
       rawBody = await c.req.json()
@@ -226,16 +209,8 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   })
 
   // ── DELETE /api/workspaces/:sid/canvases/:slug/branches/:name ──
-  app.delete('/api/workspaces/:sid/canvases/:slug/branches/:name', async (c) => {
-    const { sid, slug, name } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'delete', ['branches', ':name'], async (c, sid, slug, params) => {
+    const name = params.name as string
     const bn = validateBranchNameOrRespond(name)
     if (bn) return c.json(bn.body, bn.status)
     try {
@@ -266,16 +241,7 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // When getCurrentFrontiers / checkoutTo are provided, also:
   //   1) save the current doc.frontiers() onto the previous HEAD
   //   2) reconcile + broadcast when the new HEAD tipFrontiers is non-empty
-  app.put('/api/workspaces/:sid/canvases/:slug/head', async (c) => {
-    const { sid, slug } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'put', ['head'], async (c, sid, slug) => {
     const parsed = setHeadRequestSchema.safeParse(await c.req.json().catch(() => null))
     if (!parsed.success) {
       return c.json({ error: 'invalid_body', message: 'branch is required' }, 400)
@@ -357,8 +323,8 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // withWorkspaceWriteLock, the same way PUT /head's own handler owns its
   // branches.json read+save. Locking here too would be redundant, not
   // protective.
-  app.post('/api/workspaces/:sid/canvases/:slug/branches/:source/merge', async (c) => {
-    const { sid, slug, source } = c.req.param()
+  onCanvasesRoute(app, 'post', ['branches', ':source', 'merge'], async (c, sid, slug, params) => {
+    const source = params.source as string
     try {
       validateWorkspaceId(sid)
       validateSlug(slug)
@@ -441,16 +407,8 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // ── GET /api/workspaces/:sid/canvases/:slug/branches/:name/stats ──
   // Pre-check endpoint for the delete confirmation dialog.
   // Returns actual unmergedCommits plus isHead.
-  app.get('/api/workspaces/:sid/canvases/:slug/branches/:name/stats', async (c) => {
-    const { sid, slug, name } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'get', ['branches', ':name', 'stats'], async (c, sid, slug, params) => {
+    const name = params.name as string
     const bn = validateBranchNameOrRespond(name)
     if (bn) return c.json(bn.body, bn.status)
     try {
@@ -474,16 +432,8 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // ── PATCH /api/workspaces/:sid/canvases/:slug/branches/:name ──
   // Rename with body { name: newName }. main returns 409, conflicts return 409, missing returns 404.
   // version-store branchName updates are delegated to renameInVersions and default to 0 when omitted.
-  app.patch('/api/workspaces/:sid/canvases/:slug/branches/:name', async (c) => {
-    const { sid, slug, name } = c.req.param()
-    try {
-      validateWorkspaceId(sid)
-      validateSlug(slug)
-    } catch (err) {
-      const v = handleValidation(err)
-      if (v) return c.json(v.body, v.status)
-      throw err
-    }
+  onCanvasesRoute(app, 'patch', ['branches', ':name'], async (c, sid, slug, params) => {
+    const name = params.name as string
     const oldValidation = validateBranchNameOrRespond(name)
     if (oldValidation) return c.json(oldValidation.body, oldValidation.status)
 

--- a/packages/mcp-server/src/server/routes/canvas.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas.test.ts
@@ -188,6 +188,83 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     expect(collideSnapshot.status).toBe(200)
   })
 
+  it('drives the whole canvases family against a nested document path', async () => {
+    // The second legacy family (already workspace-first, but :slug could not
+    // match a nested path): versions, thumbnails, restore, compact, name,
+    // pin, rename, delete. One scenario, so a regression in ANY of them on a
+    // nested path is loud.
+    const app = createCanvasRouter()
+    const create = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'notes/2026/plan', kind: 'spatial' }),
+    })
+    expect(create.status).toBe(200)
+    const P = '/api/workspaces/ws1/canvases/notes/2026/plan'
+
+    // name + pin (PUT with suffix)
+    expect(
+      (
+        await app.request(`${P}/name`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Plan 2026' }),
+        })
+      ).status,
+    ).toBe(200)
+    expect(
+      (
+        await app.request(`${P}/pin`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pinned: true }),
+        })
+      ).status,
+    ).toBe(200)
+
+    // versions: create → list → thumbnail PUT/GET → restore
+    const created = await app.request(`${P}/versions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(created.status).toBe(200)
+    const { version } = (await created.json()) as { version: { id: string } }
+    const versionId = version.id
+
+    const list = await app.request(`${P}/versions`)
+    expect(list.status).toBe(200)
+
+    const putThumb = await app.request(`${P}/versions/${versionId}/thumbnail`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'image/png' },
+      body: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+    })
+    expect(putThumb.status).toBe(200)
+    expect((await app.request(`${P}/versions/${versionId}/thumbnail`)).status).toBe(200)
+    expect((await app.request(`${P}/latest-thumbnail`)).status).toBe(200)
+
+    const restore = await app.request(`${P}/versions/${versionId}/restore`, { method: 'POST' })
+    expect(restore.status).toBe(200)
+
+    // compact (POST with suffix)
+    expect((await app.request(`${P}/compact`, { method: 'POST' })).status).toBe(200)
+
+    // rename moves the whole subtree address
+    const renamed = await app.request(`${P}/slug`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'notes/2027/plan' }),
+    })
+    expect(renamed.status).toBe(200)
+
+    // delete at the NEW nested path
+    const del = await app.request('/api/workspaces/ws1/canvases/notes/2027/plan', {
+      method: 'DELETE',
+    })
+    expect(del.status).toBe(200)
+  })
+
   it('creates a kind:markdown canvas, and the list carries it back', async () => {
     const app = createCanvasRouter()
     const createRes = await app.request('/api/workspaces/ws1/canvases', {

--- a/packages/mcp-server/src/server/routes/canvas/maintenance.ts
+++ b/packages/mcp-server/src/server/routes/canvas/maintenance.ts
@@ -4,6 +4,7 @@ import { evictDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 export interface MaintenanceRouterOptions {
   versionStore: VersionStore
@@ -19,16 +20,7 @@ export function createMaintenanceRouter(options: MaintenanceRouterOptions) {
   // GC the op-log before the oldest retained version frontiers using shallow-snapshot.
   // Side effects: replace the on-disk .loro file and evict doc-cache so the next getDoc reloads the shallow doc.
   // Avoid calling this frequently on highly active multi-peer canvases because concurrent applyAndPersist calls can race.
-  app.post('/api/workspaces/:workspaceId/canvases/:slug/compact', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'post', ['compact'], async (c, workspaceId, slug) => {
     try {
       const result = await compactCanvas(workspaceId, slug, versionStore)
       if (result.compacted) evictDoc(workspaceId, slug)

--- a/packages/mcp-server/src/server/routes/canvas/metadata.ts
+++ b/packages/mcp-server/src/server/routes/canvas/metadata.ts
@@ -11,6 +11,7 @@ import {
 } from '../../store/names-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 // User-facing workspace / canvas names.
 // When unnamed, the UI falls back to session id / slug, so the API only returns stored values.
@@ -64,16 +65,7 @@ export function createCanvasMetadataRouter() {
     }
   })
 
-  app.put('/api/workspaces/:workspaceId/canvases/:slug/name', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'put', ['name'], async (c, workspaceId, slug) => {
     const parsed = setNameRequestSchema.safeParse(await c.req.json().catch(() => null))
     if (!parsed.success) {
       return c.json({ error: 'invalid_body' }, 400)
@@ -89,16 +81,7 @@ export function createCanvasMetadataRouter() {
   })
 
   // Idempotently set pin on/off and return the full updated WorkspaceNames payload.
-  app.put('/api/workspaces/:workspaceId/canvases/:slug/pin', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'put', ['pin'], async (c, workspaceId, slug) => {
     const parsed = setPinnedRequestSchema.safeParse(await c.req.json().catch(() => null))
     if (!parsed.success) {
       return c.json({ error: 'invalid_body', message: 'pinned must be boolean' }, 400)

--- a/packages/mcp-server/src/server/routes/canvas/path-route.ts
+++ b/packages/mcp-server/src/server/routes/canvas/path-route.ts
@@ -16,13 +16,25 @@ type CanvasFileHandler = (
   fileId: string,
 ) => Promise<Response> | Response
 
-function validated(c: Context, workspaceId: string, path: string): Response | null {
+function validated(
+  c: Context,
+  workspaceId: string,
+  path: string,
+  badRequest: 'legacy' | 'problem-details' = 'legacy',
+): Response | null {
   try {
     validateWorkspaceId(workspaceId)
     validateSlug(path)
   } catch (err) {
     const body = validationErrorBody(err)
-    if (body) return c.json(body, 400)
+    // Two 400 shapes coexist on this surface: the older { error, message }
+    // and Problem Details { title } (delete/rename, pinned by tests). The
+    // caller says which its route speaks.
+    if (body) {
+      return badRequest === 'problem-details'
+        ? c.json({ title: body.message }, 400)
+        : c.json(body, 400)
+    }
     throw err
   }
   return null
@@ -69,4 +81,65 @@ export function onCanvasFile(
     )
   }
   app[method](CANVAS_WILDCARD, ...(middleware as []), dispatch)
+}
+
+export const CANVASES_WILDCARD = '/api/workspaces/:workspaceId/canvases/*'
+
+const CANVASES_PREFIX = /^\/api\/workspaces\/([^/]+)\/canvases\/(.+)$/
+
+type CanvasesHandler = (
+  c: Context,
+  workspaceId: string,
+  path: string,
+  params: Record<string, string>,
+) => Promise<Response> | Response
+
+/**
+ * The `/api/workspaces/:workspaceId/canvases/<document path>/<suffix...>`
+ * family — same wildcard dispatch as onCanvasAction, with a multi-segment
+ * suffix pattern matched FROM THE END (`':x'` entries capture). The suffix
+ * anchoring is what keeps a nested path unambiguous, exactly as with the
+ * single-action routes: `a/versions/versions` is the versions listing of the
+ * document `a/versions`. An empty pattern (delete) takes the whole tail as
+ * the path.
+ */
+export function onCanvasesRoute(
+  app: Hono,
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  suffixPattern: string[],
+  handler: CanvasesHandler,
+  options: { badRequest?: 'legacy' | 'problem-details' } = {},
+  ...middleware: MiddlewareHandler[]
+): void {
+  const dispatch = async (c: Context, next: Next) => {
+    const match = c.req.path.match(CANVASES_PREFIX)
+    if (match === null) return next()
+    const workspaceId = decodePathSegment(match[1] ?? '')
+    const rawTail = (match[2] ?? '').replace(/\/$/, '').split('/')
+    const tail = rawTail.map(decodePathSegment)
+    if (workspaceId === null || tail.some((segment) => segment === null || segment === '')) {
+      return next()
+    }
+    if (tail.length < suffixPattern.length + 1) return next()
+    const params: Record<string, string> = {}
+    const suffixStart = tail.length - suffixPattern.length
+    for (const [i, expected] of suffixPattern.entries()) {
+      const actual = tail[suffixStart + i] as string
+      if (expected.startsWith(':')) params[expected.slice(1)] = actual
+      else if (actual !== expected) return next()
+    }
+    const path = (tail.slice(0, suffixStart) as string[]).join('/')
+    return (
+      validated(c, workspaceId, path, options.badRequest) ?? handler(c, workspaceId, path, params)
+    )
+  }
+  app[method](CANVASES_WILDCARD, ...(middleware as []), dispatch)
+}
+
+function decodePathSegment(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return null
+  }
 }

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -14,6 +14,7 @@ import {
   validationErrorBody,
 } from '../../validators.js'
 import { getBroadcastFn, handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 export interface RestoreRouterOptions {
   versionStore: VersionStore
@@ -86,117 +87,69 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
   const app = new Hono()
   const { versionStore } = options
 
-  app.post('/api/workspaces/:workspaceId/canvases/:slug/versions/:id/restore', async (c) => {
-    const { workspaceId, slug, id } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-      validateVersionId(id)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
-    // Body is optional. Empty body / non-JSON ⇒ in-place mode.
-    const rawText = await c.req.text()
-    let targetSlug: string | undefined
-    let overwrite = false
-    if (rawText.length > 0) {
-      let parsedJson: unknown
+  onCanvasesRoute(
+    app,
+    'post',
+    ['versions', ':id', 'restore'],
+    async (c, workspaceId, slug, params) => {
+      const id = params.id as string
       try {
-        parsedJson = JSON.parse(rawText)
-      } catch {
-        return c.json({ error: 'invalid_body', message: 'malformed JSON' }, 400)
+        validateVersionId(id)
+      } catch (err) {
+        const body = validationErrorBody(err)
+        if (body) return c.json(body, 400)
+        throw err
       }
-      const parsed = restoreVersionRequestSchema.safeParse(parsedJson)
-      if (!parsed.success) {
-        return c.json({ error: 'invalid_body', message: 'invalid restore options' }, 400)
-      }
-      targetSlug = parsed.data.targetSlug
-      overwrite = parsed.data.overwrite === true
-    }
-    try {
-      // Every doc read + save below runs inside one workspace-lock hold.
-      // getDoc() alone is unlocked, so a concurrent delete/rename that runs
-      // its whole lock-protected section between an unlocked read here and
-      // the eventual saveCanvas() would find no row left at that slug and
-      // silently insert a brand-new phantom canvas (or resurrect content
-      // onto a slug the delete just cleared). Both the in-place branch and
-      // the targetSlug-overwrite branch have that getDoc(slug)->saveCanvas(slug)
-      // shape, so one lock around the whole handler body closes it for both
-      // — mirrors live-doc.ts's POST /update handler.
-      return await withWorkspaceWriteLock(workspaceId, async () => {
-        const doc = await getDoc(workspaceId, slug)
-        const past = await versionStore.load(workspaceId, id, doc)
-        if (!past) {
-          return c.json({ error: 'not_found' }, 404)
+      // Body is optional. Empty body / non-JSON ⇒ in-place mode.
+      const rawText = await c.req.text()
+      let targetSlug: string | undefined
+      let overwrite = false
+      if (rawText.length > 0) {
+        let parsedJson: unknown
+        try {
+          parsedJson = JSON.parse(rawText)
+        } catch {
+          return c.json({ error: 'invalid_body', message: 'malformed JSON' }, 400)
         }
-
-        // Restore-as-new-canvas / overwrite-existing-canvas branch.
-        // targetSlug === slug is the same document as the in-place restore
-        // below, so route it there directly instead of forcing callers to
-        // pass overwrite:true against their own canvas.
-        if (targetSlug !== undefined && targetSlug !== slug) {
-          try {
-            validateSlug(targetSlug)
-          } catch (err) {
-            const body = validationErrorBody(err)
-            if (body) return c.json(body, 400)
-            throw err
+        const parsed = restoreVersionRequestSchema.safeParse(parsedJson)
+        if (!parsed.success) {
+          return c.json({ error: 'invalid_body', message: 'invalid restore options' }, 400)
+        }
+        targetSlug = parsed.data.targetSlug
+        overwrite = parsed.data.overwrite === true
+      }
+      try {
+        // Every doc read + save below runs inside one workspace-lock hold.
+        // getDoc() alone is unlocked, so a concurrent delete/rename that runs
+        // its whole lock-protected section between an unlocked read here and
+        // the eventual saveCanvas() would find no row left at that slug and
+        // silently insert a brand-new phantom canvas (or resurrect content
+        // onto a slug the delete just cleared). Both the in-place branch and
+        // the targetSlug-overwrite branch have that getDoc(slug)->saveCanvas(slug)
+        // shape, so one lock around the whole handler body closes it for both
+        // — mirrors live-doc.ts's POST /update handler.
+        return await withWorkspaceWriteLock(workspaceId, async () => {
+          const doc = await getDoc(workspaceId, slug)
+          const past = await versionStore.load(workspaceId, id, doc)
+          if (!past) {
+            return c.json({ error: 'not_found' }, 404)
           }
 
-          const targetAlreadyExists = await canvasExists(workspaceId, targetSlug)
-          if (targetAlreadyExists && !overwrite) {
-            return c.json(
-              {
-                error: 'output_exists',
-                message: `Target canvas "${targetSlug}" already exists. Pass overwrite=true to replace it.`,
-              },
-              409,
-            )
-          }
+          // Restore-as-new-canvas / overwrite-existing-canvas branch.
+          // targetSlug === slug is the same document as the in-place restore
+          // below, so route it there directly instead of forcing callers to
+          // pass overwrite:true against their own canvas.
+          if (targetSlug !== undefined && targetSlug !== slug) {
+            try {
+              validateSlug(targetSlug)
+            } catch (err) {
+              const body = validationErrorBody(err)
+              if (body) return c.json(body, 400)
+              throw err
+            }
 
-          if (targetAlreadyExists) {
-            // The version id belongs to the SOURCE canvas's history, so its
-            // label lives in the source's version list even though we are
-            // about to reconcile it onto the target.
-            const all = await versionStore.list(workspaceId, slug)
-            const label = all.find((v) => v.id === id)?.label
-            const targetDoc = await getDoc(workspaceId, targetSlug)
-            // The merged content is the source's own shape (spatial nodes/edges
-            // vs. a markdown body), same reasoning as the new-canvas branch
-            // below — the target's stored kind must follow it or a kind-aware
-            // consumer (editor routing) opens the overwritten canvas with the
-            // wrong editor.
-            const sourceKind = await getCanvasKind(workspaceId, slug)
-            await reconcileCommitSaveBroadcast(
-              workspaceId,
-              targetSlug,
-              targetDoc,
-              past,
-              label,
-              sourceKind,
-            )
-            return c.json({
-              canvasId: `${workspaceId}/${targetSlug}`,
-              elementCount: countAliveNodes(targetDoc),
-            })
-          }
-
-          // Genuinely new canvas: no live doc and no connected clients, so
-          // there is nothing to reconcile against. The restored content is
-          // whatever the source canvas actually stores (spatial nodes/edges
-          // maps vs. a markdown 'body' text container), so the new row must
-          // carry the source's own kind rather than falling back to the
-          // saveCanvas default.
-          try {
-            const sourceKind = await getCanvasKind(workspaceId, slug)
-            await saveCanvas(workspaceId, targetSlug, past, {
-              overwrite: false,
-              ...(sourceKind !== null ? { kind: sourceKind } : {}),
-            })
-          } catch (err) {
-            if (err instanceof ConflictError) {
+            const targetAlreadyExists = await canvasExists(workspaceId, targetSlug)
+            if (targetAlreadyExists && !overwrite) {
               return c.json(
                 {
                   error: 'output_exists',
@@ -205,29 +158,80 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
                 409,
               )
             }
-            throw err
-          }
-          // Guard against a stale cache entry from a since-deleted canvas at
-          // this slug being served instead of the just-written snapshot.
-          evictDoc(workspaceId, targetSlug)
-          return c.json({
-            canvasId: `${workspaceId}/${targetSlug}`,
-            elementCount: countAliveNodes(past),
-          })
-        }
 
-        // In-place reconcile branch (default).
-        const all = await versionStore.list(workspaceId, slug)
-        const label = all.find((v) => v.id === id)?.label
-        await reconcileCommitSaveBroadcast(workspaceId, slug, doc, past, label)
-        return c.json({ ok: true })
-      })
-    } catch (err) {
-      const issue = handleCorruptStoredData(err)
-      if (issue) return c.json(issue.body, issue.status)
-      throw err
-    }
-  })
+            if (targetAlreadyExists) {
+              // The version id belongs to the SOURCE canvas's history, so its
+              // label lives in the source's version list even though we are
+              // about to reconcile it onto the target.
+              const all = await versionStore.list(workspaceId, slug)
+              const label = all.find((v) => v.id === id)?.label
+              const targetDoc = await getDoc(workspaceId, targetSlug)
+              // The merged content is the source's own shape (spatial nodes/edges
+              // vs. a markdown body), same reasoning as the new-canvas branch
+              // below — the target's stored kind must follow it or a kind-aware
+              // consumer (editor routing) opens the overwritten canvas with the
+              // wrong editor.
+              const sourceKind = await getCanvasKind(workspaceId, slug)
+              await reconcileCommitSaveBroadcast(
+                workspaceId,
+                targetSlug,
+                targetDoc,
+                past,
+                label,
+                sourceKind,
+              )
+              return c.json({
+                canvasId: `${workspaceId}/${targetSlug}`,
+                elementCount: countAliveNodes(targetDoc),
+              })
+            }
+
+            // Genuinely new canvas: no live doc and no connected clients, so
+            // there is nothing to reconcile against. The restored content is
+            // whatever the source canvas actually stores (spatial nodes/edges
+            // maps vs. a markdown 'body' text container), so the new row must
+            // carry the source's own kind rather than falling back to the
+            // saveCanvas default.
+            try {
+              const sourceKind = await getCanvasKind(workspaceId, slug)
+              await saveCanvas(workspaceId, targetSlug, past, {
+                overwrite: false,
+                ...(sourceKind !== null ? { kind: sourceKind } : {}),
+              })
+            } catch (err) {
+              if (err instanceof ConflictError) {
+                return c.json(
+                  {
+                    error: 'output_exists',
+                    message: `Target canvas "${targetSlug}" already exists. Pass overwrite=true to replace it.`,
+                  },
+                  409,
+                )
+              }
+              throw err
+            }
+            // Guard against a stale cache entry from a since-deleted canvas at
+            // this slug being served instead of the just-written snapshot.
+            evictDoc(workspaceId, targetSlug)
+            return c.json({
+              canvasId: `${workspaceId}/${targetSlug}`,
+              elementCount: countAliveNodes(past),
+            })
+          }
+
+          // In-place reconcile branch (default).
+          const all = await versionStore.list(workspaceId, slug)
+          const label = all.find((v) => v.id === id)?.label
+          await reconcileCommitSaveBroadcast(workspaceId, slug, doc, past, label)
+          return c.json({ ok: true })
+        })
+      } catch (err) {
+        const issue = handleCorruptStoredData(err)
+        if (issue) return c.json(issue.body, issue.status)
+        throw err
+      }
+    },
+  )
 
   return app
 }

--- a/packages/mcp-server/src/server/routes/canvas/thumbnails.ts
+++ b/packages/mcp-server/src/server/routes/canvas/thumbnails.ts
@@ -9,6 +9,7 @@ import {
 } from '../../validators.js'
 import { isValidPngSignature } from '../canvas-thumbnail.js'
 import { handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 // Thumbnails are PNG blobs exported from the browser canvas. Match
 // files.ts's MAX_FILE_UPLOAD_BYTES rather than inventing a separate number.
@@ -26,24 +27,13 @@ export function createThumbnailsRouter(options: ThumbnailsRouterOptions) {
   const { versionStore } = options
 
   // Body is PNG binary from the browser exportToBlob result. Validate the PNG signature minimally.
-  app.put(
-    '/api/workspaces/:workspaceId/canvases/:slug/versions/:id/thumbnail',
-    bodyLimit({
-      maxSize: THUMBNAIL_UPLOAD_LIMIT_BYTES,
-      onError: (c) =>
-        c.json(
-          {
-            error: 'payload_too_large',
-            message: `Upload exceeds ${THUMBNAIL_UPLOAD_LIMIT_BYTES} bytes limit.`,
-          },
-          413,
-        ),
-    }),
-    async (c) => {
-      const { workspaceId, slug, id } = c.req.param()
+  onCanvasesRoute(
+    app,
+    'put',
+    ['versions', ':id', 'thumbnail'],
+    async (c, workspaceId, slug, params) => {
+      const id = params.id as string
       try {
-        validateWorkspaceId(workspaceId)
-        validateSlug(slug)
         validateVersionId(id)
       } catch (err) {
         const body = validationErrorBody(err)
@@ -62,47 +52,53 @@ export function createThumbnailsRouter(options: ThumbnailsRouterOptions) {
       }
       return c.json({ ok: true })
     },
+    {},
+    bodyLimit({
+      maxSize: THUMBNAIL_UPLOAD_LIMIT_BYTES,
+      onError: (c) =>
+        c.json(
+          {
+            error: 'payload_too_large',
+            message: `Upload exceeds ${THUMBNAIL_UPLOAD_LIMIT_BYTES} bytes limit.`,
+          },
+          413,
+        ),
+    }),
   )
 
   // Return the PNG with cache headers, or 404 if it has not been saved.
-  app.get('/api/workspaces/:workspaceId/canvases/:slug/versions/:id/thumbnail', async (c) => {
-    const { workspaceId, slug, id } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-      validateVersionId(id)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
-    try {
-      const bytes = await versionStore.loadThumbnail(workspaceId, id)
-      if (!bytes) return c.json({ error: 'not_found' }, 404)
-      return c.body(bytes.buffer as ArrayBuffer, 200, {
-        'Content-Type': 'image/png',
-        'Cache-Control': 'public, max-age=3600, immutable',
-      })
-    } catch (err) {
-      const issue = handleCorruptStoredData(err)
-      if (issue) return c.json(issue.body, issue.status)
-      throw err
-    }
-  })
+  onCanvasesRoute(
+    app,
+    'get',
+    ['versions', ':id', 'thumbnail'],
+    async (c, workspaceId, slug, params) => {
+      const id = params.id as string
+      try {
+        validateVersionId(id)
+      } catch (err) {
+        const body = validationErrorBody(err)
+        if (body) return c.json(body, 400)
+        throw err
+      }
+      try {
+        const bytes = await versionStore.loadThumbnail(workspaceId, id)
+        if (!bytes) return c.json({ error: 'not_found' }, 404)
+        return c.body(bytes.buffer as ArrayBuffer, 200, {
+          'Content-Type': 'image/png',
+          'Cache-Control': 'public, max-age=3600, immutable',
+        })
+      } catch (err) {
+        const issue = handleCorruptStoredData(err)
+        if (issue) return c.json(issue.body, issue.status)
+        throw err
+      }
+    },
+  )
 
   // Return the newest version thumbnail for canvas-switcher previews.
   // "Newest" means the first hasThumbnail=true entry in version list order (createdAt desc).
   // Keep max-age short (5 min) so fresh auto-save thumbnails replace cached ones promptly.
-  app.get('/api/workspaces/:workspaceId/canvases/:slug/latest-thumbnail', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'get', ['latest-thumbnail'], async (c, workspaceId, slug) => {
     try {
       const versions = await versionStore.list(workspaceId, slug)
       const latestWithThumb = versions.find((v) => v.hasThumbnail)

--- a/packages/mcp-server/src/server/routes/canvas/versions.ts
+++ b/packages/mcp-server/src/server/routes/canvas/versions.ts
@@ -9,6 +9,7 @@ import { getDoc } from '../../store/doc-cache.js'
 import type { OperatorInfo, VersionStore } from '../../store/version-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { defaultHumanDisplayName, handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 export interface VersionsRouterOptions {
   versionStore: VersionStore
@@ -22,16 +23,7 @@ export function createVersionsRouter(options: VersionsRouterOptions) {
   const { versionStore } = options
 
   // List versions for one canvas in reverse chronological order.
-  app.get('/api/workspaces/:workspaceId/canvases/:slug/versions', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'get', ['versions'], async (c, workspaceId, slug) => {
     try {
       const versions = await versionStore.list(workspaceId, slug)
       const response: ListVersionsResponse = { versions }
@@ -44,16 +36,7 @@ export function createVersionsRouter(options: VersionsRouterOptions) {
   })
 
   // Save a manual version with body { label?: string; operator?: OperatorInfo }. auto is false.
-  app.post('/api/workspaces/:workspaceId/canvases/:slug/versions', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json(body, 400)
-      throw err
-    }
+  onCanvasesRoute(app, 'post', ['versions'], async (c, workspaceId, slug) => {
     // Empty body is valid (no label / operator); a non-empty body must parse as
     // JSON and pass schema validation, otherwise return invalid_body.
     const rawText = await c.req.text()

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -22,6 +22,7 @@ import {
 } from '../../store/canvas-store.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
+import { onCanvasesRoute } from './path-route.js'
 
 // Names the specific field createCanvasRequestSchema rejected, instead of a
 // single message covering the whole request — a valid slug with an invalid
@@ -125,30 +126,27 @@ export function createWorkspacesRouter() {
   // Delete a canvas: row (branches/versions cascade via FK), .loro blob,
   // version thumbnails, and doc-cache entry. Idempotent-shaped 404 for a
   // missing canvas rather than a throw.
-  app.delete('/api/workspaces/:workspaceId/canvases/:slug', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json({ title: body.message }, 400)
-      throw err
-    }
-    try {
-      const deleted = await deleteCanvas(workspaceId, slug)
-      if (!deleted) {
-        return c.json({ title: `Canvas "${slug}" not found` }, 404)
+  onCanvasesRoute(
+    app,
+    'delete',
+    [],
+    async (c, workspaceId, slug) => {
+      try {
+        const deleted = await deleteCanvas(workspaceId, slug)
+        if (!deleted) {
+          return c.json({ title: `Canvas "${slug}" not found` }, 404)
+        }
+        const response: DeleteCanvasResponse = { ok: true }
+        return c.json(response)
+      } catch (err) {
+        const issue = handleCorruptStoredData(err)
+        if (issue) return c.json(issue.body, issue.status)
+        getLogger('canvas').error({ err: err as Error }, 'deleteCanvas failed unexpectedly')
+        return c.json({ title: 'Failed to delete canvas.' }, 500)
       }
-      const response: DeleteCanvasResponse = { ok: true }
-      return c.json(response)
-    } catch (err) {
-      const issue = handleCorruptStoredData(err)
-      if (issue) return c.json(issue.body, issue.status)
-      getLogger('canvas').error({ err: err as Error }, 'deleteCanvas failed unexpectedly')
-      return c.json({ title: 'Failed to delete canvas.' }, 500)
-    }
-  })
+    },
+    { badRequest: 'problem-details' },
+  )
 
   // Rename a canvas's slug in place: same canvasId, same branches/versions/blob,
   // just a new slug column. Old URLs carrying the old slug 404 by design — no
@@ -157,49 +155,46 @@ export function createWorkspacesRouter() {
   // Server-side foundation only: no MCP tool, CLI command, or apps/web
   // affordance calls this route yet. The apps/web slug-edit UI is a planned
   // follow-up, not dead code.
-  app.put('/api/workspaces/:workspaceId/canvases/:slug/slug', async (c) => {
-    const { workspaceId, slug } = c.req.param()
-    try {
-      validateWorkspaceId(workspaceId)
-      validateSlug(slug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json({ title: body.message }, 400)
-      throw err
-    }
-    const raw = await c.req.json().catch(() => null)
-    if (raw === null) {
-      return c.json({ title: 'JSON body required' }, 400)
-    }
-    const parsed = renameCanvasSlugRequestSchema.safeParse(raw)
-    if (!parsed.success) {
-      return c.json({ title: 'slug is required' }, 400)
-    }
-    const newSlug = parsed.data.slug
-    try {
-      validateSlug(newSlug)
-    } catch (err) {
-      const body = validationErrorBody(err)
-      if (body) return c.json({ title: body.message }, 400)
-      throw err
-    }
-    try {
-      const result = await renameCanvasSlug(workspaceId, slug, newSlug)
-      if (!result) {
-        return c.json({ title: `Canvas "${slug}" not found` }, 404)
+  onCanvasesRoute(
+    app,
+    'put',
+    ['slug'],
+    async (c, workspaceId, slug) => {
+      const raw = await c.req.json().catch(() => null)
+      if (raw === null) {
+        return c.json({ title: 'JSON body required' }, 400)
       }
-      const response: RenameCanvasSlugResponse = { slug: newSlug }
-      return c.json(response)
-    } catch (err) {
-      if (err instanceof ConflictError) {
-        return c.json({ title: `Canvas "${newSlug}" already exists` }, 409)
+      const parsed = renameCanvasSlugRequestSchema.safeParse(raw)
+      if (!parsed.success) {
+        return c.json({ title: 'slug is required' }, 400)
       }
-      const issue = handleCorruptStoredData(err)
-      if (issue) return c.json(issue.body, issue.status)
-      getLogger('canvas').error({ err: err as Error }, 'renameCanvasSlug failed unexpectedly')
-      return c.json({ title: 'Failed to rename canvas.' }, 500)
-    }
-  })
+      const newSlug = parsed.data.slug
+      try {
+        validateSlug(newSlug)
+      } catch (err) {
+        const body = validationErrorBody(err)
+        if (body) return c.json({ title: body.message }, 400)
+        throw err
+      }
+      try {
+        const result = await renameCanvasSlug(workspaceId, slug, newSlug)
+        if (!result) {
+          return c.json({ title: `Canvas "${slug}" not found` }, 404)
+        }
+        const response: RenameCanvasSlugResponse = { slug: newSlug }
+        return c.json(response)
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          return c.json({ title: `Canvas "${newSlug}" already exists` }, 409)
+        }
+        const issue = handleCorruptStoredData(err)
+        if (issue) return c.json(issue.body, issue.status)
+        getLogger('canvas').error({ err: err as Error }, 'renameCanvasSlug failed unexpectedly')
+        return c.json({ title: 'Failed to rename canvas.' }, 500)
+      }
+    },
+    { badRequest: 'problem-details' },
+  )
 
   return app
 }

--- a/packages/mcp-server/src/server/routes/ws-validation.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-validation.test.ts
@@ -20,6 +20,13 @@ function expectAllWsWarnings(records: LogRecord[]): void {
 }
 
 describe('parseWsTargetFromRequestUrl', () => {
+  it('takes a nested document path as plain slash segments', () => {
+    expect(parseWsTargetFromRequestUrl('/ws/ws-1/notes/2026/plan', '127.0.0.1:3099')).toEqual({
+      workspaceId: 'ws-1',
+      slug: 'notes/2026/plan',
+    })
+  })
+
   it('accepts validated workspaceId and encoded slug', () => {
     expect(parseWsTargetFromRequestUrl('/ws/sess-1/nested%2Fslug', '127.0.0.1:3099')).toEqual({
       workspaceId: 'sess-1',
@@ -36,12 +43,6 @@ describe('parseWsTargetFromRequestUrl', () => {
   it('rejects invalid slugs before websocket upgrade', () => {
     expect(() => parseWsTargetFromRequestUrl('/ws/sess-1/bad.slug', '127.0.0.1:3099')).toThrow(
       /Invalid slug/,
-    )
-  })
-
-  it('rejects unencoded extra path segments', () => {
-    expect(() => parseWsTargetFromRequestUrl('/ws/sess-1/nested/slug', '127.0.0.1:3099')).toThrow(
-      /Invalid websocket path/,
     )
   })
 

--- a/packages/mcp-server/src/server/routes/ws-validation.ts
+++ b/packages/mcp-server/src/server/routes/ws-validation.ts
@@ -10,17 +10,20 @@ export function parseWsTargetFromRequestUrl(
 ): { workspaceId: string; slug: string } {
   const url = new URL(rawUrl ?? '/', `http://${host}`)
   const parts = url.pathname.split('/')
-  if (parts.length !== 4 || parts[1] !== 'ws') {
+  // The tail is a document path, so anything from one segment up is valid —
+  // /ws/:workspaceId/<path...>. Each segment decodes separately; the
+  // separators are structure, not data.
+  if (parts.length < 4 || parts[1] !== 'ws') {
     throw new ValidationError(
       'invalid_ws_path',
-      `Invalid websocket path "${url.pathname}": expected /ws/:workspaceId/:slug`,
+      `Invalid websocket path "${url.pathname}": expected /ws/:workspaceId/<document path>`,
     )
   }
 
   const workspaceId = validateWorkspaceId(parts[2] ?? '')
   let slug = ''
   try {
-    slug = decodeURIComponent(parts[3] ?? '')
+    slug = parts.slice(3).map(decodeURIComponent).join('/')
   } catch {
     throw new ValidationError('invalid_slug', `Invalid slug in websocket path "${url.pathname}"`)
   }

--- a/packages/mcp-server/src/shared/api-contracts/canvas-url.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas-url.ts
@@ -29,6 +29,17 @@ export function canvasFileApiUrl(workspaceId: string, path: string, fileId: stri
 }
 
 /**
+ * The `/api/workspaces/:workspaceId/canvases/<document path>[/<suffix...>]`
+ * family (create/list/delete/rename/name/pin/versions/thumbnails/restore/
+ * compact). Same rule as canvasApiUrl: each path segment is encoded, the
+ * separators are not, and any suffix is appended verbatim.
+ */
+export function canvasesApiUrl(workspaceId: string, path: string, suffix = ''): string {
+  const base = `/api/workspaces/${encodeURIComponent(workspaceId)}/canvases/${encodeCanvasPath(path)}`
+  return suffix === '' ? base : `${base}/${suffix}`
+}
+
+/**
  * Splits a request path in the shape above into its parts, or null when it
  * is not one. Written by hand rather than as a Hono `{.+}` param: Hono's
  * SmartRouter picks its underlying router on the FIRST request, and with the

--- a/packages/mcp-server/src/shared/ws-protocol.ts
+++ b/packages/mcp-server/src/shared/ws-protocol.ts
@@ -26,7 +26,7 @@ export function buildWhiteboardWsUrl(
 ): string {
   const url = new URL(locationHref)
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
-  url.pathname = `/ws/${workspaceId}/${encodeURIComponent(slug)}`
+  url.pathname = `/ws/${workspaceId}/${slug.split('/').map(encodeURIComponent).join('/')}`
   url.search = ''
   url.hash = ''
   return url.toString()


### PR DESCRIPTION
The second and last slug-addressed family, following #805: everything under
`/api/workspaces/:workspaceId/canvases/:slug[/...]` — delete, rename, name,
pin, versions, thumbnails, restore, compact, branches, head — plus the
`/ws/:workspaceId/:slug` upgrade path, now takes a **nested document path**.

With this, every operation the UI offers works on a document the index can
address; the remaining UI step (widening `/w/:ws/canvas/*`'s tail) has no
server dependency left.

## How

Same wildcard dispatch as #805 (the Hono `:slug` param was the only blocker;
the SmartRouter first-request trap rules out `{.+}` params), generalised to
**multi-segment suffix patterns matched from the end** —
`['versions', ':id', 'thumbnail']` — which keeps nested paths unambiguous:
`a/versions/versions` is the versions listing of the document `a/versions`,
pinned by test. Two 400 shapes coexist on this surface (legacy
`{error,message}` vs Problem Details `{title}` on delete/rename, both pinned
by existing tests), so the dispatcher takes which one to speak per route.

Clients build these URLs through one new contract function
(`canvasesApiUrl`): **nine apps/web call sites** had each hand-rolled the
shape with `encodeURIComponent` over the whole slug — exactly the
per-segment-vs-whole-string drift the contract module exists to prevent.
Three thumbnail tests pinned that old whole-string encoding and are updated
to the segment contract. The WS client builder encodes per segment the same
way.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm knip`, mcp-node (3,376), apps/web
jsdom (2,143 + 75) all green. One canvas.test.ts scenario drives the whole
family against `notes/2026/plan` end to end, so a regression in ANY member is
loud; ws-validation pins the nested upgrade path.

Against the **real daemon**:

```
create notes/2026/plan → {"slug":"notes/2026/plan"}
PUT  .../name                       → 200
POST .../versions                   → id VrcsG8jVfhFK
GET  .../versions                   → 200
POST .../versions/<id>/restore      → 200
GET  .../branches                   → {"branches":[{"name":"main",...
PUT  .../slug {notes/2027/plan}     → {"slug":"notes/2027/plan"}
DELETE at the renamed nested path   → {"ok":true}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3
