### PR TITLE
feat(web): let the canvas URL carry a nested document path

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -63,10 +63,9 @@ Not a work queue — a lookup, so you can recognise one when you open a file.
 - The `@kamiazya/whiteboard-canvas-{model,codec,render,ports,workspace,viewer}`
   package names — `render` and `viewer` are arguably correct (they are about
   the spatial scene); `model`, `codec`, `ports` and `workspace` are not
-- `/w/:ws/canvas/:slug` and `/local/:canvasId` routes, and the UI copy around
-  them. The UI tail is still one segment, but the data path under it
-  (`/api/w/:ws/canvas/<path>/*`) now takes a document path — widening the UI
-  regex is the remaining step
+- `/local/:canvasId` and the UI copy around routes. The daemon URL is now
+  `/w/:ws/canvas/<document path>` end to end; what remains is internal
+  variable names still saying `slug` for what is a path
 - MCP tool names — ADR-0009 point 5, its own increment
 - Core facets written to spatial documents (`CanvasProperties` mounted for
   both kinds) — this one is a behaviour change, not a rename; see ADR-0009

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -858,6 +858,15 @@ describe('App URL routing', () => {
     expect(receivedDaemonPageProps?.slug).toBe('main')
   })
 
+  it('cold-loads a NESTED document path deep link, slug intact', async () => {
+    // The tail is the document's path since the data layer converged on
+    // paths; the page must receive it verbatim, separators and all.
+    renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/canvas/notes/2026/plan')
+    expect(await screen.findByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
+    expect(receivedDaemonPageProps?.slug).toBe('notes/2026/plan')
+  })
+
   it('cold-loads a /w/:workspaceId deep link into the gallery pre-scoped to that workspace', async () => {
     renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/workspace-b')
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()

--- a/apps/web/src/lib/app-routes.test.ts
+++ b/apps/web/src/lib/app-routes.test.ts
@@ -26,8 +26,8 @@ describe('app-routes', () => {
     expect(canvasPath('w1', 'main')).toBe('/w/w1/canvas/main')
   })
 
-  it('percent-encodes the workspace and the slug', () => {
-    expect(canvasPath('w 1', 'my/slug')).toBe('/w/w%201/canvas/my%2Fslug')
+  it('percent-encodes the workspace, and the slug per segment', () => {
+    expect(canvasPath('w 1', 'my/slug')).toBe('/w/w%201/canvas/my/slug')
     expect(workspacePath('w/1')).toBe('/w/w%2F1')
   })
 
@@ -54,20 +54,35 @@ describe('parseDaemonRoute', () => {
     })
   })
 
-  it('decodes percent-encoded segments', () => {
-    expect(parseDaemonRoute('/w/w%201/canvas/my%2Fslug')).toEqual({
+  it('accepts a multi-segment document path as the tail', () => {
+    // The whole point of the shape: a document's path IS the URL's tail, one
+    // URL segment per path segment, so the hierarchy the workspace shows is
+    // the hierarchy the address bar shows. The data path below has been able
+    // to load these since the canvases family took paths.
+    expect(parseDaemonRoute('/w/w1/canvas/notes/2026/plan')).toEqual({
       kind: 'canvas',
-      workspaceId: 'w 1',
-      slug: 'my/slug',
+      workspaceId: 'w1',
+      slug: 'notes/2026/plan',
     })
   })
 
-  it('does not yet accept a multi-segment tail', () => {
-    // The shape leaves room for a document path here, but the page below
-    // still loads by a single-segment slug — a URL the
-    // app cannot open is worse than a not-found, so it stays not-a-route
-    // until that data path converges too.
-    expect(parseDaemonRoute('/w/w1/canvas/notes/2026/plan')).toBeNull()
+  it('round-trips a nested path through daemonRoutePath', () => {
+    expect(daemonRoutePath({ kind: 'canvas', workspaceId: 'w1', slug: 'notes/2026/plan' })).toEqual(
+      '/w/w1/canvas/notes/2026/plan',
+    )
+  })
+
+  it('decodes each tail segment separately, keeping the separators', () => {
+    expect(parseDaemonRoute('/w/w1/canvas/a%20b/c%20d')).toEqual({
+      kind: 'canvas',
+      workspaceId: 'w1',
+      slug: 'a b/c d',
+    })
+    expect(canvasPath('w1', 'a b/c d')).toBe('/w/w1/canvas/a%20b/c%20d')
+  })
+
+  it('treats a malformed segment anywhere in the tail as not-a-route', () => {
+    expect(parseDaemonRoute('/w/w1/canvas/ok/ma%in')).toBeNull()
   })
 
   it('is not confused by the workspace-index route it now nests under', () => {

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -13,11 +13,13 @@ export function workspacePath(workspaceId: string): string {
   return `/w/${encodeURIComponent(workspaceId)}`
 }
 
-// Nested under the workspace it belongs to, so the URL reads as placement
-// rather than as two unrelated ids. The tail is one encoded segment: the
-// page below still loads by slug, so a document path cannot go here yet.
+// Nested under the workspace it belongs to, so the URL reads as placement.
+// The tail is the document's path, one URL segment per path segment: each
+// segment is encoded, the separators are not — encoding them would collapse
+// the hierarchy the workspace shows into one opaque URL segment.
 export function canvasPath(workspaceId: string, slug: string): string {
-  return `${workspacePath(workspaceId)}/canvas/${encodeURIComponent(slug)}`
+  const tail = slug.split('/').map(encodeURIComponent).join('/')
+  return `${workspacePath(workspaceId)}/canvas/${tail}`
 }
 
 export function browserLocalIndexPath(): string {
@@ -40,12 +42,14 @@ export function parseDaemonRoute(pathname: string): DaemonRoute | null {
   // The canvas branch is checked first: `/w/:ws` and `/w/:ws/canvas/...`
   // share a prefix, and the workspace pattern below is anchored so it cannot
   // swallow a canvas URL either way.
-  const canvasMatch = pathname.match(/^\/w\/([^/]+)\/canvas\/([^/]+)\/?$/)
+  const canvasMatch = pathname.match(/^\/w\/([^/]+)\/canvas\/(.+?)\/?$/)
   if (canvasMatch) {
     const workspaceId = decodeSegment(canvasMatch[1])
-    const slug = decodeSegment(canvasMatch[2])
-    if (workspaceId === null || slug === null) return null
-    return { kind: 'canvas', workspaceId, slug }
+    const segments = (canvasMatch[2] as string).split('/').map(decodeSegment)
+    if (workspaceId === null || segments.some((segment) => segment === null || segment === '')) {
+      return null
+    }
+    return { kind: 'canvas', workspaceId, slug: segments.join('/') }
   }
   const workspaceMatch = pathname.match(/^\/w\/([^/]+)\/?$/)
   if (workspaceMatch) {


### PR DESCRIPTION
The last slice of the path convergence (task #33). `/w/:workspaceId/canvas/*`'s
tail widens from one segment to the **document's path** — one URL segment per
path segment, each decoded separately, a malformed segment anywhere making the
whole URL not-a-route rather than a crash.

The single-segment refusal this replaces was deliberate and pinned by a test
("a URL the app cannot open is worse than a not-found"). With #805 (live-canvas
API) and #809 (canvases family + WS) the entire data path below loads by
document path, so the reason is gone and the pin flips to the wide contract in
the same diff.

`App.test.tsx` cold-loads `/w/w1/canvas/notes/2026/plan` into the real app and
asserts `DaemonCanvasPage` receives the path verbatim, separators and all —
the end-to-end routing behaviour, not just the parser.

With this, the address a document gets in the UI, the live-canvas API, the
canvases management API, and the WS upgrade are all the same shape:
**workspace first, then the document's path.**

Verification: `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`, apps/web jsdom
(2,146 + 75) green; app-routes suite 28/28 including the new nested/round-trip/
decode/malformed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3
