### PR TITLE
fix(server): unwind completed blob renames when migration 0008 fails midway

### DIFF
--- a/packages/mcp-server/src/server/store/db/migrations/0008-rename-compensation.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0008-rename-compensation.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+import { migration as migration0001 } from './0001-init.js'
+import { migration as migration0002 } from './0002-canvases-last-compacted-at.js'
+import { migration as migration0003 } from './0003-canvas-doc-store.js'
+import { migration as migration0005 } from './0005-canvases-kind.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+// Controllable rename failure: the N-th rename call throws EACCES.
+let failOnRenameCall = Infinity
+let renameCalls = 0
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...real,
+    rename: async (from: string, to: string) => {
+      renameCalls += 1
+      if (renameCalls === failOnRenameCall) {
+        const err = new Error('EACCES: injected') as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      return real.rename(from, to)
+    },
+  }
+})
+
+const { migration } = await import('./0008-ulid-legacy-canvas-ids.js')
+
+async function createMemoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  await migration0001.up(db as unknown as Kysely<unknown>)
+  await migration0002.up(db as unknown as Kysely<unknown>)
+  await migration0003.up(db as unknown as Kysely<unknown>)
+  await migration0005.up(db as unknown as Kysely<unknown>)
+  return db
+}
+
+async function seed(db: Kysely<DatabaseSchema>, id: string, slug: string) {
+  await db
+    .insertInto('workspaces')
+    .values({ id: 'ws-1', createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+  await db
+    .insertInto('canvases')
+    .values({
+      id,
+      workspaceId: 'ws-1',
+      slug,
+      displayName: null,
+      isPinned: 0,
+      pinOrder: null,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+      kind: 'spatial',
+    })
+    .execute()
+}
+
+describe('0008 blob-rename compensation', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'whiteboard-0008-comp-'))
+    renameCalls = 0
+    failOnRenameCall = Infinity
+  })
+
+  it('renames completed blobs BACK before rethrowing, so a rolled-back DB matches the disk', async () => {
+    // The migrator wraps up() in a transaction: a throw rolls the DB back to
+    // nanoid ids. A blob already renamed to a fresh ULID would then be
+    // orphaned forever — the ULID is regenerated on the next attempt, so
+    // nothing could ever find it again. The compensating renames put the
+    // disk back too, making the migration safe to retry.
+    const db = await createMemoryDb()
+    await seed(db, 'aaaaaaaaaaaa', 'doc-a')
+    await seed(db, 'bbbbbbbbbbbb', 'doc-b')
+    const blobDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, 'aaaaaaaaaaaa.loro'), new Uint8Array([1]))
+    await writeFile(join(blobDir, 'bbbbbbbbbbbb.loro'), new Uint8Array([2]))
+
+    failOnRenameCall = 2
+
+    await expect(migration.up(db as unknown as Kysely<unknown>)).rejects.toThrow(/EACCES/)
+
+    // Row A\'s blob was renamed on call 1, then renamed BACK when call 2
+    // failed: the disk carries exactly the nanoid names the rolled-back DB
+    // expects.
+    expect((await readdir(blobDir)).sort()).toEqual(['aaaaaaaaaaaa.loro', 'bbbbbbbbbbbb.loro'])
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0008-ulid-legacy-canvas-ids.ts
@@ -49,40 +49,71 @@ export const migration = {
     const legacy = rows.filter((row) => !CANONICAL_ULID.test(row.id))
     if (legacy.length === 0) return
 
-    for (const row of legacy) {
-      const newId = generateCanvasId()
-      // Insert-new / repoint-children / delete-old / claim-the-slug, in that
-      // order: every step satisfies the children's foreign keys AND the
-      // (workspaceId, slug) unique index on its own, so this needs no
-      // deferral and holds whether or not the migration runner wrapped us in
-      // a transaction. The new row borrows its own id as a slug until the
-      // old row is gone — the id is unique by construction.
-      await tdb
-        .insertInto('canvases')
-        .values({ ...row, id: newId, slug: newId })
-        .execute()
-      await tdb
-        .updateTable('versions')
-        .set({ canvasId: newId })
-        .where('canvasId', '=', row.id)
-        .execute()
-      await tdb
-        .updateTable('branches')
-        .set({ canvasId: newId })
-        .where('canvasId', '=', row.id)
-        .execute()
-      await tdb.deleteFrom('canvases').where('id', '=', row.id).execute()
-      await tdb.updateTable('canvases').set({ slug: row.slug }).where('id', '=', newId).execute()
+    // A blob rename is the one step here a transaction cannot roll back. If
+    // a LATER row fails, the migrator rolls the DB back to nanoid ids — and
+    // a blob already renamed to a fresh ULID would be orphaned FOREVER,
+    // because the ULID is regenerated on the next attempt and nothing could
+    // ever find it again. So every completed rename is recorded, and on any
+    // failure they are renamed BACK (best effort, loudly) before the error
+    // propagates: the disk then matches the rolled-back DB and the
+    // migration is safe to retry.
+    const completedRenames: { from: string; to: string }[] = []
+    try {
+      await rewriteLegacyRows()
+    } catch (err) {
+      for (const done of completedRenames.reverse()) {
+        try {
+          await rename(done.to, done.from)
+        } catch (undoErr) {
+          log.error(
+            { from: done.to, to: done.from, err: undoErr },
+            'could not undo a blob rename while unwinding — reconcile by hand',
+          )
+        }
+      }
+      throw err
+    }
+    return
 
-      const blobDir = join(getDataDir(), 'blobs', row.workspaceId, 'canvas')
-      try {
-        await rename(join(blobDir, `${row.id}.loro`), join(blobDir, `${newId}.loro`))
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-        log.warning(
-          { workspaceId: row.workspaceId, oldId: row.id },
-          'pre-convergence row had no blob to move',
-        )
+    async function rewriteLegacyRows(): Promise<void> {
+      for (const row of legacy) {
+        const newId = generateCanvasId()
+        // Insert-new / repoint-children / delete-old / claim-the-slug, in that
+        // order: every step satisfies the children's foreign keys AND the
+        // (workspaceId, slug) unique index on its own, so this needs no
+        // deferral and holds whether or not the migration runner wrapped us in
+        // a transaction. The new row borrows its own id as a slug until the
+        // old row is gone — the id is unique by construction.
+        await tdb
+          .insertInto('canvases')
+          .values({ ...row, id: newId, slug: newId })
+          .execute()
+        await tdb
+          .updateTable('versions')
+          .set({ canvasId: newId })
+          .where('canvasId', '=', row.id)
+          .execute()
+        await tdb
+          .updateTable('branches')
+          .set({ canvasId: newId })
+          .where('canvasId', '=', row.id)
+          .execute()
+        await tdb.deleteFrom('canvases').where('id', '=', row.id).execute()
+        await tdb.updateTable('canvases').set({ slug: row.slug }).where('id', '=', newId).execute()
+
+        const blobDir = join(getDataDir(), 'blobs', row.workspaceId, 'canvas')
+        const from = join(blobDir, `${row.id}.loro`)
+        const to = join(blobDir, `${newId}.loro`)
+        try {
+          await rename(from, to)
+          completedRenames.push({ from, to })
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+          log.warning(
+            { workspaceId: row.workspaceId, oldId: row.id },
+            'pre-convergence row had no blob to move',
+          )
+        }
       }
     }
   },


### PR DESCRIPTION
Post-merge fix for CodeRabbit's valid finding on #811 (the one comment there, triaged after merging — my miss, the finding is real).

A blob rename is the one step the migrator's transaction cannot roll back: if a LATER legacy row failed, the DB rolled back to nanoid ids while earlier blobs kept their fresh ULID names — orphaned **forever**, since the ULID is regenerated on the next attempt.

Completed renames are now recorded and renamed back (best effort, loudly logged) before the error propagates: disk matches the rolled-back DB, and the migration is safe to retry. Pinned red-first with an injected `EACCES` on the second rename — the first row's blob must be back under its nanoid name after the failure.

mcp-node 3,382 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSjf55ombrNgn1gmx6Seb3