### PR TITLE
fix(server): stop legacy rows breaking or hiding documents

### DIFF
--- a/packages/canvas-ports/src/document-index.ts
+++ b/packages/canvas-ports/src/document-index.ts
@@ -10,7 +10,12 @@ export const documentEntrySchema = z
   .object({
     canvasId: canvasIdSchema,
     path: documentPathSchema,
-    kind: canvasKindSchema,
+    // Optional: a document created before kinds existed has a placement and
+    // content but no recorded format. It must still LIST — hiding stored data
+    // is the dishonest surface — and the read path is where "format unknown"
+    // is said (wb_document_get refuses such a document with advice).
+    // createDocument's input keeps `kind` required; only pre-kind rows lack it.
+    kind: canvasKindSchema.optional(),
     /**
      * What a human reads, as opposed to `path`, which is an address. Absent
      * rather than defaulted to the last path segment: a reader that wants

--- a/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.test.ts
@@ -1,0 +1,136 @@
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+import { migration as migration0001 } from './0001-init.js'
+import { migration as migration0002 } from './0002-canvases-last-compacted-at.js'
+import { migration as migration0003 } from './0003-canvas-doc-store.js'
+import { migration as migration0005 } from './0005-canvases-kind.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const { migration } = await import('./0008-ulid-legacy-canvas-ids.js')
+
+const ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+async function createMemoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  await migration0001.up(db as unknown as Kysely<unknown>)
+  await migration0002.up(db as unknown as Kysely<unknown>)
+  await migration0003.up(db as unknown as Kysely<unknown>)
+  await migration0005.up(db as unknown as Kysely<unknown>)
+  return db
+}
+
+async function seed(db: Kysely<DatabaseSchema>, id: string, slug: string) {
+  await db
+    .insertInto('workspaces')
+    .values({ id: 'ws-1', createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+  await db
+    .insertInto('canvases')
+    .values({
+      id,
+      workspaceId: 'ws-1',
+      slug,
+      displayName: null,
+      isPinned: 0,
+      pinOrder: null,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+      kind: 'spatial',
+    })
+    .execute()
+  await db
+    .insertInto('branches')
+    .values({ canvasId: id, name: 'main', tipFrontiers: '', color: null, createdAt: 0 })
+    .execute()
+  await db
+    .insertInto('versions')
+    .values({
+      id: `v-${slug}`,
+      canvasId: id,
+      branchName: 'main',
+      auto: 0,
+      operatorKind: 'human',
+      operatorPeerId: 'p-1',
+      operatorDisplayName: 'seed',
+      elementCount: 0,
+      frontiers: '',
+      hasThumbnail: 0,
+      createdAt: 0,
+    })
+    .execute()
+}
+
+describe('0008-ulid-legacy-canvas-ids', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'whiteboard-0008-'))
+  })
+
+  it('rewrites a nanoid row to a fresh ULID, carrying versions, branches, and the blob', async () => {
+    const db = await createMemoryDb()
+    await seed(db, 'uH6qTx6Ai2hl', 'legacy-doc')
+    const blobDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([1, 2, 3]))
+
+    await migration.up(db as unknown as Kysely<unknown>)
+
+    const row = await db
+      .selectFrom('canvases')
+      .selectAll()
+      .where('slug', '=', 'legacy-doc')
+      .executeTakeFirstOrThrow()
+    expect(row.id).toMatch(ULID)
+
+    const version = await db.selectFrom('versions').selectAll().executeTakeFirstOrThrow()
+    expect(version.canvasId).toBe(row.id)
+    const branch = await db.selectFrom('branches').selectAll().executeTakeFirstOrThrow()
+    expect(branch.canvasId).toBe(row.id)
+
+    expect(await readdir(blobDir)).toEqual([`${row.id}.loro`])
+  })
+
+  it('leaves ULID rows byte-identical and is idempotent', async () => {
+    const db = await createMemoryDb()
+    await seed(db, '01ARZ3NDEKTSV4RRFFQ69G5FAV', 'modern-doc')
+
+    await migration.up(db as unknown as Kysely<unknown>)
+    await migration.up(db as unknown as Kysely<unknown>)
+
+    const row = await db.selectFrom('canvases').selectAll().executeTakeFirstOrThrow()
+    expect(row.id).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+  })
+
+  it('survives a missing blob file rather than failing bootstrap', async () => {
+    // A row can outlive its blob (a crashed delete, a hand-pruned data dir).
+    // The id rewrite is still worth doing — the row is what darkens the
+    // listing — and a migration that throws turns startup into an outage.
+    const db = await createMemoryDb()
+    await seed(db, 'Go1G4OcJKUBu', 'blobless-doc')
+
+    await migration.up(db as unknown as Kysely<unknown>)
+
+    const row = await db.selectFrom('canvases').selectAll().executeTakeFirstOrThrow()
+    expect(row.id).toMatch(ULID)
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.ts
@@ -1,0 +1,92 @@
+import { rename } from 'node:fs/promises'
+import { join } from 'node:path'
+import { generateCanvasId } from '@kamiazya/whiteboard-canvas-model'
+import type { Kysely } from 'kysely'
+import { getDataDir } from '../../../config.js'
+import { getLogger } from '../../../log.js'
+
+// The id spaces converged on the ULID (ADR-0007 decision 5): the port's
+// DocumentEntry accepts nothing else, and since the index reads `canvases`
+// directly a nanoid row reaches every agent-facing caller. listDocuments
+// skips such rows with a warning so one of them cannot darken a whole
+// listing — this migration is what empties that skip: each pre-convergence
+// row gets a fresh ULID, and everything keyed on the old id moves with it
+// in the same transaction (versions and branches carry a foreign key onto
+// canvases.id, so the parent and children cannot move separately).
+//
+// The `.loro` blob under blobs/<workspaceId>/canvas/ is named by the id, so
+// it is renamed too — after the row updates, because a missing blob must not
+// fail bootstrap (a row can outlive its blob: a crashed delete, a
+// hand-pruned data dir), while a renamed blob with an un-renamed row WOULD
+// be an outage. fs is fine here: migrations are composition-root code.
+
+interface CanvasRow {
+  id: string
+  workspaceId: string
+  slug: string
+  displayName: string | null
+  isPinned: number
+  pinOrder: number | null
+  currentBranch: string
+  createdAt: number
+  updatedAt: number
+  lastCompactedAt: number | null
+  kind: string | null
+}
+
+const CANONICAL_ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+export const migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    const tdb = db as Kysely<{
+      canvases: CanvasRow
+      versions: { canvasId: string }
+      branches: { canvasId: string }
+    }>
+    const log = getLogger('migration-0008')
+
+    const rows = await tdb.selectFrom('canvases').selectAll().execute()
+    const legacy = rows.filter((row) => !CANONICAL_ULID.test(row.id))
+    if (legacy.length === 0) return
+
+    for (const row of legacy) {
+      const newId = generateCanvasId()
+      // Insert-new / repoint-children / delete-old / claim-the-slug, in that
+      // order: every step satisfies the children's foreign keys AND the
+      // (workspaceId, slug) unique index on its own, so this needs no
+      // deferral and holds whether or not the migration runner wrapped us in
+      // a transaction. The new row borrows its own id as a slug until the
+      // old row is gone — the id is unique by construction.
+      await tdb
+        .insertInto('canvases')
+        .values({ ...row, id: newId, slug: newId })
+        .execute()
+      await tdb
+        .updateTable('versions')
+        .set({ canvasId: newId })
+        .where('canvasId', '=', row.id)
+        .execute()
+      await tdb
+        .updateTable('branches')
+        .set({ canvasId: newId })
+        .where('canvasId', '=', row.id)
+        .execute()
+      await tdb.deleteFrom('canvases').where('id', '=', row.id).execute()
+      await tdb.updateTable('canvases').set({ slug: row.slug }).where('id', '=', newId).execute()
+
+      const blobDir = join(getDataDir(), 'blobs', row.workspaceId, 'canvas')
+      try {
+        await rename(join(blobDir, `${row.id}.loro`), join(blobDir, `${newId}.loro`))
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+        log.warning(
+          { workspaceId: row.workspaceId, oldId: row.id },
+          'pre-convergence row had no blob to move',
+        )
+      }
+    }
+  },
+  async down(): Promise<void> {
+    // The nanoid is gone and nothing can want it back.
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -6,6 +6,7 @@ import { migration as workspaceIndex } from './0004-workspace-index.js'
 import { migration as canvasesKind } from './0005-canvases-kind.js'
 import { migration as dropWorkspaceIndex } from './0006-drop-workspace-index.js'
 import { migration as adoptWorkspaceTree } from './0007-adopt-workspace-tree.js'
+import { migration as ulidLegacyCanvasIds } from './0008-ulid-legacy-canvas-ids.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0002-canvases-last-compacted-at is a no-op kept only so databases created by the
@@ -18,4 +19,5 @@ export const migrations: Record<string, Migration> = {
   '0005-canvases-kind': canvasesKind,
   '0006-drop-workspace-index': dropWorkspaceIndex,
   '0007-adopt-workspace-tree': adoptWorkspaceTree,
+  '0008-ulid-legacy-canvas-ids': ulidLegacyCanvasIds,
 }

--- a/packages/mcp-server/src/server/store/db/migrator.legacy-upgrade.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrator.legacy-upgrade.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { expect, it, vi } from 'vitest'
+
+let dataDir = ''
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const { runMigrations } = await import('./migrator.js')
+const ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+it('the REAL migrator upgrades a pre-0008 data dir: nanoid row -> ULID, blob follows', async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'wb-boot-verify-'))
+  const dbPath = join(dataDir, 'whiteboard.db')
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(dbPath) as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  // Run every migration once (fresh dir, 0008 no-ops), then rewind ONLY the
+  // 0008 log entry and inject the legacy state — exactly the shape a real
+  // pre-upgrade data dir presents at next boot.
+  await runMigrations(db as never)
+  await sql`DELETE FROM kysely_migration WHERE name = '0008-ulid-legacy-canvas-ids'`.execute(db)
+  await db.insertInto('workspaces').values({ id: 'ws-boot', createdAt: 0, updatedAt: 0 }).execute()
+  await db
+    .insertInto('canvases')
+    .values({
+      id: 'uH6qTx6Ai2hl',
+      workspaceId: 'ws-boot',
+      slug: 'legacy',
+      isPinned: 0,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+      kind: 'spatial',
+    })
+    .execute()
+  const blobDir = join(dataDir, 'blobs', 'ws-boot', 'canvas')
+  await mkdir(blobDir, { recursive: true })
+  await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([9]))
+
+  await runMigrations(db as never)
+
+  const row = (await db.selectFrom('canvases').selectAll().executeTakeFirstOrThrow()) as {
+    id: string
+  }
+  expect(row.id).toMatch(ULID)
+  expect(await readdir(blobDir)).toEqual([`${row.id}.loro`])
+  await db.destroy()
+})

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -18,4 +18,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0005-canvases-kind',
   '0006-drop-workspace-index',
   '0007-adopt-workspace-tree',
+  '0008-ulid-legacy-canvas-ids',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -126,3 +126,66 @@ describe('rows written before canvasIds were ULIDs', () => {
     })
   })
 })
+
+describe('rows written before documents had a kind', () => {
+  // A document created before `kind` existed has bytes on disk and a row in
+  // `canvases`, but kind IS NULL. Hiding it from every listing while its
+  // content sits on disk is the same dishonest surface a 200-empty workspace
+  // was: the row must surface — without a kind — and the READ path is where
+  // "format unknown" is said (wb_document_get already refuses one with
+  // advice, rather than the listing pretending it does not exist).
+  async function withKindlessRow(
+    body: (index: SqliteDocumentIndex, canvasId: string) => Promise<void>,
+  ): Promise<void> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-kindless-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    const canvasId = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    try {
+      await handle.db
+        .insertInto('workspaces')
+        .values({ id: 'ws-k', createdAt: 0, updatedAt: 0 })
+        .execute()
+      await handle.db
+        .insertInto('canvases')
+        .values({
+          id: canvasId,
+          workspaceId: 'ws-k',
+          slug: 'pre-kind-doc',
+          displayName: 'Old diagram',
+          isPinned: 0,
+          pinOrder: null,
+          currentBranch: 'main',
+          createdAt: 0,
+          updatedAt: 0,
+          kind: null,
+        })
+        .execute()
+      await body(new SqliteDocumentIndex(handle.db), canvasId)
+    } finally {
+      await handle.dispose()
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+
+  it('lists the document, without a kind, and the entry satisfies the schema', async () => {
+    await withKindlessRow(async (index) => {
+      const entries = await index.listDocuments({ workspaceId: 'ws-k' })
+      expect(entries.map((entry) => entry.path)).toContain('pre-kind-doc')
+      const entry = entries.find((candidate) => candidate.path === 'pre-kind-doc')
+      expect(entry?.kind).toBeUndefined()
+      expect(entry?.name).toBe('Old diagram')
+      expect(documentEntrySchema.safeParse(entry).success).toBe(true)
+    })
+  })
+
+  it('resolves the document by id and by path', async () => {
+    await withKindlessRow(async (index, canvasId) => {
+      const byId = await index.resolveDocumentById({ workspaceId: 'ws-k', canvasId })
+      expect(byId?.path).toBe('pre-kind-doc')
+      expect(byId?.kind).toBeUndefined()
+
+      const byPath = await index.resolveDocument({ workspaceId: 'ws-k', path: 'pre-kind-doc' })
+      expect(byPath?.canvasId).toBe(canvasId)
+    })
+  })
+})

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -38,7 +38,7 @@ function toEntry(row: {
   return {
     canvasId: row.id,
     path: row.slug,
-    kind: row.kind as DocumentEntry['kind'],
+    ...(row.kind === null ? {} : { kind: row.kind as DocumentEntry['kind'] }),
     ...(row.displayName === null ? {} : { name: row.displayName }),
   }
 }
@@ -130,7 +130,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
       .where('workspaceId', '=', workspaceId)
       .where('slug', '=', path)
       .executeTakeFirst()
-    if (!row?.kind) return null
+    if (!row) return null
     return toEntry(row)
   }
 
@@ -144,7 +144,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
       .where('workspaceId', '=', workspaceId)
       .where('id', '=', canvasId)
       .executeTakeFirst()
-    if (!row?.kind) return null
+    if (!row) return null
     return toEntry(row)
   }
 
@@ -187,7 +187,6 @@ export class SqliteDocumentIndex implements DocumentIndex {
     // user's gallery), and the log is where the absence is said.
     const entries: DocumentEntry[] = []
     for (const row of rows) {
-      if (row.kind === null) continue
       if (!canvasIdSchema.safeParse(row.id).success) {
         log.warning(
           { workspaceId, slug: row.slug },


### PR DESCRIPTION
Closes task #36 — both halves of the legacy-row honesty gap found while
confirming the #795 regression, each pinned red-first.

## 1. Kind-less rows list again

A document created before `kind` existed had bytes on disk and a row in
`canvases`, and appeared in **no listing** — the same dishonest surface a
200-empty workspace was (#798). Locally this hid a 75-node diagram.

`documentEntrySchema.kind` becomes optional — on the **entry only**;
`createDocument`'s input keeps it required, so only pre-kind rows lack one.
The sqlite index lists and resolves such rows without a kind, and the READ
path stays where "format unknown" is said: `wb_document_get` already refuses
one with advice (#746/#747). A patch on such a document now fails with the
kind-level error naming what it is, rather than a false "not found".

Mutation-checked: reinstating the skip turns the listing test red. No MCP
output drift: neither the list nor resolve tool output carries `kind`.

## 2. Migration 0008 retires pre-ULID ids

The rows that originally made `wb_document_list` fail output validation
outright get fresh ULIDs at bootstrap, with everything keyed on the old id
moving in step: `versions`/`branches` (foreign keys onto `canvases.id`) and
the `.loro` blob (named by the id).

Sequencing was where the bugs lived, and each one is in the migration's
comments:

- **No `PRAGMA defer_foreign_keys`** — it does not survive autocommit, which
  is exactly how the first shape failed. Instead: insert-new →
  repoint-children → delete-old → claim-the-slug, every step individually
  valid under both the foreign keys and the `(workspaceId, slug)` unique
  index (the new row borrows its own id as a slug until the old row is gone).
- **A missing blob logs and continues** — a row can outlive its blob, and a
  migration that throws turns startup into an outage. A renamed blob with an
  un-renamed row *would* be one, so the row moves first.
- #801's `listDocuments` skip stays as the net beneath this migration.

`migrator.legacy-upgrade.test.ts` drives the **real migrator** over a
pre-0008 data dir (full migration log minus 0008, nanoid row, blob on disk)
and asserts the boot path comes out ULID-only with the blob moved — the
actual upgrade a user's daemon performs, not just the migration function.

## Verification

mcp-node (3,381) + server-core + canvas-ports (3,764 total), `pnpm lint`,
`pnpm knip`, `pnpm -r typecheck`, `pnpm smoke:e2e` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic migration of legacy canvas IDs to ULIDs, including related branches, versions, and blob filenames.
  - Preserved existing canvas slugs during ID migration.
  - Added compatibility for legacy documents without a recorded canvas kind.

- **Bug Fixes**
  - Legacy documents can now be listed and resolved by ID or path.
  - Missing blob files no longer prevent canvas ID migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->